### PR TITLE
C#: Restrict post-dominance to normal execution

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
@@ -213,7 +213,7 @@ class BasicBlock extends TBasicBlockStart {
   /**
    * Holds if this basic block strictly post-dominates basic block `bb`.
    *
-   * That is, all paths reaching an exit point basic block from basic
+   * That is, all paths reaching a normal exit point basic block from basic
    * block `bb` must go through this basic block (which must be different
    * from `bb`).
    *
@@ -239,7 +239,7 @@ class BasicBlock extends TBasicBlockStart {
   /**
    * Holds if this basic block post-dominates basic block `bb`.
    *
-   * That is, all paths reaching an exit point basic block from basic
+   * That is, all paths reaching a normal exit point basic block from basic
    * block `bb` must go through this basic block.
    *
    * Example:
@@ -333,10 +333,15 @@ private module Internal {
   /** Holds if `pred` is a basic block predecessor of `succ`. */
   private predicate predBB(BasicBlock succ, BasicBlock pred) { succBB(pred, succ) }
 
+  /** Holds if `bb` is an exit basic block that represents normal exit. */
+  private predicate normalExitBB(BasicBlock bb) {
+    bb.getANode().(ControlFlow::Nodes::AnnotatedExitNode).isNormal()
+  }
+
   /** Holds if `dom` is an immediate post-dominator of `bb`. */
   cached
   predicate bbIPostDominates(BasicBlock dom, BasicBlock bb) =
-    idominance(exitBB/1, predBB/2)(_, dom, bb)
+    idominance(normalExitBB/1, predBB/2)(_, dom, bb)
 }
 
 private import Internal
@@ -355,15 +360,20 @@ private predicate entryBB(BasicBlock bb) {
 }
 
 /**
+ * An annotated exit basic block, that is, a basic block that contains
+ * an annotated exit node.
+ */
+class AnnotatedExitBasicBlock extends BasicBlock {
+  AnnotatedExitBasicBlock() { this.getANode() instanceof ControlFlow::Nodes::AnnotatedExitNode }
+}
+
+/**
  * An exit basic block, that is, a basic block whose last node is
  * the exit node of a callable.
  */
 class ExitBasicBlock extends BasicBlock {
-  ExitBasicBlock() { exitBB(this) }
+  ExitBasicBlock() { this.getLastNode() instanceof ControlFlow::Nodes::ExitNode }
 }
-
-/** Holds if `bb` is an exit basic block. */
-private predicate exitBB(BasicBlock bb) { bb.getLastNode() instanceof ControlFlow::Nodes::ExitNode }
 
 private module JoinBlockPredecessors {
   private import ControlFlow::Nodes

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -109,7 +109,7 @@ module ControlFlow {
      * Holds if this node post-dominates `that` node.
      *
      * That is, all paths reaching a normal callable exit node (an `AnnotatedExitNode`
-     * with a normal normal exit type) from `that` node must go through this node.
+     * with a normal exit type) from `that` node must go through this node.
      *
      * Example:
      *
@@ -146,7 +146,7 @@ module ControlFlow {
      * Holds if this node strictly post-dominates `that` node.
      *
      * That is, all paths reaching a normal callable exit node (an `AnnotatedExitNode`
-     * with a normal normal exit type) from `that` node must go through this node
+     * with a normal exit type) from `that` node must go through this node
      * (which must be different from `that` node).
      *
      * Example:

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -108,8 +108,8 @@ module ControlFlow {
     /**
      * Holds if this node post-dominates `that` node.
      *
-     * That is, all paths reaching a callable exit node (`ExitNode`)
-     * from `that` node must go through this node.
+     * That is, all paths reaching a normal callable exit node (an `AnnotatedExitNode`
+     * with a normal normal exit type) from `that` node must go through this node.
      *
      * Example:
      *
@@ -145,9 +145,9 @@ module ControlFlow {
     /**
      * Holds if this node strictly post-dominates `that` node.
      *
-     * That is, all paths reaching a callable exit node (`ExitNode`)
-     * from `that` node must go through this node (which must be different
-     * from `that` node).
+     * That is, all paths reaching a normal callable exit node (an `AnnotatedExitNode`
+     * with a normal normal exit type) from `that` node must go through this node
+     * (which must be different from `that` node).
      *
      * Example:
      *
@@ -259,6 +259,38 @@ module ControlFlow {
       override string toString() { result = "enter " + getCallable().toString() }
     }
 
+    /** A node for a callable exit point, annotated with the type of exit. */
+    class AnnotatedExitNode extends Node, TAnnotatedExitNode {
+      private Callable c;
+      private boolean normal;
+
+      AnnotatedExitNode() { this = TAnnotatedExitNode(c, normal) }
+
+      /** Gets the callable that this exit applies to. */
+      Callable getCallable() { result = c }
+
+      /** Holds if this node represent a normal exit. */
+      predicate isNormal() { normal = true }
+
+      override BasicBlocks::AnnotatedExitBlock getBasicBlock() {
+        result = Node.super.getBasicBlock()
+      }
+
+      override Callable getEnclosingCallable() { result = this.getCallable() }
+
+      override Location getLocation() { result = getCallable().getLocation() }
+
+      override string toString() {
+        exists(string s |
+          normal = true and s = "normal"
+          or
+          normal = false and s = "abnormal"
+        |
+          result = "exit " + getCallable() + " (" + s + ")"
+        )
+      }
+    }
+
     /** A node for a callable exit point. */
     class ExitNode extends Node, TExitNode {
       /** Gets the callable that this exit applies to. */
@@ -342,6 +374,8 @@ module ControlFlow {
   /** Provides different types of basic blocks. */
   module BasicBlocks {
     class EntryBlock = BBs::EntryBasicBlock;
+
+    class AnnotatedExitBlock = BBs::AnnotatedExitBasicBlock;
 
     class ExitBlock = BBs::ExitBasicBlock;
 
@@ -1953,6 +1987,10 @@ module ControlFlow {
     private module Cached {
       private import semmle.code.csharp.Caching
 
+      private predicate isAbnormalExitType(SuccessorType t) {
+        t instanceof ExceptionSuccessor or t instanceof ExitSuccessor
+      }
+
       /**
        * Internal representation of control flow nodes in the control flow graph.
        * The control flow graph is pruned for unreachable nodes.
@@ -1962,6 +2000,12 @@ module ControlFlow {
         TEntryNode(Callable c) {
           Stages::ControlFlowStage::forceCachingInSameStage() and
           succEntrySplits(c, _, _, _)
+        } or
+        TAnnotatedExitNode(Callable c, boolean normal) {
+          exists(Reachability::SameSplitsBlock b, SuccessorType t | b.isReachable(_) |
+            succExitSplits(b.getAnElement(), _, c, t) and
+            if isAbnormalExitType(t) then normal = false else normal = true
+          )
         } or
         TExitNode(Callable c) {
           exists(Reachability::SameSplitsBlock b | b.isReachable(_) |
@@ -1985,8 +2029,12 @@ module ControlFlow {
         exists(ControlFlowElement predElement, Splits predSplits |
           pred = TElementNode(predElement, predSplits)
         |
-          // Element node -> callable exit
-          succExitSplits(predElement, predSplits, result.(Nodes::ExitNode).getCallable(), t)
+          // Element node -> callable exit (annotated)
+          result =
+            any(Nodes::AnnotatedExitNode exit |
+              succExitSplits(predElement, predSplits, exit.getCallable(), t) and
+              if isAbnormalExitType(t) then not exit.isNormal() else exit.isNormal()
+            )
           or
           // Element node -> element node
           exists(ControlFlowElement succElement, Splits succSplits, Completion c |
@@ -1996,6 +2044,10 @@ module ControlFlow {
             t.matchesCompletion(c)
           )
         )
+        or
+        // Callable exit (annotated) -> callable exit
+        pred.(Nodes::AnnotatedExitNode).getCallable() = result.(Nodes::ExitNode).getCallable() and
+        t instanceof SuccessorTypes::NormalSuccessor
       }
 
       /**

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -1,99 +1,100 @@
-| AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:23:5:25 | exit get_Item | 3 |
-| AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:33:5:35 | exit set_Item | 3 |
-| AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:32:7:34 | exit add_Event | 3 |
-| AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:40:7:45 | exit remove_Event | 3 |
-| AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:10:10:10:11 | exit M1 | 32 |
-| AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:19:10:19:11 | exit M2 | 40 |
-| AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:28:10:28:11 | exit M3 | 16 |
-| AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:35:10:35:11 | exit M4 | 19 |
-| AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:42:10:42:11 | exit M5 | 32 |
-| AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:49:10:49:11 | exit M6 | 41 |
-| AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:56:10:56:11 | exit M7 | 23 |
-| AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:61:10:61:11 | exit M8 | 29 |
-| AccessorCalls.cs:66:10:66:11 | enter M9 | AccessorCalls.cs:66:10:66:11 | exit M9 | 57 |
-| ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:11:3:12 | exit M1 | 4 |
-| ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | exit M2 | 5 |
-| ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | exit M3 | 7 |
-| ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | exit M4 | 12 |
+| AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:23:5:25 | exit get_Item | 4 |
+| AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:33:5:35 | exit set_Item | 4 |
+| AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:32:7:34 | exit add_Event | 4 |
+| AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:40:7:45 | exit remove_Event | 4 |
+| AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:10:10:10:11 | exit M1 | 33 |
+| AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:19:10:19:11 | exit M2 | 41 |
+| AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:28:10:28:11 | exit M3 | 17 |
+| AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:35:10:35:11 | exit M4 | 20 |
+| AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:42:10:42:11 | exit M5 | 33 |
+| AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:49:10:49:11 | exit M6 | 42 |
+| AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:56:10:56:11 | exit M7 | 24 |
+| AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:61:10:61:11 | exit M8 | 30 |
+| AccessorCalls.cs:66:10:66:11 | enter M9 | AccessorCalls.cs:66:10:66:11 | exit M9 | 58 |
+| ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:11:3:12 | exit M1 | 5 |
+| ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | exit M2 | 6 |
+| ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | exit M3 | 8 |
+| ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | exit M4 | 13 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:20:9:20 | access to parameter b | 5 |
 | Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | exit M1 | 1 |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:22:10:30 | ... != ... | 5 |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null | 1 |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" | 1 |
-| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | 1 |
-| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:11:9:11:35 | call to method WriteLine | 5 |
+| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | exit M1 (abnormal) | 2 |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:7:10:7:11 | exit M1 (normal) | 6 |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:20:16:20 | access to parameter b | 5 |
 | Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | exit M2 | 1 |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:23:17:23 | access to local variable s | 3 |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null | 1 |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" | 1 |
-| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | 1 |
-| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:18:9:18:35 | call to method WriteLine | 5 |
+| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 (abnormal) | 2 |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 (normal) | 6 |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:20:23:20 | access to parameter b | 5 |
 | Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | exit M3 | 1 |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:26:24:26 | access to local variable s | 3 |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null | 1 |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" | 1 |
-| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | 1 |
-| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:25:9:25:35 | call to method WriteLine | 5 |
+| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 (abnormal) | 2 |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 (normal) | 6 |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:20:30:20 | access to parameter b | 5 |
 | Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | exit M4 | 1 |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:23:31:31 | ... == ... | 5 |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null | 1 |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" | 1 |
-| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | 1 |
-| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:32:9:32:35 | call to method WriteLine | 5 |
+| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 (abnormal) | 2 |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 (normal) | 6 |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:20:37:20 | access to parameter b | 5 |
 | Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | exit M5 | 1 |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:23:38:31 | ... != ... | 5 |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null | 1 |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" | 1 |
-| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | 1 |
-| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:39:9:39:35 | call to method WriteLine | 5 |
+| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 (abnormal) | 2 |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 (normal) | 6 |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:20:44:20 | access to parameter b | 5 |
 | Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | exit M6 | 1 |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:24:45:32 | ... != ... | 5 |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null | 1 |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" | 1 |
-| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | 1 |
-| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:46:9:46:35 | call to method WriteLine | 5 |
+| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 (abnormal) | 2 |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 (normal) | 6 |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:20:51:20 | access to parameter b | 5 |
 | Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | exit M7 | 1 |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:24:52:32 | ... == ... | 5 |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null | 1 |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" | 1 |
-| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | 1 |
-| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:53:9:53:35 | call to method WriteLine | 5 |
+| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 (abnormal) | 2 |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 (normal) | 6 |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:20:58:20 | access to parameter b | 5 |
 | Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | exit M8 | 1 |
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | 7 |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | 7 |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | 1 |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 (abnormal) | 2 |
 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | 1 |
-| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:60:9:60:35 | call to method WriteLine | 6 |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:56:10:56:11 | exit M8 (normal) | 7 |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:20:65:20 | access to parameter b | 5 |
 | Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | exit M9 | 1 |
 | Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | 7 |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | 7 |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | 1 |
-| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:67:9:67:35 | call to method WriteLine | 6 |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 (abnormal) | 2 |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:63:10:63:11 | exit M9 (normal) | 7 |
 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | 1 |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:20:72:20 | access to parameter b | 5 |
 | Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | exit M10 | 1 |
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | 7 |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | 7 |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | 1 |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 (abnormal) | 2 |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | 1 |
-| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:74:9:74:35 | call to method WriteLine | 6 |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:70:10:70:12 | exit M10 (normal) | 7 |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:20:79:20 | access to parameter b | 5 |
 | Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | exit M11 | 1 |
 | Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | 7 |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | 7 |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | 1 |
-| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:81:9:81:35 | call to method WriteLine | 6 |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 (abnormal) | 2 |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:77:10:77:12 | exit M11 (normal) | 7 |
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | 1 |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:20:86:20 | access to parameter b | 5 |
 | Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | exit M12 | 1 |
+| Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | exit M12 (abnormal) | 1 |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | 6 |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | 6 |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | 1 |
@@ -133,19 +134,20 @@
 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | 1 |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | 16 |
 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | 1 |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:128:9:128:35 | call to method WriteLine | 7 |
-| Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:131:18:131:32 | exit AssertTrueFalse | 3 |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | exit M12 (normal) | 8 |
+| Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:131:18:131:32 | exit AssertTrueFalse | 4 |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:140:25:140:26 | access to parameter b1 | 5 |
 | Assert.cs:138:10:138:12 | exit M13 | Assert.cs:138:10:138:12 | exit M13 | 1 |
+| Assert.cs:138:10:138:12 | exit M13 (abnormal) | Assert.cs:138:10:138:12 | exit M13 (abnormal) | 1 |
 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | 3 |
 | Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:140:29:140:30 | access to parameter b2 | 1 |
 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | 2 |
-| Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | Assert.cs:141:9:141:15 | return ...; | 3 |
-| Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | exit M | 33 |
-| Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | exit (...) => ... | 3 |
-| Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | exit + | 5 |
+| Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | Assert.cs:138:10:138:12 | exit M13 (normal) | 4 |
+| Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | exit M | 34 |
+| Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | exit (...) => ... | 4 |
+| Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | exit + | 6 |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:7:33:7:36 | access to parameter args | 5 |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:3:10:3:11 | exit M1 | 1 |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:3:10:3:11 | exit M1 | 2 |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | 1 |
 | BreakInTry.cs:7:26:7:28 | String arg | BreakInTry.cs:9:21:9:31 | ... == ... | 6 |
 | BreakInTry.cs:10:21:10:26 | break; | BreakInTry.cs:10:21:10:26 | break; | 1 |
@@ -158,9 +160,9 @@
 | BreakInTry.cs:30:13:33:13 | {...} | BreakInTry.cs:31:21:31:32 | ... == ... | 5 |
 | BreakInTry.cs:32:21:32:21 | ; | BreakInTry.cs:32:21:32:21 | ; | 1 |
 | BreakInTry.cs:32:21:32:21 | [finally: break] ; | BreakInTry.cs:32:21:32:21 | [finally: break] ; | 1 |
-| BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 | 2 |
+| BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 | 3 |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:42:17:42:28 | ... == ... | 8 |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | exit M3 | 1 |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:38:10:38:11 | exit M3 | 2 |
 | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args | 3 |
 | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:47:33:47:36 | access to parameter args | 2 |
 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | 1 |
@@ -171,7 +173,7 @@
 | BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:50:21:50:26 | break; | 1 |
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:53:7:53:7 | ; | 1 |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:60:17:60:28 | ... == ... | 8 |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:56:10:56:11 | exit M4 | 1 |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:56:10:56:11 | exit M4 | 2 |
 | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args | 3 |
 | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:65:33:65:36 | access to parameter args | 2 |
 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | 1 |
@@ -180,46 +182,46 @@
 | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | 6 |
 | BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:68:21:68:26 | [finally: return] break; | 1 |
 | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:68:21:68:26 | break; | 1 |
-| CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:5:9:5:15 | exit Default | 5 |
-| CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof | 5 |
-| CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:15:10:15:15 | exit Typeof | 5 |
-| CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:20:12:20:17 | exit Nameof | 5 |
-| CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:28:10:28:10 | exit M | 14 |
+| CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:5:9:5:15 | exit Default | 6 |
+| CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof | 6 |
+| CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:15:10:15:15 | exit Typeof | 6 |
+| CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:20:12:20:17 | exit Nameof | 6 |
+| CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:28:10:28:10 | exit M | 15 |
 | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:30:28:30:32 | ... = ... | 3 |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | 1 |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | 2 |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | 2 |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:12:3:13 | exit M1 | 1 |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 | 2 |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:28:3:38 | call to method ToString | 1 |
 | ConditionalAccess.cs:3:40:3:49 | call to method ToLower | ConditionalAccess.cs:3:40:3:49 | call to method ToLower | 1 |
 | ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | 2 |
-| ConditionalAccess.cs:5:10:5:11 | exit M2 | ConditionalAccess.cs:5:10:5:11 | exit M2 | 1 |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | exit M2 | 2 |
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:28:5:34 | access to property Length | 1 |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | 3 |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:10:7:11 | exit M3 | 1 |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 | 2 |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | 1 |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:49:7:55 | access to property Length | 1 |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | 3 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:9:9:10 | exit M4 | 1 |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 | 2 |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:27:9:33 | access to property Length | 1 |
 | ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:38:9:38 | 0 | 1 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:13:13:13:13 | access to parameter s | 4 |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:11:9:11:10 | exit M5 | 1 |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | exit M5 | 2 |
 | ConditionalAccess.cs:13:15:13:21 | access to property Length | ConditionalAccess.cs:13:15:13:21 | access to property Length | 1 |
 | ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:13:13:13:25 | ... > ... | 3 |
 | ConditionalAccess.cs:14:20:14:20 | 0 | ConditionalAccess.cs:14:13:14:21 | return ...; | 2 |
 | ConditionalAccess.cs:16:20:16:20 | 1 | ConditionalAccess.cs:16:13:16:21 | return ...; | 2 |
 | ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | 2 |
-| ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:12:19:13 | exit M6 | 1 |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | exit M6 | 2 |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | 2 |
-| ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | exit M7 | 17 |
+| ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | exit M7 | 18 |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:28:30:32 | ... = ... | 3 |
-| ConditionalAccess.cs:30:10:30:12 | exit Out | ConditionalAccess.cs:30:10:30:12 | exit Out | 1 |
+| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out | 2 |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:35:9:35:12 | access to property Prop | 8 |
-| ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:32:10:32:11 | exit M8 | 1 |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 | 2 |
 | ConditionalAccess.cs:35:14:35:24 | call to method Out | ConditionalAccess.cs:35:14:35:24 | call to method Out | 1 |
-| ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith | 7 |
+| ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith | 8 |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:5:13:5:15 | access to parameter inc | 4 |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:3:10:3:19 | exit IncrOrDecr | 1 |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | exit IncrOrDecr | 2 |
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | 6 |
 | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:8:13:8:15 | ...-- | 6 |
 | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:14:13:14:13 | access to parameter b | 7 |
@@ -227,27 +229,27 @@
 | Conditions.cs:16:9:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | 4 |
 | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:18:17:18:19 | ...-- | 6 |
 | Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | 3 |
-| Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:11:9:11:10 | exit M1 | 3 |
+| Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:11:9:11:10 | exit M1 | 4 |
 | Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:25:13:25:14 | access to parameter b1 | 7 |
 | Conditions.cs:26:13:27:20 | if (...) ... | Conditions.cs:26:17:26:18 | access to parameter b2 | 2 |
 | Conditions.cs:27:17:27:20 | [b2 (line 22): true] ...; | Conditions.cs:28:13:28:14 | [b2 (line 22): true] access to parameter b2 | 5 |
 | Conditions.cs:28:9:29:16 | [b2 (line 22): false] if (...) ... | Conditions.cs:28:13:28:14 | [b2 (line 22): false] access to parameter b2 | 2 |
 | Conditions.cs:28:9:29:16 | if (...) ... | Conditions.cs:28:13:28:14 | access to parameter b2 | 2 |
 | Conditions.cs:29:13:29:16 | ...; | Conditions.cs:29:13:29:15 | ...++ | 3 |
-| Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:22:9:22:10 | exit M2 | 3 |
+| Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:22:9:22:10 | exit M2 | 4 |
 | Conditions.cs:33:9:33:10 | enter M3 | Conditions.cs:37:13:37:14 | access to parameter b1 | 10 |
 | Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:13:38:19 | ... = ... | 3 |
 | Conditions.cs:39:9:40:16 | if (...) ... | Conditions.cs:39:13:39:14 | access to local variable b2 | 2 |
 | Conditions.cs:40:13:40:16 | [b2 (line 39): true] ...; | Conditions.cs:42:13:42:15 | ...++ | 8 |
 | Conditions.cs:41:9:42:16 | [b2 (line 39): false] if (...) ... | Conditions.cs:41:13:41:14 | [b2 (line 39): false] access to local variable b2 | 2 |
-| Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:33:9:33:10 | exit M3 | 3 |
+| Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:33:9:33:10 | exit M3 | 4 |
 | Conditions.cs:46:9:46:10 | enter M4 | Conditions.cs:49:16:49:22 | ... > ... | 10 |
 | Conditions.cs:49:16:49:16 | [b (line 46): false] access to parameter x | Conditions.cs:49:16:49:22 | [b (line 46): false] ... > ... | 4 |
 | Conditions.cs:50:9:53:9 | [b (line 46): false] {...} | Conditions.cs:51:17:51:17 | [b (line 46): false] access to parameter b | 3 |
 | Conditions.cs:50:9:53:9 | [b (line 46): true] {...} | Conditions.cs:51:17:51:17 | [b (line 46): true] access to parameter b | 3 |
 | Conditions.cs:50:9:53:9 | {...} | Conditions.cs:51:17:51:17 | access to parameter b | 3 |
 | Conditions.cs:52:17:52:20 | [b (line 46): true] ...; | Conditions.cs:49:16:49:22 | [b (line 46): true] ... > ... | 7 |
-| Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:46:9:46:10 | exit M4 | 3 |
+| Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:46:9:46:10 | exit M4 | 4 |
 | Conditions.cs:57:9:57:10 | enter M5 | Conditions.cs:60:16:60:22 | ... > ... | 10 |
 | Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x | Conditions.cs:60:16:60:22 | [b (line 57): false] ... > ... | 4 |
 | Conditions.cs:61:9:64:9 | [b (line 57): false] {...} | Conditions.cs:62:17:62:17 | [b (line 57): false] access to parameter b | 3 |
@@ -258,7 +260,7 @@
 | Conditions.cs:65:9:66:16 | [b (line 57): true] if (...) ... | Conditions.cs:65:13:65:13 | [b (line 57): true] access to parameter b | 2 |
 | Conditions.cs:65:9:66:16 | if (...) ... | Conditions.cs:65:13:65:13 | access to parameter b | 2 |
 | Conditions.cs:66:13:66:16 | ...; | Conditions.cs:66:13:66:15 | ...++ | 3 |
-| Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:57:9:57:10 | exit M5 | 3 |
+| Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:57:9:57:10 | exit M5 | 4 |
 | Conditions.cs:70:9:70:10 | enter M6 | Conditions.cs:74:27:74:28 | access to parameter ss | 12 |
 | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | 1 |
 | Conditions.cs:74:22:74:22 | String _ | Conditions.cs:76:17:76:17 | access to local variable b | 4 |
@@ -267,7 +269,7 @@
 | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:25 | ... = ... | 3 |
 | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:13:81:13 | access to local variable b | 2 |
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:15 | ...++ | 3 |
-| Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:70:9:70:10 | exit M6 | 3 |
+| Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:70:9:70:10 | exit M6 | 4 |
 | Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:90:27:90:28 | access to parameter ss | 12 |
 | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | 1 |
 | Conditions.cs:90:22:90:22 | String _ | Conditions.cs:92:17:92:17 | access to local variable b | 4 |
@@ -276,15 +278,15 @@
 | Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:17:95:25 | ... = ... | 3 |
 | Conditions.cs:96:13:97:20 | if (...) ... | Conditions.cs:96:17:96:17 | access to local variable b | 2 |
 | Conditions.cs:97:17:97:20 | ...; | Conditions.cs:97:17:97:19 | ...++ | 3 |
-| Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:86:9:86:10 | exit M7 | 3 |
+| Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:86:9:86:10 | exit M7 | 4 |
 | Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:105:13:105:13 | access to parameter b | 8 |
 | Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | 10 |
 | Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... | 5 |
 | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:109:17:109:23 | ... = ... | 8 |
 | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | 3 |
-| Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:102:12:102:13 | exit M8 | 3 |
+| Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:102:12:102:13 | exit M8 | 4 |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:18:116:22 | Int32 i = ... | 8 |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | exit M9 | 1 |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | exit M9 | 2 |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:39 | ... < ... | 4 |
 | Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:44 | ...++ | 2 |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:18:119:21 | access to local variable last | 12 |
@@ -296,61 +298,65 @@
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | 4 |
 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | 14 |
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:17:145:17 | access to parameter b | 5 |
-| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | exit M11 | 1 |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | exit M11 | 2 |
 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:147:13:147:48 | call to method WriteLine | 9 |
 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:149:13:149:48 | call to method WriteLine | 9 |
-| ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | exit M1 | 7 |
-| ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | exit M2 | 7 |
-| ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | exit M3 | 6 |
-| ExitMethods.cs:25:10:25:11 | enter M4 | ExitMethods.cs:25:10:25:11 | exit M4 | 6 |
-| ExitMethods.cs:31:10:31:11 | enter M5 | ExitMethods.cs:31:10:31:11 | exit M5 | 6 |
+| ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | exit M1 | 8 |
+| ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | exit M2 | 8 |
+| ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | exit M3 | 7 |
+| ExitMethods.cs:25:10:25:11 | enter M4 | ExitMethods.cs:25:10:25:11 | exit M4 | 7 |
+| ExitMethods.cs:31:10:31:11 | enter M5 | ExitMethods.cs:31:10:31:11 | exit M5 | 7 |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:41:13:41:30 | call to method ErrorAlways | 7 |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:37:10:37:11 | exit M6 | 1 |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:37:10:37:11 | exit M6 | 2 |
 | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} | 1 |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | 1 |
 | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:45:13:45:19 | return ...; | 2 |
 | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:49:13:49:19 | return ...; | 3 |
-| ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:53:10:53:11 | exit M7 | 5 |
-| ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:59:10:59:11 | exit M8 | 5 |
+| ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:53:10:53:11 | exit M7 | 6 |
+| ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:59:10:59:11 | exit M8 | 6 |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:67:13:67:13 | access to parameter b | 4 |
 | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | 1 |
-| ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:13:68:34 | throw ...; | 2 |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | 1 |
+| ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (abnormal) | 3 |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:73:13:73:13 | access to parameter b | 4 |
-| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | 1 |
+| ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | 2 |
 | ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:13:74:34 | throw ...; | 2 |
 | ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:13:76:45 | throw ...; | 3 |
-| ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 | 5 |
-| ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 | 4 |
-| ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:86:10:86:13 | exit Exit | 6 |
-| ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:91:10:91:18 | exit ExitInTry | 8 |
-| ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit | 5 |
+| ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 | 6 |
+| ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 | 5 |
+| ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:86:10:86:13 | exit Exit | 7 |
+| ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:91:10:91:18 | exit ExitInTry | 9 |
+| ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit | 6 |
 | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:111:16:111:25 | ... != ... | 7 |
 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | 1 |
-| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:9:111:77 | return ...; | 5 |
-| ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:41:111:76 | throw ... | 3 |
+| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) | 6 |
+| ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) | 4 |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:16:116:30 | call to method Contains | 6 |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | 2 |
+| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | 3 |
 | ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 | 1 |
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 | 1 |
-| ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | 6 |
-| ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | 6 |
+| ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | 7 |
+| ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | 7 |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:48:131:48 | access to parameter b | 2 |
 | ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse | 1 |
-| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | 1 |
-| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | 1 |
-| ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | 7 |
-| Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | exit ToInt32 | 6 |
-| Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:10:24:10:29 | exit ToBool | 7 |
-| Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:23:15:33 | exit CallToInt32 | 4 |
-| Extensions.cs:20:17:20:20 | enter Main | Extensions.cs:20:17:20:20 | exit Main | 19 |
+| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse (abnormal) | 2 |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse (normal) | 2 |
+| ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | 8 |
+| Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | exit ToInt32 | 7 |
+| Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:10:24:10:29 | exit ToBool | 8 |
+| Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:23:15:33 | exit CallToInt32 | 5 |
+| Extensions.cs:20:17:20:20 | enter Main | Extensions.cs:20:17:20:20 | exit Main | 20 |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:11:31:11:36 | "Try1" | 6 |
 | Finally.cs:7:10:7:11 | exit M1 | Finally.cs:7:10:7:11 | exit M1 | 1 |
+| Finally.cs:7:10:7:11 | exit M1 (abnormal) | Finally.cs:7:10:7:11 | exit M1 (abnormal) | 1 |
 | Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:11:13:11:37 | call to method WriteLine | 1 |
 | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} | Finally.cs:15:13:15:40 | [finally: exception(Exception)] call to method WriteLine | 4 |
 | Finally.cs:14:9:16:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:15:13:15:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 4 |
-| Finally.cs:14:9:16:9 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | 4 |
+| Finally.cs:14:9:16:9 | {...} | Finally.cs:7:10:7:11 | exit M1 (normal) | 5 |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:23:31:23:36 | "Try2" | 6 |
 | Finally.cs:19:10:19:11 | exit M2 | Finally.cs:19:10:19:11 | exit M2 | 1 |
+| Finally.cs:19:10:19:11 | exit M2 (abnormal) | Finally.cs:19:10:19:11 | exit M2 (abnormal) | 1 |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:19:10:19:11 | exit M2 (normal) | 1 |
 | Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:23:13:23:37 | call to method WriteLine | 1 |
 | Finally.cs:24:13:24:19 | return ...; | Finally.cs:50:13:50:40 | [finally: return] call to method WriteLine | 5 |
 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | 1 |
@@ -362,6 +368,8 @@
 | Finally.cs:42:9:43:9 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | 5 |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:58:31:58:36 | "Try3" | 6 |
 | Finally.cs:54:10:54:11 | exit M3 | Finally.cs:54:10:54:11 | exit M3 | 1 |
+| Finally.cs:54:10:54:11 | exit M3 (abnormal) | Finally.cs:54:10:54:11 | exit M3 (abnormal) | 1 |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:54:10:54:11 | exit M3 (normal) | 1 |
 | Finally.cs:58:13:58:37 | call to method WriteLine | Finally.cs:58:13:58:37 | call to method WriteLine | 1 |
 | Finally.cs:59:13:59:19 | return ...; | Finally.cs:70:13:70:40 | [finally: return] call to method WriteLine | 5 |
 | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | 1 |
@@ -373,6 +381,8 @@
 | Finally.cs:69:9:71:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:70:13:70:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 4 |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:77:9:100:9 | while (...) ... | 6 |
 | Finally.cs:74:10:74:11 | exit M4 | Finally.cs:74:10:74:11 | exit M4 | 1 |
+| Finally.cs:74:10:74:11 | exit M4 (abnormal) | Finally.cs:74:10:74:11 | exit M4 (abnormal) | 1 |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:74:10:74:11 | exit M4 (normal) | 1 |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:77:16:77:20 | ... > ... | 3 |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:81:21:81:26 | ... == ... | 7 |
 | Finally.cs:82:21:82:27 | return ...; | Finally.cs:92:25:92:30 | [finally: return] ... == ... | 8 |
@@ -399,6 +409,8 @@
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:97:21:97:23 | ...-- | 4 |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:107:17:107:21 | access to field Field | 7 |
 | Finally.cs:103:10:103:11 | exit M5 | Finally.cs:103:10:103:11 | exit M5 | 1 |
+| Finally.cs:103:10:103:11 | exit M5 (abnormal) | Finally.cs:103:10:103:11 | exit M5 (abnormal) | 1 |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:103:10:103:11 | exit M5 (normal) | 1 |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:107:17:107:28 | access to property Length | 1 |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:107:17:107:33 | ... == ... | 2 |
 | Finally.cs:108:17:108:23 | return ...; | Finally.cs:114:19:114:35 | [finally: return] ... == ... | 9 |
@@ -425,15 +437,17 @@
 | Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; | Finally.cs:117:17:117:36 | [finally: exception(NullReferenceException)] call to method WriteLine | 3 |
 | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:117:17:117:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 3 |
 | Finally.cs:117:17:117:37 | [finally: return] ...; | Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine | 3 |
-| Finally.cs:121:10:121:11 | enter M6 | Finally.cs:121:10:121:11 | exit M6 | 11 |
+| Finally.cs:121:10:121:11 | enter M6 | Finally.cs:121:10:121:11 | exit M6 | 12 |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:137:31:137:35 | "Try" | 6 |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:133:10:133:11 | exit M7 | 1 |
+| Finally.cs:133:10:133:11 | exit M7 (abnormal) | Finally.cs:133:10:133:11 | exit M7 | 2 |
 | Finally.cs:137:13:137:36 | call to method WriteLine | Finally.cs:137:13:137:36 | call to method WriteLine | 1 |
 | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} | Finally.cs:141:13:141:44 | [finally: exception(Exception)] throw ...; | 4 |
 | Finally.cs:140:9:143:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:141:13:141:44 | [finally: exception(OutOfMemoryException)] throw ...; | 4 |
 | Finally.cs:140:9:143:9 | {...} | Finally.cs:141:13:141:44 | throw ...; | 4 |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:151:17:151:28 | ... == ... | 8 |
 | Finally.cs:147:10:147:11 | exit M8 | Finally.cs:147:10:147:11 | exit M8 | 1 |
+| Finally.cs:147:10:147:11 | exit M8 (abnormal) | Finally.cs:147:10:147:11 | exit M8 (abnormal) | 1 |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:147:10:147:11 | exit M8 (normal) | 1 |
 | Finally.cs:152:17:152:50 | throw ...; | Finally.cs:158:21:158:31 | [finally: exception(ArgumentNullException)] access to property Length | 7 |
 | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | 1 |
 | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | Finally.cs:158:21:158:31 | [finally: exception(Exception)] access to property Length | 6 |
@@ -461,6 +475,8 @@
 | Finally.cs:165:13:168:13 | catch {...} | Finally.cs:167:17:167:37 | call to method WriteLine | 5 |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:180:17:180:18 | access to parameter b1 | 6 |
 | Finally.cs:176:10:176:11 | exit M9 | Finally.cs:176:10:176:11 | exit M9 | 1 |
+| Finally.cs:176:10:176:11 | exit M9 (abnormal) | Finally.cs:176:10:176:11 | exit M9 (abnormal) | 1 |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:176:10:176:11 | exit M9 (normal) | 1 |
 | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | 6 |
 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | 1 |
 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | 5 |
@@ -482,6 +498,7 @@
 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:190:25:190:47 | [finally: exception(ExceptionA)] throw ...; | 5 |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:199:17:199:18 | access to parameter b1 | 6 |
 | Finally.cs:195:10:195:12 | exit M10 | Finally.cs:195:10:195:12 | exit M10 | 1 |
+| Finally.cs:195:10:195:12 | exit M10 (abnormal) | Finally.cs:195:10:195:12 | exit M10 (abnormal) | 1 |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 | 6 |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:199:27:199:42 | object creation of type ExceptionA | 1 |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:205:21:205:22 | [finally: exception(Exception)] access to parameter b2 | 5 |
@@ -507,106 +524,111 @@
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; | 2 |
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | 2 |
 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:209:25:209:47 | throw ...; | 2 |
-| Finally.cs:211:13:211:29 | ...; | Finally.cs:213:9:213:24 | ... = ... | 8 |
+| Finally.cs:211:13:211:29 | ...; | Finally.cs:195:10:195:12 | exit M10 (normal) | 9 |
 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... | 4 |
 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... | 4 |
 | Finally.cs:216:10:216:12 | enter M11 | Finally.cs:220:31:220:35 | "Try" | 6 |
 | Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:13:220:36 | call to method WriteLine | 1 |
 | Finally.cs:222:9:225:9 | catch {...} | Finally.cs:224:13:224:38 | call to method WriteLine | 5 |
-| Finally.cs:227:9:229:9 | {...} | Finally.cs:216:10:216:12 | exit M11 | 8 |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:216:10:216:12 | exit M11 | 9 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:8:29:8:32 | access to parameter args | 3 |
-| Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | exit M1 | 1 |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 | 2 |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | 1 |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:9:13:9:13 | ; | 2 |
 | Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:14:27:14:30 | access to parameter args | 3 |
-| Foreach.cs:12:10:12:11 | exit M2 | Foreach.cs:12:10:12:11 | exit M2 | 1 |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | exit M2 | 2 |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | 1 |
 | Foreach.cs:14:22:14:22 | String _ | Foreach.cs:15:13:15:13 | ; | 2 |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:27:20:27 | access to parameter e | 4 |
-| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:18:10:18:11 | exit M3 | 1 |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 | 2 |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | 1 |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:21:11:21:11 | ; | 2 |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:29:20:38 | call to method ToArray | 1 |
 | Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:43:20:68 | call to method Empty | 1 |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:26:36:26:39 | access to parameter args | 3 |
-| Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:24:10:24:11 | exit M4 | 1 |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | exit M4 | 2 |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | 1 |
 | Foreach.cs:26:23:26:23 | String x | Foreach.cs:27:11:27:11 | ; | 4 |
 | Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:32:32:32:35 | access to parameter args | 3 |
-| Foreach.cs:30:10:30:11 | exit M5 | Foreach.cs:30:10:30:11 | exit M5 | 1 |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:30:10:30:11 | exit M5 | 2 |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | 1 |
 | Foreach.cs:32:23:32:23 | String x | Foreach.cs:33:11:33:11 | ; | 4 |
 | Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:38:39:38:42 | access to parameter args | 3 |
-| Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:36:10:36:11 | exit M6 | 1 |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | exit M6 | 2 |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | 1 |
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:39:11:39:11 | ; | 4 |
-| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | exit Initializers | 14 |
-| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | exit Initializers | 14 |
-| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | exit M | 21 |
+| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | exit Initializers | 15 |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | exit Initializers | 15 |
+| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | exit M | 22 |
 | Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... | 2 |
-| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | exit NoConstructor | 8 |
-| Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | exit Sub | 11 |
-| Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | exit Sub | 8 |
-| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | exit Sub | 18 |
-| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | exit Test | 104 |
+| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | exit NoConstructor | 9 |
+| Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | exit Sub | 12 |
+| Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | exit Sub | 9 |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | exit Sub | 19 |
+| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | exit Test | 105 |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:9:13:9:28 | ... == ... | 7 |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 | 1 |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | exit M1 | 2 |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:10:13:10:19 | return ...; | 1 |
 | LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | 5 |
 | LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | 2 |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | 12 |
-| LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 | 1 |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:15:10:15:11 | exit M2 | 2 |
 | LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | 5 |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:24:29:24:32 | access to parameter args | 3 |
-| LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | exit M3 | 1 |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:22:10:22:11 | exit M3 | 2 |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | 1 |
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:13:26:40 | [unroll (line 25)] foreach (... ... in ...) ... | 3 |
 | LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:25:13:26:40 | foreach (... ... in ...) ... | 5 |
-| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 | 9 |
+| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 | 10 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | 20 |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 | 1 |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:36:10:36:11 | exit M5 | 2 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | 1 |
 | LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | 3 |
 | LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | 7 |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:49:9:52:9 | {...} | 14 |
 | LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:51:13:51:23 | goto ...; | 5 |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:60:17:60:17 | access to parameter b | 16 |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | exit M7 | 1 |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:55:10:55:11 | exit M7 | 2 |
 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:60:17:60:17 | [b (line 55): false] access to parameter b | 4 |
 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:60:17:60:17 | [b (line 55): true] access to parameter b | 4 |
 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | 9 |
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | 3 |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:69:14:69:23 | call to method Any | 6 |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 | 1 |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 | 2 |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; | 1 |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | 5 |
-| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 | 10 |
-| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 | 10 |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 | 11 |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 | 11 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | 9 |
-| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 | 1 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:94:10:94:12 | exit M11 | 2 |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | 6 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | 1 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | 1 |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | 1 |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | 1 |
-| MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:22:6:31 | throw ... | 2 |
+| MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | 3 |
+| MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) | 3 |
 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | 1 |
 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | 1 |
 | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | 1 |
 | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | 1 |
-| MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationA.cs:7:27:7:37 | throw ...; | 3 |
+| MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | 4 |
+| MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) | 4 |
 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | 1 |
 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | 1 |
 | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | 1 |
 | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | 1 |
-| MultiImplementationA.cs:7:45:7:59 | {...} | MultiImplementationA.cs:7:47:7:57 | throw ...; | 3 |
+| MultiImplementationA.cs:7:45:7:59 | {...} | MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | 4 |
+| MultiImplementationA.cs:7:45:7:59 | {...} | MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) | 4 |
 | MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationA.cs:8:16:8:16 | enter M | 1 |
 | MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationB.cs:5:16:5:16 | enter M | 1 |
 | MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationA.cs:8:16:8:16 | exit M | 1 |
 | MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationB.cs:5:16:5:16 | exit M | 1 |
-| MultiImplementationA.cs:8:29:8:32 | null | MultiImplementationA.cs:8:23:8:32 | throw ... | 2 |
+| MultiImplementationA.cs:8:29:8:32 | null | MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | 3 |
+| MultiImplementationA.cs:8:29:8:32 | null | MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) | 3 |
 | MultiImplementationA.cs:13:16:13:16 | this access | MultiImplementationA.cs:13:16:13:20 | ... = ... | 3 |
-| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationA.cs:14:31:14:31 | access to parameter i | 1 |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | 2 |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) | 2 |
 | MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | enter get_Item | 1 |
 | MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationB.cs:12:31:12:40 | enter get_Item | 1 |
 | MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | exit get_Item | 1 |
@@ -615,49 +637,55 @@
 | MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationB.cs:13:36:13:38 | enter get_Item | 1 |
 | MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationA.cs:15:36:15:38 | exit get_Item | 1 |
 | MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationB.cs:13:36:13:38 | exit get_Item | 1 |
-| MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:42:15:50 | return ...; | 3 |
+| MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | 4 |
+| MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) | 4 |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | enter set_Item | 1 |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | enter set_Item | 1 |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item | 1 |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item | 1 |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item | 2 |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item | 2 |
 | MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationA.cs:15:58:15:60 | {...} | 1 |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | enter M1 | 1 |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | enter M1 | 1 |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 | 1 |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 | 1 |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 | 2 |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 | 2 |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:18:9:18:22 | M2(...) | 2 |
-| MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:9:18:22 | exit M2 | 3 |
+| MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:9:18:22 | exit M2 | 4 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 | 1 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 | 1 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | exit C2 | 1 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | exit C2 | 1 |
-| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:24:20:28 | ... = ... | 5 |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | 6 |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | 6 |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | enter C2 | 1 |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | enter C2 | 1 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 | 1 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 | 1 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 | 2 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 | 2 |
 | MultiImplementationA.cs:21:24:21:24 | 0 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | 2 |
 | MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationA.cs:21:27:21:29 | {...} | 1 |
 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | 1 |
 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | 1 |
 | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | 1 |
 | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | 1 |
-| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:11:22:13 | {...} | 1 |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | 2 |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) | 2 |
 | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | 1 |
 | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | 1 |
 | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | 1 |
 | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | 1 |
-| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:50:23:53 | null | 1 |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | 2 |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) | 2 |
 | MultiImplementationA.cs:24:16:24:16 | this access | MultiImplementationA.cs:24:32:24:34 | ... = ... | 4 |
-| MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | 4 |
-| MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | 4 |
+| MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | 5 |
+| MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | 5 |
 | MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationA.cs:36:9:36:10 | enter M1 | 1 |
 | MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationB.cs:32:9:32:10 | enter M1 | 1 |
 | MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationA.cs:36:9:36:10 | exit M1 | 1 |
 | MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | exit M1 | 1 |
-| MultiImplementationA.cs:36:14:36:28 | {...} | MultiImplementationA.cs:36:16:36:26 | throw ...; | 3 |
-| MultiImplementationA.cs:37:9:37:10 | enter M2 | MultiImplementationA.cs:37:9:37:10 | exit M2 | 5 |
-| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationB.cs:3:22:3:22 | 0 | 1 |
+| MultiImplementationA.cs:36:14:36:28 | {...} | MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | 4 |
+| MultiImplementationA.cs:36:14:36:28 | {...} | MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) | 4 |
+| MultiImplementationA.cs:37:9:37:10 | enter M2 | MultiImplementationA.cs:37:9:37:10 | exit M2 | 6 |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | 2 |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) | 2 |
 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | 1 |
 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | 1 |
 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | 1 |
@@ -666,92 +694,101 @@
 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | 1 |
 | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | 1 |
 | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | 1 |
-| MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationB.cs:4:27:4:35 | return ...; | 3 |
+| MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | 4 |
+| MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) | 4 |
 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | 1 |
 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | 1 |
 | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | 1 |
 | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | 1 |
-| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationB.cs:4:43:4:45 | {...} | 1 |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | 2 |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) | 2 |
 | MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationA.cs:8:16:8:16 | enter M | 1 |
 | MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationB.cs:5:16:5:16 | enter M | 1 |
 | MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationA.cs:8:16:8:16 | exit M | 1 |
 | MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationB.cs:5:16:5:16 | exit M | 1 |
-| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationB.cs:5:23:5:23 | 2 | 1 |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationA.cs:8:16:8:16 | exit M (normal) | 2 |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationB.cs:5:16:5:16 | exit M (normal) | 2 |
 | MultiImplementationB.cs:11:16:11:16 | this access | MultiImplementationB.cs:11:16:11:20 | ... = ... | 3 |
 | MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | enter get_Item | 1 |
 | MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationB.cs:12:31:12:40 | enter get_Item | 1 |
 | MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | exit get_Item | 1 |
 | MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationB.cs:12:31:12:40 | exit get_Item | 1 |
-| MultiImplementationB.cs:12:37:12:40 | null | MultiImplementationB.cs:12:31:12:40 | throw ... | 2 |
+| MultiImplementationB.cs:12:37:12:40 | null | MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | 3 |
+| MultiImplementationB.cs:12:37:12:40 | null | MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) | 3 |
 | MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationA.cs:15:36:15:38 | enter get_Item | 1 |
 | MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationB.cs:13:36:13:38 | enter get_Item | 1 |
 | MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationA.cs:15:36:15:38 | exit get_Item | 1 |
 | MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationB.cs:13:36:13:38 | exit get_Item | 1 |
-| MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationB.cs:13:42:13:52 | throw ...; | 3 |
+| MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | 4 |
+| MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) | 4 |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | enter set_Item | 1 |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | enter set_Item | 1 |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item | 1 |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item | 1 |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item | 2 |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item | 2 |
 | MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationB.cs:13:60:13:62 | {...} | 1 |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | enter M1 | 1 |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | enter M1 | 1 |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 | 1 |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 | 1 |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 | 2 |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 | 2 |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:16:9:16:31 | M2(...) | 2 |
-| MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:9:16:31 | exit M2 | 4 |
+| MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:9:16:31 | exit M2 | 5 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 | 1 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 | 1 |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | exit C2 | 1 |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | exit C2 | 1 |
-| MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:24:18:34 | throw ...; | 3 |
+| MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | 4 |
+| MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | 4 |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | enter C2 | 1 |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | enter C2 | 1 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 | 1 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 | 1 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 | 2 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 | 2 |
 | MultiImplementationB.cs:19:24:19:24 | 1 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | 2 |
 | MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationB.cs:19:27:19:29 | {...} | 1 |
 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | 1 |
 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | 1 |
 | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | 1 |
 | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | 1 |
-| MultiImplementationB.cs:20:11:20:25 | {...} | MultiImplementationB.cs:20:13:20:23 | throw ...; | 3 |
+| MultiImplementationB.cs:20:11:20:25 | {...} | MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | 4 |
+| MultiImplementationB.cs:20:11:20:25 | {...} | MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) | 4 |
 | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | 1 |
 | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | 1 |
 | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | 1 |
 | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | 1 |
-| MultiImplementationB.cs:21:56:21:59 | null | MultiImplementationB.cs:21:50:21:59 | throw ... | 2 |
+| MultiImplementationB.cs:21:56:21:59 | null | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | 3 |
+| MultiImplementationB.cs:21:56:21:59 | null | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) | 3 |
 | MultiImplementationB.cs:22:16:22:16 | this access | MultiImplementationB.cs:22:32:22:34 | ... = ... | 4 |
-| MultiImplementationB.cs:27:21:27:23 | enter get_P3 | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | 4 |
-| MultiImplementationB.cs:27:21:27:23 | enter get_P3 | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | 4 |
+| MultiImplementationB.cs:27:21:27:23 | enter get_P3 | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | 5 |
+| MultiImplementationB.cs:27:21:27:23 | enter get_P3 | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | 5 |
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationA.cs:36:9:36:10 | enter M1 | 1 |
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationB.cs:32:9:32:10 | enter M1 | 1 |
 | MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationA.cs:36:9:36:10 | exit M1 | 1 |
 | MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | exit M1 | 1 |
-| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:17:32:17 | 0 | 1 |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | 2 |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | 2 |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:23 | access to parameter i | 3 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:9:3:10 | exit M1 | 1 |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 | 2 |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:28:3:28 | 0 | 1 |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:25:5:25 | access to parameter b | 4 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:9:5:10 | exit M2 | 1 |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 | 2 |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:30:5:34 | false | 1 |
 | NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:39:5:39 | 0 | 1 |
 | NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:43:5:43 | 1 | 1 |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | 3 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:12:7:13 | exit M3 | 1 |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 | 2 |
 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | 2 |
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:52:7:53 | "" | 1 |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:37:9:37 | access to parameter b | 4 |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:12:9:13 | exit M4 | 1 |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 | 2 |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:41:9:41 | access to parameter s | 1 |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:45:9:45 | access to parameter s | 1 |
 | NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:52 | "" | 2 |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | 4 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:9:11:10 | exit M5 | 1 |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 | 2 |
 | NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | 2 |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | 1 |
 | NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:64:11:64 | 0 | 1 |
 | NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:68:11:68 | 1 | 1 |
-| NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:13:10:13:11 | exit M6 | 18 |
+| NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:13:10:13:11 | exit M6 | 19 |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:8:13:8:23 | ... is ... | 9 |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:10:13:10:42 | call to method WriteLine | 6 |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:31 | ... is ... | 4 |
@@ -770,22 +807,24 @@
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:18:33:23 | Object v2 | 2 |
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:34:17:34:22 | break; | 1 |
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:37:17:37:22 | break; | 5 |
-| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | exit Test | 3 |
-| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | exit M1 | 6 |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | exit Test | 4 |
+| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | exit M1 | 7 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | ... is ... | 6 |
-| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | exit M2 | 1 |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 | 2 |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; | 1 |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:28 | call to method WriteLine | 3 |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:19:13:19:21 | ... is ... | 6 |
 | PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | exit M3 | 1 |
-| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:13:20:55 | throw ...; | 3 |
-| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:9:21:28 | call to method WriteLine | 3 |
-| Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | exit Method | 3 |
-| Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:23:8:34 | exit StaticMethod | 3 |
-| Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:10:10:10:10 | exit M | 57 |
-| Switch.cs:5:10:5:11 | enter M1 | Switch.cs:5:10:5:11 | exit M1 | 5 |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | 4 |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:17:10:17:11 | exit M3 (normal) | 4 |
+| Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | exit Method | 4 |
+| Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:23:8:34 | exit StaticMethod | 4 |
+| Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:10:10:10:10 | exit M | 58 |
+| Switch.cs:5:10:5:11 | enter M1 | Switch.cs:5:10:5:11 | exit M1 | 6 |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:14:18:14:20 | "a" | 6 |
 | Switch.cs:10:10:10:11 | exit M2 | Switch.cs:10:10:10:11 | exit M2 | 1 |
+| Switch.cs:10:10:10:11 | exit M2 (abnormal) | Switch.cs:10:10:10:11 | exit M2 (abnormal) | 1 |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:10:10:10:11 | exit M2 (normal) | 1 |
 | Switch.cs:15:17:15:23 | return ...; | Switch.cs:15:17:15:23 | return ...; | 1 |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:18:16:18 | 0 | 2 |
 | Switch.cs:17:23:17:37 | object creation of type Exception | Switch.cs:17:17:17:38 | throw ...; | 2 |
@@ -802,19 +841,19 @@
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | Double d | 2 |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:27:32:27:38 | call to method Throw | 1 |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:29:17:29:23 | return ...; | 4 |
-| Switch.cs:35:10:35:11 | enter M3 | Switch.cs:35:10:35:11 | exit M3 | 5 |
+| Switch.cs:35:10:35:11 | enter M3 | Switch.cs:35:10:35:11 | exit M3 | 6 |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:48:18:48:20 | access to type Int32 | 6 |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:44:10:44:11 | exit M4 | 1 |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:44:10:44:11 | exit M4 | 2 |
 | Switch.cs:49:17:49:22 | break; | Switch.cs:49:17:49:22 | break; | 1 |
 | Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:18:50:21 | access to type Boolean | 2 |
 | Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:50:30:50:38 | ... != ... | 3 |
 | Switch.cs:51:17:51:22 | break; | Switch.cs:51:17:51:22 | break; | 1 |
-| Switch.cs:55:10:55:11 | enter M5 | Switch.cs:55:10:55:11 | exit M5 | 12 |
+| Switch.cs:55:10:55:11 | enter M5 | Switch.cs:55:10:55:11 | exit M5 | 13 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:72:18:72:19 | "" | 9 |
-| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | exit M6 | 1 |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:66:10:66:11 | exit M6 | 2 |
 | Switch.cs:73:17:73:22 | break; | Switch.cs:73:17:73:22 | break; | 1 |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:81:18:81:18 | 1 | 6 |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | exit M7 | 1 |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:77:10:77:11 | exit M7 | 2 |
 | Switch.cs:82:24:82:27 | true | Switch.cs:82:17:82:28 | return ...; | 2 |
 | Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:18:83:18 | 2 | 2 |
 | Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:21:84:25 | ... > ... | 4 |
@@ -822,20 +861,20 @@
 | Switch.cs:86:24:86:27 | true | Switch.cs:86:17:86:28 | return ...; | 2 |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:9:88:21 | return ...; | 2 |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:95:18:95:20 | access to type Int32 | 6 |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | exit M8 | 1 |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:91:10:91:11 | exit M8 | 2 |
 | Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | return ...; | 2 |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:9:98:21 | return ...; | 2 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:103:17:103:17 | access to parameter s | 4 |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | exit M9 | 1 |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:101:9:101:10 | exit M9 | 2 |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:103:19:103:25 | access to property Length | 1 |
 | Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:18:105:18 | 0 | 2 |
 | Switch.cs:105:28:105:28 | 0 | Switch.cs:105:21:105:29 | return ...; | 2 |
 | Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:18:106:18 | 1 | 2 |
 | Switch.cs:106:28:106:28 | 1 | Switch.cs:106:21:106:29 | return ...; | 2 |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:9:108:18 | return ...; | 3 |
-| Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:17:111:21 | exit Throw | 4 |
+| Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:17:111:21 | exit Throw | 5 |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:117:18:117:18 | 3 | 7 |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | exit M10 | 1 |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:113:9:113:11 | exit M10 | 2 |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:25:117:34 | ... == ... | 3 |
 | Switch.cs:117:44:117:44 | 1 | Switch.cs:117:37:117:45 | return ...; | 2 |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 | 2 |
@@ -843,29 +882,31 @@
 | Switch.cs:118:43:118:43 | 2 | Switch.cs:118:36:118:44 | return ...; | 2 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:9:120:18 | return ...; | 3 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:24:125:29 | Boolean b | 7 |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | exit M11 | 1 |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 | 2 |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:34:125:34 | access to local variable b | 1 |
 | Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:42:125:46 | false | 3 |
 | Switch.cs:126:13:126:19 | return ...; | Switch.cs:126:13:126:19 | return ...; | 1 |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:28:131:35 | String s | 6 |
-| Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 | 2 |
+| Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 | 3 |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:40:131:40 | access to local variable s | 1 |
 | Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:48:131:51 | null | 3 |
 | Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:56:131:66 | call to method ToString | 1 |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:139:18:139:18 | 1 | 6 |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:134:9:134:11 | exit M13 | 1 |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 | 2 |
 | Switch.cs:138:13:138:20 | default: | Switch.cs:138:22:138:31 | return ...; | 4 |
 | Switch.cs:139:28:139:28 | 1 | Switch.cs:139:21:139:29 | return ...; | 2 |
 | Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:18:140:18 | 2 | 2 |
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:140:21:140:29 | return ...; | 2 |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:148:18:148:18 | 1 | 6 |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:144:9:144:11 | exit M14 | 1 |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:144:9:144:11 | exit M14 | 2 |
 | Switch.cs:148:28:148:28 | 1 | Switch.cs:148:21:148:29 | return ...; | 2 |
 | Switch.cs:149:13:149:20 | default: | Switch.cs:149:22:149:31 | return ...; | 4 |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:18:150:18 | 2 | 2 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; | 2 |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:28:156:31 | true | 7 |
 | Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | exit M15 | 1 |
+| Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | exit M15 (abnormal) | 1 |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | exit M15 (normal) | 1 |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:157:13:157:13 | access to parameter b | 3 |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" | 1 |
 | Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false | 2 |
@@ -874,16 +915,16 @@
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:48 | call to method WriteLine | 5 |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | ... is ... | 14 |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:25:7:25 | ; | 1 |
-| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | exit M | 4 |
-| VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | exit M1 | 18 |
-| VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:13:12:13:13 | exit M2 | 12 |
+| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | exit M | 5 |
+| VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | exit M1 | 19 |
+| VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:13:12:13:13 | exit M2 | 13 |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:20:25:20 | access to parameter b | 12 |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 | 2 |
+| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 | 3 |
 | VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:24:25:24 | access to local variable x | 1 |
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:28:25:28 | access to local variable y | 1 |
-| VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | exit Dispose | 3 |
+| VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | exit Dispose | 4 |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:11:13:11:17 | ... > ... | 15 |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:5:17:5:20 | exit Main | 1 |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:5:17:5:20 | exit Main | 2 |
 | cflow.cs:12:13:12:49 | ...; | cflow.cs:12:13:12:48 | call to method WriteLine | 3 |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:14:9:17:9 | while (...) ... | 1 |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:14:16:14:20 | ... > ... | 3 |
@@ -914,22 +955,23 @@
 | cflow.cs:56:13:56:20 | default: | cflow.cs:58:17:58:22 | break; | 5 |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:62:18:62:18 | 0 | 6 |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:23:63:33 | ... == ... | 6 |
-| cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:64:21:64:55 | throw ...; | 2 |
+| cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:37:17:37:22 | exit Switch (abnormal) | 3 |
 | cflow.cs:65:17:65:22 | break; | cflow.cs:65:17:65:22 | break; | 1 |
-| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:67:9:67:17 | return ...; | 2 |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:37:17:37:22 | exit Switch (normal) | 3 |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:72:13:72:21 | ... == ... | 6 |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:70:18:70:18 | exit M | 1 |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | exit M | 2 |
 | cflow.cs:73:13:73:19 | return ...; | cflow.cs:73:13:73:19 | return ...; | 1 |
 | cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:74:13:74:24 | ... > ... | 5 |
 | cflow.cs:75:9:77:9 | {...} | cflow.cs:76:13:76:32 | call to method WriteLine | 4 |
 | cflow.cs:79:9:81:9 | {...} | cflow.cs:80:13:80:47 | call to method WriteLine | 4 |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:86:13:86:21 | ... != ... | 7 |
-| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:84:18:84:19 | exit M2 | 1 |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 | 2 |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:37 | ... > ... | 4 |
 | cflow.cs:87:13:87:33 | ...; | cflow.cs:87:13:87:32 | call to method WriteLine | 3 |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:92:13:92:27 | call to method Equals | 6 |
 | cflow.cs:90:18:90:19 | exit M3 | cflow.cs:90:18:90:19 | exit M3 | 1 |
-| cflow.cs:93:45:93:47 | "s" | cflow.cs:93:13:93:49 | throw ...; | 3 |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | exit M3 (normal) | 1 |
+| cflow.cs:93:45:93:47 | "s" | cflow.cs:90:18:90:19 | exit M3 (abnormal) | 4 |
 | cflow.cs:94:9:94:29 | ...; | cflow.cs:96:13:96:25 | ... != ... | 8 |
 | cflow.cs:97:13:97:55 | ...; | cflow.cs:97:13:97:54 | call to method WriteLine | 4 |
 | cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:99:13:99:25 | ... != ... | 5 |
@@ -939,21 +981,21 @@
 | cflow.cs:106:18:106:19 | enter M4 | cflow.cs:108:13:108:21 | ... != ... | 6 |
 | cflow.cs:109:9:115:9 | {...} | cflow.cs:110:13:113:13 | while (...) ... | 2 |
 | cflow.cs:110:20:110:23 | true | cflow.cs:112:17:112:36 | call to method WriteLine | 5 |
-| cflow.cs:116:9:116:29 | ...; | cflow.cs:106:18:106:19 | exit M4 | 4 |
-| cflow.cs:119:20:119:21 | enter M5 | cflow.cs:119:20:119:21 | exit M5 | 13 |
+| cflow.cs:116:9:116:29 | ...; | cflow.cs:106:18:106:19 | exit M4 | 5 |
+| cflow.cs:119:20:119:21 | enter M5 | cflow.cs:119:20:119:21 | exit M5 | 14 |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:32:127:44 | ... == ... | 7 |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop | 2 |
+| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop | 3 |
 | cflow.cs:127:48:127:49 | "" | cflow.cs:127:48:127:49 | "" | 1 |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field | 2 |
-| cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:62:127:64 | exit set_Prop | 7 |
-| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | exit ControlFlow | 7 |
-| cflow.cs:134:5:134:15 | enter ControlFlow | cflow.cs:134:5:134:15 | exit ControlFlow | 8 |
-| cflow.cs:136:12:136:22 | enter ControlFlow | cflow.cs:136:12:136:22 | exit ControlFlow | 7 |
-| cflow.cs:138:40:138:40 | enter + | cflow.cs:138:40:138:40 | exit + | 8 |
-| cflow.cs:144:33:144:35 | enter get_Item | cflow.cs:144:33:144:35 | exit get_Item | 8 |
-| cflow.cs:144:56:144:58 | enter set_Item | cflow.cs:144:56:144:58 | exit set_Item | 3 |
+| cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:62:127:64 | exit set_Prop | 8 |
+| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | exit ControlFlow | 8 |
+| cflow.cs:134:5:134:15 | enter ControlFlow | cflow.cs:134:5:134:15 | exit ControlFlow | 9 |
+| cflow.cs:136:12:136:22 | enter ControlFlow | cflow.cs:136:12:136:22 | exit ControlFlow | 8 |
+| cflow.cs:138:40:138:40 | enter + | cflow.cs:138:40:138:40 | exit + | 9 |
+| cflow.cs:144:33:144:35 | enter get_Item | cflow.cs:144:33:144:35 | exit get_Item | 9 |
+| cflow.cs:144:56:144:58 | enter set_Item | cflow.cs:144:56:144:58 | exit set_Item | 4 |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:149:9:150:33 | for (...;...;...) ... | 6 |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:146:10:146:12 | exit For | 1 |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:146:10:146:12 | exit For | 2 |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:149:16:149:21 | ... < ... | 3 |
 | cflow.cs:150:13:150:33 | ...; | cflow.cs:149:24:149:26 | ++... | 5 |
 | cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:152:9:157:9 | for (...;...;...) ... | 1 |
@@ -967,12 +1009,13 @@
 | cflow.cs:173:9:176:9 | for (...;...;...) ... | cflow.cs:173:25:173:29 | Int32 j = ... | 5 |
 | cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:173:32:173:41 | ... < ... | 5 |
 | cflow.cs:174:9:176:9 | {...} | cflow.cs:173:49:173:51 | ...++ | 10 |
-| cflow.cs:179:10:179:16 | enter Lambdas | cflow.cs:179:10:179:16 | exit Lambdas | 9 |
-| cflow.cs:181:28:181:37 | enter (...) => ... | cflow.cs:181:28:181:37 | exit (...) => ... | 5 |
-| cflow.cs:182:28:182:61 | enter delegate(...) { ... } | cflow.cs:182:28:182:61 | exit delegate(...) { ... } | 7 |
-| cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:185:10:185:18 | exit LogicalOr | 19 |
+| cflow.cs:179:10:179:16 | enter Lambdas | cflow.cs:179:10:179:16 | exit Lambdas | 10 |
+| cflow.cs:181:28:181:37 | enter (...) => ... | cflow.cs:181:28:181:37 | exit (...) => ... | 6 |
+| cflow.cs:182:28:182:61 | enter delegate(...) { ... } | cflow.cs:182:28:182:61 | exit delegate(...) { ... } | 8 |
+| cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:185:10:185:18 | exit LogicalOr | 20 |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:17:195:32 | ... > ... | 9 |
 | cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:193:10:193:17 | exit Booleans | 1 |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | exit Booleans (normal) | 1 |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:15:197:31 | ... == ... | 9 |
 | cflow.cs:195:37:195:56 | !... | cflow.cs:195:39:195:55 | ... == ... | 6 |
 | cflow.cs:197:35:197:39 | false | cflow.cs:198:17:198:33 | ... == ... | 8 |
@@ -983,23 +1026,23 @@
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:15:200:31 | ... == ... | 8 |
 | cflow.cs:200:37:200:62 | !... | cflow.cs:200:40:200:56 | ... == ... | 8 |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:61:200:61 | access to local variable b | 1 |
-| cflow.cs:201:9:205:9 | {...} | cflow.cs:203:17:203:38 | throw ...; | 4 |
+| cflow.cs:201:9:205:9 | {...} | cflow.cs:193:10:193:17 | exit Booleans (abnormal) | 5 |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:210:9:221:36 | do ... while (...); | 3 |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:208:10:208:11 | exit Do | 1 |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | exit Do | 2 |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:213:17:213:32 | ... > ... | 14 |
 | cflow.cs:214:13:216:13 | {...} | cflow.cs:215:17:215:25 | continue; | 2 |
 | cflow.cs:217:13:220:13 | if (...) ... | cflow.cs:217:17:217:32 | ... < ... | 6 |
 | cflow.cs:218:13:220:13 | {...} | cflow.cs:219:17:219:22 | break; | 2 |
 | cflow.cs:221:18:221:22 | this access | cflow.cs:221:18:221:34 | ... < ... | 5 |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:226:27:226:64 | call to method Repeat | 5 |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:224:10:224:16 | exit Foreach | 1 |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:224:10:224:16 | exit Foreach | 2 |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | 1 |
 | cflow.cs:226:22:226:22 | String x | cflow.cs:229:17:229:32 | ... > ... | 15 |
 | cflow.cs:230:13:232:13 | {...} | cflow.cs:231:17:231:25 | continue; | 2 |
 | cflow.cs:233:13:236:13 | if (...) ... | cflow.cs:233:17:233:32 | ... < ... | 6 |
 | cflow.cs:234:13:236:13 | {...} | cflow.cs:235:17:235:22 | break; | 2 |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:241:5:259:5 | {...} | 2 |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:240:10:240:13 | exit Goto | 1 |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto | 2 |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:23:242:39 | ... == ... | 9 |
 | cflow.cs:242:43:242:45 | {...} | cflow.cs:242:43:242:45 | {...} | 1 |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:13:244:28 | ... > ... | 6 |
@@ -1014,12 +1057,12 @@
 | cflow.cs:261:49:261:53 | enter Yield | cflow.cs:264:18:264:22 | Int32 i = ... | 7 |
 | cflow.cs:264:25:264:25 | access to local variable i | cflow.cs:264:25:264:30 | ... < ... | 3 |
 | cflow.cs:265:9:267:9 | {...} | cflow.cs:264:33:264:35 | ...++ | 5 |
-| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:261:49:261:53 | exit Yield | 8 |
-| cflow.cs:282:5:282:18 | enter ControlFlowSub | cflow.cs:282:5:282:18 | exit ControlFlowSub | 4 |
-| cflow.cs:284:5:284:18 | enter ControlFlowSub | cflow.cs:284:5:284:18 | exit ControlFlowSub | 4 |
-| cflow.cs:286:5:286:18 | enter ControlFlowSub | cflow.cs:286:5:286:18 | exit ControlFlowSub | 6 |
-| cflow.cs:291:12:291:12 | enter M | cflow.cs:291:12:291:12 | exit M | 5 |
-| cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | exit NegationInConstructor | 3 |
+| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:261:49:261:53 | exit Yield | 9 |
+| cflow.cs:282:5:282:18 | enter ControlFlowSub | cflow.cs:282:5:282:18 | exit ControlFlowSub | 5 |
+| cflow.cs:284:5:284:18 | enter ControlFlowSub | cflow.cs:284:5:284:18 | exit ControlFlowSub | 5 |
+| cflow.cs:286:5:286:18 | enter ControlFlowSub | cflow.cs:286:5:286:18 | exit ControlFlowSub | 7 |
+| cflow.cs:291:12:291:12 | enter M | cflow.cs:291:12:291:12 | exit M | 6 |
+| cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | exit NegationInConstructor | 4 |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:300:46:300:50 | ... > ... | 9 |
 | cflow.cs:300:56:300:56 | access to parameter s | cflow.cs:300:56:300:64 | ... != ... | 3 |
-| cflow.cs:300:70:300:71 | "" | cflow.cs:298:10:298:10 | exit M | 3 |
+| cflow.cs:300:70:300:71 | "" | cflow.cs:298:10:298:10 | exit M | 4 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -771,6 +771,15 @@
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:34:17:34:22 | break; | 1 |
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:37:17:37:22 | break; | 5 |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | exit Test | 3 |
+| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | exit M1 | 6 |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | ... is ... | 6 |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | exit M2 | 1 |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; | 1 |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:28 | call to method WriteLine | 3 |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:19:13:19:21 | ... is ... | 6 |
+| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | exit M3 | 1 |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:13:20:55 | throw ...; | 3 |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:9:21:28 | call to method WriteLine | 3 |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | exit Method | 3 |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:23:8:34 | exit StaticMethod | 3 |
 | Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:10:10:10:10 | exit M | 57 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -427,7 +427,7 @@ conditionBlock
 | Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | true |
 | Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | true |
 | Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | true |
-| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | exit M9 | false |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | exit M9 (normal) | false |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i | true |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:117:9:123:9 | {...} | true |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | true |
@@ -443,6 +443,7 @@ conditionBlock
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | true |
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | false |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | false |
+| ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | false |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:68:19:68:33 | object creation of type Exception | true |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:74:19:74:33 | object creation of type Exception | true |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:76:41:76:43 | "b" | false |
@@ -461,6 +462,7 @@ conditionBlock
 | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | Finally.cs:61:38:61:39 | [exception: Exception] IOException ex | true |
 | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} | false |
 | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | Finally.cs:69:9:71:9 | [finally: exception(Exception)] {...} | false |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:74:10:74:11 | exit M4 (abnormal) | true |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:78:9:100:9 | {...} | true |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:82:21:82:27 | return ...; | true |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:83:17:84:29 | if (...) ... | true |
@@ -583,6 +585,8 @@ conditionBlock
 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; | true |
 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:117:17:117:37 | [finally: return] ...; | true |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:117:17:117:37 | ...; | true |
+| Finally.cs:147:10:147:11 | enter M8 | Finally.cs:147:10:147:11 | exit M8 (abnormal) | true |
+| Finally.cs:147:10:147:11 | enter M8 | Finally.cs:147:10:147:11 | exit M8 (normal) | false |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:152:17:152:50 | throw ...; | true |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | true |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | true |
@@ -614,6 +618,7 @@ conditionBlock
 | Finally.cs:158:36:158:36 | [finally: exception(ArgumentNullException)] 1 | Finally.cs:159:41:159:43 | [finally: exception(ArgumentNullException)] "1" | true |
 | Finally.cs:158:36:158:36 | [finally: exception(Exception)] 1 | Finally.cs:159:21:159:45 | [finally: exception(Exception)] throw ...; | true |
 | Finally.cs:158:36:158:36 | [finally: exception(Exception)] 1 | Finally.cs:159:41:159:43 | [finally: exception(Exception)] "1" | true |
+| Finally.cs:176:10:176:11 | enter M9 | Finally.cs:176:10:176:11 | exit M9 (normal) | false |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | true |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | true |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | false |
@@ -715,39 +720,39 @@ conditionBlock
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | false |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:209:31:209:46 | object creation of type ExceptionC | true |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:211:13:211:29 | ...; | false |
-| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 | true |
+| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 (normal) | true |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:22:8:24 | String arg | false |
-| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 | true |
+| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 (normal) | true |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:22:14:22 | String _ | false |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:29:20:38 | call to method ToArray | false |
-| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 | true |
+| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 (normal) | true |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x | false |
-| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | exit M4 | true |
+| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | exit M4 (normal) | true |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:23:26:23 | String x | false |
-| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | exit M5 | true |
+| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | exit M5 (normal) | true |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:23:32:23 | String x | false |
-| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 | true |
+| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 (normal) | true |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:26:38:26 | String x | false |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:10:13:10:19 | return ...; | true |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:22:11:24 | String arg | false |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:29:11:32 | access to parameter args | false |
 | LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:22:11:24 | String arg | false |
-| LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 | false |
+| LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | false |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:18:22:18:22 | String x | false |
-| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | exit M2 | true |
-| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 | true |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | true |
+| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | true |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:22:24:24 | Char arg | false |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:25:26:25:29 | Char arg0 | false |
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:26:25:29 | Char arg0 | false |
-| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 | false |
+| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | false |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | false |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:22:40:22 | String x | false |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:41:26:41:26 | String y | false |
-| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 | true |
-| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:36:10:36:11 | exit M5 | false |
+| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | true |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | false |
 | LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | false |
 | LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:26:41:26 | String y | false |
-| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:36:10:36:11 | exit M5 | true |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | true |
 | LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | true |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | false |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | true |
@@ -757,9 +762,9 @@ conditionBlock
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | false |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:70:13:70:19 | return ...; | false |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:71:9:71:21 | ...; | true |
-| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 | false |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | false |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:22:97:22 | String x | false |
-| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | exit M11 | true |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | true |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:28:3:28 | 0 | true |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:30:5:34 | false | true |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:39:5:39 | 0 | true |
@@ -810,6 +815,7 @@ conditionBlock
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:14:9:14:29 | ...; | false |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:20:45:20:53 | nameof(...) | true |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:21:9:21:29 | ...; | false |
+| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:10:10:10:11 | exit M2 (abnormal) | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:15:17:15:23 | return ...; | true |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:16:13:16:19 | case ...: | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:17:23:17:37 | object creation of type Exception | false |
@@ -923,6 +929,7 @@ conditionBlock
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:150:28:150:28 | 2 | false |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:149:13:149:20 | default: | false |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:28:150:28 | 2 | true |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | exit M15 (abnormal) | false |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:36:156:38 | "a" | true |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:41:156:52 | ... => ... | false |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:50:156:52 | "b" | false |
@@ -933,7 +940,7 @@ conditionBlock
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:24:25:24 | access to local variable x | true |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:28:25:28 | access to local variable y | false |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:12:13:12:49 | ...; | true |
-| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:5:17:5:20 | exit Main | false |
+| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:5:17:5:20 | exit Main (normal) | false |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:15:9:17:9 | {...} | true |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:19:9:22:25 | do ... while (...); | false |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:20:9:22:9 | {...} | false |
@@ -948,7 +955,7 @@ conditionBlock
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:30:18:33:37 | if (...) ... | false |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:31:17:31:42 | ...; | false |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:33:17:33:37 | ...; | false |
-| cflow.cs:20:9:22:9 | {...} | cflow.cs:5:17:5:20 | exit Main | false |
+| cflow.cs:20:9:22:9 | {...} | cflow.cs:5:17:5:20 | exit Main (normal) | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:24:9:34:9 | for (...;...;...) ... | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:24:25:24:25 | access to local variable i | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:24:34:24:34 | access to local variable i | false |
@@ -960,7 +967,7 @@ conditionBlock
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:30:18:33:37 | if (...) ... | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:31:17:31:42 | ...; | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:33:17:33:37 | ...; | false |
-| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:5:17:5:20 | exit Main | false |
+| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:5:17:5:20 | exit Main (normal) | false |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:34:24:34 | access to local variable i | true |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:25:9:34:9 | {...} | true |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:26:31:26:31 | access to local variable i | true |
@@ -1009,6 +1016,7 @@ conditionBlock
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:86:26:86:26 | access to parameter s | true |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:87:13:87:33 | ...; | true |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:87:13:87:33 | ...; | true |
+| cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | exit M3 (normal) | false |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:93:45:93:47 | "s" | true |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:94:9:94:29 | ...; | false |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:97:13:97:55 | ...; | false |
@@ -1024,7 +1032,7 @@ conditionBlock
 | cflow.cs:106:18:106:19 | enter M4 | cflow.cs:116:9:116:29 | ...; | false |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:48:127:49 | "" | true |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:53:127:57 | this access | false |
-| cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:146:10:146:12 | exit For | false |
+| cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:146:10:146:12 | exit For (normal) | false |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:150:13:150:33 | ...; | true |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:152:9:157:9 | for (...;...;...) ... | false |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:152:18:152:18 | access to local variable x | false |
@@ -1037,7 +1045,7 @@ conditionBlock
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:173:9:176:9 | for (...;...;...) ... | false |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:173:32:173:32 | access to local variable i | false |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:174:9:176:9 | {...} | false |
-| cflow.cs:153:9:157:9 | {...} | cflow.cs:146:10:146:12 | exit For | true |
+| cflow.cs:153:9:157:9 | {...} | cflow.cs:146:10:146:12 | exit For (normal) | true |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:152:18:152:18 | access to local variable x | false |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:156:17:156:22 | break; | true |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:160:9:165:9 | {...} | true |
@@ -1047,19 +1055,19 @@ conditionBlock
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:173:9:176:9 | for (...;...;...) ... | true |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:173:32:173:32 | access to local variable i | true |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:174:9:176:9 | {...} | true |
-| cflow.cs:160:9:165:9 | {...} | cflow.cs:146:10:146:12 | exit For | true |
+| cflow.cs:160:9:165:9 | {...} | cflow.cs:146:10:146:12 | exit For (normal) | true |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:164:17:164:22 | break; | true |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:167:16:167:16 | access to local variable x | true |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:168:9:171:9 | {...} | true |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:173:9:176:9 | for (...;...;...) ... | true |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:173:32:173:32 | access to local variable i | true |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:174:9:176:9 | {...} | true |
-| cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:146:10:146:12 | exit For | false |
+| cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:146:10:146:12 | exit For (normal) | false |
 | cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:168:9:171:9 | {...} | true |
 | cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:173:9:176:9 | for (...;...;...) ... | false |
 | cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:173:32:173:32 | access to local variable i | false |
 | cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:174:9:176:9 | {...} | false |
-| cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:146:10:146:12 | exit For | false |
+| cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:146:10:146:12 | exit For (normal) | false |
 | cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:174:9:176:9 | {...} | true |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:37:195:56 | !... | true |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:35:197:39 | false | true |
@@ -1069,6 +1077,7 @@ conditionBlock
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:198:45:198:48 | true | true |
 | cflow.cs:197:35:197:39 | false | cflow.cs:198:37:198:41 | false | true |
 | cflow.cs:197:35:197:39 | false | cflow.cs:198:45:198:48 | true | false |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | true |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:37:200:62 | !... | true |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:61:200:61 | access to local variable b | true |
 | cflow.cs:200:37:200:62 | !... | cflow.cs:200:61:200:61 | access to local variable b | true |
@@ -1085,7 +1094,7 @@ conditionBlock
 | cflow.cs:226:22:226:22 | String x | cflow.cs:234:13:236:13 | {...} | false |
 | cflow.cs:233:13:236:13 | if (...) ... | cflow.cs:234:13:236:13 | {...} | true |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:43:242:45 | {...} | true |
-| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:240:10:240:13 | exit Goto | false |
+| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:240:10:240:13 | exit Goto (normal) | false |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:31:244:41 | goto ...; | true |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:246:9:258:9 | switch (...) {...} | false |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:249:17:249:29 | goto default; | false |
@@ -1225,7 +1234,7 @@ conditionFlow
 | Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | false |
 | BreakInTry.cs:9:21:9:31 | ... == ... | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | false |
 | BreakInTry.cs:9:21:9:31 | ... == ... | BreakInTry.cs:10:21:10:26 | break; | true |
-| BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:3:10:3:11 | exit M1 | false |
+| BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:3:10:3:11 | exit M1 (normal) | false |
 | BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:16:17:16:17 | ; | true |
 | BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:27:21:27:26 | break; | true |
 | BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:30:13:33:13 | {...} | false |
@@ -1249,7 +1258,7 @@ conditionFlow
 | Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | true |
 | Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | false |
 | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:8:13:8:16 | ...; | false |
-| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:3:10:3:19 | exit IncrOrDecr | true |
+| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | true |
 | Conditions.cs:14:13:14:13 | access to parameter b | Conditions.cs:15:13:15:16 | [b (line 11): true] ...; | true |
 | Conditions.cs:14:13:14:13 | access to parameter b | Conditions.cs:16:9:18:20 | [b (line 11): false] if (...) ... | false |
 | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | true |
@@ -1316,7 +1325,7 @@ conditionFlow
 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:110:16:110:16 | access to local variable x | false |
 | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:109:17:109:24 | ...; | false |
 | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:110:16:110:16 | access to local variable x | true |
-| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 | false |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 (normal) | false |
 | Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:117:9:123:9 | {...} | true |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | false |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
@@ -1339,7 +1348,7 @@ conditionFlow
 | Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | false |
 | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:149:13:149:49 | ...; | false |
 | Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | Conditions.cs:147:13:147:49 | ...; | true |
-| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | false |
+| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | false |
 | ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:68:19:68:33 | object creation of type Exception | true |
 | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:74:19:74:33 | object creation of type Exception | true |
 | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:76:41:76:43 | "b" | false |
@@ -1356,7 +1365,7 @@ conditionFlow
 | Finally.cs:61:48:61:51 | [exception: Exception] true | Finally.cs:62:9:64:9 | {...} | true |
 | Finally.cs:65:35:65:51 | [exception: Exception] ... != ... | Finally.cs:66:9:67:9 | {...} | true |
 | Finally.cs:65:35:65:51 | [exception: OutOfMemoryException] ... != ... | Finally.cs:66:9:67:9 | {...} | true |
-| Finally.cs:77:16:77:20 | ... > ... | Finally.cs:74:10:74:11 | exit M4 | false |
+| Finally.cs:77:16:77:20 | ... > ... | Finally.cs:74:10:74:11 | exit M4 (normal) | false |
 | Finally.cs:77:16:77:20 | ... > ... | Finally.cs:78:9:100:9 | {...} | true |
 | Finally.cs:81:21:81:26 | ... == ... | Finally.cs:82:21:82:27 | return ...; | true |
 | Finally.cs:81:21:81:26 | ... == ... | Finally.cs:83:17:84:29 | if (...) ... | false |
@@ -1386,7 +1395,7 @@ conditionFlow
 | Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | true |
 | Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:115:17:115:41 | [finally: return] ...; | false |
 | Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | true |
-| Finally.cs:116:17:116:32 | ... > ... | Finally.cs:103:10:103:11 | exit M5 | false |
+| Finally.cs:116:17:116:32 | ... > ... | Finally.cs:103:10:103:11 | exit M5 (normal) | false |
 | Finally.cs:116:17:116:32 | ... > ... | Finally.cs:117:17:117:37 | ...; | true |
 | Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; | true |
 | Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; | true |
@@ -1394,7 +1403,7 @@ conditionFlow
 | Finally.cs:116:17:116:32 | [finally: return] ... > ... | Finally.cs:117:17:117:37 | [finally: return] ...; | true |
 | Finally.cs:151:17:151:28 | ... == ... | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | true |
 | Finally.cs:151:17:151:28 | ... == ... | Finally.cs:155:9:169:9 | {...} | false |
-| Finally.cs:158:21:158:36 | ... == ... | Finally.cs:147:10:147:11 | exit M8 | false |
+| Finally.cs:158:21:158:36 | ... == ... | Finally.cs:147:10:147:11 | exit M8 (normal) | false |
 | Finally.cs:158:21:158:36 | ... == ... | Finally.cs:159:41:159:43 | "1" | true |
 | Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... | Finally.cs:159:41:159:43 | [finally: exception(ArgumentNullException)] "1" | true |
 | Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... | Finally.cs:159:41:159:43 | [finally: exception(Exception)] "1" | true |
@@ -1412,7 +1421,7 @@ conditionFlow
 | Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: NullReferenceException] ... == ... | Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} | false |
 | Finally.cs:180:17:180:18 | access to parameter b1 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | true |
 | Finally.cs:180:17:180:18 | access to parameter b1 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | false |
-| Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 | false |
+| Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (normal) | false |
 | Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB | true |
 | Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | true |
 | Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | true |
@@ -1422,7 +1431,7 @@ conditionFlow
 | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | true |
 | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | true |
 | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | true |
-| Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 | Finally.cs:176:10:176:11 | exit M9 | false |
+| Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 | Finally.cs:176:10:176:11 | exit M9 (normal) | false |
 | Finally.cs:190:21:190:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b1 | Finally.cs:190:31:190:46 | [finally: exception(Exception)] object creation of type ExceptionC | true |
 | Finally.cs:190:21:190:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1 | Finally.cs:190:31:190:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | true |
 | Finally.cs:199:17:199:18 | access to parameter b1 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | true |
@@ -1484,7 +1493,7 @@ conditionFlow
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:27:13:27:39 | case ...: | false |
 | Switch.cs:24:48:24:55 | ... != ... | Switch.cs:25:17:25:37 | ...; | true |
 | Switch.cs:24:48:24:55 | ... != ... | Switch.cs:27:13:27:39 | case ...: | false |
-| Switch.cs:50:30:50:38 | ... != ... | Switch.cs:44:10:44:11 | exit M4 | false |
+| Switch.cs:50:30:50:38 | ... != ... | Switch.cs:44:10:44:11 | exit M4 (normal) | false |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:51:17:51:22 | break; | true |
 | Switch.cs:84:21:84:25 | ... > ... | Switch.cs:85:21:85:26 | break; | true |
 | Switch.cs:84:21:84:25 | ... > ... | Switch.cs:86:24:86:27 | true | false |
@@ -1492,9 +1501,9 @@ conditionFlow
 | Switch.cs:117:25:117:34 | ... == ... | Switch.cs:118:13:118:34 | case ...: | false |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:43:118:43 | 2 | true |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:120:17:120:17 | 1 | false |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | exit M11 | false |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | exit M11 (normal) | false |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:126:13:126:19 | return ...; | true |
-| Switch.cs:125:42:125:46 | false | Switch.cs:123:10:123:12 | exit M11 | false |
+| Switch.cs:125:42:125:46 | false | Switch.cs:123:10:123:12 | exit M11 (normal) | false |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; | true |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; | false |
 | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:7:25:7:25 | ; | true |
@@ -1507,7 +1516,7 @@ conditionFlow
 | cflow.cs:14:16:14:20 | ... > ... | cflow.cs:19:9:22:25 | do ... while (...); | false |
 | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:20:9:22:9 | {...} | true |
 | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:24:9:34:9 | for (...;...;...) ... | false |
-| cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:5:17:5:20 | exit Main | false |
+| cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:5:17:5:20 | exit Main (normal) | false |
 | cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:25:9:34:9 | {...} | true |
 | cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:31:26:31 | access to local variable i | true |
 | cflow.cs:26:17:26:26 | ... == ... | cflow.cs:28:18:33:37 | if (...) ... | false |
@@ -1523,9 +1532,9 @@ conditionFlow
 | cflow.cs:72:13:72:21 | ... == ... | cflow.cs:74:9:81:9 | if (...) ... | false |
 | cflow.cs:74:13:74:24 | ... > ... | cflow.cs:75:9:77:9 | {...} | true |
 | cflow.cs:74:13:74:24 | ... > ... | cflow.cs:79:9:81:9 | {...} | false |
-| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:84:18:84:19 | exit M2 | false |
+| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:84:18:84:19 | exit M2 (normal) | false |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:26:86:26 | access to parameter s | true |
-| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:84:18:84:19 | exit M2 | false |
+| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:84:18:84:19 | exit M2 (normal) | false |
 | cflow.cs:86:26:86:37 | ... > ... | cflow.cs:87:13:87:33 | ...; | true |
 | cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:93:45:93:47 | "s" | true |
 | cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:94:9:94:29 | ...; | false |
@@ -1533,7 +1542,7 @@ conditionFlow
 | cflow.cs:96:13:96:25 | ... != ... | cflow.cs:99:9:100:42 | if (...) ... | false |
 | cflow.cs:99:13:99:25 | ... != ... | cflow.cs:100:13:100:42 | ...; | true |
 | cflow.cs:99:13:99:25 | ... != ... | cflow.cs:102:9:103:36 | if (...) ... | false |
-| cflow.cs:102:13:102:29 | ... != ... | cflow.cs:90:18:90:19 | exit M3 | false |
+| cflow.cs:102:13:102:29 | ... != ... | cflow.cs:90:18:90:19 | exit M3 (normal) | false |
 | cflow.cs:102:13:102:29 | ... != ... | cflow.cs:103:13:103:36 | ...; | true |
 | cflow.cs:108:13:108:21 | ... != ... | cflow.cs:109:9:115:9 | {...} | true |
 | cflow.cs:108:13:108:21 | ... != ... | cflow.cs:116:9:116:29 | ...; | false |
@@ -1548,7 +1557,7 @@ conditionFlow
 | cflow.cs:163:17:163:22 | ... > ... | cflow.cs:164:17:164:22 | break; | true |
 | cflow.cs:167:16:167:21 | ... < ... | cflow.cs:168:9:171:9 | {...} | true |
 | cflow.cs:167:16:167:21 | ... < ... | cflow.cs:173:9:176:9 | for (...;...;...) ... | false |
-| cflow.cs:173:32:173:41 | ... < ... | cflow.cs:146:10:146:12 | exit For | false |
+| cflow.cs:173:32:173:41 | ... < ... | cflow.cs:146:10:146:12 | exit For (normal) | false |
 | cflow.cs:173:32:173:41 | ... < ... | cflow.cs:174:9:176:9 | {...} | true |
 | cflow.cs:187:13:187:18 | ... == ... | cflow.cs:187:23:187:23 | 2 | false |
 | cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:34:187:49 | ... && ... | false |
@@ -1563,15 +1572,15 @@ conditionFlow
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:45:198:48 | true | false |
 | cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:37:200:62 | !... | true |
 | cflow.cs:200:15:200:31 | ... == ... | cflow.cs:201:9:205:9 | {...} | false |
-| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:193:10:193:17 | exit Booleans | false |
+| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | false |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:61:200:61 | access to local variable b | true |
-| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:193:10:193:17 | exit Booleans | false |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:193:10:193:17 | exit Booleans (normal) | false |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:201:9:205:9 | {...} | true |
 | cflow.cs:213:17:213:32 | ... > ... | cflow.cs:214:13:216:13 | {...} | true |
 | cflow.cs:213:17:213:32 | ... > ... | cflow.cs:217:13:220:13 | if (...) ... | false |
 | cflow.cs:217:17:217:32 | ... < ... | cflow.cs:218:13:220:13 | {...} | true |
 | cflow.cs:217:17:217:32 | ... < ... | cflow.cs:221:18:221:22 | this access | false |
-| cflow.cs:221:18:221:34 | ... < ... | cflow.cs:208:10:208:11 | exit Do | false |
+| cflow.cs:221:18:221:34 | ... < ... | cflow.cs:208:10:208:11 | exit Do (normal) | false |
 | cflow.cs:221:18:221:34 | ... < ... | cflow.cs:211:9:221:9 | {...} | true |
 | cflow.cs:229:17:229:32 | ... > ... | cflow.cs:230:13:232:13 | {...} | true |
 | cflow.cs:229:17:229:32 | ... > ... | cflow.cs:233:13:236:13 | if (...) ... | false |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -806,6 +806,10 @@ conditionBlock
 | Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:35:13:35:20 | default: | false |
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:34:17:34:22 | break; | true |
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:35:13:35:20 | default: | false |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:13:13:13:19 | return ...; | true |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:14:9:14:29 | ...; | false |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:20:45:20:53 | nameof(...) | true |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:21:9:21:29 | ...; | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:15:17:15:23 | return ...; | true |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:16:13:16:19 | case ...: | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:17:23:17:37 | object creation of type Exception | false |
@@ -1470,6 +1474,10 @@ conditionFlow
 | Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:20:9:38:9 | switch (...) {...} | false |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:25:17:25:52 | ...; | true |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:27:13:27:24 | case ...: | false |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:13:13:13:19 | return ...; | true |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:14:9:14:29 | ...; | false |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | true |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:21:9:21:29 | ...; | false |
 | Switch.cs:21:21:21:29 | ... == ... | Switch.cs:22:21:22:27 | return ...; | true |
 | Switch.cs:21:21:21:29 | ... == ... | Switch.cs:23:27:23:27 | 0 | false |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:48:24:48 | access to local variable s | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Consistency.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Consistency.expected
@@ -7,8 +7,8 @@ breakInvariant4
 | Assert.cs:140:29:140:30 | access to parameter b2 | assertion failure | Assert.cs:140:33:140:34 | access to parameter b3 | assertion failure | assertion success | false |
 breakInvariant5
 multipleSuccessors
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | successor | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | successor | ConditionalAccess.cs:30:10:30:12 | exit Out |
+| ConditionalAccess.cs:30:28:30:32 | ... = ... | successor | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
+| ConditionalAccess.cs:30:28:30:32 | ... = ... | successor | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | successor | MultiImplementationA.cs:6:28:6:31 | null |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | successor | MultiImplementationB.cs:3:22:3:22 | 0 |
 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | successor | MultiImplementationA.cs:7:25:7:39 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -1,13 +1,18 @@
 dominance
 | AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:30:5:30 | access to parameter i |
-| AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | exit get_Item |
+| AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) | AccessorCalls.cs:5:23:5:25 | exit get_Item |
+| AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) |
 | AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:37:5:39 | {...} |
-| AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | exit set_Item |
+| AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) | AccessorCalls.cs:5:33:5:35 | exit set_Item |
+| AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) |
 | AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:36:7:38 | {...} |
-| AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | exit add_Event |
+| AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) | AccessorCalls.cs:7:32:7:34 | exit add_Event |
+| AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) |
 | AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:47:7:49 | {...} |
-| AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | exit remove_Event |
+| AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) | AccessorCalls.cs:7:40:7:45 | exit remove_Event |
+| AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) |
 | AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:11:5:17:5 | {...} |
+| AccessorCalls.cs:10:10:10:11 | exit M1 (normal) | AccessorCalls.cs:10:10:10:11 | exit M1 |
 | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:12:9:12:32 | ...; |
 | AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:22:12:25 | this access |
 | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:13:9:13:30 | ...; |
@@ -35,10 +40,11 @@ dominance
 | AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:18 | access to event Event |
 | AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:23:16:23 | access to parameter e |
 | AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:23 | ... -= ... |
-| AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:10:10:10:11 | exit M1 |
+| AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:10:10:10:11 | exit M1 (normal) |
 | AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:12 | this access |
 | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:18 | access to event Event |
 | AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:20:5:26:5 | {...} |
+| AccessorCalls.cs:19:10:19:11 | exit M2 (normal) | AccessorCalls.cs:19:10:19:11 | exit M2 |
 | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:21:9:21:36 | ...; |
 | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:14 | access to field x |
 | AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:24:21:27 | this access |
@@ -74,10 +80,11 @@ dominance
 | AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:14 | access to field x |
 | AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:25:25:25 | access to parameter e |
 | AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:25 | ... -= ... |
-| AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:19:10:19:11 | exit M2 |
+| AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:19:10:19:11 | exit M2 (normal) |
 | AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:12 | this access |
 | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:20 | access to event Event |
 | AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:29:5:33:5 | {...} |
+| AccessorCalls.cs:28:10:28:11 | exit M3 (normal) | AccessorCalls.cs:28:10:28:11 | exit M3 |
 | AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:30:9:30:21 | ...; |
 | AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:18 | access to field Field |
 | AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:20 | ...++ |
@@ -89,10 +96,11 @@ dominance
 | AccessorCalls.cs:31:9:31:20 | ...; | AccessorCalls.cs:31:9:31:12 | this access |
 | AccessorCalls.cs:32:9:32:12 | this access | AccessorCalls.cs:32:14:32:14 | 0 |
 | AccessorCalls.cs:32:9:32:15 | access to indexer | AccessorCalls.cs:32:9:32:17 | ...++ |
-| AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:28:10:28:11 | exit M3 |
+| AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:28:10:28:11 | exit M3 (normal) |
 | AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:32:9:32:12 | this access |
 | AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:9:32:15 | access to indexer |
 | AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:36:5:40:5 | {...} |
+| AccessorCalls.cs:35:10:35:11 | exit M4 (normal) | AccessorCalls.cs:35:10:35:11 | exit M4 |
 | AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:37:9:37:23 | ...; |
 | AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:14 | access to field x |
 | AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:20 | access to field Field |
@@ -107,10 +115,11 @@ dominance
 | AccessorCalls.cs:39:9:39:12 | this access | AccessorCalls.cs:39:9:39:14 | access to field x |
 | AccessorCalls.cs:39:9:39:14 | access to field x | AccessorCalls.cs:39:16:39:16 | 0 |
 | AccessorCalls.cs:39:9:39:17 | access to indexer | AccessorCalls.cs:39:9:39:19 | ...++ |
-| AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:35:10:35:11 | exit M4 |
+| AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:35:10:35:11 | exit M4 (normal) |
 | AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:39:9:39:12 | this access |
 | AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:17 | access to indexer |
 | AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:43:5:47:5 | {...} |
+| AccessorCalls.cs:42:10:42:11 | exit M5 (normal) | AccessorCalls.cs:42:10:42:11 | exit M5 |
 | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:44:9:44:33 | ...; |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field |
@@ -134,7 +143,7 @@ dominance
 | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... = ... |
 | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access |
 | AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:15 | access to indexer |
-| AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:42:10:42:11 | exit M5 |
+| AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:42:10:42:11 | exit M5 (normal) |
 | AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:12 | this access |
 | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access |
 | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer |
@@ -142,6 +151,7 @@ dominance
 | AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... |
 | AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:20:46:26 | access to indexer |
 | AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:50:5:54:5 | {...} |
+| AccessorCalls.cs:49:10:49:11 | exit M6 (normal) | AccessorCalls.cs:49:10:49:11 | exit M6 |
 | AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:51:9:51:37 | ...; |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x |
@@ -173,7 +183,7 @@ dominance
 | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... = ... |
 | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access |
 | AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:17 | access to indexer |
-| AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:49:10:49:11 | exit M6 |
+| AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:49:10:49:11 | exit M6 (normal) |
 | AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:12 | this access |
 | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:12 | this access |
 | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer |
@@ -182,9 +192,10 @@ dominance
 | AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... + ... |
 | AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:22:53:30 | access to indexer |
 | AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:57:5:59:5 | {...} |
+| AccessorCalls.cs:56:10:56:11 | exit M7 (normal) | AccessorCalls.cs:56:10:56:11 | exit M7 |
 | AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:58:9:58:86 | ...; |
 | AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access |
-| AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | exit M7 |
+| AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | exit M7 (normal) |
 | AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:10:58:13 | this access |
 | AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:22:58:25 | this access |
 | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:37:58:40 | this access |
@@ -204,9 +215,10 @@ dominance
 | AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:73:58:84 | (..., ...) |
 | AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:77:58:83 | access to indexer |
 | AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:62:5:64:5 | {...} |
+| AccessorCalls.cs:61:10:61:11 | exit M8 (normal) | AccessorCalls.cs:61:10:61:11 | exit M8 |
 | AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:63:9:63:98 | ...; |
 | AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:56:63:59 | this access |
-| AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | exit M8 |
+| AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | exit M8 (normal) |
 | AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:10:63:13 | this access |
 | AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:15 | access to field x |
 | AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:24:63:27 | this access |
@@ -232,6 +244,7 @@ dominance
 | AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:83:63:96 | (..., ...) |
 | AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:87:63:95 | access to indexer |
 | AccessorCalls.cs:66:10:66:11 | enter M9 | AccessorCalls.cs:67:5:74:5 | {...} |
+| AccessorCalls.cs:66:10:66:11 | exit M9 (normal) | AccessorCalls.cs:66:10:66:11 | exit M9 |
 | AccessorCalls.cs:67:5:74:5 | {...} | AccessorCalls.cs:68:9:68:22 | ... ...; |
 | AccessorCalls.cs:68:9:68:22 | ... ...; | AccessorCalls.cs:68:21:68:21 | access to parameter o |
 | AccessorCalls.cs:68:17:68:21 | dynamic d = ... | AccessorCalls.cs:69:9:69:36 | ...; |
@@ -267,7 +280,7 @@ dominance
 | AccessorCalls.cs:72:17:72:20 | dynamic access to element | AccessorCalls.cs:72:9:72:20 | dynamic call to operator + |
 | AccessorCalls.cs:72:19:72:19 | 1 | AccessorCalls.cs:72:17:72:20 | dynamic access to element |
 | AccessorCalls.cs:73:9:73:44 | (..., ...) | AccessorCalls.cs:73:49:73:49 | access to local variable d |
-| AccessorCalls.cs:73:9:73:83 | ... = ... | AccessorCalls.cs:66:10:66:11 | exit M9 |
+| AccessorCalls.cs:73:9:73:83 | ... = ... | AccessorCalls.cs:66:10:66:11 | exit M9 (normal) |
 | AccessorCalls.cs:73:9:73:84 | ...; | AccessorCalls.cs:73:10:73:10 | access to local variable d |
 | AccessorCalls.cs:73:10:73:10 | access to local variable d | AccessorCalls.cs:73:24:73:27 | this access |
 | AccessorCalls.cs:73:10:73:21 | dynamic access to member MaybeProp1 | AccessorCalls.cs:73:24:73:32 | access to property Prop |
@@ -288,23 +301,27 @@ dominance
 | AccessorCalls.cs:73:78:73:81 | dynamic access to element | AccessorCalls.cs:73:74:73:82 | (..., ...) |
 | AccessorCalls.cs:73:80:73:80 | 1 | AccessorCalls.cs:73:78:73:81 | dynamic access to element |
 | ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:27:3:27 | 0 |
-| ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:11:3:12 | exit M1 |
+| ArrayCreation.cs:3:11:3:12 | exit M1 (normal) | ArrayCreation.cs:3:11:3:12 | exit M1 |
+| ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:11:3:12 | exit M1 (normal) |
 | ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] |
 | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:28:5:28 | 0 |
-| ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | ArrayCreation.cs:5:12:5:13 | exit M2 |
+| ArrayCreation.cs:5:12:5:13 | exit M2 (normal) | ArrayCreation.cs:5:12:5:13 | exit M2 |
+| ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | ArrayCreation.cs:5:12:5:13 | exit M2 (normal) |
 | ArrayCreation.cs:5:28:5:28 | 0 | ArrayCreation.cs:5:31:5:31 | 1 |
 | ArrayCreation.cs:5:31:5:31 | 1 | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] |
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:19:7:36 | 2 |
+| ArrayCreation.cs:7:11:7:12 | exit M3 (normal) | ArrayCreation.cs:7:11:7:12 | exit M3 |
 | ArrayCreation.cs:7:19:7:36 | 2 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] |
 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] | ArrayCreation.cs:7:31:7:31 | 0 |
-| ArrayCreation.cs:7:29:7:36 | { ..., ... } | ArrayCreation.cs:7:11:7:12 | exit M3 |
+| ArrayCreation.cs:7:29:7:36 | { ..., ... } | ArrayCreation.cs:7:11:7:12 | exit M3 (normal) |
 | ArrayCreation.cs:7:31:7:31 | 0 | ArrayCreation.cs:7:34:7:34 | 1 |
 | ArrayCreation.cs:7:34:7:34 | 1 | ArrayCreation.cs:7:29:7:36 | { ..., ... } |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:20:9:52 | 2 |
+| ArrayCreation.cs:9:12:9:13 | exit M4 (normal) | ArrayCreation.cs:9:12:9:13 | exit M4 |
 | ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:20:9:52 | 2 |
 | ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] |
 | ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] | ArrayCreation.cs:9:35:9:35 | 0 |
-| ArrayCreation.cs:9:31:9:52 | { ..., ... } | ArrayCreation.cs:9:12:9:13 | exit M4 |
+| ArrayCreation.cs:9:31:9:52 | { ..., ... } | ArrayCreation.cs:9:12:9:13 | exit M4 (normal) |
 | ArrayCreation.cs:9:33:9:40 | { ..., ... } | ArrayCreation.cs:9:45:9:45 | 2 |
 | ArrayCreation.cs:9:35:9:35 | 0 | ArrayCreation.cs:9:38:9:38 | 1 |
 | ArrayCreation.cs:9:38:9:38 | 1 | ArrayCreation.cs:9:33:9:40 | { ..., ... } |
@@ -318,12 +335,14 @@ dominance
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:20 | access to parameter b |
+| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | exit M1 (abnormal) |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:11:9:11:36 | ...; |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:10:22:10:22 | access to local variable s |
 | Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:27:10:30 | null |
 | Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
 | Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:10:27:10:30 | null | Assert.cs:10:22:10:30 | ... != ... |
+| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:7:10:7:11 | exit M1 (normal) |
 | Assert.cs:11:9:11:36 | ...; | Assert.cs:11:27:11:27 | access to local variable s |
 | Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:27:11:34 | access to property Length |
 | Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:9:11:35 | call to method WriteLine |
@@ -334,10 +353,12 @@ dominance
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:20 | access to parameter b |
+| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 (abnormal) |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:18:9:18:36 | ...; |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:17:23:17:23 | access to local variable s |
 | Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
 | Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
+| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | exit M2 (normal) |
 | Assert.cs:18:9:18:36 | ...; | Assert.cs:18:27:18:27 | access to local variable s |
 | Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:34 | access to property Length |
 | Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:9:18:35 | call to method WriteLine |
@@ -348,10 +369,12 @@ dominance
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:20 | access to parameter b |
+| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 (abnormal) |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:25:9:25:36 | ...; |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:24:26:24:26 | access to local variable s |
 | Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
 | Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
+| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | exit M3 (normal) |
 | Assert.cs:25:9:25:36 | ...; | Assert.cs:25:27:25:27 | access to local variable s |
 | Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:34 | access to property Length |
 | Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:9:25:35 | call to method WriteLine |
@@ -362,12 +385,14 @@ dominance
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:20 | access to parameter b |
+| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 (abnormal) |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:32:9:32:36 | ...; |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:31:23:31:23 | access to local variable s |
 | Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:28:31:31 | null |
 | Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
 | Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:31:28:31:31 | null | Assert.cs:31:23:31:31 | ... == ... |
+| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:28:10:28:11 | exit M4 (normal) |
 | Assert.cs:32:9:32:36 | ...; | Assert.cs:32:27:32:27 | access to local variable s |
 | Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:27:32:34 | access to property Length |
 | Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:9:32:35 | call to method WriteLine |
@@ -378,12 +403,14 @@ dominance
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:20 | access to parameter b |
+| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 (abnormal) |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:39:9:39:36 | ...; |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:38:23:38:23 | access to local variable s |
 | Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:28:38:31 | null |
 | Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
 | Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:38:28:38:31 | null | Assert.cs:38:23:38:31 | ... != ... |
+| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:35:10:35:11 | exit M5 (normal) |
 | Assert.cs:39:9:39:36 | ...; | Assert.cs:39:27:39:27 | access to local variable s |
 | Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:27:39:34 | access to property Length |
 | Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:9:39:35 | call to method WriteLine |
@@ -394,12 +421,14 @@ dominance
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:20 | access to parameter b |
+| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 (abnormal) |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:46:9:46:36 | ...; |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:45:24:45:24 | access to local variable s |
 | Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:29:45:32 | null |
 | Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
 | Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:45:29:45:32 | null | Assert.cs:45:24:45:32 | ... != ... |
+| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:42:10:42:11 | exit M6 (normal) |
 | Assert.cs:46:9:46:36 | ...; | Assert.cs:46:27:46:27 | access to local variable s |
 | Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:27:46:34 | access to property Length |
 | Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:9:46:35 | call to method WriteLine |
@@ -410,12 +439,14 @@ dominance
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:20 | access to parameter b |
+| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 (abnormal) |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:53:9:53:36 | ...; |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:52:24:52:24 | access to local variable s |
 | Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:29:52:32 | null |
 | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
 | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:52:29:52:32 | null | Assert.cs:52:24:52:32 | ... == ... |
+| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:49:10:49:11 | exit M7 (normal) |
 | Assert.cs:53:9:53:36 | ...; | Assert.cs:53:27:53:27 | access to local variable s |
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:27:53:34 | access to property Length |
 | Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:9:53:35 | call to method WriteLine |
@@ -429,6 +460,7 @@ dominance
 | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b |
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 (abnormal) |
 | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:60:9:60:36 | ...; |
 | Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... |
 | Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... |
@@ -441,6 +473,7 @@ dominance
 | Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... |
 | Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue |
+| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 (normal) |
 | Assert.cs:60:9:60:36 | ...; | Assert.cs:60:27:60:27 | access to local variable s |
 | Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:34 | access to property Length |
 | Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:9:60:35 | call to method WriteLine |
@@ -454,6 +487,7 @@ dominance
 | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b |
 | Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 (abnormal) |
 | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:67:9:67:36 | ...; |
 | Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... |
 | Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... |
@@ -466,6 +500,7 @@ dominance
 | Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... |
 | Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse |
+| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 (normal) |
 | Assert.cs:67:9:67:36 | ...; | Assert.cs:67:27:67:27 | access to local variable s |
 | Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:34 | access to property Length |
 | Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:9:67:35 | call to method WriteLine |
@@ -479,6 +514,7 @@ dominance
 | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b |
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 (abnormal) |
 | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:74:9:74:36 | ...; |
 | Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... |
 | Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... |
@@ -491,6 +527,7 @@ dominance
 | Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... |
 | Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue |
+| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 (normal) |
 | Assert.cs:74:9:74:36 | ...; | Assert.cs:74:27:74:27 | access to local variable s |
 | Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:34 | access to property Length |
 | Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:9:74:35 | call to method WriteLine |
@@ -504,6 +541,7 @@ dominance
 | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b |
 | Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 (abnormal) |
 | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:81:9:81:36 | ...; |
 | Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... |
 | Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... |
@@ -516,6 +554,7 @@ dominance
 | Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... |
 | Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse |
+| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 (normal) |
 | Assert.cs:81:9:81:36 | ...; | Assert.cs:81:27:81:27 | access to local variable s |
 | Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:34 | access to property Length |
 | Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:9:81:35 | call to method WriteLine |
@@ -798,11 +837,13 @@ dominance
 | Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... |
 | Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse |
+| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 (normal) |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:128:27:128:27 | access to local variable s |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:34 | access to property Length |
 | Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:9:128:35 | call to method WriteLine |
 | Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:135:5:136:5 | {...} |
-| Assert.cs:135:5:136:5 | {...} | Assert.cs:131:18:131:32 | exit AssertTrueFalse |
+| Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) | Assert.cs:131:18:131:32 | exit AssertTrueFalse |
+| Assert.cs:135:5:136:5 | {...} | Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:139:5:142:5 | {...} |
 | Assert.cs:139:5:142:5 | {...} | Assert.cs:140:9:140:36 | ...; |
 | Assert.cs:140:9:140:35 | [assertion success] call to method AssertTrueFalse | Assert.cs:141:9:141:15 | return ...; |
@@ -816,7 +857,9 @@ dominance
 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse |
 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse |
 | Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion success] call to method AssertTrueFalse |
+| Assert.cs:141:9:141:15 | return ...; | Assert.cs:138:10:138:12 | exit M13 (normal) |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:4:5:15:5 | {...} |
+| Assignments.cs:3:10:3:10 | exit M (normal) | Assignments.cs:3:10:3:10 | exit M |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:5:9:5:18 | ... ...; |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:17:5:17 | 0 |
 | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:6:9:6:15 | ...; |
@@ -845,16 +888,19 @@ dominance
 | Assignments.cs:12:14:12:17 | this access | Assignments.cs:12:9:12:17 | call to operator + |
 | Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:9:14:35 | ... += ... |
 | Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:18:14:35 | (...) => ... |
-| Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:3:10:3:10 | exit M |
+| Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:3:10:3:10 | exit M (normal) |
 | Assignments.cs:14:9:14:36 | ...; | Assignments.cs:14:9:14:13 | this access |
 | Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:13 | access to event Event |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:33:14:35 | {...} |
-| Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | exit (...) => ... |
+| Assignments.cs:14:18:14:35 | exit (...) => ... (normal) | Assignments.cs:14:18:14:35 | exit (...) => ... |
+| Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | exit (...) => ... (normal) |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:18:5:20:5 | {...} |
+| Assignments.cs:17:40:17:40 | exit + (normal) | Assignments.cs:17:40:17:40 | exit + |
 | Assignments.cs:18:5:20:5 | {...} | Assignments.cs:19:16:19:16 | access to parameter x |
-| Assignments.cs:19:9:19:17 | return ...; | Assignments.cs:17:40:17:40 | exit + |
+| Assignments.cs:19:9:19:17 | return ...; | Assignments.cs:17:40:17:40 | exit + (normal) |
 | Assignments.cs:19:16:19:16 | access to parameter x | Assignments.cs:19:9:19:17 | return ...; |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:4:5:18:5 | {...} |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:3:10:3:11 | exit M1 |
 | BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:5:9:17:9 | try {...} ... |
 | BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:6:9:12:9 | {...} |
 | BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:7:33:7:36 | access to parameter args |
@@ -870,10 +916,11 @@ dominance
 | BreakInTry.cs:14:9:17:9 | {...} | BreakInTry.cs:15:13:16:17 | if (...) ... |
 | BreakInTry.cs:15:13:16:17 | if (...) ... | BreakInTry.cs:15:17:15:20 | access to parameter args |
 | BreakInTry.cs:15:17:15:20 | access to parameter args | BreakInTry.cs:15:25:15:28 | null |
-| BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:3:10:3:11 | exit M1 |
+| BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:3:10:3:11 | exit M1 (normal) |
 | BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:16:17:16:17 | ; |
 | BreakInTry.cs:15:25:15:28 | null | BreakInTry.cs:15:17:15:28 | ... == ... |
 | BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:21:5:36:5 | {...} |
+| BreakInTry.cs:20:10:20:11 | exit M2 (normal) | BreakInTry.cs:20:10:20:11 | exit M2 |
 | BreakInTry.cs:21:5:36:5 | {...} | BreakInTry.cs:22:29:22:32 | access to parameter args |
 | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:22:22:22:24 | String arg |
 | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:35:7:35:7 | ; |
@@ -898,8 +945,9 @@ dominance
 | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | BreakInTry.cs:31:29:31:32 | [finally: break] null | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... |
 | BreakInTry.cs:31:29:31:32 | null | BreakInTry.cs:31:21:31:32 | ... == ... |
-| BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 |
+| BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 (normal) |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:39:5:54:5 | {...} |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:38:10:38:11 | exit M3 |
 | BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:40:9:52:9 | try {...} ... |
 | BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:41:9:44:9 | {...} |
 | BreakInTry.cs:41:9:44:9 | {...} | BreakInTry.cs:42:13:43:23 | if (...) ... |
@@ -929,6 +977,7 @@ dominance
 | BreakInTry.cs:49:28:49:31 | [finally: return] null | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... |
 | BreakInTry.cs:49:28:49:31 | null | BreakInTry.cs:49:21:49:31 | ... == ... |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:57:5:71:5 | {...} |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:56:10:56:11 | exit M4 |
 | BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:58:9:70:9 | try {...} ... |
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:59:9:62:9 | {...} |
 | BreakInTry.cs:59:9:62:9 | {...} | BreakInTry.cs:60:13:61:23 | if (...) ... |
@@ -957,22 +1006,27 @@ dominance
 | BreakInTry.cs:67:28:67:31 | [finally: return] null | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... |
 | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:31 | ... == ... |
 | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:6:5:8:5 | {...} |
+| CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) | CompileTimeOperators.cs:5:9:5:15 | exit Default |
 | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:7:16:7:27 | default(...) |
-| CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:5:9:5:15 | exit Default |
+| CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) |
 | CompileTimeOperators.cs:7:16:7:27 | default(...) | CompileTimeOperators.cs:7:9:7:28 | return ...; |
 | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:11:5:13:5 | {...} |
+| CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof |
 | CompileTimeOperators.cs:11:5:13:5 | {...} | CompileTimeOperators.cs:12:16:12:26 | sizeof(..) |
-| CompileTimeOperators.cs:12:9:12:27 | return ...; | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof |
+| CompileTimeOperators.cs:12:9:12:27 | return ...; | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) |
 | CompileTimeOperators.cs:12:16:12:26 | sizeof(..) | CompileTimeOperators.cs:12:9:12:27 | return ...; |
 | CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:16:5:18:5 | {...} |
+| CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) | CompileTimeOperators.cs:15:10:15:15 | exit Typeof |
 | CompileTimeOperators.cs:16:5:18:5 | {...} | CompileTimeOperators.cs:17:16:17:26 | typeof(...) |
-| CompileTimeOperators.cs:17:9:17:27 | return ...; | CompileTimeOperators.cs:15:10:15:15 | exit Typeof |
+| CompileTimeOperators.cs:17:9:17:27 | return ...; | CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) |
 | CompileTimeOperators.cs:17:16:17:26 | typeof(...) | CompileTimeOperators.cs:17:9:17:27 | return ...; |
 | CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:21:5:23:5 | {...} |
+| CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) | CompileTimeOperators.cs:20:12:20:17 | exit Nameof |
 | CompileTimeOperators.cs:21:5:23:5 | {...} | CompileTimeOperators.cs:22:16:22:24 | nameof(...) |
-| CompileTimeOperators.cs:22:9:22:25 | return ...; | CompileTimeOperators.cs:20:12:20:17 | exit Nameof |
+| CompileTimeOperators.cs:22:9:22:25 | return ...; | CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) |
 | CompileTimeOperators.cs:22:16:22:24 | nameof(...) | CompileTimeOperators.cs:22:9:22:25 | return ...; |
 | CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:29:5:41:5 | {...} |
+| CompileTimeOperators.cs:28:10:28:10 | exit M (normal) | CompileTimeOperators.cs:28:10:28:10 | exit M |
 | CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:30:9:38:9 | try {...} ... |
 | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:31:9:34:9 | {...} |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:32:13:32:21 | goto ...; |
@@ -982,26 +1036,32 @@ dominance
 | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" |
 | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine |
 | CompileTimeOperators.cs:40:9:40:11 | End: | CompileTimeOperators.cs:40:14:40:38 | ...; |
-| CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | exit M |
+| CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | exit M (normal) |
 | CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:32:40:36 | "End" |
 | CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine |
 | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:30:32:30:32 | 0 |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:26:3:26 | access to parameter i |
-| ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:12:3:13 | exit M1 |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 |
+| ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) |
 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:28:3:38 | call to method ToString |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:40:3:49 | call to method ToLower |
 | ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:26:5:26 | access to parameter s |
-| ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | exit M2 |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | exit M2 |
+| ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) |
 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:28:5:34 | access to property Length |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:49:7:55 | access to property Length |
 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:27:9:33 | access to property Length |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:38:9:38 | 0 |
 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:25:9:25 | access to parameter s |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:12:5:17:5 | {...} |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | exit M5 |
 | ConditionalAccess.cs:12:5:17:5 | {...} | ConditionalAccess.cs:13:9:16:21 | if (...) ... |
 | ConditionalAccess.cs:13:9:16:21 | if (...) ... | ConditionalAccess.cs:13:13:13:13 | access to parameter s |
 | ConditionalAccess.cs:13:13:13:13 | access to parameter s | ConditionalAccess.cs:13:15:13:21 | access to property Length |
@@ -1013,10 +1073,12 @@ dominance
 | ConditionalAccess.cs:14:20:14:20 | 0 | ConditionalAccess.cs:14:13:14:21 | return ...; |
 | ConditionalAccess.cs:16:20:16:20 | 1 | ConditionalAccess.cs:16:13:16:21 | return ...; |
 | ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 |
-| ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:12:19:13 | exit M6 |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | exit M6 |
+| ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) |
 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:22:5:26:5 | {...} |
+| ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) | ConditionalAccess.cs:21:10:21:11 | exit M7 |
 | ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:23:9:23:39 | ... ...; |
 | ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:26:23:29 | null |
 | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:24:9:24:38 | ... ...; |
@@ -1027,33 +1089,37 @@ dominance
 | ConditionalAccess.cs:24:18:24:24 | (...) ... | ConditionalAccess.cs:24:27:24:37 | call to method ToString |
 | ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:18:24:24 | (...) ... |
 | ConditionalAccess.cs:24:27:24:37 | call to method ToString | ConditionalAccess.cs:24:13:24:37 | String s = ... |
-| ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:21:10:21:11 | exit M7 |
+| ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) |
 | ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:13:25:14 | "" |
 | ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:31:25:31 | access to local variable s |
 | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | ConditionalAccess.cs:25:9:25:32 | ... = ... |
 | ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:32:30:32 | 0 |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | exit Out |
+| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out |
+| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
+| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
+| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:28:30:32 | ... = ... |
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:28:30:32 | ... = ... |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:33:5:36:5 | {...} |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 |
 | ConditionalAccess.cs:33:5:36:5 | {...} | ConditionalAccess.cs:34:9:34:14 | ...; |
 | ConditionalAccess.cs:34:9:34:13 | ... = ... | ConditionalAccess.cs:35:9:35:25 | ...; |
 | ConditionalAccess.cs:34:9:34:14 | ...; | ConditionalAccess.cs:34:13:34:13 | 0 |
 | ConditionalAccess.cs:34:13:34:13 | 0 | ConditionalAccess.cs:34:9:34:13 | ... = ... |
-| ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:32:10:32:11 | exit M8 |
+| ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) |
 | ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:35:14:35:24 | call to method Out |
 | ConditionalAccess.cs:35:9:35:12 | this access | ConditionalAccess.cs:35:9:35:12 | access to property Prop |
 | ConditionalAccess.cs:35:9:35:25 | ...; | ConditionalAccess.cs:35:9:35:12 | this access |
 | ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:70:41:71 | access to parameter s1 |
+| ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith |
 | ConditionalAccess.cs:41:70:41:71 | access to parameter s1 | ConditionalAccess.cs:41:75:41:78 | ", " |
 | ConditionalAccess.cs:41:70:41:78 | ... + ... | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 |
-| ConditionalAccess.cs:41:70:41:83 | ... + ... | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith |
+| ConditionalAccess.cs:41:70:41:83 | ... + ... | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) |
 | ConditionalAccess.cs:41:75:41:78 | ", " | ConditionalAccess.cs:41:70:41:78 | ... + ... |
 | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | ConditionalAccess.cs:41:70:41:83 | ... + ... |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:4:5:9:5 | {...} |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | exit IncrOrDecr |
 | Conditions.cs:4:5:9:5 | {...} | Conditions.cs:5:9:6:16 | if (...) ... |
 | Conditions.cs:5:9:6:16 | if (...) ... | Conditions.cs:5:13:5:15 | access to parameter inc |
 | Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; |
@@ -1069,6 +1135,7 @@ dominance
 | Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:15 | ...-- |
 | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:13 | access to parameter x |
 | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:12:5:20:5 | {...} |
+| Conditions.cs:11:9:11:10 | exit M1 (normal) | Conditions.cs:11:9:11:10 | exit M1 |
 | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:13:9:13:18 | ... ...; |
 | Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:17:13:17 | 0 |
 | Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:14:9:15:16 | if (...) ... |
@@ -1094,9 +1161,10 @@ dominance
 | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:18:17:18:20 | ...; |
 | Conditions.cs:18:17:18:17 | access to local variable x | Conditions.cs:18:17:18:19 | ...-- |
 | Conditions.cs:18:17:18:20 | ...; | Conditions.cs:18:17:18:17 | access to local variable x |
-| Conditions.cs:19:9:19:17 | return ...; | Conditions.cs:11:9:11:10 | exit M1 |
+| Conditions.cs:19:9:19:17 | return ...; | Conditions.cs:11:9:11:10 | exit M1 (normal) |
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:19:9:19:17 | return ...; |
 | Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:23:5:31:5 | {...} |
+| Conditions.cs:22:9:22:10 | exit M2 (normal) | Conditions.cs:22:9:22:10 | exit M2 |
 | Conditions.cs:23:5:31:5 | {...} | Conditions.cs:24:9:24:18 | ... ...; |
 | Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:17:24:17 | 0 |
 | Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:25:9:27:20 | if (...) ... |
@@ -1115,9 +1183,10 @@ dominance
 | Conditions.cs:28:9:29:16 | if (...) ... | Conditions.cs:28:13:28:14 | access to parameter b2 |
 | Conditions.cs:29:13:29:13 | access to local variable x | Conditions.cs:29:13:29:15 | ...++ |
 | Conditions.cs:29:13:29:16 | ...; | Conditions.cs:29:13:29:13 | access to local variable x |
-| Conditions.cs:30:9:30:17 | return ...; | Conditions.cs:22:9:22:10 | exit M2 |
+| Conditions.cs:30:9:30:17 | return ...; | Conditions.cs:22:9:22:10 | exit M2 (normal) |
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:30:9:30:17 | return ...; |
 | Conditions.cs:33:9:33:10 | enter M3 | Conditions.cs:34:5:44:5 | {...} |
+| Conditions.cs:33:9:33:10 | exit M3 (normal) | Conditions.cs:33:9:33:10 | exit M3 |
 | Conditions.cs:34:5:44:5 | {...} | Conditions.cs:35:9:35:18 | ... ...; |
 | Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:17:35:17 | 0 |
 | Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:36:9:36:23 | ... ...; |
@@ -1141,9 +1210,10 @@ dominance
 | Conditions.cs:41:13:41:14 | [b2 (line 39): true] access to local variable b2 | Conditions.cs:42:13:42:16 | ...; |
 | Conditions.cs:42:13:42:13 | access to local variable x | Conditions.cs:42:13:42:15 | ...++ |
 | Conditions.cs:42:13:42:16 | ...; | Conditions.cs:42:13:42:13 | access to local variable x |
-| Conditions.cs:43:9:43:17 | return ...; | Conditions.cs:33:9:33:10 | exit M3 |
+| Conditions.cs:43:9:43:17 | return ...; | Conditions.cs:33:9:33:10 | exit M3 (normal) |
 | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:43:9:43:17 | return ...; |
 | Conditions.cs:46:9:46:10 | enter M4 | Conditions.cs:47:5:55:5 | {...} |
+| Conditions.cs:46:9:46:10 | exit M4 (normal) | Conditions.cs:46:9:46:10 | exit M4 |
 | Conditions.cs:47:5:55:5 | {...} | Conditions.cs:48:9:48:18 | ... ...; |
 | Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:17:48:17 | 0 |
 | Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:49:9:53:9 | while (...) ... |
@@ -1173,9 +1243,10 @@ dominance
 | Conditions.cs:52:17:52:17 | [b (line 46): true] access to local variable y | Conditions.cs:52:17:52:19 | [b (line 46): true] ...++ |
 | Conditions.cs:52:17:52:19 | [b (line 46): true] ...++ | Conditions.cs:49:16:49:16 | [b (line 46): true] access to parameter x |
 | Conditions.cs:52:17:52:20 | [b (line 46): true] ...; | Conditions.cs:52:17:52:17 | [b (line 46): true] access to local variable y |
-| Conditions.cs:54:9:54:17 | return ...; | Conditions.cs:46:9:46:10 | exit M4 |
+| Conditions.cs:54:9:54:17 | return ...; | Conditions.cs:46:9:46:10 | exit M4 (normal) |
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:54:9:54:17 | return ...; |
 | Conditions.cs:57:9:57:10 | enter M5 | Conditions.cs:58:5:68:5 | {...} |
+| Conditions.cs:57:9:57:10 | exit M5 (normal) | Conditions.cs:57:9:57:10 | exit M5 |
 | Conditions.cs:58:5:68:5 | {...} | Conditions.cs:59:9:59:18 | ... ...; |
 | Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:17:59:17 | 0 |
 | Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:60:9:64:9 | while (...) ... |
@@ -1212,9 +1283,10 @@ dominance
 | Conditions.cs:65:9:66:16 | if (...) ... | Conditions.cs:65:13:65:13 | access to parameter b |
 | Conditions.cs:66:13:66:13 | access to local variable y | Conditions.cs:66:13:66:15 | ...++ |
 | Conditions.cs:66:13:66:16 | ...; | Conditions.cs:66:13:66:13 | access to local variable y |
-| Conditions.cs:67:9:67:17 | return ...; | Conditions.cs:57:9:57:10 | exit M5 |
+| Conditions.cs:67:9:67:17 | return ...; | Conditions.cs:57:9:57:10 | exit M5 (normal) |
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:67:9:67:17 | return ...; |
 | Conditions.cs:70:9:70:10 | enter M6 | Conditions.cs:71:5:84:5 | {...} |
+| Conditions.cs:70:9:70:10 | exit M6 (normal) | Conditions.cs:70:9:70:10 | exit M6 |
 | Conditions.cs:71:5:84:5 | {...} | Conditions.cs:72:9:72:30 | ... ...; |
 | Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:17:72:18 | access to parameter ss |
 | Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:73:9:73:18 | ... ...; |
@@ -1246,9 +1318,10 @@ dominance
 | Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:83:16:83:16 | access to local variable x |
 | Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:82:13:82:15 | ...++ |
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:13 | access to local variable x |
-| Conditions.cs:83:9:83:17 | return ...; | Conditions.cs:70:9:70:10 | exit M6 |
+| Conditions.cs:83:9:83:17 | return ...; | Conditions.cs:70:9:70:10 | exit M6 (normal) |
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:83:9:83:17 | return ...; |
 | Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:87:5:100:5 | {...} |
+| Conditions.cs:86:9:86:10 | exit M7 (normal) | Conditions.cs:86:9:86:10 | exit M7 |
 | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:88:9:88:30 | ... ...; |
 | Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:17:88:18 | access to parameter ss |
 | Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:89:9:89:18 | ... ...; |
@@ -1280,9 +1353,10 @@ dominance
 | Conditions.cs:96:17:96:17 | access to local variable b | Conditions.cs:97:17:97:20 | ...; |
 | Conditions.cs:97:17:97:17 | access to local variable x | Conditions.cs:97:17:97:19 | ...++ |
 | Conditions.cs:97:17:97:20 | ...; | Conditions.cs:97:17:97:17 | access to local variable x |
-| Conditions.cs:99:9:99:17 | return ...; | Conditions.cs:86:9:86:10 | exit M7 |
+| Conditions.cs:99:9:99:17 | return ...; | Conditions.cs:86:9:86:10 | exit M7 (normal) |
 | Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:99:9:99:17 | return ...; |
 | Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:103:5:111:5 | {...} |
+| Conditions.cs:102:12:102:13 | exit M8 (normal) | Conditions.cs:102:12:102:13 | exit M8 |
 | Conditions.cs:103:5:111:5 | {...} | Conditions.cs:104:9:104:29 | ... ...; |
 | Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:17:104:17 | access to parameter b |
 | Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:105:9:106:20 | if (...) ... |
@@ -1315,9 +1389,10 @@ dominance
 | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:23 | ... = ... |
 | Conditions.cs:109:17:109:24 | ...; | Conditions.cs:109:17:109:17 | access to local variable x |
 | Conditions.cs:109:22:109:23 | "" | Conditions.cs:109:17:109:23 | ... + ... |
-| Conditions.cs:110:9:110:17 | return ...; | Conditions.cs:102:12:102:13 | exit M8 |
+| Conditions.cs:110:9:110:17 | return ...; | Conditions.cs:102:12:102:13 | exit M8 (normal) |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:9:110:17 | return ...; |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:114:5:124:5 | {...} |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | exit M9 |
 | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:115:9:115:24 | ... ...; |
 | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:20:115:23 | null |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... |
@@ -1326,7 +1401,7 @@ dominance
 | Conditions.cs:116:18:116:22 | Int32 i = ... | Conditions.cs:116:25:116:25 | access to local variable i |
 | Conditions.cs:116:22:116:22 | 0 | Conditions.cs:116:18:116:22 | Int32 i = ... |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:29:116:32 | access to parameter args |
-| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 (normal) |
 | Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:117:9:123:9 | {...} |
 | Conditions.cs:116:29:116:32 | access to parameter args | Conditions.cs:116:29:116:39 | access to property Length |
 | Conditions.cs:116:29:116:39 | access to property Length | Conditions.cs:116:25:116:39 | ... < ... |
@@ -1392,6 +1467,7 @@ dominance
 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true |
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:144:5:150:5 | {...} |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | exit M11 |
 | Conditions.cs:144:5:150:5 | {...} | Conditions.cs:145:9:145:30 | ... ...; |
 | Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:17:145:29 | ... ? ... : ... |
 | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... |
@@ -1414,33 +1490,39 @@ dominance
 | Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:149:45:149:45 | access to local variable s |
 | Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:149:38:149:47 | $"..." |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:8:5:11:5 | {...} |
+| ExitMethods.cs:7:10:7:11 | exit M1 (normal) | ExitMethods.cs:7:10:7:11 | exit M1 |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:9:9:9:25 | ...; |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:10:9:10:15 | return ...; |
 | ExitMethods.cs:9:9:9:25 | ...; | ExitMethods.cs:9:20:9:23 | true |
 | ExitMethods.cs:9:20:9:23 | true | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe |
-| ExitMethods.cs:10:9:10:15 | return ...; | ExitMethods.cs:7:10:7:11 | exit M1 |
+| ExitMethods.cs:10:9:10:15 | return ...; | ExitMethods.cs:7:10:7:11 | exit M1 (normal) |
 | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:14:5:17:5 | {...} |
+| ExitMethods.cs:13:10:13:11 | exit M2 (normal) | ExitMethods.cs:13:10:13:11 | exit M2 |
 | ExitMethods.cs:14:5:17:5 | {...} | ExitMethods.cs:15:9:15:26 | ...; |
 | ExitMethods.cs:15:9:15:25 | call to method ErrorMaybe | ExitMethods.cs:16:9:16:15 | return ...; |
 | ExitMethods.cs:15:9:15:26 | ...; | ExitMethods.cs:15:20:15:24 | false |
 | ExitMethods.cs:15:20:15:24 | false | ExitMethods.cs:15:9:15:25 | call to method ErrorMaybe |
-| ExitMethods.cs:16:9:16:15 | return ...; | ExitMethods.cs:13:10:13:11 | exit M2 |
+| ExitMethods.cs:16:9:16:15 | return ...; | ExitMethods.cs:13:10:13:11 | exit M2 (normal) |
 | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:20:5:23:5 | {...} |
+| ExitMethods.cs:19:10:19:11 | exit M3 (abnormal) | ExitMethods.cs:19:10:19:11 | exit M3 |
 | ExitMethods.cs:20:5:23:5 | {...} | ExitMethods.cs:21:9:21:26 | ...; |
-| ExitMethods.cs:21:9:21:25 | call to method ErrorAlways | ExitMethods.cs:19:10:19:11 | exit M3 |
+| ExitMethods.cs:21:9:21:25 | call to method ErrorAlways | ExitMethods.cs:19:10:19:11 | exit M3 (abnormal) |
 | ExitMethods.cs:21:9:21:26 | ...; | ExitMethods.cs:21:21:21:24 | true |
 | ExitMethods.cs:21:21:21:24 | true | ExitMethods.cs:21:9:21:25 | call to method ErrorAlways |
 | ExitMethods.cs:25:10:25:11 | enter M4 | ExitMethods.cs:26:5:29:5 | {...} |
+| ExitMethods.cs:25:10:25:11 | exit M4 (abnormal) | ExitMethods.cs:25:10:25:11 | exit M4 |
 | ExitMethods.cs:26:5:29:5 | {...} | ExitMethods.cs:27:9:27:15 | ...; |
-| ExitMethods.cs:27:9:27:14 | call to method Exit | ExitMethods.cs:25:10:25:11 | exit M4 |
+| ExitMethods.cs:27:9:27:14 | call to method Exit | ExitMethods.cs:25:10:25:11 | exit M4 (abnormal) |
 | ExitMethods.cs:27:9:27:14 | this access | ExitMethods.cs:27:9:27:14 | call to method Exit |
 | ExitMethods.cs:27:9:27:15 | ...; | ExitMethods.cs:27:9:27:14 | this access |
 | ExitMethods.cs:31:10:31:11 | enter M5 | ExitMethods.cs:32:5:35:5 | {...} |
+| ExitMethods.cs:31:10:31:11 | exit M5 (abnormal) | ExitMethods.cs:31:10:31:11 | exit M5 |
 | ExitMethods.cs:32:5:35:5 | {...} | ExitMethods.cs:33:9:33:26 | ...; |
-| ExitMethods.cs:33:9:33:25 | call to method ApplicationExit | ExitMethods.cs:31:10:31:11 | exit M5 |
+| ExitMethods.cs:33:9:33:25 | call to method ApplicationExit | ExitMethods.cs:31:10:31:11 | exit M5 (abnormal) |
 | ExitMethods.cs:33:9:33:25 | this access | ExitMethods.cs:33:9:33:25 | call to method ApplicationExit |
 | ExitMethods.cs:33:9:33:26 | ...; | ExitMethods.cs:33:9:33:25 | this access |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:38:5:51:5 | {...} |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:37:10:37:11 | exit M6 |
 | ExitMethods.cs:38:5:51:5 | {...} | ExitMethods.cs:39:9:50:9 | try {...} ... |
 | ExitMethods.cs:39:9:50:9 | try {...} ... | ExitMethods.cs:40:9:42:9 | {...} |
 | ExitMethods.cs:40:9:42:9 | {...} | ExitMethods.cs:41:13:41:31 | ...; |
@@ -1453,20 +1535,24 @@ dominance
 | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:48:9:50:9 | {...} |
 | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:49:13:49:19 | return ...; |
 | ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:54:5:57:5 | {...} |
+| ExitMethods.cs:53:10:53:11 | exit M7 (abnormal) | ExitMethods.cs:53:10:53:11 | exit M7 |
 | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:55:23 | ...; |
-| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:53:10:53:11 | exit M7 |
+| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:53:10:53:11 | exit M7 (abnormal) |
 | ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 |
 | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:60:5:63:5 | {...} |
+| ExitMethods.cs:59:10:59:11 | exit M8 (abnormal) | ExitMethods.cs:59:10:59:11 | exit M8 |
 | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:61:9:61:23 | ...; |
-| ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:59:10:59:11 | exit M8 |
+| ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:59:10:59:11 | exit M8 (abnormal) |
 | ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:66:5:69:5 | {...} |
 | ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:67:9:68:34 | if (...) ... |
 | ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:67:13:67:13 | access to parameter b |
-| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe |
+| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) |
 | ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
+| ExitMethods.cs:68:13:68:34 | throw ...; | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (abnormal) |
 | ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:13:68:34 | throw ...; |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:72:5:77:5 | {...} |
+| ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) | ExitMethods.cs:71:17:71:27 | exit ErrorAlways |
 | ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:73:9:76:45 | if (...) ... |
 | ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:73:13:73:13 | access to parameter b |
 | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
@@ -1475,30 +1561,36 @@ dominance
 | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | ExitMethods.cs:76:13:76:45 | throw ...; |
 | ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException |
 | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:80:5:82:5 | {...} |
+| ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 (abnormal) | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 |
 | ExitMethods.cs:80:5:82:5 | {...} | ExitMethods.cs:81:15:81:29 | object creation of type Exception |
-| ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 |
+| ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 (abnormal) |
 | ExitMethods.cs:81:15:81:29 | object creation of type Exception | ExitMethods.cs:81:9:81:30 | throw ...; |
 | ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 | ExitMethods.cs:84:41:84:55 | object creation of type Exception |
-| ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 |
+| ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 (abnormal) | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 |
+| ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 (abnormal) |
 | ExitMethods.cs:84:41:84:55 | object creation of type Exception | ExitMethods.cs:84:35:84:55 | throw ... |
 | ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:87:5:89:5 | {...} |
+| ExitMethods.cs:86:10:86:13 | exit Exit (abnormal) | ExitMethods.cs:86:10:86:13 | exit Exit |
 | ExitMethods.cs:87:5:89:5 | {...} | ExitMethods.cs:88:9:88:28 | ...; |
-| ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:86:10:86:13 | exit Exit |
+| ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:86:10:86:13 | exit Exit (abnormal) |
 | ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:88:26:88:26 | 0 |
 | ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:9:88:27 | call to method Exit |
 | ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:92:5:102:5 | {...} |
+| ExitMethods.cs:91:10:91:18 | exit ExitInTry (abnormal) | ExitMethods.cs:91:10:91:18 | exit ExitInTry |
 | ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:93:9:101:9 | try {...} ... |
 | ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:94:9:96:9 | {...} |
 | ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:95:13:95:19 | ...; |
-| ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:91:10:91:18 | exit ExitInTry |
+| ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:91:10:91:18 | exit ExitInTry (abnormal) |
 | ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:18 | call to method Exit |
 | ExitMethods.cs:95:13:95:19 | ...; | ExitMethods.cs:95:13:95:18 | this access |
 | ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:105:5:107:5 | {...} |
+| ExitMethods.cs:104:10:104:24 | exit ApplicationExit (abnormal) | ExitMethods.cs:104:10:104:24 | exit ApplicationExit |
 | ExitMethods.cs:105:5:107:5 | {...} | ExitMethods.cs:106:9:106:48 | ...; |
-| ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit |
+| ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit (abnormal) |
 | ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:106:9:106:47 | call to method Exit |
 | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:110:5:112:5 | {...} |
 | ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
+| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) |
 | ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:25:111:25 | 0 |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:29:111:29 | 1 |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:69:111:75 | "input" |
@@ -1509,50 +1601,61 @@ dominance
 | ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:33:111:37 | access to parameter input |
 | ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:9:111:77 | return ...; |
 | ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:29:111:37 | ... / ... |
+| ExitMethods.cs:111:41:111:76 | throw ... | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) |
 | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:41:111:76 | throw ... |
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:115:5:117:5 | {...} |
+| ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall |
 | ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall |
+| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) |
 | ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:27:116:29 | - |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:34:116:34 | 0 |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:38:116:38 | 1 |
 | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:16 | access to parameter s |
 | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:30 | call to method Contains |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:120:5:123:5 | {...} |
+| ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) | ExitMethods.cs:119:17:119:32 | exit FailingAssertion |
 | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:121:9:121:29 | ...; |
-| ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:119:17:119:32 | exit FailingAssertion |
+| ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) |
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:23:121:27 | false |
 | ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:126:5:129:5 | {...} |
+| ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 (abnormal) | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 |
 | ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:127:9:127:27 | ...; |
-| ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 |
+| ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 (abnormal) |
 | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion |
 | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:26 | this access |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:48:131:48 | access to parameter b |
+| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse (abnormal) |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse (normal) |
 | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
 | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:134:5:137:5 | {...} |
+| ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 (abnormal) | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 |
 | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:135:9:135:26 | ...; |
-| ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 |
+| ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 (abnormal) |
 | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:21:135:24 | true |
 | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:25 | this access |
 | ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:6:5:8:5 | {...} |
+| Extensions.cs:5:23:5:29 | exit ToInt32 (normal) | Extensions.cs:5:23:5:29 | exit ToInt32 |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:28:7:28 | access to parameter s |
-| Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | exit ToInt32 |
+| Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | exit ToInt32 (normal) |
 | Extensions.cs:7:16:7:29 | call to method Parse | Extensions.cs:7:9:7:30 | return ...; |
 | Extensions.cs:7:28:7:28 | access to parameter s | Extensions.cs:7:16:7:29 | call to method Parse |
 | Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:11:5:13:5 | {...} |
+| Extensions.cs:10:24:10:29 | exit ToBool (normal) | Extensions.cs:10:24:10:29 | exit ToBool |
 | Extensions.cs:11:5:13:5 | {...} | Extensions.cs:12:16:12:16 | access to parameter f |
-| Extensions.cs:12:9:12:20 | return ...; | Extensions.cs:10:24:10:29 | exit ToBool |
+| Extensions.cs:12:9:12:20 | return ...; | Extensions.cs:10:24:10:29 | exit ToBool (normal) |
 | Extensions.cs:12:16:12:16 | access to parameter f | Extensions.cs:12:18:12:18 | access to parameter s |
 | Extensions.cs:12:16:12:19 | delegate call | Extensions.cs:12:9:12:20 | return ...; |
 | Extensions.cs:12:18:12:18 | access to parameter s | Extensions.cs:12:16:12:19 | delegate call |
 | Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:48:15:50 | "0" |
-| Extensions.cs:15:40:15:51 | call to method ToInt32 | Extensions.cs:15:23:15:33 | exit CallToInt32 |
+| Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) | Extensions.cs:15:23:15:33 | exit CallToInt32 |
+| Extensions.cs:15:40:15:51 | call to method ToInt32 | Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) |
 | Extensions.cs:15:48:15:50 | "0" | Extensions.cs:15:40:15:51 | call to method ToInt32 |
 | Extensions.cs:20:17:20:20 | enter Main | Extensions.cs:21:5:26:5 | {...} |
+| Extensions.cs:20:17:20:20 | exit Main (normal) | Extensions.cs:20:17:20:20 | exit Main |
 | Extensions.cs:21:5:26:5 | {...} | Extensions.cs:22:9:22:20 | ...; |
 | Extensions.cs:22:9:22:9 | access to parameter s | Extensions.cs:22:9:22:19 | call to method ToInt32 |
 | Extensions.cs:22:9:22:19 | call to method ToInt32 | Extensions.cs:23:9:23:31 | ...; |
@@ -1566,7 +1669,7 @@ dominance
 | Extensions.cs:24:35:24:44 | access to method Parse | Extensions.cs:24:35:24:44 | delegate creation of type Func<String,Boolean> |
 | Extensions.cs:24:35:24:44 | delegate creation of type Func<String,Boolean> | Extensions.cs:24:9:24:45 | call to method ToBool |
 | Extensions.cs:25:9:25:14 | "true" | Extensions.cs:25:23:25:32 | access to method Parse |
-| Extensions.cs:25:9:25:33 | call to method ToBool | Extensions.cs:20:17:20:20 | exit Main |
+| Extensions.cs:25:9:25:33 | call to method ToBool | Extensions.cs:20:17:20:20 | exit Main (normal) |
 | Extensions.cs:25:9:25:34 | ...; | Extensions.cs:25:9:25:14 | "true" |
 | Extensions.cs:25:23:25:32 | access to method Parse | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> |
 | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | Extensions.cs:25:9:25:33 | call to method ToBool |
@@ -1582,6 +1685,7 @@ dominance
 | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} | Finally.cs:15:13:15:41 | [finally: exception(Exception)] ...; |
 | Finally.cs:14:9:16:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:15:13:15:41 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:14:9:16:9 | {...} | Finally.cs:15:13:15:41 | ...; |
+| Finally.cs:15:13:15:40 | call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 (normal) |
 | Finally.cs:15:13:15:41 | ...; | Finally.cs:15:31:15:39 | "Finally" |
 | Finally.cs:15:13:15:41 | [finally: exception(Exception)] ...; | Finally.cs:15:31:15:39 | [finally: exception(Exception)] "Finally" |
 | Finally.cs:15:13:15:41 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:15:31:15:39 | [finally: exception(OutOfMemoryException)] "Finally" |
@@ -1684,7 +1788,7 @@ dominance
 | Finally.cs:76:17:76:18 | 10 | Finally.cs:76:13:76:18 | Int32 i = ... |
 | Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:77:16:77:16 | access to local variable i |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:77:20:77:20 | 0 |
-| Finally.cs:77:16:77:20 | ... > ... | Finally.cs:74:10:74:11 | exit M4 |
+| Finally.cs:77:16:77:20 | ... > ... | Finally.cs:74:10:74:11 | exit M4 (normal) |
 | Finally.cs:77:16:77:20 | ... > ... | Finally.cs:78:9:100:9 | {...} |
 | Finally.cs:77:20:77:20 | 0 | Finally.cs:77:16:77:20 | ... > ... |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:79:13:99:13 | try {...} ... |
@@ -1896,16 +2000,18 @@ dominance
 | Finally.cs:117:35:117:35 | [finally: exception(OutOfMemoryException)] 1 | Finally.cs:117:17:117:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
 | Finally.cs:117:35:117:35 | [finally: return] 1 | Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine |
 | Finally.cs:121:10:121:11 | enter M6 | Finally.cs:122:5:131:5 | {...} |
+| Finally.cs:121:10:121:11 | exit M6 (normal) | Finally.cs:121:10:121:11 | exit M6 |
 | Finally.cs:122:5:131:5 | {...} | Finally.cs:123:9:130:9 | try {...} ... |
 | Finally.cs:123:9:130:9 | try {...} ... | Finally.cs:124:9:126:9 | {...} |
 | Finally.cs:124:9:126:9 | {...} | Finally.cs:125:13:125:41 | ... ...; |
 | Finally.cs:125:13:125:41 | ... ...; | Finally.cs:125:24:125:24 | 0 |
-| Finally.cs:125:17:125:40 | Double temp = ... | Finally.cs:121:10:121:11 | exit M6 |
+| Finally.cs:125:17:125:40 | Double temp = ... | Finally.cs:121:10:121:11 | exit M6 (normal) |
 | Finally.cs:125:24:125:24 | 0 | Finally.cs:125:24:125:24 | (...) ... |
 | Finally.cs:125:24:125:24 | (...) ... | Finally.cs:125:28:125:40 | access to constant E |
 | Finally.cs:125:24:125:40 | ... / ... | Finally.cs:125:17:125:40 | Double temp = ... |
 | Finally.cs:125:28:125:40 | access to constant E | Finally.cs:125:24:125:40 | ... / ... |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:134:5:145:5 | {...} |
+| Finally.cs:133:10:133:11 | exit M7 (abnormal) | Finally.cs:133:10:133:11 | exit M7 |
 | Finally.cs:134:5:145:5 | {...} | Finally.cs:135:9:143:9 | try {...} ... |
 | Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:136:9:138:9 | {...} |
 | Finally.cs:136:9:138:9 | {...} | Finally.cs:137:13:137:37 | ...; |
@@ -2050,6 +2156,7 @@ dominance
 | Finally.cs:186:17:186:47 | [b1 (line 176): false] if (...) ... | Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 |
 | Finally.cs:186:17:186:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... | Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 |
 | Finally.cs:186:17:186:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... | Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 |
+| Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (normal) |
 | Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB |
 | Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB |
 | Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB |
@@ -2165,9 +2272,11 @@ dominance
 | Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" | Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... |
 | Finally.cs:211:26:211:28 | [finally: exception(ExceptionA)] "0" | Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... |
 | Finally.cs:213:9:213:12 | this access | Finally.cs:213:22:213:24 | "1" |
+| Finally.cs:213:9:213:24 | ... = ... | Finally.cs:195:10:195:12 | exit M10 (normal) |
 | Finally.cs:213:9:213:25 | ...; | Finally.cs:213:9:213:12 | this access |
 | Finally.cs:213:22:213:24 | "1" | Finally.cs:213:9:213:24 | ... = ... |
 | Finally.cs:216:10:216:12 | enter M11 | Finally.cs:217:5:231:5 | {...} |
+| Finally.cs:216:10:216:12 | exit M11 (normal) | Finally.cs:216:10:216:12 | exit M11 |
 | Finally.cs:217:5:231:5 | {...} | Finally.cs:218:9:229:9 | try {...} ... |
 | Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:219:9:221:9 | {...} |
 | Finally.cs:219:9:221:9 | {...} | Finally.cs:220:13:220:37 | ...; |
@@ -2182,48 +2291,54 @@ dominance
 | Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:230:9:230:34 | ...; |
 | Finally.cs:228:13:228:41 | ...; | Finally.cs:228:31:228:39 | "Finally" |
 | Finally.cs:228:31:228:39 | "Finally" | Finally.cs:228:13:228:40 | call to method WriteLine |
-| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | exit M11 |
+| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | exit M11 (normal) |
 | Finally.cs:230:9:230:34 | ...; | Finally.cs:230:27:230:32 | "Done" |
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:33 | call to method WriteLine |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:7:5:10:5 | {...} |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:8:29:8:32 | access to parameter args |
-| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 |
+| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 (normal) |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:22:8:24 | String arg |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:9:13:9:13 | ; |
 | Foreach.cs:8:29:8:32 | access to parameter args | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
 | Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:13:5:16:5 | {...} |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | exit M2 |
 | Foreach.cs:13:5:16:5 | {...} | Foreach.cs:14:27:14:30 | access to parameter args |
-| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 |
+| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 (normal) |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:22:14:22 | String _ |
 | Foreach.cs:14:22:14:22 | String _ | Foreach.cs:15:13:15:13 | ; |
 | Foreach.cs:14:27:14:30 | access to parameter args | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:19:5:22:5 | {...} |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 |
 | Foreach.cs:19:5:22:5 | {...} | Foreach.cs:20:27:20:68 | ... ?? ... |
-| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 |
+| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 (normal) |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:21:11:21:11 | ; |
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:27:20:27 | access to parameter e |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:25:5:28:5 | {...} |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | exit M4 |
 | Foreach.cs:25:5:28:5 | {...} | Foreach.cs:26:36:26:39 | access to parameter args |
-| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | exit M4 |
+| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | exit M4 (normal) |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:23:26:23 | String x |
 | Foreach.cs:26:18:26:31 | (..., ...) | Foreach.cs:27:11:27:11 | ; |
 | Foreach.cs:26:23:26:23 | String x | Foreach.cs:26:30:26:30 | Int32 y |
 | Foreach.cs:26:30:26:30 | Int32 y | Foreach.cs:26:18:26:31 | (..., ...) |
 | Foreach.cs:26:36:26:39 | access to parameter args | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |
 | Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:31:5:34:5 | {...} |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:30:10:30:11 | exit M5 |
 | Foreach.cs:31:5:34:5 | {...} | Foreach.cs:32:32:32:35 | access to parameter args |
-| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | exit M5 |
+| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | exit M5 (normal) |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:23:32:23 | String x |
 | Foreach.cs:32:18:32:27 | (..., ...) | Foreach.cs:33:11:33:11 | ; |
 | Foreach.cs:32:23:32:23 | String x | Foreach.cs:32:26:32:26 | Int32 y |
 | Foreach.cs:32:26:32:26 | Int32 y | Foreach.cs:32:18:32:27 | (..., ...) |
 | Foreach.cs:32:32:32:35 | access to parameter args | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... |
 | Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:37:5:40:5 | {...} |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | exit M6 |
 | Foreach.cs:37:5:40:5 | {...} | Foreach.cs:38:39:38:42 | access to parameter args |
-| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 |
+| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 (normal) |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:26:38:26 | String x |
 | Foreach.cs:38:18:38:34 | (..., ...) | Foreach.cs:39:11:39:11 | ; |
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:38:33:38:33 | Int32 y |
@@ -2252,10 +2367,13 @@ dominance
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... |
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access |
-| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | exit Initializers |
+| Initializers.cs:8:5:8:16 | exit Initializers (normal) | Initializers.cs:8:5:8:16 | exit Initializers |
+| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | exit Initializers (normal) |
 | Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access |
-| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | exit Initializers |
+| Initializers.cs:10:5:10:16 | exit Initializers (normal) | Initializers.cs:10:5:10:16 | exit Initializers |
+| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | exit Initializers (normal) |
 | Initializers.cs:12:10:12:10 | enter M | Initializers.cs:13:5:16:5 | {...} |
+| Initializers.cs:12:10:12:10 | exit M (normal) | Initializers.cs:12:10:12:10 | exit M |
 | Initializers.cs:13:5:16:5 | {...} | Initializers.cs:14:9:14:54 | ... ...; |
 | Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:14:34:14:35 | "" |
 | Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:15:9:15:64 | ... ...; |
@@ -2268,7 +2386,7 @@ dominance
 | Initializers.cs:14:47:14:51 | ... = ... | Initializers.cs:14:38:14:53 | { ..., ... } |
 | Initializers.cs:14:51:14:51 | 1 | Initializers.cs:14:47:14:47 | access to property G |
 | Initializers.cs:15:9:15:64 | ... ...; | Initializers.cs:15:18:15:63 | 2 |
-| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:12:10:12:10 | exit M |
+| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:12:10:12:10 | exit M (normal) |
 | Initializers.cs:15:18:15:63 | 2 | Initializers.cs:15:18:15:63 | array creation of type Initializers[] |
 | Initializers.cs:15:18:15:63 | array creation of type Initializers[] | Initializers.cs:15:39:15:39 | access to local variable i |
 | Initializers.cs:15:37:15:63 | { ..., ... } | Initializers.cs:15:13:15:63 | Initializers[] iz = ... |
@@ -2277,6 +2395,7 @@ dominance
 | Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:42:15:61 | object creation of type Initializers |
 | Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... |
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:20:11:20:23 | exit NoConstructor |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 |
 | Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access |
@@ -2285,7 +2404,7 @@ dominance
 | Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... |
 | Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 |
 | Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 |
-| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | exit NoConstructor |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) |
 | Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:28:13:28:13 | this access |
 | Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... |
 | Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... |
@@ -2296,28 +2415,32 @@ dominance
 | Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... |
 | Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:17:31:20 | call to constructor NoConstructor |
+| Initializers.cs:31:9:31:11 | exit Sub (normal) | Initializers.cs:31:9:31:11 | exit Sub |
 | Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:28:13:28:13 | this access |
 | Initializers.cs:31:24:31:33 | {...} | Initializers.cs:31:26:31:31 | ...; |
 | Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:30:31:30 | 3 |
-| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:9:31:11 | exit Sub |
+| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:9:31:11 | exit Sub (normal) |
 | Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:26:31:26 | this access |
 | Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:26:31:30 | ... = ... |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:22:33:25 | call to constructor Sub |
+| Initializers.cs:33:9:33:11 | exit Sub (normal) | Initializers.cs:33:9:33:11 | exit Sub |
 | Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:29:33:38 | {...} |
 | Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:31:33:36 | ...; |
 | Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:35:33:35 | access to parameter i |
-| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub |
+| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub (normal) |
 | Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:31 | this access |
 | Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:35 | ... = ... |
 | Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:35:9:35:11 | exit Sub (normal) | Initializers.cs:35:9:35:11 | exit Sub |
 | Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:29:35:38 | ...; |
 | Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:33:35:33 | access to parameter i |
-| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:9:35:11 | exit Sub |
+| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:9:35:11 | exit Sub (normal) |
 | Initializers.cs:35:29:35:38 | ...; | Initializers.cs:35:29:35:29 | this access |
 | Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:37:35:37 | access to parameter j |
 | Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:29:35:37 | ... = ... |
 | Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:33:35:37 | ... + ... |
 | Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:52:5:66:5 | {...} |
+| Initializers.cs:51:10:51:13 | exit Test (normal) | Initializers.cs:51:10:51:13 | exit Test |
 | Initializers.cs:52:5:66:5 | {...} | Initializers.cs:54:9:54:96 | ... ...; |
 | Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |
 | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:57:9:65:10 | ... ...; |
@@ -2338,7 +2461,7 @@ dominance
 | Initializers.cs:54:84:54:84 | 2 | Initializers.cs:54:80:54:84 | ... + ... |
 | Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:79:54:85 | access to indexer |
 | Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:24:65:9 | object creation of type Compound |
-| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | exit Test |
+| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | exit Test (normal) |
 | Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:59:34:59:34 | 0 |
 | Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:57:13:65:9 | Compound compound = ... |
 | Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:60:37:60:37 | 3 |
@@ -2421,6 +2544,7 @@ dominance
 | Initializers.cs:64:54:64:54 | 0 | Initializers.cs:64:50:64:54 | ... + ... |
 | Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:46:64:61 | ... = ... |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:8:5:13:5 | {...} |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | exit M1 |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:9:9:10:19 | if (...) ... |
 | LoopUnrolling.cs:9:9:10:19 | if (...) ... | LoopUnrolling.cs:9:13:9:16 | access to parameter args |
 | LoopUnrolling.cs:9:13:9:16 | access to parameter args | LoopUnrolling.cs:9:13:9:23 | access to property Length |
@@ -2435,6 +2559,7 @@ dominance
 | LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:12:31:12:33 | access to local variable arg |
 | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:16:5:20:5 | {...} |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:15:10:15:11 | exit M2 |
 | LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:17:9:17:48 | ... ...; |
 | LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:17:18:17:47 | 3 |
 | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:18:27:18:28 | access to local variable xs |
@@ -2445,15 +2570,16 @@ dominance
 | LoopUnrolling.cs:17:38:17:40 | "b" | LoopUnrolling.cs:17:43:17:45 | "c" |
 | LoopUnrolling.cs:17:43:17:45 | "c" | LoopUnrolling.cs:17:31:17:47 | { ..., ... } |
 | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:18:22:18:22 | String x |
-| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:15:10:15:11 | exit M2 |
+| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) |
 | LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:19:13:19:33 | ...; |
 | LoopUnrolling.cs:18:27:18:28 | access to local variable xs | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:19:31:19:31 | access to local variable x |
 | LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:23:5:27:5 | {...} |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:22:10:22:11 | exit M3 |
 | LoopUnrolling.cs:23:5:27:5 | {...} | LoopUnrolling.cs:24:29:24:32 | access to parameter args |
-| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 |
+| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:22:24:24 | Char arg |
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:34:25:37 | access to parameter args |
 | LoopUnrolling.cs:24:29:24:32 | access to parameter args | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |
@@ -2464,14 +2590,16 @@ dominance
 | LoopUnrolling.cs:26:17:26:40 | ...; | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 |
 | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 | LoopUnrolling.cs:26:17:26:39 | call to method WriteLine |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:30:5:34:5 | {...} |
+| LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) | LoopUnrolling.cs:29:10:29:11 | exit M4 |
 | LoopUnrolling.cs:30:5:34:5 | {...} | LoopUnrolling.cs:31:9:31:31 | ... ...; |
 | LoopUnrolling.cs:31:9:31:31 | ... ...; | LoopUnrolling.cs:31:29:31:29 | 0 |
 | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs |
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] |
-| LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 |
+| LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) |
 | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:37:5:43:5 | {...} |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:36:10:36:11 | exit M5 |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:38:9:38:48 | ... ...; |
 | LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:38:18:38:47 | 3 |
 | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:39:9:39:48 | ... ...; |
@@ -2490,7 +2618,7 @@ dominance
 | LoopUnrolling.cs:39:38:39:40 | "1" | LoopUnrolling.cs:39:43:39:45 | "2" |
 | LoopUnrolling.cs:39:43:39:45 | "2" | LoopUnrolling.cs:39:31:39:47 | { ..., ... } |
 | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x |
-| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 |
+| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) |
 | LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:31:41:32 | access to local variable ys |
 | LoopUnrolling.cs:40:27:40:28 | access to local variable xs | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | LoopUnrolling.cs:41:26:41:26 | String y |
@@ -2521,6 +2649,7 @@ dominance
 | LoopUnrolling.cs:50:16:50:36 | ...; | LoopUnrolling.cs:50:34:50:34 | access to local variable x |
 | LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:50:16:50:35 | call to method WriteLine |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:56:5:65:5 | {...} |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:55:10:55:11 | exit M7 |
 | LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:57:9:57:48 | ... ...; |
 | LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:57:18:57:47 | 3 |
 | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:58:27:58:28 | access to local variable xs |
@@ -2556,6 +2685,7 @@ dominance
 | LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; | LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x |
 | LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x | LoopUnrolling.cs:63:17:63:36 | [b (line 55): true] call to method WriteLine |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:68:5:74:5 | {...} |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:69:9:70:19 | if (...) ... |
 | LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:13:69:23 | !... |
 | LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:14:69:17 | access to parameter args |
@@ -2567,24 +2697,27 @@ dominance
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:12 | access to parameter args |
 | LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:77:5:83:5 | {...} |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) | LoopUnrolling.cs:76:10:76:11 | exit M9 |
 | LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:78:9:78:34 | ... ...; |
 | LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:78:29:78:29 | 2 |
 | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs |
 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... |
 | LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:32:78:32 | 0 |
 | LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] |
-| LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 |
+| LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) |
 | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:86:5:92:5 | {...} |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) | LoopUnrolling.cs:85:10:85:12 | exit M10 |
 | LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:87:9:87:34 | ... ...; |
 | LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:87:29:87:29 | 0 |
 | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs |
 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... |
 | LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:32:87:32 | 2 |
 | LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] |
-| LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 |
+| LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) |
 | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:95:5:101:5 | {...} |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:94:10:94:12 | exit M11 |
 | LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:96:9:96:34 | ... ...; |
 | LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:96:29:96:29 | 2 |
 | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:97:27:97:28 | access to local variable xs |
@@ -2592,7 +2725,7 @@ dominance
 | LoopUnrolling.cs:96:29:96:29 | 2 | LoopUnrolling.cs:96:32:96:32 | 2 |
 | LoopUnrolling.cs:96:32:96:32 | 2 | LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] |
 | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | LoopUnrolling.cs:97:22:97:22 | String x |
-| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:94:10:94:12 | exit M11 |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:98:9:100:9 | {...} |
 | LoopUnrolling.cs:97:27:97:28 | access to local variable xs | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:98:9:100:9 | {...} | LoopUnrolling.cs:99:13:99:33 | ...; |
@@ -2601,131 +2734,195 @@ dominance
 | LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:28:6:31 | null |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 |
+| MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) |
+| MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) |
 | MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:22:6:31 | throw ... |
 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationA.cs:7:25:7:39 | {...} |
 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationB.cs:4:25:4:37 | {...} |
 | MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationA.cs:7:33:7:36 | null |
+| MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) |
+| MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) |
 | MultiImplementationA.cs:7:33:7:36 | null | MultiImplementationA.cs:7:27:7:37 | throw ...; |
 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationA.cs:7:45:7:59 | {...} |
 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} |
 | MultiImplementationA.cs:7:45:7:59 | {...} | MultiImplementationA.cs:7:53:7:56 | null |
+| MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) |
+| MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) |
 | MultiImplementationA.cs:7:53:7:56 | null | MultiImplementationA.cs:7:47:7:57 | throw ...; |
 | MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationA.cs:8:29:8:32 | null |
 | MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationB.cs:5:23:5:23 | 2 |
+| MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) |
+| MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) |
 | MultiImplementationA.cs:8:29:8:32 | null | MultiImplementationA.cs:8:23:8:32 | throw ... |
 | MultiImplementationA.cs:13:16:13:16 | this access | MultiImplementationA.cs:13:20:13:20 | 0 |
 | MultiImplementationA.cs:13:20:13:20 | 0 | MultiImplementationA.cs:13:16:13:20 | ... = ... |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) |
 | MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
 | MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationB.cs:12:37:12:40 | null |
 | MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationA.cs:15:40:15:52 | {...} |
 | MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationB.cs:13:40:13:54 | {...} |
 | MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:49:15:49 | access to parameter s |
+| MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) |
+| MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) |
 | MultiImplementationA.cs:15:49:15:49 | access to parameter s | MultiImplementationA.cs:15:42:15:50 | return ...; |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:58:15:60 | {...} |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:60:13:62 | {...} |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:15:5:17:5 | {...} |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:18:9:18:22 | M2(...) |
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:21:18:21 | 0 |
-| MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | exit M2 |
+| MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | MultiImplementationA.cs:18:9:18:22 | exit M2 |
+| MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:11:16:11:16 | this access |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:24:20:29 | ...; |
 | MultiImplementationA.cs:20:24:20:24 | this access | MultiImplementationA.cs:20:28:20:28 | access to parameter i |
+| MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) |
+| MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) |
 | MultiImplementationA.cs:20:24:20:29 | ...; | MultiImplementationA.cs:20:24:20:24 | this access |
 | MultiImplementationA.cs:20:28:20:28 | access to parameter i | MultiImplementationA.cs:20:24:20:28 | ... = ... |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:24:21:24 | 0 |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:24:19:24 | 1 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 |
 | MultiImplementationA.cs:21:24:21:24 | 0 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 |
 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} |
 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationB.cs:20:11:20:25 | {...} |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) |
 | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationA.cs:23:50:23:53 | null |
 | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationB.cs:21:56:21:59 | null |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) |
 | MultiImplementationA.cs:24:16:24:16 | access to property P | MultiImplementationA.cs:24:32:24:34 | ... = ... |
 | MultiImplementationA.cs:24:16:24:16 | this access | MultiImplementationA.cs:24:34:24:34 | 0 |
 | MultiImplementationA.cs:24:34:24:34 | 0 | MultiImplementationA.cs:24:16:24:16 | access to property P |
 | MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationA.cs:30:34:30:37 | null |
-| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationA.cs:30:21:30:23 | exit get_P3 |
-| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationB.cs:27:21:27:23 | exit get_P3 |
+| MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:21:30:23 | exit get_P3 |
+| MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | MultiImplementationB.cs:27:21:27:23 | exit get_P3 |
+| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) |
+| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) |
 | MultiImplementationA.cs:30:34:30:37 | null | MultiImplementationA.cs:30:28:30:37 | throw ... |
 | MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationA.cs:36:14:36:28 | {...} |
 | MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationB.cs:32:17:32:17 | 0 |
 | MultiImplementationA.cs:36:14:36:28 | {...} | MultiImplementationA.cs:36:22:36:25 | null |
+| MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) |
+| MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) |
 | MultiImplementationA.cs:36:22:36:25 | null | MultiImplementationA.cs:36:16:36:26 | throw ...; |
 | MultiImplementationA.cs:37:9:37:10 | enter M2 | MultiImplementationA.cs:37:14:37:28 | {...} |
+| MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) | MultiImplementationA.cs:37:9:37:10 | exit M2 |
 | MultiImplementationA.cs:37:14:37:28 | {...} | MultiImplementationA.cs:37:22:37:25 | null |
-| MultiImplementationA.cs:37:16:37:26 | throw ...; | MultiImplementationA.cs:37:9:37:10 | exit M2 |
+| MultiImplementationA.cs:37:16:37:26 | throw ...; | MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) |
 | MultiImplementationA.cs:37:22:37:25 | null | MultiImplementationA.cs:37:16:37:26 | throw ...; |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) |
 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationA.cs:6:28:6:31 | null |
 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 |
 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationA.cs:7:25:7:39 | {...} |
 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationB.cs:4:25:4:37 | {...} |
 | MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationB.cs:4:34:4:34 | 1 |
+| MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) |
+| MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) |
 | MultiImplementationB.cs:4:34:4:34 | 1 | MultiImplementationB.cs:4:27:4:35 | return ...; |
 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationA.cs:7:45:7:59 | {...} |
 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) |
 | MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationA.cs:8:29:8:32 | null |
 | MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationB.cs:5:23:5:23 | 2 |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationA.cs:8:16:8:16 | exit M (normal) |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationB.cs:5:16:5:16 | exit M (normal) |
 | MultiImplementationB.cs:11:16:11:16 | this access | MultiImplementationB.cs:11:20:11:20 | 1 |
 | MultiImplementationB.cs:11:20:11:20 | 1 | MultiImplementationB.cs:11:16:11:20 | ... = ... |
 | MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
 | MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationB.cs:12:37:12:40 | null |
+| MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) |
+| MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) |
 | MultiImplementationB.cs:12:37:12:40 | null | MultiImplementationB.cs:12:31:12:40 | throw ... |
 | MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationA.cs:15:40:15:52 | {...} |
 | MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationB.cs:13:40:13:54 | {...} |
 | MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationB.cs:13:48:13:51 | null |
+| MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) |
+| MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) |
 | MultiImplementationB.cs:13:48:13:51 | null | MultiImplementationB.cs:13:42:13:52 | throw ...; |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationA.cs:15:58:15:60 | {...} |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:60:13:62 | {...} |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:15:5:17:5 | {...} |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:16:9:16:31 | M2(...) |
 | MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:27:16:30 | null |
-| MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:9:16:31 | exit M2 |
+| MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | MultiImplementationB.cs:16:9:16:31 | exit M2 |
+| MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) |
 | MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:21:16:30 | throw ... |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:11:16:11:16 | this access |
 | MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:30:18:33 | null |
+| MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) |
+| MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) |
 | MultiImplementationB.cs:18:30:18:33 | null | MultiImplementationB.cs:18:24:18:34 | throw ...; |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:24:21:24 | 0 |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:24:19:24 | 1 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 |
 | MultiImplementationB.cs:19:24:19:24 | 1 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 |
 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} |
 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationB.cs:20:11:20:25 | {...} |
 | MultiImplementationB.cs:20:11:20:25 | {...} | MultiImplementationB.cs:20:19:20:22 | null |
+| MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) |
+| MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) |
 | MultiImplementationB.cs:20:19:20:22 | null | MultiImplementationB.cs:20:13:20:23 | throw ...; |
 | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationA.cs:23:50:23:53 | null |
 | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationB.cs:21:56:21:59 | null |
+| MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) |
+| MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) |
 | MultiImplementationB.cs:21:56:21:59 | null | MultiImplementationB.cs:21:50:21:59 | throw ... |
 | MultiImplementationB.cs:22:16:22:16 | access to property P | MultiImplementationB.cs:22:32:22:34 | ... = ... |
 | MultiImplementationB.cs:22:16:22:16 | this access | MultiImplementationB.cs:22:34:22:34 | 1 |
 | MultiImplementationB.cs:22:34:22:34 | 1 | MultiImplementationB.cs:22:16:22:16 | access to property P |
 | MultiImplementationB.cs:27:21:27:23 | enter get_P3 | MultiImplementationA.cs:30:34:30:37 | null |
+| MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:21:30:23 | exit get_P3 |
+| MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | MultiImplementationB.cs:27:21:27:23 | exit get_P3 |
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationA.cs:36:14:36:28 | {...} |
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationB.cs:32:17:32:17 | 0 |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
-| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:9:3:10 | exit M1 |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 |
+| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
 | NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:28:3:28 | 0 |
 | NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:23 | access to parameter i |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 |
 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:25:5:34 | ... ?? ... |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:30:5:34 | false |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:39:5:39 | 0 |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:43:5:43 | 1 |
 | NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:25:5:25 | access to parameter b |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
-| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:12:7:13 | exit M3 |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 |
+| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
 | NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |
 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:36:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 |
 | NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:41:9:41 | access to parameter s |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:45:9:45 | access to parameter s |
 | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:37:9:37 | access to parameter b |
 | NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:52 | "" |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 |
 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:44:11:59 | ... ?? ... |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:51:11:58 | ... && ... |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:64:11:64 | 0 |
@@ -2734,6 +2931,7 @@ dominance
 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
 | NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 |
 | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:14:5:18:5 | {...} |
+| NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | NullCoalescing.cs:13:10:13:11 | exit M6 |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:15:9:15:32 | ... ...; |
 | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:16:9:16:26 | ... ...; |
@@ -2745,12 +2943,13 @@ dominance
 | NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:17:9:17:25 | ...; |
 | NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:13:16:25 | String s = ... |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" |
-| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:13:10:13:11 | exit M6 |
+| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) |
 | NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:9:17:24 | ... = ... |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:6:5:43:5 | {...} |
+| Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:5:10:5:13 | exit Test |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:7:9:7:24 | ... ...; |
 | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:20:7:23 | null |
 | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:8:9:18:9 | if (...) ... |
@@ -2819,13 +3018,15 @@ dominance
 | Patterns.cs:36:17:36:52 | ...; | Patterns.cs:36:35:36:50 | "Something else" |
 | Patterns.cs:36:35:36:50 | "Something else" | Patterns.cs:36:17:36:51 | call to method WriteLine |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o |
-| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | exit Test |
+| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | exit Test (normal) |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:6:5:8:5 | {...} |
+| PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | exit M1 |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:29 | ...; |
-| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:5:10:5:11 | exit M1 |
+| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:5:10:5:11 | exit M1 (normal) |
 | PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:27:7:27 | access to parameter s |
 | PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:7:9:7:28 | call to method WriteLine |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:11:5:15:5 | {...} |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 |
 | PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:12:9:13:19 | if (...) ... |
 | PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:12:13:12:13 | access to parameter s |
 | PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:18:12:21 | null |
@@ -2841,15 +3042,20 @@ dominance
 | PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) |
 | PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:21:9:21:29 | ...; |
 | PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | ... is ... |
+| PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:17:10:17:11 | exit M3 (abnormal) |
 | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:13:20:55 | throw ...; |
 | PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException |
+| PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:17:10:17:11 | exit M3 (normal) |
 | PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:27:21:27 | access to parameter s |
 | PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:9:21:28 | call to method WriteLine |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:28:7:31 | null |
-| Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | exit Method |
+| Qualifiers.cs:7:16:7:21 | exit Method (normal) | Qualifiers.cs:7:16:7:21 | exit Method |
+| Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | exit Method (normal) |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:41:8:44 | null |
-| Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:23:8:34 | exit StaticMethod |
+| Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) | Qualifiers.cs:8:23:8:34 | exit StaticMethod |
+| Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) |
 | Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:11:5:31:5 | {...} |
+| Qualifiers.cs:10:10:10:10 | exit M (normal) | Qualifiers.cs:10:10:10:10 | exit M |
 | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:12:9:12:22 | ... ...; |
 | Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:17:12:21 | this access |
 | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:13:9:13:21 | ...; |
@@ -2901,14 +3107,15 @@ dominance
 | Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:13:29:37 | access to property StaticProperty |
 | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:13:29:46 | access to property Property |
 | Qualifiers.cs:29:13:29:46 | access to property Property | Qualifiers.cs:29:9:29:46 | ... = ... |
-| Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:10:10:10:10 | exit M |
+| Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:10:10:10:10 | exit M (normal) |
 | Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:13:30:37 | call to method StaticMethod |
 | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:13:30:46 | call to method Method |
 | Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:30:9:30:46 | ... = ... |
 | Switch.cs:5:10:5:11 | enter M1 | Switch.cs:6:5:8:5 | {...} |
+| Switch.cs:5:10:5:11 | exit M1 (normal) | Switch.cs:5:10:5:11 | exit M1 |
 | Switch.cs:6:5:8:5 | {...} | Switch.cs:7:9:7:22 | switch (...) {...} |
 | Switch.cs:7:9:7:22 | switch (...) {...} | Switch.cs:7:17:7:17 | access to parameter o |
-| Switch.cs:7:17:7:17 | access to parameter o | Switch.cs:5:10:5:11 | exit M1 |
+| Switch.cs:7:17:7:17 | access to parameter o | Switch.cs:5:10:5:11 | exit M1 (normal) |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:11:5:33:5 | {...} |
 | Switch.cs:11:5:33:5 | {...} | Switch.cs:12:9:32:9 | switch (...) {...} |
 | Switch.cs:12:9:32:9 | switch (...) {...} | Switch.cs:12:17:12:17 | access to parameter o |
@@ -2952,10 +3159,12 @@ dominance
 | Switch.cs:30:13:30:20 | default: | Switch.cs:31:17:31:27 | goto ...; |
 | Switch.cs:31:17:31:27 | goto ...; | Switch.cs:28:13:28:17 | Label: |
 | Switch.cs:35:10:35:11 | enter M3 | Switch.cs:36:5:42:5 | {...} |
+| Switch.cs:35:10:35:11 | exit M3 (abnormal) | Switch.cs:35:10:35:11 | exit M3 |
 | Switch.cs:36:5:42:5 | {...} | Switch.cs:37:9:41:9 | switch (...) {...} |
 | Switch.cs:37:9:41:9 | switch (...) {...} | Switch.cs:37:17:37:23 | call to method Throw |
-| Switch.cs:37:17:37:23 | call to method Throw | Switch.cs:35:10:35:11 | exit M3 |
+| Switch.cs:37:17:37:23 | call to method Throw | Switch.cs:35:10:35:11 | exit M3 (abnormal) |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:45:5:53:5 | {...} |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:44:10:44:11 | exit M4 |
 | Switch.cs:45:5:53:5 | {...} | Switch.cs:46:9:52:9 | switch (...) {...} |
 | Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:46:17:46:17 | access to parameter o |
 | Switch.cs:46:17:46:17 | access to parameter o | Switch.cs:48:13:48:23 | case ...: |
@@ -2968,6 +3177,7 @@ dominance
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:51:17:51:22 | break; |
 | Switch.cs:50:35:50:38 | null | Switch.cs:50:30:50:38 | ... != ... |
 | Switch.cs:55:10:55:11 | enter M5 | Switch.cs:56:5:64:5 | {...} |
+| Switch.cs:55:10:55:11 | exit M5 (normal) | Switch.cs:55:10:55:11 | exit M5 |
 | Switch.cs:56:5:64:5 | {...} | Switch.cs:57:9:63:9 | switch (...) {...} |
 | Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:57:17:57:17 | 1 |
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:57:21:57:21 | 2 |
@@ -2977,8 +3187,9 @@ dominance
 | Switch.cs:59:18:59:18 | 2 | Switch.cs:61:13:61:19 | case ...: |
 | Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:18:61:18 | 3 |
 | Switch.cs:61:18:61:18 | 3 | Switch.cs:62:17:62:22 | break; |
-| Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | exit M5 |
+| Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | exit M5 (normal) |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:67:5:75:5 | {...} |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:66:10:66:11 | exit M6 |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:68:9:74:9 | switch (...) {...} |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:68:25:68:25 | access to parameter s |
 | Switch.cs:68:17:68:25 | (...) ... | Switch.cs:70:13:70:23 | case ...: |
@@ -2986,9 +3197,10 @@ dominance
 | Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 |
 | Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:72:13:72:20 | case ...: |
 | Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:18:72:19 | "" |
-| Switch.cs:72:18:72:19 | "" | Switch.cs:66:10:66:11 | exit M6 |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:66:10:66:11 | exit M6 (normal) |
 | Switch.cs:72:18:72:19 | "" | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:78:5:89:5 | {...} |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:77:10:77:11 | exit M7 |
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:79:9:87:9 | switch (...) {...} |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:79:17:79:17 | access to parameter i |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:81:13:81:19 | case ...: |
@@ -3007,6 +3219,7 @@ dominance
 | Switch.cs:86:24:86:27 | true | Switch.cs:86:17:86:28 | return ...; |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:9:88:21 | return ...; |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:92:5:99:5 | {...} |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:91:10:91:11 | exit M8 |
 | Switch.cs:92:5:99:5 | {...} | Switch.cs:93:9:97:9 | switch (...) {...} |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:93:17:93:17 | access to parameter o |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:95:13:95:23 | case ...: |
@@ -3016,6 +3229,7 @@ dominance
 | Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | return ...; |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:9:98:21 | return ...; |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:102:5:109:5 | {...} |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:101:9:101:10 | exit M9 |
 | Switch.cs:102:5:109:5 | {...} | Switch.cs:103:9:107:9 | switch (...) {...} |
 | Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:103:17:103:17 | access to parameter s |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:19:103:25 | access to property Length |
@@ -3031,9 +3245,11 @@ dominance
 | Switch.cs:108:16:108:17 | -... | Switch.cs:108:9:108:18 | return ...; |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:16:108:17 | -... |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:34:111:48 | object creation of type Exception |
-| Switch.cs:111:28:111:48 | throw ... | Switch.cs:111:17:111:21 | exit Throw |
+| Switch.cs:111:17:111:21 | exit Throw (abnormal) | Switch.cs:111:17:111:21 | exit Throw |
+| Switch.cs:111:28:111:48 | throw ... | Switch.cs:111:17:111:21 | exit Throw (abnormal) |
 | Switch.cs:111:34:111:48 | object creation of type Exception | Switch.cs:111:28:111:48 | throw ... |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:114:5:121:5 | {...} |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:113:9:113:11 | exit M10 |
 | Switch.cs:114:5:121:5 | {...} | Switch.cs:115:9:119:9 | switch (...) {...} |
 | Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:115:17:115:17 | access to parameter s |
 | Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:115:17:115:24 | access to property Length |
@@ -3055,6 +3271,7 @@ dominance
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:9:120:18 | return ...; |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:16:120:17 | -... |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:124:5:127:5 | {...} |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 |
 | Switch.cs:124:5:127:5 | {...} | Switch.cs:125:9:126:19 | if (...) ... |
 | Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:13:125:48 | ... switch { ... } |
 | Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:24:125:34 | ... => ... |
@@ -3066,8 +3283,9 @@ dominance
 | Switch.cs:125:37:125:37 | _ | Switch.cs:125:42:125:46 | false |
 | Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:37 | _ |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:130:5:132:5 | {...} |
+| Switch.cs:129:12:129:14 | exit M12 (normal) | Switch.cs:129:12:129:14 | exit M12 |
 | Switch.cs:130:5:132:5 | {...} | Switch.cs:131:17:131:53 | ... switch { ... } |
-| Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 |
+| Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 (normal) |
 | Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:28:131:40 | ... => ... |
 | Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:17:131:17 | access to parameter o |
 | Switch.cs:131:28:131:35 | String s | Switch.cs:131:40:131:40 | access to local variable s |
@@ -3077,6 +3295,7 @@ dominance
 | Switch.cs:131:43:131:43 | _ | Switch.cs:131:48:131:51 | null |
 | Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:43 | _ |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:135:5:142:5 | {...} |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 |
 | Switch.cs:135:5:142:5 | {...} | Switch.cs:136:9:141:9 | switch (...) {...} |
 | Switch.cs:136:9:141:9 | switch (...) {...} | Switch.cs:136:17:136:17 | access to parameter i |
 | Switch.cs:136:17:136:17 | access to parameter i | Switch.cs:139:13:139:19 | case ...: |
@@ -3092,6 +3311,7 @@ dominance
 | Switch.cs:140:18:140:18 | 2 | Switch.cs:140:28:140:28 | 2 |
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:140:21:140:29 | return ...; |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:145:5:152:5 | {...} |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:144:9:144:11 | exit M14 |
 | Switch.cs:145:5:152:5 | {...} | Switch.cs:146:9:151:9 | switch (...) {...} |
 | Switch.cs:146:9:151:9 | switch (...) {...} | Switch.cs:146:17:146:17 | access to parameter i |
 | Switch.cs:146:17:146:17 | access to parameter i | Switch.cs:148:13:148:19 | case ...: |
@@ -3115,6 +3335,7 @@ dominance
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:36:156:38 | "a" |
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:41:156:52 | ... => ... |
 | Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true |
+| Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:13:157:13 | access to parameter b |
@@ -3129,6 +3350,7 @@ dominance
 | Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:45:160:45 | access to local variable s |
 | Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:38:160:47 | $"..." |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:4:5:9:5 | {...} |
+| TypeAccesses.cs:3:10:3:10 | exit M (normal) | TypeAccesses.cs:3:10:3:10 | exit M |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:5:9:5:26 | ... ...; |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:25:5:25 | access to parameter o |
 | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:6:9:6:24 | ...; |
@@ -3144,9 +3366,10 @@ dominance
 | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; |
 | TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | ... is ... |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:17:8:27 | typeof(...) |
-| TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:3:10:3:10 | exit M |
+| TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:3:10:3:10 | exit M (normal) |
 | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:13:8:27 | Type t = ... |
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:6:5:11:5 | {...} |
+| VarDecls.cs:5:18:5:19 | exit M1 (normal) | VarDecls.cs:5:18:5:19 | exit M1 |
 | VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:7:9:10:9 | fixed(...) { ... } |
 | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:27:7:33 | access to parameter strings |
 | VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:44:7:50 | access to parameter strings |
@@ -3160,21 +3383,23 @@ dominance
 | VarDecls.cs:7:44:7:53 | access to array element | VarDecls.cs:7:44:7:53 | (...) ... |
 | VarDecls.cs:7:52:7:52 | 1 | VarDecls.cs:7:44:7:53 | access to array element |
 | VarDecls.cs:8:9:10:9 | {...} | VarDecls.cs:9:27:9:28 | access to local variable c1 |
-| VarDecls.cs:9:13:9:29 | return ...; | VarDecls.cs:5:18:5:19 | exit M1 |
+| VarDecls.cs:9:13:9:29 | return ...; | VarDecls.cs:5:18:5:19 | exit M1 (normal) |
 | VarDecls.cs:9:20:9:28 | (...) ... | VarDecls.cs:9:13:9:29 | return ...; |
 | VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:9:20:9:28 | (...) ... |
 | VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:14:5:17:5 | {...} |
+| VarDecls.cs:13:12:13:13 | exit M2 (normal) | VarDecls.cs:13:12:13:13 | exit M2 |
 | VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:15:9:15:30 | ... ...; |
 | VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:21:15:21 | access to parameter s |
 | VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:29:15:29 | access to parameter s |
 | VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:16:15:21 | String s1 = ... |
 | VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:16:16:16:17 | access to local variable s1 |
 | VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:24:15:29 | String s2 = ... |
-| VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:13:12:13:13 | exit M2 |
+| VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:13:12:13:13 | exit M2 (normal) |
 | VarDecls.cs:16:16:16:17 | access to local variable s1 | VarDecls.cs:16:21:16:22 | access to local variable s2 |
 | VarDecls.cs:16:16:16:22 | ... + ... | VarDecls.cs:16:9:16:23 | return ...; |
 | VarDecls.cs:16:21:16:22 | access to local variable s2 | VarDecls.cs:16:16:16:22 | ... + ... |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:20:5:26:5 | {...} |
+| VarDecls.cs:19:7:19:8 | exit M3 (normal) | VarDecls.cs:19:7:19:8 | exit M3 |
 | VarDecls.cs:20:5:26:5 | {...} | VarDecls.cs:21:9:22:13 | using (...) {...} |
 | VarDecls.cs:21:9:22:13 | using (...) {...} | VarDecls.cs:21:16:21:22 | object creation of type C |
 | VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:22:13:22:13 | ; |
@@ -3184,13 +3409,15 @@ dominance
 | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... |
 | VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
 | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:31:24:41 | C y = ... |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 |
+| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 (normal) |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:24:25:24 | access to local variable x |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:28:25:28 | access to local variable y |
 | VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:20:25:20 | access to parameter b |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:51:28:53 | {...} |
-| VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | exit Dispose |
+| VarDecls.cs:28:41:28:47 | exit Dispose (normal) | VarDecls.cs:28:41:28:47 | exit Dispose |
+| VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | exit Dispose (normal) |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:6:5:35:5 | {...} |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:5:17:5:20 | exit Main |
 | cflow.cs:6:5:35:5 | {...} | cflow.cs:7:9:7:28 | ... ...; |
 | cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:17:7:20 | access to parameter args |
 | cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:9:9:9:40 | ...; |
@@ -3233,7 +3460,7 @@ dominance
 | cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:24:22:24:22 | 1 | cflow.cs:24:18:24:22 | Int32 i = ... |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:30:24:31 | 20 |
-| cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:5:17:5:20 | exit Main |
+| cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:5:17:5:20 | exit Main (normal) |
 | cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:25:9:34:9 | {...} |
 | cflow.cs:24:30:24:31 | 20 | cflow.cs:24:25:24:31 | ... <= ... |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:24:34:24:36 | ...++ |
@@ -3323,9 +3550,12 @@ dominance
 | cflow.cs:63:23:63:33 | ... == ... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
 | cflow.cs:63:23:63:33 | ... == ... | cflow.cs:65:17:65:22 | break; |
 | cflow.cs:63:32:63:33 | "" | cflow.cs:63:23:63:33 | ... == ... |
+| cflow.cs:64:21:64:55 | throw ...; | cflow.cs:37:17:37:22 | exit Switch (abnormal) |
 | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:64:21:64:55 | throw ...; |
+| cflow.cs:67:9:67:17 | return ...; | cflow.cs:37:17:37:22 | exit Switch (normal) |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:67:9:67:17 | return ...; |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:71:5:82:5 | {...} |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | exit M |
 | cflow.cs:71:5:82:5 | {...} | cflow.cs:72:9:73:19 | if (...) ... |
 | cflow.cs:72:9:73:19 | if (...) ... | cflow.cs:72:13:72:13 | access to parameter s |
 | cflow.cs:72:13:72:13 | access to parameter s | cflow.cs:72:18:72:21 | null |
@@ -3345,10 +3575,11 @@ dominance
 | cflow.cs:80:13:80:48 | ...; | cflow.cs:80:31:80:46 | "<empty string>" |
 | cflow.cs:80:31:80:46 | "<empty string>" | cflow.cs:80:13:80:47 | call to method WriteLine |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:85:5:88:5 | {...} |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 |
 | cflow.cs:85:5:88:5 | {...} | cflow.cs:86:9:87:33 | if (...) ... |
 | cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:13:86:37 | ... && ... |
 | cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:18:86:21 | null |
-| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:84:18:84:19 | exit M2 |
+| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:84:18:84:19 | exit M2 (normal) |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:26:86:26 | access to parameter s |
 | cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:13:86:13 | access to parameter s |
 | cflow.cs:86:18:86:21 | null | cflow.cs:86:13:86:21 | ... != ... |
@@ -3365,6 +3596,7 @@ dominance
 | cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:94:9:94:29 | ...; |
 | cflow.cs:92:20:92:20 | access to parameter s | cflow.cs:92:23:92:26 | null |
 | cflow.cs:92:23:92:26 | null | cflow.cs:92:13:92:27 | call to method Equals |
+| cflow.cs:93:13:93:49 | throw ...; | cflow.cs:90:18:90:19 | exit M3 (abnormal) |
 | cflow.cs:93:19:93:48 | object creation of type ArgumentNullException | cflow.cs:93:13:93:49 | throw ...; |
 | cflow.cs:93:45:93:47 | "s" | cflow.cs:93:19:93:48 | object creation of type ArgumentNullException |
 | cflow.cs:94:9:94:28 | call to method WriteLine | cflow.cs:96:9:97:55 | if (...) ... |
@@ -3391,12 +3623,14 @@ dominance
 | cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:102:13:102:16 | this access |
 | cflow.cs:102:13:102:16 | this access | cflow.cs:102:13:102:21 | access to property Prop |
 | cflow.cs:102:13:102:21 | access to property Prop | cflow.cs:102:26:102:29 | null |
+| cflow.cs:102:13:102:29 | ... != ... | cflow.cs:90:18:90:19 | exit M3 (normal) |
 | cflow.cs:102:13:102:29 | ... != ... | cflow.cs:103:13:103:36 | ...; |
 | cflow.cs:102:26:102:29 | null | cflow.cs:102:13:102:29 | ... != ... |
 | cflow.cs:103:13:103:36 | ...; | cflow.cs:103:31:103:34 | this access |
 | cflow.cs:103:31:103:34 | access to property Prop | cflow.cs:103:13:103:35 | call to method WriteLine |
 | cflow.cs:103:31:103:34 | this access | cflow.cs:103:31:103:34 | access to property Prop |
 | cflow.cs:106:18:106:19 | enter M4 | cflow.cs:107:5:117:5 | {...} |
+| cflow.cs:106:18:106:19 | exit M4 (normal) | cflow.cs:106:18:106:19 | exit M4 |
 | cflow.cs:107:5:117:5 | {...} | cflow.cs:108:9:115:9 | if (...) ... |
 | cflow.cs:108:9:115:9 | if (...) ... | cflow.cs:108:13:108:13 | access to parameter s |
 | cflow.cs:108:13:108:13 | access to parameter s | cflow.cs:108:18:108:21 | null |
@@ -3409,10 +3643,11 @@ dominance
 | cflow.cs:111:13:113:13 | {...} | cflow.cs:112:17:112:37 | ...; |
 | cflow.cs:112:17:112:37 | ...; | cflow.cs:112:35:112:35 | access to parameter s |
 | cflow.cs:112:35:112:35 | access to parameter s | cflow.cs:112:17:112:36 | call to method WriteLine |
-| cflow.cs:116:9:116:28 | call to method WriteLine | cflow.cs:106:18:106:19 | exit M4 |
+| cflow.cs:116:9:116:28 | call to method WriteLine | cflow.cs:106:18:106:19 | exit M4 (normal) |
 | cflow.cs:116:9:116:29 | ...; | cflow.cs:116:27:116:27 | access to parameter s |
 | cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:116:9:116:28 | call to method WriteLine |
 | cflow.cs:119:20:119:21 | enter M5 | cflow.cs:120:5:124:5 | {...} |
+| cflow.cs:119:20:119:21 | exit M5 (normal) | cflow.cs:119:20:119:21 | exit M5 |
 | cflow.cs:120:5:124:5 | {...} | cflow.cs:121:9:121:18 | ... ...; |
 | cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:17:121:17 | access to parameter s |
 | cflow.cs:121:13:121:17 | String x = ... | cflow.cs:122:9:122:20 | ...; |
@@ -3422,11 +3657,12 @@ dominance
 | cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:17:122:19 | " " |
 | cflow.cs:122:13:122:19 | ... + ... | cflow.cs:122:9:122:19 | ... = ... |
 | cflow.cs:122:17:122:19 | " " | cflow.cs:122:13:122:19 | ... + ... |
-| cflow.cs:123:9:123:17 | return ...; | cflow.cs:119:20:119:21 | exit M5 |
+| cflow.cs:123:9:123:17 | return ...; | cflow.cs:119:20:119:21 | exit M5 (normal) |
 | cflow.cs:123:16:123:16 | access to local variable x | cflow.cs:123:9:123:17 | return ...; |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:23:127:60 | {...} |
+| cflow.cs:127:19:127:21 | exit get_Prop (normal) | cflow.cs:127:19:127:21 | exit get_Prop |
 | cflow.cs:127:23:127:60 | {...} | cflow.cs:127:32:127:57 | ... ? ... : ... |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop |
+| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop (normal) |
 | cflow.cs:127:32:127:36 | access to field Field | cflow.cs:127:41:127:44 | null |
 | cflow.cs:127:32:127:36 | this access | cflow.cs:127:32:127:36 | access to field Field |
 | cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:48:127:49 | "" |
@@ -3435,47 +3671,55 @@ dominance
 | cflow.cs:127:41:127:44 | null | cflow.cs:127:32:127:44 | ... == ... |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:66:127:83 | {...} |
+| cflow.cs:127:62:127:64 | exit set_Prop (normal) | cflow.cs:127:62:127:64 | exit set_Prop |
 | cflow.cs:127:66:127:83 | {...} | cflow.cs:127:68:127:81 | ...; |
 | cflow.cs:127:68:127:72 | this access | cflow.cs:127:76:127:80 | access to parameter value |
-| cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | exit set_Prop |
+| cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | exit set_Prop (normal) |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:72 | this access |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:80 | ... = ... |
 | cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:130:5:132:5 | {...} |
+| cflow.cs:129:5:129:15 | exit ControlFlow (normal) | cflow.cs:129:5:129:15 | exit ControlFlow |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:18 | ...; |
 | cflow.cs:131:9:131:13 | this access | cflow.cs:131:17:131:17 | access to parameter s |
-| cflow.cs:131:9:131:17 | ... = ... | cflow.cs:129:5:129:15 | exit ControlFlow |
+| cflow.cs:131:9:131:17 | ... = ... | cflow.cs:129:5:129:15 | exit ControlFlow (normal) |
 | cflow.cs:131:9:131:18 | ...; | cflow.cs:131:9:131:13 | this access |
 | cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:131:9:131:17 | ... = ... |
 | cflow.cs:134:5:134:15 | enter ControlFlow | cflow.cs:134:31:134:31 | access to parameter i |
+| cflow.cs:134:5:134:15 | exit ControlFlow (normal) | cflow.cs:134:5:134:15 | exit ControlFlow |
 | cflow.cs:134:26:134:29 | call to constructor ControlFlow | cflow.cs:134:39:134:41 | {...} |
 | cflow.cs:134:31:134:31 | (...) ... | cflow.cs:134:35:134:36 | "" |
 | cflow.cs:134:31:134:31 | access to parameter i | cflow.cs:134:31:134:31 | (...) ... |
 | cflow.cs:134:31:134:36 | ... + ... | cflow.cs:134:26:134:29 | call to constructor ControlFlow |
 | cflow.cs:134:35:134:36 | "" | cflow.cs:134:31:134:36 | ... + ... |
-| cflow.cs:134:39:134:41 | {...} | cflow.cs:134:5:134:15 | exit ControlFlow |
+| cflow.cs:134:39:134:41 | {...} | cflow.cs:134:5:134:15 | exit ControlFlow (normal) |
 | cflow.cs:136:12:136:22 | enter ControlFlow | cflow.cs:136:33:136:33 | 0 |
+| cflow.cs:136:12:136:22 | exit ControlFlow (normal) | cflow.cs:136:12:136:22 | exit ControlFlow |
 | cflow.cs:136:28:136:31 | call to constructor ControlFlow | cflow.cs:136:40:136:42 | {...} |
 | cflow.cs:136:33:136:33 | 0 | cflow.cs:136:37:136:37 | 1 |
 | cflow.cs:136:33:136:37 | ... + ... | cflow.cs:136:28:136:31 | call to constructor ControlFlow |
 | cflow.cs:136:37:136:37 | 1 | cflow.cs:136:33:136:37 | ... + ... |
-| cflow.cs:136:40:136:42 | {...} | cflow.cs:136:12:136:22 | exit ControlFlow |
+| cflow.cs:136:40:136:42 | {...} | cflow.cs:136:12:136:22 | exit ControlFlow (normal) |
 | cflow.cs:138:40:138:40 | enter + | cflow.cs:139:5:142:5 | {...} |
+| cflow.cs:138:40:138:40 | exit + (normal) | cflow.cs:138:40:138:40 | exit + |
 | cflow.cs:139:5:142:5 | {...} | cflow.cs:140:9:140:29 | ...; |
 | cflow.cs:140:9:140:28 | call to method WriteLine | cflow.cs:141:16:141:16 | access to parameter y |
 | cflow.cs:140:9:140:29 | ...; | cflow.cs:140:27:140:27 | access to parameter x |
 | cflow.cs:140:27:140:27 | access to parameter x | cflow.cs:140:9:140:28 | call to method WriteLine |
-| cflow.cs:141:9:141:17 | return ...; | cflow.cs:138:40:138:40 | exit + |
+| cflow.cs:141:9:141:17 | return ...; | cflow.cs:138:40:138:40 | exit + (normal) |
 | cflow.cs:141:16:141:16 | access to parameter y | cflow.cs:141:9:141:17 | return ...; |
 | cflow.cs:144:33:144:35 | enter get_Item | cflow.cs:144:37:144:54 | {...} |
+| cflow.cs:144:33:144:35 | exit get_Item (normal) | cflow.cs:144:33:144:35 | exit get_Item |
 | cflow.cs:144:37:144:54 | {...} | cflow.cs:144:46:144:46 | access to parameter i |
-| cflow.cs:144:39:144:52 | return ...; | cflow.cs:144:33:144:35 | exit get_Item |
+| cflow.cs:144:39:144:52 | return ...; | cflow.cs:144:33:144:35 | exit get_Item (normal) |
 | cflow.cs:144:46:144:46 | (...) ... | cflow.cs:144:50:144:51 | "" |
 | cflow.cs:144:46:144:46 | access to parameter i | cflow.cs:144:46:144:46 | (...) ... |
 | cflow.cs:144:46:144:51 | ... + ... | cflow.cs:144:39:144:52 | return ...; |
 | cflow.cs:144:50:144:51 | "" | cflow.cs:144:46:144:51 | ... + ... |
 | cflow.cs:144:56:144:58 | enter set_Item | cflow.cs:144:60:144:62 | {...} |
-| cflow.cs:144:60:144:62 | {...} | cflow.cs:144:56:144:58 | exit set_Item |
+| cflow.cs:144:56:144:58 | exit set_Item (normal) | cflow.cs:144:56:144:58 | exit set_Item |
+| cflow.cs:144:60:144:62 | {...} | cflow.cs:144:56:144:58 | exit set_Item (normal) |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:147:5:177:5 | {...} |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:146:10:146:12 | exit For |
 | cflow.cs:147:5:177:5 | {...} | cflow.cs:148:9:148:18 | ... ...; |
 | cflow.cs:148:9:148:18 | ... ...; | cflow.cs:148:17:148:17 | 0 |
 | cflow.cs:148:13:148:17 | Int32 x = ... | cflow.cs:149:9:150:33 | for (...;...;...) ... |
@@ -3532,7 +3776,7 @@ dominance
 | cflow.cs:173:29:173:29 | 0 | cflow.cs:173:25:173:29 | Int32 j = ... |
 | cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:173:36:173:36 | access to local variable j |
 | cflow.cs:173:32:173:36 | ... + ... | cflow.cs:173:40:173:41 | 10 |
-| cflow.cs:173:32:173:41 | ... < ... | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:173:32:173:41 | ... < ... | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:173:32:173:41 | ... < ... | cflow.cs:174:9:176:9 | {...} |
 | cflow.cs:173:36:173:36 | access to local variable j | cflow.cs:173:32:173:36 | ... + ... |
 | cflow.cs:173:40:173:41 | 10 | cflow.cs:173:32:173:41 | ... < ... |
@@ -3546,24 +3790,28 @@ dominance
 | cflow.cs:175:31:175:35 | ... + ... | cflow.cs:175:13:175:36 | call to method WriteLine |
 | cflow.cs:175:35:175:35 | access to local variable j | cflow.cs:175:31:175:35 | ... + ... |
 | cflow.cs:179:10:179:16 | enter Lambdas | cflow.cs:180:5:183:5 | {...} |
+| cflow.cs:179:10:179:16 | exit Lambdas (normal) | cflow.cs:179:10:179:16 | exit Lambdas |
 | cflow.cs:180:5:183:5 | {...} | cflow.cs:181:9:181:38 | ... ...; |
 | cflow.cs:181:9:181:38 | ... ...; | cflow.cs:181:28:181:37 | (...) => ... |
 | cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... | cflow.cs:182:9:182:62 | ... ...; |
 | cflow.cs:181:28:181:37 | (...) => ... | cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... |
 | cflow.cs:181:28:181:37 | enter (...) => ... | cflow.cs:181:33:181:33 | access to parameter x |
+| cflow.cs:181:28:181:37 | exit (...) => ... (normal) | cflow.cs:181:28:181:37 | exit (...) => ... |
 | cflow.cs:181:33:181:33 | access to parameter x | cflow.cs:181:37:181:37 | 1 |
-| cflow.cs:181:33:181:37 | ... + ... | cflow.cs:181:28:181:37 | exit (...) => ... |
+| cflow.cs:181:33:181:37 | ... + ... | cflow.cs:181:28:181:37 | exit (...) => ... (normal) |
 | cflow.cs:181:37:181:37 | 1 | cflow.cs:181:33:181:37 | ... + ... |
 | cflow.cs:182:9:182:62 | ... ...; | cflow.cs:182:28:182:61 | delegate(...) { ... } |
-| cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... | cflow.cs:179:10:179:16 | exit Lambdas |
+| cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... | cflow.cs:179:10:179:16 | exit Lambdas (normal) |
 | cflow.cs:182:28:182:61 | delegate(...) { ... } | cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... |
 | cflow.cs:182:28:182:61 | enter delegate(...) { ... } | cflow.cs:182:45:182:61 | {...} |
+| cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) | cflow.cs:182:28:182:61 | exit delegate(...) { ... } |
 | cflow.cs:182:45:182:61 | {...} | cflow.cs:182:54:182:54 | access to parameter x |
-| cflow.cs:182:47:182:59 | return ...; | cflow.cs:182:28:182:61 | exit delegate(...) { ... } |
+| cflow.cs:182:47:182:59 | return ...; | cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) |
 | cflow.cs:182:54:182:54 | access to parameter x | cflow.cs:182:58:182:58 | 1 |
 | cflow.cs:182:54:182:58 | ... + ... | cflow.cs:182:47:182:59 | return ...; |
 | cflow.cs:182:58:182:58 | 1 | cflow.cs:182:54:182:58 | ... + ... |
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:186:5:191:5 | {...} |
+| cflow.cs:185:10:185:18 | exit LogicalOr (normal) | cflow.cs:185:10:185:18 | exit LogicalOr |
 | cflow.cs:186:5:191:5 | {...} | cflow.cs:187:9:190:52 | if (...) ... |
 | cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:187:13:187:50 | ... \|\| ... |
 | cflow.cs:187:13:187:13 | 1 | cflow.cs:187:18:187:18 | 2 |
@@ -3578,7 +3826,7 @@ dominance
 | cflow.cs:187:34:187:39 | ... == ... | cflow.cs:190:13:190:52 | ...; |
 | cflow.cs:187:34:187:49 | ... && ... | cflow.cs:187:34:187:34 | 1 |
 | cflow.cs:187:39:187:39 | 3 | cflow.cs:187:34:187:39 | ... == ... |
-| cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:185:10:185:18 | exit LogicalOr |
+| cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:185:10:185:18 | exit LogicalOr (normal) |
 | cflow.cs:190:13:190:52 | ...; | cflow.cs:190:31:190:50 | "This should happen" |
 | cflow.cs:190:31:190:50 | "This should happen" | cflow.cs:190:13:190:51 | call to method WriteLine |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:194:5:206:5 | {...} |
@@ -3629,13 +3877,16 @@ dominance
 | cflow.cs:200:40:200:44 | access to field Field | cflow.cs:200:40:200:51 | access to property Length |
 | cflow.cs:200:40:200:44 | this access | cflow.cs:200:40:200:44 | access to field Field |
 | cflow.cs:200:40:200:51 | access to property Length | cflow.cs:200:56:200:56 | 1 |
+| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:193:10:193:17 | exit Booleans (normal) |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:61:200:61 | access to local variable b |
 | cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:40:200:44 | this access |
 | cflow.cs:200:56:200:56 | 1 | cflow.cs:200:40:200:56 | ... == ... |
 | cflow.cs:201:9:205:9 | {...} | cflow.cs:202:13:204:13 | {...} |
 | cflow.cs:202:13:204:13 | {...} | cflow.cs:203:23:203:37 | object creation of type Exception |
+| cflow.cs:203:17:203:38 | throw ...; | cflow.cs:193:10:193:17 | exit Booleans (abnormal) |
 | cflow.cs:203:23:203:37 | object creation of type Exception | cflow.cs:203:17:203:38 | throw ...; |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:209:5:222:5 | {...} |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | exit Do |
 | cflow.cs:209:5:222:5 | {...} | cflow.cs:210:9:221:36 | do ... while (...); |
 | cflow.cs:210:9:221:36 | do ... while (...); | cflow.cs:211:9:221:9 | {...} |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:212:13:212:25 | ...; |
@@ -3666,8 +3917,9 @@ dominance
 | cflow.cs:221:18:221:29 | access to property Length | cflow.cs:221:33:221:34 | 10 |
 | cflow.cs:221:33:221:34 | 10 | cflow.cs:221:18:221:34 | ... < ... |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:225:5:238:5 | {...} |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:224:10:224:16 | exit Foreach |
 | cflow.cs:225:5:238:5 | {...} | cflow.cs:226:57:226:59 | "a" |
-| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | exit Foreach |
+| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | exit Foreach (normal) |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:226:22:226:22 | String x |
 | cflow.cs:226:22:226:22 | String x | cflow.cs:227:9:237:9 | {...} |
 | cflow.cs:226:27:226:64 | call to method Repeat | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... |
@@ -3697,6 +3949,7 @@ dominance
 | cflow.cs:233:32:233:32 | 0 | cflow.cs:233:17:233:32 | ... < ... |
 | cflow.cs:234:13:236:13 | {...} | cflow.cs:235:17:235:22 | break; |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:241:5:259:5 | {...} |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto |
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:242:9:242:13 | Label: |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:16:242:45 | if (...) ... |
 | cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:20:242:40 | !... |
@@ -3737,6 +3990,7 @@ dominance
 | cflow.cs:256:17:256:37 | ...; | cflow.cs:256:35:256:35 | 0 |
 | cflow.cs:256:35:256:35 | 0 | cflow.cs:256:17:256:36 | call to method WriteLine |
 | cflow.cs:261:49:261:53 | enter Yield | cflow.cs:262:5:277:5 | {...} |
+| cflow.cs:261:49:261:53 | exit Yield (normal) | cflow.cs:261:49:261:53 | exit Yield |
 | cflow.cs:262:5:277:5 | {...} | cflow.cs:263:22:263:22 | 0 |
 | cflow.cs:263:9:263:23 | yield return ...; | cflow.cs:264:9:267:9 | for (...;...;...) ... |
 | cflow.cs:263:22:263:22 | 0 | cflow.cs:263:9:263:23 | yield return ...; |
@@ -3755,29 +4009,35 @@ dominance
 | cflow.cs:269:9:272:9 | {...} | cflow.cs:270:13:270:24 | yield break; |
 | cflow.cs:270:13:270:24 | yield break; | cflow.cs:274:9:276:9 | [finally: return] {...} |
 | cflow.cs:274:9:276:9 | [finally: return] {...} | cflow.cs:275:13:275:42 | [finally: return] ...; |
-| cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine | cflow.cs:261:49:261:53 | exit Yield |
+| cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine | cflow.cs:261:49:261:53 | exit Yield (normal) |
 | cflow.cs:275:13:275:42 | [finally: return] ...; | cflow.cs:275:31:275:40 | [finally: return] "not dead" |
 | cflow.cs:275:31:275:40 | [finally: return] "not dead" | cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine |
 | cflow.cs:282:5:282:18 | enter ControlFlowSub | cflow.cs:282:24:282:27 | call to constructor ControlFlow |
+| cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) | cflow.cs:282:5:282:18 | exit ControlFlowSub |
 | cflow.cs:282:24:282:27 | call to constructor ControlFlow | cflow.cs:282:31:282:33 | {...} |
-| cflow.cs:282:31:282:33 | {...} | cflow.cs:282:5:282:18 | exit ControlFlowSub |
+| cflow.cs:282:31:282:33 | {...} | cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) |
 | cflow.cs:284:5:284:18 | enter ControlFlowSub | cflow.cs:284:32:284:35 | call to constructor ControlFlowSub |
+| cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) | cflow.cs:284:5:284:18 | exit ControlFlowSub |
 | cflow.cs:284:32:284:35 | call to constructor ControlFlowSub | cflow.cs:284:39:284:41 | {...} |
-| cflow.cs:284:39:284:41 | {...} | cflow.cs:284:5:284:18 | exit ControlFlowSub |
+| cflow.cs:284:39:284:41 | {...} | cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) |
 | cflow.cs:286:5:286:18 | enter ControlFlowSub | cflow.cs:286:34:286:34 | access to parameter i |
+| cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) | cflow.cs:286:5:286:18 | exit ControlFlowSub |
 | cflow.cs:286:29:286:32 | call to constructor ControlFlowSub | cflow.cs:286:48:286:50 | {...} |
 | cflow.cs:286:34:286:34 | access to parameter i | cflow.cs:286:34:286:45 | call to method ToString |
 | cflow.cs:286:34:286:45 | call to method ToString | cflow.cs:286:29:286:32 | call to constructor ControlFlowSub |
-| cflow.cs:286:48:286:50 | {...} | cflow.cs:286:5:286:18 | exit ControlFlowSub |
+| cflow.cs:286:48:286:50 | {...} | cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) |
 | cflow.cs:291:12:291:12 | enter M | cflow.cs:291:38:291:38 | access to parameter f |
+| cflow.cs:291:12:291:12 | exit M (normal) | cflow.cs:291:12:291:12 | exit M |
 | cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:40:291:40 | 0 |
-| cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:12:291:12 | exit M |
+| cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:12:291:12 | exit M (normal) |
 | cflow.cs:291:40:291:40 | 0 | cflow.cs:291:38:291:41 | delegate call |
 | cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:52:296:54 | {...} |
-| cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | exit NegationInConstructor |
+| cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | cflow.cs:296:5:296:25 | exit NegationInConstructor |
+| cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:299:5:301:5 | {...} |
+| cflow.cs:298:10:298:10 | exit M (normal) | cflow.cs:298:10:298:10 | exit M |
 | cflow.cs:299:5:301:5 | {...} | cflow.cs:300:9:300:73 | ...; |
-| cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:298:10:298:10 | exit M |
+| cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:298:10:298:10 | exit M (normal) |
 | cflow.cs:300:9:300:73 | ...; | cflow.cs:300:38:300:38 | 0 |
 | cflow.cs:300:38:300:38 | 0 | cflow.cs:300:44:300:64 | ... && ... |
 | cflow.cs:300:44:300:51 | !... | cflow.cs:300:46:300:46 | access to parameter i |
@@ -3790,15 +4050,20 @@ dominance
 | cflow.cs:300:61:300:64 | null | cflow.cs:300:56:300:64 | ... != ... |
 | cflow.cs:300:70:300:71 | "" | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor |
 postDominance
-| AccessorCalls.cs:5:23:5:25 | exit get_Item | AccessorCalls.cs:5:30:5:30 | access to parameter i |
+| AccessorCalls.cs:5:23:5:25 | exit get_Item | AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) |
+| AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) | AccessorCalls.cs:5:30:5:30 | access to parameter i |
 | AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | enter get_Item |
-| AccessorCalls.cs:5:33:5:35 | exit set_Item | AccessorCalls.cs:5:37:5:39 | {...} |
+| AccessorCalls.cs:5:33:5:35 | exit set_Item | AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) |
+| AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) | AccessorCalls.cs:5:37:5:39 | {...} |
 | AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | enter set_Item |
-| AccessorCalls.cs:7:32:7:34 | exit add_Event | AccessorCalls.cs:7:36:7:38 | {...} |
+| AccessorCalls.cs:7:32:7:34 | exit add_Event | AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) |
+| AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) | AccessorCalls.cs:7:36:7:38 | {...} |
 | AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | enter add_Event |
-| AccessorCalls.cs:7:40:7:45 | exit remove_Event | AccessorCalls.cs:7:47:7:49 | {...} |
+| AccessorCalls.cs:7:40:7:45 | exit remove_Event | AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) |
+| AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) | AccessorCalls.cs:7:47:7:49 | {...} |
 | AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | enter remove_Event |
-| AccessorCalls.cs:10:10:10:11 | exit M1 | AccessorCalls.cs:16:9:16:23 | ... -= ... |
+| AccessorCalls.cs:10:10:10:11 | exit M1 | AccessorCalls.cs:10:10:10:11 | exit M1 (normal) |
+| AccessorCalls.cs:10:10:10:11 | exit M1 (normal) | AccessorCalls.cs:16:9:16:23 | ... -= ... |
 | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:10:10:10:11 | enter M1 |
 | AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:32 | ...; |
 | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:12:22:12:31 | access to field Field |
@@ -3829,7 +4094,8 @@ postDominance
 | AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:16:9:16:18 | access to event Event |
 | AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:15:9:15:23 | ... += ... |
 | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:12 | this access |
-| AccessorCalls.cs:19:10:19:11 | exit M2 | AccessorCalls.cs:25:9:25:25 | ... -= ... |
+| AccessorCalls.cs:19:10:19:11 | exit M2 | AccessorCalls.cs:19:10:19:11 | exit M2 (normal) |
+| AccessorCalls.cs:19:10:19:11 | exit M2 (normal) | AccessorCalls.cs:25:9:25:25 | ... -= ... |
 | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:19:10:19:11 | enter M2 |
 | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:36 | ...; |
 | AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:12 | this access |
@@ -3868,7 +4134,8 @@ postDominance
 | AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:25:9:25:20 | access to event Event |
 | AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:24:9:24:25 | ... += ... |
 | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:14 | access to field x |
-| AccessorCalls.cs:28:10:28:11 | exit M3 | AccessorCalls.cs:32:9:32:17 | ...++ |
+| AccessorCalls.cs:28:10:28:11 | exit M3 | AccessorCalls.cs:28:10:28:11 | exit M3 (normal) |
+| AccessorCalls.cs:28:10:28:11 | exit M3 (normal) | AccessorCalls.cs:32:9:32:17 | ...++ |
 | AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:28:10:28:11 | enter M3 |
 | AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:21 | ...; |
 | AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:12 | this access |
@@ -3883,7 +4150,8 @@ postDominance
 | AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:32:9:32:15 | access to indexer |
 | AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:31:9:31:19 | ...++ |
 | AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:9:32:12 | this access |
-| AccessorCalls.cs:35:10:35:11 | exit M4 | AccessorCalls.cs:39:9:39:19 | ...++ |
+| AccessorCalls.cs:35:10:35:11 | exit M4 | AccessorCalls.cs:35:10:35:11 | exit M4 (normal) |
+| AccessorCalls.cs:35:10:35:11 | exit M4 (normal) | AccessorCalls.cs:39:9:39:19 | ...++ |
 | AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:35:10:35:11 | enter M4 |
 | AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:23 | ...; |
 | AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:12 | this access |
@@ -3901,7 +4169,8 @@ postDominance
 | AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:39:9:39:17 | access to indexer |
 | AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:38:9:38:21 | ...++ |
 | AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:14 | access to field x |
-| AccessorCalls.cs:42:10:42:11 | exit M5 | AccessorCalls.cs:46:9:46:26 | ... = ... |
+| AccessorCalls.cs:42:10:42:11 | exit M5 | AccessorCalls.cs:42:10:42:11 | exit M5 (normal) |
+| AccessorCalls.cs:42:10:42:11 | exit M5 (normal) | AccessorCalls.cs:46:9:46:26 | ... = ... |
 | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:42:10:42:11 | enter M5 |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:33 | ...; |
@@ -3932,7 +4201,8 @@ postDominance
 | AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:9:46:15 | access to indexer |
 | AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:25:46:25 | 0 |
 | AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:20:46:23 | this access |
-| AccessorCalls.cs:49:10:49:11 | exit M6 | AccessorCalls.cs:53:9:53:30 | ... = ... |
+| AccessorCalls.cs:49:10:49:11 | exit M6 | AccessorCalls.cs:49:10:49:11 | exit M6 (normal) |
+| AccessorCalls.cs:49:10:49:11 | exit M6 (normal) | AccessorCalls.cs:53:9:53:30 | ... = ... |
 | AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:49:10:49:11 | enter M6 |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:37 | ...; |
@@ -3972,7 +4242,8 @@ postDominance
 | AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:22:53:25 | this access |
 | AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:29:53:29 | 0 |
 | AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:22:53:27 | access to field x |
-| AccessorCalls.cs:56:10:56:11 | exit M7 | AccessorCalls.cs:58:9:58:85 | ... = ... |
+| AccessorCalls.cs:56:10:56:11 | exit M7 | AccessorCalls.cs:56:10:56:11 | exit M7 (normal) |
+| AccessorCalls.cs:56:10:56:11 | exit M7 (normal) | AccessorCalls.cs:58:9:58:85 | ... = ... |
 | AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:56:10:56:11 | enter M7 |
 | AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:33:58:44 | (..., ...) |
 | AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:58:37:58:43 | access to indexer |
@@ -3994,7 +4265,8 @@ postDominance
 | AccessorCalls.cs:58:77:58:80 | this access | AccessorCalls.cs:58:74:58:74 | 0 |
 | AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:82:58:82 | 1 |
 | AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:77:58:80 | this access |
-| AccessorCalls.cs:61:10:61:11 | exit M8 | AccessorCalls.cs:63:9:63:97 | ... = ... |
+| AccessorCalls.cs:61:10:61:11 | exit M8 | AccessorCalls.cs:61:10:61:11 | exit M8 (normal) |
+| AccessorCalls.cs:61:10:61:11 | exit M8 (normal) | AccessorCalls.cs:63:9:63:97 | ... = ... |
 | AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:61:10:61:11 | enter M8 |
 | AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:37:63:50 | (..., ...) |
 | AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:63:41:63:49 | access to indexer |
@@ -4022,7 +4294,8 @@ postDominance
 | AccessorCalls.cs:63:87:63:92 | access to field x | AccessorCalls.cs:63:87:63:90 | this access |
 | AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:94:63:94 | 1 |
 | AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:87:63:92 | access to field x |
-| AccessorCalls.cs:66:10:66:11 | exit M9 | AccessorCalls.cs:73:9:73:83 | ... = ... |
+| AccessorCalls.cs:66:10:66:11 | exit M9 | AccessorCalls.cs:66:10:66:11 | exit M9 (normal) |
+| AccessorCalls.cs:66:10:66:11 | exit M9 (normal) | AccessorCalls.cs:73:9:73:83 | ... = ... |
 | AccessorCalls.cs:67:5:74:5 | {...} | AccessorCalls.cs:66:10:66:11 | enter M9 |
 | AccessorCalls.cs:68:9:68:22 | ... ...; | AccessorCalls.cs:67:5:74:5 | {...} |
 | AccessorCalls.cs:68:17:68:21 | dynamic d = ... | AccessorCalls.cs:68:21:68:21 | access to parameter o |
@@ -4078,20 +4351,24 @@ postDominance
 | AccessorCalls.cs:73:78:73:78 | access to local variable d | AccessorCalls.cs:73:75:73:75 | 0 |
 | AccessorCalls.cs:73:78:73:81 | dynamic access to element | AccessorCalls.cs:73:80:73:80 | 1 |
 | AccessorCalls.cs:73:80:73:80 | 1 | AccessorCalls.cs:73:78:73:78 | access to local variable d |
-| ArrayCreation.cs:3:11:3:12 | exit M1 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] |
+| ArrayCreation.cs:3:11:3:12 | exit M1 | ArrayCreation.cs:3:11:3:12 | exit M1 (normal) |
+| ArrayCreation.cs:3:11:3:12 | exit M1 (normal) | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] |
 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:27:3:27 | 0 |
 | ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:11:3:12 | enter M1 |
-| ArrayCreation.cs:5:12:5:13 | exit M2 | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] |
+| ArrayCreation.cs:5:12:5:13 | exit M2 | ArrayCreation.cs:5:12:5:13 | exit M2 (normal) |
+| ArrayCreation.cs:5:12:5:13 | exit M2 (normal) | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] |
 | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | ArrayCreation.cs:5:31:5:31 | 1 |
 | ArrayCreation.cs:5:28:5:28 | 0 | ArrayCreation.cs:5:12:5:13 | enter M2 |
 | ArrayCreation.cs:5:31:5:31 | 1 | ArrayCreation.cs:5:28:5:28 | 0 |
-| ArrayCreation.cs:7:11:7:12 | exit M3 | ArrayCreation.cs:7:29:7:36 | { ..., ... } |
+| ArrayCreation.cs:7:11:7:12 | exit M3 | ArrayCreation.cs:7:11:7:12 | exit M3 (normal) |
+| ArrayCreation.cs:7:11:7:12 | exit M3 (normal) | ArrayCreation.cs:7:29:7:36 | { ..., ... } |
 | ArrayCreation.cs:7:19:7:36 | 2 | ArrayCreation.cs:7:11:7:12 | enter M3 |
 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] | ArrayCreation.cs:7:19:7:36 | 2 |
 | ArrayCreation.cs:7:29:7:36 | { ..., ... } | ArrayCreation.cs:7:34:7:34 | 1 |
 | ArrayCreation.cs:7:31:7:31 | 0 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] |
 | ArrayCreation.cs:7:34:7:34 | 1 | ArrayCreation.cs:7:31:7:31 | 0 |
-| ArrayCreation.cs:9:12:9:13 | exit M4 | ArrayCreation.cs:9:31:9:52 | { ..., ... } |
+| ArrayCreation.cs:9:12:9:13 | exit M4 | ArrayCreation.cs:9:12:9:13 | exit M4 (normal) |
+| ArrayCreation.cs:9:12:9:13 | exit M4 (normal) | ArrayCreation.cs:9:31:9:52 | { ..., ... } |
 | ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:12:9:13 | enter M4 |
 | ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:20:9:52 | 2 |
 | ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] | ArrayCreation.cs:9:20:9:52 | 2 |
@@ -4102,14 +4379,15 @@ postDominance
 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:48:9:48 | 3 |
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:33:9:40 | { ..., ... } |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:45:9:45 | 2 |
-| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
-| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:11:9:11:35 | call to method WriteLine |
+| Assert.cs:7:10:7:11 | exit M1 (abnormal) | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
+| Assert.cs:7:10:7:11 | exit M1 (normal) | Assert.cs:11:9:11:35 | call to method WriteLine |
 | Assert.cs:8:5:12:5 | {...} | Assert.cs:7:10:7:11 | enter M1 |
 | Assert.cs:9:9:9:33 | ... ...; | Assert.cs:8:5:12:5 | {...} |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:20:9:32 | ... ? ... : ... |
 | Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:9:9:33 | ... ...; |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:10:22:10:30 | ... != ... |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:9:16:9:32 | String s = ... |
 | Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:9:10:32 | ...; |
 | Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:27:10:30 | null |
@@ -4118,42 +4396,45 @@ postDominance
 | Assert.cs:11:9:11:36 | ...; | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:9:11:36 | ...; |
 | Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:27:11:27 | access to local variable s |
-| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
-| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:18:9:18:35 | call to method WriteLine |
+| Assert.cs:14:10:14:11 | exit M2 (abnormal) | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
+| Assert.cs:14:10:14:11 | exit M2 (normal) | Assert.cs:18:9:18:35 | call to method WriteLine |
 | Assert.cs:15:5:19:5 | {...} | Assert.cs:14:10:14:11 | enter M2 |
 | Assert.cs:16:9:16:33 | ... ...; | Assert.cs:15:5:19:5 | {...} |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:20:16:32 | ... ? ... : ... |
 | Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:9:16:33 | ... ...; |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:17:23:17:23 | access to local variable s |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:16:16:16:32 | String s = ... |
 | Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:25 | ...; |
 | Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:18:27:18:34 | access to property Length |
 | Assert.cs:18:9:18:36 | ...; | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:9:18:36 | ...; |
 | Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:27:18:27 | access to local variable s |
-| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
-| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:25:9:25:35 | call to method WriteLine |
+| Assert.cs:21:10:21:11 | exit M3 (abnormal) | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
+| Assert.cs:21:10:21:11 | exit M3 (normal) | Assert.cs:25:9:25:35 | call to method WriteLine |
 | Assert.cs:22:5:26:5 | {...} | Assert.cs:21:10:21:11 | enter M3 |
 | Assert.cs:23:9:23:33 | ... ...; | Assert.cs:22:5:26:5 | {...} |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:20:23:32 | ... ? ... : ... |
 | Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:9:23:33 | ... ...; |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:24:26:24:26 | access to local variable s |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:23:16:23:32 | String s = ... |
 | Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:28 | ...; |
 | Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:25:27:25:34 | access to property Length |
 | Assert.cs:25:9:25:36 | ...; | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:9:25:36 | ...; |
 | Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:27:25:27 | access to local variable s |
-| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
-| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:32:9:32:35 | call to method WriteLine |
+| Assert.cs:28:10:28:11 | exit M4 (abnormal) | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:28:10:28:11 | exit M4 (normal) | Assert.cs:32:9:32:35 | call to method WriteLine |
 | Assert.cs:29:5:33:5 | {...} | Assert.cs:28:10:28:11 | enter M4 |
 | Assert.cs:30:9:30:33 | ... ...; | Assert.cs:29:5:33:5 | {...} |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:20:30:32 | ... ? ... : ... |
 | Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:9:30:33 | ... ...; |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:31:23:31:31 | ... == ... |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:30:16:30:32 | String s = ... |
 | Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:9:31:33 | ...; |
 | Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:28:31:31 | null |
@@ -4162,14 +4443,15 @@ postDominance
 | Assert.cs:32:9:32:36 | ...; | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:9:32:36 | ...; |
 | Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:27:32:27 | access to local variable s |
-| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
-| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:39:9:39:35 | call to method WriteLine |
+| Assert.cs:35:10:35:11 | exit M5 (abnormal) | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:35:10:35:11 | exit M5 (normal) | Assert.cs:39:9:39:35 | call to method WriteLine |
 | Assert.cs:36:5:40:5 | {...} | Assert.cs:35:10:35:11 | enter M5 |
 | Assert.cs:37:9:37:33 | ... ...; | Assert.cs:36:5:40:5 | {...} |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:20:37:32 | ... ? ... : ... |
 | Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:9:37:33 | ... ...; |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:38:23:38:31 | ... != ... |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:37:16:37:32 | String s = ... |
 | Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:9:38:33 | ...; |
 | Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:28:38:31 | null |
@@ -4178,14 +4460,15 @@ postDominance
 | Assert.cs:39:9:39:36 | ...; | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:9:39:36 | ...; |
 | Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:27:39:27 | access to local variable s |
-| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
-| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:46:9:46:35 | call to method WriteLine |
+| Assert.cs:42:10:42:11 | exit M6 (abnormal) | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:42:10:42:11 | exit M6 (normal) | Assert.cs:46:9:46:35 | call to method WriteLine |
 | Assert.cs:43:5:47:5 | {...} | Assert.cs:42:10:42:11 | enter M6 |
 | Assert.cs:44:9:44:33 | ... ...; | Assert.cs:43:5:47:5 | {...} |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:20:44:32 | ... ? ... : ... |
 | Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:9:44:33 | ... ...; |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:45:24:45:32 | ... != ... |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:44:16:44:32 | String s = ... |
 | Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:9:45:34 | ...; |
 | Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:29:45:32 | null |
@@ -4194,14 +4477,15 @@ postDominance
 | Assert.cs:46:9:46:36 | ...; | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:9:46:36 | ...; |
 | Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:27:46:27 | access to local variable s |
-| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
-| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:53:9:53:35 | call to method WriteLine |
+| Assert.cs:49:10:49:11 | exit M7 (abnormal) | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:49:10:49:11 | exit M7 (normal) | Assert.cs:53:9:53:35 | call to method WriteLine |
 | Assert.cs:50:5:54:5 | {...} | Assert.cs:49:10:49:11 | enter M7 |
 | Assert.cs:51:9:51:33 | ... ...; | Assert.cs:50:5:54:5 | {...} |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:20:51:32 | ... ? ... : ... |
 | Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:9:51:33 | ... ...; |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:52:24:52:32 | ... == ... |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:51:16:51:32 | String s = ... |
 | Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:9:52:34 | ...; |
 | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:29:52:32 | null |
@@ -4210,16 +4494,15 @@ postDominance
 | Assert.cs:53:9:53:36 | ...; | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:9:53:36 | ...; |
 | Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:27:53:27 | access to local variable s |
-| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
-| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:60:9:60:35 | call to method WriteLine |
+| Assert.cs:56:10:56:11 | exit M8 (abnormal) | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:56:10:56:11 | exit M8 (normal) | Assert.cs:60:9:60:35 | call to method WriteLine |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:56:10:56:11 | enter M8 |
 | Assert.cs:58:9:58:33 | ... ...; | Assert.cs:57:5:61:5 | {...} |
 | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
 | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:58:24:58:27 | [b (line 56): true] null |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:32 | ... ? ... : ... |
 | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:9:58:33 | ... ...; |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:20:58:20 | access to parameter b |
 | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
 | Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... |
 | Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... |
@@ -4231,20 +4514,20 @@ postDominance
 | Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | Assert.cs:59:9:59:38 | [b (line 56): true] ...; |
 | Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s |
 | Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... |
 | Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:60:27:60:34 | access to property Length |
 | Assert.cs:60:9:60:36 | ...; | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue |
 | Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:9:60:36 | ...; |
 | Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:27:60:27 | access to local variable s |
-| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
-| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:67:9:67:35 | call to method WriteLine |
+| Assert.cs:63:10:63:11 | exit M9 (abnormal) | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:63:10:63:11 | exit M9 (normal) | Assert.cs:67:9:67:35 | call to method WriteLine |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:63:10:63:11 | enter M9 |
 | Assert.cs:65:9:65:33 | ... ...; | Assert.cs:64:5:68:5 | {...} |
 | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
 | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:65:24:65:27 | [b (line 63): true] null |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... |
 | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:9:65:33 | ... ...; |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:20:65:20 | access to parameter b |
 | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
 | Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... |
 | Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... |
@@ -4256,20 +4539,20 @@ postDominance
 | Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | Assert.cs:66:9:66:39 | [b (line 63): true] ...; |
 | Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s |
 | Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... |
 | Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:67:27:67:34 | access to property Length |
 | Assert.cs:67:9:67:36 | ...; | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse |
 | Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:9:67:36 | ...; |
 | Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:27:67:27 | access to local variable s |
-| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
-| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:74:9:74:35 | call to method WriteLine |
+| Assert.cs:70:10:70:12 | exit M10 (abnormal) | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:70:10:70:12 | exit M10 (normal) | Assert.cs:74:9:74:35 | call to method WriteLine |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:70:10:70:12 | enter M10 |
 | Assert.cs:72:9:72:33 | ... ...; | Assert.cs:71:5:75:5 | {...} |
 | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
 | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:72:24:72:27 | [b (line 70): true] null |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... |
 | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:9:72:33 | ... ...; |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:20:72:20 | access to parameter b |
 | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
 | Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... |
 | Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... |
@@ -4281,20 +4564,20 @@ postDominance
 | Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | Assert.cs:73:9:73:38 | [b (line 70): true] ...; |
 | Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s |
 | Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... |
 | Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:74:27:74:34 | access to property Length |
 | Assert.cs:74:9:74:36 | ...; | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue |
 | Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:9:74:36 | ...; |
 | Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:27:74:27 | access to local variable s |
-| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
-| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:81:9:81:35 | call to method WriteLine |
+| Assert.cs:77:10:77:12 | exit M11 (abnormal) | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:77:10:77:12 | exit M11 (normal) | Assert.cs:81:9:81:35 | call to method WriteLine |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:77:10:77:12 | enter M11 |
 | Assert.cs:79:9:79:33 | ... ...; | Assert.cs:78:5:82:5 | {...} |
 | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
 | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:79:24:79:27 | [b (line 77): true] null |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... |
 | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:9:79:33 | ... ...; |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:20:79:20 | access to parameter b |
 | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
 | Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... |
 | Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... |
@@ -4306,36 +4589,20 @@ postDominance
 | Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | Assert.cs:80:9:80:39 | [b (line 77): true] ...; |
 | Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s |
 | Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... |
 | Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:81:27:81:34 | access to property Length |
 | Assert.cs:81:9:81:36 | ...; | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse |
 | Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:9:81:36 | ...; |
 | Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:27:81:27 | access to local variable s |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:128:9:128:35 | call to method WriteLine |
+| Assert.cs:84:10:84:12 | exit M12 (normal) | Assert.cs:128:9:128:35 | call to method WriteLine |
 | Assert.cs:85:5:129:5 | {...} | Assert.cs:84:10:84:12 | enter M12 |
 | Assert.cs:86:9:86:33 | ... ...; | Assert.cs:85:5:129:5 | {...} |
 | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
 | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:20:86:32 | ... ? ... : ... |
 | Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:9:86:33 | ... ...; |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:20:86:20 | access to parameter b |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... |
 | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... |
 | Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... |
 | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:87:9:87:32 | [b (line 84): false] ...; |
@@ -4362,6 +4629,7 @@ postDominance
 | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:9:90:26 | [b (line 84): true] ...; |
 | Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... |
 | Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... |
 | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:25 | [b (line 84): false] ...; |
@@ -4384,6 +4652,7 @@ postDominance
 | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:9:94:26 | [b (line 84): true] ...; |
 | Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s |
 | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... |
 | Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... |
 | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:28 | [b (line 84): false] ...; |
@@ -4406,6 +4675,7 @@ postDominance
 | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:9:98:26 | [b (line 84): true] ...; |
 | Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... |
 | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... |
 | Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... |
 | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:99:9:99:33 | [b (line 84): false] ...; |
@@ -4432,6 +4702,7 @@ postDominance
 | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:9:102:26 | [b (line 84): true] ...; |
 | Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... |
 | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... |
 | Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... |
 | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:103:9:103:33 | [b (line 84): false] ...; |
@@ -4458,6 +4729,7 @@ postDominance
 | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:9:106:26 | [b (line 84): true] ...; |
 | Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... |
 | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... |
 | Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... |
 | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:107:9:107:34 | [b (line 84): false] ...; |
@@ -4484,6 +4756,7 @@ postDominance
 | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:9:110:26 | [b (line 84): true] ...; |
 | Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... |
 | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... |
 | Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... |
 | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:111:9:111:34 | [b (line 84): false] ...; |
@@ -4510,8 +4783,6 @@ postDominance
 | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:9:114:26 | [b (line 84): true] ...; |
 | Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
 | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... |
 | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... |
@@ -4523,6 +4794,7 @@ postDominance
 | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:115:9:115:38 | [b (line 84): true] ...; |
 | Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s |
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... |
 | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length |
 | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:9:116:36 | [b (line 84): true] ...; |
@@ -4538,6 +4810,7 @@ postDominance
 | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:29:119:32 | [b (line 84): true] null |
 | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... |
 | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length |
 | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse |
@@ -4554,6 +4827,7 @@ postDominance
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:28:123:31 | [b (line 84): true] null |
 | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length |
 | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:9:124:36 | [b (line 84): true] ...; |
@@ -4569,16 +4843,16 @@ postDominance
 | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:29:127:32 | [b (line 84): true] null |
 | Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | Assert.cs:127:9:127:40 | [b (line 84): true] ...; |
 | Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... |
 | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:128:27:128:34 | access to property Length |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:9:128:36 | ...; |
 | Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:27:128:27 | access to local variable s |
-| Assert.cs:131:18:131:32 | exit AssertTrueFalse | Assert.cs:135:5:136:5 | {...} |
+| Assert.cs:131:18:131:32 | exit AssertTrueFalse | Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) |
+| Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) | Assert.cs:135:5:136:5 | {...} |
 | Assert.cs:135:5:136:5 | {...} | Assert.cs:131:18:131:32 | enter AssertTrueFalse |
-| Assert.cs:138:10:138:12 | exit M13 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse |
-| Assert.cs:138:10:138:12 | exit M13 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse |
-| Assert.cs:138:10:138:12 | exit M13 | Assert.cs:141:9:141:15 | return ...; |
+| Assert.cs:138:10:138:12 | exit M13 (normal) | Assert.cs:141:9:141:15 | return ...; |
 | Assert.cs:139:5:142:5 | {...} | Assert.cs:138:10:138:12 | enter M13 |
 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 |
 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 |
@@ -4586,9 +4860,12 @@ postDominance
 | Assert.cs:140:9:140:35 | this access | Assert.cs:140:9:140:36 | ...; |
 | Assert.cs:140:9:140:36 | ...; | Assert.cs:139:5:142:5 | {...} |
 | Assert.cs:140:25:140:26 | access to parameter b1 | Assert.cs:140:9:140:35 | this access |
+| Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:140:25:140:26 | access to parameter b1 |
 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 |
+| Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | Assert.cs:140:29:140:30 | access to parameter b2 |
 | Assert.cs:141:9:141:15 | return ...; | Assert.cs:140:9:140:35 | [assertion success] call to method AssertTrueFalse |
-| Assignments.cs:3:10:3:10 | exit M | Assignments.cs:14:9:14:35 | ... += ... |
+| Assignments.cs:3:10:3:10 | exit M | Assignments.cs:3:10:3:10 | exit M (normal) |
+| Assignments.cs:3:10:3:10 | exit M (normal) | Assignments.cs:14:9:14:35 | ... += ... |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:3:10:3:10 | enter M |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:4:5:15:5 | {...} |
 | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:5:17:5:17 | 0 |
@@ -4620,14 +4897,17 @@ postDominance
 | Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:14:9:14:13 | access to event Event |
 | Assignments.cs:14:9:14:36 | ...; | Assignments.cs:12:9:12:17 | ... = ... |
 | Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:13 | this access |
-| Assignments.cs:14:18:14:35 | exit (...) => ... | Assignments.cs:14:33:14:35 | {...} |
+| Assignments.cs:14:18:14:35 | exit (...) => ... | Assignments.cs:14:18:14:35 | exit (...) => ... (normal) |
+| Assignments.cs:14:18:14:35 | exit (...) => ... (normal) | Assignments.cs:14:33:14:35 | {...} |
 | Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | enter (...) => ... |
-| Assignments.cs:17:40:17:40 | exit + | Assignments.cs:19:9:19:17 | return ...; |
+| Assignments.cs:17:40:17:40 | exit + | Assignments.cs:17:40:17:40 | exit + (normal) |
+| Assignments.cs:17:40:17:40 | exit + (normal) | Assignments.cs:19:9:19:17 | return ...; |
 | Assignments.cs:18:5:20:5 | {...} | Assignments.cs:17:40:17:40 | enter + |
 | Assignments.cs:19:9:19:17 | return ...; | Assignments.cs:19:16:19:16 | access to parameter x |
 | Assignments.cs:19:16:19:16 | access to parameter x | Assignments.cs:18:5:20:5 | {...} |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:15:17:15:28 | ... == ... |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:16:17:16:17 | ; |
+| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:3:10:3:11 | exit M1 (normal) |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:15:17:15:28 | ... == ... |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:16:17:16:17 | ; |
 | BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:3:10:3:11 | enter M1 |
 | BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:4:5:18:5 | {...} |
 | BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:5:9:17:9 | try {...} ... |
@@ -4644,7 +4924,8 @@ postDominance
 | BreakInTry.cs:15:17:15:20 | access to parameter args | BreakInTry.cs:15:13:16:17 | if (...) ... |
 | BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:15:25:15:28 | null |
 | BreakInTry.cs:15:25:15:28 | null | BreakInTry.cs:15:17:15:20 | access to parameter args |
-| BreakInTry.cs:20:10:20:11 | exit M2 | BreakInTry.cs:35:7:35:7 | ; |
+| BreakInTry.cs:20:10:20:11 | exit M2 | BreakInTry.cs:20:10:20:11 | exit M2 (normal) |
+| BreakInTry.cs:20:10:20:11 | exit M2 (normal) | BreakInTry.cs:35:7:35:7 | ; |
 | BreakInTry.cs:21:5:36:5 | {...} | BreakInTry.cs:20:10:20:11 | enter M2 |
 | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:22:29:22:32 | access to parameter args |
 | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:31:21:31:32 | ... == ... |
@@ -4669,9 +4950,10 @@ postDominance
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... |
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... |
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:53:7:53:7 | ; |
+| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | exit M3 (normal) |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:53:7:53:7 | ; |
 | BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:38:10:38:11 | enter M3 |
 | BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:39:5:54:5 | {...} |
 | BreakInTry.cs:41:9:44:9 | {...} | BreakInTry.cs:40:9:52:9 | try {...} ... |
@@ -4696,10 +4978,11 @@ postDominance
 | BreakInTry.cs:49:28:49:31 | null | BreakInTry.cs:49:21:49:23 | access to local variable arg |
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:50:21:50:26 | break; |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:68:21:68:26 | break; |
+| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:56:10:56:11 | exit M4 (normal) |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:68:21:68:26 | break; |
 | BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:56:10:56:11 | enter M4 |
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:57:5:71:5 | {...} |
 | BreakInTry.cs:59:9:62:9 | {...} | BreakInTry.cs:58:9:70:9 | try {...} ... |
@@ -4722,23 +5005,28 @@ postDominance
 | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:67:28:67:31 | [finally: return] null |
 | BreakInTry.cs:67:28:67:31 | [finally: return] null | BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg |
 | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:23 | access to local variable arg |
-| CompileTimeOperators.cs:5:9:5:15 | exit Default | CompileTimeOperators.cs:7:9:7:28 | return ...; |
+| CompileTimeOperators.cs:5:9:5:15 | exit Default | CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) |
+| CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) | CompileTimeOperators.cs:7:9:7:28 | return ...; |
 | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:5:9:5:15 | enter Default |
 | CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:7:16:7:27 | default(...) |
 | CompileTimeOperators.cs:7:16:7:27 | default(...) | CompileTimeOperators.cs:6:5:8:5 | {...} |
-| CompileTimeOperators.cs:10:9:10:14 | exit Sizeof | CompileTimeOperators.cs:12:9:12:27 | return ...; |
+| CompileTimeOperators.cs:10:9:10:14 | exit Sizeof | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) |
+| CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) | CompileTimeOperators.cs:12:9:12:27 | return ...; |
 | CompileTimeOperators.cs:11:5:13:5 | {...} | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof |
 | CompileTimeOperators.cs:12:9:12:27 | return ...; | CompileTimeOperators.cs:12:16:12:26 | sizeof(..) |
 | CompileTimeOperators.cs:12:16:12:26 | sizeof(..) | CompileTimeOperators.cs:11:5:13:5 | {...} |
-| CompileTimeOperators.cs:15:10:15:15 | exit Typeof | CompileTimeOperators.cs:17:9:17:27 | return ...; |
+| CompileTimeOperators.cs:15:10:15:15 | exit Typeof | CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) |
+| CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) | CompileTimeOperators.cs:17:9:17:27 | return ...; |
 | CompileTimeOperators.cs:16:5:18:5 | {...} | CompileTimeOperators.cs:15:10:15:15 | enter Typeof |
 | CompileTimeOperators.cs:17:9:17:27 | return ...; | CompileTimeOperators.cs:17:16:17:26 | typeof(...) |
 | CompileTimeOperators.cs:17:16:17:26 | typeof(...) | CompileTimeOperators.cs:16:5:18:5 | {...} |
-| CompileTimeOperators.cs:20:12:20:17 | exit Nameof | CompileTimeOperators.cs:22:9:22:25 | return ...; |
+| CompileTimeOperators.cs:20:12:20:17 | exit Nameof | CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) |
+| CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) | CompileTimeOperators.cs:22:9:22:25 | return ...; |
 | CompileTimeOperators.cs:21:5:23:5 | {...} | CompileTimeOperators.cs:20:12:20:17 | enter Nameof |
 | CompileTimeOperators.cs:22:9:22:25 | return ...; | CompileTimeOperators.cs:22:16:22:24 | nameof(...) |
 | CompileTimeOperators.cs:22:16:22:24 | nameof(...) | CompileTimeOperators.cs:21:5:23:5 | {...} |
-| CompileTimeOperators.cs:28:10:28:10 | exit M | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine |
+| CompileTimeOperators.cs:28:10:28:10 | exit M | CompileTimeOperators.cs:28:10:28:10 | exit M (normal) |
+| CompileTimeOperators.cs:28:10:28:10 | exit M (normal) | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine |
 | CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:28:10:28:10 | enter M |
 | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:29:5:41:5 | {...} |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:30:9:38:9 | try {...} ... |
@@ -4751,25 +5039,31 @@ postDominance
 | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:40:32:40:36 | "End" |
 | CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:9:40:11 | End: |
 | CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:40:14:40:38 | ...; |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:30:28:30:32 | ... = ... |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:30:28:30:32 | ... = ... |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:26:3:26 | access to parameter i |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:28:3:38 | call to method ToString |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:40:3:49 | call to method ToLower |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:30:28:30:32 | ... = ... |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:30:28:30:32 | ... = ... |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:26:3:26 | access to parameter i |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:28:3:38 | call to method ToString |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:40:3:49 | call to method ToLower |
 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:12:3:13 | enter M1 |
-| ConditionalAccess.cs:5:10:5:11 | exit M2 | ConditionalAccess.cs:5:26:5:26 | access to parameter s |
-| ConditionalAccess.cs:5:10:5:11 | exit M2 | ConditionalAccess.cs:5:28:5:34 | access to property Length |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:26:5:26 | access to parameter s |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:28:5:34 | access to property Length |
 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | enter M2 |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:49:7:55 | access to property Length |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:49:7:55 | access to property Length |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:10:7:11 | enter M3 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:27:9:33 | access to property Length |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:38:9:38 | 0 |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:27:9:33 | access to property Length |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:38:9:38 | 0 |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |
 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:9:9:10 | enter M4 |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:14:13:14:21 | return ...; |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:16:13:16:21 | return ...; |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:14:13:14:21 | return ...; |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:16:13:16:21 | return ...; |
 | ConditionalAccess.cs:12:5:17:5 | {...} | ConditionalAccess.cs:11:9:11:10 | enter M5 |
 | ConditionalAccess.cs:13:9:16:21 | if (...) ... | ConditionalAccess.cs:12:5:17:5 | {...} |
 | ConditionalAccess.cs:13:13:13:13 | access to parameter s | ConditionalAccess.cs:13:9:16:21 | if (...) ... |
@@ -4779,11 +5073,13 @@ postDominance
 | ConditionalAccess.cs:13:25:13:25 | (...) ... | ConditionalAccess.cs:13:25:13:25 | 0 |
 | ConditionalAccess.cs:14:13:14:21 | return ...; | ConditionalAccess.cs:14:20:14:20 | 0 |
 | ConditionalAccess.cs:16:13:16:21 | return ...; | ConditionalAccess.cs:16:20:16:20 | 1 |
-| ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 |
-| ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith |
 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:12:19:13 | enter M6 |
 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 |
-| ConditionalAccess.cs:21:10:21:11 | exit M7 | ConditionalAccess.cs:25:9:25:32 | ... = ... |
+| ConditionalAccess.cs:21:10:21:11 | exit M7 | ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) |
+| ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) | ConditionalAccess.cs:25:9:25:32 | ... = ... |
 | ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:21:10:21:11 | enter M7 |
 | ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:22:5:26:5 | {...} |
 | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:23:18:23:29 | (...) ... |
@@ -4799,13 +5095,15 @@ postDominance
 | ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:9:25:33 | ...; |
 | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | ConditionalAccess.cs:25:31:25:31 | access to local variable s |
 | ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:13:25:14 | "" |
-| ConditionalAccess.cs:30:10:30:12 | exit Out | ConditionalAccess.cs:30:28:30:32 | ... = ... |
+| ConditionalAccess.cs:30:10:30:12 | exit Out | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
+| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:28:30:32 | ... = ... |
 | ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:32:30:32 | 0 |
 | ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:32:30:32 | 0 |
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess |
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:10:30:12 | enter Out |
-| ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:35:9:35:12 | access to property Prop |
-| ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:35:14:35:24 | call to method Out |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:35:9:35:12 | access to property Prop |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:35:14:35:24 | call to method Out |
 | ConditionalAccess.cs:33:5:36:5 | {...} | ConditionalAccess.cs:32:10:32:11 | enter M8 |
 | ConditionalAccess.cs:34:9:34:13 | ... = ... | ConditionalAccess.cs:34:13:34:13 | 0 |
 | ConditionalAccess.cs:34:9:34:14 | ...; | ConditionalAccess.cs:33:5:36:5 | {...} |
@@ -4813,14 +5111,16 @@ postDominance
 | ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:35:9:35:12 | this access |
 | ConditionalAccess.cs:35:9:35:12 | this access | ConditionalAccess.cs:35:9:35:25 | ...; |
 | ConditionalAccess.cs:35:9:35:25 | ...; | ConditionalAccess.cs:34:9:34:13 | ... = ... |
-| ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith | ConditionalAccess.cs:41:70:41:83 | ... + ... |
+| ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) |
+| ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) | ConditionalAccess.cs:41:70:41:83 | ... + ... |
 | ConditionalAccess.cs:41:70:41:71 | access to parameter s1 | ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith |
 | ConditionalAccess.cs:41:70:41:78 | ... + ... | ConditionalAccess.cs:41:75:41:78 | ", " |
 | ConditionalAccess.cs:41:70:41:83 | ... + ... | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 |
 | ConditionalAccess.cs:41:75:41:78 | ", " | ConditionalAccess.cs:41:70:41:71 | access to parameter s1 |
 | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | ConditionalAccess.cs:41:70:41:78 | ... + ... |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:8:13:8:15 | ...-- |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:8:13:8:15 | ...-- |
 | Conditions.cs:4:5:9:5 | {...} | Conditions.cs:3:10:3:19 | enter IncrOrDecr |
 | Conditions.cs:5:9:6:16 | if (...) ... | Conditions.cs:4:5:9:5 | {...} |
 | Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:5:9:6:16 | if (...) ... |
@@ -4834,7 +5134,8 @@ postDominance
 | Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:16 | ...; |
 | Conditions.cs:8:13:8:15 | ...-- | Conditions.cs:8:13:8:13 | access to parameter x |
 | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc |
-| Conditions.cs:11:9:11:10 | exit M1 | Conditions.cs:19:9:19:17 | return ...; |
+| Conditions.cs:11:9:11:10 | exit M1 | Conditions.cs:11:9:11:10 | exit M1 (normal) |
+| Conditions.cs:11:9:11:10 | exit M1 (normal) | Conditions.cs:19:9:19:17 | return ...; |
 | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:11:9:11:10 | enter M1 |
 | Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:12:5:20:5 | {...} |
 | Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:13:17:13:17 | 0 |
@@ -4862,7 +5163,8 @@ postDominance
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... |
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b |
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:18:17:18:19 | ...-- |
-| Conditions.cs:22:9:22:10 | exit M2 | Conditions.cs:30:9:30:17 | return ...; |
+| Conditions.cs:22:9:22:10 | exit M2 | Conditions.cs:22:9:22:10 | exit M2 (normal) |
+| Conditions.cs:22:9:22:10 | exit M2 (normal) | Conditions.cs:30:9:30:17 | return ...; |
 | Conditions.cs:23:5:31:5 | {...} | Conditions.cs:22:9:22:10 | enter M2 |
 | Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:23:5:31:5 | {...} |
 | Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:24:17:24:17 | 0 |
@@ -4883,7 +5185,8 @@ postDominance
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:28:13:28:14 | [b2 (line 22): false] access to parameter b2 |
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:28:13:28:14 | access to parameter b2 |
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:29:13:29:15 | ...++ |
-| Conditions.cs:33:9:33:10 | exit M3 | Conditions.cs:43:9:43:17 | return ...; |
+| Conditions.cs:33:9:33:10 | exit M3 | Conditions.cs:33:9:33:10 | exit M3 (normal) |
+| Conditions.cs:33:9:33:10 | exit M3 (normal) | Conditions.cs:43:9:43:17 | return ...; |
 | Conditions.cs:34:5:44:5 | {...} | Conditions.cs:33:9:33:10 | enter M3 |
 | Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:34:5:44:5 | {...} |
 | Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:35:17:35:17 | 0 |
@@ -4909,7 +5212,8 @@ postDominance
 | Conditions.cs:43:9:43:17 | return ...; | Conditions.cs:43:16:43:16 | access to local variable x |
 | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:41:13:41:14 | [b2 (line 39): false] access to local variable b2 |
 | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:42:13:42:15 | ...++ |
-| Conditions.cs:46:9:46:10 | exit M4 | Conditions.cs:54:9:54:17 | return ...; |
+| Conditions.cs:46:9:46:10 | exit M4 | Conditions.cs:46:9:46:10 | exit M4 (normal) |
+| Conditions.cs:46:9:46:10 | exit M4 (normal) | Conditions.cs:54:9:54:17 | return ...; |
 | Conditions.cs:47:5:55:5 | {...} | Conditions.cs:46:9:46:10 | enter M4 |
 | Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:47:5:55:5 | {...} |
 | Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:48:17:48:17 | 0 |
@@ -4940,7 +5244,8 @@ postDominance
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:49:16:49:22 | ... > ... |
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:49:16:49:22 | [b (line 46): false] ... > ... |
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:49:16:49:22 | [b (line 46): true] ... > ... |
-| Conditions.cs:57:9:57:10 | exit M5 | Conditions.cs:67:9:67:17 | return ...; |
+| Conditions.cs:57:9:57:10 | exit M5 | Conditions.cs:57:9:57:10 | exit M5 (normal) |
+| Conditions.cs:57:9:57:10 | exit M5 (normal) | Conditions.cs:67:9:67:17 | return ...; |
 | Conditions.cs:58:5:68:5 | {...} | Conditions.cs:57:9:57:10 | enter M5 |
 | Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:58:5:68:5 | {...} |
 | Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:59:17:59:17 | 0 |
@@ -4979,7 +5284,8 @@ postDominance
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:65:13:65:13 | [b (line 57): false] access to parameter b |
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:65:13:65:13 | access to parameter b |
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:66:13:66:15 | ...++ |
-| Conditions.cs:70:9:70:10 | exit M6 | Conditions.cs:83:9:83:17 | return ...; |
+| Conditions.cs:70:9:70:10 | exit M6 | Conditions.cs:70:9:70:10 | exit M6 (normal) |
+| Conditions.cs:70:9:70:10 | exit M6 (normal) | Conditions.cs:83:9:83:17 | return ...; |
 | Conditions.cs:71:5:84:5 | {...} | Conditions.cs:70:9:70:10 | enter M6 |
 | Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:71:5:84:5 | {...} |
 | Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:72:17:72:29 | ... > ... |
@@ -5013,7 +5319,8 @@ postDominance
 | Conditions.cs:83:9:83:17 | return ...; | Conditions.cs:83:16:83:16 | access to local variable x |
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:81:13:81:13 | access to local variable b |
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:82:13:82:15 | ...++ |
-| Conditions.cs:86:9:86:10 | exit M7 | Conditions.cs:99:9:99:17 | return ...; |
+| Conditions.cs:86:9:86:10 | exit M7 | Conditions.cs:86:9:86:10 | exit M7 (normal) |
+| Conditions.cs:86:9:86:10 | exit M7 (normal) | Conditions.cs:99:9:99:17 | return ...; |
 | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:86:9:86:10 | enter M7 |
 | Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:87:5:100:5 | {...} |
 | Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:88:17:88:29 | ... > ... |
@@ -5047,7 +5354,8 @@ postDominance
 | Conditions.cs:97:17:97:19 | ...++ | Conditions.cs:97:17:97:17 | access to local variable x |
 | Conditions.cs:99:9:99:17 | return ...; | Conditions.cs:99:16:99:16 | access to local variable x |
 | Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... |
-| Conditions.cs:102:12:102:13 | exit M8 | Conditions.cs:110:9:110:17 | return ...; |
+| Conditions.cs:102:12:102:13 | exit M8 | Conditions.cs:102:12:102:13 | exit M8 (normal) |
+| Conditions.cs:102:12:102:13 | exit M8 (normal) | Conditions.cs:110:9:110:17 | return ...; |
 | Conditions.cs:103:5:111:5 | {...} | Conditions.cs:102:12:102:13 | enter M8 |
 | Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:103:5:111:5 | {...} |
 | Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:104:17:104:28 | call to method ToString |
@@ -5082,7 +5390,8 @@ postDominance
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:109:17:109:23 | ... = ... |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:116:25:116:39 | ... < ... |
+| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | exit M9 (normal) |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:116:25:116:39 | ... < ... |
 | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:113:10:113:11 | enter M9 |
 | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:114:5:124:5 | {...} |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:115:20:115:23 | null |
@@ -5152,8 +5461,9 @@ postDominance
 | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; |
 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
-| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:147:13:147:48 | call to method WriteLine |
-| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:149:13:149:48 | call to method WriteLine |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | exit M11 (normal) |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:147:13:147:48 | call to method WriteLine |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:149:13:149:48 | call to method WriteLine |
 | Conditions.cs:144:5:150:5 | {...} | Conditions.cs:143:10:143:12 | enter M11 |
 | Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:144:5:150:5 | {...} |
 | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
@@ -5174,35 +5484,41 @@ postDominance
 | Conditions.cs:149:38:149:47 | $"..." | Conditions.cs:149:45:149:45 | access to local variable s |
 | Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:149:13:149:49 | ...; |
 | Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:149:40:149:43 | "b = " |
-| ExitMethods.cs:7:10:7:11 | exit M1 | ExitMethods.cs:10:9:10:15 | return ...; |
+| ExitMethods.cs:7:10:7:11 | exit M1 | ExitMethods.cs:7:10:7:11 | exit M1 (normal) |
+| ExitMethods.cs:7:10:7:11 | exit M1 (normal) | ExitMethods.cs:10:9:10:15 | return ...; |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:7:10:7:11 | enter M1 |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:9:20:9:23 | true |
 | ExitMethods.cs:9:9:9:25 | ...; | ExitMethods.cs:8:5:11:5 | {...} |
 | ExitMethods.cs:9:20:9:23 | true | ExitMethods.cs:9:9:9:25 | ...; |
 | ExitMethods.cs:10:9:10:15 | return ...; | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe |
-| ExitMethods.cs:13:10:13:11 | exit M2 | ExitMethods.cs:16:9:16:15 | return ...; |
+| ExitMethods.cs:13:10:13:11 | exit M2 | ExitMethods.cs:13:10:13:11 | exit M2 (normal) |
+| ExitMethods.cs:13:10:13:11 | exit M2 (normal) | ExitMethods.cs:16:9:16:15 | return ...; |
 | ExitMethods.cs:14:5:17:5 | {...} | ExitMethods.cs:13:10:13:11 | enter M2 |
 | ExitMethods.cs:15:9:15:25 | call to method ErrorMaybe | ExitMethods.cs:15:20:15:24 | false |
 | ExitMethods.cs:15:9:15:26 | ...; | ExitMethods.cs:14:5:17:5 | {...} |
 | ExitMethods.cs:15:20:15:24 | false | ExitMethods.cs:15:9:15:26 | ...; |
 | ExitMethods.cs:16:9:16:15 | return ...; | ExitMethods.cs:15:9:15:25 | call to method ErrorMaybe |
-| ExitMethods.cs:19:10:19:11 | exit M3 | ExitMethods.cs:21:9:21:25 | call to method ErrorAlways |
+| ExitMethods.cs:19:10:19:11 | exit M3 | ExitMethods.cs:19:10:19:11 | exit M3 (abnormal) |
+| ExitMethods.cs:19:10:19:11 | exit M3 (abnormal) | ExitMethods.cs:21:9:21:25 | call to method ErrorAlways |
 | ExitMethods.cs:20:5:23:5 | {...} | ExitMethods.cs:19:10:19:11 | enter M3 |
 | ExitMethods.cs:21:9:21:25 | call to method ErrorAlways | ExitMethods.cs:21:21:21:24 | true |
 | ExitMethods.cs:21:9:21:26 | ...; | ExitMethods.cs:20:5:23:5 | {...} |
 | ExitMethods.cs:21:21:21:24 | true | ExitMethods.cs:21:9:21:26 | ...; |
-| ExitMethods.cs:25:10:25:11 | exit M4 | ExitMethods.cs:27:9:27:14 | call to method Exit |
+| ExitMethods.cs:25:10:25:11 | exit M4 | ExitMethods.cs:25:10:25:11 | exit M4 (abnormal) |
+| ExitMethods.cs:25:10:25:11 | exit M4 (abnormal) | ExitMethods.cs:27:9:27:14 | call to method Exit |
 | ExitMethods.cs:26:5:29:5 | {...} | ExitMethods.cs:25:10:25:11 | enter M4 |
 | ExitMethods.cs:27:9:27:14 | call to method Exit | ExitMethods.cs:27:9:27:14 | this access |
 | ExitMethods.cs:27:9:27:14 | this access | ExitMethods.cs:27:9:27:15 | ...; |
 | ExitMethods.cs:27:9:27:15 | ...; | ExitMethods.cs:26:5:29:5 | {...} |
-| ExitMethods.cs:31:10:31:11 | exit M5 | ExitMethods.cs:33:9:33:25 | call to method ApplicationExit |
+| ExitMethods.cs:31:10:31:11 | exit M5 | ExitMethods.cs:31:10:31:11 | exit M5 (abnormal) |
+| ExitMethods.cs:31:10:31:11 | exit M5 (abnormal) | ExitMethods.cs:33:9:33:25 | call to method ApplicationExit |
 | ExitMethods.cs:32:5:35:5 | {...} | ExitMethods.cs:31:10:31:11 | enter M5 |
 | ExitMethods.cs:33:9:33:25 | call to method ApplicationExit | ExitMethods.cs:33:9:33:25 | this access |
 | ExitMethods.cs:33:9:33:25 | this access | ExitMethods.cs:33:9:33:26 | ...; |
 | ExitMethods.cs:33:9:33:26 | ...; | ExitMethods.cs:32:5:35:5 | {...} |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:45:13:45:19 | return ...; |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:49:13:49:19 | return ...; |
+| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:37:10:37:11 | exit M6 (normal) |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:45:13:45:19 | return ...; |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:49:13:49:19 | return ...; |
 | ExitMethods.cs:38:5:51:5 | {...} | ExitMethods.cs:37:10:37:11 | enter M6 |
 | ExitMethods.cs:39:9:50:9 | try {...} ... | ExitMethods.cs:38:5:51:5 | {...} |
 | ExitMethods.cs:40:9:42:9 | {...} | ExitMethods.cs:39:9:50:9 | try {...} ... |
@@ -5213,53 +5529,59 @@ postDominance
 | ExitMethods.cs:45:13:45:19 | return ...; | ExitMethods.cs:44:9:46:9 | {...} |
 | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} |
 | ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:48:9:50:9 | {...} |
-| ExitMethods.cs:53:10:53:11 | exit M7 | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 |
+| ExitMethods.cs:53:10:53:11 | exit M7 | ExitMethods.cs:53:10:53:11 | exit M7 (abnormal) |
+| ExitMethods.cs:53:10:53:11 | exit M7 (abnormal) | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 |
 | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:53:10:53:11 | enter M7 |
 | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:55:9:55:23 | ...; |
 | ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:54:5:57:5 | {...} |
-| ExitMethods.cs:59:10:59:11 | exit M8 | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 |
+| ExitMethods.cs:59:10:59:11 | exit M8 | ExitMethods.cs:59:10:59:11 | exit M8 (abnormal) |
+| ExitMethods.cs:59:10:59:11 | exit M8 (abnormal) | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 |
 | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:59:10:59:11 | enter M8 |
 | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:61:9:61:23 | ...; |
 | ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:60:5:63:5 | {...} |
-| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:67:13:67:13 | access to parameter b |
-| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:68:13:68:34 | throw ...; |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (abnormal) | ExitMethods.cs:68:13:68:34 | throw ...; |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | ExitMethods.cs:67:13:67:13 | access to parameter b |
 | ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe |
 | ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:66:5:69:5 | {...} |
 | ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:67:9:68:34 | if (...) ... |
 | ExitMethods.cs:68:13:68:34 | throw ...; | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
-| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:74:13:74:34 | throw ...; |
-| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:76:13:76:45 | throw ...; |
+| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) |
 | ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:71:17:71:27 | enter ErrorAlways |
 | ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:72:5:77:5 | {...} |
 | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:73:9:76:45 | if (...) ... |
 | ExitMethods.cs:74:13:74:34 | throw ...; | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
 | ExitMethods.cs:76:13:76:45 | throw ...; | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException |
 | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | ExitMethods.cs:76:41:76:43 | "b" |
-| ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 | ExitMethods.cs:81:9:81:30 | throw ...; |
+| ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 (abnormal) |
+| ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 (abnormal) | ExitMethods.cs:81:9:81:30 | throw ...; |
 | ExitMethods.cs:80:5:82:5 | {...} | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 |
 | ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:81:15:81:29 | object creation of type Exception |
 | ExitMethods.cs:81:15:81:29 | object creation of type Exception | ExitMethods.cs:80:5:82:5 | {...} |
-| ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 | ExitMethods.cs:84:35:84:55 | throw ... |
+| ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 (abnormal) |
+| ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 (abnormal) | ExitMethods.cs:84:35:84:55 | throw ... |
 | ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:41:84:55 | object creation of type Exception |
 | ExitMethods.cs:84:41:84:55 | object creation of type Exception | ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 |
-| ExitMethods.cs:86:10:86:13 | exit Exit | ExitMethods.cs:88:9:88:27 | call to method Exit |
+| ExitMethods.cs:86:10:86:13 | exit Exit | ExitMethods.cs:86:10:86:13 | exit Exit (abnormal) |
+| ExitMethods.cs:86:10:86:13 | exit Exit (abnormal) | ExitMethods.cs:88:9:88:27 | call to method Exit |
 | ExitMethods.cs:87:5:89:5 | {...} | ExitMethods.cs:86:10:86:13 | enter Exit |
 | ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:88:26:88:26 | 0 |
 | ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:87:5:89:5 | {...} |
 | ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:9:88:28 | ...; |
-| ExitMethods.cs:91:10:91:18 | exit ExitInTry | ExitMethods.cs:95:13:95:18 | call to method Exit |
+| ExitMethods.cs:91:10:91:18 | exit ExitInTry | ExitMethods.cs:91:10:91:18 | exit ExitInTry (abnormal) |
+| ExitMethods.cs:91:10:91:18 | exit ExitInTry (abnormal) | ExitMethods.cs:95:13:95:18 | call to method Exit |
 | ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:91:10:91:18 | enter ExitInTry |
 | ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:92:5:102:5 | {...} |
 | ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:93:9:101:9 | try {...} ... |
 | ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:95:13:95:18 | this access |
 | ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:19 | ...; |
 | ExitMethods.cs:95:13:95:19 | ...; | ExitMethods.cs:94:9:96:9 | {...} |
-| ExitMethods.cs:104:10:104:24 | exit ApplicationExit | ExitMethods.cs:106:9:106:47 | call to method Exit |
+| ExitMethods.cs:104:10:104:24 | exit ApplicationExit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit (abnormal) |
+| ExitMethods.cs:104:10:104:24 | exit ApplicationExit (abnormal) | ExitMethods.cs:106:9:106:47 | call to method Exit |
 | ExitMethods.cs:105:5:107:5 | {...} | ExitMethods.cs:104:10:104:24 | enter ApplicationExit |
 | ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:106:9:106:48 | ...; |
 | ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:105:5:107:5 | {...} |
-| ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:111:9:111:77 | return ...; |
-| ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:111:41:111:76 | throw ... |
+| ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) | ExitMethods.cs:111:41:111:76 | throw ... |
+| ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) | ExitMethods.cs:111:9:111:77 | return ...; |
 | ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:109:13:109:21 | enter ThrowExpr |
 | ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:111:29:111:37 | ... / ... |
 | ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
@@ -5267,12 +5589,14 @@ postDominance
 | ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:110:5:112:5 | {...} |
 | ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:16:111:20 | access to parameter input |
 | ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:25:111:25 | 0 |
+| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:16:111:25 | ... != ... |
 | ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:29:111:29 | 1 |
 | ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:33:111:37 | access to parameter input |
 | ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:29:111:29 | (...) ... |
 | ExitMethods.cs:111:41:111:76 | throw ... | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException |
 | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:69:111:75 | "input" |
-| ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | ExitMethods.cs:116:9:116:39 | return ...; |
+| ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) |
+| ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) | ExitMethods.cs:116:9:116:39 | return ...; |
 | ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
 | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:34:116:34 | 0 |
 | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:38:116:38 | 1 |
@@ -5280,40 +5604,48 @@ postDominance
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:27:116:29 | - |
 | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:115:5:117:5 | {...} |
 | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:16 | access to parameter s |
-| ExitMethods.cs:119:17:119:32 | exit FailingAssertion | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue |
+| ExitMethods.cs:119:17:119:32 | exit FailingAssertion | ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) |
+| ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue |
 | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:119:17:119:32 | enter FailingAssertion |
 | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:121:23:121:27 | false |
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:120:5:123:5 | {...} |
 | ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:29 | ...; |
-| ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion |
+| ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 (abnormal) |
+| ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 (abnormal) | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion |
 | ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 |
 | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:127:9:127:26 | this access |
 | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:27 | ...; |
 | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:126:5:129:5 | {...} |
-| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
-| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse (abnormal) | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse (normal) | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:48:131:48 | access to parameter b |
 | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
-| ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse |
+| ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 (abnormal) |
+| ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 (abnormal) | ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse |
 | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 |
 | ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:135:21:135:24 | true |
 | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:9:135:26 | ...; |
 | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:134:5:137:5 | {...} |
 | ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | this access |
-| Extensions.cs:5:23:5:29 | exit ToInt32 | Extensions.cs:7:9:7:30 | return ...; |
+| Extensions.cs:5:23:5:29 | exit ToInt32 | Extensions.cs:5:23:5:29 | exit ToInt32 (normal) |
+| Extensions.cs:5:23:5:29 | exit ToInt32 (normal) | Extensions.cs:7:9:7:30 | return ...; |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:5:23:5:29 | enter ToInt32 |
 | Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:7:16:7:29 | call to method Parse |
 | Extensions.cs:7:16:7:29 | call to method Parse | Extensions.cs:7:28:7:28 | access to parameter s |
 | Extensions.cs:7:28:7:28 | access to parameter s | Extensions.cs:6:5:8:5 | {...} |
-| Extensions.cs:10:24:10:29 | exit ToBool | Extensions.cs:12:9:12:20 | return ...; |
+| Extensions.cs:10:24:10:29 | exit ToBool | Extensions.cs:10:24:10:29 | exit ToBool (normal) |
+| Extensions.cs:10:24:10:29 | exit ToBool (normal) | Extensions.cs:12:9:12:20 | return ...; |
 | Extensions.cs:11:5:13:5 | {...} | Extensions.cs:10:24:10:29 | enter ToBool |
 | Extensions.cs:12:9:12:20 | return ...; | Extensions.cs:12:16:12:19 | delegate call |
 | Extensions.cs:12:16:12:16 | access to parameter f | Extensions.cs:11:5:13:5 | {...} |
 | Extensions.cs:12:16:12:19 | delegate call | Extensions.cs:12:18:12:18 | access to parameter s |
 | Extensions.cs:12:18:12:18 | access to parameter s | Extensions.cs:12:16:12:16 | access to parameter f |
-| Extensions.cs:15:23:15:33 | exit CallToInt32 | Extensions.cs:15:40:15:51 | call to method ToInt32 |
+| Extensions.cs:15:23:15:33 | exit CallToInt32 | Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) |
+| Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) | Extensions.cs:15:40:15:51 | call to method ToInt32 |
 | Extensions.cs:15:40:15:51 | call to method ToInt32 | Extensions.cs:15:48:15:50 | "0" |
 | Extensions.cs:15:48:15:50 | "0" | Extensions.cs:15:23:15:33 | enter CallToInt32 |
-| Extensions.cs:20:17:20:20 | exit Main | Extensions.cs:25:9:25:33 | call to method ToBool |
+| Extensions.cs:20:17:20:20 | exit Main | Extensions.cs:20:17:20:20 | exit Main (normal) |
+| Extensions.cs:20:17:20:20 | exit Main (normal) | Extensions.cs:25:9:25:33 | call to method ToBool |
 | Extensions.cs:21:5:26:5 | {...} | Extensions.cs:20:17:20:20 | enter Main |
 | Extensions.cs:22:9:22:9 | access to parameter s | Extensions.cs:22:9:22:20 | ...; |
 | Extensions.cs:22:9:22:19 | call to method ToInt32 | Extensions.cs:22:9:22:9 | access to parameter s |
@@ -5331,14 +5663,14 @@ postDominance
 | Extensions.cs:25:9:25:34 | ...; | Extensions.cs:24:9:24:45 | call to method ToBool |
 | Extensions.cs:25:23:25:32 | access to method Parse | Extensions.cs:25:9:25:14 | "true" |
 | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | Extensions.cs:25:23:25:32 | access to method Parse |
-| Finally.cs:7:10:7:11 | exit M1 | Finally.cs:15:13:15:40 | [finally: exception(Exception)] call to method WriteLine |
-| Finally.cs:7:10:7:11 | exit M1 | Finally.cs:15:13:15:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
-| Finally.cs:7:10:7:11 | exit M1 | Finally.cs:15:13:15:40 | call to method WriteLine |
+| Finally.cs:7:10:7:11 | exit M1 (normal) | Finally.cs:15:13:15:40 | call to method WriteLine |
 | Finally.cs:8:5:17:5 | {...} | Finally.cs:7:10:7:11 | enter M1 |
 | Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:8:5:17:5 | {...} |
 | Finally.cs:10:9:12:9 | {...} | Finally.cs:9:9:16:9 | try {...} ... |
+| Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:11:31:11:36 | "Try1" |
 | Finally.cs:11:13:11:38 | ...; | Finally.cs:10:9:12:9 | {...} |
 | Finally.cs:11:31:11:36 | "Try1" | Finally.cs:11:13:11:38 | ...; |
+| Finally.cs:14:9:16:9 | {...} | Finally.cs:11:13:11:37 | call to method WriteLine |
 | Finally.cs:15:13:15:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:15:31:15:39 | [finally: exception(Exception)] "Finally" |
 | Finally.cs:15:13:15:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:15:31:15:39 | [finally: exception(OutOfMemoryException)] "Finally" |
 | Finally.cs:15:13:15:40 | call to method WriteLine | Finally.cs:15:31:15:39 | "Finally" |
@@ -5348,10 +5680,8 @@ postDominance
 | Finally.cs:15:31:15:39 | "Finally" | Finally.cs:15:13:15:41 | ...; |
 | Finally.cs:15:31:15:39 | [finally: exception(Exception)] "Finally" | Finally.cs:15:13:15:41 | [finally: exception(Exception)] ...; |
 | Finally.cs:15:31:15:39 | [finally: exception(OutOfMemoryException)] "Finally" | Finally.cs:15:13:15:41 | [finally: exception(OutOfMemoryException)] ...; |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:50:13:50:40 | [finally: exception(Exception)] call to method WriteLine |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:50:13:50:40 | [finally: exception(IOException)] call to method WriteLine |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:50:13:50:40 | [finally: return] call to method WriteLine |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:50:13:50:40 | call to method WriteLine |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:50:13:50:40 | [finally: return] call to method WriteLine |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:50:13:50:40 | call to method WriteLine |
 | Finally.cs:20:5:52:5 | {...} | Finally.cs:19:10:19:11 | enter M2 |
 | Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:20:5:52:5 | {...} |
 | Finally.cs:22:9:25:9 | {...} | Finally.cs:21:9:51:9 | try {...} ... |
@@ -5360,6 +5690,7 @@ postDominance
 | Finally.cs:26:48:26:51 | [exception: Exception] true | Finally.cs:26:38:26:39 | [exception: Exception] IOException ex |
 | Finally.cs:27:9:29:9 | {...} | Finally.cs:26:48:26:51 | [exception: Exception] true |
 | Finally.cs:28:13:28:18 | throw ...; | Finally.cs:27:9:29:9 | {...} |
+| Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:30:9:40:9 | [exception: OutOfMemoryException] catch (...) {...} | Finally.cs:26:9:29:9 | [exception: OutOfMemoryException] catch (...) {...} |
 | Finally.cs:31:9:40:9 | {...} | Finally.cs:30:41:30:42 | [exception: Exception] ArgumentException ex |
 | Finally.cs:32:13:39:13 | try {...} ... | Finally.cs:31:9:40:9 | {...} |
@@ -5371,6 +5702,7 @@ postDominance
 | Finally.cs:38:17:38:44 | [finally: exception(ArgumentException)] throw ...; | Finally.cs:38:23:38:43 | [finally: exception(ArgumentException)] object creation of type Exception |
 | Finally.cs:38:23:38:43 | [finally: exception(ArgumentException)] object creation of type Exception | Finally.cs:38:37:38:42 | [finally: exception(ArgumentException)] "Boo!" |
 | Finally.cs:38:37:38:42 | [finally: exception(ArgumentException)] "Boo!" | Finally.cs:37:13:39:13 | [finally: exception(ArgumentException)] {...} |
+| Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:41:9:43:9 | [exception: OutOfMemoryException] catch (...) {...} | Finally.cs:30:9:40:9 | [exception: OutOfMemoryException] catch (...) {...} |
 | Finally.cs:42:9:43:9 | {...} | Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:42:9:43:9 | {...} | Finally.cs:41:9:43:9 | [exception: OutOfMemoryException] catch (...) {...} |
@@ -5390,11 +5722,8 @@ postDominance
 | Finally.cs:50:31:50:39 | [finally: exception(Exception)] "Finally" | Finally.cs:50:13:50:41 | [finally: exception(Exception)] ...; |
 | Finally.cs:50:31:50:39 | [finally: exception(IOException)] "Finally" | Finally.cs:50:13:50:41 | [finally: exception(IOException)] ...; |
 | Finally.cs:50:31:50:39 | [finally: return] "Finally" | Finally.cs:50:13:50:41 | [finally: return] ...; |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:70:13:70:40 | [finally: exception(Exception)] call to method WriteLine |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:70:13:70:40 | [finally: exception(IOException)] call to method WriteLine |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:70:13:70:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:70:13:70:40 | [finally: return] call to method WriteLine |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:70:13:70:40 | call to method WriteLine |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:70:13:70:40 | [finally: return] call to method WriteLine |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:70:13:70:40 | call to method WriteLine |
 | Finally.cs:55:5:72:5 | {...} | Finally.cs:54:10:54:11 | enter M3 |
 | Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:55:5:72:5 | {...} |
 | Finally.cs:57:9:60:9 | {...} | Finally.cs:56:9:71:9 | try {...} ... |
@@ -5403,6 +5732,7 @@ postDominance
 | Finally.cs:61:48:61:51 | [exception: Exception] true | Finally.cs:61:38:61:39 | [exception: Exception] IOException ex |
 | Finally.cs:62:9:64:9 | {...} | Finally.cs:61:48:61:51 | [exception: Exception] true |
 | Finally.cs:63:13:63:18 | throw ...; | Finally.cs:62:9:64:9 | {...} |
+| Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:65:9:67:9 | [exception: OutOfMemoryException] catch (...) {...} | Finally.cs:61:9:64:9 | [exception: OutOfMemoryException] catch (...) {...} |
 | Finally.cs:65:26:65:26 | [exception: Exception] Exception e | Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:65:26:65:26 | [exception: OutOfMemoryException] Exception e | Finally.cs:65:9:67:9 | [exception: OutOfMemoryException] catch (...) {...} |
@@ -5414,6 +5744,8 @@ postDominance
 | Finally.cs:65:35:65:51 | [exception: OutOfMemoryException] ... != ... | Finally.cs:65:48:65:51 | [exception: OutOfMemoryException] null |
 | Finally.cs:65:48:65:51 | [exception: Exception] null | Finally.cs:65:35:65:43 | [exception: Exception] access to property Message |
 | Finally.cs:65:48:65:51 | [exception: OutOfMemoryException] null | Finally.cs:65:35:65:43 | [exception: OutOfMemoryException] access to property Message |
+| Finally.cs:66:9:67:9 | {...} | Finally.cs:65:35:65:51 | [exception: Exception] ... != ... |
+| Finally.cs:66:9:67:9 | {...} | Finally.cs:65:35:65:51 | [exception: OutOfMemoryException] ... != ... |
 | Finally.cs:69:9:71:9 | [finally: exception(IOException)] {...} | Finally.cs:63:13:63:18 | throw ...; |
 | Finally.cs:69:9:71:9 | [finally: return] {...} | Finally.cs:59:13:59:19 | return ...; |
 | Finally.cs:69:9:71:9 | {...} | Finally.cs:66:9:67:9 | {...} |
@@ -5432,13 +5764,9 @@ postDominance
 | Finally.cs:70:31:70:39 | [finally: exception(IOException)] "Finally" | Finally.cs:70:13:70:41 | [finally: exception(IOException)] ...; |
 | Finally.cs:70:31:70:39 | [finally: exception(OutOfMemoryException)] "Finally" | Finally.cs:70:13:70:41 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:70:31:70:39 | [finally: return] "Finally" | Finally.cs:70:13:70:41 | [finally: return] ...; |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:77:16:77:20 | ... > ... |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:97:21:97:23 | [finally(2): exception(Exception)] ...-- |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:97:21:97:23 | [finally: break, finally(2): exception(Exception)] ...-- |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:97:21:97:23 | [finally: break] ...-- |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:97:21:97:23 | [finally: continue, finally(2): exception(Exception)] ...-- |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:97:21:97:23 | [finally: return, finally(2): exception(Exception)] ...-- |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:97:21:97:23 | [finally: return] ...-- |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:77:16:77:20 | ... > ... |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:97:21:97:23 | [finally: break] ...-- |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:97:21:97:23 | [finally: return] ...-- |
 | Finally.cs:75:5:101:5 | {...} | Finally.cs:74:10:74:11 | enter M4 |
 | Finally.cs:76:9:76:19 | ... ...; | Finally.cs:75:5:101:5 | {...} |
 | Finally.cs:76:13:76:18 | Int32 i = ... | Finally.cs:76:17:76:18 | 10 |
@@ -5488,14 +5816,10 @@ postDominance
 | Finally.cs:92:30:92:30 | [finally: break] 3 | Finally.cs:92:25:92:25 | [finally: break] access to local variable i |
 | Finally.cs:92:30:92:30 | [finally: continue] 3 | Finally.cs:92:25:92:25 | [finally: continue] access to local variable i |
 | Finally.cs:92:30:92:30 | [finally: return] 3 | Finally.cs:92:25:92:25 | [finally: return] access to local variable i |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:93:25:93:46 | throw ...; |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:93:25:93:46 | [finally: break] throw ...; |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:93:25:93:46 | [finally: continue] throw ...; |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:93:25:93:46 | [finally: return] throw ...; |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception |
+| Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:92:25:92:30 | [finally: break] ... == ... |
+| Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:92:25:92:30 | [finally: continue] ... == ... |
+| Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:92:25:92:30 | [finally: return] ... == ... |
+| Finally.cs:96:17:98:17 | {...} | Finally.cs:92:25:92:30 | ... == ... |
 | Finally.cs:97:21:97:21 | [finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:24 | [finally(2): exception(Exception)] ...; |
 | Finally.cs:97:21:97:21 | [finally: break, finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:24 | [finally: break, finally(2): exception(Exception)] ...; |
 | Finally.cs:97:21:97:21 | [finally: break] access to local variable i | Finally.cs:97:21:97:24 | [finally: break] ...; |
@@ -5520,28 +5844,27 @@ postDominance
 | Finally.cs:97:21:97:24 | [finally: continue] ...; | Finally.cs:96:17:98:17 | [finally: continue] {...} |
 | Finally.cs:97:21:97:24 | [finally: return, finally(2): exception(Exception)] ...; | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
 | Finally.cs:97:21:97:24 | [finally: return] ...; | Finally.cs:96:17:98:17 | [finally: return] {...} |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:116:17:116:32 | ... > ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:116:17:116:32 | [finally: return] ... > ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:117:17:117:36 | [finally: exception(Exception)] call to method WriteLine |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:117:17:117:36 | [finally: exception(NullReferenceException)] call to method WriteLine |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:117:17:117:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:117:17:117:36 | call to method WriteLine |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:116:17:116:32 | ... > ... |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:116:17:116:32 | [finally: return] ... > ... |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:117:17:117:36 | call to method WriteLine |
 | Finally.cs:104:5:119:5 | {...} | Finally.cs:103:10:103:11 | enter M5 |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:104:5:119:5 | {...} |
 | Finally.cs:106:9:111:9 | {...} | Finally.cs:105:9:118:9 | try {...} ... |
 | Finally.cs:107:13:108:23 | if (...) ... | Finally.cs:106:9:111:9 | {...} |
 | Finally.cs:107:17:107:21 | access to field Field | Finally.cs:107:17:107:21 | this access |
 | Finally.cs:107:17:107:21 | this access | Finally.cs:107:13:108:23 | if (...) ... |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:107:17:107:21 | access to field Field |
 | Finally.cs:107:17:107:33 | ... == ... | Finally.cs:107:33:107:33 | 0 |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:107:17:107:28 | access to property Length |
 | Finally.cs:109:17:109:21 | access to field Field | Finally.cs:109:17:109:21 | this access |
 | Finally.cs:109:17:109:21 | this access | Finally.cs:109:13:110:49 | if (...) ... |
+| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:109:17:109:21 | access to field Field |
 | Finally.cs:109:17:109:33 | ... == ... | Finally.cs:109:33:109:33 | 1 |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:109:17:109:28 | access to property Length |
 | Finally.cs:113:9:118:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:110:17:110:49 | throw ...; |
 | Finally.cs:113:9:118:9 | [finally: return] {...} | Finally.cs:108:17:108:23 | return ...; |
+| Finally.cs:113:9:118:9 | {...} | Finally.cs:109:17:109:33 | ... == ... |
 | Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} |
 | Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:113:9:118:9 | [finally: exception(OutOfMemoryException)] {...} |
@@ -5592,12 +5915,6 @@ postDominance
 | Finally.cs:115:35:115:39 | [finally: return] this access | Finally.cs:115:17:115:41 | [finally: return] ...; |
 | Finally.cs:115:35:115:39 | access to field Field | Finally.cs:115:35:115:39 | this access |
 | Finally.cs:115:35:115:39 | this access | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... |
-| Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:115:17:115:40 | [finally: exception(Exception)] call to method WriteLine |
-| Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... |
-| Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:115:17:115:40 | [finally: exception(NullReferenceException)] call to method WriteLine |
-| Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... |
-| Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:115:17:115:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:114:19:114:35 | [finally: return] ... == ... |
 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:115:17:115:40 | [finally: return] call to method WriteLine |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:114:19:114:35 | ... == ... |
@@ -5637,7 +5954,8 @@ postDominance
 | Finally.cs:117:35:117:35 | [finally: exception(NullReferenceException)] 1 | Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; |
 | Finally.cs:117:35:117:35 | [finally: exception(OutOfMemoryException)] 1 | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:117:35:117:35 | [finally: return] 1 | Finally.cs:117:17:117:37 | [finally: return] ...; |
-| Finally.cs:121:10:121:11 | exit M6 | Finally.cs:125:17:125:40 | Double temp = ... |
+| Finally.cs:121:10:121:11 | exit M6 | Finally.cs:121:10:121:11 | exit M6 (normal) |
+| Finally.cs:121:10:121:11 | exit M6 (normal) | Finally.cs:125:17:125:40 | Double temp = ... |
 | Finally.cs:122:5:131:5 | {...} | Finally.cs:121:10:121:11 | enter M6 |
 | Finally.cs:123:9:130:9 | try {...} ... | Finally.cs:122:5:131:5 | {...} |
 | Finally.cs:124:9:126:9 | {...} | Finally.cs:123:9:130:9 | try {...} ... |
@@ -5647,9 +5965,7 @@ postDominance
 | Finally.cs:125:24:125:24 | (...) ... | Finally.cs:125:24:125:24 | 0 |
 | Finally.cs:125:24:125:40 | ... / ... | Finally.cs:125:28:125:40 | access to constant E |
 | Finally.cs:125:28:125:40 | access to constant E | Finally.cs:125:24:125:24 | (...) ... |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:141:13:141:44 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:141:13:141:44 | [finally: exception(OutOfMemoryException)] throw ...; |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:141:13:141:44 | throw ...; |
+| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:133:10:133:11 | exit M7 (abnormal) |
 | Finally.cs:134:5:145:5 | {...} | Finally.cs:133:10:133:11 | enter M7 |
 | Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:134:5:145:5 | {...} |
 | Finally.cs:136:9:138:9 | {...} | Finally.cs:135:9:143:9 | try {...} ... |
@@ -5664,15 +5980,9 @@ postDominance
 | Finally.cs:141:41:141:42 | "" | Finally.cs:140:9:143:9 | {...} |
 | Finally.cs:141:41:141:42 | [finally: exception(Exception)] "" | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:141:41:141:42 | [finally: exception(OutOfMemoryException)] "" | Finally.cs:140:9:143:9 | [finally: exception(OutOfMemoryException)] {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:158:21:158:36 | ... == ... |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:163:17:163:42 | [finally: exception(ArgumentNullException)] call to method WriteLine |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:163:17:163:42 | [finally: exception(Exception)] call to method WriteLine |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:163:17:163:42 | call to method WriteLine |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:167:17:167:37 | [finally: exception(ArgumentNullException)] call to method WriteLine |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:167:17:167:37 | [finally: exception(Exception)] call to method WriteLine |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:167:17:167:37 | call to method WriteLine |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:158:21:158:36 | ... == ... |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:163:17:163:42 | call to method WriteLine |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:167:17:167:37 | call to method WriteLine |
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:147:10:147:11 | enter M8 |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:148:5:170:5 | {...} |
 | Finally.cs:150:9:153:9 | {...} | Finally.cs:149:9:169:9 | try {...} ... |
@@ -5681,6 +5991,7 @@ postDominance
 | Finally.cs:151:17:151:28 | ... == ... | Finally.cs:151:25:151:28 | null |
 | Finally.cs:151:25:151:28 | null | Finally.cs:151:17:151:20 | access to parameter args |
 | Finally.cs:155:9:169:9 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:152:17:152:50 | throw ...; |
+| Finally.cs:155:9:169:9 | {...} | Finally.cs:151:17:151:28 | ... == ... |
 | Finally.cs:156:13:168:13 | [finally: exception(ArgumentNullException)] try {...} ... | Finally.cs:155:9:169:9 | [finally: exception(ArgumentNullException)] {...} |
 | Finally.cs:156:13:168:13 | [finally: exception(Exception)] try {...} ... | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:156:13:168:13 | try {...} ... | Finally.cs:155:9:169:9 | {...} |
@@ -5704,10 +6015,6 @@ postDominance
 | Finally.cs:159:27:159:44 | object creation of type Exception | Finally.cs:159:41:159:43 | "1" |
 | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | Finally.cs:159:21:159:45 | throw ...; |
 | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | Finally.cs:159:27:159:44 | object creation of type Exception |
-| Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | Finally.cs:159:21:159:45 | [finally: exception(ArgumentNullException)] throw ...; |
-| Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | Finally.cs:159:27:159:44 | [finally: exception(ArgumentNullException)] object creation of type Exception |
-| Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | Finally.cs:159:21:159:45 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | Finally.cs:159:27:159:44 | [finally: exception(Exception)] object creation of type Exception |
 | Finally.cs:161:30:161:30 | [exception: Exception] Exception e | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} |
 | Finally.cs:161:30:161:30 | [exception: NullReferenceException] Exception e | Finally.cs:161:13:164:13 | [exception: NullReferenceException] catch (...) {...} |
 | Finally.cs:161:30:161:30 | [finally: exception(ArgumentNullException), exception: Exception] Exception e | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} |
@@ -5765,20 +6072,14 @@ postDominance
 | Finally.cs:167:35:167:36 | "" | Finally.cs:167:17:167:38 | ...; |
 | Finally.cs:167:35:167:36 | [finally: exception(ArgumentNullException)] "" | Finally.cs:167:17:167:38 | [finally: exception(ArgumentNullException)] ...; |
 | Finally.cs:167:35:167:36 | [finally: exception(Exception)] "" | Finally.cs:167:17:167:38 | [finally: exception(Exception)] ...; |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:190:25:190:47 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:190:25:190:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 |
 | Finally.cs:177:5:193:5 | {...} | Finally.cs:176:10:176:11 | enter M9 |
 | Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:177:5:193:5 | {...} |
 | Finally.cs:179:9:181:9 | {...} | Finally.cs:178:9:192:9 | try {...} ... |
 | Finally.cs:180:13:180:43 | if (...) ... | Finally.cs:179:9:181:9 | {...} |
 | Finally.cs:180:17:180:18 | access to parameter b1 | Finally.cs:180:13:180:43 | if (...) ... |
+| Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:180:17:180:18 | access to parameter b1 |
 | Finally.cs:183:9:192:9 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; |
 | Finally.cs:184:13:191:13 | [b1 (line 176): false] try {...} ... | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} |
 | Finally.cs:184:13:191:13 | [finally: exception(Exception), b1 (line 176): true] try {...} ... | Finally.cs:183:9:192:9 | [finally: exception(Exception), b1 (line 176): true] {...} |
@@ -5795,15 +6096,12 @@ postDominance
 | Finally.cs:188:13:191:13 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; |
 | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:186:25:186:47 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...; |
 | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:186:25:186:47 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...; |
+| Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} |
 | Finally.cs:188:38:188:39 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | Finally.cs:188:13:191:13 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...} |
 | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} |
 | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} |
 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 |
 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | Finally.cs:188:38:188:39 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2 |
-| Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
-| Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
-| Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
-| Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
 | Finally.cs:190:17:190:47 | [b1 (line 176): false] if (...) ... | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} |
 | Finally.cs:190:17:190:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} |
 | Finally.cs:190:17:190:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} |
@@ -5814,30 +6112,14 @@ postDominance
 | Finally.cs:190:25:190:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:190:31:190:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
 | Finally.cs:190:31:190:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:190:21:190:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b1 |
 | Finally.cs:190:31:190:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:190:21:190:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1 |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:25:209:47 | throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:213:9:213:24 | ... = ... |
+| Finally.cs:195:10:195:12 | exit M10 (normal) | Finally.cs:213:9:213:24 | ... = ... |
 | Finally.cs:196:5:214:5 | {...} | Finally.cs:195:10:195:12 | enter M10 |
 | Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:196:5:214:5 | {...} |
 | Finally.cs:198:9:200:9 | {...} | Finally.cs:197:9:212:9 | try {...} ... |
 | Finally.cs:199:13:199:43 | if (...) ... | Finally.cs:198:9:200:9 | {...} |
 | Finally.cs:199:17:199:18 | access to parameter b1 | Finally.cs:199:13:199:43 | if (...) ... |
 | Finally.cs:202:9:212:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:199:21:199:43 | throw ...; |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:199:17:199:18 | access to parameter b1 |
 | Finally.cs:203:13:210:13 | [finally: exception(Exception)] try {...} ... | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:203:13:210:13 | [finally: exception(ExceptionA)] try {...} ... | Finally.cs:202:9:212:9 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:203:13:210:13 | try {...} ... | Finally.cs:202:9:212:9 | {...} |
@@ -5853,6 +6135,7 @@ postDominance
 | Finally.cs:208:13:210:13 | [finally(2): exception(ExceptionB)] {...} | Finally.cs:205:25:205:47 | throw ...; |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(ExceptionB)] {...} | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] {...} | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:208:13:210:13 | {...} | Finally.cs:205:21:205:22 | access to parameter b2 |
 | Finally.cs:209:17:209:47 | [finally(2): exception(Exception)] if (...) ... | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} |
 | Finally.cs:209:17:209:47 | [finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:208:13:210:13 | [finally(2): exception(ExceptionB)] {...} |
 | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
@@ -5886,6 +6169,7 @@ postDominance
 | Finally.cs:211:13:211:28 | ... = ... | Finally.cs:211:26:211:28 | "0" |
 | Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... | Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" |
 | Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... | Finally.cs:211:26:211:28 | [finally: exception(ExceptionA)] "0" |
+| Finally.cs:211:13:211:29 | ...; | Finally.cs:209:21:209:22 | access to parameter b3 |
 | Finally.cs:211:26:211:28 | "0" | Finally.cs:211:13:211:16 | this access |
 | Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" | Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access |
 | Finally.cs:211:26:211:28 | [finally: exception(ExceptionA)] "0" | Finally.cs:211:13:211:16 | [finally: exception(ExceptionA)] this access |
@@ -5893,7 +6177,8 @@ postDominance
 | Finally.cs:213:9:213:24 | ... = ... | Finally.cs:213:22:213:24 | "1" |
 | Finally.cs:213:9:213:25 | ...; | Finally.cs:211:13:211:28 | ... = ... |
 | Finally.cs:213:22:213:24 | "1" | Finally.cs:213:9:213:12 | this access |
-| Finally.cs:216:10:216:12 | exit M11 | Finally.cs:230:9:230:33 | call to method WriteLine |
+| Finally.cs:216:10:216:12 | exit M11 | Finally.cs:216:10:216:12 | exit M11 (normal) |
+| Finally.cs:216:10:216:12 | exit M11 (normal) | Finally.cs:230:9:230:33 | call to method WriteLine |
 | Finally.cs:217:5:231:5 | {...} | Finally.cs:216:10:216:12 | enter M11 |
 | Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:217:5:231:5 | {...} |
 | Finally.cs:219:9:221:9 | {...} | Finally.cs:218:9:229:9 | try {...} ... |
@@ -5911,19 +6196,22 @@ postDominance
 | Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:230:27:230:32 | "Done" |
 | Finally.cs:230:9:230:34 | ...; | Finally.cs:228:13:228:40 | call to method WriteLine |
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:34 | ...; |
-| Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
+| Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | exit M1 (normal) |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:6:10:6:11 | enter M1 |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:29:8:32 | access to parameter args |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:9:13:9:13 | ; |
 | Foreach.cs:8:29:8:32 | access to parameter args | Foreach.cs:7:5:10:5 | {...} |
 | Foreach.cs:9:13:9:13 | ; | Foreach.cs:8:22:8:24 | String arg |
-| Foreach.cs:12:10:12:11 | exit M2 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |
+| Foreach.cs:12:10:12:11 | exit M2 | Foreach.cs:12:10:12:11 | exit M2 (normal) |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |
 | Foreach.cs:13:5:16:5 | {...} | Foreach.cs:12:10:12:11 | enter M2 |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:27:14:30 | access to parameter args |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:15:13:15:13 | ; |
 | Foreach.cs:14:27:14:30 | access to parameter args | Foreach.cs:13:5:16:5 | {...} |
 | Foreach.cs:15:13:15:13 | ; | Foreach.cs:14:22:14:22 | String _ |
-| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
+| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:18:10:18:11 | exit M3 (normal) |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
 | Foreach.cs:19:5:22:5 | {...} | Foreach.cs:18:10:18:11 | enter M3 |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:43:20:68 | call to method Empty |
@@ -5931,7 +6219,8 @@ postDominance
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:27:20:68 | ... ?? ... |
 | Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:19:5:22:5 | {...} |
 | Foreach.cs:21:11:21:11 | ; | Foreach.cs:20:22:20:22 | String x |
-| Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |
+| Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:24:10:24:11 | exit M4 (normal) |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |
 | Foreach.cs:25:5:28:5 | {...} | Foreach.cs:24:10:24:11 | enter M4 |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:36:26:39 | access to parameter args |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:27:11:27:11 | ; |
@@ -5939,7 +6228,8 @@ postDominance
 | Foreach.cs:26:30:26:30 | Int32 y | Foreach.cs:26:23:26:23 | String x |
 | Foreach.cs:26:36:26:39 | access to parameter args | Foreach.cs:25:5:28:5 | {...} |
 | Foreach.cs:27:11:27:11 | ; | Foreach.cs:26:18:26:31 | (..., ...) |
-| Foreach.cs:30:10:30:11 | exit M5 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... |
+| Foreach.cs:30:10:30:11 | exit M5 | Foreach.cs:30:10:30:11 | exit M5 (normal) |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... |
 | Foreach.cs:31:5:34:5 | {...} | Foreach.cs:30:10:30:11 | enter M5 |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:32:32:35 | access to parameter args |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:33:11:33:11 | ; |
@@ -5947,7 +6237,8 @@ postDominance
 | Foreach.cs:32:26:32:26 | Int32 y | Foreach.cs:32:23:32:23 | String x |
 | Foreach.cs:32:32:32:35 | access to parameter args | Foreach.cs:31:5:34:5 | {...} |
 | Foreach.cs:33:11:33:11 | ; | Foreach.cs:32:18:32:27 | (..., ...) |
-| Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |
+| Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:36:10:36:11 | exit M6 (normal) |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |
 | Foreach.cs:37:5:40:5 | {...} | Foreach.cs:36:10:36:11 | enter M6 |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:39:38:42 | access to parameter args |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:39:11:39:11 | ; |
@@ -5977,11 +6268,14 @@ postDominance
 | Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:31:6:31 | 2 |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:27 | access to field H |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:27 | access to field H |
-| Initializers.cs:8:5:8:16 | exit Initializers | Initializers.cs:8:20:8:22 | {...} |
+| Initializers.cs:8:5:8:16 | exit Initializers | Initializers.cs:8:5:8:16 | exit Initializers (normal) |
+| Initializers.cs:8:5:8:16 | exit Initializers (normal) | Initializers.cs:8:20:8:22 | {...} |
 | Initializers.cs:8:20:8:22 | {...} | Initializers.cs:6:25:6:31 | ... = ... |
-| Initializers.cs:10:5:10:16 | exit Initializers | Initializers.cs:10:28:10:30 | {...} |
+| Initializers.cs:10:5:10:16 | exit Initializers | Initializers.cs:10:5:10:16 | exit Initializers (normal) |
+| Initializers.cs:10:5:10:16 | exit Initializers (normal) | Initializers.cs:10:28:10:30 | {...} |
 | Initializers.cs:10:28:10:30 | {...} | Initializers.cs:6:25:6:31 | ... = ... |
-| Initializers.cs:12:10:12:10 | exit M | Initializers.cs:15:13:15:63 | Initializers[] iz = ... |
+| Initializers.cs:12:10:12:10 | exit M | Initializers.cs:12:10:12:10 | exit M (normal) |
+| Initializers.cs:12:10:12:10 | exit M (normal) | Initializers.cs:15:13:15:63 | Initializers[] iz = ... |
 | Initializers.cs:13:5:16:5 | {...} | Initializers.cs:12:10:12:10 | enter M |
 | Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:13:5:16:5 | {...} |
 | Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:14:38:14:53 | { ..., ... } |
@@ -6002,7 +6296,8 @@ postDominance
 | Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:59:15:60 | "" |
 | Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:39:15:39 | access to local variable i |
 | Initializers.cs:18:16:18:20 | ... = ... | Initializers.cs:18:20:18:20 | 1 |
-| Initializers.cs:20:11:20:23 | exit NoConstructor | Initializers.cs:23:23:23:27 | ... = ... |
+| Initializers.cs:20:11:20:23 | exit NoConstructor | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) |
+| Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:23:23:23:27 | ... = ... |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:20:11:20:23 | enter NoConstructor |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:35:9:35:11 | enter Sub |
 | Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:22:27:22:27 | 0 |
@@ -6021,21 +6316,24 @@ postDominance
 | Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:28:17:28:17 | 2 |
 | Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:13 | this access |
 | Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:13 | this access |
-| Initializers.cs:31:9:31:11 | exit Sub | Initializers.cs:31:26:31:30 | ... = ... |
+| Initializers.cs:31:9:31:11 | exit Sub | Initializers.cs:31:9:31:11 | exit Sub (normal) |
+| Initializers.cs:31:9:31:11 | exit Sub (normal) | Initializers.cs:31:26:31:30 | ... = ... |
 | Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:31:9:31:11 | enter Sub |
 | Initializers.cs:31:24:31:33 | {...} | Initializers.cs:28:13:28:17 | ... = ... |
 | Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:26:31:31 | ...; |
 | Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:30:31:30 | 3 |
 | Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:24:31:33 | {...} |
 | Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:26:31:26 | this access |
-| Initializers.cs:33:9:33:11 | exit Sub | Initializers.cs:33:31:33:35 | ... = ... |
+| Initializers.cs:33:9:33:11 | exit Sub | Initializers.cs:33:9:33:11 | exit Sub (normal) |
+| Initializers.cs:33:9:33:11 | exit Sub (normal) | Initializers.cs:33:31:33:35 | ... = ... |
 | Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:9:33:11 | enter Sub |
 | Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:22:33:25 | call to constructor Sub |
 | Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:31:33:36 | ...; |
 | Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:35:33:35 | access to parameter i |
 | Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:29:33:38 | {...} |
 | Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:31 | this access |
-| Initializers.cs:35:9:35:11 | exit Sub | Initializers.cs:35:29:35:37 | ... = ... |
+| Initializers.cs:35:9:35:11 | exit Sub | Initializers.cs:35:9:35:11 | exit Sub (normal) |
+| Initializers.cs:35:9:35:11 | exit Sub (normal) | Initializers.cs:35:29:35:37 | ... = ... |
 | Initializers.cs:35:27:35:40 | {...} | Initializers.cs:28:13:28:17 | ... = ... |
 | Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:29:35:38 | ...; |
 | Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:33:35:37 | ... + ... |
@@ -6043,7 +6341,8 @@ postDominance
 | Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:29:35:29 | this access |
 | Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:37:35:37 | access to parameter j |
 | Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:33:35:33 | access to parameter i |
-| Initializers.cs:51:10:51:13 | exit Test | Initializers.cs:57:13:65:9 | Compound compound = ... |
+| Initializers.cs:51:10:51:13 | exit Test | Initializers.cs:51:10:51:13 | exit Test (normal) |
+| Initializers.cs:51:10:51:13 | exit Test (normal) | Initializers.cs:57:13:65:9 | Compound compound = ... |
 | Initializers.cs:52:5:66:5 | {...} | Initializers.cs:51:10:51:13 | enter Test |
 | Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:52:5:66:5 | {...} |
 | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:54:50:54:95 | { ..., ... } |
@@ -6146,8 +6445,9 @@ postDominance
 | Initializers.cs:64:50:64:54 | ... + ... | Initializers.cs:64:54:64:54 | 0 |
 | Initializers.cs:64:54:64:54 | 0 | Initializers.cs:64:50:64:50 | access to parameter i |
 | Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:50:64:54 | ... + ... |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:10:13:10:19 | return ...; |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:10:13:10:19 | return ...; |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:7:10:7:11 | enter M1 |
 | LoopUnrolling.cs:9:9:10:19 | if (...) ... | LoopUnrolling.cs:8:5:13:5 | {...} |
 | LoopUnrolling.cs:9:13:9:16 | access to parameter args | LoopUnrolling.cs:9:9:10:19 | if (...) ... |
@@ -6160,7 +6460,8 @@ postDominance
 | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | LoopUnrolling.cs:12:31:12:33 | access to local variable arg |
 | LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:11:22:11:24 | String arg |
 | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:12:13:12:35 | ...; |
-| LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:15:10:15:11 | enter M2 |
 | LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:16:5:20:5 | {...} |
 | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:17:31:17:47 | { ..., ... } |
@@ -6177,7 +6478,8 @@ postDominance
 | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | LoopUnrolling.cs:19:31:19:31 | access to local variable x |
 | LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:18:22:18:22 | String x |
 | LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:19:13:19:33 | ...; |
-| LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:23:5:27:5 | {...} | LoopUnrolling.cs:22:10:22:11 | enter M3 |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:29:24:32 | access to parameter args |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:25:13:26:40 | foreach (... ... in ...) ... |
@@ -6189,7 +6491,8 @@ postDominance
 | LoopUnrolling.cs:26:17:26:39 | call to method WriteLine | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 |
 | LoopUnrolling.cs:26:17:26:40 | ...; | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
 | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 | LoopUnrolling.cs:26:17:26:40 | ...; |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) |
+| LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) | LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:30:5:34:5 | {...} | LoopUnrolling.cs:29:10:29:11 | enter M4 |
 | LoopUnrolling.cs:31:9:31:31 | ... ...; | LoopUnrolling.cs:30:5:34:5 | {...} |
 | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] |
@@ -6197,7 +6500,8 @@ postDominance
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:9:31:31 | ... ...; |
 | LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs |
 | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:36:10:36:11 | enter M5 |
 | LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:37:5:43:5 | {...} |
 | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:38:31:38:47 | { ..., ... } |
@@ -6245,8 +6549,9 @@ postDominance
 | LoopUnrolling.cs:50:16:50:36 | ...; | LoopUnrolling.cs:50:9:50:13 | Label: |
 | LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:50:16:50:36 | ...; |
 | LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:50:16:50:35 | call to method WriteLine |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:55:10:55:11 | enter M7 |
 | LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:56:5:65:5 | {...} |
 | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:57:31:57:47 | { ..., ... } |
@@ -6280,8 +6585,9 @@ postDominance
 | LoopUnrolling.cs:63:17:63:36 | [b (line 55): true] call to method WriteLine | LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x |
 | LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; | LoopUnrolling.cs:62:17:62:17 | [b (line 55): true] access to parameter b |
 | LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x | LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:70:13:70:19 | return ...; |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:70:13:70:19 | return ...; |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:67:10:67:11 | enter M8 |
 | LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:68:5:74:5 | {...} |
 | LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:9:70:19 | if (...) ... |
@@ -6291,7 +6597,8 @@ postDominance
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:71:9:71:12 | access to parameter args |
 | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | LoopUnrolling.cs:72:29:72:32 | access to parameter args |
 | LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear |
-| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) | LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:76:10:76:11 | enter M9 |
 | LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:77:5:83:5 | {...} |
 | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] |
@@ -6300,7 +6607,8 @@ postDominance
 | LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:29:78:29 | 2 |
 | LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs |
 | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... |
-| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) | LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:85:10:85:12 | enter M10 |
 | LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:86:5:92:5 | {...} |
 | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] |
@@ -6309,7 +6617,8 @@ postDominance
 | LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:29:87:29 | 0 |
 | LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs |
 | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... |
-| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:94:10:94:12 | enter M11 |
 | LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:95:5:101:5 | {...} |
 | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] |
@@ -6324,140 +6633,185 @@ postDominance
 | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | LoopUnrolling.cs:99:31:99:31 | access to local variable x |
 | LoopUnrolling.cs:99:13:99:33 | ...; | LoopUnrolling.cs:98:9:100:9 | {...} |
 | LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:99:13:99:33 | ...; |
-| MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | throw ... |
-| MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | MultiImplementationA.cs:6:22:6:31 | throw ... |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | MultiImplementationB.cs:3:22:3:22 | 0 |
 | MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:28:6:31 | null |
-| MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationA.cs:7:27:7:37 | throw ...; |
-| MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationB.cs:4:27:4:35 | return ...; |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | MultiImplementationA.cs:7:27:7:37 | throw ...; |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | MultiImplementationB.cs:4:27:4:35 | return ...; |
 | MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationA.cs:7:33:7:36 | null |
 | MultiImplementationA.cs:7:33:7:36 | null | MultiImplementationA.cs:7:25:7:39 | {...} |
-| MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationA.cs:7:47:7:57 | throw ...; |
-| MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | MultiImplementationA.cs:7:47:7:57 | throw ...; |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | MultiImplementationB.cs:4:43:4:45 | {...} |
 | MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationA.cs:7:53:7:56 | null |
 | MultiImplementationA.cs:7:53:7:56 | null | MultiImplementationA.cs:7:45:7:59 | {...} |
-| MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationA.cs:8:23:8:32 | throw ... |
-| MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationB.cs:5:23:5:23 | 2 |
+| MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | MultiImplementationA.cs:8:23:8:32 | throw ... |
+| MultiImplementationA.cs:8:16:8:16 | exit M (normal) | MultiImplementationB.cs:5:23:5:23 | 2 |
 | MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationA.cs:8:29:8:32 | null |
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | MultiImplementationA.cs:13:20:13:20 | 0 |
 | MultiImplementationA.cs:13:20:13:20 | 0 | MultiImplementationA.cs:13:16:13:16 | this access |
-| MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
-| MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationB.cs:12:31:12:40 | throw ... |
-| MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationA.cs:15:42:15:50 | return ...; |
-| MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationB.cs:13:42:13:52 | throw ...; |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationA.cs:14:31:14:31 | enter get_Item |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationB.cs:12:31:12:40 | enter get_Item |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | MultiImplementationB.cs:12:31:12:40 | throw ... |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | MultiImplementationB.cs:13:42:13:52 | throw ...; |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | MultiImplementationA.cs:15:42:15:50 | return ...; |
+| MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:36:15:38 | enter get_Item |
+| MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationB.cs:13:36:13:38 | enter get_Item |
 | MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationA.cs:15:49:15:49 | access to parameter s |
 | MultiImplementationA.cs:15:49:15:49 | access to parameter s | MultiImplementationA.cs:15:40:15:52 | {...} |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationA.cs:15:58:15:60 | {...} |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationB.cs:13:60:13:62 | {...} |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationA.cs:18:9:18:22 | M2(...) |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationB.cs:16:9:16:31 | M2(...) |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:58:15:60 | {...} |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:60:13:62 | {...} |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:18:9:18:22 | M2(...) |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:16:9:16:31 | M2(...) |
 | MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationA.cs:17:5:19:5 | {...} |
-| MultiImplementationA.cs:18:9:18:22 | exit M2 | MultiImplementationA.cs:18:21:18:21 | 0 |
+| MultiImplementationA.cs:18:9:18:22 | exit M2 | MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) |
+| MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | MultiImplementationA.cs:18:21:18:21 | 0 |
 | MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | enter M2 |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:20:24:20:28 | ... = ... |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationB.cs:18:24:18:34 | throw ...; |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | MultiImplementationB.cs:18:24:18:34 | throw ...; |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | MultiImplementationA.cs:20:24:20:28 | ... = ... |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:24:32:24:34 | ... = ... |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:22:32:22:34 | ... = ... |
 | MultiImplementationA.cs:20:24:20:24 | this access | MultiImplementationA.cs:20:24:20:29 | ...; |
 | MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationA.cs:20:28:20:28 | access to parameter i |
 | MultiImplementationA.cs:20:24:20:29 | ...; | MultiImplementationA.cs:20:22:20:31 | {...} |
 | MultiImplementationA.cs:20:28:20:28 | access to parameter i | MultiImplementationA.cs:20:24:20:24 | this access |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationA.cs:21:27:21:29 | {...} |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationB.cs:19:27:19:29 | {...} |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:27:21:29 | {...} |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:27:19:29 | {...} |
 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | MultiImplementationA.cs:21:24:21:24 | 0 |
-| MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} |
-| MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationB.cs:20:13:20:23 | throw ...; |
-| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationA.cs:23:50:23:53 | null |
-| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationB.cs:21:50:21:59 | throw ... |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | MultiImplementationB.cs:20:13:20:23 | throw ...; |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | MultiImplementationA.cs:22:11:22:13 | {...} |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:6:22:7 | enter ~C2 |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationB.cs:20:6:20:7 | enter ~C2 |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | MultiImplementationB.cs:21:50:21:59 | throw ... |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | MultiImplementationA.cs:23:50:23:53 | null |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion |
 | MultiImplementationA.cs:24:16:24:16 | access to property P | MultiImplementationA.cs:24:34:24:34 | 0 |
 | MultiImplementationA.cs:24:32:24:34 | ... = ... | MultiImplementationA.cs:24:16:24:16 | access to property P |
 | MultiImplementationA.cs:24:34:24:34 | 0 | MultiImplementationA.cs:24:16:24:16 | this access |
-| MultiImplementationA.cs:30:21:30:23 | exit get_P3 | MultiImplementationA.cs:30:28:30:37 | throw ... |
+| MultiImplementationA.cs:30:21:30:23 | exit get_P3 | MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) |
+| MultiImplementationA.cs:30:21:30:23 | exit get_P3 | MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) |
+| MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:28:30:37 | throw ... |
 | MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationA.cs:30:34:30:37 | null |
 | MultiImplementationA.cs:30:34:30:37 | null | MultiImplementationA.cs:30:21:30:23 | enter get_P3 |
 | MultiImplementationA.cs:30:34:30:37 | null | MultiImplementationB.cs:27:21:27:23 | enter get_P3 |
-| MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationA.cs:36:16:36:26 | throw ...; |
-| MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationB.cs:32:17:32:17 | 0 |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | MultiImplementationA.cs:36:16:36:26 | throw ...; |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | MultiImplementationB.cs:32:17:32:17 | 0 |
 | MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationA.cs:36:22:36:25 | null |
 | MultiImplementationA.cs:36:22:36:25 | null | MultiImplementationA.cs:36:14:36:28 | {...} |
-| MultiImplementationA.cs:37:9:37:10 | exit M2 | MultiImplementationA.cs:37:16:37:26 | throw ...; |
+| MultiImplementationA.cs:37:9:37:10 | exit M2 | MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) |
+| MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) | MultiImplementationA.cs:37:16:37:26 | throw ...; |
 | MultiImplementationA.cs:37:14:37:28 | {...} | MultiImplementationA.cs:37:9:37:10 | enter M2 |
 | MultiImplementationA.cs:37:16:37:26 | throw ...; | MultiImplementationA.cs:37:22:37:25 | null |
 | MultiImplementationA.cs:37:22:37:25 | null | MultiImplementationA.cs:37:14:37:28 | {...} |
-| MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | throw ... |
-| MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 |
-| MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationA.cs:7:27:7:37 | throw ...; |
-| MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationB.cs:4:27:4:35 | return ...; |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 |
+| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) | MultiImplementationA.cs:6:22:6:31 | throw ... |
+| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) | MultiImplementationB.cs:3:22:3:22 | 0 |
+| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) | MultiImplementationA.cs:7:27:7:37 | throw ...; |
+| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) | MultiImplementationB.cs:4:27:4:35 | return ...; |
+| MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationA.cs:7:21:7:23 | enter get_P2 |
+| MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationB.cs:4:21:4:23 | enter get_P2 |
 | MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationB.cs:4:34:4:34 | 1 |
 | MultiImplementationB.cs:4:34:4:34 | 1 | MultiImplementationB.cs:4:25:4:37 | {...} |
-| MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationA.cs:7:47:7:57 | throw ...; |
-| MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} |
-| MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationA.cs:8:23:8:32 | throw ... |
-| MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationB.cs:5:23:5:23 | 2 |
+| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) | MultiImplementationA.cs:7:47:7:57 | throw ...; |
+| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) | MultiImplementationB.cs:4:43:4:45 | {...} |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationA.cs:7:41:7:43 | enter set_P2 |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationB.cs:4:39:4:41 | enter set_P2 |
+| MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) | MultiImplementationA.cs:8:23:8:32 | throw ... |
+| MultiImplementationB.cs:5:16:5:16 | exit M (normal) | MultiImplementationB.cs:5:23:5:23 | 2 |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationA.cs:8:16:8:16 | enter M |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationB.cs:5:16:5:16 | enter M |
 | MultiImplementationB.cs:11:16:11:20 | ... = ... | MultiImplementationB.cs:11:20:11:20 | 1 |
 | MultiImplementationB.cs:11:20:11:20 | 1 | MultiImplementationB.cs:11:16:11:16 | this access |
-| MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
-| MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationB.cs:12:31:12:40 | throw ... |
+| MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) | MultiImplementationB.cs:12:31:12:40 | throw ... |
+| MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
 | MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationB.cs:12:37:12:40 | null |
-| MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationA.cs:15:42:15:50 | return ...; |
-| MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationB.cs:13:42:13:52 | throw ...; |
+| MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) | MultiImplementationB.cs:13:42:13:52 | throw ...; |
+| MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) | MultiImplementationA.cs:15:42:15:50 | return ...; |
 | MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationB.cs:13:48:13:51 | null |
 | MultiImplementationB.cs:13:48:13:51 | null | MultiImplementationB.cs:13:40:13:54 | {...} |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationA.cs:15:58:15:60 | {...} |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationB.cs:13:60:13:62 | {...} |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationA.cs:18:9:18:22 | M2(...) |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationB.cs:16:9:16:31 | M2(...) |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:58:15:60 | {...} |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:60:13:62 | {...} |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:18:9:18:22 | M2(...) |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:16:9:16:31 | M2(...) |
 | MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationB.cs:15:5:17:5 | {...} |
-| MultiImplementationB.cs:16:9:16:31 | exit M2 | MultiImplementationB.cs:16:21:16:30 | throw ... |
+| MultiImplementationB.cs:16:9:16:31 | exit M2 | MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) |
+| MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | MultiImplementationB.cs:16:21:16:30 | throw ... |
 | MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:27:16:30 | null |
 | MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:9:16:31 | enter M2 |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:20:24:20:28 | ... = ... |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationB.cs:18:24:18:34 | throw ...; |
+| MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | MultiImplementationB.cs:18:24:18:34 | throw ...; |
+| MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | MultiImplementationA.cs:20:24:20:28 | ... = ... |
 | MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationB.cs:18:30:18:33 | null |
 | MultiImplementationB.cs:18:30:18:33 | null | MultiImplementationB.cs:18:22:18:36 | {...} |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationA.cs:21:27:21:29 | {...} |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationB.cs:19:27:19:29 | {...} |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:27:21:29 | {...} |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:27:19:29 | {...} |
 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | MultiImplementationB.cs:19:24:19:24 | 1 |
-| MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} |
-| MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationB.cs:20:13:20:23 | throw ...; |
+| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) | MultiImplementationB.cs:20:13:20:23 | throw ...; |
+| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) | MultiImplementationA.cs:22:11:22:13 | {...} |
 | MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationB.cs:20:19:20:22 | null |
 | MultiImplementationB.cs:20:19:20:22 | null | MultiImplementationB.cs:20:11:20:25 | {...} |
-| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationA.cs:23:50:23:53 | null |
-| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationB.cs:21:50:21:59 | throw ... |
+| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) | MultiImplementationB.cs:21:50:21:59 | throw ... |
+| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) | MultiImplementationA.cs:23:50:23:53 | null |
 | MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationB.cs:21:56:21:59 | null |
 | MultiImplementationB.cs:22:16:22:16 | access to property P | MultiImplementationB.cs:22:34:22:34 | 1 |
 | MultiImplementationB.cs:22:32:22:34 | ... = ... | MultiImplementationB.cs:22:16:22:16 | access to property P |
 | MultiImplementationB.cs:22:34:22:34 | 1 | MultiImplementationB.cs:22:16:22:16 | this access |
-| MultiImplementationB.cs:27:21:27:23 | exit get_P3 | MultiImplementationA.cs:30:28:30:37 | throw ... |
-| MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationA.cs:36:16:36:26 | throw ...; |
-| MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationB.cs:32:17:32:17 | 0 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:23:3:23 | access to parameter i |
-| NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:28:3:28 | 0 |
+| MultiImplementationB.cs:27:21:27:23 | exit get_P3 | MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) |
+| MultiImplementationB.cs:27:21:27:23 | exit get_P3 | MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) |
+| MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:28:30:37 | throw ... |
+| MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) | MultiImplementationA.cs:36:16:36:26 | throw ...; |
+| MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | MultiImplementationB.cs:32:17:32:17 | 0 |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | enter M1 |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | enter M1 |
+| NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:23:3:23 | access to parameter i |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:28:3:28 | 0 |
 | NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
 | NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:9:3:10 | enter M1 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:39:5:39 | 0 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:43:5:43 | 1 |
+| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:39:5:39 | 0 |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:43:5:43 | 1 |
 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | enter M2 |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | ... ?? ... |
 | NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |
 | NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:30:5:34 | false |
-| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:52:7:53 | "" |
+| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
 | NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | enter M3 |
 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:41:9:41 | access to parameter s |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:45:9:45 | access to parameter s |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:51:9:52 | "" |
+| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:41:9:41 | access to parameter s |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:45:9:45 | access to parameter s |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:51:9:52 | "" |
 | NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | enter M4 |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... |
 | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... |
 | NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:64:11:64 | 0 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:68:11:68 | 1 |
+| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:64:11:64 | 0 |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:68:11:68 | 1 |
 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | enter M5 |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | ... ?? ... |
 | NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:58 | ... && ... |
-| NullCoalescing.cs:13:10:13:11 | exit M6 | NullCoalescing.cs:17:9:17:24 | ... = ... |
+| NullCoalescing.cs:13:10:13:11 | exit M6 | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) |
+| NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | NullCoalescing.cs:17:9:17:24 | ... = ... |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:13:10:13:11 | enter M6 |
 | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:14:5:18:5 | {...} |
 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:15:31:15:31 | 0 |
@@ -6474,7 +6828,8 @@ postDominance
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:9:17:25 | ...; |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
-| Patterns.cs:5:10:5:13 | exit Test | Patterns.cs:40:17:40:17 | access to local variable o |
+| Patterns.cs:5:10:5:13 | exit Test | Patterns.cs:5:10:5:13 | exit Test (normal) |
+| Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:40:17:40:17 | access to local variable o |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:5:10:5:13 | enter Test |
 | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:6:5:43:5 | {...} |
 | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:7:20:7:23 | null |
@@ -6538,13 +6893,15 @@ postDominance
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:37:17:37:22 | break; |
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:40:9:42:9 | switch (...) {...} |
-| PostDominance.cs:5:10:5:11 | exit M1 | PostDominance.cs:7:9:7:28 | call to method WriteLine |
+| PostDominance.cs:5:10:5:11 | exit M1 | PostDominance.cs:5:10:5:11 | exit M1 (normal) |
+| PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:7:9:7:28 | call to method WriteLine |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:5:10:5:11 | enter M1 |
 | PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:7:27:7:27 | access to parameter s |
 | PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:6:5:8:5 | {...} |
 | PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:7:9:7:29 | ...; |
-| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:13:13:13:19 | return ...; |
-| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:14:9:14:28 | call to method WriteLine |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | exit M2 (normal) |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:14:9:14:28 | call to method WriteLine |
 | PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:10:10:10:11 | enter M2 |
 | PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:11:5:15:5 | {...} |
 | PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:9:13:19 | if (...) ... |
@@ -6552,8 +6909,8 @@ postDominance
 | PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:13 | access to parameter s |
 | PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:14:27:14:27 | access to parameter s |
 | PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:9:14:29 | ...; |
-| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:20:13:20:55 | throw ...; |
-| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:21:9:21:28 | call to method WriteLine |
+| PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | PostDominance.cs:20:13:20:55 | throw ...; |
+| PostDominance.cs:17:10:17:11 | exit M3 (normal) | PostDominance.cs:21:9:21:28 | call to method WriteLine |
 | PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:17:10:17:11 | enter M3 |
 | PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:18:5:22:5 | {...} |
 | PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:9:20:55 | if (...) ... |
@@ -6562,12 +6919,16 @@ postDominance
 | PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException |
 | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:45:20:53 | nameof(...) |
 | PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:21:27:21:27 | access to parameter s |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:19:13:19:21 | ... is ... |
 | PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:9:21:29 | ...; |
-| Qualifiers.cs:7:16:7:21 | exit Method | Qualifiers.cs:7:28:7:31 | null |
+| Qualifiers.cs:7:16:7:21 | exit Method | Qualifiers.cs:7:16:7:21 | exit Method (normal) |
+| Qualifiers.cs:7:16:7:21 | exit Method (normal) | Qualifiers.cs:7:28:7:31 | null |
 | Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | enter Method |
-| Qualifiers.cs:8:23:8:34 | exit StaticMethod | Qualifiers.cs:8:41:8:44 | null |
+| Qualifiers.cs:8:23:8:34 | exit StaticMethod | Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) |
+| Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) | Qualifiers.cs:8:41:8:44 | null |
 | Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:23:8:34 | enter StaticMethod |
-| Qualifiers.cs:10:10:10:10 | exit M | Qualifiers.cs:30:9:30:46 | ... = ... |
+| Qualifiers.cs:10:10:10:10 | exit M | Qualifiers.cs:10:10:10:10 | exit M (normal) |
+| Qualifiers.cs:10:10:10:10 | exit M (normal) | Qualifiers.cs:30:9:30:46 | ... = ... |
 | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:10:10:10:10 | enter M |
 | Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:11:5:31:5 | {...} |
 | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:12:17:12:21 | access to field Field |
@@ -6623,16 +6984,15 @@ postDominance
 | Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:29:9:29:46 | ... = ... |
 | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:9:30:47 | ...; |
 | Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:30:13:30:37 | call to method StaticMethod |
-| Switch.cs:5:10:5:11 | exit M1 | Switch.cs:7:17:7:17 | access to parameter o |
+| Switch.cs:5:10:5:11 | exit M1 | Switch.cs:5:10:5:11 | exit M1 (normal) |
+| Switch.cs:5:10:5:11 | exit M1 (normal) | Switch.cs:7:17:7:17 | access to parameter o |
 | Switch.cs:6:5:8:5 | {...} | Switch.cs:5:10:5:11 | enter M1 |
 | Switch.cs:7:9:7:22 | switch (...) {...} | Switch.cs:6:5:8:5 | {...} |
 | Switch.cs:7:17:7:17 | access to parameter o | Switch.cs:7:9:7:22 | switch (...) {...} |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:15:17:15:23 | return ...; |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:17:17:17:38 | throw ...; |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:22:21:22:27 | return ...; |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:26:17:26:23 | return ...; |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:27:32:27:38 | call to method Throw |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:29:17:29:23 | return ...; |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:15:17:15:23 | return ...; |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:22:21:22:27 | return ...; |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:26:17:26:23 | return ...; |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:29:17:29:23 | return ...; |
 | Switch.cs:11:5:33:5 | {...} | Switch.cs:10:10:10:11 | enter M2 |
 | Switch.cs:12:9:32:9 | switch (...) {...} | Switch.cs:11:5:33:5 | {...} |
 | Switch.cs:12:17:12:17 | access to parameter o | Switch.cs:12:9:32:9 | switch (...) {...} |
@@ -6641,6 +7001,7 @@ postDominance
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:23:17:23:28 | goto case ...; |
 | Switch.cs:16:18:16:18 | 0 | Switch.cs:16:13:16:19 | case ...: |
 | Switch.cs:17:17:17:38 | throw ...; | Switch.cs:17:23:17:37 | object creation of type Exception |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:16:18:16:18 | 0 |
 | Switch.cs:18:18:18:21 | null | Switch.cs:18:13:18:22 | case ...: |
 | Switch.cs:20:18:20:22 | Int32 i | Switch.cs:20:13:20:23 | case ...: |
 | Switch.cs:21:21:21:21 | access to parameter o | Switch.cs:21:17:22:27 | if (...) ... |
@@ -6661,15 +7022,18 @@ postDominance
 | Switch.cs:28:13:28:17 | Label: | Switch.cs:31:17:31:27 | goto ...; |
 | Switch.cs:29:17:29:23 | return ...; | Switch.cs:28:13:28:17 | Label: |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:19:17:19:29 | goto default; |
+| Switch.cs:30:13:30:20 | default: | Switch.cs:27:18:27:25 | Double d |
 | Switch.cs:31:17:31:27 | goto ...; | Switch.cs:30:13:30:20 | default: |
-| Switch.cs:35:10:35:11 | exit M3 | Switch.cs:37:17:37:23 | call to method Throw |
+| Switch.cs:35:10:35:11 | exit M3 | Switch.cs:35:10:35:11 | exit M3 (abnormal) |
+| Switch.cs:35:10:35:11 | exit M3 (abnormal) | Switch.cs:37:17:37:23 | call to method Throw |
 | Switch.cs:36:5:42:5 | {...} | Switch.cs:35:10:35:11 | enter M3 |
 | Switch.cs:37:9:41:9 | switch (...) {...} | Switch.cs:36:5:42:5 | {...} |
 | Switch.cs:37:17:37:23 | call to method Throw | Switch.cs:37:9:41:9 | switch (...) {...} |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:49:17:49:22 | break; |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:50:18:50:21 | access to type Boolean |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:50:30:50:38 | ... != ... |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:51:17:51:22 | break; |
+| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:44:10:44:11 | exit M4 (normal) |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:49:17:49:22 | break; |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:50:18:50:21 | access to type Boolean |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:50:30:50:38 | ... != ... |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:51:17:51:22 | break; |
 | Switch.cs:45:5:53:5 | {...} | Switch.cs:44:10:44:11 | enter M4 |
 | Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:45:5:53:5 | {...} |
 | Switch.cs:46:17:46:17 | access to parameter o | Switch.cs:46:9:52:9 | switch (...) {...} |
@@ -6678,7 +7042,8 @@ postDominance
 | Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:13:50:39 | case ...: |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:50:35:50:38 | null |
 | Switch.cs:50:35:50:38 | null | Switch.cs:50:30:50:30 | access to parameter o |
-| Switch.cs:55:10:55:11 | exit M5 | Switch.cs:62:17:62:22 | break; |
+| Switch.cs:55:10:55:11 | exit M5 | Switch.cs:55:10:55:11 | exit M5 (normal) |
+| Switch.cs:55:10:55:11 | exit M5 (normal) | Switch.cs:62:17:62:22 | break; |
 | Switch.cs:56:5:64:5 | {...} | Switch.cs:55:10:55:11 | enter M5 |
 | Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:56:5:64:5 | {...} |
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:57:9:63:9 | switch (...) {...} |
@@ -6689,8 +7054,9 @@ postDominance
 | Switch.cs:61:13:61:19 | case ...: | Switch.cs:59:18:59:18 | 2 |
 | Switch.cs:61:18:61:18 | 3 | Switch.cs:61:13:61:19 | case ...: |
 | Switch.cs:62:17:62:22 | break; | Switch.cs:61:18:61:18 | 3 |
-| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:72:18:72:19 | "" |
-| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:73:17:73:22 | break; |
+| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | exit M6 (normal) |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:72:18:72:19 | "" |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:66:10:66:11 | enter M6 |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:67:5:75:5 | {...} |
 | Switch.cs:68:17:68:25 | (...) ... | Switch.cs:68:25:68:25 | access to parameter s |
@@ -6699,9 +7065,10 @@ postDominance
 | Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:13:70:23 | case ...: |
 | Switch.cs:72:13:72:20 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 |
 | Switch.cs:72:18:72:19 | "" | Switch.cs:72:13:72:20 | case ...: |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:82:17:82:28 | return ...; |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:86:17:86:28 | return ...; |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:88:9:88:21 | return ...; |
+| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | exit M7 (normal) |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:82:17:82:28 | return ...; |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:86:17:86:28 | return ...; |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:88:9:88:21 | return ...; |
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:77:10:77:11 | enter M7 |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:78:5:89:5 | {...} |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:79:9:87:9 | switch (...) {...} |
@@ -6715,8 +7082,9 @@ postDominance
 | Switch.cs:86:17:86:28 | return ...; | Switch.cs:86:24:86:27 | true |
 | Switch.cs:88:9:88:21 | return ...; | Switch.cs:88:16:88:20 | false |
 | Switch.cs:88:16:88:20 | false | Switch.cs:85:21:85:26 | break; |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:96:17:96:28 | return ...; |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:98:9:98:21 | return ...; |
+| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | exit M8 (normal) |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:96:17:96:28 | return ...; |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:98:9:98:21 | return ...; |
 | Switch.cs:92:5:99:5 | {...} | Switch.cs:91:10:91:11 | enter M8 |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:92:5:99:5 | {...} |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:93:9:97:9 | switch (...) {...} |
@@ -6724,9 +7092,10 @@ postDominance
 | Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:13:95:23 | case ...: |
 | Switch.cs:96:17:96:28 | return ...; | Switch.cs:96:24:96:27 | true |
 | Switch.cs:98:9:98:21 | return ...; | Switch.cs:98:16:98:20 | false |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:105:21:105:29 | return ...; |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:106:21:106:29 | return ...; |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:108:9:108:18 | return ...; |
+| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | exit M9 (normal) |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:105:21:105:29 | return ...; |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:106:21:106:29 | return ...; |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:108:9:108:18 | return ...; |
 | Switch.cs:102:5:109:5 | {...} | Switch.cs:101:9:101:10 | enter M9 |
 | Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:102:5:109:5 | {...} |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:9:107:9 | switch (...) {...} |
@@ -6738,12 +7107,14 @@ postDominance
 | Switch.cs:106:21:106:29 | return ...; | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:108:9:108:18 | return ...; | Switch.cs:108:16:108:17 | -... |
 | Switch.cs:108:16:108:17 | -... | Switch.cs:108:17:108:17 | 1 |
-| Switch.cs:111:17:111:21 | exit Throw | Switch.cs:111:28:111:48 | throw ... |
+| Switch.cs:111:17:111:21 | exit Throw | Switch.cs:111:17:111:21 | exit Throw (abnormal) |
+| Switch.cs:111:17:111:21 | exit Throw (abnormal) | Switch.cs:111:28:111:48 | throw ... |
 | Switch.cs:111:28:111:48 | throw ... | Switch.cs:111:34:111:48 | object creation of type Exception |
 | Switch.cs:111:34:111:48 | object creation of type Exception | Switch.cs:111:17:111:21 | enter Throw |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:117:37:117:45 | return ...; |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:36:118:44 | return ...; |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:120:9:120:18 | return ...; |
+| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | exit M10 (normal) |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:117:37:117:45 | return ...; |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:118:36:118:44 | return ...; |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:120:9:120:18 | return ...; |
 | Switch.cs:114:5:121:5 | {...} | Switch.cs:113:9:113:11 | enter M10 |
 | Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:114:5:121:5 | {...} |
 | Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:115:9:119:9 | switch (...) {...} |
@@ -6759,9 +7130,10 @@ postDominance
 | Switch.cs:118:36:118:44 | return ...; | Switch.cs:118:43:118:43 | 2 |
 | Switch.cs:120:9:120:18 | return ...; | Switch.cs:120:16:120:17 | -... |
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:17:120:17 | 1 |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:125:34:125:34 | access to local variable b |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:125:42:125:46 | false |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:126:13:126:19 | return ...; |
+| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | exit M11 (normal) |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:34:125:34 | access to local variable b |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:42:125:46 | false |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:126:13:126:19 | return ...; |
 | Switch.cs:124:5:127:5 | {...} | Switch.cs:123:10:123:12 | enter M11 |
 | Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:124:5:127:5 | {...} |
 | Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:13:125:48 | ... switch { ... } |
@@ -6770,7 +7142,8 @@ postDominance
 | Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:13:125:13 | access to parameter o |
 | Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:46 | ... => ... |
 | Switch.cs:125:42:125:46 | false | Switch.cs:125:37:125:37 | _ |
-| Switch.cs:129:12:129:14 | exit M12 | Switch.cs:131:9:131:67 | return ...; |
+| Switch.cs:129:12:129:14 | exit M12 | Switch.cs:129:12:129:14 | exit M12 (normal) |
+| Switch.cs:129:12:129:14 | exit M12 (normal) | Switch.cs:131:9:131:67 | return ...; |
 | Switch.cs:130:5:132:5 | {...} | Switch.cs:129:12:129:14 | enter M12 |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:40:131:40 | access to local variable s |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:48:131:51 | null |
@@ -6781,9 +7154,10 @@ postDominance
 | Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:17:131:17 | access to parameter o |
 | Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:51 | ... => ... |
 | Switch.cs:131:48:131:51 | null | Switch.cs:131:43:131:43 | _ |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:138:22:138:31 | return ...; |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:139:21:139:29 | return ...; |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:140:21:140:29 | return ...; |
+| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:134:9:134:11 | exit M13 (normal) |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:138:22:138:31 | return ...; |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:139:21:139:29 | return ...; |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:140:21:140:29 | return ...; |
 | Switch.cs:135:5:142:5 | {...} | Switch.cs:134:9:134:11 | enter M13 |
 | Switch.cs:136:9:141:9 | switch (...) {...} | Switch.cs:135:5:142:5 | {...} |
 | Switch.cs:136:17:136:17 | access to parameter i | Switch.cs:136:9:141:9 | switch (...) {...} |
@@ -6795,9 +7169,10 @@ postDominance
 | Switch.cs:139:21:139:29 | return ...; | Switch.cs:139:28:139:28 | 1 |
 | Switch.cs:140:18:140:18 | 2 | Switch.cs:140:13:140:19 | case ...: |
 | Switch.cs:140:21:140:29 | return ...; | Switch.cs:140:28:140:28 | 2 |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:148:21:148:29 | return ...; |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:149:22:149:31 | return ...; |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:150:21:150:29 | return ...; |
+| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:144:9:144:11 | exit M14 (normal) |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:148:21:148:29 | return ...; |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:149:22:149:31 | return ...; |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:150:21:150:29 | return ...; |
 | Switch.cs:145:5:152:5 | {...} | Switch.cs:144:9:144:11 | enter M14 |
 | Switch.cs:146:9:151:9 | switch (...) {...} | Switch.cs:145:5:152:5 | {...} |
 | Switch.cs:146:17:146:17 | access to parameter i | Switch.cs:146:9:151:9 | switch (...) {...} |
@@ -6809,9 +7184,8 @@ postDominance
 | Switch.cs:149:30:149:30 | 1 | Switch.cs:149:13:149:20 | default: |
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:150:13:150:19 | case ...: |
 | Switch.cs:150:21:150:29 | return ...; | Switch.cs:150:28:150:28 | 2 |
-| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:156:41:156:45 | false |
-| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:158:13:158:48 | call to method WriteLine |
-| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:160:13:160:48 | call to method WriteLine |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:158:13:158:48 | call to method WriteLine |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:160:13:160:48 | call to method WriteLine |
 | Switch.cs:155:5:161:5 | {...} | Switch.cs:154:10:154:12 | enter M15 |
 | Switch.cs:156:9:156:55 | ... ...; | Switch.cs:155:5:161:5 | {...} |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:36:156:38 | "a" |
@@ -6821,6 +7195,7 @@ postDominance
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:38 | ... => ... |
 | Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:17:156:17 | access to parameter b |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:45 | false |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:156:13:156:54 | String s = ... |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:157:9:160:49 | if (...) ... |
 | Switch.cs:158:13:158:48 | call to method WriteLine | Switch.cs:158:38:158:47 | $"..." |
@@ -6831,7 +7206,8 @@ postDominance
 | Switch.cs:160:38:160:47 | $"..." | Switch.cs:160:45:160:45 | access to local variable s |
 | Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:13:160:49 | ...; |
 | Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:40:160:43 | "b = " |
-| TypeAccesses.cs:3:10:3:10 | exit M | TypeAccesses.cs:8:13:8:27 | Type t = ... |
+| TypeAccesses.cs:3:10:3:10 | exit M | TypeAccesses.cs:3:10:3:10 | exit M (normal) |
+| TypeAccesses.cs:3:10:3:10 | exit M (normal) | TypeAccesses.cs:8:13:8:27 | Type t = ... |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:3:10:3:10 | enter M |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:4:5:9:5 | {...} |
 | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:5:17:5:25 | (...) ... |
@@ -6849,7 +7225,8 @@ postDominance
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:7:25:7:25 | ; |
 | TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:8:17:8:27 | typeof(...) |
 | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:9:8:28 | ... ...; |
-| VarDecls.cs:5:18:5:19 | exit M1 | VarDecls.cs:9:13:9:29 | return ...; |
+| VarDecls.cs:5:18:5:19 | exit M1 | VarDecls.cs:5:18:5:19 | exit M1 (normal) |
+| VarDecls.cs:5:18:5:19 | exit M1 (normal) | VarDecls.cs:9:13:9:29 | return ...; |
 | VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:5:18:5:19 | enter M1 |
 | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:6:5:11:5 | {...} |
 | VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:27:7:36 | (...) ... |
@@ -6866,7 +7243,8 @@ postDominance
 | VarDecls.cs:9:13:9:29 | return ...; | VarDecls.cs:9:20:9:28 | (...) ... |
 | VarDecls.cs:9:20:9:28 | (...) ... | VarDecls.cs:9:27:9:28 | access to local variable c1 |
 | VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:8:9:10:9 | {...} |
-| VarDecls.cs:13:12:13:13 | exit M2 | VarDecls.cs:16:9:16:23 | return ...; |
+| VarDecls.cs:13:12:13:13 | exit M2 | VarDecls.cs:13:12:13:13 | exit M2 (normal) |
+| VarDecls.cs:13:12:13:13 | exit M2 (normal) | VarDecls.cs:16:9:16:23 | return ...; |
 | VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:13:12:13:13 | enter M2 |
 | VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:14:5:17:5 | {...} |
 | VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:21:15:21 | access to parameter s |
@@ -6877,7 +7255,8 @@ postDominance
 | VarDecls.cs:16:16:16:17 | access to local variable s1 | VarDecls.cs:15:24:15:29 | String s2 = ... |
 | VarDecls.cs:16:16:16:22 | ... + ... | VarDecls.cs:16:21:16:22 | access to local variable s2 |
 | VarDecls.cs:16:21:16:22 | access to local variable s2 | VarDecls.cs:16:16:16:17 | access to local variable s1 |
-| VarDecls.cs:19:7:19:8 | exit M3 | VarDecls.cs:25:13:25:29 | return ...; |
+| VarDecls.cs:19:7:19:8 | exit M3 | VarDecls.cs:19:7:19:8 | exit M3 (normal) |
+| VarDecls.cs:19:7:19:8 | exit M3 (normal) | VarDecls.cs:25:13:25:29 | return ...; |
 | VarDecls.cs:20:5:26:5 | {...} | VarDecls.cs:19:7:19:8 | enter M3 |
 | VarDecls.cs:21:9:22:13 | using (...) {...} | VarDecls.cs:20:5:26:5 | {...} |
 | VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:21:9:22:13 | using (...) {...} |
@@ -6891,9 +7270,11 @@ postDominance
 | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:28:25:28 | access to local variable y |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
 | VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:24:31:24:41 | C y = ... |
-| VarDecls.cs:28:41:28:47 | exit Dispose | VarDecls.cs:28:51:28:53 | {...} |
+| VarDecls.cs:28:41:28:47 | exit Dispose | VarDecls.cs:28:41:28:47 | exit Dispose (normal) |
+| VarDecls.cs:28:41:28:47 | exit Dispose (normal) | VarDecls.cs:28:51:28:53 | {...} |
 | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | enter Dispose |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:24:25:24:31 | ... <= ... |
+| cflow.cs:5:17:5:20 | exit Main | cflow.cs:5:17:5:20 | exit Main (normal) |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:24:25:24:31 | ... <= ... |
 | cflow.cs:6:5:35:5 | {...} | cflow.cs:5:17:5:20 | enter Main |
 | cflow.cs:7:9:7:28 | ... ...; | cflow.cs:6:5:35:5 | {...} |
 | cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:7:17:7:27 | access to property Length |
@@ -6973,8 +7354,8 @@ postDominance
 | cflow.cs:31:35:31:40 | "Buzz" | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:33:17:33:36 | call to method WriteLine | cflow.cs:33:35:33:35 | access to local variable i |
 | cflow.cs:33:35:33:35 | access to local variable i | cflow.cs:33:17:33:37 | ...; |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:64:21:64:55 | throw ...; |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:67:9:67:17 | return ...; |
+| cflow.cs:37:17:37:22 | exit Switch (abnormal) | cflow.cs:64:21:64:55 | throw ...; |
+| cflow.cs:37:17:37:22 | exit Switch (normal) | cflow.cs:67:9:67:17 | return ...; |
 | cflow.cs:38:5:68:5 | {...} | cflow.cs:37:17:37:22 | enter Switch |
 | cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:38:5:68:5 | {...} |
 | cflow.cs:39:17:39:17 | access to parameter a | cflow.cs:39:9:50:9 | switch (...) {...} |
@@ -7022,11 +7403,14 @@ postDominance
 | cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:32:63:33 | "" |
 | cflow.cs:63:32:63:33 | "" | cflow.cs:63:23:63:27 | access to field Field |
 | cflow.cs:64:21:64:55 | throw ...; | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
+| cflow.cs:65:17:65:22 | break; | cflow.cs:63:23:63:33 | ... == ... |
 | cflow.cs:67:9:67:17 | return ...; | cflow.cs:67:16:67:16 | access to parameter a |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:62:18:62:18 | 0 |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:65:17:65:22 | break; |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:73:13:73:19 | return ...; |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:76:13:76:32 | call to method WriteLine |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:80:13:80:47 | call to method WriteLine |
+| cflow.cs:70:18:70:18 | exit M | cflow.cs:70:18:70:18 | exit M (normal) |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:73:13:73:19 | return ...; |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:76:13:76:32 | call to method WriteLine |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:80:13:80:47 | call to method WriteLine |
 | cflow.cs:71:5:82:5 | {...} | cflow.cs:70:18:70:18 | enter M |
 | cflow.cs:72:9:73:19 | if (...) ... | cflow.cs:71:5:82:5 | {...} |
 | cflow.cs:72:13:72:13 | access to parameter s | cflow.cs:72:9:73:19 | if (...) ... |
@@ -7042,9 +7426,10 @@ postDominance
 | cflow.cs:80:13:80:47 | call to method WriteLine | cflow.cs:80:31:80:46 | "<empty string>" |
 | cflow.cs:80:13:80:48 | ...; | cflow.cs:79:9:81:9 | {...} |
 | cflow.cs:80:31:80:46 | "<empty string>" | cflow.cs:80:13:80:48 | ...; |
-| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:86:13:86:21 | ... != ... |
-| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:86:26:86:37 | ... > ... |
-| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:87:13:87:32 | call to method WriteLine |
+| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:84:18:84:19 | exit M2 (normal) |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:86:13:86:21 | ... != ... |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:86:26:86:37 | ... > ... |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:87:13:87:32 | call to method WriteLine |
 | cflow.cs:85:5:88:5 | {...} | cflow.cs:84:18:84:19 | enter M2 |
 | cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:85:5:88:5 | {...} |
 | cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:13:86:37 | ... && ... |
@@ -7056,9 +7441,9 @@ postDominance
 | cflow.cs:86:37:86:37 | 0 | cflow.cs:86:26:86:33 | access to property Length |
 | cflow.cs:87:13:87:32 | call to method WriteLine | cflow.cs:87:31:87:31 | access to parameter s |
 | cflow.cs:87:31:87:31 | access to parameter s | cflow.cs:87:13:87:33 | ...; |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:93:13:93:49 | throw ...; |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:102:13:102:29 | ... != ... |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:103:13:103:35 | call to method WriteLine |
+| cflow.cs:90:18:90:19 | exit M3 (abnormal) | cflow.cs:93:13:93:49 | throw ...; |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:102:13:102:29 | ... != ... |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:103:13:103:35 | call to method WriteLine |
 | cflow.cs:91:5:104:5 | {...} | cflow.cs:90:18:90:19 | enter M3 |
 | cflow.cs:92:9:93:49 | if (...) ... | cflow.cs:91:5:104:5 | {...} |
 | cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:92:23:92:26 | null |
@@ -7067,6 +7452,7 @@ postDominance
 | cflow.cs:93:13:93:49 | throw ...; | cflow.cs:93:19:93:48 | object creation of type ArgumentNullException |
 | cflow.cs:93:19:93:48 | object creation of type ArgumentNullException | cflow.cs:93:45:93:47 | "s" |
 | cflow.cs:94:9:94:28 | call to method WriteLine | cflow.cs:94:27:94:27 | access to parameter s |
+| cflow.cs:94:9:94:29 | ...; | cflow.cs:92:13:92:27 | call to method Equals |
 | cflow.cs:94:27:94:27 | access to parameter s | cflow.cs:94:9:94:29 | ...; |
 | cflow.cs:96:9:97:55 | if (...) ... | cflow.cs:94:9:94:28 | call to method WriteLine |
 | cflow.cs:96:13:96:17 | access to field Field | cflow.cs:96:13:96:17 | this access |
@@ -7094,7 +7480,8 @@ postDominance
 | cflow.cs:103:13:103:35 | call to method WriteLine | cflow.cs:103:31:103:34 | access to property Prop |
 | cflow.cs:103:31:103:34 | access to property Prop | cflow.cs:103:31:103:34 | this access |
 | cflow.cs:103:31:103:34 | this access | cflow.cs:103:13:103:36 | ...; |
-| cflow.cs:106:18:106:19 | exit M4 | cflow.cs:116:9:116:28 | call to method WriteLine |
+| cflow.cs:106:18:106:19 | exit M4 | cflow.cs:106:18:106:19 | exit M4 (normal) |
+| cflow.cs:106:18:106:19 | exit M4 (normal) | cflow.cs:116:9:116:28 | call to method WriteLine |
 | cflow.cs:107:5:117:5 | {...} | cflow.cs:106:18:106:19 | enter M4 |
 | cflow.cs:108:9:115:9 | if (...) ... | cflow.cs:107:5:117:5 | {...} |
 | cflow.cs:108:13:108:13 | access to parameter s | cflow.cs:108:9:115:9 | if (...) ... |
@@ -7108,7 +7495,8 @@ postDominance
 | cflow.cs:116:9:116:28 | call to method WriteLine | cflow.cs:116:27:116:27 | access to parameter s |
 | cflow.cs:116:9:116:29 | ...; | cflow.cs:108:13:108:21 | ... != ... |
 | cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:116:9:116:29 | ...; |
-| cflow.cs:119:20:119:21 | exit M5 | cflow.cs:123:9:123:17 | return ...; |
+| cflow.cs:119:20:119:21 | exit M5 | cflow.cs:119:20:119:21 | exit M5 (normal) |
+| cflow.cs:119:20:119:21 | exit M5 (normal) | cflow.cs:123:9:123:17 | return ...; |
 | cflow.cs:120:5:124:5 | {...} | cflow.cs:119:20:119:21 | enter M5 |
 | cflow.cs:121:9:121:18 | ... ...; | cflow.cs:120:5:124:5 | {...} |
 | cflow.cs:121:13:121:17 | String x = ... | cflow.cs:121:17:121:17 | access to parameter s |
@@ -7120,7 +7508,8 @@ postDominance
 | cflow.cs:122:17:122:19 | " " | cflow.cs:122:13:122:13 | access to local variable x |
 | cflow.cs:123:9:123:17 | return ...; | cflow.cs:123:16:123:16 | access to local variable x |
 | cflow.cs:123:16:123:16 | access to local variable x | cflow.cs:122:9:122:19 | ... = ... |
-| cflow.cs:127:19:127:21 | exit get_Prop | cflow.cs:127:25:127:58 | return ...; |
+| cflow.cs:127:19:127:21 | exit get_Prop | cflow.cs:127:19:127:21 | exit get_Prop (normal) |
+| cflow.cs:127:19:127:21 | exit get_Prop (normal) | cflow.cs:127:25:127:58 | return ...; |
 | cflow.cs:127:23:127:60 | {...} | cflow.cs:127:19:127:21 | enter get_Prop |
 | cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:48:127:49 | "" |
 | cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:53:127:57 | access to field Field |
@@ -7130,48 +7519,56 @@ postDominance
 | cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:23:127:60 | {...} |
 | cflow.cs:127:41:127:44 | null | cflow.cs:127:32:127:36 | access to field Field |
 | cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:53:127:57 | this access |
-| cflow.cs:127:62:127:64 | exit set_Prop | cflow.cs:127:68:127:80 | ... = ... |
+| cflow.cs:127:62:127:64 | exit set_Prop | cflow.cs:127:62:127:64 | exit set_Prop (normal) |
+| cflow.cs:127:62:127:64 | exit set_Prop (normal) | cflow.cs:127:68:127:80 | ... = ... |
 | cflow.cs:127:66:127:83 | {...} | cflow.cs:127:62:127:64 | enter set_Prop |
 | cflow.cs:127:68:127:72 | this access | cflow.cs:127:68:127:81 | ...; |
 | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:76:127:80 | access to parameter value |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:66:127:83 | {...} |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:72 | this access |
-| cflow.cs:129:5:129:15 | exit ControlFlow | cflow.cs:131:9:131:17 | ... = ... |
+| cflow.cs:129:5:129:15 | exit ControlFlow | cflow.cs:129:5:129:15 | exit ControlFlow (normal) |
+| cflow.cs:129:5:129:15 | exit ControlFlow (normal) | cflow.cs:131:9:131:17 | ... = ... |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:129:5:129:15 | enter ControlFlow |
 | cflow.cs:131:9:131:13 | this access | cflow.cs:131:9:131:18 | ...; |
 | cflow.cs:131:9:131:17 | ... = ... | cflow.cs:131:17:131:17 | access to parameter s |
 | cflow.cs:131:9:131:18 | ...; | cflow.cs:130:5:132:5 | {...} |
 | cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:131:9:131:13 | this access |
-| cflow.cs:134:5:134:15 | exit ControlFlow | cflow.cs:134:39:134:41 | {...} |
+| cflow.cs:134:5:134:15 | exit ControlFlow | cflow.cs:134:5:134:15 | exit ControlFlow (normal) |
+| cflow.cs:134:5:134:15 | exit ControlFlow (normal) | cflow.cs:134:39:134:41 | {...} |
 | cflow.cs:134:26:134:29 | call to constructor ControlFlow | cflow.cs:134:31:134:36 | ... + ... |
 | cflow.cs:134:31:134:31 | (...) ... | cflow.cs:134:31:134:31 | access to parameter i |
 | cflow.cs:134:31:134:31 | access to parameter i | cflow.cs:134:5:134:15 | enter ControlFlow |
 | cflow.cs:134:31:134:36 | ... + ... | cflow.cs:134:35:134:36 | "" |
 | cflow.cs:134:35:134:36 | "" | cflow.cs:134:31:134:31 | (...) ... |
 | cflow.cs:134:39:134:41 | {...} | cflow.cs:134:26:134:29 | call to constructor ControlFlow |
-| cflow.cs:136:12:136:22 | exit ControlFlow | cflow.cs:136:40:136:42 | {...} |
+| cflow.cs:136:12:136:22 | exit ControlFlow | cflow.cs:136:12:136:22 | exit ControlFlow (normal) |
+| cflow.cs:136:12:136:22 | exit ControlFlow (normal) | cflow.cs:136:40:136:42 | {...} |
 | cflow.cs:136:28:136:31 | call to constructor ControlFlow | cflow.cs:136:33:136:37 | ... + ... |
 | cflow.cs:136:33:136:33 | 0 | cflow.cs:136:12:136:22 | enter ControlFlow |
 | cflow.cs:136:33:136:37 | ... + ... | cflow.cs:136:37:136:37 | 1 |
 | cflow.cs:136:37:136:37 | 1 | cflow.cs:136:33:136:33 | 0 |
 | cflow.cs:136:40:136:42 | {...} | cflow.cs:136:28:136:31 | call to constructor ControlFlow |
-| cflow.cs:138:40:138:40 | exit + | cflow.cs:141:9:141:17 | return ...; |
+| cflow.cs:138:40:138:40 | exit + | cflow.cs:138:40:138:40 | exit + (normal) |
+| cflow.cs:138:40:138:40 | exit + (normal) | cflow.cs:141:9:141:17 | return ...; |
 | cflow.cs:139:5:142:5 | {...} | cflow.cs:138:40:138:40 | enter + |
 | cflow.cs:140:9:140:28 | call to method WriteLine | cflow.cs:140:27:140:27 | access to parameter x |
 | cflow.cs:140:9:140:29 | ...; | cflow.cs:139:5:142:5 | {...} |
 | cflow.cs:140:27:140:27 | access to parameter x | cflow.cs:140:9:140:29 | ...; |
 | cflow.cs:141:9:141:17 | return ...; | cflow.cs:141:16:141:16 | access to parameter y |
 | cflow.cs:141:16:141:16 | access to parameter y | cflow.cs:140:9:140:28 | call to method WriteLine |
-| cflow.cs:144:33:144:35 | exit get_Item | cflow.cs:144:39:144:52 | return ...; |
+| cflow.cs:144:33:144:35 | exit get_Item | cflow.cs:144:33:144:35 | exit get_Item (normal) |
+| cflow.cs:144:33:144:35 | exit get_Item (normal) | cflow.cs:144:39:144:52 | return ...; |
 | cflow.cs:144:37:144:54 | {...} | cflow.cs:144:33:144:35 | enter get_Item |
 | cflow.cs:144:39:144:52 | return ...; | cflow.cs:144:46:144:51 | ... + ... |
 | cflow.cs:144:46:144:46 | (...) ... | cflow.cs:144:46:144:46 | access to parameter i |
 | cflow.cs:144:46:144:46 | access to parameter i | cflow.cs:144:37:144:54 | {...} |
 | cflow.cs:144:46:144:51 | ... + ... | cflow.cs:144:50:144:51 | "" |
 | cflow.cs:144:50:144:51 | "" | cflow.cs:144:46:144:46 | (...) ... |
-| cflow.cs:144:56:144:58 | exit set_Item | cflow.cs:144:60:144:62 | {...} |
+| cflow.cs:144:56:144:58 | exit set_Item | cflow.cs:144:56:144:58 | exit set_Item (normal) |
+| cflow.cs:144:56:144:58 | exit set_Item (normal) | cflow.cs:144:60:144:62 | {...} |
 | cflow.cs:144:60:144:62 | {...} | cflow.cs:144:56:144:58 | enter set_Item |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:173:32:173:41 | ... < ... |
+| cflow.cs:146:10:146:12 | exit For | cflow.cs:146:10:146:12 | exit For (normal) |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:173:32:173:41 | ... < ... |
 | cflow.cs:147:5:177:5 | {...} | cflow.cs:146:10:146:12 | enter For |
 | cflow.cs:148:9:148:18 | ... ...; | cflow.cs:147:5:177:5 | {...} |
 | cflow.cs:148:13:148:17 | Int32 x = ... | cflow.cs:148:17:148:17 | 0 |
@@ -7241,25 +7638,29 @@ postDominance
 | cflow.cs:175:31:175:31 | access to local variable i | cflow.cs:175:13:175:37 | ...; |
 | cflow.cs:175:31:175:35 | ... + ... | cflow.cs:175:35:175:35 | access to local variable j |
 | cflow.cs:175:35:175:35 | access to local variable j | cflow.cs:175:31:175:31 | access to local variable i |
-| cflow.cs:179:10:179:16 | exit Lambdas | cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... |
+| cflow.cs:179:10:179:16 | exit Lambdas | cflow.cs:179:10:179:16 | exit Lambdas (normal) |
+| cflow.cs:179:10:179:16 | exit Lambdas (normal) | cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... |
 | cflow.cs:180:5:183:5 | {...} | cflow.cs:179:10:179:16 | enter Lambdas |
 | cflow.cs:181:9:181:38 | ... ...; | cflow.cs:180:5:183:5 | {...} |
 | cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... | cflow.cs:181:28:181:37 | (...) => ... |
 | cflow.cs:181:28:181:37 | (...) => ... | cflow.cs:181:9:181:38 | ... ...; |
-| cflow.cs:181:28:181:37 | exit (...) => ... | cflow.cs:181:33:181:37 | ... + ... |
+| cflow.cs:181:28:181:37 | exit (...) => ... | cflow.cs:181:28:181:37 | exit (...) => ... (normal) |
+| cflow.cs:181:28:181:37 | exit (...) => ... (normal) | cflow.cs:181:33:181:37 | ... + ... |
 | cflow.cs:181:33:181:33 | access to parameter x | cflow.cs:181:28:181:37 | enter (...) => ... |
 | cflow.cs:181:33:181:37 | ... + ... | cflow.cs:181:37:181:37 | 1 |
 | cflow.cs:181:37:181:37 | 1 | cflow.cs:181:33:181:33 | access to parameter x |
 | cflow.cs:182:9:182:62 | ... ...; | cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... |
 | cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... | cflow.cs:182:28:182:61 | delegate(...) { ... } |
 | cflow.cs:182:28:182:61 | delegate(...) { ... } | cflow.cs:182:9:182:62 | ... ...; |
-| cflow.cs:182:28:182:61 | exit delegate(...) { ... } | cflow.cs:182:47:182:59 | return ...; |
+| cflow.cs:182:28:182:61 | exit delegate(...) { ... } | cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) |
+| cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) | cflow.cs:182:47:182:59 | return ...; |
 | cflow.cs:182:45:182:61 | {...} | cflow.cs:182:28:182:61 | enter delegate(...) { ... } |
 | cflow.cs:182:47:182:59 | return ...; | cflow.cs:182:54:182:58 | ... + ... |
 | cflow.cs:182:54:182:54 | access to parameter x | cflow.cs:182:45:182:61 | {...} |
 | cflow.cs:182:54:182:58 | ... + ... | cflow.cs:182:58:182:58 | 1 |
 | cflow.cs:182:58:182:58 | 1 | cflow.cs:182:54:182:54 | access to parameter x |
-| cflow.cs:185:10:185:18 | exit LogicalOr | cflow.cs:190:13:190:51 | call to method WriteLine |
+| cflow.cs:185:10:185:18 | exit LogicalOr | cflow.cs:185:10:185:18 | exit LogicalOr (normal) |
+| cflow.cs:185:10:185:18 | exit LogicalOr (normal) | cflow.cs:190:13:190:51 | call to method WriteLine |
 | cflow.cs:186:5:191:5 | {...} | cflow.cs:185:10:185:18 | enter LogicalOr |
 | cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:186:5:191:5 | {...} |
 | cflow.cs:187:13:187:13 | 1 | cflow.cs:187:13:187:28 | ... \|\| ... |
@@ -7277,9 +7678,9 @@ postDominance
 | cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:190:31:190:50 | "This should happen" |
 | cflow.cs:190:13:190:52 | ...; | cflow.cs:187:34:187:39 | ... == ... |
 | cflow.cs:190:31:190:50 | "This should happen" | cflow.cs:190:13:190:52 | ...; |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:200:40:200:56 | ... == ... |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:200:61:200:61 | access to local variable b |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:203:17:203:38 | throw ...; |
+| cflow.cs:193:10:193:17 | exit Booleans (abnormal) | cflow.cs:203:17:203:38 | throw ...; |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:40:200:56 | ... == ... |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:61:200:61 | access to local variable b |
 | cflow.cs:194:5:206:5 | {...} | cflow.cs:193:10:193:17 | enter Booleans |
 | cflow.cs:195:9:195:57 | ... ...; | cflow.cs:194:5:206:5 | {...} |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:17:195:32 | ... > ... |
@@ -7321,6 +7722,7 @@ postDominance
 | cflow.cs:200:15:200:26 | access to property Length | cflow.cs:200:15:200:19 | access to field Field |
 | cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:31:200:31 | 0 |
 | cflow.cs:200:31:200:31 | 0 | cflow.cs:200:15:200:26 | access to property Length |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:200:15:200:31 | ... == ... |
 | cflow.cs:200:38:200:62 | !... | cflow.cs:200:37:200:62 | !... |
 | cflow.cs:200:40:200:44 | access to field Field | cflow.cs:200:40:200:44 | this access |
 | cflow.cs:200:40:200:44 | this access | cflow.cs:200:40:200:61 | ... && ... |
@@ -7331,8 +7733,9 @@ postDominance
 | cflow.cs:202:13:204:13 | {...} | cflow.cs:201:9:205:9 | {...} |
 | cflow.cs:203:17:203:38 | throw ...; | cflow.cs:203:23:203:37 | object creation of type Exception |
 | cflow.cs:203:23:203:37 | object creation of type Exception | cflow.cs:202:13:204:13 | {...} |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:219:17:219:22 | break; |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:221:18:221:34 | ... < ... |
+| cflow.cs:208:10:208:11 | exit Do | cflow.cs:208:10:208:11 | exit Do (normal) |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:219:17:219:22 | break; |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:221:18:221:34 | ... < ... |
 | cflow.cs:209:5:222:5 | {...} | cflow.cs:208:10:208:11 | enter Do |
 | cflow.cs:210:9:221:36 | do ... while (...); | cflow.cs:209:5:222:5 | {...} |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:210:9:221:36 | do ... while (...); |
@@ -7361,8 +7764,9 @@ postDominance
 | cflow.cs:221:18:221:29 | access to property Length | cflow.cs:221:18:221:22 | access to field Field |
 | cflow.cs:221:18:221:34 | ... < ... | cflow.cs:221:33:221:34 | 10 |
 | cflow.cs:221:33:221:34 | 10 | cflow.cs:221:18:221:29 | access to property Length |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:235:17:235:22 | break; |
+| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:224:10:224:16 | exit Foreach (normal) |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:235:17:235:22 | break; |
 | cflow.cs:225:5:238:5 | {...} | cflow.cs:224:10:224:16 | enter Foreach |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:226:27:226:64 | call to method Repeat |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:231:17:231:25 | continue; |
@@ -7390,8 +7794,9 @@ postDominance
 | cflow.cs:233:17:233:32 | ... < ... | cflow.cs:233:32:233:32 | 0 |
 | cflow.cs:233:32:233:32 | 0 | cflow.cs:233:17:233:28 | access to property Length |
 | cflow.cs:235:17:235:22 | break; | cflow.cs:234:13:236:13 | {...} |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:252:17:252:22 | break; |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:257:17:257:22 | break; |
+| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:240:10:240:13 | exit Goto (normal) |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:252:17:252:22 | break; |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:257:17:257:22 | break; |
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:240:10:240:13 | enter Goto |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:241:5:259:5 | {...} |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:244:31:244:41 | goto ...; |
@@ -7429,7 +7834,8 @@ postDominance
 | cflow.cs:256:17:256:37 | ...; | cflow.cs:255:13:255:20 | default: |
 | cflow.cs:256:35:256:35 | 0 | cflow.cs:256:17:256:37 | ...; |
 | cflow.cs:257:17:257:22 | break; | cflow.cs:256:17:256:36 | call to method WriteLine |
-| cflow.cs:261:49:261:53 | exit Yield | cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine |
+| cflow.cs:261:49:261:53 | exit Yield | cflow.cs:261:49:261:53 | exit Yield (normal) |
+| cflow.cs:261:49:261:53 | exit Yield (normal) | cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine |
 | cflow.cs:262:5:277:5 | {...} | cflow.cs:261:49:261:53 | enter Yield |
 | cflow.cs:263:9:263:23 | yield return ...; | cflow.cs:263:22:263:22 | 0 |
 | cflow.cs:263:22:263:22 | 0 | cflow.cs:262:5:277:5 | {...} |
@@ -7451,24 +7857,30 @@ postDominance
 | cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine | cflow.cs:275:31:275:40 | [finally: return] "not dead" |
 | cflow.cs:275:13:275:42 | [finally: return] ...; | cflow.cs:274:9:276:9 | [finally: return] {...} |
 | cflow.cs:275:31:275:40 | [finally: return] "not dead" | cflow.cs:275:13:275:42 | [finally: return] ...; |
-| cflow.cs:282:5:282:18 | exit ControlFlowSub | cflow.cs:282:31:282:33 | {...} |
+| cflow.cs:282:5:282:18 | exit ControlFlowSub | cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) |
+| cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) | cflow.cs:282:31:282:33 | {...} |
 | cflow.cs:282:24:282:27 | call to constructor ControlFlow | cflow.cs:282:5:282:18 | enter ControlFlowSub |
 | cflow.cs:282:31:282:33 | {...} | cflow.cs:282:24:282:27 | call to constructor ControlFlow |
-| cflow.cs:284:5:284:18 | exit ControlFlowSub | cflow.cs:284:39:284:41 | {...} |
+| cflow.cs:284:5:284:18 | exit ControlFlowSub | cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) |
+| cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) | cflow.cs:284:39:284:41 | {...} |
 | cflow.cs:284:32:284:35 | call to constructor ControlFlowSub | cflow.cs:284:5:284:18 | enter ControlFlowSub |
 | cflow.cs:284:39:284:41 | {...} | cflow.cs:284:32:284:35 | call to constructor ControlFlowSub |
-| cflow.cs:286:5:286:18 | exit ControlFlowSub | cflow.cs:286:48:286:50 | {...} |
+| cflow.cs:286:5:286:18 | exit ControlFlowSub | cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) |
+| cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) | cflow.cs:286:48:286:50 | {...} |
 | cflow.cs:286:29:286:32 | call to constructor ControlFlowSub | cflow.cs:286:34:286:45 | call to method ToString |
 | cflow.cs:286:34:286:34 | access to parameter i | cflow.cs:286:5:286:18 | enter ControlFlowSub |
 | cflow.cs:286:34:286:45 | call to method ToString | cflow.cs:286:34:286:34 | access to parameter i |
 | cflow.cs:286:48:286:50 | {...} | cflow.cs:286:29:286:32 | call to constructor ControlFlowSub |
-| cflow.cs:291:12:291:12 | exit M | cflow.cs:291:38:291:41 | delegate call |
+| cflow.cs:291:12:291:12 | exit M | cflow.cs:291:12:291:12 | exit M (normal) |
+| cflow.cs:291:12:291:12 | exit M (normal) | cflow.cs:291:38:291:41 | delegate call |
 | cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:12:291:12 | enter M |
 | cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:40:291:40 | 0 |
 | cflow.cs:291:40:291:40 | 0 | cflow.cs:291:38:291:38 | access to parameter f |
-| cflow.cs:296:5:296:25 | exit NegationInConstructor | cflow.cs:296:52:296:54 | {...} |
+| cflow.cs:296:5:296:25 | exit NegationInConstructor | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) |
+| cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | cflow.cs:296:52:296:54 | {...} |
 | cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | enter NegationInConstructor |
-| cflow.cs:298:10:298:10 | exit M | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor |
+| cflow.cs:298:10:298:10 | exit M | cflow.cs:298:10:298:10 | exit M (normal) |
+| cflow.cs:298:10:298:10 | exit M (normal) | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor |
 | cflow.cs:299:5:301:5 | {...} | cflow.cs:298:10:298:10 | enter M |
 | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:300:70:300:71 | "" |
 | cflow.cs:300:9:300:73 | ...; | cflow.cs:299:5:301:5 | {...} |
@@ -7674,6 +8086,7 @@ blockDominance
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | enter M12 |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | exit M12 |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | exit M12 (abnormal) |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
@@ -7715,6 +8128,7 @@ blockDominance
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
 | Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | exit M12 |
+| Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | exit M12 (abnormal) |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
@@ -7962,11 +8376,13 @@ blockDominance
 | Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:131:18:131:32 | enter AssertTrueFalse |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:138:10:138:12 | enter M13 |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:138:10:138:12 | exit M13 |
+| Assert.cs:138:10:138:12 | enter M13 | Assert.cs:138:10:138:12 | exit M13 (abnormal) |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:140:29:140:30 | access to parameter b2 |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 |
 | Assert.cs:138:10:138:12 | exit M13 | Assert.cs:138:10:138:12 | exit M13 |
+| Assert.cs:138:10:138:12 | exit M13 (abnormal) | Assert.cs:138:10:138:12 | exit M13 (abnormal) |
 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 |
 | Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:140:29:140:30 | access to parameter b2 |
 | Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 |
@@ -7977,14 +8393,14 @@ blockDominance
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | enter (...) => ... |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | enter + |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:3:10:3:11 | enter M1 |
-| BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:3:10:3:11 | exit M1 |
+| BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:3:10:3:11 | exit M1 (normal) |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:7:26:7:28 | String arg |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:10:21:10:26 | break; |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:14:9:17:9 | {...} |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:16:17:16:17 | ; |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:3:10:3:11 | exit M1 |
-| BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:3:10:3:11 | exit M1 |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:3:10:3:11 | exit M1 (normal) |
+| BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:3:10:3:11 | exit M1 (normal) |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:7:26:7:28 | String arg |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:10:21:10:26 | break; |
@@ -7993,7 +8409,7 @@ blockDominance
 | BreakInTry.cs:7:26:7:28 | String arg | BreakInTry.cs:7:26:7:28 | String arg |
 | BreakInTry.cs:7:26:7:28 | String arg | BreakInTry.cs:10:21:10:26 | break; |
 | BreakInTry.cs:10:21:10:26 | break; | BreakInTry.cs:10:21:10:26 | break; |
-| BreakInTry.cs:14:9:17:9 | {...} | BreakInTry.cs:3:10:3:11 | exit M1 |
+| BreakInTry.cs:14:9:17:9 | {...} | BreakInTry.cs:3:10:3:11 | exit M1 (normal) |
 | BreakInTry.cs:14:9:17:9 | {...} | BreakInTry.cs:14:9:17:9 | {...} |
 | BreakInTry.cs:14:9:17:9 | {...} | BreakInTry.cs:16:17:16:17 | ; |
 | BreakInTry.cs:16:17:16:17 | ; | BreakInTry.cs:16:17:16:17 | ; |
@@ -8025,7 +8441,7 @@ blockDominance
 | BreakInTry.cs:32:21:32:21 | [finally: break] ; | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:35:7:35:7 | ; |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:38:10:38:11 | enter M3 |
-| BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:38:10:38:11 | exit M3 |
+| BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:38:10:38:11 | exit M3 (normal) |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:43:17:43:23 | return ...; |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:46:9:52:9 | {...} |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
@@ -8035,7 +8451,7 @@ blockDominance
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:50:21:50:26 | break; |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:53:7:53:7 | ; |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | exit M3 |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:38:10:38:11 | exit M3 (normal) |
 | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:43:17:43:23 | return ...; |
 | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
 | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
@@ -8060,7 +8476,7 @@ blockDominance
 | BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:50:21:50:26 | break; |
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:53:7:53:7 | ; |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:56:10:56:11 | enter M4 |
-| BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:56:10:56:11 | exit M4 |
+| BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:56:10:56:11 | exit M4 (normal) |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:61:17:61:23 | return ...; |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:64:9:70:9 | {...} |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
@@ -8069,7 +8485,7 @@ blockDominance
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:68:21:68:26 | break; |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:56:10:56:11 | exit M4 |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:56:10:56:11 | exit M4 (normal) |
 | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:61:17:61:23 | return ...; |
 | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
 | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
@@ -8096,70 +8512,70 @@ blockDominance
 | CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:20:12:20:17 | enter Nameof |
 | CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:28:10:28:10 | enter M |
 | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess |
+| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | enter M1 |
-| ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | exit M1 |
+| ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:28:3:38 | call to method ToString |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:40:3:49 | call to method ToLower |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:12:3:13 | exit M1 |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:28:3:38 | call to method ToString |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:40:3:49 | call to method ToLower |
 | ConditionalAccess.cs:3:40:3:49 | call to method ToLower | ConditionalAccess.cs:3:40:3:49 | call to method ToLower |
 | ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:10:5:11 | enter M2 |
-| ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:10:5:11 | exit M2 |
+| ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) |
 | ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:28:5:34 | access to property Length |
-| ConditionalAccess.cs:5:10:5:11 | exit M2 | ConditionalAccess.cs:5:10:5:11 | exit M2 |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) |
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:28:5:34 | access to property Length |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:10:7:11 | enter M3 |
-| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:10:7:11 | exit M3 |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:49:7:55 | access to property Length |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:10:7:11 | exit M3 |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:49:7:55 | access to property Length |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | enter M4 |
-| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | exit M4 |
+| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:27:9:33 | access to property Length |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:38:9:38 | 0 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:9:9:10 | exit M4 |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:27:9:33 | access to property Length |
 | ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:38:9:38 | 0 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:11:9:11:10 | enter M5 |
-| ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:11:9:11:10 | exit M5 |
+| ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:13:15:13:21 | access to property Length |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:13:25:13:25 | 0 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:14:20:14:20 | 0 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:16:20:16:20 | 1 |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:11:9:11:10 | exit M5 |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) |
 | ConditionalAccess.cs:13:15:13:21 | access to property Length | ConditionalAccess.cs:13:15:13:21 | access to property Length |
-| ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:11:9:11:10 | exit M5 |
+| ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) |
 | ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:13:25:13:25 | 0 |
 | ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:14:20:14:20 | 0 |
 | ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:16:20:16:20 | 1 |
 | ConditionalAccess.cs:14:20:14:20 | 0 | ConditionalAccess.cs:14:20:14:20 | 0 |
 | ConditionalAccess.cs:16:20:16:20 | 1 | ConditionalAccess.cs:16:20:16:20 | 1 |
 | ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:12:19:13 | enter M6 |
-| ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:12:19:13 | exit M6 |
+| ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) |
 | ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 |
-| ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:12:19:13 | exit M6 |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | enter M7 |
-| ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess |
+| ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | enter Out |
-| ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | exit Out |
-| ConditionalAccess.cs:30:10:30:12 | exit Out | ConditionalAccess.cs:30:10:30:12 | exit Out |
+| ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
+| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | enter M8 |
-| ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | exit M8 |
+| ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:35:14:35:24 | call to method Out |
-| ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:32:10:32:11 | exit M8 |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) |
 | ConditionalAccess.cs:35:14:35:24 | call to method Out | ConditionalAccess.cs:35:14:35:24 | call to method Out |
 | ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:3:10:3:19 | enter IncrOrDecr |
-| Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:3:10:3:19 | exit IncrOrDecr |
+| Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:3:10:3:19 | exit IncrOrDecr |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) |
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; |
 | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... |
 | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:11:9:11:10 | enter M1 |
@@ -8331,14 +8747,14 @@ blockDominance
 | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:16:110:16 | access to local variable x |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:113:10:113:11 | enter M9 |
-| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:113:10:113:11 | exit M9 |
+| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:113:10:113:11 | exit M9 (normal) |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:25:116:25 | access to local variable i |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:117:9:123:9 | {...} |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | exit M9 |
-| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | exit M9 |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | exit M9 (normal) |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | exit M9 (normal) |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:25 | access to local variable i |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:117:9:123:9 | {...} |
@@ -8363,10 +8779,10 @@ blockDominance
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | enter M11 |
-| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | exit M11 |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | exit M11 (normal) |
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
-| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | exit M11 |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | exit M11 (normal) |
 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | enter M1 |
@@ -8375,12 +8791,12 @@ blockDominance
 | ExitMethods.cs:25:10:25:11 | enter M4 | ExitMethods.cs:25:10:25:11 | enter M4 |
 | ExitMethods.cs:31:10:31:11 | enter M5 | ExitMethods.cs:31:10:31:11 | enter M5 |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:37:10:37:11 | enter M6 |
-| ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:37:10:37:11 | exit M6 |
+| ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:37:10:37:11 | exit M6 (normal) |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:44:9:46:9 | {...} |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:37:10:37:11 | exit M6 |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:37:10:37:11 | exit M6 (normal) |
 | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} |
@@ -8390,14 +8806,16 @@ blockDominance
 | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:59:10:59:11 | enter M8 |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe |
+| ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
 | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) |
 | ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:71:17:71:27 | enter ErrorAlways |
-| ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:71:17:71:27 | exit ErrorAlways |
+| ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:76:41:76:43 | "b" |
-| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | exit ErrorAlways |
+| ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) | ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) |
 | ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
 | ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:41:76:43 | "b" |
 | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 |
@@ -8435,11 +8853,13 @@ blockDominance
 | Extensions.cs:20:17:20:20 | enter Main | Extensions.cs:20:17:20:20 | enter Main |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:7:10:7:11 | enter M1 |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:7:10:7:11 | exit M1 |
+| Finally.cs:7:10:7:11 | enter M1 | Finally.cs:7:10:7:11 | exit M1 (abnormal) |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:11:13:11:37 | call to method WriteLine |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:14:9:16:9 | [finally: exception(OutOfMemoryException)] {...} |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:14:9:16:9 | {...} |
 | Finally.cs:7:10:7:11 | exit M1 | Finally.cs:7:10:7:11 | exit M1 |
+| Finally.cs:7:10:7:11 | exit M1 (abnormal) | Finally.cs:7:10:7:11 | exit M1 (abnormal) |
 | Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:11:13:11:37 | call to method WriteLine |
 | Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:14:9:16:9 | {...} |
@@ -8448,6 +8868,8 @@ blockDominance
 | Finally.cs:14:9:16:9 | {...} | Finally.cs:14:9:16:9 | {...} |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:19:10:19:11 | enter M2 |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:19:10:19:11 | exit M2 |
+| Finally.cs:19:10:19:11 | enter M2 | Finally.cs:19:10:19:11 | exit M2 (abnormal) |
+| Finally.cs:19:10:19:11 | enter M2 | Finally.cs:19:10:19:11 | exit M2 (normal) |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:23:13:23:37 | call to method WriteLine |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:24:13:24:19 | return ...; |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} |
@@ -8458,6 +8880,9 @@ blockDominance
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:42:9:43:9 | {...} |
 | Finally.cs:19:10:19:11 | exit M2 | Finally.cs:19:10:19:11 | exit M2 |
+| Finally.cs:19:10:19:11 | exit M2 (abnormal) | Finally.cs:19:10:19:11 | exit M2 (abnormal) |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:19:10:19:11 | exit M2 (normal) |
+| Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (abnormal) |
 | Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:23:13:23:37 | call to method WriteLine |
 | Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:24:13:24:19 | return ...; |
 | Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} |
@@ -8466,6 +8891,7 @@ blockDominance
 | Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:30:41:30:42 | [exception: Exception] ArgumentException ex |
 | Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:24:13:24:19 | return ...; | Finally.cs:24:13:24:19 | return ...; |
+| Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:19:10:19:11 | exit M2 (abnormal) |
 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:26:38:26:39 | [exception: Exception] IOException ex |
 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} |
@@ -8481,6 +8907,8 @@ blockDominance
 | Finally.cs:42:9:43:9 | {...} | Finally.cs:42:9:43:9 | {...} |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:54:10:54:11 | enter M3 |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:54:10:54:11 | exit M3 |
+| Finally.cs:54:10:54:11 | enter M3 | Finally.cs:54:10:54:11 | exit M3 (abnormal) |
+| Finally.cs:54:10:54:11 | enter M3 | Finally.cs:54:10:54:11 | exit M3 (normal) |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:58:13:58:37 | call to method WriteLine |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:59:13:59:19 | return ...; |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} |
@@ -8491,6 +8919,8 @@ blockDominance
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:69:9:71:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:69:9:71:9 | [finally: exception(OutOfMemoryException)] {...} |
 | Finally.cs:54:10:54:11 | exit M3 | Finally.cs:54:10:54:11 | exit M3 |
+| Finally.cs:54:10:54:11 | exit M3 (abnormal) | Finally.cs:54:10:54:11 | exit M3 (abnormal) |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:54:10:54:11 | exit M3 (normal) |
 | Finally.cs:58:13:58:37 | call to method WriteLine | Finally.cs:58:13:58:37 | call to method WriteLine |
 | Finally.cs:58:13:58:37 | call to method WriteLine | Finally.cs:59:13:59:19 | return ...; |
 | Finally.cs:58:13:58:37 | call to method WriteLine | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} |
@@ -8512,6 +8942,8 @@ blockDominance
 | Finally.cs:69:9:71:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:69:9:71:9 | [finally: exception(OutOfMemoryException)] {...} |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:74:10:74:11 | enter M4 |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:74:10:74:11 | exit M4 |
+| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:74:10:74:11 | exit M4 (abnormal) |
+| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:74:10:74:11 | exit M4 (normal) |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:77:16:77:16 | access to local variable i |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:78:9:100:9 | {...} |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:82:21:82:27 | return ...; |
@@ -8537,7 +8969,11 @@ blockDominance
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally: return] {...} |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:74:10:74:11 | exit M4 | Finally.cs:74:10:74:11 | exit M4 |
+| Finally.cs:74:10:74:11 | exit M4 (abnormal) | Finally.cs:74:10:74:11 | exit M4 (abnormal) |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:74:10:74:11 | exit M4 (normal) |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:74:10:74:11 | exit M4 |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:74:10:74:11 | exit M4 (abnormal) |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:74:10:74:11 | exit M4 (normal) |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:77:16:77:16 | access to local variable i |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:78:9:100:9 | {...} |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:82:21:82:27 | return ...; |
@@ -8562,6 +8998,7 @@ blockDominance
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: return] {...} |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | {...} |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:74:10:74:11 | exit M4 (abnormal) |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:78:9:100:9 | {...} |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:82:21:82:27 | return ...; |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:83:17:84:29 | if (...) ... |
@@ -8659,6 +9096,8 @@ blockDominance
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:103:10:103:11 | enter M5 |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:103:10:103:11 | exit M5 |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:103:10:103:11 | exit M5 (abnormal) |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:103:10:103:11 | exit M5 (normal) |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:107:17:107:28 | access to property Length |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:107:33:107:33 | 0 |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:108:17:108:23 | return ...; |
@@ -8686,6 +9125,9 @@ blockDominance
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:117:17:117:37 | [finally: return] ...; |
 | Finally.cs:103:10:103:11 | exit M5 | Finally.cs:103:10:103:11 | exit M5 |
+| Finally.cs:103:10:103:11 | exit M5 (abnormal) | Finally.cs:103:10:103:11 | exit M5 (abnormal) |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:103:10:103:11 | exit M5 (normal) |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:103:10:103:11 | exit M5 (normal) |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:107:17:107:28 | access to property Length |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:107:33:107:33 | 0 |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:108:17:108:23 | return ...; |
@@ -8708,6 +9150,7 @@ blockDominance
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:117:17:117:37 | [finally: return] ...; |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:103:10:103:11 | exit M5 (normal) |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:107:33:107:33 | 0 |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:108:17:108:23 | return ...; |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:109:13:110:49 | if (...) ... |
@@ -8805,12 +9248,12 @@ blockDominance
 | Finally.cs:117:17:117:37 | [finally: return] ...; | Finally.cs:117:17:117:37 | [finally: return] ...; |
 | Finally.cs:121:10:121:11 | enter M6 | Finally.cs:121:10:121:11 | enter M6 |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:133:10:133:11 | enter M7 |
-| Finally.cs:133:10:133:11 | enter M7 | Finally.cs:133:10:133:11 | exit M7 |
+| Finally.cs:133:10:133:11 | enter M7 | Finally.cs:133:10:133:11 | exit M7 (abnormal) |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:137:13:137:36 | call to method WriteLine |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:140:9:143:9 | [finally: exception(OutOfMemoryException)] {...} |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:140:9:143:9 | {...} |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:133:10:133:11 | exit M7 |
+| Finally.cs:133:10:133:11 | exit M7 (abnormal) | Finally.cs:133:10:133:11 | exit M7 (abnormal) |
 | Finally.cs:137:13:137:36 | call to method WriteLine | Finally.cs:137:13:137:36 | call to method WriteLine |
 | Finally.cs:137:13:137:36 | call to method WriteLine | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:137:13:137:36 | call to method WriteLine | Finally.cs:140:9:143:9 | {...} |
@@ -8819,6 +9262,8 @@ blockDominance
 | Finally.cs:140:9:143:9 | {...} | Finally.cs:140:9:143:9 | {...} |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:147:10:147:11 | enter M8 |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:147:10:147:11 | exit M8 |
+| Finally.cs:147:10:147:11 | enter M8 | Finally.cs:147:10:147:11 | exit M8 (abnormal) |
+| Finally.cs:147:10:147:11 | enter M8 | Finally.cs:147:10:147:11 | exit M8 (normal) |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:152:17:152:50 | throw ...; |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} |
@@ -8845,6 +9290,8 @@ blockDominance
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:165:13:168:13 | catch {...} |
 | Finally.cs:147:10:147:11 | exit M8 | Finally.cs:147:10:147:11 | exit M8 |
+| Finally.cs:147:10:147:11 | exit M8 (abnormal) | Finally.cs:147:10:147:11 | exit M8 (abnormal) |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:147:10:147:11 | exit M8 (normal) |
 | Finally.cs:152:17:152:50 | throw ...; | Finally.cs:152:17:152:50 | throw ...; |
 | Finally.cs:152:17:152:50 | throw ...; | Finally.cs:158:36:158:36 | [finally: exception(ArgumentNullException)] 1 |
 | Finally.cs:152:17:152:50 | throw ...; | Finally.cs:159:21:159:45 | [finally: exception(ArgumentNullException)] throw ...; |
@@ -8853,6 +9300,7 @@ blockDominance
 | Finally.cs:152:17:152:50 | throw ...; | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...} |
 | Finally.cs:152:17:152:50 | throw ...; | Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} |
 | Finally.cs:152:17:152:50 | throw ...; | Finally.cs:165:13:168:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:147:10:147:11 | exit M8 (abnormal) |
 | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:152:17:152:50 | throw ...; |
 | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException |
 | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} |
@@ -8878,6 +9326,7 @@ blockDominance
 | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: NullReferenceException] catch (...) {...} |
 | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | Finally.cs:162:13:164:13 | [finally: exception(Exception)] {...} |
 | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} |
+| Finally.cs:155:9:169:9 | {...} | Finally.cs:147:10:147:11 | exit M8 (normal) |
 | Finally.cs:155:9:169:9 | {...} | Finally.cs:155:9:169:9 | {...} |
 | Finally.cs:155:9:169:9 | {...} | Finally.cs:158:36:158:36 | 1 |
 | Finally.cs:155:9:169:9 | {...} | Finally.cs:159:21:159:45 | throw ...; |
@@ -8918,6 +9367,8 @@ blockDominance
 | Finally.cs:165:13:168:13 | catch {...} | Finally.cs:165:13:168:13 | catch {...} |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:176:10:176:11 | enter M9 |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:176:10:176:11 | exit M9 |
+| Finally.cs:176:10:176:11 | enter M9 | Finally.cs:176:10:176:11 | exit M9 (abnormal) |
+| Finally.cs:176:10:176:11 | enter M9 | Finally.cs:176:10:176:11 | exit M9 (normal) |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} |
@@ -8938,6 +9389,8 @@ blockDominance
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} |
 | Finally.cs:176:10:176:11 | exit M9 | Finally.cs:176:10:176:11 | exit M9 |
+| Finally.cs:176:10:176:11 | exit M9 (abnormal) | Finally.cs:176:10:176:11 | exit M9 (abnormal) |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:176:10:176:11 | exit M9 (normal) |
 | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; |
 | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | Finally.cs:186:25:186:47 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...; |
 | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB |
@@ -8957,6 +9410,7 @@ blockDominance
 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} |
 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} |
+| Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:176:10:176:11 | exit M9 (normal) |
 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} |
 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; |
 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB |
@@ -9001,6 +9455,7 @@ blockDominance
 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:195:10:195:12 | enter M10 |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:195:10:195:12 | exit M10 |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:195:10:195:12 | exit M10 (abnormal) |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:199:21:199:43 | throw ...; |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:199:27:199:42 | object creation of type ExceptionA |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} |
@@ -9030,6 +9485,7 @@ blockDominance
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; |
 | Finally.cs:195:10:195:12 | exit M10 | Finally.cs:195:10:195:12 | exit M10 |
+| Finally.cs:195:10:195:12 | exit M10 (abnormal) | Finally.cs:195:10:195:12 | exit M10 (abnormal) |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:199:21:199:43 | throw ...; |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB |
@@ -9132,60 +9588,60 @@ blockDominance
 | Finally.cs:222:9:225:9 | catch {...} | Finally.cs:222:9:225:9 | catch {...} |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:227:9:229:9 | {...} |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | enter M1 |
-| Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | exit M1 |
+| Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | exit M1 (normal) |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:8:22:8:24 | String arg |
-| Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | exit M1 |
-| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 (normal) |
+| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 (normal) |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:22:8:24 | String arg |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:8:22:8:24 | String arg |
 | Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:12:10:12:11 | enter M2 |
-| Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:12:10:12:11 | exit M2 |
+| Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:12:10:12:11 | exit M2 (normal) |
 | Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |
 | Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:14:22:14:22 | String _ |
-| Foreach.cs:12:10:12:11 | exit M2 | Foreach.cs:12:10:12:11 | exit M2 |
-| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | exit M2 (normal) |
+| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 (normal) |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:22:14:22 | String _ |
 | Foreach.cs:14:22:14:22 | String _ | Foreach.cs:14:22:14:22 | String _ |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:18:10:18:11 | enter M3 |
-| Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:18:10:18:11 | exit M3 |
+| Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:18:10:18:11 | exit M3 (normal) |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:22:20:22 | String x |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:43:20:68 | call to method Empty |
-| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:18:10:18:11 | exit M3 |
-| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 (normal) |
+| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 (normal) |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:20:22:20:22 | String x |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:24:10:24:11 | enter M4 |
-| Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:24:10:24:11 | exit M4 |
+| Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:24:10:24:11 | exit M4 (normal) |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:26:23:26:23 | String x |
-| Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:24:10:24:11 | exit M4 |
-| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | exit M4 |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | exit M4 (normal) |
+| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | exit M4 (normal) |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:23:26:23 | String x |
 | Foreach.cs:26:23:26:23 | String x | Foreach.cs:26:23:26:23 | String x |
 | Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:30:10:30:11 | enter M5 |
-| Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:30:10:30:11 | exit M5 |
+| Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:30:10:30:11 | exit M5 (normal) |
 | Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... |
 | Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:32:23:32:23 | String x |
-| Foreach.cs:30:10:30:11 | exit M5 | Foreach.cs:30:10:30:11 | exit M5 |
-| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | exit M5 |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:30:10:30:11 | exit M5 (normal) |
+| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | exit M5 (normal) |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:23:32:23 | String x |
 | Foreach.cs:32:23:32:23 | String x | Foreach.cs:32:23:32:23 | String x |
 | Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:36:10:36:11 | enter M6 |
-| Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:36:10:36:11 | exit M6 |
+| Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:36:10:36:11 | exit M6 (normal) |
 | Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |
 | Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:38:26:38:26 | String x |
-| Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:36:10:36:11 | exit M6 |
-| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | exit M6 (normal) |
+| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 (normal) |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:26:38:26 | String x |
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:38:26:38:26 | String x |
@@ -9199,28 +9655,28 @@ blockDominance
 | Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | enter Sub |
 | Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | enter Test |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | enter M1 |
-| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 |
+| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:10:13:10:19 | return ...; |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:22:11:24 | String arg |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:10:13:10:19 | return ...; |
 | LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:22:11:24 | String arg |
 | LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:22:11:24 | String arg |
 | LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | enter M2 |
-| LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 |
+| LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:18:22:18:22 | String x |
-| LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 |
-| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | exit M2 |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) |
 | LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:18:22:18:22 | String x |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:22:10:22:11 | enter M3 |
-| LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:22:10:22:11 | exit M3 |
+| LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:24:22:24:24 | Char arg |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
-| LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | exit M3 |
-| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) |
+| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:22:24:24 | Char arg |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
@@ -9229,30 +9685,30 @@ blockDominance
 | LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | enter M4 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | enter M5 |
-| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 |
+| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:22:40:22 | String x |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:41:26:41:26 | String y |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 |
-| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) |
+| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:36:10:36:11 | exit M5 |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) |
 | LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:40:22:40:22 | String x |
 | LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:26:41:26 | String y |
-| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:36:10:36:11 | exit M5 |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) |
 | LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:41:26:41:26 | String y |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:45:10:45:11 | enter M6 |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:50:9:50:13 | Label: |
 | LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:50:9:50:13 | Label: |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | enter M7 |
-| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | exit M7 |
+| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | exit M7 |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) |
 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
@@ -9260,19 +9716,19 @@ blockDominance
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | enter M8 |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 |
+| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:71:9:71:21 | ...; |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | enter M9 |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | enter M10 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
-| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:22:97:22 | String x |
-| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 |
-| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | exit M11 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:97:22:97:22 | String x |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 |
@@ -9330,22 +9786,22 @@ blockDominance
 | MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationB.cs:13:36:13:38 | exit get_Item |
 | MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:40:15:52 | {...} |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | enter set_Item |
-| MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item |
+| MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:58:15:60 | {...} |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | enter set_Item |
-| MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item |
+| MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:60:13:62 | {...} |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) |
 | MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationA.cs:15:58:15:60 | {...} |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | enter M1 |
-| MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 |
+| MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | enter M1 |
-| MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 |
+| MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:15:5:17:5 | {...} |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:9:18:22 | enter M2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access |
@@ -9362,15 +9818,15 @@ blockDominance
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | exit C2 |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:22:20:31 | {...} |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | enter C2 |
-| MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 |
+| MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:24:21:24 | 0 |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:27:21:29 | {...} |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | enter C2 |
-| MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 |
+| MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:24:19:24 | 1 |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:27:19:29 | {...} |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) |
 | MultiImplementationA.cs:21:24:21:24 | 0 | MultiImplementationA.cs:21:24:21:24 | 0 |
 | MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationA.cs:21:27:21:29 | {...} |
 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 |
@@ -9460,22 +9916,22 @@ blockDominance
 | MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationB.cs:13:36:13:38 | exit get_Item |
 | MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationB.cs:13:40:13:54 | {...} |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | enter set_Item |
-| MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item |
+| MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationA.cs:15:58:15:60 | {...} |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | enter set_Item |
-| MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item |
+| MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:60:13:62 | {...} |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) |
 | MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationB.cs:13:60:13:62 | {...} |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | enter M1 |
-| MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 |
+| MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | enter M1 |
-| MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 |
+| MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:15:5:17:5 | {...} |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:15:5:17:5 | {...} |
 | MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:9:16:31 | enter M2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access |
@@ -9492,15 +9948,15 @@ blockDominance
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | exit C2 |
 | MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:22:18:36 | {...} |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | enter C2 |
-| MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 |
+| MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:24:21:24 | 0 |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:27:21:29 | {...} |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | enter C2 |
-| MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 |
+| MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:24:19:24 | 1 |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:27:19:29 | {...} |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) |
 | MultiImplementationB.cs:19:24:19:24 | 1 | MultiImplementationB.cs:19:24:19:24 | 1 |
 | MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationB.cs:19:27:19:29 | {...} |
 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 |
@@ -9534,43 +9990,43 @@ blockDominance
 | MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | exit M1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:17:32:17 | 0 |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:9:3:10 | enter M1 |
-| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:9:3:10 | exit M1 |
+| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:28:3:28 | 0 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:9:3:10 | exit M1 |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:28:3:28 | 0 |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:9:5:10 | enter M2 |
-| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:9:5:10 | exit M2 |
+| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:30:5:34 | false |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:39:5:39 | 0 |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:43:5:43 | 1 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:9:5:10 | exit M2 |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:30:5:34 | false |
 | NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:39:5:39 | 0 |
 | NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:43:5:43 | 1 |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:12:7:13 | enter M3 |
-| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:12:7:13 | exit M3 |
+| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:52:7:53 | "" |
-| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:12:7:13 | exit M3 |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:12:9:13 | enter M4 |
-| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:12:9:13 | exit M4 |
+| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:41:9:41 | access to parameter s |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:45:9:45 | access to parameter s |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:12:9:13 | exit M4 |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:41:9:41 | access to parameter s |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:45:9:45 | access to parameter s |
 | NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:9:11:10 | enter M5 |
-| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:9:11:10 | exit M5 |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:51:11:58 | ... && ... |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:64:11:64 | 0 |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:68:11:68 | 1 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:9:11:10 | exit M5 |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) |
 | NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:58 | ... && ... |
 | NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
@@ -9654,10 +10110,10 @@ blockDominance
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |
-| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | exit M2 |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | exit M2 (normal) |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:13:13:13:19 | return ...; |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:14:9:14:29 | ...; |
-| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | exit M2 |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 (normal) |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:29 | ...; |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | enter M3 |
@@ -9673,6 +10129,8 @@ blockDominance
 | Switch.cs:5:10:5:11 | enter M1 | Switch.cs:5:10:5:11 | enter M1 |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:10:10:10:11 | enter M2 |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:10:10:10:11 | exit M2 |
+| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:10:10:10:11 | exit M2 (abnormal) |
+| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:10:10:10:11 | exit M2 (normal) |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:15:17:15:23 | return ...; |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:16:13:16:19 | case ...: |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:17:23:17:37 | object creation of type Exception |
@@ -9690,7 +10148,10 @@ blockDominance
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:27:32:27:38 | call to method Throw |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:30:13:30:20 | default: |
 | Switch.cs:10:10:10:11 | exit M2 | Switch.cs:10:10:10:11 | exit M2 |
+| Switch.cs:10:10:10:11 | exit M2 (abnormal) | Switch.cs:10:10:10:11 | exit M2 (abnormal) |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:10:10:10:11 | exit M2 (normal) |
 | Switch.cs:15:17:15:23 | return ...; | Switch.cs:15:17:15:23 | return ...; |
+| Switch.cs:16:13:16:19 | case ...: | Switch.cs:10:10:10:11 | exit M2 (abnormal) |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:13:16:19 | case ...: |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:17:23:17:37 | object creation of type Exception |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:18:13:18:22 | case ...: |
@@ -9754,12 +10215,12 @@ blockDominance
 | Switch.cs:30:13:30:20 | default: | Switch.cs:30:13:30:20 | default: |
 | Switch.cs:35:10:35:11 | enter M3 | Switch.cs:35:10:35:11 | enter M3 |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:44:10:44:11 | enter M4 |
-| Switch.cs:44:10:44:11 | enter M4 | Switch.cs:44:10:44:11 | exit M4 |
+| Switch.cs:44:10:44:11 | enter M4 | Switch.cs:44:10:44:11 | exit M4 (normal) |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:49:17:49:22 | break; |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:50:13:50:39 | case ...: |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:50:30:50:30 | access to parameter o |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:51:17:51:22 | break; |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:44:10:44:11 | exit M4 |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:44:10:44:11 | exit M4 (normal) |
 | Switch.cs:49:17:49:22 | break; | Switch.cs:49:17:49:22 | break; |
 | Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:13:50:39 | case ...: |
 | Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:30:50:30 | access to parameter o |
@@ -9769,19 +10230,19 @@ blockDominance
 | Switch.cs:51:17:51:22 | break; | Switch.cs:51:17:51:22 | break; |
 | Switch.cs:55:10:55:11 | enter M5 | Switch.cs:55:10:55:11 | enter M5 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | enter M6 |
-| Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | exit M6 |
+| Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | exit M6 (normal) |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:73:17:73:22 | break; |
-| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | exit M6 |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:66:10:66:11 | exit M6 (normal) |
 | Switch.cs:73:17:73:22 | break; | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | enter M7 |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | exit M7 |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | exit M7 (normal) |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:82:24:82:27 | true |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:83:13:83:19 | case ...: |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:84:17:85:26 | if (...) ... |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:85:21:85:26 | break; |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:86:24:86:27 | true |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:88:16:88:20 | false |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | exit M7 |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:77:10:77:11 | exit M7 (normal) |
 | Switch.cs:82:24:82:27 | true | Switch.cs:82:24:82:27 | true |
 | Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:13:83:19 | case ...: |
 | Switch.cs:83:13:83:19 | case ...: | Switch.cs:84:17:85:26 | if (...) ... |
@@ -9795,23 +10256,23 @@ blockDominance
 | Switch.cs:86:24:86:27 | true | Switch.cs:86:24:86:27 | true |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:16:88:20 | false |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | enter M8 |
-| Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | exit M8 |
+| Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | exit M8 (normal) |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:96:24:96:27 | true |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:98:16:98:20 | false |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | exit M8 |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:91:10:91:11 | exit M8 (normal) |
 | Switch.cs:96:24:96:27 | true | Switch.cs:96:24:96:27 | true |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:16:98:20 | false |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | enter M9 |
-| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | exit M9 |
+| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | exit M9 (normal) |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:103:19:103:25 | access to property Length |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:105:13:105:19 | case ...: |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:105:28:105:28 | 0 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:106:13:106:19 | case ...: |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:108:17:108:17 | 1 |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | exit M9 |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:101:9:101:10 | exit M9 (normal) |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:103:19:103:25 | access to property Length |
-| Switch.cs:105:13:105:19 | case ...: | Switch.cs:101:9:101:10 | exit M9 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:101:9:101:10 | exit M9 (normal) |
 | Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:13:105:19 | case ...: |
 | Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:28:105:28 | 0 |
 | Switch.cs:105:13:105:19 | case ...: | Switch.cs:106:13:106:19 | case ...: |
@@ -9825,14 +10286,14 @@ blockDominance
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:17:108:17 | 1 |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:17:111:21 | enter Throw |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:113:9:113:11 | enter M10 |
-| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:113:9:113:11 | exit M10 |
+| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:113:9:113:11 | exit M10 (normal) |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:117:25:117:25 | access to parameter s |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:117:44:117:44 | 1 |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:118:13:118:34 | case ...: |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:118:25:118:25 | access to parameter s |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:118:43:118:43 | 2 |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:120:17:120:17 | 1 |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | exit M10 |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:113:9:113:11 | exit M10 (normal) |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:25:117:25 | access to parameter s |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:44:117:44 | 1 |
 | Switch.cs:117:44:117:44 | 1 | Switch.cs:117:44:117:44 | 1 |
@@ -9845,11 +10306,11 @@ blockDominance
 | Switch.cs:118:43:118:43 | 2 | Switch.cs:118:43:118:43 | 2 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | enter M11 |
-| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | exit M11 |
+| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | exit M11 (normal) |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:34:125:34 | access to local variable b |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:37:125:46 | ... => ... |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:126:13:126:19 | return ...; |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | exit M11 |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 (normal) |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:34:125:34 | access to local variable b |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:126:13:126:19 | return ...; |
 | Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:46 | ... => ... |
@@ -9865,12 +10326,12 @@ blockDominance
 | Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:51 | ... => ... |
 | Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:56:131:66 | call to method ToString |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | enter M13 |
-| Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | exit M13 |
+| Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | exit M13 (normal) |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:138:13:138:20 | default: |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:139:28:139:28 | 1 |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:140:13:140:19 | case ...: |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:140:28:140:28 | 2 |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:134:9:134:11 | exit M13 |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 (normal) |
 | Switch.cs:138:13:138:20 | default: | Switch.cs:138:13:138:20 | default: |
 | Switch.cs:139:28:139:28 | 1 | Switch.cs:139:28:139:28 | 1 |
 | Switch.cs:140:13:140:19 | case ...: | Switch.cs:138:13:138:20 | default: |
@@ -9878,12 +10339,12 @@ blockDominance
 | Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:28:140:28 | 2 |
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:140:28:140:28 | 2 |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:144:9:144:11 | enter M14 |
-| Switch.cs:144:9:144:11 | enter M14 | Switch.cs:144:9:144:11 | exit M14 |
+| Switch.cs:144:9:144:11 | enter M14 | Switch.cs:144:9:144:11 | exit M14 (normal) |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:148:28:148:28 | 1 |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:149:13:149:20 | default: |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:150:13:150:19 | case ...: |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:150:28:150:28 | 2 |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:144:9:144:11 | exit M14 |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:144:9:144:11 | exit M14 (normal) |
 | Switch.cs:148:28:148:28 | 1 | Switch.cs:148:28:148:28 | 1 |
 | Switch.cs:149:13:149:20 | default: | Switch.cs:149:13:149:20 | default: |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:149:13:149:20 | default: |
@@ -9892,6 +10353,8 @@ blockDominance
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:28:150:28 | 2 |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | enter M15 |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | exit M15 |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | exit M15 (normal) |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:13:156:54 | String s = ... |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:36:156:38 | "a" |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:41:156:52 | ... => ... |
@@ -9899,10 +10362,14 @@ blockDominance
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:160:13:160:49 | ...; |
 | Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | exit M15 |
+| Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | exit M15 (normal) |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:154:10:154:12 | exit M15 (normal) |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:13:156:54 | String s = ... |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:160:13:160:49 | ...; |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
 | Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | ... => ... |
 | Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" |
@@ -9924,7 +10391,7 @@ blockDominance
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:28:25:28 | access to local variable y |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | enter Dispose |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:5:17:5:20 | enter Main |
-| cflow.cs:5:17:5:20 | enter Main | cflow.cs:5:17:5:20 | exit Main |
+| cflow.cs:5:17:5:20 | enter Main | cflow.cs:5:17:5:20 | exit Main (normal) |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:12:13:12:49 | ...; |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:14:9:17:9 | while (...) ... |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:14:16:14:16 | access to local variable a |
@@ -9942,9 +10409,9 @@ blockDominance
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:33:17:33:37 | ...; |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:5:17:5:20 | exit Main |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:5:17:5:20 | exit Main (normal) |
 | cflow.cs:12:13:12:49 | ...; | cflow.cs:12:13:12:49 | ...; |
-| cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:5:17:5:20 | exit Main |
+| cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:5:17:5:20 | exit Main (normal) |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:14:9:17:9 | while (...) ... |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:14:16:14:16 | access to local variable a |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:15:9:17:9 | {...} |
@@ -9961,7 +10428,7 @@ blockDominance
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:33:17:33:37 | ...; |
-| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:5:17:5:20 | exit Main |
+| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:5:17:5:20 | exit Main (normal) |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:14:16:14:16 | access to local variable a |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:15:9:17:9 | {...} |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:19:9:22:25 | do ... while (...); |
@@ -9978,7 +10445,7 @@ blockDominance
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:33:17:33:37 | ...; |
 | cflow.cs:15:9:17:9 | {...} | cflow.cs:15:9:17:9 | {...} |
-| cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:5:17:5:20 | exit Main |
+| cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:5:17:5:20 | exit Main (normal) |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:19:9:22:25 | do ... while (...); |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:20:9:22:9 | {...} |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:24:9:34:9 | for (...;...;...) ... |
@@ -9992,7 +10459,7 @@ blockDominance
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:33:17:33:37 | ...; |
-| cflow.cs:20:9:22:9 | {...} | cflow.cs:5:17:5:20 | exit Main |
+| cflow.cs:20:9:22:9 | {...} | cflow.cs:5:17:5:20 | exit Main (normal) |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:20:9:22:9 | {...} |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:24:9:34:9 | for (...;...;...) ... |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:24:25:24:25 | access to local variable i |
@@ -10005,7 +10472,7 @@ blockDominance
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:33:17:33:37 | ...; |
-| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:5:17:5:20 | exit Main |
+| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:5:17:5:20 | exit Main (normal) |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:9:34:9 | for (...;...;...) ... |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:34:24:34 | access to local variable i |
@@ -10017,7 +10484,7 @@ blockDominance
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:33:17:33:37 | ...; |
-| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:5:17:5:20 | exit Main |
+| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:5:17:5:20 | exit Main (normal) |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:25:9:34:9 | {...} |
@@ -10135,12 +10602,12 @@ blockDominance
 | cflow.cs:65:17:65:22 | break; | cflow.cs:65:17:65:22 | break; |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:70:18:70:18 | enter M |
-| cflow.cs:70:18:70:18 | enter M | cflow.cs:70:18:70:18 | exit M |
+| cflow.cs:70:18:70:18 | enter M | cflow.cs:70:18:70:18 | exit M (normal) |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:73:13:73:19 | return ...; |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:74:9:81:9 | if (...) ... |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:75:9:77:9 | {...} |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:79:9:81:9 | {...} |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:70:18:70:18 | exit M |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | exit M (normal) |
 | cflow.cs:73:13:73:19 | return ...; | cflow.cs:73:13:73:19 | return ...; |
 | cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:74:9:81:9 | if (...) ... |
 | cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:75:9:77:9 | {...} |
@@ -10148,15 +10615,16 @@ blockDominance
 | cflow.cs:75:9:77:9 | {...} | cflow.cs:75:9:77:9 | {...} |
 | cflow.cs:79:9:81:9 | {...} | cflow.cs:79:9:81:9 | {...} |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:84:18:84:19 | enter M2 |
-| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:84:18:84:19 | exit M2 |
+| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:84:18:84:19 | exit M2 (normal) |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:86:26:86:26 | access to parameter s |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:87:13:87:33 | ...; |
-| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:84:18:84:19 | exit M2 |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 (normal) |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:26 | access to parameter s |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:87:13:87:33 | ...; |
 | cflow.cs:87:13:87:33 | ...; | cflow.cs:87:13:87:33 | ...; |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | enter M3 |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | exit M3 |
+| cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | exit M3 (normal) |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:93:45:93:47 | "s" |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:94:9:94:29 | ...; |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:97:13:97:55 | ...; |
@@ -10165,7 +10633,9 @@ blockDominance
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:102:9:103:36 | if (...) ... |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:103:13:103:36 | ...; |
 | cflow.cs:90:18:90:19 | exit M3 | cflow.cs:90:18:90:19 | exit M3 |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | exit M3 (normal) |
 | cflow.cs:93:45:93:47 | "s" | cflow.cs:93:45:93:47 | "s" |
+| cflow.cs:94:9:94:29 | ...; | cflow.cs:90:18:90:19 | exit M3 (normal) |
 | cflow.cs:94:9:94:29 | ...; | cflow.cs:94:9:94:29 | ...; |
 | cflow.cs:94:9:94:29 | ...; | cflow.cs:97:13:97:55 | ...; |
 | cflow.cs:94:9:94:29 | ...; | cflow.cs:99:9:100:42 | if (...) ... |
@@ -10173,11 +10643,13 @@ blockDominance
 | cflow.cs:94:9:94:29 | ...; | cflow.cs:102:9:103:36 | if (...) ... |
 | cflow.cs:94:9:94:29 | ...; | cflow.cs:103:13:103:36 | ...; |
 | cflow.cs:97:13:97:55 | ...; | cflow.cs:97:13:97:55 | ...; |
+| cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:90:18:90:19 | exit M3 (normal) |
 | cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:99:9:100:42 | if (...) ... |
 | cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:100:13:100:42 | ...; |
 | cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:102:9:103:36 | if (...) ... |
 | cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:103:13:103:36 | ...; |
 | cflow.cs:100:13:100:42 | ...; | cflow.cs:100:13:100:42 | ...; |
+| cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:90:18:90:19 | exit M3 (normal) |
 | cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:102:9:103:36 | if (...) ... |
 | cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:103:13:103:36 | ...; |
 | cflow.cs:103:13:103:36 | ...; | cflow.cs:103:13:103:36 | ...; |
@@ -10205,7 +10677,7 @@ blockDominance
 | cflow.cs:144:33:144:35 | enter get_Item | cflow.cs:144:33:144:35 | enter get_Item |
 | cflow.cs:144:56:144:58 | enter set_Item | cflow.cs:144:56:144:58 | enter set_Item |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:146:10:146:12 | enter For |
-| cflow.cs:146:10:146:12 | enter For | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:146:10:146:12 | enter For | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:149:16:149:16 | access to local variable x |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:150:13:150:33 | ...; |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:152:9:157:9 | for (...;...;...) ... |
@@ -10219,8 +10691,8 @@ blockDominance
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:173:9:176:9 | for (...;...;...) ... |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:173:32:173:32 | access to local variable i |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:174:9:176:9 | {...} |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:146:10:146:12 | exit For |
-| cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:146:10:146:12 | exit For (normal) |
+| cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:149:16:149:16 | access to local variable x |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:150:13:150:33 | ...; |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:152:9:157:9 | for (...;...;...) ... |
@@ -10235,7 +10707,7 @@ blockDominance
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:173:32:173:32 | access to local variable i |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:174:9:176:9 | {...} |
 | cflow.cs:150:13:150:33 | ...; | cflow.cs:150:13:150:33 | ...; |
-| cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:152:9:157:9 | for (...;...;...) ... |
 | cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:152:18:152:18 | access to local variable x |
 | cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:153:9:157:9 | {...} |
@@ -10248,7 +10720,7 @@ blockDominance
 | cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:173:32:173:32 | access to local variable i |
 | cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:174:9:176:9 | {...} |
 | cflow.cs:152:18:152:18 | access to local variable x | cflow.cs:152:18:152:18 | access to local variable x |
-| cflow.cs:153:9:157:9 | {...} | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:153:9:157:9 | {...} | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:152:18:152:18 | access to local variable x |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:153:9:157:9 | {...} |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:156:17:156:22 | break; |
@@ -10259,7 +10731,7 @@ blockDominance
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:173:9:176:9 | for (...;...;...) ... |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:173:32:173:32 | access to local variable i |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:174:9:176:9 | {...} |
-| cflow.cs:156:17:156:22 | break; | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:156:17:156:22 | break; | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:156:17:156:22 | break; | cflow.cs:156:17:156:22 | break; |
 | cflow.cs:156:17:156:22 | break; | cflow.cs:160:9:165:9 | {...} |
 | cflow.cs:156:17:156:22 | break; | cflow.cs:164:17:164:22 | break; |
@@ -10268,7 +10740,7 @@ blockDominance
 | cflow.cs:156:17:156:22 | break; | cflow.cs:173:9:176:9 | for (...;...;...) ... |
 | cflow.cs:156:17:156:22 | break; | cflow.cs:173:32:173:32 | access to local variable i |
 | cflow.cs:156:17:156:22 | break; | cflow.cs:174:9:176:9 | {...} |
-| cflow.cs:160:9:165:9 | {...} | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:160:9:165:9 | {...} | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:160:9:165:9 | {...} |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:164:17:164:22 | break; |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:167:16:167:16 | access to local variable x |
@@ -10276,25 +10748,25 @@ blockDominance
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:173:9:176:9 | for (...;...;...) ... |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:173:32:173:32 | access to local variable i |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:174:9:176:9 | {...} |
-| cflow.cs:164:17:164:22 | break; | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:164:17:164:22 | break; | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:164:17:164:22 | break; | cflow.cs:164:17:164:22 | break; |
 | cflow.cs:164:17:164:22 | break; | cflow.cs:167:16:167:16 | access to local variable x |
 | cflow.cs:164:17:164:22 | break; | cflow.cs:168:9:171:9 | {...} |
 | cflow.cs:164:17:164:22 | break; | cflow.cs:173:9:176:9 | for (...;...;...) ... |
 | cflow.cs:164:17:164:22 | break; | cflow.cs:173:32:173:32 | access to local variable i |
 | cflow.cs:164:17:164:22 | break; | cflow.cs:174:9:176:9 | {...} |
-| cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:167:16:167:16 | access to local variable x |
 | cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:168:9:171:9 | {...} |
 | cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:173:9:176:9 | for (...;...;...) ... |
 | cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:173:32:173:32 | access to local variable i |
 | cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:174:9:176:9 | {...} |
 | cflow.cs:168:9:171:9 | {...} | cflow.cs:168:9:171:9 | {...} |
-| cflow.cs:173:9:176:9 | for (...;...;...) ... | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:173:9:176:9 | for (...;...;...) ... | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:173:9:176:9 | for (...;...;...) ... | cflow.cs:173:9:176:9 | for (...;...;...) ... |
 | cflow.cs:173:9:176:9 | for (...;...;...) ... | cflow.cs:173:32:173:32 | access to local variable i |
 | cflow.cs:173:9:176:9 | for (...;...;...) ... | cflow.cs:174:9:176:9 | {...} |
-| cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:146:10:146:12 | exit For |
+| cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:146:10:146:12 | exit For (normal) |
 | cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:173:32:173:32 | access to local variable i |
 | cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:174:9:176:9 | {...} |
 | cflow.cs:174:9:176:9 | {...} | cflow.cs:174:9:176:9 | {...} |
@@ -10304,6 +10776,7 @@ blockDominance
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:185:10:185:18 | enter LogicalOr |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | enter Booleans |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | exit Booleans |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | exit Booleans (normal) |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:13:195:56 | Boolean b = ... |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:37:195:56 | !... |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:197:35:197:39 | false |
@@ -10316,7 +10789,9 @@ blockDominance
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:200:61:200:61 | access to local variable b |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:201:9:205:9 | {...} |
 | cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:193:10:193:17 | exit Booleans |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | exit Booleans (normal) |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:193:10:193:17 | exit Booleans |
+| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:193:10:193:17 | exit Booleans (normal) |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:13:195:56 | Boolean b = ... |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:35:197:39 | false |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:43:197:46 | true |
@@ -10337,23 +10812,25 @@ blockDominance
 | cflow.cs:198:37:198:41 | false | cflow.cs:198:37:198:41 | false |
 | cflow.cs:198:45:198:48 | true | cflow.cs:198:45:198:48 | true |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:193:10:193:17 | exit Booleans |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:193:10:193:17 | exit Booleans (normal) |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:9:205:9 | if (...) ... |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:37:200:62 | !... |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:61:200:61 | access to local variable b |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:201:9:205:9 | {...} |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:193:10:193:17 | exit Booleans (normal) |
 | cflow.cs:200:37:200:62 | !... | cflow.cs:200:37:200:62 | !... |
 | cflow.cs:200:37:200:62 | !... | cflow.cs:200:61:200:61 | access to local variable b |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:61:200:61 | access to local variable b |
 | cflow.cs:201:9:205:9 | {...} | cflow.cs:201:9:205:9 | {...} |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:208:10:208:11 | enter Do |
-| cflow.cs:208:10:208:11 | enter Do | cflow.cs:208:10:208:11 | exit Do |
+| cflow.cs:208:10:208:11 | enter Do | cflow.cs:208:10:208:11 | exit Do (normal) |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:211:9:221:9 | {...} |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:214:13:216:13 | {...} |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:217:13:220:13 | if (...) ... |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:218:13:220:13 | {...} |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:221:18:221:22 | this access |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:208:10:208:11 | exit Do |
-| cflow.cs:211:9:221:9 | {...} | cflow.cs:208:10:208:11 | exit Do |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | exit Do (normal) |
+| cflow.cs:211:9:221:9 | {...} | cflow.cs:208:10:208:11 | exit Do (normal) |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:211:9:221:9 | {...} |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:214:13:216:13 | {...} |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:217:13:220:13 | if (...) ... |
@@ -10365,14 +10842,14 @@ blockDominance
 | cflow.cs:218:13:220:13 | {...} | cflow.cs:218:13:220:13 | {...} |
 | cflow.cs:221:18:221:22 | this access | cflow.cs:221:18:221:22 | this access |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:224:10:224:16 | enter Foreach |
-| cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:224:10:224:16 | exit Foreach |
+| cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:224:10:224:16 | exit Foreach (normal) |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:226:22:226:22 | String x |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:230:13:232:13 | {...} |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:233:13:236:13 | if (...) ... |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:234:13:236:13 | {...} |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:224:10:224:16 | exit Foreach |
-| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | exit Foreach |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:224:10:224:16 | exit Foreach (normal) |
+| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | exit Foreach (normal) |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:226:22:226:22 | String x |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:230:13:232:13 | {...} |
@@ -10387,7 +10864,7 @@ blockDominance
 | cflow.cs:233:13:236:13 | if (...) ... | cflow.cs:234:13:236:13 | {...} |
 | cflow.cs:234:13:236:13 | {...} | cflow.cs:234:13:236:13 | {...} |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:240:10:240:13 | enter Goto |
-| cflow.cs:240:10:240:13 | enter Goto | cflow.cs:240:10:240:13 | exit Goto |
+| cflow.cs:240:10:240:13 | enter Goto | cflow.cs:240:10:240:13 | exit Goto (normal) |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:242:9:242:13 | Label: |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:242:43:242:45 | {...} |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:244:9:244:41 | if (...) ... |
@@ -10399,8 +10876,8 @@ blockDominance
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:253:13:253:19 | case ...: |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:254:17:254:27 | goto ...; |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:255:13:255:20 | default: |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:240:10:240:13 | exit Goto |
-| cflow.cs:242:9:242:13 | Label: | cflow.cs:240:10:240:13 | exit Goto |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto (normal) |
+| cflow.cs:242:9:242:13 | Label: | cflow.cs:240:10:240:13 | exit Goto (normal) |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:9:242:13 | Label: |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:43:242:45 | {...} |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:244:9:244:41 | if (...) ... |
@@ -10413,7 +10890,7 @@ blockDominance
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:254:17:254:27 | goto ...; |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:255:13:255:20 | default: |
 | cflow.cs:242:43:242:45 | {...} | cflow.cs:242:43:242:45 | {...} |
-| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:240:10:240:13 | exit Goto |
+| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:240:10:240:13 | exit Goto (normal) |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:9:244:41 | if (...) ... |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:31:244:41 | goto ...; |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:246:9:258:9 | switch (...) {...} |
@@ -10424,7 +10901,7 @@ blockDominance
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:254:17:254:27 | goto ...; |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:255:13:255:20 | default: |
 | cflow.cs:244:31:244:41 | goto ...; | cflow.cs:244:31:244:41 | goto ...; |
-| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:240:10:240:13 | exit Goto |
+| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:240:10:240:13 | exit Goto (normal) |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:246:9:258:9 | switch (...) {...} |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:249:17:249:29 | goto default; |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:250:13:250:19 | case ...: |
@@ -10480,13 +10957,7 @@ postBlockDominance
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | enter M3 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | enter M4 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | enter M1 |
-| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | enter M1 |
 | Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | exit M1 |
-| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:9:16:9:32 | String s = ... |
-| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:9:24:9:27 | null |
-| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:9:31:9:32 | "" |
-| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
-| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | enter M1 |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:16:9:32 | String s = ... |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:24:9:27 | null |
@@ -10494,15 +10965,13 @@ postBlockDominance
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:7:10:7:11 | enter M1 |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:9:16:9:32 | String s = ... |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:9:24:9:27 | null |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | enter M2 |
-| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | enter M2 |
 | Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | exit M2 |
-| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:16:16:16:32 | String s = ... |
-| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:16:24:16:27 | null |
-| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:16:31:16:32 | "" |
-| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
-| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | enter M2 |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:16:16:32 | String s = ... |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:24:16:27 | null |
@@ -10510,15 +10979,13 @@ postBlockDominance
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:14:10:14:11 | enter M2 |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:16:16:16:32 | String s = ... |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:16:24:16:27 | null |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | enter M3 |
-| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | enter M3 |
 | Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | exit M3 |
-| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:23:16:23:32 | String s = ... |
-| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:23:24:23:27 | null |
-| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:23:31:23:32 | "" |
-| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
-| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | enter M3 |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:16:23:32 | String s = ... |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:24:23:27 | null |
@@ -10526,15 +10993,13 @@ postBlockDominance
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:21:10:21:11 | enter M3 |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:23:16:23:32 | String s = ... |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:23:24:23:27 | null |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | enter M4 |
-| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | enter M4 |
 | Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | exit M4 |
-| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:30:16:30:32 | String s = ... |
-| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:30:24:30:27 | null |
-| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:30:31:30:32 | "" |
-| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
-| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | enter M4 |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:16:30:32 | String s = ... |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:24:30:27 | null |
@@ -10542,15 +11007,13 @@ postBlockDominance
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:28:10:28:11 | enter M4 |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:30:16:30:32 | String s = ... |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:30:24:30:27 | null |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | enter M5 |
-| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | enter M5 |
 | Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | exit M5 |
-| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:37:16:37:32 | String s = ... |
-| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:37:24:37:27 | null |
-| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:37:31:37:32 | "" |
-| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
-| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | enter M5 |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:16:37:32 | String s = ... |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:24:37:27 | null |
@@ -10558,15 +11021,13 @@ postBlockDominance
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:35:10:35:11 | enter M5 |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:37:16:37:32 | String s = ... |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:37:24:37:27 | null |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | enter M6 |
-| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | enter M6 |
 | Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | exit M6 |
-| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:44:16:44:32 | String s = ... |
-| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:44:24:44:27 | null |
-| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:44:31:44:32 | "" |
-| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
-| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | enter M6 |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:16:44:32 | String s = ... |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:24:44:27 | null |
@@ -10574,15 +11035,13 @@ postBlockDominance
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:42:10:42:11 | enter M6 |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:44:16:44:32 | String s = ... |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:44:24:44:27 | null |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | enter M7 |
-| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | enter M7 |
 | Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | exit M7 |
-| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:51:16:51:32 | String s = ... |
-| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:51:24:51:27 | null |
-| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:51:31:51:32 | "" |
-| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
-| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | enter M7 |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:16:51:32 | String s = ... |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:24:51:27 | null |
@@ -10590,175 +11049,194 @@ postBlockDominance
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:49:10:49:11 | enter M7 |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:51:16:51:32 | String s = ... |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:51:24:51:27 | null |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | enter M8 |
-| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | enter M8 |
 | Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | exit M8 |
-| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:58:24:58:27 | [b (line 56): true] null |
-| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
-| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
-| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
-| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:56:10:56:11 | enter M8 |
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:24:58:27 | [b (line 56): true] null |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
 | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:56:10:56:11 | enter M8 |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:58:24:58:27 | [b (line 56): true] null |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | enter M9 |
-| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | enter M9 |
 | Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | exit M9 |
-| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:65:24:65:27 | [b (line 63): true] null |
-| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
-| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
-| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
-| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
 | Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:24:65:27 | [b (line 63): true] null |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:63:10:63:11 | enter M9 |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:65:24:65:27 | [b (line 63): true] null |
 | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:63:10:63:11 | enter M9 |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | enter M10 |
-| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | enter M10 |
 | Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | exit M10 |
-| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:72:24:72:27 | [b (line 70): true] null |
-| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
-| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
-| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
-| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:70:10:70:12 | enter M10 |
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:24:72:27 | [b (line 70): true] null |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
 | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:70:10:70:12 | enter M10 |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:72:24:72:27 | [b (line 70): true] null |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | enter M11 |
-| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | enter M11 |
 | Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | exit M11 |
-| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:79:24:79:27 | [b (line 77): true] null |
-| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
-| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
-| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
-| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
 | Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:24:79:27 | [b (line 77): true] null |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:77:10:77:12 | enter M11 |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:79:24:79:27 | [b (line 77): true] null |
 | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:77:10:77:12 | enter M11 |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | enter M12 |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | enter M12 |
 | Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | exit M12 |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:86:24:86:27 | [b (line 84): true] null |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | exit M12 (abnormal) |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:84:10:84:12 | enter M12 |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
 | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
 | Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
 | Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:131:18:131:32 | enter AssertTrueFalse |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:138:10:138:12 | enter M13 |
-| Assert.cs:138:10:138:12 | exit M13 | Assert.cs:138:10:138:12 | enter M13 |
 | Assert.cs:138:10:138:12 | exit M13 | Assert.cs:138:10:138:12 | exit M13 |
-| Assert.cs:138:10:138:12 | exit M13 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 |
-| Assert.cs:138:10:138:12 | exit M13 | Assert.cs:140:29:140:30 | access to parameter b2 |
-| Assert.cs:138:10:138:12 | exit M13 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 |
-| Assert.cs:138:10:138:12 | exit M13 | Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 |
+| Assert.cs:138:10:138:12 | exit M13 (abnormal) | Assert.cs:138:10:138:12 | exit M13 (abnormal) |
 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 |
+| Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:138:10:138:12 | enter M13 |
 | Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:140:29:140:30 | access to parameter b2 |
 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 |
+| Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | Assert.cs:138:10:138:12 | enter M13 |
+| Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | Assert.cs:140:29:140:30 | access to parameter b2 |
 | Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | enter M |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | enter (...) => ... |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | enter + |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:3:10:3:11 | enter M1 |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:3:10:3:11 | enter M1 |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:3:10:3:11 | exit M1 |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:7:26:7:28 | String arg |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:10:21:10:26 | break; |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:14:9:17:9 | {...} |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:16:17:16:17 | ; |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:3:10:3:11 | enter M1 |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:3:10:3:11 | exit M1 (normal) |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:7:26:7:28 | String arg |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:10:21:10:26 | break; |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:14:9:17:9 | {...} |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:16:17:16:17 | ; |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:3:10:3:11 | enter M1 |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... |
 | BreakInTry.cs:7:26:7:28 | String arg | BreakInTry.cs:7:26:7:28 | String arg |
@@ -10788,17 +11266,17 @@ postBlockDominance
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:35:7:35:7 | ; |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:38:10:38:11 | enter M3 |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | enter M3 |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | exit M3 |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:43:17:43:23 | return ...; |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:46:9:52:9 | {...} |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:26:47:28 | String arg |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:50:21:50:26 | break; |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:53:7:53:7 | ; |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:38:10:38:11 | enter M3 |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:38:10:38:11 | exit M3 (normal) |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:43:17:43:23 | return ...; |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:46:9:52:9 | {...} |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:47:26:47:28 | String arg |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:50:21:50:26 | break; |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:53:7:53:7 | ; |
 | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:43:17:43:23 | return ...; |
 | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:46:9:52:9 | {...} |
 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:43:17:43:23 | return ...; |
@@ -10815,16 +11293,16 @@ postBlockDominance
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:50:21:50:26 | break; |
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:53:7:53:7 | ; |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:56:10:56:11 | enter M4 |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:56:10:56:11 | enter M4 |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:56:10:56:11 | exit M4 |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:61:17:61:23 | return ...; |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:64:9:70:9 | {...} |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:26:65:28 | String arg |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:68:21:68:26 | break; |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:56:10:56:11 | enter M4 |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:56:10:56:11 | exit M4 (normal) |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:61:17:61:23 | return ...; |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:64:9:70:9 | {...} |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:65:26:65:28 | String arg |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:68:21:68:26 | break; |
 | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:61:17:61:23 | return ...; |
 | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:64:9:70:9 | {...} |
 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:61:17:61:23 | return ...; |
@@ -10841,42 +11319,42 @@ postBlockDominance
 | CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:20:12:20:17 | enter Nameof |
 | CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:28:10:28:10 | enter M |
 | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:30:10:30:12 | enter Out |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:30:10:30:12 | enter Out |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | enter M1 |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:12:3:13 | enter M1 |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:12:3:13 | exit M1 |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:28:3:38 | call to method ToString |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:40:3:49 | call to method ToLower |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | enter M1 |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:28:3:38 | call to method ToString |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:40:3:49 | call to method ToLower |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:28:3:38 | call to method ToString |
 | ConditionalAccess.cs:3:40:3:49 | call to method ToLower | ConditionalAccess.cs:3:40:3:49 | call to method ToLower |
 | ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:10:5:11 | enter M2 |
-| ConditionalAccess.cs:5:10:5:11 | exit M2 | ConditionalAccess.cs:5:10:5:11 | enter M2 |
-| ConditionalAccess.cs:5:10:5:11 | exit M2 | ConditionalAccess.cs:5:10:5:11 | exit M2 |
-| ConditionalAccess.cs:5:10:5:11 | exit M2 | ConditionalAccess.cs:5:28:5:34 | access to property Length |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | enter M2 |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:28:5:34 | access to property Length |
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:28:5:34 | access to property Length |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:10:7:11 | enter M3 |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:10:7:11 | enter M3 |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:10:7:11 | exit M3 |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:49:7:55 | access to property Length |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | enter M3 |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:49:7:55 | access to property Length |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:49:7:55 | access to property Length |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | enter M4 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:9:9:10 | enter M4 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:9:9:10 | exit M4 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:27:9:33 | access to property Length |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:38:9:38 | 0 |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | enter M4 |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:27:9:33 | access to property Length |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:38:9:38 | 0 |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:27:9:33 | access to property Length |
 | ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:38:9:38 | 0 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:11:9:11:10 | enter M5 |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:11:9:11:10 | enter M5 |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:11:9:11:10 | exit M5 |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:13:15:13:21 | access to property Length |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:13:25:13:25 | 0 |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:14:20:14:20 | 0 |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:16:20:16:20 | 1 |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | enter M5 |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:13:15:13:21 | access to property Length |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:13:25:13:25 | 0 |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:14:20:14:20 | 0 |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:16:20:16:20 | 1 |
 | ConditionalAccess.cs:13:15:13:21 | access to property Length | ConditionalAccess.cs:13:15:13:21 | access to property Length |
 | ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:11:9:11:10 | enter M5 |
 | ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:13:15:13:21 | access to property Length |
@@ -10884,25 +11362,25 @@ postBlockDominance
 | ConditionalAccess.cs:14:20:14:20 | 0 | ConditionalAccess.cs:14:20:14:20 | 0 |
 | ConditionalAccess.cs:16:20:16:20 | 1 | ConditionalAccess.cs:16:20:16:20 | 1 |
 | ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:12:19:13 | enter M6 |
-| ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:12:19:13 | enter M6 |
-| ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:12:19:13 | exit M6 |
-| ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | enter M6 |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | enter M7 |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | enter Out |
-| ConditionalAccess.cs:30:10:30:12 | exit Out | ConditionalAccess.cs:30:10:30:12 | enter Out |
-| ConditionalAccess.cs:30:10:30:12 | exit Out | ConditionalAccess.cs:30:10:30:12 | exit Out |
+| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | enter Out |
+| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | enter M8 |
-| ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:32:10:32:11 | enter M8 |
-| ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:32:10:32:11 | exit M8 |
-| ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:35:14:35:24 | call to method Out |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | enter M8 |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:35:14:35:24 | call to method Out |
 | ConditionalAccess.cs:35:14:35:24 | call to method Out | ConditionalAccess.cs:35:14:35:24 | call to method Out |
 | ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:3:10:3:19 | enter IncrOrDecr |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:3:10:3:19 | enter IncrOrDecr |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:3:10:3:19 | exit IncrOrDecr |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | enter IncrOrDecr |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... |
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; |
 | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... |
 | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:11:9:11:10 | enter M1 |
@@ -11060,13 +11538,13 @@ postBlockDominance
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:16:110:16 | access to local variable x |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:113:10:113:11 | enter M9 |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | enter M9 |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | exit M9 |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:116:25:116:25 | access to local variable i |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:116:42:116:42 | access to local variable i |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | enter M9 |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | exit M9 (normal) |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:116:25:116:25 | access to local variable i |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:116:42:116:42 | access to local variable i |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:117:9:123:9 | {...} |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | enter M9 |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:25 | access to local variable i |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
@@ -11086,10 +11564,10 @@ postBlockDominance
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | enter M11 |
-| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | enter M11 |
-| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | exit M11 |
-| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
-| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | enter M11 |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | exit M11 (normal) |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | enter M1 |
@@ -11098,12 +11576,12 @@ postBlockDominance
 | ExitMethods.cs:25:10:25:11 | enter M4 | ExitMethods.cs:25:10:25:11 | enter M4 |
 | ExitMethods.cs:31:10:31:11 | enter M5 | ExitMethods.cs:31:10:31:11 | enter M5 |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:37:10:37:11 | enter M6 |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:37:10:37:11 | enter M6 |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:37:10:37:11 | exit M6 |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:44:9:46:9 | {...} |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:37:10:37:11 | enter M6 |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:37:10:37:11 | exit M6 (normal) |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:44:9:46:9 | {...} |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} |
 | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} |
 | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} |
@@ -11112,15 +11590,12 @@ postBlockDominance
 | ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:53:10:53:11 | enter M7 |
 | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:59:10:59:11 | enter M8 |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe |
-| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe |
 | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe |
-| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) |
 | ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:71:17:71:27 | enter ErrorAlways |
-| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | enter ErrorAlways |
-| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | exit ErrorAlways |
-| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
-| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:76:41:76:43 | "b" |
+| ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) | ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) |
 | ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
 | ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:41:76:43 | "b" |
 | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 |
@@ -11129,10 +11604,8 @@ postBlockDominance
 | ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:91:10:91:18 | enter ExitInTry |
 | ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:104:10:104:24 | enter ApplicationExit |
 | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:109:13:109:21 | enter ThrowExpr |
-| ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:109:13:109:21 | enter ThrowExpr |
 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:109:13:109:21 | exit ThrowExpr |
-| ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:111:29:111:29 | 1 |
-| ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:111:69:111:75 | "input" |
+| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:109:13:109:21 | enter ThrowExpr |
 | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | 1 |
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:69:111:75 | "input" |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
@@ -11145,11 +11618,9 @@ postBlockDominance
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | enter FailingAssertion |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
-| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
 | ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse |
-| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
-| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
 | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
 | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | enter ToInt32 |
@@ -11157,89 +11628,88 @@ postBlockDominance
 | Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:23:15:33 | enter CallToInt32 |
 | Extensions.cs:20:17:20:20 | enter Main | Extensions.cs:20:17:20:20 | enter Main |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:7:10:7:11 | enter M1 |
-| Finally.cs:7:10:7:11 | exit M1 | Finally.cs:7:10:7:11 | enter M1 |
 | Finally.cs:7:10:7:11 | exit M1 | Finally.cs:7:10:7:11 | exit M1 |
-| Finally.cs:7:10:7:11 | exit M1 | Finally.cs:11:13:11:37 | call to method WriteLine |
-| Finally.cs:7:10:7:11 | exit M1 | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} |
-| Finally.cs:7:10:7:11 | exit M1 | Finally.cs:14:9:16:9 | [finally: exception(OutOfMemoryException)] {...} |
-| Finally.cs:7:10:7:11 | exit M1 | Finally.cs:14:9:16:9 | {...} |
+| Finally.cs:7:10:7:11 | exit M1 (abnormal) | Finally.cs:7:10:7:11 | exit M1 (abnormal) |
+| Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:7:10:7:11 | enter M1 |
 | Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:11:13:11:37 | call to method WriteLine |
 | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:14:9:16:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:14:9:16:9 | [finally: exception(OutOfMemoryException)] {...} |
+| Finally.cs:14:9:16:9 | {...} | Finally.cs:7:10:7:11 | enter M1 |
+| Finally.cs:14:9:16:9 | {...} | Finally.cs:11:13:11:37 | call to method WriteLine |
 | Finally.cs:14:9:16:9 | {...} | Finally.cs:14:9:16:9 | {...} |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:19:10:19:11 | enter M2 |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:19:10:19:11 | enter M2 |
 | Finally.cs:19:10:19:11 | exit M2 | Finally.cs:19:10:19:11 | exit M2 |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:23:13:23:37 | call to method WriteLine |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:24:13:24:19 | return ...; |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:26:9:29:9 | [exception: OutOfMemoryException] catch (...) {...} |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:26:38:26:39 | [exception: Exception] IOException ex |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:30:41:30:42 | [exception: Exception] ArgumentException ex |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} |
-| Finally.cs:19:10:19:11 | exit M2 | Finally.cs:42:9:43:9 | {...} |
+| Finally.cs:19:10:19:11 | exit M2 (abnormal) | Finally.cs:19:10:19:11 | exit M2 (abnormal) |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:19:10:19:11 | enter M2 |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:19:10:19:11 | exit M2 (normal) |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:23:13:23:37 | call to method WriteLine |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:24:13:24:19 | return ...; |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:26:9:29:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:42:9:43:9 | {...} |
 | Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:23:13:23:37 | call to method WriteLine |
 | Finally.cs:24:13:24:19 | return ...; | Finally.cs:24:13:24:19 | return ...; |
 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:26:9:29:9 | [exception: OutOfMemoryException] catch (...) {...} | Finally.cs:26:9:29:9 | [exception: OutOfMemoryException] catch (...) {...} |
 | Finally.cs:26:38:26:39 | [exception: Exception] IOException ex | Finally.cs:26:38:26:39 | [exception: Exception] IOException ex |
+| Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:30:41:30:42 | [exception: Exception] ArgumentException ex | Finally.cs:30:41:30:42 | [exception: Exception] ArgumentException ex |
+| Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} |
+| Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} | Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} |
+| Finally.cs:42:9:43:9 | {...} | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:42:9:43:9 | {...} | Finally.cs:26:9:29:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| Finally.cs:42:9:43:9 | {...} | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:42:9:43:9 | {...} | Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:42:9:43:9 | {...} | Finally.cs:42:9:43:9 | {...} |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:54:10:54:11 | enter M3 |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:54:10:54:11 | enter M3 |
 | Finally.cs:54:10:54:11 | exit M3 | Finally.cs:54:10:54:11 | exit M3 |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:58:13:58:37 | call to method WriteLine |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:59:13:59:19 | return ...; |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:61:9:64:9 | [exception: OutOfMemoryException] catch (...) {...} |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:61:38:61:39 | [exception: Exception] IOException ex |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:66:9:67:9 | {...} |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:69:9:71:9 | [finally: exception(Exception)] {...} |
-| Finally.cs:54:10:54:11 | exit M3 | Finally.cs:69:9:71:9 | [finally: exception(OutOfMemoryException)] {...} |
+| Finally.cs:54:10:54:11 | exit M3 (abnormal) | Finally.cs:54:10:54:11 | exit M3 (abnormal) |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:54:10:54:11 | enter M3 |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:54:10:54:11 | exit M3 (normal) |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:58:13:58:37 | call to method WriteLine |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:59:13:59:19 | return ...; |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:61:9:64:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:66:9:67:9 | {...} |
 | Finally.cs:58:13:58:37 | call to method WriteLine | Finally.cs:58:13:58:37 | call to method WriteLine |
 | Finally.cs:59:13:59:19 | return ...; | Finally.cs:59:13:59:19 | return ...; |
 | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:61:9:64:9 | [exception: OutOfMemoryException] catch (...) {...} | Finally.cs:61:9:64:9 | [exception: OutOfMemoryException] catch (...) {...} |
 | Finally.cs:61:38:61:39 | [exception: Exception] IOException ex | Finally.cs:61:38:61:39 | [exception: Exception] IOException ex |
+| Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} | Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} |
+| Finally.cs:66:9:67:9 | {...} | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} |
+| Finally.cs:66:9:67:9 | {...} | Finally.cs:61:9:64:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| Finally.cs:66:9:67:9 | {...} | Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} |
 | Finally.cs:66:9:67:9 | {...} | Finally.cs:66:9:67:9 | {...} |
 | Finally.cs:69:9:71:9 | [finally: exception(Exception)] {...} | Finally.cs:69:9:71:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:69:9:71:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:69:9:71:9 | [finally: exception(OutOfMemoryException)] {...} |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:74:10:74:11 | enter M4 |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:74:10:74:11 | enter M4 |
 | Finally.cs:74:10:74:11 | exit M4 | Finally.cs:74:10:74:11 | exit M4 |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:77:16:77:16 | access to local variable i |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:78:9:100:9 | {...} |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:82:21:82:27 | return ...; |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:83:17:84:29 | if (...) ... |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:84:21:84:29 | continue; |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:85:17:86:26 | if (...) ... |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:86:21:86:26 | break; |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:89:13:99:13 | {...} |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:93:25:93:46 | [finally: break] throw ...; |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:93:25:93:46 | [finally: continue] throw ...; |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:93:25:93:46 | [finally: return] throw ...; |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:93:25:93:46 | throw ...; |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:96:17:98:17 | [finally: break] {...} |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:96:17:98:17 | [finally: continue] {...} |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:96:17:98:17 | [finally: return] {...} |
-| Finally.cs:74:10:74:11 | exit M4 | Finally.cs:96:17:98:17 | {...} |
+| Finally.cs:74:10:74:11 | exit M4 (abnormal) | Finally.cs:74:10:74:11 | exit M4 (abnormal) |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:74:10:74:11 | enter M4 |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:74:10:74:11 | exit M4 (normal) |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:77:16:77:16 | access to local variable i |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:78:9:100:9 | {...} |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:82:21:82:27 | return ...; |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:83:17:84:29 | if (...) ... |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:84:21:84:29 | continue; |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:85:17:86:26 | if (...) ... |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:86:21:86:26 | break; |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:89:13:99:13 | {...} |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:96:17:98:17 | [finally: break] {...} |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:96:17:98:17 | [finally: continue] {...} |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:96:17:98:17 | [finally: return] {...} |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:74:10:74:11 | enter M4 |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:77:16:77:16 | access to local variable i |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:84:21:84:29 | continue; |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:89:13:99:13 | {...} |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: continue] {...} |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:78:9:100:9 | {...} |
@@ -11257,79 +11727,70 @@ postBlockDominance
 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception |
 | Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:93:25:93:46 | throw ...; |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:93:31:93:45 | object creation of type Exception |
 | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:93:25:93:46 | [finally: break] throw ...; |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception |
 | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:86:21:86:26 | break; |
 | Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:96:17:98:17 | [finally: break] {...} |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:93:25:93:46 | [finally: continue] throw ...; |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
 | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:84:21:84:29 | continue; |
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:96:17:98:17 | [finally: continue] {...} |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:93:25:93:46 | [finally: return] throw ...; |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception |
 | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:82:21:82:27 | return ...; |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:96:17:98:17 | [finally: return] {...} |
+| Finally.cs:96:17:98:17 | {...} | Finally.cs:89:13:99:13 | {...} |
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:103:10:103:11 | enter M5 |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:103:10:103:11 | enter M5 |
 | Finally.cs:103:10:103:11 | exit M5 | Finally.cs:103:10:103:11 | exit M5 |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:107:17:107:28 | access to property Length |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:107:33:107:33 | 0 |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:108:17:108:23 | return ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:109:13:110:49 | if (...) ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:109:17:109:28 | access to property Length |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:109:33:109:33 | 1 |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:110:17:110:49 | throw ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:115:17:115:41 | [finally: return] ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:116:13:117:37 | if (...) ... |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:117:17:117:37 | ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; |
-| Finally.cs:103:10:103:11 | exit M5 | Finally.cs:117:17:117:37 | [finally: return] ...; |
+| Finally.cs:103:10:103:11 | exit M5 (abnormal) | Finally.cs:103:10:103:11 | exit M5 (abnormal) |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:103:10:103:11 | enter M5 |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:103:10:103:11 | exit M5 (normal) |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:107:17:107:28 | access to property Length |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:107:33:107:33 | 0 |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:108:17:108:23 | return ...; |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:109:13:110:49 | if (...) ... |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:109:17:109:28 | access to property Length |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:109:33:109:33 | 1 |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:113:9:118:9 | {...} |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:115:17:115:41 | ...; |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:115:17:115:41 | [finally: return] ...; |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:116:13:117:37 | [finally: return] if (...) ... |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:116:13:117:37 | if (...) ... |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:117:17:117:37 | ...; |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:117:17:117:37 | [finally: return] ...; |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:103:10:103:11 | enter M5 |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:107:17:107:28 | access to property Length |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:103:10:103:11 | enter M5 |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:107:17:107:28 | access to property Length |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:107:33:107:33 | 0 |
 | Finally.cs:108:17:108:23 | return ...; | Finally.cs:108:17:108:23 | return ...; |
 | Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:109:13:110:49 | if (...) ... |
+| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:109:13:110:49 | if (...) ... |
 | Finally.cs:109:17:109:28 | access to property Length | Finally.cs:109:17:109:28 | access to property Length |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:109:13:110:49 | if (...) ... |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:109:17:109:28 | access to property Length |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:109:33:109:33 | 1 |
 | Finally.cs:110:17:110:49 | throw ...; | Finally.cs:110:17:110:49 | throw ...; |
 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException |
 | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} |
+| Finally.cs:113:9:118:9 | {...} | Finally.cs:109:13:110:49 | if (...) ... |
+| Finally.cs:113:9:118:9 | {...} | Finally.cs:109:17:109:28 | access to property Length |
+| Finally.cs:113:9:118:9 | {...} | Finally.cs:109:33:109:33 | 1 |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:113:9:118:9 | {...} |
 | Finally.cs:115:17:115:41 | ...; | Finally.cs:115:17:115:41 | ...; |
 | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
 | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; |
 | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:115:17:115:41 | [finally: return] ...; | Finally.cs:115:17:115:41 | [finally: return] ...; |
-| Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} |
-| Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
 | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... |
-| Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} |
-| Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; |
 | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... |
-| Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:110:17:110:49 | throw ...; |
-| Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:108:17:108:23 | return ...; |
 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:115:17:115:41 | [finally: return] ...; |
 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:116:13:117:37 | [finally: return] if (...) ... |
+| Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:109:13:110:49 | if (...) ... |
+| Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:109:17:109:28 | access to property Length |
+| Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:109:33:109:33 | 1 |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:113:9:118:9 | {...} |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:115:17:115:41 | ...; |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:116:13:117:37 | if (...) ... |
@@ -11340,47 +11801,28 @@ postBlockDominance
 | Finally.cs:117:17:117:37 | [finally: return] ...; | Finally.cs:117:17:117:37 | [finally: return] ...; |
 | Finally.cs:121:10:121:11 | enter M6 | Finally.cs:121:10:121:11 | enter M6 |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:133:10:133:11 | enter M7 |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:133:10:133:11 | enter M7 |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:133:10:133:11 | exit M7 |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:137:13:137:36 | call to method WriteLine |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:140:9:143:9 | [finally: exception(OutOfMemoryException)] {...} |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:140:9:143:9 | {...} |
+| Finally.cs:133:10:133:11 | exit M7 (abnormal) | Finally.cs:133:10:133:11 | exit M7 (abnormal) |
 | Finally.cs:137:13:137:36 | call to method WriteLine | Finally.cs:137:13:137:36 | call to method WriteLine |
 | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:140:9:143:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:140:9:143:9 | [finally: exception(OutOfMemoryException)] {...} |
 | Finally.cs:140:9:143:9 | {...} | Finally.cs:140:9:143:9 | {...} |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:147:10:147:11 | enter M8 |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:147:10:147:11 | enter M8 |
 | Finally.cs:147:10:147:11 | exit M8 | Finally.cs:147:10:147:11 | exit M8 |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:152:17:152:50 | throw ...; |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:155:9:169:9 | {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:158:36:158:36 | 1 |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:158:36:158:36 | [finally: exception(ArgumentNullException)] 1 |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:158:36:158:36 | [finally: exception(Exception)] 1 |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:159:21:159:45 | [finally: exception(ArgumentNullException)] throw ...; |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:159:21:159:45 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:159:21:159:45 | throw ...; |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:159:41:159:43 | "1" |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:159:41:159:43 | [finally: exception(ArgumentNullException)] "1" |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:159:41:159:43 | [finally: exception(Exception)] "1" |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:161:13:164:13 | [exception: NullReferenceException] catch (...) {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: NullReferenceException] catch (...) {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:162:13:164:13 | [finally: exception(Exception)] {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:162:13:164:13 | {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:165:13:168:13 | [finally: exception(ArgumentNullException)] catch {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} |
-| Finally.cs:147:10:147:11 | exit M8 | Finally.cs:165:13:168:13 | catch {...} |
+| Finally.cs:147:10:147:11 | exit M8 (abnormal) | Finally.cs:147:10:147:11 | exit M8 (abnormal) |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:147:10:147:11 | enter M8 |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:147:10:147:11 | exit M8 (normal) |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:155:9:169:9 | {...} |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:158:36:158:36 | 1 |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:159:21:159:45 | throw ...; |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:159:41:159:43 | "1" |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:161:13:164:13 | [exception: NullReferenceException] catch (...) {...} |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:162:13:164:13 | {...} |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:165:13:168:13 | catch {...} |
 | Finally.cs:152:17:152:50 | throw ...; | Finally.cs:152:17:152:50 | throw ...; |
 | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException |
 | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} |
+| Finally.cs:155:9:169:9 | {...} | Finally.cs:147:10:147:11 | enter M8 |
 | Finally.cs:155:9:169:9 | {...} | Finally.cs:155:9:169:9 | {...} |
 | Finally.cs:158:36:158:36 | 1 | Finally.cs:158:36:158:36 | 1 |
 | Finally.cs:158:36:158:36 | [finally: exception(ArgumentNullException)] 1 | Finally.cs:158:36:158:36 | [finally: exception(ArgumentNullException)] 1 |
@@ -11395,12 +11837,8 @@ postBlockDominance
 | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | Finally.cs:159:41:159:43 | "1" |
 | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} |
 | Finally.cs:161:13:164:13 | [exception: NullReferenceException] catch (...) {...} | Finally.cs:161:13:164:13 | [exception: NullReferenceException] catch (...) {...} |
-| Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | Finally.cs:159:21:159:45 | [finally: exception(ArgumentNullException)] throw ...; |
-| Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | Finally.cs:159:41:159:43 | [finally: exception(ArgumentNullException)] "1" |
 | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} |
 | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...} | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...} |
-| Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | Finally.cs:159:21:159:45 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | Finally.cs:159:41:159:43 | [finally: exception(Exception)] "1" |
 | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} |
 | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: NullReferenceException] catch (...) {...} | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: NullReferenceException] catch (...) {...} |
 | Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} |
@@ -11410,29 +11848,19 @@ postBlockDominance
 | Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} | Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} |
 | Finally.cs:165:13:168:13 | catch {...} | Finally.cs:165:13:168:13 | catch {...} |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:176:10:176:11 | enter M9 |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:176:10:176:11 | enter M9 |
 | Finally.cs:176:10:176:11 | exit M9 | Finally.cs:176:10:176:11 | exit M9 |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:183:9:192:9 | [finally: exception(Exception), b1 (line 176): true] {...} |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:186:25:186:47 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...; |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:186:25:186:47 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...; |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} |
-| Finally.cs:176:10:176:11 | exit M9 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} |
+| Finally.cs:176:10:176:11 | exit M9 (abnormal) | Finally.cs:176:10:176:11 | exit M9 (abnormal) |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:176:10:176:11 | enter M9 |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:176:10:176:11 | exit M9 (normal) |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} |
 | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; |
 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA |
+| Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:176:10:176:11 | enter M9 |
 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} |
 | Finally.cs:183:9:192:9 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:183:9:192:9 | [finally: exception(Exception), b1 (line 176): true] {...} |
 | Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; | Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; |
@@ -11444,52 +11872,24 @@ postBlockDominance
 | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} |
 | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} |
 | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} |
+| Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} |
 | Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 |
 | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
 | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; |
+| Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB |
+| Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} |
 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 |
 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} |
-| Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:186:25:186:47 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...; |
-| Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
 | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} |
-| Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:186:25:186:47 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...; |
-| Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 |
 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:195:10:195:12 | enter M10 |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:195:10:195:12 | enter M10 |
 | Finally.cs:195:10:195:12 | exit M10 | Finally.cs:195:10:195:12 | exit M10 |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:199:21:199:43 | throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:199:27:199:42 | object creation of type ExceptionA |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:202:9:212:9 | {...} |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:205:25:205:47 | throw ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:205:31:205:46 | object creation of type ExceptionB |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:208:13:210:13 | {...} |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:209:31:209:46 | object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:211:13:211:29 | ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
-| Finally.cs:195:10:195:12 | exit M10 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; |
+| Finally.cs:195:10:195:12 | exit M10 (abnormal) | Finally.cs:195:10:195:12 | exit M10 (abnormal) |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:199:21:199:43 | throw ...; |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:199:27:199:42 | object creation of type ExceptionA |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:195:10:195:12 | enter M10 |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:202:9:212:9 | {...} |
 | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; |
 | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
@@ -11502,6 +11902,8 @@ postBlockDominance
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:208:13:210:13 | {...} | Finally.cs:195:10:195:12 | enter M10 |
+| Finally.cs:208:13:210:13 | {...} | Finally.cs:202:9:212:9 | {...} |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:208:13:210:13 | {...} |
 | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC |
 | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC |
@@ -11512,6 +11914,9 @@ postBlockDominance
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:209:31:209:46 | object creation of type ExceptionC |
+| Finally.cs:211:13:211:29 | ...; | Finally.cs:195:10:195:12 | enter M10 |
+| Finally.cs:211:13:211:29 | ...; | Finally.cs:202:9:212:9 | {...} |
+| Finally.cs:211:13:211:29 | ...; | Finally.cs:208:13:210:13 | {...} |
 | Finally.cs:211:13:211:29 | ...; | Finally.cs:211:13:211:29 | ...; |
 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; |
@@ -11523,30 +11928,30 @@ postBlockDominance
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:222:9:225:9 | catch {...} |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:227:9:229:9 | {...} |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | enter M1 |
-| Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | enter M1 |
-| Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | exit M1 |
-| Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
-| Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:8:22:8:24 | String arg |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | enter M1 |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 (normal) |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:8:22:8:24 | String arg |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | enter M1 |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:22:8:24 | String arg |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:8:22:8:24 | String arg |
 | Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:12:10:12:11 | enter M2 |
-| Foreach.cs:12:10:12:11 | exit M2 | Foreach.cs:12:10:12:11 | enter M2 |
-| Foreach.cs:12:10:12:11 | exit M2 | Foreach.cs:12:10:12:11 | exit M2 |
-| Foreach.cs:12:10:12:11 | exit M2 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |
-| Foreach.cs:12:10:12:11 | exit M2 | Foreach.cs:14:22:14:22 | String _ |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | enter M2 |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | exit M2 (normal) |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:14:22:14:22 | String _ |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | enter M2 |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:22:14:22 | String _ |
 | Foreach.cs:14:22:14:22 | String _ | Foreach.cs:14:22:14:22 | String _ |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:18:10:18:11 | enter M3 |
-| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:18:10:18:11 | enter M3 |
-| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:18:10:18:11 | exit M3 |
-| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
-| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:20:22:20:22 | String x |
-| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:20:29:20:38 | call to method ToArray |
-| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:20:43:20:68 | call to method Empty |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | enter M3 |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 (normal) |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:22:20:22 | String x |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:29:20:38 | call to method ToArray |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | enter M3 |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x |
@@ -11556,28 +11961,28 @@ postBlockDominance
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:24:10:24:11 | enter M4 |
-| Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:24:10:24:11 | enter M4 |
-| Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:24:10:24:11 | exit M4 |
-| Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |
-| Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:26:23:26:23 | String x |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | enter M4 |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | exit M4 (normal) |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:26:23:26:23 | String x |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | enter M4 |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:23:26:23 | String x |
 | Foreach.cs:26:23:26:23 | String x | Foreach.cs:26:23:26:23 | String x |
 | Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:30:10:30:11 | enter M5 |
-| Foreach.cs:30:10:30:11 | exit M5 | Foreach.cs:30:10:30:11 | enter M5 |
-| Foreach.cs:30:10:30:11 | exit M5 | Foreach.cs:30:10:30:11 | exit M5 |
-| Foreach.cs:30:10:30:11 | exit M5 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... |
-| Foreach.cs:30:10:30:11 | exit M5 | Foreach.cs:32:23:32:23 | String x |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:30:10:30:11 | enter M5 |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:30:10:30:11 | exit M5 (normal) |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:32:23:32:23 | String x |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | enter M5 |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:23:32:23 | String x |
 | Foreach.cs:32:23:32:23 | String x | Foreach.cs:32:23:32:23 | String x |
 | Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:36:10:36:11 | enter M6 |
-| Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:36:10:36:11 | enter M6 |
-| Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:36:10:36:11 | exit M6 |
-| Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |
-| Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:38:26:38:26 | String x |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | enter M6 |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | exit M6 (normal) |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:38:26:38:26 | String x |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | enter M6 |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:26:38:26 | String x |
@@ -11592,27 +11997,27 @@ postBlockDominance
 | Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | enter Sub |
 | Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | enter Test |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | enter M1 |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | enter M1 |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:10:13:10:19 | return ...; |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:11:22:11:24 | String arg |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | enter M1 |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:10:13:10:19 | return ...; |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:11:22:11:24 | String arg |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:10:13:10:19 | return ...; |
 | LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:22:11:24 | String arg |
 | LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | enter M2 |
-| LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | enter M2 |
-| LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 |
-| LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:18:22:18:22 | String x |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:15:10:15:11 | enter M2 |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:18:22:18:22 | String x |
 | LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | enter M2 |
 | LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:18:22:18:22 | String x |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:22:10:22:11 | enter M3 |
-| LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | enter M3 |
-| LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | exit M3 |
-| LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:24:22:24:24 | Char arg |
-| LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:22:10:22:11 | enter M3 |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:24:22:24:24 | Char arg |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | enter M3 |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:22:24:24 | Char arg |
@@ -11622,11 +12027,11 @@ postBlockDominance
 | LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | enter M4 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | enter M5 |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | enter M5 |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:40:22:40:22 | String x |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:41:26:41:26 | String y |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:36:10:36:11 | enter M5 |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:40:22:40:22 | String x |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:41:26:41:26 | String y |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | enter M5 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x |
@@ -11639,12 +12044,12 @@ postBlockDominance
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:45:10:45:11 | enter M6 |
 | LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:50:9:50:13 | Label: |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | enter M7 |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | enter M7 |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | exit M7 |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:55:10:55:11 | enter M7 |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... |
 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
@@ -11652,317 +12057,253 @@ postBlockDominance
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | enter M8 |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | enter M8 |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:70:13:70:19 | return ...; |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:71:9:71:21 | ...; |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | enter M8 |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:70:13:70:19 | return ...; |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | enter M9 |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | enter M10 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
-| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
-| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 |
-| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:97:22:97:22 | String x |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:94:10:94:12 | enter M11 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:97:22:97:22 | String x |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | enter M11 |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:97:22:97:22 | String x |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 |
-| MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 |
-| MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:28:6:31 | null |
-| MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 |
-| MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 |
 | MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:28:6:31 | null |
 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 |
 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 |
-| MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 |
 | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationA.cs:7:21:7:23 | exit get_P2 |
-| MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationA.cs:7:25:7:39 | {...} |
-| MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 |
 | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationB.cs:4:21:4:23 | exit get_P2 |
-| MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationB.cs:4:25:4:37 | {...} |
 | MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationA.cs:7:25:7:39 | {...} |
 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 |
 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 |
-| MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 |
 | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationA.cs:7:41:7:43 | exit set_P2 |
-| MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationA.cs:7:45:7:59 | {...} |
-| MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 |
 | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationB.cs:4:39:4:41 | exit set_P2 |
-| MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} |
 | MultiImplementationA.cs:7:45:7:59 | {...} | MultiImplementationA.cs:7:45:7:59 | {...} |
 | MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationA.cs:8:16:8:16 | enter M |
 | MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationB.cs:5:16:5:16 | enter M |
-| MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationA.cs:8:16:8:16 | enter M |
 | MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationA.cs:8:16:8:16 | exit M |
-| MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationA.cs:8:29:8:32 | null |
-| MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationB.cs:5:16:5:16 | enter M |
 | MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationB.cs:5:16:5:16 | exit M |
-| MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationB.cs:5:23:5:23 | 2 |
 | MultiImplementationA.cs:8:29:8:32 | null | MultiImplementationA.cs:8:29:8:32 | null |
 | MultiImplementationA.cs:13:16:13:16 | this access | MultiImplementationA.cs:13:16:13:16 | this access |
 | MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationA.cs:14:31:14:31 | enter get_Item |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationB.cs:12:31:12:40 | enter get_Item |
 | MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | enter get_Item |
 | MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationB.cs:12:31:12:40 | enter get_Item |
-| MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
-| MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | enter get_Item |
 | MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | exit get_Item |
-| MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationB.cs:12:31:12:40 | enter get_Item |
 | MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationB.cs:12:31:12:40 | exit get_Item |
-| MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationB.cs:12:37:12:40 | null |
 | MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationA.cs:15:36:15:38 | enter get_Item |
 | MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationB.cs:13:36:13:38 | enter get_Item |
-| MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationA.cs:15:36:15:38 | enter get_Item |
 | MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationA.cs:15:36:15:38 | exit get_Item |
-| MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationA.cs:15:40:15:52 | {...} |
-| MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationB.cs:13:36:13:38 | enter get_Item |
 | MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationB.cs:13:36:13:38 | exit get_Item |
-| MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationB.cs:13:40:13:54 | {...} |
+| MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:36:15:38 | enter get_Item |
 | MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:40:15:52 | {...} |
+| MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationB.cs:13:36:13:38 | enter get_Item |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | enter set_Item |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | enter set_Item |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | enter set_Item |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationA.cs:15:58:15:60 | {...} |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | enter set_Item |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationB.cs:13:60:13:62 | {...} |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | enter set_Item |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:58:15:60 | {...} |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | enter set_Item |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:60:13:62 | {...} |
 | MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationA.cs:15:58:15:60 | {...} |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | enter M1 |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | enter M1 |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | enter M1 |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationA.cs:17:5:19:5 | {...} |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | enter M1 |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationB.cs:15:5:17:5 | {...} |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | enter M1 |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:17:5:19:5 | {...} |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | enter M1 |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:15:5:17:5 | {...} |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:9:18:22 | enter M2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:13:16:13:16 | this access |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | exit C2 |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:20:22:20:31 | {...} |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:24:16:24:16 | this access |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationB.cs:11:16:11:16 | this access |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | exit C2 |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationB.cs:18:22:18:36 | {...} |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationB.cs:22:16:22:16 | this access |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:13:16:13:16 | this access |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:12:20:13 | enter C2 |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:22:20:31 | {...} |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:24:16:24:16 | this access |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:11:16:11:16 | this access |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:18:12:18:13 | enter C2 |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:22:16:22:16 | this access |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | enter C2 |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | enter C2 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | enter C2 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationA.cs:21:24:21:24 | 0 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationA.cs:21:27:21:29 | {...} |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | enter C2 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationB.cs:19:24:19:24 | 1 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationB.cs:19:27:19:29 | {...} |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | enter C2 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:24:21:24 | 0 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:27:21:29 | {...} |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | enter C2 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:24:19:24 | 1 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:27:19:29 | {...} |
 | MultiImplementationA.cs:21:24:21:24 | 0 | MultiImplementationA.cs:21:24:21:24 | 0 |
 | MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationA.cs:21:27:21:29 | {...} |
 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 |
 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 |
-| MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 |
 | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationA.cs:22:6:22:7 | exit ~C2 |
-| MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} |
-| MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 |
 | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationB.cs:20:6:20:7 | exit ~C2 |
-| MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationB.cs:20:11:20:25 | {...} |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:6:22:7 | enter ~C2 |
 | MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:11:22:13 | {...} |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationB.cs:20:6:20:7 | enter ~C2 |
 | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion |
 | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion |
-| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion |
 | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion |
-| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationA.cs:23:50:23:53 | null |
-| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion |
 | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion |
-| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationB.cs:21:56:21:59 | null |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion |
 | MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:50:23:53 | null |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion |
 | MultiImplementationA.cs:24:16:24:16 | this access | MultiImplementationA.cs:24:16:24:16 | this access |
 | MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationA.cs:30:21:30:23 | enter get_P3 |
 | MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationB.cs:27:21:27:23 | enter get_P3 |
 | MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationA.cs:36:9:36:10 | enter M1 |
 | MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationB.cs:32:9:32:10 | enter M1 |
-| MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationA.cs:36:9:36:10 | enter M1 |
 | MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationA.cs:36:9:36:10 | exit M1 |
-| MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationA.cs:36:14:36:28 | {...} |
-| MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | enter M1 |
 | MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | exit M1 |
-| MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationB.cs:32:17:32:17 | 0 |
 | MultiImplementationA.cs:36:14:36:28 | {...} | MultiImplementationA.cs:36:14:36:28 | {...} |
 | MultiImplementationA.cs:37:9:37:10 | enter M2 | MultiImplementationA.cs:37:9:37:10 | enter M2 |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 |
 | MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationB.cs:3:22:3:22 | 0 |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 |
 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 |
 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 |
-| MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 |
 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 |
-| MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationA.cs:6:28:6:31 | null |
-| MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 |
-| MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 |
 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 |
 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 |
 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 |
-| MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 |
 | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationA.cs:7:21:7:23 | exit get_P2 |
-| MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationA.cs:7:25:7:39 | {...} |
-| MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 |
 | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationB.cs:4:21:4:23 | exit get_P2 |
-| MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationB.cs:4:25:4:37 | {...} |
+| MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationA.cs:7:21:7:23 | enter get_P2 |
+| MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationB.cs:4:21:4:23 | enter get_P2 |
 | MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationB.cs:4:25:4:37 | {...} |
 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 |
 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 |
-| MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 |
 | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationA.cs:7:41:7:43 | exit set_P2 |
-| MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationA.cs:7:45:7:59 | {...} |
-| MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 |
 | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationB.cs:4:39:4:41 | exit set_P2 |
-| MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationA.cs:7:41:7:43 | enter set_P2 |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationB.cs:4:39:4:41 | enter set_P2 |
 | MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationB.cs:4:43:4:45 | {...} |
 | MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationA.cs:8:16:8:16 | enter M |
 | MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationB.cs:5:16:5:16 | enter M |
-| MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationA.cs:8:16:8:16 | enter M |
 | MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationA.cs:8:16:8:16 | exit M |
-| MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationA.cs:8:29:8:32 | null |
-| MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationB.cs:5:16:5:16 | enter M |
 | MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationB.cs:5:16:5:16 | exit M |
-| MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationB.cs:5:23:5:23 | 2 |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationA.cs:8:16:8:16 | enter M |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationB.cs:5:16:5:16 | enter M |
 | MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationB.cs:5:23:5:23 | 2 |
 | MultiImplementationB.cs:11:16:11:16 | this access | MultiImplementationB.cs:11:16:11:16 | this access |
 | MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | enter get_Item |
 | MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationB.cs:12:31:12:40 | enter get_Item |
-| MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
-| MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | enter get_Item |
 | MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | exit get_Item |
-| MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationB.cs:12:31:12:40 | enter get_Item |
 | MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationB.cs:12:31:12:40 | exit get_Item |
-| MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationB.cs:12:37:12:40 | null |
 | MultiImplementationB.cs:12:37:12:40 | null | MultiImplementationB.cs:12:37:12:40 | null |
 | MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationA.cs:15:36:15:38 | enter get_Item |
 | MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationB.cs:13:36:13:38 | enter get_Item |
-| MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationA.cs:15:36:15:38 | enter get_Item |
 | MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationA.cs:15:36:15:38 | exit get_Item |
-| MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationA.cs:15:40:15:52 | {...} |
-| MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationB.cs:13:36:13:38 | enter get_Item |
 | MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationB.cs:13:36:13:38 | exit get_Item |
-| MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationB.cs:13:40:13:54 | {...} |
 | MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationB.cs:13:40:13:54 | {...} |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | enter set_Item |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | enter set_Item |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | enter set_Item |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | exit set_Item |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationA.cs:15:58:15:60 | {...} |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | enter set_Item |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | exit set_Item |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationB.cs:13:60:13:62 | {...} |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | enter set_Item |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:58:15:60 | {...} |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | enter set_Item |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:60:13:62 | {...} |
 | MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationB.cs:13:60:13:62 | {...} |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | enter M1 |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | enter M1 |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | enter M1 |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | exit M1 |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationA.cs:17:5:19:5 | {...} |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | enter M1 |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | exit M1 |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationB.cs:15:5:17:5 | {...} |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | enter M1 |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:17:5:19:5 | {...} |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | enter M1 |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:15:5:17:5 | {...} |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:15:5:17:5 | {...} |
 | MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:9:16:31 | enter M2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:13:16:13:16 | this access |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | exit C2 |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:20:22:20:31 | {...} |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:24:16:24:16 | this access |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationB.cs:11:16:11:16 | this access |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | exit C2 |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationB.cs:18:22:18:36 | {...} |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationB.cs:22:16:22:16 | this access |
 | MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:22:18:36 | {...} |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | enter C2 |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | enter C2 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | enter C2 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | exit C2 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationA.cs:21:24:21:24 | 0 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationA.cs:21:27:21:29 | {...} |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | enter C2 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | exit C2 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationB.cs:19:24:19:24 | 1 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationB.cs:19:27:19:29 | {...} |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | enter C2 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:24:21:24 | 0 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:27:21:29 | {...} |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | enter C2 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:24:19:24 | 1 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:27:19:29 | {...} |
 | MultiImplementationB.cs:19:24:19:24 | 1 | MultiImplementationB.cs:19:24:19:24 | 1 |
 | MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationB.cs:19:27:19:29 | {...} |
 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 |
 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 |
-| MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 |
 | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationA.cs:22:6:22:7 | exit ~C2 |
-| MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} |
-| MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 |
 | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationB.cs:20:6:20:7 | exit ~C2 |
-| MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationB.cs:20:11:20:25 | {...} |
 | MultiImplementationB.cs:20:11:20:25 | {...} | MultiImplementationB.cs:20:11:20:25 | {...} |
 | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion |
 | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion |
-| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion |
 | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion |
-| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationA.cs:23:50:23:53 | null |
-| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion |
 | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion |
-| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationB.cs:21:56:21:59 | null |
 | MultiImplementationB.cs:21:56:21:59 | null | MultiImplementationB.cs:21:56:21:59 | null |
 | MultiImplementationB.cs:22:16:22:16 | this access | MultiImplementationB.cs:22:16:22:16 | this access |
 | MultiImplementationB.cs:27:21:27:23 | enter get_P3 | MultiImplementationA.cs:30:21:30:23 | enter get_P3 |
 | MultiImplementationB.cs:27:21:27:23 | enter get_P3 | MultiImplementationB.cs:27:21:27:23 | enter get_P3 |
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationA.cs:36:9:36:10 | enter M1 |
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationB.cs:32:9:32:10 | enter M1 |
-| MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationA.cs:36:9:36:10 | enter M1 |
 | MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationA.cs:36:9:36:10 | exit M1 |
-| MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationA.cs:36:14:36:28 | {...} |
-| MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | enter M1 |
 | MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | exit M1 |
-| MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationB.cs:32:17:32:17 | 0 |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | enter M1 |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | enter M1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:17:32:17 | 0 |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:9:3:10 | enter M1 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:9:3:10 | enter M1 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:9:3:10 | exit M1 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:28:3:28 | 0 |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | enter M1 |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:28:3:28 | 0 |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:28:3:28 | 0 |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:9:5:10 | enter M2 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:9:5:10 | enter M2 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:9:5:10 | exit M2 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:30:5:34 | false |
-| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:39:5:39 | 0 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:43:5:43 | 1 |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | enter M2 |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:30:5:34 | false |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:39:5:39 | 0 |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:43:5:43 | 1 |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:30:5:34 | false |
 | NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:39:5:39 | 0 |
 | NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:30:5:34 | false |
 | NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:43:5:43 | 1 |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:12:7:13 | enter M3 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:12:7:13 | enter M3 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:12:7:13 | exit M3 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
-| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:52:7:53 | "" |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | enter M3 |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:12:9:13 | enter M4 |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:12:9:13 | enter M4 |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:12:9:13 | exit M4 |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:41:9:41 | access to parameter s |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:45:9:45 | access to parameter s |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | enter M4 |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:41:9:41 | access to parameter s |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:45:9:45 | access to parameter s |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:41:9:41 | access to parameter s |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:45:9:45 | access to parameter s |
 | NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:9:11:10 | enter M5 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:9:11:10 | enter M5 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:9:11:10 | exit M5 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:51:11:58 | ... && ... |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:64:11:64 | 0 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:68:11:68 | 1 |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | enter M5 |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:51:11:58 | ... && ... |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:64:11:64 | 0 |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:68:11:68 | 1 |
 | NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:58 | ... && ... |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
 | NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:64:11:64 | 0 |
@@ -12013,47 +12354,47 @@ postBlockDominance
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |
-| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | enter M2 |
-| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | exit M2 |
-| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:13:13:13:19 | return ...; |
-| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | enter M2 |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 (normal) |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:14:9:14:29 | ...; |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:29 | ...; |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | enter M3 |
-| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | enter M3 |
 | PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | exit M3 |
-| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:20:45:20:53 | nameof(...) |
-| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:21:9:21:29 | ...; |
 | PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:17:10:17:11 | enter M3 |
 | PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:9:21:29 | ...; |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | enter Method |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:23:8:34 | enter StaticMethod |
 | Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:10:10:10:10 | enter M |
 | Switch.cs:5:10:5:11 | enter M1 | Switch.cs:5:10:5:11 | enter M1 |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:10:10:10:11 | enter M2 |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:10:10:10:11 | enter M2 |
 | Switch.cs:10:10:10:11 | exit M2 | Switch.cs:10:10:10:11 | exit M2 |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:15:17:15:23 | return ...; |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:16:13:16:19 | case ...: |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:17:23:17:37 | object creation of type Exception |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:18:13:18:22 | case ...: |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:19:17:19:29 | goto default; |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:20:13:20:23 | case ...: |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:21:17:22:27 | if (...) ... |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:22:21:22:27 | return ...; |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:23:27:23:27 | 0 |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:24:13:24:56 | case ...: |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:24:32:24:55 | ... && ... |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:25:17:25:37 | ...; |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:27:13:27:39 | case ...: |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:27:32:27:38 | call to method Throw |
-| Switch.cs:10:10:10:11 | exit M2 | Switch.cs:30:13:30:20 | default: |
+| Switch.cs:10:10:10:11 | exit M2 (abnormal) | Switch.cs:10:10:10:11 | exit M2 (abnormal) |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:10:10:10:11 | enter M2 |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:10:10:10:11 | exit M2 (normal) |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:15:17:15:23 | return ...; |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:16:13:16:19 | case ...: |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:18:13:18:22 | case ...: |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:19:17:19:29 | goto default; |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:20:13:20:23 | case ...: |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:21:17:22:27 | if (...) ... |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:22:21:22:27 | return ...; |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:23:27:23:27 | 0 |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:24:13:24:56 | case ...: |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:24:48:24:48 | access to local variable s |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:25:17:25:37 | ...; |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:30:13:30:20 | default: |
 | Switch.cs:15:17:15:23 | return ...; | Switch.cs:15:17:15:23 | return ...; |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:13:16:19 | case ...: |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:17:23:17:37 | object creation of type Exception | Switch.cs:17:23:17:37 | object creation of type Exception |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:16:13:16:19 | case ...: |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:18:13:18:22 | case ...: |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:19:17:19:29 | goto default; | Switch.cs:19:17:19:29 | goto default; |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:20:13:20:23 | case ...: |
 | Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:21:17:22:27 | if (...) ... |
@@ -12066,34 +12407,35 @@ postBlockDominance
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:27:32:27:38 | call to method Throw |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:19:17:19:29 | goto default; |
+| Switch.cs:30:13:30:20 | default: | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:30:13:30:20 | default: |
 | Switch.cs:35:10:35:11 | enter M3 | Switch.cs:35:10:35:11 | enter M3 |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:44:10:44:11 | enter M4 |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:44:10:44:11 | enter M4 |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:44:10:44:11 | exit M4 |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:49:17:49:22 | break; |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:50:13:50:39 | case ...: |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:50:30:50:30 | access to parameter o |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:51:17:51:22 | break; |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:44:10:44:11 | enter M4 |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:44:10:44:11 | exit M4 (normal) |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:49:17:49:22 | break; |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:50:13:50:39 | case ...: |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:50:30:50:30 | access to parameter o |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:51:17:51:22 | break; |
 | Switch.cs:49:17:49:22 | break; | Switch.cs:49:17:49:22 | break; |
 | Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:13:50:39 | case ...: |
 | Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:50:30:50:30 | access to parameter o |
 | Switch.cs:51:17:51:22 | break; | Switch.cs:51:17:51:22 | break; |
 | Switch.cs:55:10:55:11 | enter M5 | Switch.cs:55:10:55:11 | enter M5 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | enter M6 |
-| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | enter M6 |
-| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | exit M6 |
-| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:73:17:73:22 | break; |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:66:10:66:11 | enter M6 |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:66:10:66:11 | exit M6 (normal) |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:73:17:73:22 | break; | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | enter M7 |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | enter M7 |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | exit M7 |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:82:24:82:27 | true |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:83:13:83:19 | case ...: |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:84:17:85:26 | if (...) ... |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:85:21:85:26 | break; |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:86:24:86:27 | true |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:88:16:88:20 | false |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:77:10:77:11 | enter M7 |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:77:10:77:11 | exit M7 (normal) |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:82:24:82:27 | true |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:83:13:83:19 | case ...: |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:84:17:85:26 | if (...) ... |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:85:21:85:26 | break; |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:86:24:86:27 | true |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:88:16:88:20 | false |
 | Switch.cs:82:24:82:27 | true | Switch.cs:82:24:82:27 | true |
 | Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:13:83:19 | case ...: |
 | Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:17:85:26 | if (...) ... |
@@ -12102,21 +12444,21 @@ postBlockDominance
 | Switch.cs:88:16:88:20 | false | Switch.cs:85:21:85:26 | break; |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:16:88:20 | false |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | enter M8 |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | enter M8 |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | exit M8 |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:96:24:96:27 | true |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:98:16:98:20 | false |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:91:10:91:11 | enter M8 |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:91:10:91:11 | exit M8 (normal) |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:96:24:96:27 | true |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:98:16:98:20 | false |
 | Switch.cs:96:24:96:27 | true | Switch.cs:96:24:96:27 | true |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:16:98:20 | false |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | enter M9 |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | enter M9 |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | exit M9 |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:103:19:103:25 | access to property Length |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:105:13:105:19 | case ...: |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:105:28:105:28 | 0 |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:106:13:106:19 | case ...: |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:106:28:106:28 | 1 |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:108:17:108:17 | 1 |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:101:9:101:10 | enter M9 |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:101:9:101:10 | exit M9 (normal) |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:103:19:103:25 | access to property Length |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:105:13:105:19 | case ...: |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:105:28:105:28 | 0 |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:106:13:106:19 | case ...: |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:106:28:106:28 | 1 |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:108:17:108:17 | 1 |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:103:19:103:25 | access to property Length |
 | Switch.cs:105:13:105:19 | case ...: | Switch.cs:101:9:101:10 | enter M9 |
 | Switch.cs:105:13:105:19 | case ...: | Switch.cs:103:19:103:25 | access to property Length |
@@ -12127,14 +12469,14 @@ postBlockDominance
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:17:108:17 | 1 |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:17:111:21 | enter Throw |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:113:9:113:11 | enter M10 |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | enter M10 |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | exit M10 |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:117:25:117:25 | access to parameter s |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:117:44:117:44 | 1 |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:13:118:34 | case ...: |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:25:118:25 | access to parameter s |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:43:118:43 | 2 |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:120:17:120:17 | 1 |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:113:9:113:11 | enter M10 |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:113:9:113:11 | exit M10 (normal) |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:117:25:117:25 | access to parameter s |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:117:44:117:44 | 1 |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:118:13:118:34 | case ...: |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:118:25:118:25 | access to parameter s |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:118:43:118:43 | 2 |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:25:117:25 | access to parameter s |
 | Switch.cs:117:44:117:44 | 1 | Switch.cs:117:44:117:44 | 1 |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | case ...: |
@@ -12142,11 +12484,11 @@ postBlockDominance
 | Switch.cs:118:43:118:43 | 2 | Switch.cs:118:43:118:43 | 2 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | enter M11 |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | enter M11 |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | exit M11 |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:125:34:125:34 | access to local variable b |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:125:37:125:46 | ... => ... |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:126:13:126:19 | return ...; |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | enter M11 |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 (normal) |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:34:125:34 | access to local variable b |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:37:125:46 | ... => ... |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:126:13:126:19 | return ...; |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:34:125:34 | access to local variable b |
 | Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:46 | ... => ... |
 | Switch.cs:126:13:126:19 | return ...; | Switch.cs:126:13:126:19 | return ...; |
@@ -12160,41 +12502,46 @@ postBlockDominance
 | Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:51 | ... => ... |
 | Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:56:131:66 | call to method ToString |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | enter M13 |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:134:9:134:11 | enter M13 |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:134:9:134:11 | exit M13 |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:138:13:138:20 | default: |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:139:28:139:28 | 1 |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:140:13:140:19 | case ...: |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:140:28:140:28 | 2 |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | enter M13 |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 (normal) |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:138:13:138:20 | default: |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:139:28:139:28 | 1 |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:140:13:140:19 | case ...: |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:140:28:140:28 | 2 |
 | Switch.cs:138:13:138:20 | default: | Switch.cs:138:13:138:20 | default: |
 | Switch.cs:139:28:139:28 | 1 | Switch.cs:139:28:139:28 | 1 |
 | Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:13:140:19 | case ...: |
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:140:28:140:28 | 2 |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:144:9:144:11 | enter M14 |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:144:9:144:11 | enter M14 |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:144:9:144:11 | exit M14 |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:148:28:148:28 | 1 |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:149:13:149:20 | default: |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:150:13:150:19 | case ...: |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:150:28:150:28 | 2 |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:144:9:144:11 | enter M14 |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:144:9:144:11 | exit M14 (normal) |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:148:28:148:28 | 1 |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:149:13:149:20 | default: |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:150:13:150:19 | case ...: |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:150:28:150:28 | 2 |
 | Switch.cs:148:28:148:28 | 1 | Switch.cs:148:28:148:28 | 1 |
 | Switch.cs:149:13:149:20 | default: | Switch.cs:149:13:149:20 | default: |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:13:150:19 | case ...: |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:28:150:28 | 2 |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | enter M15 |
-| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | enter M15 |
 | Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | exit M15 |
-| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:156:13:156:54 | String s = ... |
-| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:156:36:156:38 | "a" |
-| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:156:41:156:52 | ... => ... |
-| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:156:50:156:52 | "b" |
-| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:158:13:158:49 | ...; |
-| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | enter M15 |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | exit M15 (normal) |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:156:13:156:54 | String s = ... |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:158:13:158:49 | ...; |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:154:10:154:12 | enter M15 |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:13:156:54 | String s = ... |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:41:156:52 | ... => ... |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" |
 | Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:52 | ... => ... |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:49 | ...; |
@@ -12214,25 +12561,25 @@ postBlockDominance
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:28:25:28 | access to local variable y |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | enter Dispose |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:5:17:5:20 | enter Main |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:5:17:5:20 | enter Main |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:5:17:5:20 | exit Main |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:12:13:12:49 | ...; |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:14:9:17:9 | while (...) ... |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:14:16:14:16 | access to local variable a |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:15:9:17:9 | {...} |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:19:9:22:25 | do ... while (...); |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:20:9:22:9 | {...} |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:24:9:34:9 | for (...;...;...) ... |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:24:25:24:25 | access to local variable i |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:24:34:24:34 | access to local variable i |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:25:9:34:9 | {...} |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:28:18:33:37 | if (...) ... |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:29:17:29:42 | ...; |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:30:18:33:37 | if (...) ... |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:31:17:31:42 | ...; |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:33:17:33:37 | ...; |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:5:17:5:20 | enter Main |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:5:17:5:20 | exit Main (normal) |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:12:13:12:49 | ...; |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:14:9:17:9 | while (...) ... |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:14:16:14:16 | access to local variable a |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:15:9:17:9 | {...} |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:19:9:22:25 | do ... while (...); |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:20:9:22:9 | {...} |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:24:9:34:9 | for (...;...;...) ... |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:24:25:24:25 | access to local variable i |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:24:34:24:34 | access to local variable i |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:26:31:26:31 | access to local variable i |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:27:17:27:46 | ...; |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:28:18:33:37 | if (...) ... |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:29:17:29:42 | ...; |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:30:18:33:37 | if (...) ... |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:31:17:31:42 | ...; |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:33:17:33:37 | ...; |
 | cflow.cs:12:13:12:49 | ...; | cflow.cs:12:13:12:49 | ...; |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:5:17:5:20 | enter Main |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:12:13:12:49 | ...; |
@@ -12300,22 +12647,7 @@ postBlockDominance
 | cflow.cs:31:17:31:42 | ...; | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:33:17:33:37 | ...; | cflow.cs:33:17:33:37 | ...; |
 | cflow.cs:37:17:37:22 | enter Switch | cflow.cs:37:17:37:22 | enter Switch |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:37:17:37:22 | enter Switch |
 | cflow.cs:37:17:37:22 | exit Switch | cflow.cs:37:17:37:22 | exit Switch |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:41:13:41:19 | case ...: |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:42:17:42:39 | ...; |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:44:13:44:19 | case ...: |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:45:17:45:39 | ...; |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:47:13:47:19 | case ...: |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:48:17:48:39 | ...; |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:51:9:59:9 | switch (...) {...} |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:54:17:54:48 | ...; |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:56:13:56:20 | default: |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:60:9:66:9 | switch (...) {...} |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:65:17:65:22 | break; |
-| cflow.cs:37:17:37:22 | exit Switch | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:37:17:37:22 | enter Switch |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:41:13:41:19 | case ...: |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:45:17:45:39 | ...; |
@@ -12356,44 +12688,60 @@ postBlockDominance
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:17:64:55 | if (...) ... |
 | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
+| cflow.cs:65:17:65:22 | break; | cflow.cs:63:17:64:55 | if (...) ... |
 | cflow.cs:65:17:65:22 | break; | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:37:17:37:22 | enter Switch |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:41:13:41:19 | case ...: |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:42:17:42:39 | ...; |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:44:13:44:19 | case ...: |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:45:17:45:39 | ...; |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:47:13:47:19 | case ...: |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:48:17:48:39 | ...; |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:51:9:59:9 | switch (...) {...} |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:54:17:54:48 | ...; |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:56:13:56:20 | default: |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:60:9:66:9 | switch (...) {...} |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:63:17:64:55 | if (...) ... |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:65:17:65:22 | break; |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:70:18:70:18 | enter M |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:70:18:70:18 | enter M |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:70:18:70:18 | exit M |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:73:13:73:19 | return ...; |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:74:9:81:9 | if (...) ... |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:75:9:77:9 | {...} |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:79:9:81:9 | {...} |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | enter M |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | exit M (normal) |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:73:13:73:19 | return ...; |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:74:9:81:9 | if (...) ... |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:75:9:77:9 | {...} |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:79:9:81:9 | {...} |
 | cflow.cs:73:13:73:19 | return ...; | cflow.cs:73:13:73:19 | return ...; |
 | cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:74:9:81:9 | if (...) ... |
 | cflow.cs:75:9:77:9 | {...} | cflow.cs:75:9:77:9 | {...} |
 | cflow.cs:79:9:81:9 | {...} | cflow.cs:79:9:81:9 | {...} |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:84:18:84:19 | enter M2 |
-| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:84:18:84:19 | enter M2 |
-| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:84:18:84:19 | exit M2 |
-| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:86:26:86:26 | access to parameter s |
-| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:87:13:87:33 | ...; |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | enter M2 |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 (normal) |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:86:26:86:26 | access to parameter s |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:87:13:87:33 | ...; |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:26 | access to parameter s |
 | cflow.cs:87:13:87:33 | ...; | cflow.cs:87:13:87:33 | ...; |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | enter M3 |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:90:18:90:19 | enter M3 |
 | cflow.cs:90:18:90:19 | exit M3 | cflow.cs:90:18:90:19 | exit M3 |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:93:45:93:47 | "s" |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:94:9:94:29 | ...; |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:97:13:97:55 | ...; |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:99:9:100:42 | if (...) ... |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:100:13:100:42 | ...; |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:102:9:103:36 | if (...) ... |
-| cflow.cs:90:18:90:19 | exit M3 | cflow.cs:103:13:103:36 | ...; |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | enter M3 |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | exit M3 (normal) |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:94:9:94:29 | ...; |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:97:13:97:55 | ...; |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:99:9:100:42 | if (...) ... |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:100:13:100:42 | ...; |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:102:9:103:36 | if (...) ... |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:103:13:103:36 | ...; |
 | cflow.cs:93:45:93:47 | "s" | cflow.cs:93:45:93:47 | "s" |
+| cflow.cs:94:9:94:29 | ...; | cflow.cs:90:18:90:19 | enter M3 |
 | cflow.cs:94:9:94:29 | ...; | cflow.cs:94:9:94:29 | ...; |
 | cflow.cs:97:13:97:55 | ...; | cflow.cs:97:13:97:55 | ...; |
+| cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:90:18:90:19 | enter M3 |
 | cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:94:9:94:29 | ...; |
 | cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:97:13:97:55 | ...; |
 | cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:99:9:100:42 | if (...) ... |
 | cflow.cs:100:13:100:42 | ...; | cflow.cs:100:13:100:42 | ...; |
+| cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:90:18:90:19 | enter M3 |
 | cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:94:9:94:29 | ...; |
 | cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:97:13:97:55 | ...; |
 | cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:99:9:100:42 | if (...) ... |
@@ -12421,21 +12769,21 @@ postBlockDominance
 | cflow.cs:144:33:144:35 | enter get_Item | cflow.cs:144:33:144:35 | enter get_Item |
 | cflow.cs:144:56:144:58 | enter set_Item | cflow.cs:144:56:144:58 | enter set_Item |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:146:10:146:12 | enter For |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:146:10:146:12 | enter For |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:146:10:146:12 | exit For |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:149:16:149:16 | access to local variable x |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:150:13:150:33 | ...; |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:152:9:157:9 | for (...;...;...) ... |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:152:18:152:18 | access to local variable x |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:153:9:157:9 | {...} |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:156:17:156:22 | break; |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:160:9:165:9 | {...} |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:164:17:164:22 | break; |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:167:16:167:16 | access to local variable x |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:168:9:171:9 | {...} |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:173:9:176:9 | for (...;...;...) ... |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:173:32:173:32 | access to local variable i |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:174:9:176:9 | {...} |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:146:10:146:12 | enter For |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:146:10:146:12 | exit For (normal) |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:149:16:149:16 | access to local variable x |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:150:13:150:33 | ...; |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:152:9:157:9 | for (...;...;...) ... |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:152:18:152:18 | access to local variable x |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:153:9:157:9 | {...} |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:156:17:156:22 | break; |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:160:9:165:9 | {...} |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:164:17:164:22 | break; |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:167:16:167:16 | access to local variable x |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:168:9:171:9 | {...} |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:173:9:176:9 | for (...;...;...) ... |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:173:32:173:32 | access to local variable i |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:174:9:176:9 | {...} |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:146:10:146:12 | enter For |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:149:16:149:16 | access to local variable x |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:150:13:150:33 | ...; |
@@ -12519,19 +12867,19 @@ postBlockDominance
 | cflow.cs:182:28:182:61 | enter delegate(...) { ... } | cflow.cs:182:28:182:61 | enter delegate(...) { ... } |
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:185:10:185:18 | enter LogicalOr |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | enter Booleans |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:193:10:193:17 | enter Booleans |
 | cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:193:10:193:17 | exit Booleans |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:195:13:195:56 | Boolean b = ... |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:195:37:195:56 | !... |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:197:35:197:39 | false |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:197:43:197:46 | true |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:198:13:198:48 | ... = ... |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:198:37:198:41 | false |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:198:45:198:48 | true |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:200:9:205:9 | if (...) ... |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:200:37:200:62 | !... |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:200:61:200:61 | access to local variable b |
-| cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:201:9:205:9 | {...} |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | enter Booleans |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | exit Booleans (normal) |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:195:13:195:56 | Boolean b = ... |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:195:37:195:56 | !... |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:197:35:197:39 | false |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:197:43:197:46 | true |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:198:13:198:48 | ... = ... |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:198:37:198:41 | false |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:198:45:198:48 | true |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:9:205:9 | if (...) ... |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:37:200:62 | !... |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:61:200:61 | access to local variable b |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:193:10:193:17 | enter Booleans |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:13:195:56 | Boolean b = ... |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:37:195:56 | !... |
@@ -12553,17 +12901,26 @@ postBlockDominance
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:198:37:198:41 | false |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:198:45:198:48 | true |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:9:205:9 | if (...) ... |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:193:10:193:17 | enter Booleans |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:195:13:195:56 | Boolean b = ... |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:195:37:195:56 | !... |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:197:35:197:39 | false |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:197:43:197:46 | true |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:198:13:198:48 | ... = ... |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:198:37:198:41 | false |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:198:45:198:48 | true |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:200:9:205:9 | if (...) ... |
 | cflow.cs:200:37:200:62 | !... | cflow.cs:200:37:200:62 | !... |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:61:200:61 | access to local variable b |
 | cflow.cs:201:9:205:9 | {...} | cflow.cs:201:9:205:9 | {...} |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:208:10:208:11 | enter Do |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:208:10:208:11 | enter Do |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:208:10:208:11 | exit Do |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:211:9:221:9 | {...} |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:214:13:216:13 | {...} |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:217:13:220:13 | if (...) ... |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:218:13:220:13 | {...} |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:221:18:221:22 | this access |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | enter Do |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | exit Do (normal) |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:211:9:221:9 | {...} |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:214:13:216:13 | {...} |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:217:13:220:13 | if (...) ... |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:218:13:220:13 | {...} |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:221:18:221:22 | this access |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:208:10:208:11 | enter Do |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:211:9:221:9 | {...} |
 | cflow.cs:214:13:216:13 | {...} | cflow.cs:214:13:216:13 | {...} |
@@ -12572,13 +12929,13 @@ postBlockDominance
 | cflow.cs:221:18:221:22 | this access | cflow.cs:214:13:216:13 | {...} |
 | cflow.cs:221:18:221:22 | this access | cflow.cs:221:18:221:22 | this access |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:224:10:224:16 | enter Foreach |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:224:10:224:16 | enter Foreach |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:224:10:224:16 | exit Foreach |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:226:22:226:22 | String x |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:230:13:232:13 | {...} |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:233:13:236:13 | if (...) ... |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:234:13:236:13 | {...} |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:224:10:224:16 | enter Foreach |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:224:10:224:16 | exit Foreach (normal) |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:226:22:226:22 | String x |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:230:13:232:13 | {...} |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:233:13:236:13 | if (...) ... |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:234:13:236:13 | {...} |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | enter Foreach |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:230:13:232:13 | {...} |
@@ -12587,19 +12944,19 @@ postBlockDominance
 | cflow.cs:233:13:236:13 | if (...) ... | cflow.cs:233:13:236:13 | if (...) ... |
 | cflow.cs:234:13:236:13 | {...} | cflow.cs:234:13:236:13 | {...} |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:240:10:240:13 | enter Goto |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:240:10:240:13 | enter Goto |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:240:10:240:13 | exit Goto |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:242:9:242:13 | Label: |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:242:43:242:45 | {...} |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:244:9:244:41 | if (...) ... |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:244:31:244:41 | goto ...; |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:246:9:258:9 | switch (...) {...} |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:249:17:249:29 | goto default; |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:250:13:250:19 | case ...: |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:251:17:251:37 | ...; |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:253:13:253:19 | case ...: |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:254:17:254:27 | goto ...; |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:255:13:255:20 | default: |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | enter Goto |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto (normal) |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:242:9:242:13 | Label: |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:242:43:242:45 | {...} |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:244:9:244:41 | if (...) ... |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:244:31:244:41 | goto ...; |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:246:9:258:9 | switch (...) {...} |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:249:17:249:29 | goto default; |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:250:13:250:19 | case ...: |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:251:17:251:37 | ...; |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:253:13:253:19 | case ...: |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:254:17:254:27 | goto ...; |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:255:13:255:20 | default: |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:240:10:240:13 | enter Goto |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:9:242:13 | Label: |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:244:31:244:41 | goto ...; |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -2820,6 +2820,31 @@ dominance
 | Patterns.cs:36:35:36:50 | "Something else" | Patterns.cs:36:17:36:51 | call to method WriteLine |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o |
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | exit Test |
+| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:6:5:8:5 | {...} |
+| PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:29 | ...; |
+| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:5:10:5:11 | exit M1 |
+| PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:27:7:27 | access to parameter s |
+| PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:7:9:7:28 | call to method WriteLine |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:11:5:15:5 | {...} |
+| PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:12:9:13:19 | if (...) ... |
+| PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:12:13:12:13 | access to parameter s |
+| PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:18:12:21 | null |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | ... is ... |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:27:14:27 | access to parameter s |
+| PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:9:14:28 | call to method WriteLine |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:18:5:22:5 | {...} |
+| PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:19:9:20:55 | if (...) ... |
+| PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:19:13:19:13 | access to parameter s |
+| PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:18:19:21 | null |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:21:9:21:29 | ...; |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | ... is ... |
+| PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:13:20:55 | throw ...; |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:27:21:27 | access to parameter s |
+| PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:9:21:28 | call to method WriteLine |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:28:7:31 | null |
 | Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | exit Method |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:41:8:44 | null |
@@ -6513,6 +6538,31 @@ postDominance
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:37:17:37:22 | break; |
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:40:9:42:9 | switch (...) {...} |
+| PostDominance.cs:5:10:5:11 | exit M1 | PostDominance.cs:7:9:7:28 | call to method WriteLine |
+| PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:5:10:5:11 | enter M1 |
+| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:7:27:7:27 | access to parameter s |
+| PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:6:5:8:5 | {...} |
+| PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:7:9:7:29 | ...; |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:14:9:14:28 | call to method WriteLine |
+| PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:10:10:10:11 | enter M2 |
+| PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:11:5:15:5 | {...} |
+| PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:9:13:19 | if (...) ... |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:12:18:12:21 | null |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:13 | access to parameter s |
+| PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:14:27:14:27 | access to parameter s |
+| PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:20:13:20:55 | throw ...; |
+| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:21:9:21:28 | call to method WriteLine |
+| PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:17:10:17:11 | enter M3 |
+| PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:18:5:22:5 | {...} |
+| PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:9:20:55 | if (...) ... |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:19:18:19:21 | null |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:13 | access to parameter s |
+| PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException |
+| PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:21:27:21:27 | access to parameter s |
+| PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:9:21:29 | ...; |
 | Qualifiers.cs:7:16:7:21 | exit Method | Qualifiers.cs:7:28:7:31 | null |
 | Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | enter Method |
 | Qualifiers.cs:8:23:8:34 | exit StaticMethod | Qualifiers.cs:8:41:8:44 | null |
@@ -9602,6 +9652,21 @@ blockDominance
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:35:13:35:20 | default: |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
+| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | exit M2 |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | exit M2 |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | enter M3 |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | exit M3 |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:21:9:21:29 | ...; |
+| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | exit M3 |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:9:21:29 | ...; |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | enter Method |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:23:8:34 | enter StaticMethod |
 | Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:10:10:10:10 | enter M |
@@ -11946,6 +12011,21 @@ postBlockDominance
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:35:13:35:20 | default: |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
+| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | enter M2 |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | exit M2 |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | enter M3 |
+| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | enter M3 |
+| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | exit M3 |
+| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:21:9:21:29 | ...; |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:9:21:29 | ...; |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | enter Method |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:23:8:34 | enter StaticMethod |
 | Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:10:10:10:10 | enter M |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -3193,6 +3193,36 @@ nodeEnclosing
 | Patterns.cs:37:17:37:22 | break; | Patterns.cs:5:10:5:13 | Test |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | Test |
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | Test |
+| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | M1 |
+| PostDominance.cs:5:10:5:11 | exit M1 | PostDominance.cs:5:10:5:11 | M1 |
+| PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:5:10:5:11 | M1 |
+| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:5:10:5:11 | M1 |
+| PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:5:10:5:11 | M1 |
+| PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:5:10:5:11 | M1 |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:17:10:17:11 | M3 |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | Method |
 | Qualifiers.cs:7:16:7:21 | exit Method | Qualifiers.cs:7:16:7:21 | Method |
 | Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | Method |
@@ -5024,6 +5054,15 @@ blockEnclosing
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:5:10:5:13 | Test |
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:5:10:5:13 | Test |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | Test |
+| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | M1 |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:17:10:17:11 | M3 |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | Method |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:23:8:34 | StaticMethod |
 | Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:10:10:10:10 | M |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -1,18 +1,23 @@
 nodeEnclosing
 | AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:23:5:25 | get_Item |
 | AccessorCalls.cs:5:23:5:25 | exit get_Item | AccessorCalls.cs:5:23:5:25 | get_Item |
+| AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) | AccessorCalls.cs:5:23:5:25 | get_Item |
 | AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | get_Item |
 | AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:33:5:35 | set_Item |
 | AccessorCalls.cs:5:33:5:35 | exit set_Item | AccessorCalls.cs:5:33:5:35 | set_Item |
+| AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) | AccessorCalls.cs:5:33:5:35 | set_Item |
 | AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | set_Item |
 | AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:32:7:34 | add_Event |
 | AccessorCalls.cs:7:32:7:34 | exit add_Event | AccessorCalls.cs:7:32:7:34 | add_Event |
+| AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) | AccessorCalls.cs:7:32:7:34 | add_Event |
 | AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | add_Event |
 | AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:40:7:45 | remove_Event |
 | AccessorCalls.cs:7:40:7:45 | exit remove_Event | AccessorCalls.cs:7:40:7:45 | remove_Event |
+| AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) | AccessorCalls.cs:7:40:7:45 | remove_Event |
 | AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | remove_Event |
 | AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:10:10:10:11 | M1 |
 | AccessorCalls.cs:10:10:10:11 | exit M1 | AccessorCalls.cs:10:10:10:11 | M1 |
+| AccessorCalls.cs:10:10:10:11 | exit M1 (normal) | AccessorCalls.cs:10:10:10:11 | M1 |
 | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:10:10:10:11 | M1 |
 | AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:10:10:10:11 | M1 |
 | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:10:10:10:11 | M1 |
@@ -45,6 +50,7 @@ nodeEnclosing
 | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:10:10:10:11 | M1 |
 | AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:19:10:19:11 | M2 |
 | AccessorCalls.cs:19:10:19:11 | exit M2 | AccessorCalls.cs:19:10:19:11 | M2 |
+| AccessorCalls.cs:19:10:19:11 | exit M2 (normal) | AccessorCalls.cs:19:10:19:11 | M2 |
 | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:19:10:19:11 | M2 |
 | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:19:10:19:11 | M2 |
 | AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:19:10:19:11 | M2 |
@@ -85,6 +91,7 @@ nodeEnclosing
 | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:19:10:19:11 | M2 |
 | AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:28:10:28:11 | M3 |
 | AccessorCalls.cs:28:10:28:11 | exit M3 | AccessorCalls.cs:28:10:28:11 | M3 |
+| AccessorCalls.cs:28:10:28:11 | exit M3 (normal) | AccessorCalls.cs:28:10:28:11 | M3 |
 | AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:28:10:28:11 | M3 |
 | AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:28:10:28:11 | M3 |
 | AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:28:10:28:11 | M3 |
@@ -101,6 +108,7 @@ nodeEnclosing
 | AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:28:10:28:11 | M3 |
 | AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:35:10:35:11 | M4 |
 | AccessorCalls.cs:35:10:35:11 | exit M4 | AccessorCalls.cs:35:10:35:11 | M4 |
+| AccessorCalls.cs:35:10:35:11 | exit M4 (normal) | AccessorCalls.cs:35:10:35:11 | M4 |
 | AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:35:10:35:11 | M4 |
 | AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:35:10:35:11 | M4 |
 | AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:35:10:35:11 | M4 |
@@ -120,6 +128,7 @@ nodeEnclosing
 | AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:35:10:35:11 | M4 |
 | AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:42:10:42:11 | M5 |
 | AccessorCalls.cs:42:10:42:11 | exit M5 | AccessorCalls.cs:42:10:42:11 | M5 |
+| AccessorCalls.cs:42:10:42:11 | exit M5 (normal) | AccessorCalls.cs:42:10:42:11 | M5 |
 | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:42:10:42:11 | M5 |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:42:10:42:11 | M5 |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:42:10:42:11 | M5 |
@@ -152,6 +161,7 @@ nodeEnclosing
 | AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:42:10:42:11 | M5 |
 | AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:49:10:49:11 | M6 |
 | AccessorCalls.cs:49:10:49:11 | exit M6 | AccessorCalls.cs:49:10:49:11 | M6 |
+| AccessorCalls.cs:49:10:49:11 | exit M6 (normal) | AccessorCalls.cs:49:10:49:11 | M6 |
 | AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:49:10:49:11 | M6 |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:49:10:49:11 | M6 |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:49:10:49:11 | M6 |
@@ -193,6 +203,7 @@ nodeEnclosing
 | AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:49:10:49:11 | M6 |
 | AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:56:10:56:11 | M7 |
 | AccessorCalls.cs:56:10:56:11 | exit M7 | AccessorCalls.cs:56:10:56:11 | M7 |
+| AccessorCalls.cs:56:10:56:11 | exit M7 (normal) | AccessorCalls.cs:56:10:56:11 | M7 |
 | AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:56:10:56:11 | M7 |
 | AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:56:10:56:11 | M7 |
 | AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | M7 |
@@ -216,6 +227,7 @@ nodeEnclosing
 | AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:56:10:56:11 | M7 |
 | AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:61:10:61:11 | M8 |
 | AccessorCalls.cs:61:10:61:11 | exit M8 | AccessorCalls.cs:61:10:61:11 | M8 |
+| AccessorCalls.cs:61:10:61:11 | exit M8 (normal) | AccessorCalls.cs:61:10:61:11 | M8 |
 | AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:61:10:61:11 | M8 |
 | AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:61:10:61:11 | M8 |
 | AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | M8 |
@@ -245,6 +257,7 @@ nodeEnclosing
 | AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:61:10:61:11 | M8 |
 | AccessorCalls.cs:66:10:66:11 | enter M9 | AccessorCalls.cs:66:10:66:11 | M9 |
 | AccessorCalls.cs:66:10:66:11 | exit M9 | AccessorCalls.cs:66:10:66:11 | M9 |
+| AccessorCalls.cs:66:10:66:11 | exit M9 (normal) | AccessorCalls.cs:66:10:66:11 | M9 |
 | AccessorCalls.cs:67:5:74:5 | {...} | AccessorCalls.cs:66:10:66:11 | M9 |
 | AccessorCalls.cs:68:9:68:22 | ... ...; | AccessorCalls.cs:66:10:66:11 | M9 |
 | AccessorCalls.cs:68:17:68:21 | dynamic d = ... | AccessorCalls.cs:66:10:66:11 | M9 |
@@ -302,15 +315,18 @@ nodeEnclosing
 | AccessorCalls.cs:73:80:73:80 | 1 | AccessorCalls.cs:66:10:66:11 | M9 |
 | ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:11:3:12 | M1 |
 | ArrayCreation.cs:3:11:3:12 | exit M1 | ArrayCreation.cs:3:11:3:12 | M1 |
+| ArrayCreation.cs:3:11:3:12 | exit M1 (normal) | ArrayCreation.cs:3:11:3:12 | M1 |
 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:11:3:12 | M1 |
 | ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:11:3:12 | M1 |
 | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | M2 |
 | ArrayCreation.cs:5:12:5:13 | exit M2 | ArrayCreation.cs:5:12:5:13 | M2 |
+| ArrayCreation.cs:5:12:5:13 | exit M2 (normal) | ArrayCreation.cs:5:12:5:13 | M2 |
 | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | ArrayCreation.cs:5:12:5:13 | M2 |
 | ArrayCreation.cs:5:28:5:28 | 0 | ArrayCreation.cs:5:12:5:13 | M2 |
 | ArrayCreation.cs:5:31:5:31 | 1 | ArrayCreation.cs:5:12:5:13 | M2 |
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | M3 |
 | ArrayCreation.cs:7:11:7:12 | exit M3 | ArrayCreation.cs:7:11:7:12 | M3 |
+| ArrayCreation.cs:7:11:7:12 | exit M3 (normal) | ArrayCreation.cs:7:11:7:12 | M3 |
 | ArrayCreation.cs:7:19:7:36 | 2 | ArrayCreation.cs:7:11:7:12 | M3 |
 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] | ArrayCreation.cs:7:11:7:12 | M3 |
 | ArrayCreation.cs:7:29:7:36 | { ..., ... } | ArrayCreation.cs:7:11:7:12 | M3 |
@@ -318,6 +334,7 @@ nodeEnclosing
 | ArrayCreation.cs:7:34:7:34 | 1 | ArrayCreation.cs:7:11:7:12 | M3 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | M4 |
 | ArrayCreation.cs:9:12:9:13 | exit M4 | ArrayCreation.cs:9:12:9:13 | M4 |
+| ArrayCreation.cs:9:12:9:13 | exit M4 (normal) | ArrayCreation.cs:9:12:9:13 | M4 |
 | ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:12:9:13 | M4 |
 | ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:12:9:13 | M4 |
 | ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] | ArrayCreation.cs:9:12:9:13 | M4 |
@@ -330,6 +347,8 @@ nodeEnclosing
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:12:9:13 | M4 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:7:10:7:11 | exit M1 (abnormal) | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:7:10:7:11 | exit M1 (normal) | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:8:5:12:5 | {...} | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:9:9:9:33 | ... ...; | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | M1 |
@@ -349,6 +368,8 @@ nodeEnclosing
 | Assert.cs:11:27:11:34 | access to property Length | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:14:10:14:11 | exit M2 (abnormal) | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:14:10:14:11 | exit M2 (normal) | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:15:5:19:5 | {...} | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:16:9:16:33 | ... ...; | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | M2 |
@@ -366,6 +387,8 @@ nodeEnclosing
 | Assert.cs:18:27:18:34 | access to property Length | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:21:10:21:11 | exit M3 (abnormal) | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:21:10:21:11 | exit M3 (normal) | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:22:5:26:5 | {...} | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:23:9:23:33 | ... ...; | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | M3 |
@@ -383,6 +406,8 @@ nodeEnclosing
 | Assert.cs:25:27:25:34 | access to property Length | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:28:10:28:11 | exit M4 (abnormal) | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:28:10:28:11 | exit M4 (normal) | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:29:5:33:5 | {...} | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:30:9:30:33 | ... ...; | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | M4 |
@@ -402,6 +427,8 @@ nodeEnclosing
 | Assert.cs:32:27:32:34 | access to property Length | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:35:10:35:11 | exit M5 (abnormal) | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:35:10:35:11 | exit M5 (normal) | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:36:5:40:5 | {...} | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:37:9:37:33 | ... ...; | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | M5 |
@@ -421,6 +448,8 @@ nodeEnclosing
 | Assert.cs:39:27:39:34 | access to property Length | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:42:10:42:11 | exit M6 (abnormal) | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:42:10:42:11 | exit M6 (normal) | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:43:5:47:5 | {...} | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:44:9:44:33 | ... ...; | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | M6 |
@@ -440,6 +469,8 @@ nodeEnclosing
 | Assert.cs:46:27:46:34 | access to property Length | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:49:10:49:11 | exit M7 (abnormal) | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:49:10:49:11 | exit M7 (normal) | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:50:5:54:5 | {...} | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:51:9:51:33 | ... ...; | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | M7 |
@@ -459,6 +490,8 @@ nodeEnclosing
 | Assert.cs:53:27:53:34 | access to property Length | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:56:10:56:11 | exit M8 (abnormal) | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:56:10:56:11 | exit M8 (normal) | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:9:58:33 | ... ...; | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:56:10:56:11 | M8 |
@@ -487,6 +520,8 @@ nodeEnclosing
 | Assert.cs:60:27:60:34 | access to property Length | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:63:10:63:11 | exit M9 (abnormal) | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:63:10:63:11 | exit M9 (normal) | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:9:65:33 | ... ...; | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:63:10:63:11 | M9 |
@@ -515,6 +550,8 @@ nodeEnclosing
 | Assert.cs:67:27:67:34 | access to property Length | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:70:10:70:12 | exit M10 (abnormal) | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:70:10:70:12 | exit M10 (normal) | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:9:72:33 | ... ...; | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:70:10:70:12 | M10 |
@@ -543,6 +580,8 @@ nodeEnclosing
 | Assert.cs:74:27:74:34 | access to property Length | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:77:10:77:12 | exit M11 (abnormal) | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:77:10:77:12 | exit M11 (normal) | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:9:79:33 | ... ...; | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:77:10:77:12 | M11 |
@@ -571,6 +610,8 @@ nodeEnclosing
 | Assert.cs:81:27:81:34 | access to property Length | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:84:10:84:12 | exit M12 (normal) | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:85:5:129:5 | {...} | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:9:86:33 | ... ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:84:10:84:12 | M12 |
@@ -855,9 +896,12 @@ nodeEnclosing
 | Assert.cs:128:27:128:34 | access to property Length | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:131:18:131:32 | AssertTrueFalse |
 | Assert.cs:131:18:131:32 | exit AssertTrueFalse | Assert.cs:131:18:131:32 | AssertTrueFalse |
+| Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) | Assert.cs:131:18:131:32 | AssertTrueFalse |
 | Assert.cs:135:5:136:5 | {...} | Assert.cs:131:18:131:32 | AssertTrueFalse |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:138:10:138:12 | M13 |
 | Assert.cs:138:10:138:12 | exit M13 | Assert.cs:138:10:138:12 | M13 |
+| Assert.cs:138:10:138:12 | exit M13 (abnormal) | Assert.cs:138:10:138:12 | M13 |
+| Assert.cs:138:10:138:12 | exit M13 (normal) | Assert.cs:138:10:138:12 | M13 |
 | Assert.cs:139:5:142:5 | {...} | Assert.cs:138:10:138:12 | M13 |
 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:138:10:138:12 | M13 |
 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:138:10:138:12 | M13 |
@@ -873,6 +917,7 @@ nodeEnclosing
 | Assert.cs:141:9:141:15 | return ...; | Assert.cs:138:10:138:12 | M13 |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | M |
 | Assignments.cs:3:10:3:10 | exit M | Assignments.cs:3:10:3:10 | M |
+| Assignments.cs:3:10:3:10 | exit M (normal) | Assignments.cs:3:10:3:10 | M |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:3:10:3:10 | M |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:3:10:3:10 | M |
 | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:3:10:3:10 | M |
@@ -906,14 +951,17 @@ nodeEnclosing
 | Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:3:10:3:10 | M |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | (...) => ... |
 | Assignments.cs:14:18:14:35 | exit (...) => ... | Assignments.cs:14:18:14:35 | (...) => ... |
+| Assignments.cs:14:18:14:35 | exit (...) => ... (normal) | Assignments.cs:14:18:14:35 | (...) => ... |
 | Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | (...) => ... |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | + |
 | Assignments.cs:17:40:17:40 | exit + | Assignments.cs:17:40:17:40 | + |
+| Assignments.cs:17:40:17:40 | exit + (normal) | Assignments.cs:17:40:17:40 | + |
 | Assignments.cs:18:5:20:5 | {...} | Assignments.cs:17:40:17:40 | + |
 | Assignments.cs:19:9:19:17 | return ...; | Assignments.cs:17:40:17:40 | + |
 | Assignments.cs:19:16:19:16 | access to parameter x | Assignments.cs:17:40:17:40 | + |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:3:10:3:11 | M1 |
 | BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:3:10:3:11 | M1 |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:3:10:3:11 | M1 |
 | BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:3:10:3:11 | M1 |
 | BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:3:10:3:11 | M1 |
 | BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:3:10:3:11 | M1 |
@@ -934,6 +982,7 @@ nodeEnclosing
 | BreakInTry.cs:16:17:16:17 | ; | BreakInTry.cs:3:10:3:11 | M1 |
 | BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:20:10:20:11 | M2 |
 | BreakInTry.cs:20:10:20:11 | exit M2 | BreakInTry.cs:20:10:20:11 | M2 |
+| BreakInTry.cs:20:10:20:11 | exit M2 (normal) | BreakInTry.cs:20:10:20:11 | M2 |
 | BreakInTry.cs:21:5:36:5 | {...} | BreakInTry.cs:20:10:20:11 | M2 |
 | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:20:10:20:11 | M2 |
 | BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:20:10:20:11 | M2 |
@@ -961,6 +1010,7 @@ nodeEnclosing
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | M2 |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:38:10:38:11 | M3 |
 | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | M3 |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:38:10:38:11 | M3 |
 | BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:38:10:38:11 | M3 |
 | BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:38:10:38:11 | M3 |
 | BreakInTry.cs:41:9:44:9 | {...} | BreakInTry.cs:38:10:38:11 | M3 |
@@ -992,6 +1042,7 @@ nodeEnclosing
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:38:10:38:11 | M3 |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:56:10:56:11 | M4 |
 | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:56:10:56:11 | M4 |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:56:10:56:11 | M4 |
 | BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:56:10:56:11 | M4 |
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:56:10:56:11 | M4 |
 | BreakInTry.cs:59:9:62:9 | {...} | BreakInTry.cs:56:10:56:11 | M4 |
@@ -1022,26 +1073,31 @@ nodeEnclosing
 | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:56:10:56:11 | M4 |
 | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:5:9:5:15 | Default |
 | CompileTimeOperators.cs:5:9:5:15 | exit Default | CompileTimeOperators.cs:5:9:5:15 | Default |
+| CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) | CompileTimeOperators.cs:5:9:5:15 | Default |
 | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:5:9:5:15 | Default |
 | CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:5:9:5:15 | Default |
 | CompileTimeOperators.cs:7:16:7:27 | default(...) | CompileTimeOperators.cs:5:9:5:15 | Default |
 | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:10:9:10:14 | Sizeof |
 | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof | CompileTimeOperators.cs:10:9:10:14 | Sizeof |
+| CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) | CompileTimeOperators.cs:10:9:10:14 | Sizeof |
 | CompileTimeOperators.cs:11:5:13:5 | {...} | CompileTimeOperators.cs:10:9:10:14 | Sizeof |
 | CompileTimeOperators.cs:12:9:12:27 | return ...; | CompileTimeOperators.cs:10:9:10:14 | Sizeof |
 | CompileTimeOperators.cs:12:16:12:26 | sizeof(..) | CompileTimeOperators.cs:10:9:10:14 | Sizeof |
 | CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:15:10:15:15 | Typeof |
 | CompileTimeOperators.cs:15:10:15:15 | exit Typeof | CompileTimeOperators.cs:15:10:15:15 | Typeof |
+| CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) | CompileTimeOperators.cs:15:10:15:15 | Typeof |
 | CompileTimeOperators.cs:16:5:18:5 | {...} | CompileTimeOperators.cs:15:10:15:15 | Typeof |
 | CompileTimeOperators.cs:17:9:17:27 | return ...; | CompileTimeOperators.cs:15:10:15:15 | Typeof |
 | CompileTimeOperators.cs:17:16:17:26 | typeof(...) | CompileTimeOperators.cs:15:10:15:15 | Typeof |
 | CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:20:12:20:17 | Nameof |
 | CompileTimeOperators.cs:20:12:20:17 | exit Nameof | CompileTimeOperators.cs:20:12:20:17 | Nameof |
+| CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) | CompileTimeOperators.cs:20:12:20:17 | Nameof |
 | CompileTimeOperators.cs:21:5:23:5 | {...} | CompileTimeOperators.cs:20:12:20:17 | Nameof |
 | CompileTimeOperators.cs:22:9:22:25 | return ...; | CompileTimeOperators.cs:20:12:20:17 | Nameof |
 | CompileTimeOperators.cs:22:16:22:24 | nameof(...) | CompileTimeOperators.cs:20:12:20:17 | Nameof |
 | CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:28:10:28:10 | M |
 | CompileTimeOperators.cs:28:10:28:10 | exit M | CompileTimeOperators.cs:28:10:28:10 | M |
+| CompileTimeOperators.cs:28:10:28:10 | exit M (normal) | CompileTimeOperators.cs:28:10:28:10 | M |
 | CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:28:10:28:10 | M |
 | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:28:10:28:10 | M |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:28:10:28:10 | M |
@@ -1056,29 +1112,35 @@ nodeEnclosing
 | CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:28:10:28:10 | M |
 | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
 | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:12:3:13 | M1 |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:3:40:3:49 | call to method ToLower | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:10:5:11 | M2 |
 | ConditionalAccess.cs:5:10:5:11 | exit M2 | ConditionalAccess.cs:5:10:5:11 | M2 |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | M2 |
 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | M2 |
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:10:5:11 | M2 |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:10:7:11 | M3 |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:9:9:10 | M4 |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:11:9:11:10 | M5 |
 | ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:11:9:11:10 | M5 |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | M5 |
 | ConditionalAccess.cs:12:5:17:5 | {...} | ConditionalAccess.cs:11:9:11:10 | M5 |
 | ConditionalAccess.cs:13:9:16:21 | if (...) ... | ConditionalAccess.cs:11:9:11:10 | M5 |
 | ConditionalAccess.cs:13:13:13:13 | access to parameter s | ConditionalAccess.cs:11:9:11:10 | M5 |
@@ -1092,11 +1154,13 @@ nodeEnclosing
 | ConditionalAccess.cs:16:20:16:20 | 1 | ConditionalAccess.cs:11:9:11:10 | M5 |
 | ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:12:19:13 | M6 |
 | ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:12:19:13 | M6 |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | M6 |
 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:12:19:13 | M6 |
 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | ConditionalAccess.cs:19:12:19:13 | M6 |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:12:19:13 | M6 |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | M7 |
 | ConditionalAccess.cs:21:10:21:11 | exit M7 | ConditionalAccess.cs:21:10:21:11 | M7 |
+| ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) | ConditionalAccess.cs:21:10:21:11 | M7 |
 | ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:21:10:21:11 | M7 |
 | ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:21:10:21:11 | M7 |
 | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:21:10:21:11 | M7 |
@@ -1114,6 +1178,7 @@ nodeEnclosing
 | ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:21:10:21:11 | M7 |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | Out |
 | ConditionalAccess.cs:30:10:30:12 | exit Out | ConditionalAccess.cs:30:10:30:12 | Out |
+| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | Out |
 | ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
 | ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | Out |
 | ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | Out |
@@ -1122,6 +1187,7 @@ nodeEnclosing
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:10:30:12 | Out |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | M8 |
 | ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:32:10:32:11 | M8 |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | M8 |
 | ConditionalAccess.cs:33:5:36:5 | {...} | ConditionalAccess.cs:32:10:32:11 | M8 |
 | ConditionalAccess.cs:34:9:34:13 | ... = ... | ConditionalAccess.cs:32:10:32:11 | M8 |
 | ConditionalAccess.cs:34:9:34:14 | ...; | ConditionalAccess.cs:32:10:32:11 | M8 |
@@ -1132,6 +1198,7 @@ nodeEnclosing
 | ConditionalAccess.cs:35:14:35:24 | call to method Out | ConditionalAccess.cs:32:10:32:11 | M8 |
 | ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:26:41:38 | CommaJoinWith |
 | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith | ConditionalAccess.cs:41:26:41:38 | CommaJoinWith |
+| ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) | ConditionalAccess.cs:41:26:41:38 | CommaJoinWith |
 | ConditionalAccess.cs:41:70:41:71 | access to parameter s1 | ConditionalAccess.cs:41:26:41:38 | CommaJoinWith |
 | ConditionalAccess.cs:41:70:41:78 | ... + ... | ConditionalAccess.cs:41:26:41:38 | CommaJoinWith |
 | ConditionalAccess.cs:41:70:41:83 | ... + ... | ConditionalAccess.cs:41:26:41:38 | CommaJoinWith |
@@ -1139,6 +1206,7 @@ nodeEnclosing
 | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | ConditionalAccess.cs:41:26:41:38 | CommaJoinWith |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:3:10:3:19 | IncrOrDecr |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:4:5:9:5 | {...} | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:5:9:6:16 | if (...) ... | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:3:10:3:19 | IncrOrDecr |
@@ -1156,6 +1224,7 @@ nodeEnclosing
 | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:11:9:11:10 | M1 |
 | Conditions.cs:11:9:11:10 | exit M1 | Conditions.cs:11:9:11:10 | M1 |
+| Conditions.cs:11:9:11:10 | exit M1 (normal) | Conditions.cs:11:9:11:10 | M1 |
 | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:11:9:11:10 | M1 |
 | Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:11:9:11:10 | M1 |
 | Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:11:9:11:10 | M1 |
@@ -1186,6 +1255,7 @@ nodeEnclosing
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:11:9:11:10 | M1 |
 | Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:22:9:22:10 | M2 |
 | Conditions.cs:22:9:22:10 | exit M2 | Conditions.cs:22:9:22:10 | M2 |
+| Conditions.cs:22:9:22:10 | exit M2 (normal) | Conditions.cs:22:9:22:10 | M2 |
 | Conditions.cs:23:5:31:5 | {...} | Conditions.cs:22:9:22:10 | M2 |
 | Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:22:9:22:10 | M2 |
 | Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:22:9:22:10 | M2 |
@@ -1210,6 +1280,7 @@ nodeEnclosing
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:22:9:22:10 | M2 |
 | Conditions.cs:33:9:33:10 | enter M3 | Conditions.cs:33:9:33:10 | M3 |
 | Conditions.cs:33:9:33:10 | exit M3 | Conditions.cs:33:9:33:10 | M3 |
+| Conditions.cs:33:9:33:10 | exit M3 (normal) | Conditions.cs:33:9:33:10 | M3 |
 | Conditions.cs:34:5:44:5 | {...} | Conditions.cs:33:9:33:10 | M3 |
 | Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:33:9:33:10 | M3 |
 | Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:33:9:33:10 | M3 |
@@ -1238,6 +1309,7 @@ nodeEnclosing
 | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:33:9:33:10 | M3 |
 | Conditions.cs:46:9:46:10 | enter M4 | Conditions.cs:46:9:46:10 | M4 |
 | Conditions.cs:46:9:46:10 | exit M4 | Conditions.cs:46:9:46:10 | M4 |
+| Conditions.cs:46:9:46:10 | exit M4 (normal) | Conditions.cs:46:9:46:10 | M4 |
 | Conditions.cs:47:5:55:5 | {...} | Conditions.cs:46:9:46:10 | M4 |
 | Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:46:9:46:10 | M4 |
 | Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:46:9:46:10 | M4 |
@@ -1271,6 +1343,7 @@ nodeEnclosing
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:46:9:46:10 | M4 |
 | Conditions.cs:57:9:57:10 | enter M5 | Conditions.cs:57:9:57:10 | M5 |
 | Conditions.cs:57:9:57:10 | exit M5 | Conditions.cs:57:9:57:10 | M5 |
+| Conditions.cs:57:9:57:10 | exit M5 (normal) | Conditions.cs:57:9:57:10 | M5 |
 | Conditions.cs:58:5:68:5 | {...} | Conditions.cs:57:9:57:10 | M5 |
 | Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:57:9:57:10 | M5 |
 | Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:57:9:57:10 | M5 |
@@ -1313,6 +1386,7 @@ nodeEnclosing
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:57:9:57:10 | M5 |
 | Conditions.cs:70:9:70:10 | enter M6 | Conditions.cs:70:9:70:10 | M6 |
 | Conditions.cs:70:9:70:10 | exit M6 | Conditions.cs:70:9:70:10 | M6 |
+| Conditions.cs:70:9:70:10 | exit M6 (normal) | Conditions.cs:70:9:70:10 | M6 |
 | Conditions.cs:71:5:84:5 | {...} | Conditions.cs:70:9:70:10 | M6 |
 | Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:70:9:70:10 | M6 |
 | Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:70:9:70:10 | M6 |
@@ -1348,6 +1422,7 @@ nodeEnclosing
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:70:9:70:10 | M6 |
 | Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:86:9:86:10 | M7 |
 | Conditions.cs:86:9:86:10 | exit M7 | Conditions.cs:86:9:86:10 | M7 |
+| Conditions.cs:86:9:86:10 | exit M7 (normal) | Conditions.cs:86:9:86:10 | M7 |
 | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:86:9:86:10 | M7 |
 | Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:86:9:86:10 | M7 |
 | Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:86:9:86:10 | M7 |
@@ -1383,6 +1458,7 @@ nodeEnclosing
 | Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:86:9:86:10 | M7 |
 | Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:102:12:102:13 | exit M8 | Conditions.cs:102:12:102:13 | M8 |
+| Conditions.cs:102:12:102:13 | exit M8 (normal) | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:103:5:111:5 | {...} | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:102:12:102:13 | M8 |
@@ -1420,6 +1496,7 @@ nodeEnclosing
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:113:10:113:11 | M9 |
@@ -1497,6 +1574,7 @@ nodeEnclosing
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:129:10:129:12 | M10 |
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:144:5:150:5 | {...} | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:143:10:143:12 | M11 |
@@ -1521,6 +1599,7 @@ nodeEnclosing
 | Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:143:10:143:12 | M11 |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | M1 |
 | ExitMethods.cs:7:10:7:11 | exit M1 | ExitMethods.cs:7:10:7:11 | M1 |
+| ExitMethods.cs:7:10:7:11 | exit M1 (normal) | ExitMethods.cs:7:10:7:11 | M1 |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:7:10:7:11 | M1 |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:7:10:7:11 | M1 |
 | ExitMethods.cs:9:9:9:25 | ...; | ExitMethods.cs:7:10:7:11 | M1 |
@@ -1528,6 +1607,7 @@ nodeEnclosing
 | ExitMethods.cs:10:9:10:15 | return ...; | ExitMethods.cs:7:10:7:11 | M1 |
 | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | M2 |
 | ExitMethods.cs:13:10:13:11 | exit M2 | ExitMethods.cs:13:10:13:11 | M2 |
+| ExitMethods.cs:13:10:13:11 | exit M2 (normal) | ExitMethods.cs:13:10:13:11 | M2 |
 | ExitMethods.cs:14:5:17:5 | {...} | ExitMethods.cs:13:10:13:11 | M2 |
 | ExitMethods.cs:15:9:15:25 | call to method ErrorMaybe | ExitMethods.cs:13:10:13:11 | M2 |
 | ExitMethods.cs:15:9:15:26 | ...; | ExitMethods.cs:13:10:13:11 | M2 |
@@ -1535,24 +1615,28 @@ nodeEnclosing
 | ExitMethods.cs:16:9:16:15 | return ...; | ExitMethods.cs:13:10:13:11 | M2 |
 | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | M3 |
 | ExitMethods.cs:19:10:19:11 | exit M3 | ExitMethods.cs:19:10:19:11 | M3 |
+| ExitMethods.cs:19:10:19:11 | exit M3 (abnormal) | ExitMethods.cs:19:10:19:11 | M3 |
 | ExitMethods.cs:20:5:23:5 | {...} | ExitMethods.cs:19:10:19:11 | M3 |
 | ExitMethods.cs:21:9:21:25 | call to method ErrorAlways | ExitMethods.cs:19:10:19:11 | M3 |
 | ExitMethods.cs:21:9:21:26 | ...; | ExitMethods.cs:19:10:19:11 | M3 |
 | ExitMethods.cs:21:21:21:24 | true | ExitMethods.cs:19:10:19:11 | M3 |
 | ExitMethods.cs:25:10:25:11 | enter M4 | ExitMethods.cs:25:10:25:11 | M4 |
 | ExitMethods.cs:25:10:25:11 | exit M4 | ExitMethods.cs:25:10:25:11 | M4 |
+| ExitMethods.cs:25:10:25:11 | exit M4 (abnormal) | ExitMethods.cs:25:10:25:11 | M4 |
 | ExitMethods.cs:26:5:29:5 | {...} | ExitMethods.cs:25:10:25:11 | M4 |
 | ExitMethods.cs:27:9:27:14 | call to method Exit | ExitMethods.cs:25:10:25:11 | M4 |
 | ExitMethods.cs:27:9:27:14 | this access | ExitMethods.cs:25:10:25:11 | M4 |
 | ExitMethods.cs:27:9:27:15 | ...; | ExitMethods.cs:25:10:25:11 | M4 |
 | ExitMethods.cs:31:10:31:11 | enter M5 | ExitMethods.cs:31:10:31:11 | M5 |
 | ExitMethods.cs:31:10:31:11 | exit M5 | ExitMethods.cs:31:10:31:11 | M5 |
+| ExitMethods.cs:31:10:31:11 | exit M5 (abnormal) | ExitMethods.cs:31:10:31:11 | M5 |
 | ExitMethods.cs:32:5:35:5 | {...} | ExitMethods.cs:31:10:31:11 | M5 |
 | ExitMethods.cs:33:9:33:25 | call to method ApplicationExit | ExitMethods.cs:31:10:31:11 | M5 |
 | ExitMethods.cs:33:9:33:25 | this access | ExitMethods.cs:31:10:31:11 | M5 |
 | ExitMethods.cs:33:9:33:26 | ...; | ExitMethods.cs:31:10:31:11 | M5 |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:37:10:37:11 | M6 |
 | ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:37:10:37:11 | M6 |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:37:10:37:11 | M6 |
 | ExitMethods.cs:38:5:51:5 | {...} | ExitMethods.cs:37:10:37:11 | M6 |
 | ExitMethods.cs:39:9:50:9 | try {...} ... | ExitMethods.cs:37:10:37:11 | M6 |
 | ExitMethods.cs:40:9:42:9 | {...} | ExitMethods.cs:37:10:37:11 | M6 |
@@ -1568,16 +1652,20 @@ nodeEnclosing
 | ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:37:10:37:11 | M6 |
 | ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:53:10:53:11 | M7 |
 | ExitMethods.cs:53:10:53:11 | exit M7 | ExitMethods.cs:53:10:53:11 | M7 |
+| ExitMethods.cs:53:10:53:11 | exit M7 (abnormal) | ExitMethods.cs:53:10:53:11 | M7 |
 | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:53:10:53:11 | M7 |
 | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:53:10:53:11 | M7 |
 | ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:53:10:53:11 | M7 |
 | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:59:10:59:11 | M8 |
 | ExitMethods.cs:59:10:59:11 | exit M8 | ExitMethods.cs:59:10:59:11 | M8 |
+| ExitMethods.cs:59:10:59:11 | exit M8 (abnormal) | ExitMethods.cs:59:10:59:11 | M8 |
 | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:59:10:59:11 | M8 |
 | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:59:10:59:11 | M8 |
 | ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:59:10:59:11 | M8 |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
 | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (abnormal) | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
 | ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
 | ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
 | ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
@@ -1585,6 +1673,7 @@ nodeEnclosing
 | ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:71:17:71:27 | ErrorAlways |
 | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | ErrorAlways |
+| ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) | ExitMethods.cs:71:17:71:27 | ErrorAlways |
 | ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:71:17:71:27 | ErrorAlways |
 | ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:71:17:71:27 | ErrorAlways |
 | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:71:17:71:27 | ErrorAlways |
@@ -1595,21 +1684,25 @@ nodeEnclosing
 | ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:71:17:71:27 | ErrorAlways |
 | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:79:17:79:28 | ErrorAlways2 |
 | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 | ExitMethods.cs:79:17:79:28 | ErrorAlways2 |
+| ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 (abnormal) | ExitMethods.cs:79:17:79:28 | ErrorAlways2 |
 | ExitMethods.cs:80:5:82:5 | {...} | ExitMethods.cs:79:17:79:28 | ErrorAlways2 |
 | ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:79:17:79:28 | ErrorAlways2 |
 | ExitMethods.cs:81:15:81:29 | object creation of type Exception | ExitMethods.cs:79:17:79:28 | ErrorAlways2 |
 | ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 | ExitMethods.cs:84:17:84:28 | ErrorAlways3 |
 | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 | ExitMethods.cs:84:17:84:28 | ErrorAlways3 |
+| ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 (abnormal) | ExitMethods.cs:84:17:84:28 | ErrorAlways3 |
 | ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:17:84:28 | ErrorAlways3 |
 | ExitMethods.cs:84:41:84:55 | object creation of type Exception | ExitMethods.cs:84:17:84:28 | ErrorAlways3 |
 | ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:86:10:86:13 | Exit |
 | ExitMethods.cs:86:10:86:13 | exit Exit | ExitMethods.cs:86:10:86:13 | Exit |
+| ExitMethods.cs:86:10:86:13 | exit Exit (abnormal) | ExitMethods.cs:86:10:86:13 | Exit |
 | ExitMethods.cs:87:5:89:5 | {...} | ExitMethods.cs:86:10:86:13 | Exit |
 | ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:86:10:86:13 | Exit |
 | ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:86:10:86:13 | Exit |
 | ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:86:10:86:13 | Exit |
 | ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:91:10:91:18 | ExitInTry |
 | ExitMethods.cs:91:10:91:18 | exit ExitInTry | ExitMethods.cs:91:10:91:18 | ExitInTry |
+| ExitMethods.cs:91:10:91:18 | exit ExitInTry (abnormal) | ExitMethods.cs:91:10:91:18 | ExitInTry |
 | ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:91:10:91:18 | ExitInTry |
 | ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:91:10:91:18 | ExitInTry |
 | ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:91:10:91:18 | ExitInTry |
@@ -1618,11 +1711,14 @@ nodeEnclosing
 | ExitMethods.cs:95:13:95:19 | ...; | ExitMethods.cs:91:10:91:18 | ExitInTry |
 | ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:104:10:104:24 | ApplicationExit |
 | ExitMethods.cs:104:10:104:24 | exit ApplicationExit | ExitMethods.cs:104:10:104:24 | ApplicationExit |
+| ExitMethods.cs:104:10:104:24 | exit ApplicationExit (abnormal) | ExitMethods.cs:104:10:104:24 | ApplicationExit |
 | ExitMethods.cs:105:5:107:5 | {...} | ExitMethods.cs:104:10:104:24 | ApplicationExit |
 | ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:104:10:104:24 | ApplicationExit |
 | ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:104:10:104:24 | ApplicationExit |
 | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:109:13:109:21 | ThrowExpr |
 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:109:13:109:21 | ThrowExpr |
+| ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) | ExitMethods.cs:109:13:109:21 | ThrowExpr |
+| ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) | ExitMethods.cs:109:13:109:21 | ThrowExpr |
 | ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:109:13:109:21 | ThrowExpr |
 | ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:109:13:109:21 | ThrowExpr |
 | ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:109:13:109:21 | ThrowExpr |
@@ -1639,6 +1735,7 @@ nodeEnclosing
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:109:13:109:21 | ThrowExpr |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
 | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
+| ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
 | ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
 | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
 | ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
@@ -1649,23 +1746,28 @@ nodeEnclosing
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | ExitMethods.cs:119:17:119:32 | FailingAssertion |
+| ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | FailingAssertion2 |
 | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | ExitMethods.cs:125:17:125:33 | FailingAssertion2 |
+| ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 (abnormal) | ExitMethods.cs:125:17:125:33 | FailingAssertion2 |
 | ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:125:17:125:33 | FailingAssertion2 |
 | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:125:17:125:33 | FailingAssertion2 |
 | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:125:17:125:33 | FailingAssertion2 |
 | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:125:17:125:33 | FailingAssertion2 |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
 | ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse (abnormal) | ExitMethods.cs:131:10:131:20 | AssertFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse (normal) | ExitMethods.cs:131:10:131:20 | AssertFalse |
 | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
 | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
 | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:10:131:20 | AssertFalse |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
+| ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 (abnormal) | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
@@ -1673,12 +1775,14 @@ nodeEnclosing
 | ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | ToInt32 |
 | Extensions.cs:5:23:5:29 | exit ToInt32 | Extensions.cs:5:23:5:29 | ToInt32 |
+| Extensions.cs:5:23:5:29 | exit ToInt32 (normal) | Extensions.cs:5:23:5:29 | ToInt32 |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:5:23:5:29 | ToInt32 |
 | Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | ToInt32 |
 | Extensions.cs:7:16:7:29 | call to method Parse | Extensions.cs:5:23:5:29 | ToInt32 |
 | Extensions.cs:7:28:7:28 | access to parameter s | Extensions.cs:5:23:5:29 | ToInt32 |
 | Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:10:24:10:29 | ToBool |
 | Extensions.cs:10:24:10:29 | exit ToBool | Extensions.cs:10:24:10:29 | ToBool |
+| Extensions.cs:10:24:10:29 | exit ToBool (normal) | Extensions.cs:10:24:10:29 | ToBool |
 | Extensions.cs:11:5:13:5 | {...} | Extensions.cs:10:24:10:29 | ToBool |
 | Extensions.cs:12:9:12:20 | return ...; | Extensions.cs:10:24:10:29 | ToBool |
 | Extensions.cs:12:16:12:16 | access to parameter f | Extensions.cs:10:24:10:29 | ToBool |
@@ -1686,10 +1790,12 @@ nodeEnclosing
 | Extensions.cs:12:18:12:18 | access to parameter s | Extensions.cs:10:24:10:29 | ToBool |
 | Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:23:15:33 | CallToInt32 |
 | Extensions.cs:15:23:15:33 | exit CallToInt32 | Extensions.cs:15:23:15:33 | CallToInt32 |
+| Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) | Extensions.cs:15:23:15:33 | CallToInt32 |
 | Extensions.cs:15:40:15:51 | call to method ToInt32 | Extensions.cs:15:23:15:33 | CallToInt32 |
 | Extensions.cs:15:48:15:50 | "0" | Extensions.cs:15:23:15:33 | CallToInt32 |
 | Extensions.cs:20:17:20:20 | enter Main | Extensions.cs:20:17:20:20 | Main |
 | Extensions.cs:20:17:20:20 | exit Main | Extensions.cs:20:17:20:20 | Main |
+| Extensions.cs:20:17:20:20 | exit Main (normal) | Extensions.cs:20:17:20:20 | Main |
 | Extensions.cs:21:5:26:5 | {...} | Extensions.cs:20:17:20:20 | Main |
 | Extensions.cs:22:9:22:9 | access to parameter s | Extensions.cs:20:17:20:20 | Main |
 | Extensions.cs:22:9:22:19 | call to method ToInt32 | Extensions.cs:20:17:20:20 | Main |
@@ -1709,6 +1815,8 @@ nodeEnclosing
 | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | Extensions.cs:20:17:20:20 | Main |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:7:10:7:11 | exit M1 | Finally.cs:7:10:7:11 | M1 |
+| Finally.cs:7:10:7:11 | exit M1 (abnormal) | Finally.cs:7:10:7:11 | M1 |
+| Finally.cs:7:10:7:11 | exit M1 (normal) | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:8:5:17:5 | {...} | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:10:9:12:9 | {...} | Finally.cs:7:10:7:11 | M1 |
@@ -1729,6 +1837,8 @@ nodeEnclosing
 | Finally.cs:15:31:15:39 | [finally: exception(OutOfMemoryException)] "Finally" | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:19:10:19:11 | M2 |
 | Finally.cs:19:10:19:11 | exit M2 | Finally.cs:19:10:19:11 | M2 |
+| Finally.cs:19:10:19:11 | exit M2 (abnormal) | Finally.cs:19:10:19:11 | M2 |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:19:10:19:11 | M2 |
 | Finally.cs:20:5:52:5 | {...} | Finally.cs:19:10:19:11 | M2 |
 | Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:19:10:19:11 | M2 |
 | Finally.cs:22:9:25:9 | {...} | Finally.cs:19:10:19:11 | M2 |
@@ -1776,6 +1886,8 @@ nodeEnclosing
 | Finally.cs:50:31:50:39 | [finally: return] "Finally" | Finally.cs:19:10:19:11 | M2 |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:54:10:54:11 | M3 |
 | Finally.cs:54:10:54:11 | exit M3 | Finally.cs:54:10:54:11 | M3 |
+| Finally.cs:54:10:54:11 | exit M3 (abnormal) | Finally.cs:54:10:54:11 | M3 |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:54:10:54:11 | M3 |
 | Finally.cs:55:5:72:5 | {...} | Finally.cs:54:10:54:11 | M3 |
 | Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:54:10:54:11 | M3 |
 | Finally.cs:57:9:60:9 | {...} | Finally.cs:54:10:54:11 | M3 |
@@ -1824,6 +1936,8 @@ nodeEnclosing
 | Finally.cs:70:31:70:39 | [finally: return] "Finally" | Finally.cs:54:10:54:11 | M3 |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:74:10:74:11 | exit M4 | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:74:10:74:11 | exit M4 (abnormal) | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:75:5:101:5 | {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:76:9:76:19 | ... ...; | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:76:13:76:18 | Int32 i = ... | Finally.cs:74:10:74:11 | M4 |
@@ -1920,6 +2034,8 @@ nodeEnclosing
 | Finally.cs:97:21:97:24 | [finally: return] ...; | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:103:10:103:11 | exit M5 | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:103:10:103:11 | exit M5 (abnormal) | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:104:5:119:5 | {...} | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:106:9:111:9 | {...} | Finally.cs:103:10:103:11 | M5 |
@@ -2045,6 +2161,7 @@ nodeEnclosing
 | Finally.cs:117:35:117:35 | [finally: return] 1 | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:121:10:121:11 | enter M6 | Finally.cs:121:10:121:11 | M6 |
 | Finally.cs:121:10:121:11 | exit M6 | Finally.cs:121:10:121:11 | M6 |
+| Finally.cs:121:10:121:11 | exit M6 (normal) | Finally.cs:121:10:121:11 | M6 |
 | Finally.cs:122:5:131:5 | {...} | Finally.cs:121:10:121:11 | M6 |
 | Finally.cs:123:9:130:9 | try {...} ... | Finally.cs:121:10:121:11 | M6 |
 | Finally.cs:124:9:126:9 | {...} | Finally.cs:121:10:121:11 | M6 |
@@ -2056,6 +2173,7 @@ nodeEnclosing
 | Finally.cs:125:28:125:40 | access to constant E | Finally.cs:121:10:121:11 | M6 |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:133:10:133:11 | M7 |
 | Finally.cs:133:10:133:11 | exit M7 | Finally.cs:133:10:133:11 | M7 |
+| Finally.cs:133:10:133:11 | exit M7 (abnormal) | Finally.cs:133:10:133:11 | M7 |
 | Finally.cs:134:5:145:5 | {...} | Finally.cs:133:10:133:11 | M7 |
 | Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:133:10:133:11 | M7 |
 | Finally.cs:136:9:138:9 | {...} | Finally.cs:133:10:133:11 | M7 |
@@ -2076,6 +2194,8 @@ nodeEnclosing
 | Finally.cs:141:41:141:42 | [finally: exception(OutOfMemoryException)] "" | Finally.cs:133:10:133:11 | M7 |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:147:10:147:11 | M8 |
 | Finally.cs:147:10:147:11 | exit M8 | Finally.cs:147:10:147:11 | M8 |
+| Finally.cs:147:10:147:11 | exit M8 (abnormal) | Finally.cs:147:10:147:11 | M8 |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:147:10:147:11 | M8 |
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:147:10:147:11 | M8 |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:147:10:147:11 | M8 |
 | Finally.cs:150:9:153:9 | {...} | Finally.cs:147:10:147:11 | M8 |
@@ -2189,6 +2309,8 @@ nodeEnclosing
 | Finally.cs:167:35:167:36 | [finally: exception(Exception)] "" | Finally.cs:147:10:147:11 | M8 |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:176:10:176:11 | M9 |
 | Finally.cs:176:10:176:11 | exit M9 | Finally.cs:176:10:176:11 | M9 |
+| Finally.cs:176:10:176:11 | exit M9 (abnormal) | Finally.cs:176:10:176:11 | M9 |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:176:10:176:11 | M9 |
 | Finally.cs:177:5:193:5 | {...} | Finally.cs:176:10:176:11 | M9 |
 | Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:176:10:176:11 | M9 |
 | Finally.cs:179:9:181:9 | {...} | Finally.cs:176:10:176:11 | M9 |
@@ -2244,6 +2366,8 @@ nodeEnclosing
 | Finally.cs:190:31:190:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:176:10:176:11 | M9 |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:195:10:195:12 | exit M10 | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:195:10:195:12 | exit M10 (abnormal) | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:195:10:195:12 | exit M10 (normal) | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:196:5:214:5 | {...} | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:198:9:200:9 | {...} | Finally.cs:195:10:195:12 | M10 |
@@ -2335,6 +2459,7 @@ nodeEnclosing
 | Finally.cs:213:22:213:24 | "1" | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:216:10:216:12 | enter M11 | Finally.cs:216:10:216:12 | M11 |
 | Finally.cs:216:10:216:12 | exit M11 | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:216:10:216:12 | exit M11 (normal) | Finally.cs:216:10:216:12 | M11 |
 | Finally.cs:217:5:231:5 | {...} | Finally.cs:216:10:216:12 | M11 |
 | Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:216:10:216:12 | M11 |
 | Finally.cs:219:9:221:9 | {...} | Finally.cs:216:10:216:12 | M11 |
@@ -2355,6 +2480,7 @@ nodeEnclosing
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:216:10:216:12 | M11 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | M1 |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:6:10:6:11 | M1 |
@@ -2362,6 +2488,7 @@ nodeEnclosing
 | Foreach.cs:9:13:9:13 | ; | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:12:10:12:11 | M2 |
 | Foreach.cs:12:10:12:11 | exit M2 | Foreach.cs:12:10:12:11 | M2 |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | M2 |
 | Foreach.cs:13:5:16:5 | {...} | Foreach.cs:12:10:12:11 | M2 |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | M2 |
 | Foreach.cs:14:22:14:22 | String _ | Foreach.cs:12:10:12:11 | M2 |
@@ -2369,6 +2496,7 @@ nodeEnclosing
 | Foreach.cs:15:13:15:13 | ; | Foreach.cs:12:10:12:11 | M2 |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:18:10:18:11 | M3 |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:19:5:22:5 | {...} | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:18:10:18:11 | M3 |
@@ -2379,6 +2507,7 @@ nodeEnclosing
 | Foreach.cs:21:11:21:11 | ; | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:24:10:24:11 | M4 |
 | Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:24:10:24:11 | M4 |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | M4 |
 | Foreach.cs:25:5:28:5 | {...} | Foreach.cs:24:10:24:11 | M4 |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | M4 |
 | Foreach.cs:26:18:26:31 | (..., ...) | Foreach.cs:24:10:24:11 | M4 |
@@ -2388,6 +2517,7 @@ nodeEnclosing
 | Foreach.cs:27:11:27:11 | ; | Foreach.cs:24:10:24:11 | M4 |
 | Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:30:10:30:11 | M5 |
 | Foreach.cs:30:10:30:11 | exit M5 | Foreach.cs:30:10:30:11 | M5 |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:30:10:30:11 | M5 |
 | Foreach.cs:31:5:34:5 | {...} | Foreach.cs:30:10:30:11 | M5 |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | M5 |
 | Foreach.cs:32:18:32:27 | (..., ...) | Foreach.cs:30:10:30:11 | M5 |
@@ -2397,6 +2527,7 @@ nodeEnclosing
 | Foreach.cs:33:11:33:11 | ; | Foreach.cs:30:10:30:11 | M5 |
 | Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:36:10:36:11 | M6 |
 | Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:36:10:36:11 | M6 |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | M6 |
 | Foreach.cs:37:5:40:5 | {...} | Foreach.cs:36:10:36:11 | M6 |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | M6 |
 | Foreach.cs:38:18:38:34 | (..., ...) | Foreach.cs:36:10:36:11 | M6 |
@@ -2428,12 +2559,15 @@ nodeEnclosing
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:10:5:10:16 | Initializers |
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | Initializers |
 | Initializers.cs:8:5:8:16 | exit Initializers | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:8:5:8:16 | exit Initializers (normal) | Initializers.cs:8:5:8:16 | Initializers |
 | Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | Initializers |
 | Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | Initializers |
 | Initializers.cs:10:5:10:16 | exit Initializers | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:10:5:10:16 | exit Initializers (normal) | Initializers.cs:10:5:10:16 | Initializers |
 | Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | Initializers |
 | Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | M |
 | Initializers.cs:12:10:12:10 | exit M | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:12:10:12:10 | exit M (normal) | Initializers.cs:12:10:12:10 | M |
 | Initializers.cs:13:5:16:5 | {...} | Initializers.cs:12:10:12:10 | M |
 | Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:12:10:12:10 | M |
 | Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:12:10:12:10 | M |
@@ -2455,6 +2589,7 @@ nodeEnclosing
 | Initializers.cs:15:59:15:60 | "" | Initializers.cs:12:10:12:10 | M |
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | NoConstructor |
 | Initializers.cs:20:11:20:23 | exit NoConstructor | Initializers.cs:20:11:20:23 | NoConstructor |
+| Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:20:11:20:23 | NoConstructor |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:20:11:20:23 | NoConstructor |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:20:11:20:23 | NoConstructor |
@@ -2475,6 +2610,7 @@ nodeEnclosing
 | Initializers.cs:28:17:28:17 | 2 | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | Sub |
 | Initializers.cs:31:9:31:11 | exit Sub | Initializers.cs:31:9:31:11 | Sub |
+| Initializers.cs:31:9:31:11 | exit Sub (normal) | Initializers.cs:31:9:31:11 | Sub |
 | Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:31:9:31:11 | Sub |
 | Initializers.cs:31:24:31:33 | {...} | Initializers.cs:31:9:31:11 | Sub |
 | Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:9:31:11 | Sub |
@@ -2483,6 +2619,7 @@ nodeEnclosing
 | Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:9:31:11 | Sub |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | Sub |
 | Initializers.cs:33:9:33:11 | exit Sub | Initializers.cs:33:9:33:11 | Sub |
+| Initializers.cs:33:9:33:11 | exit Sub (normal) | Initializers.cs:33:9:33:11 | Sub |
 | Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:9:33:11 | Sub |
 | Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:9:33:11 | Sub |
 | Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:9:33:11 | Sub |
@@ -2491,6 +2628,7 @@ nodeEnclosing
 | Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:9:33:11 | Sub |
 | Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:35:9:35:11 | exit Sub | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:35:9:35:11 | exit Sub (normal) | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:9:35:11 | Sub |
@@ -2500,6 +2638,7 @@ nodeEnclosing
 | Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:51:10:51:13 | exit Test | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:51:10:51:13 | exit Test (normal) | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:52:5:66:5 | {...} | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:51:10:51:13 | Test |
@@ -2604,6 +2743,7 @@ nodeEnclosing
 | Initializers.cs:64:59:64:61 | "1" | Initializers.cs:51:10:51:13 | Test |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:9:9:10:19 | if (...) ... | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:9:13:9:16 | access to parameter args | LoopUnrolling.cs:7:10:7:11 | M1 |
@@ -2620,6 +2760,7 @@ nodeEnclosing
 | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:15:10:15:11 | M2 |
@@ -2638,6 +2779,7 @@ nodeEnclosing
 | LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | M3 |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:23:5:27:5 | {...} | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:22:10:22:11 | M3 |
@@ -2651,6 +2793,7 @@ nodeEnclosing
 | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | M4 |
+| LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:30:5:34:5 | {...} | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:31:9:31:31 | ... ...; | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:29:10:29:11 | M4 |
@@ -2660,6 +2803,7 @@ nodeEnclosing
 | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:36:10:36:11 | M5 |
@@ -2711,6 +2855,7 @@ nodeEnclosing
 | LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:45:10:45:11 | M6 |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:55:10:55:11 | M7 |
@@ -2748,6 +2893,7 @@ nodeEnclosing
 | LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:67:10:67:11 | M8 |
@@ -2761,6 +2907,7 @@ nodeEnclosing
 | LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:76:10:76:11 | M9 |
@@ -2771,6 +2918,7 @@ nodeEnclosing
 | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:85:10:85:12 | M10 |
@@ -2781,6 +2929,7 @@ nodeEnclosing
 | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
 | LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:94:10:94:12 | M11 |
 | LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:94:10:94:12 | M11 |
 | LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:94:10:94:12 | M11 |
 | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:94:10:94:12 | M11 |
@@ -2799,6 +2948,10 @@ nodeEnclosing
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | get_P1 |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | MultiImplementationA.cs:6:22:6:31 | get_P1 |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | MultiImplementationB.cs:3:22:3:22 | get_P1 |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | MultiImplementationA.cs:6:22:6:31 | get_P1 |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | MultiImplementationB.cs:3:22:3:22 | get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:22:6:31 | get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationB.cs:3:22:3:22 | get_P1 |
 | MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:22:6:31 | get_P1 |
@@ -2807,6 +2960,10 @@ nodeEnclosing
 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationB.cs:4:21:4:23 | get_P2 |
 | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationA.cs:7:21:7:23 | get_P2 |
 | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | MultiImplementationB.cs:4:21:4:23 | get_P2 |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | MultiImplementationA.cs:7:21:7:23 | get_P2 |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | MultiImplementationB.cs:4:21:4:23 | get_P2 |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | MultiImplementationA.cs:7:21:7:23 | get_P2 |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | MultiImplementationB.cs:4:21:4:23 | get_P2 |
 | MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationA.cs:7:21:7:23 | get_P2 |
 | MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationB.cs:4:21:4:23 | get_P2 |
 | MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationA.cs:7:21:7:23 | get_P2 |
@@ -2817,6 +2974,10 @@ nodeEnclosing
 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationB.cs:4:39:4:41 | set_P2 |
 | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationA.cs:7:41:7:43 | set_P2 |
 | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | MultiImplementationB.cs:4:39:4:41 | set_P2 |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | MultiImplementationA.cs:7:41:7:43 | set_P2 |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | MultiImplementationB.cs:4:39:4:41 | set_P2 |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | MultiImplementationA.cs:7:41:7:43 | set_P2 |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | MultiImplementationB.cs:4:39:4:41 | set_P2 |
 | MultiImplementationA.cs:7:45:7:59 | {...} | MultiImplementationA.cs:7:41:7:43 | set_P2 |
 | MultiImplementationA.cs:7:45:7:59 | {...} | MultiImplementationB.cs:4:39:4:41 | set_P2 |
 | MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationA.cs:7:41:7:43 | set_P2 |
@@ -2827,6 +2988,10 @@ nodeEnclosing
 | MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationB.cs:5:16:5:16 | M |
 | MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationA.cs:8:16:8:16 | M |
 | MultiImplementationA.cs:8:16:8:16 | exit M | MultiImplementationB.cs:5:16:5:16 | M |
+| MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | MultiImplementationA.cs:8:16:8:16 | M |
+| MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | MultiImplementationB.cs:5:16:5:16 | M |
+| MultiImplementationA.cs:8:16:8:16 | exit M (normal) | MultiImplementationA.cs:8:16:8:16 | M |
+| MultiImplementationA.cs:8:16:8:16 | exit M (normal) | MultiImplementationB.cs:5:16:5:16 | M |
 | MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationA.cs:8:16:8:16 | M |
 | MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationB.cs:5:16:5:16 | M |
 | MultiImplementationA.cs:8:29:8:32 | null | MultiImplementationA.cs:8:16:8:16 | M |
@@ -2843,10 +3008,18 @@ nodeEnclosing
 | MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationB.cs:12:31:12:40 | get_Item |
 | MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | get_Item |
 | MultiImplementationA.cs:14:31:14:31 | exit get_Item | MultiImplementationB.cs:12:31:12:40 | get_Item |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | MultiImplementationA.cs:14:31:14:31 | get_Item |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | MultiImplementationB.cs:12:31:12:40 | get_Item |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | MultiImplementationA.cs:14:31:14:31 | get_Item |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | MultiImplementationB.cs:12:31:12:40 | get_Item |
 | MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationA.cs:15:36:15:38 | get_Item |
 | MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationB.cs:13:36:13:38 | get_Item |
 | MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationA.cs:15:36:15:38 | get_Item |
 | MultiImplementationA.cs:15:36:15:38 | exit get_Item | MultiImplementationB.cs:13:36:13:38 | get_Item |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | MultiImplementationA.cs:15:36:15:38 | get_Item |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | MultiImplementationB.cs:13:36:13:38 | get_Item |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | MultiImplementationA.cs:15:36:15:38 | get_Item |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | MultiImplementationB.cs:13:36:13:38 | get_Item |
 | MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:36:15:38 | get_Item |
 | MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationB.cs:13:36:13:38 | get_Item |
 | MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationA.cs:15:36:15:38 | get_Item |
@@ -2857,23 +3030,32 @@ nodeEnclosing
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | set_Item |
 | MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | set_Item |
 | MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | set_Item |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | set_Item |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | set_Item |
 | MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationA.cs:15:54:15:56 | set_Item |
 | MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationB.cs:13:56:13:58 | set_Item |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | M1 |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | M1 |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:9:18:22 | M2 |
 | MultiImplementationA.cs:18:9:18:22 | exit M2 | MultiImplementationA.cs:18:9:18:22 | M2 |
+| MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | MultiImplementationA.cs:18:9:18:22 | M2 |
 | MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | M2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | C2 |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | MultiImplementationA.cs:20:12:20:13 | C2 |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | MultiImplementationB.cs:18:12:18:13 | C2 |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | MultiImplementationA.cs:20:12:20:13 | C2 |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:12:20:13 | C2 |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationA.cs:20:24:20:24 | this access | MultiImplementationA.cs:20:12:20:13 | C2 |
@@ -2888,6 +3070,8 @@ nodeEnclosing
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | C2 |
 | MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | C2 |
 | MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | C2 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | C2 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | C2 |
 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | MultiImplementationA.cs:21:12:21:13 | C2 |
 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | MultiImplementationB.cs:19:12:19:13 | C2 |
 | MultiImplementationA.cs:21:24:21:24 | 0 | MultiImplementationA.cs:21:12:21:13 | C2 |
@@ -2898,12 +3082,20 @@ nodeEnclosing
 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationB.cs:20:6:20:7 | ~C2 |
 | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationA.cs:22:6:22:7 | ~C2 |
 | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | MultiImplementationB.cs:20:6:20:7 | ~C2 |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | MultiImplementationA.cs:22:6:22:7 | ~C2 |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | MultiImplementationB.cs:20:6:20:7 | ~C2 |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | MultiImplementationA.cs:22:6:22:7 | ~C2 |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | MultiImplementationB.cs:20:6:20:7 | ~C2 |
 | MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:6:22:7 | ~C2 |
 | MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationB.cs:20:6:20:7 | ~C2 |
 | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationA.cs:23:28:23:35 | implicit conversion |
 | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationB.cs:21:28:21:35 | implicit conversion |
 | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationA.cs:23:28:23:35 | implicit conversion |
 | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | MultiImplementationB.cs:21:28:21:35 | implicit conversion |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | MultiImplementationA.cs:23:28:23:35 | implicit conversion |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | MultiImplementationB.cs:21:28:21:35 | implicit conversion |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | MultiImplementationA.cs:23:28:23:35 | implicit conversion |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | MultiImplementationB.cs:21:28:21:35 | implicit conversion |
 | MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:28:23:35 | implicit conversion |
 | MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationB.cs:21:28:21:35 | implicit conversion |
 | MultiImplementationA.cs:24:16:24:16 | access to property P | MultiImplementationA.cs:20:12:20:13 | C2 |
@@ -2918,6 +3110,8 @@ nodeEnclosing
 | MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationB.cs:27:21:27:23 | get_P3 |
 | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | MultiImplementationA.cs:30:21:30:23 | get_P3 |
 | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | MultiImplementationB.cs:27:21:27:23 | get_P3 |
+| MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:21:30:23 | get_P3 |
+| MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | MultiImplementationB.cs:27:21:27:23 | get_P3 |
 | MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationA.cs:30:21:30:23 | get_P3 |
 | MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationB.cs:27:21:27:23 | get_P3 |
 | MultiImplementationA.cs:30:34:30:37 | null | MultiImplementationA.cs:30:21:30:23 | get_P3 |
@@ -2926,6 +3120,10 @@ nodeEnclosing
 | MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationB.cs:32:9:32:10 | M1 |
 | MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationA.cs:36:9:36:10 | M1 |
 | MultiImplementationA.cs:36:9:36:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | M1 |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | MultiImplementationA.cs:36:9:36:10 | M1 |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | MultiImplementationB.cs:32:9:32:10 | M1 |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | MultiImplementationA.cs:36:9:36:10 | M1 |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | MultiImplementationB.cs:32:9:32:10 | M1 |
 | MultiImplementationA.cs:36:14:36:28 | {...} | MultiImplementationA.cs:36:9:36:10 | M1 |
 | MultiImplementationA.cs:36:14:36:28 | {...} | MultiImplementationB.cs:32:9:32:10 | M1 |
 | MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationA.cs:36:9:36:10 | M1 |
@@ -2934,6 +3132,7 @@ nodeEnclosing
 | MultiImplementationA.cs:36:22:36:25 | null | MultiImplementationB.cs:32:9:32:10 | M1 |
 | MultiImplementationA.cs:37:9:37:10 | enter M2 | MultiImplementationA.cs:37:9:37:10 | M2 |
 | MultiImplementationA.cs:37:9:37:10 | exit M2 | MultiImplementationA.cs:37:9:37:10 | M2 |
+| MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) | MultiImplementationA.cs:37:9:37:10 | M2 |
 | MultiImplementationA.cs:37:14:37:28 | {...} | MultiImplementationA.cs:37:9:37:10 | M2 |
 | MultiImplementationA.cs:37:16:37:26 | throw ...; | MultiImplementationA.cs:37:9:37:10 | M2 |
 | MultiImplementationA.cs:37:22:37:25 | null | MultiImplementationA.cs:37:9:37:10 | M2 |
@@ -2943,10 +3142,18 @@ nodeEnclosing
 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | get_P1 |
 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | get_P1 |
 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | get_P1 |
+| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) | MultiImplementationA.cs:6:22:6:31 | get_P1 |
+| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) | MultiImplementationB.cs:3:22:3:22 | get_P1 |
+| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) | MultiImplementationA.cs:6:22:6:31 | get_P1 |
+| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) | MultiImplementationB.cs:3:22:3:22 | get_P1 |
 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationA.cs:7:21:7:23 | get_P2 |
 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationB.cs:4:21:4:23 | get_P2 |
 | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationA.cs:7:21:7:23 | get_P2 |
 | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | MultiImplementationB.cs:4:21:4:23 | get_P2 |
+| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) | MultiImplementationA.cs:7:21:7:23 | get_P2 |
+| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) | MultiImplementationB.cs:4:21:4:23 | get_P2 |
+| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) | MultiImplementationA.cs:7:21:7:23 | get_P2 |
+| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) | MultiImplementationB.cs:4:21:4:23 | get_P2 |
 | MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationA.cs:7:21:7:23 | get_P2 |
 | MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationB.cs:4:21:4:23 | get_P2 |
 | MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationA.cs:7:21:7:23 | get_P2 |
@@ -2957,12 +3164,20 @@ nodeEnclosing
 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationB.cs:4:39:4:41 | set_P2 |
 | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationA.cs:7:41:7:43 | set_P2 |
 | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | MultiImplementationB.cs:4:39:4:41 | set_P2 |
+| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) | MultiImplementationA.cs:7:41:7:43 | set_P2 |
+| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) | MultiImplementationB.cs:4:39:4:41 | set_P2 |
+| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) | MultiImplementationA.cs:7:41:7:43 | set_P2 |
+| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) | MultiImplementationB.cs:4:39:4:41 | set_P2 |
 | MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationA.cs:7:41:7:43 | set_P2 |
 | MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationB.cs:4:39:4:41 | set_P2 |
 | MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationA.cs:8:16:8:16 | M |
 | MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationB.cs:5:16:5:16 | M |
 | MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationA.cs:8:16:8:16 | M |
 | MultiImplementationB.cs:5:16:5:16 | exit M | MultiImplementationB.cs:5:16:5:16 | M |
+| MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) | MultiImplementationA.cs:8:16:8:16 | M |
+| MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) | MultiImplementationB.cs:5:16:5:16 | M |
+| MultiImplementationB.cs:5:16:5:16 | exit M (normal) | MultiImplementationA.cs:8:16:8:16 | M |
+| MultiImplementationB.cs:5:16:5:16 | exit M (normal) | MultiImplementationB.cs:5:16:5:16 | M |
 | MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationA.cs:8:16:8:16 | M |
 | MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationB.cs:5:16:5:16 | M |
 | MultiImplementationB.cs:11:16:11:16 | this access | MultiImplementationA.cs:20:12:20:13 | C2 |
@@ -2975,6 +3190,10 @@ nodeEnclosing
 | MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationB.cs:12:31:12:40 | get_Item |
 | MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationA.cs:14:31:14:31 | get_Item |
 | MultiImplementationB.cs:12:31:12:40 | exit get_Item | MultiImplementationB.cs:12:31:12:40 | get_Item |
+| MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) | MultiImplementationA.cs:14:31:14:31 | get_Item |
+| MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) | MultiImplementationB.cs:12:31:12:40 | get_Item |
+| MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) | MultiImplementationA.cs:14:31:14:31 | get_Item |
+| MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) | MultiImplementationB.cs:12:31:12:40 | get_Item |
 | MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationA.cs:14:31:14:31 | get_Item |
 | MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationB.cs:12:31:12:40 | get_Item |
 | MultiImplementationB.cs:12:37:12:40 | null | MultiImplementationA.cs:14:31:14:31 | get_Item |
@@ -2983,6 +3202,10 @@ nodeEnclosing
 | MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationB.cs:13:36:13:38 | get_Item |
 | MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationA.cs:15:36:15:38 | get_Item |
 | MultiImplementationB.cs:13:36:13:38 | exit get_Item | MultiImplementationB.cs:13:36:13:38 | get_Item |
+| MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) | MultiImplementationA.cs:15:36:15:38 | get_Item |
+| MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) | MultiImplementationB.cs:13:36:13:38 | get_Item |
+| MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) | MultiImplementationA.cs:15:36:15:38 | get_Item |
+| MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) | MultiImplementationB.cs:13:36:13:38 | get_Item |
 | MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationA.cs:15:36:15:38 | get_Item |
 | MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationB.cs:13:36:13:38 | get_Item |
 | MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationA.cs:15:36:15:38 | get_Item |
@@ -2993,24 +3216,33 @@ nodeEnclosing
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | set_Item |
 | MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | set_Item |
 | MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | set_Item |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | set_Item |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | set_Item |
 | MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationA.cs:15:54:15:56 | set_Item |
 | MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationB.cs:13:56:13:58 | set_Item |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | M1 |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | M1 |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:9:16:31 | M2 |
 | MultiImplementationB.cs:16:9:16:31 | exit M2 | MultiImplementationB.cs:16:9:16:31 | M2 |
+| MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | MultiImplementationB.cs:16:9:16:31 | M2 |
 | MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:9:16:31 | M2 |
 | MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:9:16:31 | M2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | C2 |
+| MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | MultiImplementationA.cs:20:12:20:13 | C2 |
+| MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | MultiImplementationB.cs:18:12:18:13 | C2 |
+| MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | MultiImplementationA.cs:20:12:20:13 | C2 |
+| MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationA.cs:20:12:20:13 | C2 |
 | MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationA.cs:20:12:20:13 | C2 |
@@ -3021,6 +3253,8 @@ nodeEnclosing
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | C2 |
 | MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | C2 |
 | MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | C2 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | C2 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | C2 |
 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | MultiImplementationA.cs:21:12:21:13 | C2 |
 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | MultiImplementationB.cs:19:12:19:13 | C2 |
 | MultiImplementationB.cs:19:24:19:24 | 1 | MultiImplementationA.cs:21:12:21:13 | C2 |
@@ -3031,6 +3265,10 @@ nodeEnclosing
 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationB.cs:20:6:20:7 | ~C2 |
 | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationA.cs:22:6:22:7 | ~C2 |
 | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | MultiImplementationB.cs:20:6:20:7 | ~C2 |
+| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) | MultiImplementationA.cs:22:6:22:7 | ~C2 |
+| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) | MultiImplementationB.cs:20:6:20:7 | ~C2 |
+| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) | MultiImplementationA.cs:22:6:22:7 | ~C2 |
+| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) | MultiImplementationB.cs:20:6:20:7 | ~C2 |
 | MultiImplementationB.cs:20:11:20:25 | {...} | MultiImplementationA.cs:22:6:22:7 | ~C2 |
 | MultiImplementationB.cs:20:11:20:25 | {...} | MultiImplementationB.cs:20:6:20:7 | ~C2 |
 | MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationA.cs:22:6:22:7 | ~C2 |
@@ -3041,6 +3279,10 @@ nodeEnclosing
 | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationB.cs:21:28:21:35 | implicit conversion |
 | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationA.cs:23:28:23:35 | implicit conversion |
 | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | MultiImplementationB.cs:21:28:21:35 | implicit conversion |
+| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) | MultiImplementationA.cs:23:28:23:35 | implicit conversion |
+| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) | MultiImplementationB.cs:21:28:21:35 | implicit conversion |
+| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) | MultiImplementationA.cs:23:28:23:35 | implicit conversion |
+| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) | MultiImplementationB.cs:21:28:21:35 | implicit conversion |
 | MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationA.cs:23:28:23:35 | implicit conversion |
 | MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationB.cs:21:28:21:35 | implicit conversion |
 | MultiImplementationB.cs:21:56:21:59 | null | MultiImplementationA.cs:23:28:23:35 | implicit conversion |
@@ -3057,19 +3299,27 @@ nodeEnclosing
 | MultiImplementationB.cs:27:21:27:23 | enter get_P3 | MultiImplementationB.cs:27:21:27:23 | get_P3 |
 | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | MultiImplementationA.cs:30:21:30:23 | get_P3 |
 | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | MultiImplementationB.cs:27:21:27:23 | get_P3 |
+| MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:21:30:23 | get_P3 |
+| MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | MultiImplementationB.cs:27:21:27:23 | get_P3 |
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationA.cs:36:9:36:10 | M1 |
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationB.cs:32:9:32:10 | M1 |
 | MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationA.cs:36:9:36:10 | M1 |
 | MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | M1 |
+| MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) | MultiImplementationA.cs:36:9:36:10 | M1 |
+| MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) | MultiImplementationB.cs:32:9:32:10 | M1 |
+| MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | MultiImplementationA.cs:36:9:36:10 | M1 |
+| MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | MultiImplementationB.cs:32:9:32:10 | M1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | M1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | M1 |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:9:3:10 | M1 |
 | NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:9:3:10 | M1 |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | M1 |
 | NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:9:3:10 | M1 |
 | NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:9:3:10 | M1 |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:9:3:10 | M1 |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:9:5:10 | M2 |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:9:5:10 | M2 |
@@ -3078,6 +3328,7 @@ nodeEnclosing
 | NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:12:7:13 | M3 |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:12:7:13 | M3 |
@@ -3085,6 +3336,7 @@ nodeEnclosing
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:12:9:13 | M4 |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:12:9:13 | M4 |
@@ -3094,6 +3346,7 @@ nodeEnclosing
 | NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:9:11:10 | M5 |
@@ -3104,6 +3357,7 @@ nodeEnclosing
 | NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:13:10:13:11 | M6 |
 | NullCoalescing.cs:13:10:13:11 | exit M6 | NullCoalescing.cs:13:10:13:11 | M6 |
+| NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | NullCoalescing.cs:13:10:13:11 | M6 |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:13:10:13:11 | M6 |
 | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:13:10:13:11 | M6 |
 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:13:10:13:11 | M6 |
@@ -3122,6 +3376,7 @@ nodeEnclosing
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:13:10:13:11 | M6 |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:5:10:5:13 | Test |
 | Patterns.cs:5:10:5:13 | exit Test | Patterns.cs:5:10:5:13 | Test |
+| Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:5:10:5:13 | Test |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:5:10:5:13 | Test |
 | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:5:10:5:13 | Test |
 | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:5:10:5:13 | Test |
@@ -3195,12 +3450,14 @@ nodeEnclosing
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | Test |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:5:10:5:11 | exit M1 | PostDominance.cs:5:10:5:11 | M1 |
+| PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:10:10:10:11 | M2 |
@@ -3212,6 +3469,8 @@ nodeEnclosing
 | PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:17:10:17:11 | exit M3 (normal) | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:17:10:17:11 | M3 |
@@ -3225,12 +3484,15 @@ nodeEnclosing
 | PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:17:10:17:11 | M3 |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | Method |
 | Qualifiers.cs:7:16:7:21 | exit Method | Qualifiers.cs:7:16:7:21 | Method |
+| Qualifiers.cs:7:16:7:21 | exit Method (normal) | Qualifiers.cs:7:16:7:21 | Method |
 | Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | Method |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:23:8:34 | StaticMethod |
 | Qualifiers.cs:8:23:8:34 | exit StaticMethod | Qualifiers.cs:8:23:8:34 | StaticMethod |
+| Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) | Qualifiers.cs:8:23:8:34 | StaticMethod |
 | Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:23:8:34 | StaticMethod |
 | Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:10:10:10:10 | M |
 | Qualifiers.cs:10:10:10:10 | exit M | Qualifiers.cs:10:10:10:10 | M |
+| Qualifiers.cs:10:10:10:10 | exit M (normal) | Qualifiers.cs:10:10:10:10 | M |
 | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:10:10:10:10 | M |
 | Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:10:10:10:10 | M |
 | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:10:10:10:10 | M |
@@ -3288,11 +3550,14 @@ nodeEnclosing
 | Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:10:10:10:10 | M |
 | Switch.cs:5:10:5:11 | enter M1 | Switch.cs:5:10:5:11 | M1 |
 | Switch.cs:5:10:5:11 | exit M1 | Switch.cs:5:10:5:11 | M1 |
+| Switch.cs:5:10:5:11 | exit M1 (normal) | Switch.cs:5:10:5:11 | M1 |
 | Switch.cs:6:5:8:5 | {...} | Switch.cs:5:10:5:11 | M1 |
 | Switch.cs:7:9:7:22 | switch (...) {...} | Switch.cs:5:10:5:11 | M1 |
 | Switch.cs:7:17:7:17 | access to parameter o | Switch.cs:5:10:5:11 | M1 |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:10:10:10:11 | exit M2 | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:10:10:10:11 | exit M2 (abnormal) | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:11:5:33:5 | {...} | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:12:9:32:9 | switch (...) {...} | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:12:17:12:17 | access to parameter o | Switch.cs:10:10:10:11 | M2 |
@@ -3338,11 +3603,13 @@ nodeEnclosing
 | Switch.cs:31:17:31:27 | goto ...; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:35:10:35:11 | enter M3 | Switch.cs:35:10:35:11 | M3 |
 | Switch.cs:35:10:35:11 | exit M3 | Switch.cs:35:10:35:11 | M3 |
+| Switch.cs:35:10:35:11 | exit M3 (abnormal) | Switch.cs:35:10:35:11 | M3 |
 | Switch.cs:36:5:42:5 | {...} | Switch.cs:35:10:35:11 | M3 |
 | Switch.cs:37:9:41:9 | switch (...) {...} | Switch.cs:35:10:35:11 | M3 |
 | Switch.cs:37:17:37:23 | call to method Throw | Switch.cs:35:10:35:11 | M3 |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:44:10:44:11 | exit M4 | Switch.cs:44:10:44:11 | M4 |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:45:5:53:5 | {...} | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:46:17:46:17 | access to parameter o | Switch.cs:44:10:44:11 | M4 |
@@ -3357,6 +3624,7 @@ nodeEnclosing
 | Switch.cs:51:17:51:22 | break; | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:55:10:55:11 | enter M5 | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:55:10:55:11 | exit M5 | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:55:10:55:11 | exit M5 (normal) | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:56:5:64:5 | {...} | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:55:10:55:11 | M5 |
@@ -3369,6 +3637,7 @@ nodeEnclosing
 | Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:68:17:68:25 | (...) ... | Switch.cs:66:10:66:11 | M6 |
@@ -3380,6 +3649,7 @@ nodeEnclosing
 | Switch.cs:73:17:73:22 | break; | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:77:10:77:11 | M7 |
@@ -3400,6 +3670,7 @@ nodeEnclosing
 | Switch.cs:88:16:88:20 | false | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | M8 |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:92:5:99:5 | {...} | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:91:10:91:11 | M8 |
@@ -3411,6 +3682,7 @@ nodeEnclosing
 | Switch.cs:98:16:98:20 | false | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:102:5:109:5 | {...} | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:101:9:101:10 | M9 |
@@ -3428,10 +3700,12 @@ nodeEnclosing
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:17:111:21 | Throw |
 | Switch.cs:111:17:111:21 | exit Throw | Switch.cs:111:17:111:21 | Throw |
+| Switch.cs:111:17:111:21 | exit Throw (abnormal) | Switch.cs:111:17:111:21 | Throw |
 | Switch.cs:111:28:111:48 | throw ... | Switch.cs:111:17:111:21 | Throw |
 | Switch.cs:111:34:111:48 | object creation of type Exception | Switch.cs:111:17:111:21 | Throw |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:114:5:121:5 | {...} | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:113:9:113:11 | M10 |
@@ -3455,6 +3729,7 @@ nodeEnclosing
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:124:5:127:5 | {...} | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:123:10:123:12 | M11 |
@@ -3468,6 +3743,7 @@ nodeEnclosing
 | Switch.cs:126:13:126:19 | return ...; | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:129:12:129:14 | exit M12 | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:129:12:129:14 | exit M12 (normal) | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:130:5:132:5 | {...} | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:129:12:129:14 | M12 |
@@ -3481,6 +3757,7 @@ nodeEnclosing
 | Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:134:9:134:11 | exit M13 | Switch.cs:134:9:134:11 | M13 |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:135:5:142:5 | {...} | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:136:9:141:9 | switch (...) {...} | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:136:17:136:17 | access to parameter i | Switch.cs:134:9:134:11 | M13 |
@@ -3498,6 +3775,7 @@ nodeEnclosing
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:144:9:144:11 | exit M14 | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:145:5:152:5 | {...} | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:146:9:151:9 | switch (...) {...} | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:146:17:146:17 | access to parameter i | Switch.cs:144:9:144:11 | M14 |
@@ -3515,6 +3793,8 @@ nodeEnclosing
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:155:5:161:5 | {...} | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:9:156:55 | ... ...; | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:154:10:154:12 | M15 |
@@ -3540,6 +3820,7 @@ nodeEnclosing
 | Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:154:10:154:12 | M15 |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:3:10:3:10 | exit M | TypeAccesses.cs:3:10:3:10 | M |
+| TypeAccesses.cs:3:10:3:10 | exit M (normal) | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:3:10:3:10 | M |
@@ -3559,6 +3840,7 @@ nodeEnclosing
 | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:3:10:3:10 | M |
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | M1 |
 | VarDecls.cs:5:18:5:19 | exit M1 | VarDecls.cs:5:18:5:19 | M1 |
+| VarDecls.cs:5:18:5:19 | exit M1 (normal) | VarDecls.cs:5:18:5:19 | M1 |
 | VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:5:18:5:19 | M1 |
 | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:5:18:5:19 | M1 |
 | VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:5:18:5:19 | M1 |
@@ -3577,6 +3859,7 @@ nodeEnclosing
 | VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:5:18:5:19 | M1 |
 | VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:13:12:13:13 | M2 |
 | VarDecls.cs:13:12:13:13 | exit M2 | VarDecls.cs:13:12:13:13 | M2 |
+| VarDecls.cs:13:12:13:13 | exit M2 (normal) | VarDecls.cs:13:12:13:13 | M2 |
 | VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:13:12:13:13 | M2 |
 | VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:13:12:13:13 | M2 |
 | VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:13:12:13:13 | M2 |
@@ -3589,6 +3872,7 @@ nodeEnclosing
 | VarDecls.cs:16:21:16:22 | access to local variable s2 | VarDecls.cs:13:12:13:13 | M2 |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:19:7:19:8 | M3 |
 | VarDecls.cs:19:7:19:8 | exit M3 | VarDecls.cs:19:7:19:8 | M3 |
+| VarDecls.cs:19:7:19:8 | exit M3 (normal) | VarDecls.cs:19:7:19:8 | M3 |
 | VarDecls.cs:20:5:26:5 | {...} | VarDecls.cs:19:7:19:8 | M3 |
 | VarDecls.cs:21:9:22:13 | using (...) {...} | VarDecls.cs:19:7:19:8 | M3 |
 | VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:19:7:19:8 | M3 |
@@ -3605,9 +3889,11 @@ nodeEnclosing
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:19:7:19:8 | M3 |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | Dispose |
 | VarDecls.cs:28:41:28:47 | exit Dispose | VarDecls.cs:28:41:28:47 | Dispose |
+| VarDecls.cs:28:41:28:47 | exit Dispose (normal) | VarDecls.cs:28:41:28:47 | Dispose |
 | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | Dispose |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:5:17:5:20 | exit Main | cflow.cs:5:17:5:20 | Main |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:6:5:35:5 | {...} | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:7:9:7:28 | ... ...; | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:5:17:5:20 | Main |
@@ -3693,6 +3979,8 @@ nodeEnclosing
 | cflow.cs:33:35:33:35 | access to local variable i | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:37:17:37:22 | enter Switch | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:37:17:37:22 | exit Switch | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:37:17:37:22 | exit Switch (abnormal) | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:37:17:37:22 | exit Switch (normal) | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:38:5:68:5 | {...} | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:39:17:39:17 | access to parameter a | cflow.cs:37:17:37:22 | Switch |
@@ -3748,6 +4036,7 @@ nodeEnclosing
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:70:18:70:18 | M |
 | cflow.cs:70:18:70:18 | exit M | cflow.cs:70:18:70:18 | M |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | M |
 | cflow.cs:71:5:82:5 | {...} | cflow.cs:70:18:70:18 | M |
 | cflow.cs:72:9:73:19 | if (...) ... | cflow.cs:70:18:70:18 | M |
 | cflow.cs:72:13:72:13 | access to parameter s | cflow.cs:70:18:70:18 | M |
@@ -3769,6 +4058,7 @@ nodeEnclosing
 | cflow.cs:80:31:80:46 | "<empty string>" | cflow.cs:70:18:70:18 | M |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:84:18:84:19 | exit M2 | cflow.cs:84:18:84:19 | M2 |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:85:5:88:5 | {...} | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:84:18:84:19 | M2 |
@@ -3784,6 +4074,8 @@ nodeEnclosing
 | cflow.cs:87:31:87:31 | access to parameter s | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:90:18:90:19 | exit M3 | cflow.cs:90:18:90:19 | M3 |
+| cflow.cs:90:18:90:19 | exit M3 (abnormal) | cflow.cs:90:18:90:19 | M3 |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:91:5:104:5 | {...} | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:92:9:93:49 | if (...) ... | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:90:18:90:19 | M3 |
@@ -3824,6 +4116,7 @@ nodeEnclosing
 | cflow.cs:103:31:103:34 | this access | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:106:18:106:19 | enter M4 | cflow.cs:106:18:106:19 | M4 |
 | cflow.cs:106:18:106:19 | exit M4 | cflow.cs:106:18:106:19 | M4 |
+| cflow.cs:106:18:106:19 | exit M4 (normal) | cflow.cs:106:18:106:19 | M4 |
 | cflow.cs:107:5:117:5 | {...} | cflow.cs:106:18:106:19 | M4 |
 | cflow.cs:108:9:115:9 | if (...) ... | cflow.cs:106:18:106:19 | M4 |
 | cflow.cs:108:13:108:13 | access to parameter s | cflow.cs:106:18:106:19 | M4 |
@@ -3841,6 +4134,7 @@ nodeEnclosing
 | cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:106:18:106:19 | M4 |
 | cflow.cs:119:20:119:21 | enter M5 | cflow.cs:119:20:119:21 | M5 |
 | cflow.cs:119:20:119:21 | exit M5 | cflow.cs:119:20:119:21 | M5 |
+| cflow.cs:119:20:119:21 | exit M5 (normal) | cflow.cs:119:20:119:21 | M5 |
 | cflow.cs:120:5:124:5 | {...} | cflow.cs:119:20:119:21 | M5 |
 | cflow.cs:121:9:121:18 | ... ...; | cflow.cs:119:20:119:21 | M5 |
 | cflow.cs:121:13:121:17 | String x = ... | cflow.cs:119:20:119:21 | M5 |
@@ -3854,6 +4148,7 @@ nodeEnclosing
 | cflow.cs:123:16:123:16 | access to local variable x | cflow.cs:119:20:119:21 | M5 |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:19:127:21 | get_Prop |
 | cflow.cs:127:19:127:21 | exit get_Prop | cflow.cs:127:19:127:21 | get_Prop |
+| cflow.cs:127:19:127:21 | exit get_Prop (normal) | cflow.cs:127:19:127:21 | get_Prop |
 | cflow.cs:127:23:127:60 | {...} | cflow.cs:127:19:127:21 | get_Prop |
 | cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | get_Prop |
 | cflow.cs:127:32:127:36 | access to field Field | cflow.cs:127:19:127:21 | get_Prop |
@@ -3866,6 +4161,7 @@ nodeEnclosing
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:19:127:21 | get_Prop |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:62:127:64 | set_Prop |
 | cflow.cs:127:62:127:64 | exit set_Prop | cflow.cs:127:62:127:64 | set_Prop |
+| cflow.cs:127:62:127:64 | exit set_Prop (normal) | cflow.cs:127:62:127:64 | set_Prop |
 | cflow.cs:127:66:127:83 | {...} | cflow.cs:127:62:127:64 | set_Prop |
 | cflow.cs:127:68:127:72 | this access | cflow.cs:127:62:127:64 | set_Prop |
 | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | set_Prop |
@@ -3873,6 +4169,7 @@ nodeEnclosing
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:62:127:64 | set_Prop |
 | cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | ControlFlow |
 | cflow.cs:129:5:129:15 | exit ControlFlow | cflow.cs:129:5:129:15 | ControlFlow |
+| cflow.cs:129:5:129:15 | exit ControlFlow (normal) | cflow.cs:129:5:129:15 | ControlFlow |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:129:5:129:15 | ControlFlow |
 | cflow.cs:131:9:131:13 | this access | cflow.cs:129:5:129:15 | ControlFlow |
 | cflow.cs:131:9:131:17 | ... = ... | cflow.cs:129:5:129:15 | ControlFlow |
@@ -3880,6 +4177,7 @@ nodeEnclosing
 | cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:129:5:129:15 | ControlFlow |
 | cflow.cs:134:5:134:15 | enter ControlFlow | cflow.cs:134:5:134:15 | ControlFlow |
 | cflow.cs:134:5:134:15 | exit ControlFlow | cflow.cs:134:5:134:15 | ControlFlow |
+| cflow.cs:134:5:134:15 | exit ControlFlow (normal) | cflow.cs:134:5:134:15 | ControlFlow |
 | cflow.cs:134:26:134:29 | call to constructor ControlFlow | cflow.cs:134:5:134:15 | ControlFlow |
 | cflow.cs:134:31:134:31 | (...) ... | cflow.cs:134:5:134:15 | ControlFlow |
 | cflow.cs:134:31:134:31 | access to parameter i | cflow.cs:134:5:134:15 | ControlFlow |
@@ -3888,6 +4186,7 @@ nodeEnclosing
 | cflow.cs:134:39:134:41 | {...} | cflow.cs:134:5:134:15 | ControlFlow |
 | cflow.cs:136:12:136:22 | enter ControlFlow | cflow.cs:136:12:136:22 | ControlFlow |
 | cflow.cs:136:12:136:22 | exit ControlFlow | cflow.cs:136:12:136:22 | ControlFlow |
+| cflow.cs:136:12:136:22 | exit ControlFlow (normal) | cflow.cs:136:12:136:22 | ControlFlow |
 | cflow.cs:136:28:136:31 | call to constructor ControlFlow | cflow.cs:136:12:136:22 | ControlFlow |
 | cflow.cs:136:33:136:33 | 0 | cflow.cs:136:12:136:22 | ControlFlow |
 | cflow.cs:136:33:136:37 | ... + ... | cflow.cs:136:12:136:22 | ControlFlow |
@@ -3895,6 +4194,7 @@ nodeEnclosing
 | cflow.cs:136:40:136:42 | {...} | cflow.cs:136:12:136:22 | ControlFlow |
 | cflow.cs:138:40:138:40 | enter + | cflow.cs:138:40:138:40 | + |
 | cflow.cs:138:40:138:40 | exit + | cflow.cs:138:40:138:40 | + |
+| cflow.cs:138:40:138:40 | exit + (normal) | cflow.cs:138:40:138:40 | + |
 | cflow.cs:139:5:142:5 | {...} | cflow.cs:138:40:138:40 | + |
 | cflow.cs:140:9:140:28 | call to method WriteLine | cflow.cs:138:40:138:40 | + |
 | cflow.cs:140:9:140:29 | ...; | cflow.cs:138:40:138:40 | + |
@@ -3903,6 +4203,7 @@ nodeEnclosing
 | cflow.cs:141:16:141:16 | access to parameter y | cflow.cs:138:40:138:40 | + |
 | cflow.cs:144:33:144:35 | enter get_Item | cflow.cs:144:33:144:35 | get_Item |
 | cflow.cs:144:33:144:35 | exit get_Item | cflow.cs:144:33:144:35 | get_Item |
+| cflow.cs:144:33:144:35 | exit get_Item (normal) | cflow.cs:144:33:144:35 | get_Item |
 | cflow.cs:144:37:144:54 | {...} | cflow.cs:144:33:144:35 | get_Item |
 | cflow.cs:144:39:144:52 | return ...; | cflow.cs:144:33:144:35 | get_Item |
 | cflow.cs:144:46:144:46 | (...) ... | cflow.cs:144:33:144:35 | get_Item |
@@ -3911,9 +4212,11 @@ nodeEnclosing
 | cflow.cs:144:50:144:51 | "" | cflow.cs:144:33:144:35 | get_Item |
 | cflow.cs:144:56:144:58 | enter set_Item | cflow.cs:144:56:144:58 | set_Item |
 | cflow.cs:144:56:144:58 | exit set_Item | cflow.cs:144:56:144:58 | set_Item |
+| cflow.cs:144:56:144:58 | exit set_Item (normal) | cflow.cs:144:56:144:58 | set_Item |
 | cflow.cs:144:60:144:62 | {...} | cflow.cs:144:56:144:58 | set_Item |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:146:10:146:12 | For |
 | cflow.cs:146:10:146:12 | exit For | cflow.cs:146:10:146:12 | For |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:146:10:146:12 | For |
 | cflow.cs:147:5:177:5 | {...} | cflow.cs:146:10:146:12 | For |
 | cflow.cs:148:9:148:18 | ... ...; | cflow.cs:146:10:146:12 | For |
 | cflow.cs:148:13:148:17 | Int32 x = ... | cflow.cs:146:10:146:12 | For |
@@ -3985,12 +4288,14 @@ nodeEnclosing
 | cflow.cs:175:35:175:35 | access to local variable j | cflow.cs:146:10:146:12 | For |
 | cflow.cs:179:10:179:16 | enter Lambdas | cflow.cs:179:10:179:16 | Lambdas |
 | cflow.cs:179:10:179:16 | exit Lambdas | cflow.cs:179:10:179:16 | Lambdas |
+| cflow.cs:179:10:179:16 | exit Lambdas (normal) | cflow.cs:179:10:179:16 | Lambdas |
 | cflow.cs:180:5:183:5 | {...} | cflow.cs:179:10:179:16 | Lambdas |
 | cflow.cs:181:9:181:38 | ... ...; | cflow.cs:179:10:179:16 | Lambdas |
 | cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... | cflow.cs:179:10:179:16 | Lambdas |
 | cflow.cs:181:28:181:37 | (...) => ... | cflow.cs:179:10:179:16 | Lambdas |
 | cflow.cs:181:28:181:37 | enter (...) => ... | cflow.cs:181:28:181:37 | (...) => ... |
 | cflow.cs:181:28:181:37 | exit (...) => ... | cflow.cs:181:28:181:37 | (...) => ... |
+| cflow.cs:181:28:181:37 | exit (...) => ... (normal) | cflow.cs:181:28:181:37 | (...) => ... |
 | cflow.cs:181:33:181:33 | access to parameter x | cflow.cs:181:28:181:37 | (...) => ... |
 | cflow.cs:181:33:181:37 | ... + ... | cflow.cs:181:28:181:37 | (...) => ... |
 | cflow.cs:181:37:181:37 | 1 | cflow.cs:181:28:181:37 | (...) => ... |
@@ -3999,6 +4304,7 @@ nodeEnclosing
 | cflow.cs:182:28:182:61 | delegate(...) { ... } | cflow.cs:179:10:179:16 | Lambdas |
 | cflow.cs:182:28:182:61 | enter delegate(...) { ... } | cflow.cs:182:28:182:61 | delegate(...) { ... } |
 | cflow.cs:182:28:182:61 | exit delegate(...) { ... } | cflow.cs:182:28:182:61 | delegate(...) { ... } |
+| cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) | cflow.cs:182:28:182:61 | delegate(...) { ... } |
 | cflow.cs:182:45:182:61 | {...} | cflow.cs:182:28:182:61 | delegate(...) { ... } |
 | cflow.cs:182:47:182:59 | return ...; | cflow.cs:182:28:182:61 | delegate(...) { ... } |
 | cflow.cs:182:54:182:54 | access to parameter x | cflow.cs:182:28:182:61 | delegate(...) { ... } |
@@ -4006,6 +4312,7 @@ nodeEnclosing
 | cflow.cs:182:58:182:58 | 1 | cflow.cs:182:28:182:61 | delegate(...) { ... } |
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:185:10:185:18 | exit LogicalOr | cflow.cs:185:10:185:18 | LogicalOr |
+| cflow.cs:185:10:185:18 | exit LogicalOr (normal) | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:186:5:191:5 | {...} | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:13:187:13 | 1 | cflow.cs:185:10:185:18 | LogicalOr |
@@ -4025,6 +4332,8 @@ nodeEnclosing
 | cflow.cs:190:31:190:50 | "This should happen" | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:193:10:193:17 | exit Booleans (abnormal) | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:194:5:206:5 | {...} | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:195:9:195:57 | ... ...; | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:193:10:193:17 | Booleans |
@@ -4083,6 +4392,7 @@ nodeEnclosing
 | cflow.cs:203:23:203:37 | object creation of type Exception | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:208:10:208:11 | exit Do | cflow.cs:208:10:208:11 | Do |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:209:5:222:5 | {...} | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:210:9:221:36 | do ... while (...); | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:208:10:208:11 | Do |
@@ -4116,6 +4426,7 @@ nodeEnclosing
 | cflow.cs:221:33:221:34 | 10 | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:224:10:224:16 | Foreach |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:225:5:238:5 | {...} | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:226:22:226:22 | String x | cflow.cs:224:10:224:16 | Foreach |
@@ -4148,6 +4459,7 @@ nodeEnclosing
 | cflow.cs:235:17:235:22 | break; | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:240:10:240:13 | exit Goto | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:240:10:240:13 | Goto |
@@ -4191,6 +4503,7 @@ nodeEnclosing
 | cflow.cs:257:17:257:22 | break; | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:261:49:261:53 | enter Yield | cflow.cs:261:49:261:53 | Yield |
 | cflow.cs:261:49:261:53 | exit Yield | cflow.cs:261:49:261:53 | Yield |
+| cflow.cs:261:49:261:53 | exit Yield (normal) | cflow.cs:261:49:261:53 | Yield |
 | cflow.cs:262:5:277:5 | {...} | cflow.cs:261:49:261:53 | Yield |
 | cflow.cs:263:9:263:23 | yield return ...; | cflow.cs:261:49:261:53 | Yield |
 | cflow.cs:263:22:263:22 | 0 | cflow.cs:261:49:261:53 | Yield |
@@ -4214,28 +4527,34 @@ nodeEnclosing
 | cflow.cs:275:31:275:40 | [finally: return] "not dead" | cflow.cs:261:49:261:53 | Yield |
 | cflow.cs:282:5:282:18 | enter ControlFlowSub | cflow.cs:282:5:282:18 | ControlFlowSub |
 | cflow.cs:282:5:282:18 | exit ControlFlowSub | cflow.cs:282:5:282:18 | ControlFlowSub |
+| cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) | cflow.cs:282:5:282:18 | ControlFlowSub |
 | cflow.cs:282:24:282:27 | call to constructor ControlFlow | cflow.cs:282:5:282:18 | ControlFlowSub |
 | cflow.cs:282:31:282:33 | {...} | cflow.cs:282:5:282:18 | ControlFlowSub |
 | cflow.cs:284:5:284:18 | enter ControlFlowSub | cflow.cs:284:5:284:18 | ControlFlowSub |
 | cflow.cs:284:5:284:18 | exit ControlFlowSub | cflow.cs:284:5:284:18 | ControlFlowSub |
+| cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) | cflow.cs:284:5:284:18 | ControlFlowSub |
 | cflow.cs:284:32:284:35 | call to constructor ControlFlowSub | cflow.cs:284:5:284:18 | ControlFlowSub |
 | cflow.cs:284:39:284:41 | {...} | cflow.cs:284:5:284:18 | ControlFlowSub |
 | cflow.cs:286:5:286:18 | enter ControlFlowSub | cflow.cs:286:5:286:18 | ControlFlowSub |
 | cflow.cs:286:5:286:18 | exit ControlFlowSub | cflow.cs:286:5:286:18 | ControlFlowSub |
+| cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) | cflow.cs:286:5:286:18 | ControlFlowSub |
 | cflow.cs:286:29:286:32 | call to constructor ControlFlowSub | cflow.cs:286:5:286:18 | ControlFlowSub |
 | cflow.cs:286:34:286:34 | access to parameter i | cflow.cs:286:5:286:18 | ControlFlowSub |
 | cflow.cs:286:34:286:45 | call to method ToString | cflow.cs:286:5:286:18 | ControlFlowSub |
 | cflow.cs:286:48:286:50 | {...} | cflow.cs:286:5:286:18 | ControlFlowSub |
 | cflow.cs:291:12:291:12 | enter M | cflow.cs:291:12:291:12 | M |
 | cflow.cs:291:12:291:12 | exit M | cflow.cs:291:12:291:12 | M |
+| cflow.cs:291:12:291:12 | exit M (normal) | cflow.cs:291:12:291:12 | M |
 | cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:12:291:12 | M |
 | cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:12:291:12 | M |
 | cflow.cs:291:40:291:40 | 0 | cflow.cs:291:12:291:12 | M |
 | cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | NegationInConstructor |
 | cflow.cs:296:5:296:25 | exit NegationInConstructor | cflow.cs:296:5:296:25 | NegationInConstructor |
+| cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | cflow.cs:296:5:296:25 | NegationInConstructor |
 | cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | NegationInConstructor |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:298:10:298:10 | M |
 | cflow.cs:298:10:298:10 | exit M | cflow.cs:298:10:298:10 | M |
+| cflow.cs:298:10:298:10 | exit M (normal) | cflow.cs:298:10:298:10 | M |
 | cflow.cs:299:5:301:5 | {...} | cflow.cs:298:10:298:10 | M |
 | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:298:10:298:10 | M |
 | cflow.cs:300:9:300:73 | ...; | cflow.cs:298:10:298:10 | M |
@@ -4346,6 +4665,7 @@ blockEnclosing
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | M12 |
@@ -4389,6 +4709,7 @@ blockEnclosing
 | Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:131:18:131:32 | AssertTrueFalse |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:138:10:138:12 | M13 |
 | Assert.cs:138:10:138:12 | exit M13 | Assert.cs:138:10:138:12 | M13 |
+| Assert.cs:138:10:138:12 | exit M13 (abnormal) | Assert.cs:138:10:138:12 | M13 |
 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | Assert.cs:138:10:138:12 | M13 |
 | Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:138:10:138:12 | M13 |
 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:138:10:138:12 | M13 |
@@ -4397,7 +4718,7 @@ blockEnclosing
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | (...) => ... |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | + |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:3:10:3:11 | M1 |
-| BreakInTry.cs:3:10:3:11 | exit M1 | BreakInTry.cs:3:10:3:11 | M1 |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:3:10:3:11 | M1 |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:3:10:3:11 | M1 |
 | BreakInTry.cs:7:26:7:28 | String arg | BreakInTry.cs:3:10:3:11 | M1 |
 | BreakInTry.cs:10:21:10:26 | break; | BreakInTry.cs:3:10:3:11 | M1 |
@@ -4412,7 +4733,7 @@ blockEnclosing
 | BreakInTry.cs:32:21:32:21 | [finally: break] ; | BreakInTry.cs:20:10:20:11 | M2 |
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | M2 |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:38:10:38:11 | M3 |
-| BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | M3 |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:38:10:38:11 | M3 |
 | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:38:10:38:11 | M3 |
 | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:38:10:38:11 | M3 |
 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:38:10:38:11 | M3 |
@@ -4423,7 +4744,7 @@ blockEnclosing
 | BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:38:10:38:11 | M3 |
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:38:10:38:11 | M3 |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:56:10:56:11 | M4 |
-| BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:56:10:56:11 | M4 |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:56:10:56:11 | M4 |
 | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:56:10:56:11 | M4 |
 | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:56:10:56:11 | M4 |
 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | M4 |
@@ -4438,40 +4759,40 @@ blockEnclosing
 | CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:20:12:20:17 | Nameof |
 | CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:28:10:28:10 | M |
 | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | M1 |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:12:3:13 | M1 |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:3:40:3:49 | call to method ToLower | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:10:5:11 | M2 |
-| ConditionalAccess.cs:5:10:5:11 | exit M2 | ConditionalAccess.cs:5:10:5:11 | M2 |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | M2 |
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:10:5:11 | M2 |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:10:7:11 | M3 |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:10:7:11 | M3 |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | M4 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:9:9:10 | M4 |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:11:9:11:10 | M5 |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:11:9:11:10 | M5 |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | M5 |
 | ConditionalAccess.cs:13:15:13:21 | access to property Length | ConditionalAccess.cs:11:9:11:10 | M5 |
 | ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:11:9:11:10 | M5 |
 | ConditionalAccess.cs:14:20:14:20 | 0 | ConditionalAccess.cs:11:9:11:10 | M5 |
 | ConditionalAccess.cs:16:20:16:20 | 1 | ConditionalAccess.cs:11:9:11:10 | M5 |
 | ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:12:19:13 | M6 |
-| ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:12:19:13 | M6 |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | M6 |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:12:19:13 | M6 |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | M7 |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | Out |
-| ConditionalAccess.cs:30:10:30:12 | exit Out | ConditionalAccess.cs:30:10:30:12 | Out |
+| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | Out |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | M8 |
-| ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:32:10:32:11 | M8 |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | M8 |
 | ConditionalAccess.cs:35:14:35:24 | call to method Out | ConditionalAccess.cs:32:10:32:11 | M8 |
 | ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:26:41:38 | CommaJoinWith |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:3:10:3:19 | IncrOrDecr |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:3:10:3:19 | IncrOrDecr |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:11:9:11:10 | M1 |
@@ -4536,7 +4857,7 @@ blockEnclosing
 | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:113:10:113:11 | M9 |
@@ -4548,7 +4869,7 @@ blockEnclosing
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:129:10:129:12 | M10 |
 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:129:10:129:12 | M10 |
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | M11 |
-| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:143:10:143:12 | M11 |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | M1 |
@@ -4557,7 +4878,7 @@ blockEnclosing
 | ExitMethods.cs:25:10:25:11 | enter M4 | ExitMethods.cs:25:10:25:11 | M4 |
 | ExitMethods.cs:31:10:31:11 | enter M5 | ExitMethods.cs:31:10:31:11 | M5 |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:37:10:37:11 | M6 |
-| ExitMethods.cs:37:10:37:11 | exit M6 | ExitMethods.cs:37:10:37:11 | M6 |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:37:10:37:11 | M6 |
 | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} | ExitMethods.cs:37:10:37:11 | M6 |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:37:10:37:11 | M6 |
 | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:37:10:37:11 | M6 |
@@ -4566,9 +4887,10 @@ blockEnclosing
 | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:59:10:59:11 | M8 |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
 | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
 | ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:65:17:65:26 | ErrorMaybe |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:71:17:71:27 | ErrorAlways |
-| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | ErrorAlways |
+| ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) | ExitMethods.cs:71:17:71:27 | ErrorAlways |
 | ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:71:17:71:27 | ErrorAlways |
 | ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:71:17:71:27 | ErrorAlways |
 | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:79:17:79:28 | ErrorAlways2 |
@@ -4597,12 +4919,15 @@ blockEnclosing
 | Extensions.cs:20:17:20:20 | enter Main | Extensions.cs:20:17:20:20 | Main |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:7:10:7:11 | exit M1 | Finally.cs:7:10:7:11 | M1 |
+| Finally.cs:7:10:7:11 | exit M1 (abnormal) | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:14:9:16:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:14:9:16:9 | {...} | Finally.cs:7:10:7:11 | M1 |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:19:10:19:11 | M2 |
 | Finally.cs:19:10:19:11 | exit M2 | Finally.cs:19:10:19:11 | M2 |
+| Finally.cs:19:10:19:11 | exit M2 (abnormal) | Finally.cs:19:10:19:11 | M2 |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:19:10:19:11 | M2 |
 | Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:19:10:19:11 | M2 |
 | Finally.cs:24:13:24:19 | return ...; | Finally.cs:19:10:19:11 | M2 |
 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:19:10:19:11 | M2 |
@@ -4614,6 +4939,8 @@ blockEnclosing
 | Finally.cs:42:9:43:9 | {...} | Finally.cs:19:10:19:11 | M2 |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:54:10:54:11 | M3 |
 | Finally.cs:54:10:54:11 | exit M3 | Finally.cs:54:10:54:11 | M3 |
+| Finally.cs:54:10:54:11 | exit M3 (abnormal) | Finally.cs:54:10:54:11 | M3 |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:54:10:54:11 | M3 |
 | Finally.cs:58:13:58:37 | call to method WriteLine | Finally.cs:54:10:54:11 | M3 |
 | Finally.cs:59:13:59:19 | return ...; | Finally.cs:54:10:54:11 | M3 |
 | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | Finally.cs:54:10:54:11 | M3 |
@@ -4625,6 +4952,8 @@ blockEnclosing
 | Finally.cs:69:9:71:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:54:10:54:11 | M3 |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:74:10:74:11 | exit M4 | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:74:10:74:11 | exit M4 (abnormal) | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:82:21:82:27 | return ...; | Finally.cs:74:10:74:11 | M4 |
@@ -4651,6 +4980,8 @@ blockEnclosing
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:103:10:103:11 | exit M5 | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:103:10:103:11 | exit M5 (abnormal) | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:108:17:108:23 | return ...; | Finally.cs:103:10:103:11 | M5 |
@@ -4679,13 +5010,15 @@ blockEnclosing
 | Finally.cs:117:17:117:37 | [finally: return] ...; | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:121:10:121:11 | enter M6 | Finally.cs:121:10:121:11 | M6 |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:133:10:133:11 | M7 |
-| Finally.cs:133:10:133:11 | exit M7 | Finally.cs:133:10:133:11 | M7 |
+| Finally.cs:133:10:133:11 | exit M7 (abnormal) | Finally.cs:133:10:133:11 | M7 |
 | Finally.cs:137:13:137:36 | call to method WriteLine | Finally.cs:133:10:133:11 | M7 |
 | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} | Finally.cs:133:10:133:11 | M7 |
 | Finally.cs:140:9:143:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:133:10:133:11 | M7 |
 | Finally.cs:140:9:143:9 | {...} | Finally.cs:133:10:133:11 | M7 |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:147:10:147:11 | M8 |
 | Finally.cs:147:10:147:11 | exit M8 | Finally.cs:147:10:147:11 | M8 |
+| Finally.cs:147:10:147:11 | exit M8 (abnormal) | Finally.cs:147:10:147:11 | M8 |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:147:10:147:11 | M8 |
 | Finally.cs:152:17:152:50 | throw ...; | Finally.cs:147:10:147:11 | M8 |
 | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:147:10:147:11 | M8 |
 | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | Finally.cs:147:10:147:11 | M8 |
@@ -4713,6 +5046,8 @@ blockEnclosing
 | Finally.cs:165:13:168:13 | catch {...} | Finally.cs:147:10:147:11 | M8 |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:176:10:176:11 | M9 |
 | Finally.cs:176:10:176:11 | exit M9 | Finally.cs:176:10:176:11 | M9 |
+| Finally.cs:176:10:176:11 | exit M9 (abnormal) | Finally.cs:176:10:176:11 | M9 |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:176:10:176:11 | M9 |
 | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | Finally.cs:176:10:176:11 | M9 |
 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | Finally.cs:176:10:176:11 | M9 |
 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:176:10:176:11 | M9 |
@@ -4734,6 +5069,7 @@ blockEnclosing
 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:176:10:176:11 | M9 |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:195:10:195:12 | exit M10 | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:195:10:195:12 | exit M10 (abnormal) | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
@@ -4767,29 +5103,29 @@ blockEnclosing
 | Finally.cs:222:9:225:9 | catch {...} | Finally.cs:216:10:216:12 | M11 |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:216:10:216:12 | M11 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | M1 |
-| Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | M1 |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:12:10:12:11 | M2 |
-| Foreach.cs:12:10:12:11 | exit M2 | Foreach.cs:12:10:12:11 | M2 |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | M2 |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | M2 |
 | Foreach.cs:14:22:14:22 | String _ | Foreach.cs:12:10:12:11 | M2 |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:18:10:18:11 | M3 |
-| Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:18:10:18:11 | M3 |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:24:10:24:11 | M4 |
-| Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:24:10:24:11 | M4 |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | M4 |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | M4 |
 | Foreach.cs:26:23:26:23 | String x | Foreach.cs:24:10:24:11 | M4 |
 | Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:30:10:30:11 | M5 |
-| Foreach.cs:30:10:30:11 | exit M5 | Foreach.cs:30:10:30:11 | M5 |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:30:10:30:11 | M5 |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | M5 |
 | Foreach.cs:32:23:32:23 | String x | Foreach.cs:30:10:30:11 | M5 |
 | Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:36:10:36:11 | M6 |
-| Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:36:10:36:11 | M6 |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | M6 |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | M6 |
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:36:10:36:11 | M6 |
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | Initializers |
@@ -4801,40 +5137,40 @@ blockEnclosing
 | Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | Test |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:22:10:22:11 | M3 |
-| LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | M3 |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:45:10:45:11 | M6 |
 | LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:45:10:45:11 | M6 |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
-| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:94:10:94:12 | M11 |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | M11 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | get_P1 |
@@ -4876,14 +5212,14 @@ blockEnclosing
 | MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationB.cs:13:36:13:38 | get_Item |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | set_Item |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | set_Item |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | set_Item |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | set_Item |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | set_Item |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | set_Item |
 | MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationA.cs:15:54:15:56 | set_Item |
 | MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationB.cs:13:56:13:58 | set_Item |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | M1 |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | M1 |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | M1 |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | M1 |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:9:18:22 | M2 |
@@ -4895,8 +5231,8 @@ blockEnclosing
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | C2 |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | C2 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | C2 |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | C2 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | C2 |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | C2 |
 | MultiImplementationA.cs:21:24:21:24 | 0 | MultiImplementationA.cs:21:12:21:13 | C2 |
 | MultiImplementationA.cs:21:24:21:24 | 0 | MultiImplementationB.cs:19:12:19:13 | C2 |
 | MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationA.cs:21:12:21:13 | C2 |
@@ -4964,14 +5300,14 @@ blockEnclosing
 | MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationB.cs:13:36:13:38 | get_Item |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationA.cs:15:54:15:56 | set_Item |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:56:13:58 | set_Item |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationA.cs:15:54:15:56 | set_Item |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item | MultiImplementationB.cs:13:56:13:58 | set_Item |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | set_Item |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | set_Item |
 | MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationA.cs:15:54:15:56 | set_Item |
 | MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationB.cs:13:56:13:58 | set_Item |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:14:17:14:18 | M1 |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationA.cs:16:17:16:18 | M1 |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 | MultiImplementationB.cs:14:17:14:18 | M1 |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | M1 |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:9:16:31 | M2 |
@@ -4983,8 +5319,8 @@ blockEnclosing
 | MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | C2 |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:12:19:13 | C2 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationA.cs:21:12:21:13 | C2 |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 | MultiImplementationB.cs:19:12:19:13 | C2 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | C2 |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | C2 |
 | MultiImplementationB.cs:19:24:19:24 | 1 | MultiImplementationA.cs:21:12:21:13 | C2 |
 | MultiImplementationB.cs:19:24:19:24 | 1 | MultiImplementationB.cs:19:12:19:13 | C2 |
 | MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationA.cs:21:12:21:13 | C2 |
@@ -5012,24 +5348,24 @@ blockEnclosing
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | M1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | M1 |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:9:3:10 | M1 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:9:3:10 | M1 |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | M1 |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:9:3:10 | M1 |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:9:5:10 | M2 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:9:5:10 | M2 |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:12:7:13 | M3 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:12:7:13 | M3 |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:12:9:13 | M4 |
-| NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:12:9:13 | M4 |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:9:11:10 | M5 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:9:11:10 | M5 |
@@ -5056,7 +5392,7 @@ blockEnclosing
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | Test |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | M2 |
-| PostDominance.cs:10:10:10:11 | exit M2 | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | M3 |
@@ -5069,6 +5405,8 @@ blockEnclosing
 | Switch.cs:5:10:5:11 | enter M1 | Switch.cs:5:10:5:11 | M1 |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:10:10:10:11 | exit M2 | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:10:10:10:11 | exit M2 (abnormal) | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:15:17:15:23 | return ...; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:17:23:17:37 | object creation of type Exception | Switch.cs:10:10:10:11 | M2 |
@@ -5087,17 +5425,17 @@ blockEnclosing
 | Switch.cs:30:13:30:20 | default: | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:35:10:35:11 | enter M3 | Switch.cs:35:10:35:11 | M3 |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:44:10:44:11 | M4 |
-| Switch.cs:44:10:44:11 | exit M4 | Switch.cs:44:10:44:11 | M4 |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:49:17:49:22 | break; | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:50:13:50:39 | case ...: | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:51:17:51:22 | break; | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:55:10:55:11 | enter M5 | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | M6 |
-| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:73:17:73:22 | break; | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:82:24:82:27 | true | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:83:13:83:19 | case ...: | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:77:10:77:11 | M7 |
@@ -5105,11 +5443,11 @@ blockEnclosing
 | Switch.cs:86:24:86:27 | true | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:88:16:88:20 | false | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | M8 |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | M8 |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:96:24:96:27 | true | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:98:16:98:20 | false | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:105:13:105:19 | case ...: | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:105:28:105:28 | 0 | Switch.cs:101:9:101:10 | M9 |
@@ -5118,7 +5456,7 @@ blockEnclosing
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:17:111:21 | Throw |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:44:117:44 | 1 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:113:9:113:11 | M10 |
@@ -5126,7 +5464,7 @@ blockEnclosing
 | Switch.cs:118:43:118:43 | 2 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | M11 |
-| Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:37:125:46 | ... => ... | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:126:13:126:19 | return ...; | Switch.cs:123:10:123:12 | M11 |
@@ -5136,19 +5474,21 @@ blockEnclosing
 | Switch.cs:131:43:131:51 | ... => ... | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | M13 |
-| Switch.cs:134:9:134:11 | exit M13 | Switch.cs:134:9:134:11 | M13 |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:138:13:138:20 | default: | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:139:28:139:28 | 1 | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:140:13:140:19 | case ...: | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:144:9:144:11 | M14 |
-| Switch.cs:144:9:144:11 | exit M14 | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:148:28:148:28 | 1 | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:149:13:149:20 | default: | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:41:156:52 | ... => ... | Switch.cs:154:10:154:12 | M15 |
@@ -5166,7 +5506,7 @@ blockEnclosing
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:19:7:19:8 | M3 |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | Dispose |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:5:17:5:20 | Main |
-| cflow.cs:5:17:5:20 | exit Main | cflow.cs:5:17:5:20 | Main |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:12:13:12:49 | ...; | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:5:17:5:20 | Main |
@@ -5201,17 +5541,18 @@ blockEnclosing
 | cflow.cs:65:17:65:22 | break; | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:70:18:70:18 | M |
-| cflow.cs:70:18:70:18 | exit M | cflow.cs:70:18:70:18 | M |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | M |
 | cflow.cs:73:13:73:19 | return ...; | cflow.cs:70:18:70:18 | M |
 | cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:70:18:70:18 | M |
 | cflow.cs:75:9:77:9 | {...} | cflow.cs:70:18:70:18 | M |
 | cflow.cs:79:9:81:9 | {...} | cflow.cs:70:18:70:18 | M |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:84:18:84:19 | M2 |
-| cflow.cs:84:18:84:19 | exit M2 | cflow.cs:84:18:84:19 | M2 |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:87:13:87:33 | ...; | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:90:18:90:19 | exit M3 | cflow.cs:90:18:90:19 | M3 |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:93:45:93:47 | "s" | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:94:9:94:29 | ...; | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:97:13:97:55 | ...; | cflow.cs:90:18:90:19 | M3 |
@@ -5236,7 +5577,7 @@ blockEnclosing
 | cflow.cs:144:33:144:35 | enter get_Item | cflow.cs:144:33:144:35 | get_Item |
 | cflow.cs:144:56:144:58 | enter set_Item | cflow.cs:144:56:144:58 | set_Item |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:146:10:146:12 | For |
-| cflow.cs:146:10:146:12 | exit For | cflow.cs:146:10:146:12 | For |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:146:10:146:12 | For |
 | cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:146:10:146:12 | For |
 | cflow.cs:150:13:150:33 | ...; | cflow.cs:146:10:146:12 | For |
 | cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:146:10:146:12 | For |
@@ -5256,6 +5597,7 @@ blockEnclosing
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:195:37:195:56 | !... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:35:197:39 | false | cflow.cs:193:10:193:17 | Booleans |
@@ -5268,21 +5610,21 @@ blockEnclosing
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:201:9:205:9 | {...} | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:208:10:208:11 | Do |
-| cflow.cs:208:10:208:11 | exit Do | cflow.cs:208:10:208:11 | Do |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:214:13:216:13 | {...} | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:217:13:220:13 | if (...) ... | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:218:13:220:13 | {...} | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:221:18:221:22 | this access | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:224:10:224:16 | Foreach |
-| cflow.cs:224:10:224:16 | exit Foreach | cflow.cs:224:10:224:16 | Foreach |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:226:22:226:22 | String x | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:230:13:232:13 | {...} | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:233:13:236:13 | if (...) ... | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:234:13:236:13 | {...} | cflow.cs:224:10:224:16 | Foreach |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:240:10:240:13 | Goto |
-| cflow.cs:240:10:240:13 | exit Goto | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:242:43:242:45 | {...} | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:240:10:240:13 | Goto |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -2167,6 +2167,31 @@
 | Patterns.cs:37:17:37:22 | break; | Patterns.cs:37:17:37:22 | break; |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:40:17:40:17 | access to local variable o |
+| PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:6:5:8:5 | {...} |
+| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:7:27:7:27 | access to parameter s |
+| PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:9:7:29 | ...; |
+| PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:7:27:7:27 | access to parameter s |
+| PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:11:5:15:5 | {...} |
+| PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:12:9:13:19 | if (...) ... |
+| PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:13:12:13 | access to parameter s |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:12:13:12:13 | access to parameter s |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:18:12:21 | null |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:14:27:14:27 | access to parameter s |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:27:14:27 | access to parameter s |
+| PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:18:5:22:5 | {...} |
+| PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:19:9:20:55 | if (...) ... |
+| PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:13:19:13 | access to parameter s |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:19:13:19:13 | access to parameter s |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:18:19:21 | null |
+| PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:20:52:20:52 | access to parameter s | PostDominance.cs:20:52:20:52 | access to parameter s |
+| PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:21:27:21:27 | access to parameter s |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:9:21:29 | ...; |
+| PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:27:21:27 | access to parameter s |
 | Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:28:7:31 | null |
 | Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:41:8:44 | null |
 | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:11:5:31:5 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -2910,6 +2910,37 @@
 | Patterns.cs:37:17:37:22 | break; | Patterns.cs:37:17:37:22 | break; | break |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o | normal |
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:40:17:40:17 | access to local variable o | normal |
+| PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:28 | call to method WriteLine | normal |
+| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:7:9:7:28 | call to method WriteLine | normal |
+| PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:9:7:28 | call to method WriteLine | normal |
+| PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:7:27:7:27 | access to parameter s | normal |
+| PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:13:13:13:19 | return ...; | return |
+| PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:14:9:14:28 | call to method WriteLine | normal |
+| PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:12:13:12:21 | ... is ... | false |
+| PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:13:13:13:19 | return ...; | return |
+| PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:13:12:13 | access to parameter s | normal |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:12:13:12:21 | ... is ... | false |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:12:13:12:21 | ... is ... | true |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:18:12:21 | null | normal |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; | return |
+| PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:14:9:14:28 | call to method WriteLine | normal |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:28 | call to method WriteLine | normal |
+| PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:27:14:27 | access to parameter s | normal |
+| PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:20:13:20:55 | throw ...; | throw(ArgumentNullException) |
+| PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:21:9:21:28 | call to method WriteLine | normal |
+| PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:19:13:19:21 | ... is ... | false |
+| PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:20:13:20:55 | throw ...; | throw(ArgumentNullException) |
+| PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:13:19:13 | access to parameter s | normal |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:19:13:19:21 | ... is ... | false |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:19:13:19:21 | ... is ... | true |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:18:19:21 | null | normal |
+| PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:20:13:20:55 | throw ...; | throw(ArgumentNullException) |
+| PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | normal |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:45:20:53 | nameof(...) | normal |
+| PostDominance.cs:20:52:20:52 | access to parameter s | PostDominance.cs:20:52:20:52 | access to parameter s | normal |
+| PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:21:9:21:28 | call to method WriteLine | normal |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:9:21:28 | call to method WriteLine | normal |
+| PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:27:21:27 | access to parameter s | normal |
 | Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:28:7:31 | null | normal |
 | Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:41:8:44 | null | normal |
 | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:30:9:30:46 | ... = ... | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -3222,6 +3222,35 @@
 | Patterns.cs:37:17:37:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | semmle.label | break |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o | semmle.label | successor |
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | exit Test | semmle.label | successor |
+| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:6:5:8:5 | {...} | semmle.label | successor |
+| PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:29 | ...; | semmle.label | successor |
+| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:5:10:5:11 | exit M1 | semmle.label | successor |
+| PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:27:7:27 | access to parameter s | semmle.label | successor |
+| PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:7:9:7:28 | call to method WriteLine | semmle.label | successor |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:11:5:15:5 | {...} | semmle.label | successor |
+| PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:12:9:13:19 | if (...) ... | semmle.label | successor |
+| PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:12:13:12:13 | access to parameter s | semmle.label | successor |
+| PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:18:12:21 | null | semmle.label | successor |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:13:13:13:19 | return ...; | semmle.label | true |
+| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:14:9:14:29 | ...; | semmle.label | false |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | ... is ... | semmle.label | successor |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | exit M2 | semmle.label | return |
+| PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:10:10:10:11 | exit M2 | semmle.label | successor |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:27:14:27 | access to parameter s | semmle.label | successor |
+| PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:9:14:28 | call to method WriteLine | semmle.label | successor |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:18:5:22:5 | {...} | semmle.label | successor |
+| PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:19:9:20:55 | if (...) ... | semmle.label | successor |
+| PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:19:13:19:13 | access to parameter s | semmle.label | successor |
+| PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:18:19:21 | null | semmle.label | successor |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | semmle.label | true |
+| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:21:9:21:29 | ...; | semmle.label | false |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | ... is ... | semmle.label | successor |
+| PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:17:10:17:11 | exit M3 | semmle.label | exception(ArgumentNullException) |
+| PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:13:20:55 | throw ...; | semmle.label | successor |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | semmle.label | successor |
+| PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:17:10:17:11 | exit M3 | semmle.label | successor |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:27:21:27 | access to parameter s | semmle.label | successor |
+| PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:9:21:28 | call to method WriteLine | semmle.label | successor |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:28:7:31 | null | semmle.label | successor |
 | Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | exit Method | semmle.label | successor |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:41:8:44 | null | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -1,12 +1,17 @@
 | AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:30:5:30 | access to parameter i | semmle.label | successor |
-| AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | exit get_Item | semmle.label | successor |
+| AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) | AccessorCalls.cs:5:23:5:25 | exit get_Item | semmle.label | successor |
+| AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) | semmle.label | successor |
 | AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:37:5:39 | {...} | semmle.label | successor |
-| AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | exit set_Item | semmle.label | successor |
+| AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) | AccessorCalls.cs:5:33:5:35 | exit set_Item | semmle.label | successor |
+| AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) | semmle.label | successor |
 | AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:36:7:38 | {...} | semmle.label | successor |
-| AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | exit add_Event | semmle.label | successor |
+| AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) | AccessorCalls.cs:7:32:7:34 | exit add_Event | semmle.label | successor |
+| AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) | semmle.label | successor |
 | AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:47:7:49 | {...} | semmle.label | successor |
-| AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | exit remove_Event | semmle.label | successor |
+| AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) | AccessorCalls.cs:7:40:7:45 | exit remove_Event | semmle.label | successor |
+| AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) | semmle.label | successor |
 | AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:11:5:17:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:10:10:10:11 | exit M1 (normal) | AccessorCalls.cs:10:10:10:11 | exit M1 | semmle.label | successor |
 | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:12:9:12:32 | ...; | semmle.label | successor |
 | AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:22:12:25 | this access | semmle.label | successor |
 | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:13:9:13:30 | ...; | semmle.label | successor |
@@ -34,10 +39,11 @@
 | AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:18 | access to event Event | semmle.label | successor |
 | AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:23:16:23 | access to parameter e | semmle.label | successor |
 | AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:23 | ... -= ... | semmle.label | successor |
-| AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:10:10:10:11 | exit M1 | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:10:10:10:11 | exit M1 (normal) | semmle.label | successor |
 | AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:18 | access to event Event | semmle.label | successor |
 | AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:20:5:26:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:19:10:19:11 | exit M2 (normal) | AccessorCalls.cs:19:10:19:11 | exit M2 | semmle.label | successor |
 | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:21:9:21:36 | ...; | semmle.label | successor |
 | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:24:21:27 | this access | semmle.label | successor |
@@ -73,10 +79,11 @@
 | AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:25:25:25 | access to parameter e | semmle.label | successor |
 | AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:25 | ... -= ... | semmle.label | successor |
-| AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:19:10:19:11 | exit M2 | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:19:10:19:11 | exit M2 (normal) | semmle.label | successor |
 | AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:20 | access to event Event | semmle.label | successor |
 | AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:29:5:33:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:28:10:28:11 | exit M3 (normal) | AccessorCalls.cs:28:10:28:11 | exit M3 | semmle.label | successor |
 | AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:30:9:30:21 | ...; | semmle.label | successor |
 | AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:18 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:20 | ...++ | semmle.label | successor |
@@ -88,10 +95,11 @@
 | AccessorCalls.cs:31:9:31:20 | ...; | AccessorCalls.cs:31:9:31:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:32:9:32:12 | this access | AccessorCalls.cs:32:14:32:14 | 0 | semmle.label | successor |
 | AccessorCalls.cs:32:9:32:15 | access to indexer | AccessorCalls.cs:32:9:32:17 | ...++ | semmle.label | successor |
-| AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:28:10:28:11 | exit M3 | semmle.label | successor |
+| AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:28:10:28:11 | exit M3 (normal) | semmle.label | successor |
 | AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:32:9:32:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:9:32:15 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:36:5:40:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:35:10:35:11 | exit M4 (normal) | AccessorCalls.cs:35:10:35:11 | exit M4 | semmle.label | successor |
 | AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:37:9:37:23 | ...; | semmle.label | successor |
 | AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:20 | access to field Field | semmle.label | successor |
@@ -106,10 +114,11 @@
 | AccessorCalls.cs:39:9:39:12 | this access | AccessorCalls.cs:39:9:39:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:39:9:39:14 | access to field x | AccessorCalls.cs:39:16:39:16 | 0 | semmle.label | successor |
 | AccessorCalls.cs:39:9:39:17 | access to indexer | AccessorCalls.cs:39:9:39:19 | ...++ | semmle.label | successor |
-| AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:35:10:35:11 | exit M4 | semmle.label | successor |
+| AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:35:10:35:11 | exit M4 (normal) | semmle.label | successor |
 | AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:39:9:39:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:17 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:43:5:47:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:42:10:42:11 | exit M5 (normal) | AccessorCalls.cs:42:10:42:11 | exit M5 | semmle.label | successor |
 | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:44:9:44:33 | ...; | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field | semmle.label | successor |
@@ -133,7 +142,7 @@
 | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:42:10:42:11 | exit M5 | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:42:10:42:11 | exit M5 (normal) | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
@@ -141,6 +150,7 @@
 | AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... | semmle.label | successor |
 | AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:20:46:26 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:50:5:54:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:49:10:49:11 | exit M6 (normal) | AccessorCalls.cs:49:10:49:11 | exit M6 | semmle.label | successor |
 | AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:51:9:51:37 | ...; | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
@@ -172,7 +182,7 @@
 | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:49:10:49:11 | exit M6 | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:49:10:49:11 | exit M6 (normal) | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
@@ -181,9 +191,10 @@
 | AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... + ... | semmle.label | successor |
 | AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:22:53:30 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:57:5:59:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:56:10:56:11 | exit M7 (normal) | AccessorCalls.cs:56:10:56:11 | exit M7 | semmle.label | successor |
 | AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:58:9:58:86 | ...; | semmle.label | successor |
 | AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | exit M7 | semmle.label | successor |
+| AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | exit M7 (normal) | semmle.label | successor |
 | AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:10:58:13 | this access | semmle.label | successor |
 | AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:22:58:25 | this access | semmle.label | successor |
 | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:37:58:40 | this access | semmle.label | successor |
@@ -203,9 +214,10 @@
 | AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:73:58:84 | (..., ...) | semmle.label | successor |
 | AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:77:58:83 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:62:5:64:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:61:10:61:11 | exit M8 (normal) | AccessorCalls.cs:61:10:61:11 | exit M8 | semmle.label | successor |
 | AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:63:9:63:98 | ...; | semmle.label | successor |
 | AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:56:63:59 | this access | semmle.label | successor |
-| AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | exit M8 | semmle.label | successor |
+| AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | exit M8 (normal) | semmle.label | successor |
 | AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:10:63:13 | this access | semmle.label | successor |
 | AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:15 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:24:63:27 | this access | semmle.label | successor |
@@ -231,6 +243,7 @@
 | AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:83:63:96 | (..., ...) | semmle.label | successor |
 | AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:87:63:95 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:66:10:66:11 | enter M9 | AccessorCalls.cs:67:5:74:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:66:10:66:11 | exit M9 (normal) | AccessorCalls.cs:66:10:66:11 | exit M9 | semmle.label | successor |
 | AccessorCalls.cs:67:5:74:5 | {...} | AccessorCalls.cs:68:9:68:22 | ... ...; | semmle.label | successor |
 | AccessorCalls.cs:68:9:68:22 | ... ...; | AccessorCalls.cs:68:21:68:21 | access to parameter o | semmle.label | successor |
 | AccessorCalls.cs:68:17:68:21 | dynamic d = ... | AccessorCalls.cs:69:9:69:36 | ...; | semmle.label | successor |
@@ -266,7 +279,7 @@
 | AccessorCalls.cs:72:17:72:20 | dynamic access to element | AccessorCalls.cs:72:9:72:20 | dynamic call to operator + | semmle.label | successor |
 | AccessorCalls.cs:72:19:72:19 | 1 | AccessorCalls.cs:72:17:72:20 | dynamic access to element | semmle.label | successor |
 | AccessorCalls.cs:73:9:73:44 | (..., ...) | AccessorCalls.cs:73:49:73:49 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:73:9:73:83 | ... = ... | AccessorCalls.cs:66:10:66:11 | exit M9 | semmle.label | successor |
+| AccessorCalls.cs:73:9:73:83 | ... = ... | AccessorCalls.cs:66:10:66:11 | exit M9 (normal) | semmle.label | successor |
 | AccessorCalls.cs:73:9:73:84 | ...; | AccessorCalls.cs:73:10:73:10 | access to local variable d | semmle.label | successor |
 | AccessorCalls.cs:73:10:73:10 | access to local variable d | AccessorCalls.cs:73:24:73:27 | this access | semmle.label | successor |
 | AccessorCalls.cs:73:10:73:21 | dynamic access to member MaybeProp1 | AccessorCalls.cs:73:24:73:32 | access to property Prop | semmle.label | successor |
@@ -287,23 +300,27 @@
 | AccessorCalls.cs:73:78:73:81 | dynamic access to element | AccessorCalls.cs:73:74:73:82 | (..., ...) | semmle.label | successor |
 | AccessorCalls.cs:73:80:73:80 | 1 | AccessorCalls.cs:73:78:73:81 | dynamic access to element | semmle.label | successor |
 | ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:27:3:27 | 0 | semmle.label | successor |
-| ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:11:3:12 | exit M1 | semmle.label | successor |
+| ArrayCreation.cs:3:11:3:12 | exit M1 (normal) | ArrayCreation.cs:3:11:3:12 | exit M1 | semmle.label | successor |
+| ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:11:3:12 | exit M1 (normal) | semmle.label | successor |
 | ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | semmle.label | successor |
 | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:28:5:28 | 0 | semmle.label | successor |
-| ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | ArrayCreation.cs:5:12:5:13 | exit M2 | semmle.label | successor |
+| ArrayCreation.cs:5:12:5:13 | exit M2 (normal) | ArrayCreation.cs:5:12:5:13 | exit M2 | semmle.label | successor |
+| ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | ArrayCreation.cs:5:12:5:13 | exit M2 (normal) | semmle.label | successor |
 | ArrayCreation.cs:5:28:5:28 | 0 | ArrayCreation.cs:5:31:5:31 | 1 | semmle.label | successor |
 | ArrayCreation.cs:5:31:5:31 | 1 | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | semmle.label | successor |
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:19:7:36 | 2 | semmle.label | successor |
+| ArrayCreation.cs:7:11:7:12 | exit M3 (normal) | ArrayCreation.cs:7:11:7:12 | exit M3 | semmle.label | successor |
 | ArrayCreation.cs:7:19:7:36 | 2 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] | semmle.label | successor |
 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] | ArrayCreation.cs:7:31:7:31 | 0 | semmle.label | successor |
-| ArrayCreation.cs:7:29:7:36 | { ..., ... } | ArrayCreation.cs:7:11:7:12 | exit M3 | semmle.label | successor |
+| ArrayCreation.cs:7:29:7:36 | { ..., ... } | ArrayCreation.cs:7:11:7:12 | exit M3 (normal) | semmle.label | successor |
 | ArrayCreation.cs:7:31:7:31 | 0 | ArrayCreation.cs:7:34:7:34 | 1 | semmle.label | successor |
 | ArrayCreation.cs:7:34:7:34 | 1 | ArrayCreation.cs:7:29:7:36 | { ..., ... } | semmle.label | successor |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:20:9:52 | 2 | semmle.label | successor |
+| ArrayCreation.cs:9:12:9:13 | exit M4 (normal) | ArrayCreation.cs:9:12:9:13 | exit M4 | semmle.label | successor |
 | ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:20:9:52 | 2 | semmle.label | successor |
 | ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] | semmle.label | successor |
 | ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] | ArrayCreation.cs:9:35:9:35 | 0 | semmle.label | successor |
-| ArrayCreation.cs:9:31:9:52 | { ..., ... } | ArrayCreation.cs:9:12:9:13 | exit M4 | semmle.label | successor |
+| ArrayCreation.cs:9:31:9:52 | { ..., ... } | ArrayCreation.cs:9:12:9:13 | exit M4 (normal) | semmle.label | successor |
 | ArrayCreation.cs:9:33:9:40 | { ..., ... } | ArrayCreation.cs:9:45:9:45 | 2 | semmle.label | successor |
 | ArrayCreation.cs:9:35:9:35 | 0 | ArrayCreation.cs:9:38:9:38 | 1 | semmle.label | successor |
 | ArrayCreation.cs:9:38:9:38 | 1 | ArrayCreation.cs:9:33:9:40 | { ..., ... } | semmle.label | successor |
@@ -311,6 +328,8 @@
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:48:9:48 | 3 | semmle.label | successor |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | semmle.label | successor |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:8:5:12:5 | {...} | semmle.label | successor |
+| Assert.cs:7:10:7:11 | exit M1 (abnormal) | Assert.cs:7:10:7:11 | exit M1 | semmle.label | successor |
+| Assert.cs:7:10:7:11 | exit M1 (normal) | Assert.cs:7:10:7:11 | exit M1 | semmle.label | successor |
 | Assert.cs:8:5:12:5 | {...} | Assert.cs:9:9:9:33 | ... ...; | semmle.label | successor |
 | Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:20:9:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:32 | ...; | semmle.label | successor |
@@ -319,18 +338,20 @@
 | Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:16:9:32 | String s = ... | semmle.label | successor |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:16:9:32 | String s = ... | semmle.label | successor |
-| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | exit M1 | semmle.label | exit |
+| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | exit M1 (abnormal) | semmle.label | exit |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:11:9:11:36 | ...; | semmle.label | successor |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:10:22:10:22 | access to local variable s | semmle.label | successor |
 | Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:27:10:30 | null | semmle.label | successor |
 | Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | semmle.label | false |
 | Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | semmle.label | true |
 | Assert.cs:10:27:10:30 | null | Assert.cs:10:22:10:30 | ... != ... | semmle.label | successor |
-| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:7:10:7:11 | exit M1 | semmle.label | successor |
+| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:7:10:7:11 | exit M1 (normal) | semmle.label | successor |
 | Assert.cs:11:9:11:36 | ...; | Assert.cs:11:27:11:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:27:11:34 | access to property Length | semmle.label | successor |
 | Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:9:11:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:15:5:19:5 | {...} | semmle.label | successor |
+| Assert.cs:14:10:14:11 | exit M2 (abnormal) | Assert.cs:14:10:14:11 | exit M2 | semmle.label | successor |
+| Assert.cs:14:10:14:11 | exit M2 (normal) | Assert.cs:14:10:14:11 | exit M2 | semmle.label | successor |
 | Assert.cs:15:5:19:5 | {...} | Assert.cs:16:9:16:33 | ... ...; | semmle.label | successor |
 | Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:20:16:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:25 | ...; | semmle.label | successor |
@@ -339,16 +360,18 @@
 | Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:16:16:32 | String s = ... | semmle.label | successor |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:16:16:32 | String s = ... | semmle.label | successor |
-| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:18:9:18:36 | ...; | semmle.label | successor |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:17:23:17:23 | access to local variable s | semmle.label | successor |
 | Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | semmle.label | non-null |
 | Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | semmle.label | null |
-| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | exit M2 | semmle.label | successor |
+| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | exit M2 (normal) | semmle.label | successor |
 | Assert.cs:18:9:18:36 | ...; | Assert.cs:18:27:18:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:34 | access to property Length | semmle.label | successor |
 | Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:9:18:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:22:5:26:5 | {...} | semmle.label | successor |
+| Assert.cs:21:10:21:11 | exit M3 (abnormal) | Assert.cs:21:10:21:11 | exit M3 | semmle.label | successor |
+| Assert.cs:21:10:21:11 | exit M3 (normal) | Assert.cs:21:10:21:11 | exit M3 | semmle.label | successor |
 | Assert.cs:22:5:26:5 | {...} | Assert.cs:23:9:23:33 | ... ...; | semmle.label | successor |
 | Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:20:23:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:28 | ...; | semmle.label | successor |
@@ -357,16 +380,18 @@
 | Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:16:23:32 | String s = ... | semmle.label | successor |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:16:23:32 | String s = ... | semmle.label | successor |
-| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:25:9:25:36 | ...; | semmle.label | successor |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:24:26:24:26 | access to local variable s | semmle.label | successor |
 | Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | semmle.label | null |
 | Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | semmle.label | non-null |
-| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | exit M3 | semmle.label | successor |
+| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | exit M3 (normal) | semmle.label | successor |
 | Assert.cs:25:9:25:36 | ...; | Assert.cs:25:27:25:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:34 | access to property Length | semmle.label | successor |
 | Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:9:25:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:29:5:33:5 | {...} | semmle.label | successor |
+| Assert.cs:28:10:28:11 | exit M4 (abnormal) | Assert.cs:28:10:28:11 | exit M4 | semmle.label | successor |
+| Assert.cs:28:10:28:11 | exit M4 (normal) | Assert.cs:28:10:28:11 | exit M4 | semmle.label | successor |
 | Assert.cs:29:5:33:5 | {...} | Assert.cs:30:9:30:33 | ... ...; | semmle.label | successor |
 | Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:20:30:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:33 | ...; | semmle.label | successor |
@@ -375,18 +400,20 @@
 | Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:16:30:32 | String s = ... | semmle.label | successor |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:16:30:32 | String s = ... | semmle.label | successor |
-| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:32:9:32:36 | ...; | semmle.label | successor |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:31:23:31:23 | access to local variable s | semmle.label | successor |
 | Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:28:31:31 | null | semmle.label | successor |
 | Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | semmle.label | false |
 | Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | semmle.label | true |
 | Assert.cs:31:28:31:31 | null | Assert.cs:31:23:31:31 | ... == ... | semmle.label | successor |
-| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:28:10:28:11 | exit M4 | semmle.label | successor |
+| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:28:10:28:11 | exit M4 (normal) | semmle.label | successor |
 | Assert.cs:32:9:32:36 | ...; | Assert.cs:32:27:32:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:27:32:34 | access to property Length | semmle.label | successor |
 | Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:9:32:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:36:5:40:5 | {...} | semmle.label | successor |
+| Assert.cs:35:10:35:11 | exit M5 (abnormal) | Assert.cs:35:10:35:11 | exit M5 | semmle.label | successor |
+| Assert.cs:35:10:35:11 | exit M5 (normal) | Assert.cs:35:10:35:11 | exit M5 | semmle.label | successor |
 | Assert.cs:36:5:40:5 | {...} | Assert.cs:37:9:37:33 | ... ...; | semmle.label | successor |
 | Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:20:37:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:33 | ...; | semmle.label | successor |
@@ -395,18 +422,20 @@
 | Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:16:37:32 | String s = ... | semmle.label | successor |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:16:37:32 | String s = ... | semmle.label | successor |
-| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:39:9:39:36 | ...; | semmle.label | successor |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:38:23:38:23 | access to local variable s | semmle.label | successor |
 | Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:28:38:31 | null | semmle.label | successor |
 | Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | semmle.label | false |
 | Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | semmle.label | true |
 | Assert.cs:38:28:38:31 | null | Assert.cs:38:23:38:31 | ... != ... | semmle.label | successor |
-| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:35:10:35:11 | exit M5 | semmle.label | successor |
+| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:35:10:35:11 | exit M5 (normal) | semmle.label | successor |
 | Assert.cs:39:9:39:36 | ...; | Assert.cs:39:27:39:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:27:39:34 | access to property Length | semmle.label | successor |
 | Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:9:39:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:43:5:47:5 | {...} | semmle.label | successor |
+| Assert.cs:42:10:42:11 | exit M6 (abnormal) | Assert.cs:42:10:42:11 | exit M6 | semmle.label | successor |
+| Assert.cs:42:10:42:11 | exit M6 (normal) | Assert.cs:42:10:42:11 | exit M6 | semmle.label | successor |
 | Assert.cs:43:5:47:5 | {...} | Assert.cs:44:9:44:33 | ... ...; | semmle.label | successor |
 | Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:20:44:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:34 | ...; | semmle.label | successor |
@@ -415,18 +444,20 @@
 | Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:16:44:32 | String s = ... | semmle.label | successor |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:16:44:32 | String s = ... | semmle.label | successor |
-| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:46:9:46:36 | ...; | semmle.label | successor |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:45:24:45:24 | access to local variable s | semmle.label | successor |
 | Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:29:45:32 | null | semmle.label | successor |
 | Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | semmle.label | true |
 | Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | semmle.label | false |
 | Assert.cs:45:29:45:32 | null | Assert.cs:45:24:45:32 | ... != ... | semmle.label | successor |
-| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:42:10:42:11 | exit M6 | semmle.label | successor |
+| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:42:10:42:11 | exit M6 (normal) | semmle.label | successor |
 | Assert.cs:46:9:46:36 | ...; | Assert.cs:46:27:46:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:27:46:34 | access to property Length | semmle.label | successor |
 | Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:9:46:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:50:5:54:5 | {...} | semmle.label | successor |
+| Assert.cs:49:10:49:11 | exit M7 (abnormal) | Assert.cs:49:10:49:11 | exit M7 | semmle.label | successor |
+| Assert.cs:49:10:49:11 | exit M7 (normal) | Assert.cs:49:10:49:11 | exit M7 | semmle.label | successor |
 | Assert.cs:50:5:54:5 | {...} | Assert.cs:51:9:51:33 | ... ...; | semmle.label | successor |
 | Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:20:51:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:34 | ...; | semmle.label | successor |
@@ -435,18 +466,20 @@
 | Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:16:51:32 | String s = ... | semmle.label | successor |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:16:51:32 | String s = ... | semmle.label | successor |
-| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:53:9:53:36 | ...; | semmle.label | successor |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:52:24:52:24 | access to local variable s | semmle.label | successor |
 | Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:29:52:32 | null | semmle.label | successor |
 | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | semmle.label | true |
 | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | semmle.label | false |
 | Assert.cs:52:29:52:32 | null | Assert.cs:52:24:52:32 | ... == ... | semmle.label | successor |
-| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:49:10:49:11 | exit M7 | semmle.label | successor |
+| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:49:10:49:11 | exit M7 (normal) | semmle.label | successor |
 | Assert.cs:53:9:53:36 | ...; | Assert.cs:53:27:53:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:27:53:34 | access to property Length | semmle.label | successor |
 | Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:9:53:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:57:5:61:5 | {...} | semmle.label | successor |
+| Assert.cs:56:10:56:11 | exit M8 (abnormal) | Assert.cs:56:10:56:11 | exit M8 | semmle.label | successor |
+| Assert.cs:56:10:56:11 | exit M8 (normal) | Assert.cs:56:10:56:11 | exit M8 | semmle.label | successor |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:58:9:58:33 | ... ...; | semmle.label | successor |
 | Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): false] ...; | semmle.label | successor |
@@ -456,7 +489,7 @@
 | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | semmle.label | successor |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | semmle.label | successor |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:60:9:60:36 | ...; | semmle.label | successor |
 | Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | semmle.label | successor |
 | Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | semmle.label | successor |
@@ -472,11 +505,13 @@
 | Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | semmle.label | successor |
 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | semmle.label | false |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | semmle.label | true |
-| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 | semmle.label | successor |
+| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 (normal) | semmle.label | successor |
 | Assert.cs:60:9:60:36 | ...; | Assert.cs:60:27:60:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:34 | access to property Length | semmle.label | successor |
 | Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:9:60:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:64:5:68:5 | {...} | semmle.label | successor |
+| Assert.cs:63:10:63:11 | exit M9 (abnormal) | Assert.cs:63:10:63:11 | exit M9 | semmle.label | successor |
+| Assert.cs:63:10:63:11 | exit M9 (normal) | Assert.cs:63:10:63:11 | exit M9 | semmle.label | successor |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:65:9:65:33 | ... ...; | semmle.label | successor |
 | Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): false] ...; | semmle.label | successor |
@@ -486,7 +521,7 @@
 | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | semmle.label | successor |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | semmle.label | successor |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:67:9:67:36 | ...; | semmle.label | successor |
 | Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | semmle.label | successor |
 | Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | semmle.label | successor |
@@ -502,11 +537,13 @@
 | Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | semmle.label | successor |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | semmle.label | false |
 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | semmle.label | true |
-| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 | semmle.label | successor |
+| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 (normal) | semmle.label | successor |
 | Assert.cs:67:9:67:36 | ...; | Assert.cs:67:27:67:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:34 | access to property Length | semmle.label | successor |
 | Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:9:67:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:71:5:75:5 | {...} | semmle.label | successor |
+| Assert.cs:70:10:70:12 | exit M10 (abnormal) | Assert.cs:70:10:70:12 | exit M10 | semmle.label | successor |
+| Assert.cs:70:10:70:12 | exit M10 (normal) | Assert.cs:70:10:70:12 | exit M10 | semmle.label | successor |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:72:9:72:33 | ... ...; | semmle.label | successor |
 | Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): false] ...; | semmle.label | successor |
@@ -516,7 +553,7 @@
 | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | semmle.label | successor |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | semmle.label | successor |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:74:9:74:36 | ...; | semmle.label | successor |
 | Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | semmle.label | successor |
 | Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | semmle.label | successor |
@@ -532,11 +569,13 @@
 | Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | semmle.label | successor |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | semmle.label | false |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | semmle.label | true |
-| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 | semmle.label | successor |
+| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 (normal) | semmle.label | successor |
 | Assert.cs:74:9:74:36 | ...; | Assert.cs:74:27:74:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:34 | access to property Length | semmle.label | successor |
 | Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:9:74:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:78:5:82:5 | {...} | semmle.label | successor |
+| Assert.cs:77:10:77:12 | exit M11 (abnormal) | Assert.cs:77:10:77:12 | exit M11 | semmle.label | successor |
+| Assert.cs:77:10:77:12 | exit M11 (normal) | Assert.cs:77:10:77:12 | exit M11 | semmle.label | successor |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:79:9:79:33 | ... ...; | semmle.label | successor |
 | Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): false] ...; | semmle.label | successor |
@@ -546,7 +585,7 @@
 | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | semmle.label | successor |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | semmle.label | successor |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:81:9:81:36 | ...; | semmle.label | successor |
 | Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | semmle.label | successor |
 | Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | semmle.label | successor |
@@ -562,11 +601,13 @@
 | Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | semmle.label | successor |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | semmle.label | false |
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | semmle.label | true |
-| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 | semmle.label | successor |
+| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 (normal) | semmle.label | successor |
 | Assert.cs:81:9:81:36 | ...; | Assert.cs:81:27:81:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:34 | access to property Length | semmle.label | successor |
 | Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:9:81:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:85:5:129:5 | {...} | semmle.label | successor |
+| Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | exit M12 | semmle.label | successor |
+| Assert.cs:84:10:84:12 | exit M12 (normal) | Assert.cs:84:10:84:12 | exit M12 | semmle.label | successor |
 | Assert.cs:85:5:129:5 | {...} | Assert.cs:86:9:86:33 | ... ...; | semmle.label | successor |
 | Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:20:86:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | semmle.label | successor |
@@ -576,8 +617,8 @@
 | Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | semmle.label | successor |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | semmle.label | successor |
-| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exit |
-| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exit |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exit |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exit |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | semmle.label | successor |
@@ -608,8 +649,8 @@
 | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
-| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
@@ -636,8 +677,8 @@
 | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
-| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | semmle.label | successor |
@@ -664,8 +705,8 @@
 | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
-| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
@@ -696,8 +737,8 @@
 | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
-| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
@@ -728,8 +769,8 @@
 | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
-| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | semmle.label | successor |
@@ -760,8 +801,8 @@
 | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
-| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | semmle.label | successor |
@@ -792,8 +833,8 @@
 | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | semmle.label | successor |
 | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | semmle.label | successor |
@@ -818,7 +859,7 @@
 | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null | semmle.label | true |
 | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | semmle.label | successor |
 | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): true] null | semmle.label | successor |
@@ -837,7 +878,7 @@
 | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null | semmle.label | true |
 | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | semmle.label | successor |
 | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): true] null | semmle.label | successor |
@@ -855,7 +896,7 @@
 | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | [b (line 84): true] null | semmle.label | true |
 | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:128:9:128:36 | ...; | semmle.label | successor |
 | Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | semmle.label | successor |
 | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:127:29:127:32 | [b (line 84): true] null | semmle.label | successor |
@@ -865,16 +906,19 @@
 | Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | semmle.label | successor |
 | Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | semmle.label | true |
-| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 | semmle.label | successor |
+| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 (normal) | semmle.label | successor |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:128:27:128:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:34 | access to property Length | semmle.label | successor |
 | Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:9:128:35 | call to method WriteLine | semmle.label | successor |
 | Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:135:5:136:5 | {...} | semmle.label | successor |
-| Assert.cs:135:5:136:5 | {...} | Assert.cs:131:18:131:32 | exit AssertTrueFalse | semmle.label | successor |
+| Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) | Assert.cs:131:18:131:32 | exit AssertTrueFalse | semmle.label | successor |
+| Assert.cs:135:5:136:5 | {...} | Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) | semmle.label | successor |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:139:5:142:5 | {...} | semmle.label | successor |
+| Assert.cs:138:10:138:12 | exit M13 (abnormal) | Assert.cs:138:10:138:12 | exit M13 | semmle.label | successor |
+| Assert.cs:138:10:138:12 | exit M13 (normal) | Assert.cs:138:10:138:12 | exit M13 | semmle.label | successor |
 | Assert.cs:139:5:142:5 | {...} | Assert.cs:140:9:140:36 | ...; | semmle.label | successor |
-| Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:138:10:138:12 | exit M13 | semmle.label | exception(Exception) |
-| Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:138:10:138:12 | exit M13 | semmle.label | exception(Exception) |
+| Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:138:10:138:12 | exit M13 (abnormal) | semmle.label | exception(Exception) |
+| Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:138:10:138:12 | exit M13 (abnormal) | semmle.label | exception(Exception) |
 | Assert.cs:140:9:140:35 | [assertion success] call to method AssertTrueFalse | Assert.cs:141:9:141:15 | return ...; | semmle.label | successor |
 | Assert.cs:140:9:140:35 | this access | Assert.cs:140:25:140:26 | access to parameter b1 | semmle.label | successor |
 | Assert.cs:140:9:140:36 | ...; | Assert.cs:140:9:140:35 | this access | semmle.label | successor |
@@ -887,8 +931,9 @@
 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | semmle.label | successor |
 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | semmle.label | successor |
 | Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion success] call to method AssertTrueFalse | semmle.label | successor |
-| Assert.cs:141:9:141:15 | return ...; | Assert.cs:138:10:138:12 | exit M13 | semmle.label | return |
+| Assert.cs:141:9:141:15 | return ...; | Assert.cs:138:10:138:12 | exit M13 (normal) | semmle.label | return |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:4:5:15:5 | {...} | semmle.label | successor |
+| Assignments.cs:3:10:3:10 | exit M (normal) | Assignments.cs:3:10:3:10 | exit M | semmle.label | successor |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:5:9:5:18 | ... ...; | semmle.label | successor |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:17:5:17 | 0 | semmle.label | successor |
 | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:6:9:6:15 | ...; | semmle.label | successor |
@@ -917,16 +962,19 @@
 | Assignments.cs:12:14:12:17 | this access | Assignments.cs:12:9:12:17 | call to operator + | semmle.label | successor |
 | Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:9:14:35 | ... += ... | semmle.label | successor |
 | Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:18:14:35 | (...) => ... | semmle.label | successor |
-| Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:3:10:3:10 | exit M | semmle.label | successor |
+| Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:3:10:3:10 | exit M (normal) | semmle.label | successor |
 | Assignments.cs:14:9:14:36 | ...; | Assignments.cs:14:9:14:13 | this access | semmle.label | successor |
 | Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:13 | access to event Event | semmle.label | successor |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:33:14:35 | {...} | semmle.label | successor |
-| Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | exit (...) => ... | semmle.label | successor |
+| Assignments.cs:14:18:14:35 | exit (...) => ... (normal) | Assignments.cs:14:18:14:35 | exit (...) => ... | semmle.label | successor |
+| Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | exit (...) => ... (normal) | semmle.label | successor |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:18:5:20:5 | {...} | semmle.label | successor |
+| Assignments.cs:17:40:17:40 | exit + (normal) | Assignments.cs:17:40:17:40 | exit + | semmle.label | successor |
 | Assignments.cs:18:5:20:5 | {...} | Assignments.cs:19:16:19:16 | access to parameter x | semmle.label | successor |
-| Assignments.cs:19:9:19:17 | return ...; | Assignments.cs:17:40:17:40 | exit + | semmle.label | return |
+| Assignments.cs:19:9:19:17 | return ...; | Assignments.cs:17:40:17:40 | exit + (normal) | semmle.label | return |
 | Assignments.cs:19:16:19:16 | access to parameter x | Assignments.cs:19:9:19:17 | return ...; | semmle.label | successor |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:4:5:18:5 | {...} | semmle.label | successor |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:3:10:3:11 | exit M1 | semmle.label | successor |
 | BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:5:9:17:9 | try {...} ... | semmle.label | successor |
 | BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:6:9:12:9 | {...} | semmle.label | successor |
 | BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:7:33:7:36 | access to parameter args | semmle.label | successor |
@@ -944,11 +992,12 @@
 | BreakInTry.cs:14:9:17:9 | {...} | BreakInTry.cs:15:13:16:17 | if (...) ... | semmle.label | successor |
 | BreakInTry.cs:15:13:16:17 | if (...) ... | BreakInTry.cs:15:17:15:20 | access to parameter args | semmle.label | successor |
 | BreakInTry.cs:15:17:15:20 | access to parameter args | BreakInTry.cs:15:25:15:28 | null | semmle.label | successor |
-| BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:3:10:3:11 | exit M1 | semmle.label | false |
+| BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:3:10:3:11 | exit M1 (normal) | semmle.label | false |
 | BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:16:17:16:17 | ; | semmle.label | true |
 | BreakInTry.cs:15:25:15:28 | null | BreakInTry.cs:15:17:15:28 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:16:17:16:17 | ; | BreakInTry.cs:3:10:3:11 | exit M1 | semmle.label | successor |
+| BreakInTry.cs:16:17:16:17 | ; | BreakInTry.cs:3:10:3:11 | exit M1 (normal) | semmle.label | successor |
 | BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:21:5:36:5 | {...} | semmle.label | successor |
+| BreakInTry.cs:20:10:20:11 | exit M2 (normal) | BreakInTry.cs:20:10:20:11 | exit M2 | semmle.label | successor |
 | BreakInTry.cs:21:5:36:5 | {...} | BreakInTry.cs:22:29:22:32 | access to parameter args | semmle.label | successor |
 | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:22:22:22:24 | String arg | semmle.label | non-empty |
 | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:35:7:35:7 | ; | semmle.label | empty |
@@ -977,8 +1026,9 @@
 | BreakInTry.cs:31:29:31:32 | null | BreakInTry.cs:31:21:31:32 | ... == ... | semmle.label | successor |
 | BreakInTry.cs:32:21:32:21 | ; | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | semmle.label | successor |
 | BreakInTry.cs:32:21:32:21 | [finally: break] ; | BreakInTry.cs:35:7:35:7 | ; | semmle.label | break |
-| BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 | semmle.label | successor |
+| BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 (normal) | semmle.label | successor |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:39:5:54:5 | {...} | semmle.label | successor |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:38:10:38:11 | exit M3 | semmle.label | successor |
 | BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:40:9:52:9 | try {...} ... | semmle.label | successor |
 | BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:41:9:44:9 | {...} | semmle.label | successor |
 | BreakInTry.cs:41:9:44:9 | {...} | BreakInTry.cs:42:13:43:23 | if (...) ... | semmle.label | successor |
@@ -990,7 +1040,7 @@
 | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:46:9:52:9 | [finally: return] {...} | semmle.label | return |
 | BreakInTry.cs:46:9:52:9 | [finally: return] {...} | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args | semmle.label | successor |
 | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:47:33:47:36 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:38:10:38:11 | exit M3 | semmle.label | return |
+| BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:38:10:38:11 | exit M3 (normal) | semmle.label | return |
 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | [finally: return] String arg | semmle.label | non-empty |
 | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | String arg | semmle.label | non-empty |
 | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:53:7:53:7 | ; | semmle.label | empty |
@@ -1010,10 +1060,11 @@
 | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | BreakInTry.cs:50:21:50:26 | [finally: return] break; | semmle.label | true |
 | BreakInTry.cs:49:28:49:31 | [finally: return] null | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | semmle.label | successor |
 | BreakInTry.cs:49:28:49:31 | null | BreakInTry.cs:49:21:49:31 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:50:21:50:26 | [finally: return] break; | BreakInTry.cs:38:10:38:11 | exit M3 | semmle.label | return |
+| BreakInTry.cs:50:21:50:26 | [finally: return] break; | BreakInTry.cs:38:10:38:11 | exit M3 (normal) | semmle.label | return |
 | BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:53:7:53:7 | ; | semmle.label | break |
-| BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:38:10:38:11 | exit M3 | semmle.label | successor |
+| BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:38:10:38:11 | exit M3 (normal) | semmle.label | successor |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:57:5:71:5 | {...} | semmle.label | successor |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | successor |
 | BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:58:9:70:9 | try {...} ... | semmle.label | successor |
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:59:9:62:9 | {...} | semmle.label | successor |
 | BreakInTry.cs:59:9:62:9 | {...} | BreakInTry.cs:60:13:61:23 | if (...) ... | semmle.label | successor |
@@ -1025,9 +1076,9 @@
 | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:64:9:70:9 | [finally: return] {...} | semmle.label | return |
 | BreakInTry.cs:64:9:70:9 | [finally: return] {...} | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args | semmle.label | successor |
 | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:65:33:65:36 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | return |
+| BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | semmle.label | return |
 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | semmle.label | non-empty |
-| BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | empty |
+| BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | semmle.label | empty |
 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | String arg | semmle.label | non-empty |
 | BreakInTry.cs:65:26:65:28 | String arg | BreakInTry.cs:66:13:69:13 | {...} | semmle.label | successor |
 | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:66:13:69:13 | [finally: return] {...} | semmle.label | successor |
@@ -1045,25 +1096,30 @@
 | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; | semmle.label | true |
 | BreakInTry.cs:67:28:67:31 | [finally: return] null | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | semmle.label | successor |
 | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:31 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | return |
-| BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | break |
+| BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | semmle.label | return |
+| BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | semmle.label | break |
 | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:6:5:8:5 | {...} | semmle.label | successor |
+| CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) | CompileTimeOperators.cs:5:9:5:15 | exit Default | semmle.label | successor |
 | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:7:16:7:27 | default(...) | semmle.label | successor |
-| CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:5:9:5:15 | exit Default | semmle.label | return |
+| CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) | semmle.label | return |
 | CompileTimeOperators.cs:7:16:7:27 | default(...) | CompileTimeOperators.cs:7:9:7:28 | return ...; | semmle.label | successor |
 | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:11:5:13:5 | {...} | semmle.label | successor |
+| CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof | semmle.label | successor |
 | CompileTimeOperators.cs:11:5:13:5 | {...} | CompileTimeOperators.cs:12:16:12:26 | sizeof(..) | semmle.label | successor |
-| CompileTimeOperators.cs:12:9:12:27 | return ...; | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof | semmle.label | return |
+| CompileTimeOperators.cs:12:9:12:27 | return ...; | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) | semmle.label | return |
 | CompileTimeOperators.cs:12:16:12:26 | sizeof(..) | CompileTimeOperators.cs:12:9:12:27 | return ...; | semmle.label | successor |
 | CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:16:5:18:5 | {...} | semmle.label | successor |
+| CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) | CompileTimeOperators.cs:15:10:15:15 | exit Typeof | semmle.label | successor |
 | CompileTimeOperators.cs:16:5:18:5 | {...} | CompileTimeOperators.cs:17:16:17:26 | typeof(...) | semmle.label | successor |
-| CompileTimeOperators.cs:17:9:17:27 | return ...; | CompileTimeOperators.cs:15:10:15:15 | exit Typeof | semmle.label | return |
+| CompileTimeOperators.cs:17:9:17:27 | return ...; | CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) | semmle.label | return |
 | CompileTimeOperators.cs:17:16:17:26 | typeof(...) | CompileTimeOperators.cs:17:9:17:27 | return ...; | semmle.label | successor |
 | CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:21:5:23:5 | {...} | semmle.label | successor |
+| CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) | CompileTimeOperators.cs:20:12:20:17 | exit Nameof | semmle.label | successor |
 | CompileTimeOperators.cs:21:5:23:5 | {...} | CompileTimeOperators.cs:22:16:22:24 | nameof(...) | semmle.label | successor |
-| CompileTimeOperators.cs:22:9:22:25 | return ...; | CompileTimeOperators.cs:20:12:20:17 | exit Nameof | semmle.label | return |
+| CompileTimeOperators.cs:22:9:22:25 | return ...; | CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) | semmle.label | return |
 | CompileTimeOperators.cs:22:16:22:24 | nameof(...) | CompileTimeOperators.cs:22:9:22:25 | return ...; | semmle.label | successor |
 | CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:29:5:41:5 | {...} | semmle.label | successor |
+| CompileTimeOperators.cs:28:10:28:10 | exit M (normal) | CompileTimeOperators.cs:28:10:28:10 | exit M | semmle.label | successor |
 | CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | semmle.label | successor |
 | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:31:9:34:9 | {...} | semmle.label | successor |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:32:13:32:21 | goto ...; | semmle.label | successor |
@@ -1073,35 +1129,41 @@
 | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" | semmle.label | successor |
 | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine | semmle.label | successor |
 | CompileTimeOperators.cs:40:9:40:11 | End: | CompileTimeOperators.cs:40:14:40:38 | ...; | semmle.label | successor |
-| CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | exit M | semmle.label | successor |
+| CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | exit M (normal) | semmle.label | successor |
 | CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:32:40:36 | "End" | semmle.label | successor |
 | CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | semmle.label | successor |
 | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:30:32:30:32 | 0 | semmle.label | successor |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | semmle.label | successor |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | semmle.label | successor |
-| ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:12:3:13 | exit M1 | semmle.label | null |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 | semmle.label | successor |
+| ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | semmle.label | null |
 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:28:3:38 | call to method ToString | semmle.label | non-null |
-| ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:12:3:13 | exit M1 | semmle.label | null |
+| ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | semmle.label | null |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:40:3:49 | call to method ToLower | semmle.label | non-null |
-| ConditionalAccess.cs:3:40:3:49 | call to method ToLower | ConditionalAccess.cs:3:12:3:13 | exit M1 | semmle.label | successor |
+| ConditionalAccess.cs:3:40:3:49 | call to method ToLower | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | semmle.label | successor |
 | ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | semmle.label | successor |
-| ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | exit M2 | semmle.label | null |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | exit M2 | semmle.label | successor |
+| ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | semmle.label | null |
 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:28:5:34 | access to property Length | semmle.label | non-null |
-| ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:10:5:11 | exit M2 | semmle.label | successor |
+| ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | semmle.label | successor |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | semmle.label | successor |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 | semmle.label | successor |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | semmle.label | null |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:49:7:55 | access to property Length | semmle.label | non-null |
 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | semmle.label | successor |
-| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:10:7:11 | exit M3 | semmle.label | null |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | semmle.label | null |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:49:7:55 | access to property Length | semmle.label | non-null |
-| ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:10:7:11 | exit M3 | semmle.label | successor |
+| ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | semmle.label | successor |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | semmle.label | successor |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 | semmle.label | successor |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:27:9:33 | access to property Length | semmle.label | non-null |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:38:9:38 | 0 | semmle.label | null |
 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:25:9:25 | access to parameter s | semmle.label | successor |
-| ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:9:9:10 | exit M4 | semmle.label | non-null |
+| ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | semmle.label | non-null |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:38:9:38 | 0 | semmle.label | null |
-| ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:9:9:10 | exit M4 | semmle.label | successor |
+| ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | semmle.label | successor |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:12:5:17:5 | {...} | semmle.label | successor |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | exit M5 | semmle.label | successor |
 | ConditionalAccess.cs:12:5:17:5 | {...} | ConditionalAccess.cs:13:9:16:21 | if (...) ... | semmle.label | successor |
 | ConditionalAccess.cs:13:9:16:21 | if (...) ... | ConditionalAccess.cs:13:13:13:13 | access to parameter s | semmle.label | successor |
 | ConditionalAccess.cs:13:13:13:13 | access to parameter s | ConditionalAccess.cs:13:15:13:21 | access to property Length | semmle.label | non-null |
@@ -1111,16 +1173,18 @@
 | ConditionalAccess.cs:13:15:13:21 | access to property Length | ConditionalAccess.cs:13:25:13:25 | 0 | semmle.label | successor |
 | ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:13:25:13:25 | (...) ... | semmle.label | successor |
 | ConditionalAccess.cs:13:25:13:25 | (...) ... | ConditionalAccess.cs:13:13:13:25 | ... > ... | semmle.label | successor |
-| ConditionalAccess.cs:14:13:14:21 | return ...; | ConditionalAccess.cs:11:9:11:10 | exit M5 | semmle.label | return |
+| ConditionalAccess.cs:14:13:14:21 | return ...; | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | semmle.label | return |
 | ConditionalAccess.cs:14:20:14:20 | 0 | ConditionalAccess.cs:14:13:14:21 | return ...; | semmle.label | successor |
-| ConditionalAccess.cs:16:13:16:21 | return ...; | ConditionalAccess.cs:11:9:11:10 | exit M5 | semmle.label | return |
+| ConditionalAccess.cs:16:13:16:21 | return ...; | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | semmle.label | return |
 | ConditionalAccess.cs:16:20:16:20 | 1 | ConditionalAccess.cs:16:13:16:21 | return ...; | semmle.label | successor |
 | ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | semmle.label | successor |
-| ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:12:19:13 | exit M6 | semmle.label | null |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | exit M6 | semmle.label | successor |
+| ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | semmle.label | null |
 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | semmle.label | non-null |
-| ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | ConditionalAccess.cs:19:12:19:13 | exit M6 | semmle.label | successor |
+| ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | semmle.label | successor |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | semmle.label | successor |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:22:5:26:5 | {...} | semmle.label | successor |
+| ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) | ConditionalAccess.cs:21:10:21:11 | exit M7 | semmle.label | successor |
 | ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:23:9:23:39 | ... ...; | semmle.label | successor |
 | ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:26:23:29 | null | semmle.label | successor |
 | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:24:9:24:38 | ... ...; | semmle.label | successor |
@@ -1131,34 +1195,38 @@
 | ConditionalAccess.cs:24:18:24:24 | (...) ... | ConditionalAccess.cs:24:27:24:37 | call to method ToString | semmle.label | non-null |
 | ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:18:24:24 | (...) ... | semmle.label | successor |
 | ConditionalAccess.cs:24:27:24:37 | call to method ToString | ConditionalAccess.cs:24:13:24:37 | String s = ... | semmle.label | successor |
-| ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:21:10:21:11 | exit M7 | semmle.label | successor |
+| ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) | semmle.label | successor |
 | ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:13:25:14 | "" | semmle.label | successor |
 | ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:31:25:31 | access to local variable s | semmle.label | non-null |
 | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | ConditionalAccess.cs:25:9:25:32 | ... = ... | semmle.label | successor |
 | ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | semmle.label | successor |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:32:30:32 | 0 | semmle.label | successor |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | semmle.label | successor |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | semmle.label | successor |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | exit Out | semmle.label | successor |
+| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out | semmle.label | successor |
+| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | semmle.label | successor |
+| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | semmle.label | successor |
+| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | semmle.label | successor |
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:28:30:32 | ... = ... | semmle.label | successor |
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:28:30:32 | ... = ... | semmle.label | successor |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:33:5:36:5 | {...} | semmle.label | successor |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 | semmle.label | successor |
 | ConditionalAccess.cs:33:5:36:5 | {...} | ConditionalAccess.cs:34:9:34:14 | ...; | semmle.label | successor |
 | ConditionalAccess.cs:34:9:34:13 | ... = ... | ConditionalAccess.cs:35:9:35:25 | ...; | semmle.label | successor |
 | ConditionalAccess.cs:34:9:34:14 | ...; | ConditionalAccess.cs:34:13:34:13 | 0 | semmle.label | successor |
 | ConditionalAccess.cs:34:13:34:13 | 0 | ConditionalAccess.cs:34:9:34:13 | ... = ... | semmle.label | successor |
-| ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:32:10:32:11 | exit M8 | semmle.label | null |
+| ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | semmle.label | null |
 | ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:35:14:35:24 | call to method Out | semmle.label | non-null |
 | ConditionalAccess.cs:35:9:35:12 | this access | ConditionalAccess.cs:35:9:35:12 | access to property Prop | semmle.label | successor |
 | ConditionalAccess.cs:35:9:35:25 | ...; | ConditionalAccess.cs:35:9:35:12 | this access | semmle.label | successor |
-| ConditionalAccess.cs:35:14:35:24 | call to method Out | ConditionalAccess.cs:32:10:32:11 | exit M8 | semmle.label | successor |
+| ConditionalAccess.cs:35:14:35:24 | call to method Out | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | semmle.label | successor |
 | ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:70:41:71 | access to parameter s1 | semmle.label | successor |
+| ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith | semmle.label | successor |
 | ConditionalAccess.cs:41:70:41:71 | access to parameter s1 | ConditionalAccess.cs:41:75:41:78 | ", " | semmle.label | successor |
 | ConditionalAccess.cs:41:70:41:78 | ... + ... | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | semmle.label | successor |
-| ConditionalAccess.cs:41:70:41:83 | ... + ... | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith | semmle.label | successor |
+| ConditionalAccess.cs:41:70:41:83 | ... + ... | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) | semmle.label | successor |
 | ConditionalAccess.cs:41:75:41:78 | ", " | ConditionalAccess.cs:41:70:41:78 | ... + ... | semmle.label | successor |
 | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | ConditionalAccess.cs:41:70:41:83 | ... + ... | semmle.label | successor |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:4:5:9:5 | {...} | semmle.label | successor |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | exit IncrOrDecr | semmle.label | successor |
 | Conditions.cs:4:5:9:5 | {...} | Conditions.cs:5:9:6:16 | if (...) ... | semmle.label | successor |
 | Conditions.cs:5:9:6:16 | if (...) ... | Conditions.cs:5:13:5:15 | access to parameter inc | semmle.label | successor |
 | Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | semmle.label | true |
@@ -1171,11 +1239,12 @@
 | Conditions.cs:7:13:7:16 | [inc (line 3): false] !... | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | semmle.label | successor |
 | Conditions.cs:7:13:7:16 | [inc (line 3): true] !... | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | semmle.label | successor |
 | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:8:13:8:16 | ...; | semmle.label | false |
-| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:3:10:3:19 | exit IncrOrDecr | semmle.label | true |
+| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | semmle.label | true |
 | Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:15 | ...-- | semmle.label | successor |
-| Conditions.cs:8:13:8:15 | ...-- | Conditions.cs:3:10:3:19 | exit IncrOrDecr | semmle.label | successor |
+| Conditions.cs:8:13:8:15 | ...-- | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | semmle.label | successor |
 | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:13 | access to parameter x | semmle.label | successor |
 | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:12:5:20:5 | {...} | semmle.label | successor |
+| Conditions.cs:11:9:11:10 | exit M1 (normal) | Conditions.cs:11:9:11:10 | exit M1 | semmle.label | successor |
 | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:13:9:13:18 | ... ...; | semmle.label | successor |
 | Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:17:13:17 | 0 | semmle.label | successor |
 | Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:14:9:15:16 | if (...) ... | semmle.label | successor |
@@ -1205,9 +1274,10 @@
 | Conditions.cs:18:17:18:17 | access to local variable x | Conditions.cs:18:17:18:19 | ...-- | semmle.label | successor |
 | Conditions.cs:18:17:18:19 | ...-- | Conditions.cs:19:16:19:16 | access to local variable x | semmle.label | successor |
 | Conditions.cs:18:17:18:20 | ...; | Conditions.cs:18:17:18:17 | access to local variable x | semmle.label | successor |
-| Conditions.cs:19:9:19:17 | return ...; | Conditions.cs:11:9:11:10 | exit M1 | semmle.label | return |
+| Conditions.cs:19:9:19:17 | return ...; | Conditions.cs:11:9:11:10 | exit M1 (normal) | semmle.label | return |
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:19:9:19:17 | return ...; | semmle.label | successor |
 | Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:23:5:31:5 | {...} | semmle.label | successor |
+| Conditions.cs:22:9:22:10 | exit M2 (normal) | Conditions.cs:22:9:22:10 | exit M2 | semmle.label | successor |
 | Conditions.cs:23:5:31:5 | {...} | Conditions.cs:24:9:24:18 | ... ...; | semmle.label | successor |
 | Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:17:24:17 | 0 | semmle.label | successor |
 | Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:25:9:27:20 | if (...) ... | semmle.label | successor |
@@ -1231,9 +1301,10 @@
 | Conditions.cs:29:13:29:13 | access to local variable x | Conditions.cs:29:13:29:15 | ...++ | semmle.label | successor |
 | Conditions.cs:29:13:29:15 | ...++ | Conditions.cs:30:16:30:16 | access to local variable x | semmle.label | successor |
 | Conditions.cs:29:13:29:16 | ...; | Conditions.cs:29:13:29:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:30:9:30:17 | return ...; | Conditions.cs:22:9:22:10 | exit M2 | semmle.label | return |
+| Conditions.cs:30:9:30:17 | return ...; | Conditions.cs:22:9:22:10 | exit M2 (normal) | semmle.label | return |
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:30:9:30:17 | return ...; | semmle.label | successor |
 | Conditions.cs:33:9:33:10 | enter M3 | Conditions.cs:34:5:44:5 | {...} | semmle.label | successor |
+| Conditions.cs:33:9:33:10 | exit M3 (normal) | Conditions.cs:33:9:33:10 | exit M3 | semmle.label | successor |
 | Conditions.cs:34:5:44:5 | {...} | Conditions.cs:35:9:35:18 | ... ...; | semmle.label | successor |
 | Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:17:35:17 | 0 | semmle.label | successor |
 | Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:36:9:36:23 | ... ...; | semmle.label | successor |
@@ -1260,9 +1331,10 @@
 | Conditions.cs:42:13:42:13 | access to local variable x | Conditions.cs:42:13:42:15 | ...++ | semmle.label | successor |
 | Conditions.cs:42:13:42:15 | ...++ | Conditions.cs:43:16:43:16 | access to local variable x | semmle.label | successor |
 | Conditions.cs:42:13:42:16 | ...; | Conditions.cs:42:13:42:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:43:9:43:17 | return ...; | Conditions.cs:33:9:33:10 | exit M3 | semmle.label | return |
+| Conditions.cs:43:9:43:17 | return ...; | Conditions.cs:33:9:33:10 | exit M3 (normal) | semmle.label | return |
 | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:43:9:43:17 | return ...; | semmle.label | successor |
 | Conditions.cs:46:9:46:10 | enter M4 | Conditions.cs:47:5:55:5 | {...} | semmle.label | successor |
+| Conditions.cs:46:9:46:10 | exit M4 (normal) | Conditions.cs:46:9:46:10 | exit M4 | semmle.label | successor |
 | Conditions.cs:47:5:55:5 | {...} | Conditions.cs:48:9:48:18 | ... ...; | semmle.label | successor |
 | Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:17:48:17 | 0 | semmle.label | successor |
 | Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:49:9:53:9 | while (...) ... | semmle.label | successor |
@@ -1296,9 +1368,10 @@
 | Conditions.cs:52:17:52:17 | [b (line 46): true] access to local variable y | Conditions.cs:52:17:52:19 | [b (line 46): true] ...++ | semmle.label | successor |
 | Conditions.cs:52:17:52:19 | [b (line 46): true] ...++ | Conditions.cs:49:16:49:16 | [b (line 46): true] access to parameter x | semmle.label | successor |
 | Conditions.cs:52:17:52:20 | [b (line 46): true] ...; | Conditions.cs:52:17:52:17 | [b (line 46): true] access to local variable y | semmle.label | successor |
-| Conditions.cs:54:9:54:17 | return ...; | Conditions.cs:46:9:46:10 | exit M4 | semmle.label | return |
+| Conditions.cs:54:9:54:17 | return ...; | Conditions.cs:46:9:46:10 | exit M4 (normal) | semmle.label | return |
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:54:9:54:17 | return ...; | semmle.label | successor |
 | Conditions.cs:57:9:57:10 | enter M5 | Conditions.cs:58:5:68:5 | {...} | semmle.label | successor |
+| Conditions.cs:57:9:57:10 | exit M5 (normal) | Conditions.cs:57:9:57:10 | exit M5 | semmle.label | successor |
 | Conditions.cs:58:5:68:5 | {...} | Conditions.cs:59:9:59:18 | ... ...; | semmle.label | successor |
 | Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:17:59:17 | 0 | semmle.label | successor |
 | Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:60:9:64:9 | while (...) ... | semmle.label | successor |
@@ -1342,9 +1415,10 @@
 | Conditions.cs:66:13:66:13 | access to local variable y | Conditions.cs:66:13:66:15 | ...++ | semmle.label | successor |
 | Conditions.cs:66:13:66:15 | ...++ | Conditions.cs:67:16:67:16 | access to local variable y | semmle.label | successor |
 | Conditions.cs:66:13:66:16 | ...; | Conditions.cs:66:13:66:13 | access to local variable y | semmle.label | successor |
-| Conditions.cs:67:9:67:17 | return ...; | Conditions.cs:57:9:57:10 | exit M5 | semmle.label | return |
+| Conditions.cs:67:9:67:17 | return ...; | Conditions.cs:57:9:57:10 | exit M5 (normal) | semmle.label | return |
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:67:9:67:17 | return ...; | semmle.label | successor |
 | Conditions.cs:70:9:70:10 | enter M6 | Conditions.cs:71:5:84:5 | {...} | semmle.label | successor |
+| Conditions.cs:70:9:70:10 | exit M6 (normal) | Conditions.cs:70:9:70:10 | exit M6 | semmle.label | successor |
 | Conditions.cs:71:5:84:5 | {...} | Conditions.cs:72:9:72:30 | ... ...; | semmle.label | successor |
 | Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:17:72:18 | access to parameter ss | semmle.label | successor |
 | Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:73:9:73:18 | ... ...; | semmle.label | successor |
@@ -1380,9 +1454,10 @@
 | Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:82:13:82:15 | ...++ | semmle.label | successor |
 | Conditions.cs:82:13:82:15 | ...++ | Conditions.cs:83:16:83:16 | access to local variable x | semmle.label | successor |
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:83:9:83:17 | return ...; | Conditions.cs:70:9:70:10 | exit M6 | semmle.label | return |
+| Conditions.cs:83:9:83:17 | return ...; | Conditions.cs:70:9:70:10 | exit M6 (normal) | semmle.label | return |
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:83:9:83:17 | return ...; | semmle.label | successor |
 | Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:87:5:100:5 | {...} | semmle.label | successor |
+| Conditions.cs:86:9:86:10 | exit M7 (normal) | Conditions.cs:86:9:86:10 | exit M7 | semmle.label | successor |
 | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:88:9:88:30 | ... ...; | semmle.label | successor |
 | Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:17:88:18 | access to parameter ss | semmle.label | successor |
 | Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:89:9:89:18 | ... ...; | semmle.label | successor |
@@ -1418,9 +1493,10 @@
 | Conditions.cs:97:17:97:17 | access to local variable x | Conditions.cs:97:17:97:19 | ...++ | semmle.label | successor |
 | Conditions.cs:97:17:97:19 | ...++ | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | semmle.label | successor |
 | Conditions.cs:97:17:97:20 | ...; | Conditions.cs:97:17:97:17 | access to local variable x | semmle.label | successor |
-| Conditions.cs:99:9:99:17 | return ...; | Conditions.cs:86:9:86:10 | exit M7 | semmle.label | return |
+| Conditions.cs:99:9:99:17 | return ...; | Conditions.cs:86:9:86:10 | exit M7 (normal) | semmle.label | return |
 | Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:99:9:99:17 | return ...; | semmle.label | successor |
 | Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:103:5:111:5 | {...} | semmle.label | successor |
+| Conditions.cs:102:12:102:13 | exit M8 (normal) | Conditions.cs:102:12:102:13 | exit M8 | semmle.label | successor |
 | Conditions.cs:103:5:111:5 | {...} | Conditions.cs:104:9:104:29 | ... ...; | semmle.label | successor |
 | Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:17:104:17 | access to parameter b | semmle.label | successor |
 | Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:105:9:106:20 | if (...) ... | semmle.label | successor |
@@ -1457,9 +1533,10 @@
 | Conditions.cs:109:17:109:23 | ... = ... | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | successor |
 | Conditions.cs:109:17:109:24 | ...; | Conditions.cs:109:17:109:17 | access to local variable x | semmle.label | successor |
 | Conditions.cs:109:22:109:23 | "" | Conditions.cs:109:17:109:23 | ... + ... | semmle.label | successor |
-| Conditions.cs:110:9:110:17 | return ...; | Conditions.cs:102:12:102:13 | exit M8 | semmle.label | return |
+| Conditions.cs:110:9:110:17 | return ...; | Conditions.cs:102:12:102:13 | exit M8 (normal) | semmle.label | return |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:9:110:17 | return ...; | semmle.label | successor |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:114:5:124:5 | {...} | semmle.label | successor |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | exit M9 | semmle.label | successor |
 | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:115:9:115:24 | ... ...; | semmle.label | successor |
 | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:20:115:23 | null | semmle.label | successor |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... | semmle.label | successor |
@@ -1468,7 +1545,7 @@
 | Conditions.cs:116:18:116:22 | Int32 i = ... | Conditions.cs:116:25:116:25 | access to local variable i | semmle.label | successor |
 | Conditions.cs:116:22:116:22 | 0 | Conditions.cs:116:18:116:22 | Int32 i = ... | semmle.label | successor |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:29:116:32 | access to parameter args | semmle.label | successor |
-| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 | semmle.label | false |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 (normal) | semmle.label | false |
 | Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:117:9:123:9 | {...} | semmle.label | true |
 | Conditions.cs:116:29:116:32 | access to parameter args | Conditions.cs:116:29:116:39 | access to property Length | semmle.label | successor |
 | Conditions.cs:116:29:116:39 | access to property Length | Conditions.cs:116:25:116:39 | ... < ... | semmle.label | successor |
@@ -1540,6 +1617,7 @@
 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | semmle.label | successor |
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | semmle.label | successor |
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:144:5:150:5 | {...} | semmle.label | successor |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | exit M11 | semmle.label | successor |
 | Conditions.cs:144:5:150:5 | {...} | Conditions.cs:145:9:145:30 | ... ...; | semmle.label | successor |
 | Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:17:145:29 | ... ? ... : ... | semmle.label | successor |
 | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | semmle.label | successor |
@@ -1553,45 +1631,51 @@
 | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | semmle.label | successor |
 | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:149:13:149:49 | ...; | semmle.label | false |
 | Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | Conditions.cs:147:13:147:49 | ...; | semmle.label | true |
-| Conditions.cs:147:13:147:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | exit M11 | semmle.label | successor |
+| Conditions.cs:147:13:147:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | exit M11 (normal) | semmle.label | successor |
 | Conditions.cs:147:13:147:49 | ...; | Conditions.cs:147:40:147:43 | "a = " | semmle.label | successor |
 | Conditions.cs:147:38:147:47 | $"..." | Conditions.cs:147:13:147:48 | call to method WriteLine | semmle.label | successor |
 | Conditions.cs:147:40:147:43 | "a = " | Conditions.cs:147:45:147:45 | access to local variable s | semmle.label | successor |
 | Conditions.cs:147:45:147:45 | access to local variable s | Conditions.cs:147:38:147:47 | $"..." | semmle.label | successor |
-| Conditions.cs:149:13:149:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | exit M11 | semmle.label | successor |
+| Conditions.cs:149:13:149:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | exit M11 (normal) | semmle.label | successor |
 | Conditions.cs:149:13:149:49 | ...; | Conditions.cs:149:40:149:43 | "b = " | semmle.label | successor |
 | Conditions.cs:149:38:149:47 | $"..." | Conditions.cs:149:13:149:48 | call to method WriteLine | semmle.label | successor |
 | Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:149:45:149:45 | access to local variable s | semmle.label | successor |
 | Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:149:38:149:47 | $"..." | semmle.label | successor |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:8:5:11:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:7:10:7:11 | exit M1 (normal) | ExitMethods.cs:7:10:7:11 | exit M1 | semmle.label | successor |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:9:9:9:25 | ...; | semmle.label | successor |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:10:9:10:15 | return ...; | semmle.label | successor |
 | ExitMethods.cs:9:9:9:25 | ...; | ExitMethods.cs:9:20:9:23 | true | semmle.label | successor |
 | ExitMethods.cs:9:20:9:23 | true | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | semmle.label | successor |
-| ExitMethods.cs:10:9:10:15 | return ...; | ExitMethods.cs:7:10:7:11 | exit M1 | semmle.label | return |
+| ExitMethods.cs:10:9:10:15 | return ...; | ExitMethods.cs:7:10:7:11 | exit M1 (normal) | semmle.label | return |
 | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:14:5:17:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:13:10:13:11 | exit M2 (normal) | ExitMethods.cs:13:10:13:11 | exit M2 | semmle.label | successor |
 | ExitMethods.cs:14:5:17:5 | {...} | ExitMethods.cs:15:9:15:26 | ...; | semmle.label | successor |
 | ExitMethods.cs:15:9:15:25 | call to method ErrorMaybe | ExitMethods.cs:16:9:16:15 | return ...; | semmle.label | successor |
 | ExitMethods.cs:15:9:15:26 | ...; | ExitMethods.cs:15:20:15:24 | false | semmle.label | successor |
 | ExitMethods.cs:15:20:15:24 | false | ExitMethods.cs:15:9:15:25 | call to method ErrorMaybe | semmle.label | successor |
-| ExitMethods.cs:16:9:16:15 | return ...; | ExitMethods.cs:13:10:13:11 | exit M2 | semmle.label | return |
+| ExitMethods.cs:16:9:16:15 | return ...; | ExitMethods.cs:13:10:13:11 | exit M2 (normal) | semmle.label | return |
 | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:20:5:23:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:19:10:19:11 | exit M3 (abnormal) | ExitMethods.cs:19:10:19:11 | exit M3 | semmle.label | successor |
 | ExitMethods.cs:20:5:23:5 | {...} | ExitMethods.cs:21:9:21:26 | ...; | semmle.label | successor |
-| ExitMethods.cs:21:9:21:25 | call to method ErrorAlways | ExitMethods.cs:19:10:19:11 | exit M3 | semmle.label | exception(ArgumentException) |
-| ExitMethods.cs:21:9:21:25 | call to method ErrorAlways | ExitMethods.cs:19:10:19:11 | exit M3 | semmle.label | exception(Exception) |
+| ExitMethods.cs:21:9:21:25 | call to method ErrorAlways | ExitMethods.cs:19:10:19:11 | exit M3 (abnormal) | semmle.label | exception(ArgumentException) |
+| ExitMethods.cs:21:9:21:25 | call to method ErrorAlways | ExitMethods.cs:19:10:19:11 | exit M3 (abnormal) | semmle.label | exception(Exception) |
 | ExitMethods.cs:21:9:21:26 | ...; | ExitMethods.cs:21:21:21:24 | true | semmle.label | successor |
 | ExitMethods.cs:21:21:21:24 | true | ExitMethods.cs:21:9:21:25 | call to method ErrorAlways | semmle.label | successor |
 | ExitMethods.cs:25:10:25:11 | enter M4 | ExitMethods.cs:26:5:29:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:25:10:25:11 | exit M4 (abnormal) | ExitMethods.cs:25:10:25:11 | exit M4 | semmle.label | successor |
 | ExitMethods.cs:26:5:29:5 | {...} | ExitMethods.cs:27:9:27:15 | ...; | semmle.label | successor |
-| ExitMethods.cs:27:9:27:14 | call to method Exit | ExitMethods.cs:25:10:25:11 | exit M4 | semmle.label | exit |
+| ExitMethods.cs:27:9:27:14 | call to method Exit | ExitMethods.cs:25:10:25:11 | exit M4 (abnormal) | semmle.label | exit |
 | ExitMethods.cs:27:9:27:14 | this access | ExitMethods.cs:27:9:27:14 | call to method Exit | semmle.label | successor |
 | ExitMethods.cs:27:9:27:15 | ...; | ExitMethods.cs:27:9:27:14 | this access | semmle.label | successor |
 | ExitMethods.cs:31:10:31:11 | enter M5 | ExitMethods.cs:32:5:35:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:31:10:31:11 | exit M5 (abnormal) | ExitMethods.cs:31:10:31:11 | exit M5 | semmle.label | successor |
 | ExitMethods.cs:32:5:35:5 | {...} | ExitMethods.cs:33:9:33:26 | ...; | semmle.label | successor |
-| ExitMethods.cs:33:9:33:25 | call to method ApplicationExit | ExitMethods.cs:31:10:31:11 | exit M5 | semmle.label | exit |
+| ExitMethods.cs:33:9:33:25 | call to method ApplicationExit | ExitMethods.cs:31:10:31:11 | exit M5 (abnormal) | semmle.label | exit |
 | ExitMethods.cs:33:9:33:25 | this access | ExitMethods.cs:33:9:33:25 | call to method ApplicationExit | semmle.label | successor |
 | ExitMethods.cs:33:9:33:26 | ...; | ExitMethods.cs:33:9:33:25 | this access | semmle.label | successor |
 | ExitMethods.cs:37:10:37:11 | enter M6 | ExitMethods.cs:38:5:51:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:37:10:37:11 | exit M6 (normal) | ExitMethods.cs:37:10:37:11 | exit M6 | semmle.label | successor |
 | ExitMethods.cs:38:5:51:5 | {...} | ExitMethods.cs:39:9:50:9 | try {...} ... | semmle.label | successor |
 | ExitMethods.cs:39:9:50:9 | try {...} ... | ExitMethods.cs:40:9:42:9 | {...} | semmle.label | successor |
 | ExitMethods.cs:40:9:42:9 | {...} | ExitMethods.cs:41:13:41:31 | ...; | semmle.label | successor |
@@ -1603,61 +1687,73 @@
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:44:9:46:9 | {...} | semmle.label | match |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | semmle.label | no-match |
 | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:45:13:45:19 | return ...; | semmle.label | successor |
-| ExitMethods.cs:45:13:45:19 | return ...; | ExitMethods.cs:37:10:37:11 | exit M6 | semmle.label | return |
+| ExitMethods.cs:45:13:45:19 | return ...; | ExitMethods.cs:37:10:37:11 | exit M6 (normal) | semmle.label | return |
 | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:48:9:50:9 | {...} | semmle.label | match |
 | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:49:13:49:19 | return ...; | semmle.label | successor |
-| ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:37:10:37:11 | exit M6 | semmle.label | return |
+| ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:37:10:37:11 | exit M6 (normal) | semmle.label | return |
 | ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:54:5:57:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:53:10:53:11 | exit M7 (abnormal) | ExitMethods.cs:53:10:53:11 | exit M7 | semmle.label | successor |
 | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:55:23 | ...; | semmle.label | successor |
-| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:53:10:53:11 | exit M7 | semmle.label | exception(Exception) |
+| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:53:10:53:11 | exit M7 (abnormal) | semmle.label | exception(Exception) |
 | ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | semmle.label | successor |
 | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:60:5:63:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:59:10:59:11 | exit M8 (abnormal) | ExitMethods.cs:59:10:59:11 | exit M8 | semmle.label | successor |
 | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:61:9:61:23 | ...; | semmle.label | successor |
-| ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:59:10:59:11 | exit M8 | semmle.label | exception(Exception) |
+| ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:59:10:59:11 | exit M8 (abnormal) | semmle.label | exception(Exception) |
 | ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | semmle.label | successor |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:66:5:69:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (abnormal) | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | semmle.label | successor |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | semmle.label | successor |
 | ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:67:9:68:34 | if (...) ... | semmle.label | successor |
 | ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:67:13:67:13 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | semmle.label | false |
+| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (normal) | semmle.label | false |
 | ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:68:19:68:33 | object creation of type Exception | semmle.label | true |
-| ExitMethods.cs:68:13:68:34 | throw ...; | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | semmle.label | exception(Exception) |
+| ExitMethods.cs:68:13:68:34 | throw ...; | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe (abnormal) | semmle.label | exception(Exception) |
 | ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:13:68:34 | throw ...; | semmle.label | successor |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:72:5:77:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | semmle.label | successor |
 | ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:73:9:76:45 | if (...) ... | semmle.label | successor |
 | ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:73:13:73:13 | access to parameter b | semmle.label | successor |
 | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:74:19:74:33 | object creation of type Exception | semmle.label | true |
 | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:76:41:76:43 | "b" | semmle.label | false |
-| ExitMethods.cs:74:13:74:34 | throw ...; | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | semmle.label | exception(Exception) |
+| ExitMethods.cs:74:13:74:34 | throw ...; | ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) | semmle.label | exception(Exception) |
 | ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:13:74:34 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:76:13:76:45 | throw ...; | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | semmle.label | exception(ArgumentException) |
+| ExitMethods.cs:76:13:76:45 | throw ...; | ExitMethods.cs:71:17:71:27 | exit ErrorAlways (abnormal) | semmle.label | exception(ArgumentException) |
 | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | ExitMethods.cs:76:13:76:45 | throw ...; | semmle.label | successor |
 | ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | semmle.label | successor |
 | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:80:5:82:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 (abnormal) | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 | semmle.label | successor |
 | ExitMethods.cs:80:5:82:5 | {...} | ExitMethods.cs:81:15:81:29 | object creation of type Exception | semmle.label | successor |
-| ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 | semmle.label | exception(Exception) |
+| ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 (abnormal) | semmle.label | exception(Exception) |
 | ExitMethods.cs:81:15:81:29 | object creation of type Exception | ExitMethods.cs:81:9:81:30 | throw ...; | semmle.label | successor |
 | ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 | ExitMethods.cs:84:41:84:55 | object creation of type Exception | semmle.label | successor |
-| ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 | semmle.label | exception(Exception) |
+| ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 (abnormal) | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 | semmle.label | successor |
+| ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 (abnormal) | semmle.label | exception(Exception) |
 | ExitMethods.cs:84:41:84:55 | object creation of type Exception | ExitMethods.cs:84:35:84:55 | throw ... | semmle.label | successor |
 | ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:87:5:89:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:86:10:86:13 | exit Exit (abnormal) | ExitMethods.cs:86:10:86:13 | exit Exit | semmle.label | successor |
 | ExitMethods.cs:87:5:89:5 | {...} | ExitMethods.cs:88:9:88:28 | ...; | semmle.label | successor |
-| ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:86:10:86:13 | exit Exit | semmle.label | exit |
+| ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:86:10:86:13 | exit Exit (abnormal) | semmle.label | exit |
 | ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:88:26:88:26 | 0 | semmle.label | successor |
 | ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:9:88:27 | call to method Exit | semmle.label | successor |
 | ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:92:5:102:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:91:10:91:18 | exit ExitInTry (abnormal) | ExitMethods.cs:91:10:91:18 | exit ExitInTry | semmle.label | successor |
 | ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:93:9:101:9 | try {...} ... | semmle.label | successor |
 | ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:94:9:96:9 | {...} | semmle.label | successor |
 | ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:95:13:95:19 | ...; | semmle.label | successor |
-| ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:91:10:91:18 | exit ExitInTry | semmle.label | exit |
+| ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:91:10:91:18 | exit ExitInTry (abnormal) | semmle.label | exit |
 | ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:18 | call to method Exit | semmle.label | successor |
 | ExitMethods.cs:95:13:95:19 | ...; | ExitMethods.cs:95:13:95:18 | this access | semmle.label | successor |
 | ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:105:5:107:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:104:10:104:24 | exit ApplicationExit (abnormal) | ExitMethods.cs:104:10:104:24 | exit ApplicationExit | semmle.label | successor |
 | ExitMethods.cs:105:5:107:5 | {...} | ExitMethods.cs:106:9:106:48 | ...; | semmle.label | successor |
-| ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit | semmle.label | exit |
+| ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit (abnormal) | semmle.label | exit |
 | ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:106:9:106:47 | call to method Exit | semmle.label | successor |
 | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:110:5:112:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | semmle.label | successor |
+| ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | semmle.label | successor |
 | ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:16:111:76 | ... ? ... : ... | semmle.label | successor |
-| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | semmle.label | return |
+| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) | semmle.label | return |
 | ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:25:111:25 | 0 | semmle.label | successor |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:29:111:29 | 1 | semmle.label | true |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:69:111:75 | "input" | semmle.label | false |
@@ -1668,12 +1764,13 @@
 | ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:33:111:37 | access to parameter input | semmle.label | successor |
 | ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:9:111:77 | return ...; | semmle.label | successor |
 | ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:29:111:37 | ... / ... | semmle.label | successor |
-| ExitMethods.cs:111:41:111:76 | throw ... | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | semmle.label | exception(ArgumentException) |
+| ExitMethods.cs:111:41:111:76 | throw ... | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) | semmle.label | exception(ArgumentException) |
 | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:41:111:76 | throw ... | semmle.label | successor |
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | semmle.label | successor |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:115:5:117:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | semmle.label | successor |
 | ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | semmle.label | successor |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | semmle.label | return |
+| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) | semmle.label | return |
 | ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:27:116:29 | - | semmle.label | successor |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:34:116:34 | 0 | semmle.label | true |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:38:116:38 | 1 | semmle.label | false |
@@ -1682,41 +1779,50 @@
 | ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:9:116:39 | return ...; | semmle.label | successor |
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:9:116:39 | return ...; | semmle.label | successor |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:120:5:123:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | semmle.label | successor |
 | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:121:9:121:29 | ...; | semmle.label | successor |
-| ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | semmle.label | exception(AssertFailedException) |
+| ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) | semmle.label | exception(AssertFailedException) |
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:23:121:27 | false | semmle.label | successor |
 | ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | semmle.label | false |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:126:5:129:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 (abnormal) | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | semmle.label | successor |
 | ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:127:9:127:27 | ...; | semmle.label | successor |
-| ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | semmle.label | exception(AssertFailedException) |
+| ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 (abnormal) | semmle.label | exception(AssertFailedException) |
 | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | semmle.label | successor |
 | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:26 | this access | semmle.label | successor |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:48:131:48 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse | semmle.label | exception(AssertFailedException) |
-| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse | semmle.label | successor |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse (abnormal) | ExitMethods.cs:131:10:131:20 | exit AssertFalse | semmle.label | successor |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse (normal) | ExitMethods.cs:131:10:131:20 | exit AssertFalse | semmle.label | successor |
+| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse (abnormal) | semmle.label | exception(AssertFailedException) |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse (normal) | semmle.label | successor |
 | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | semmle.label | true |
 | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | semmle.label | false |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:134:5:137:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 (abnormal) | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | semmle.label | successor |
 | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:135:9:135:26 | ...; | semmle.label | successor |
-| ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | semmle.label | exception(AssertFailedException) |
+| ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 (abnormal) | semmle.label | exception(AssertFailedException) |
 | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:21:135:24 | true | semmle.label | successor |
 | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:25 | this access | semmle.label | successor |
 | ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | semmle.label | true |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:6:5:8:5 | {...} | semmle.label | successor |
+| Extensions.cs:5:23:5:29 | exit ToInt32 (normal) | Extensions.cs:5:23:5:29 | exit ToInt32 | semmle.label | successor |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:28:7:28 | access to parameter s | semmle.label | successor |
-| Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | exit ToInt32 | semmle.label | return |
+| Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | exit ToInt32 (normal) | semmle.label | return |
 | Extensions.cs:7:16:7:29 | call to method Parse | Extensions.cs:7:9:7:30 | return ...; | semmle.label | successor |
 | Extensions.cs:7:28:7:28 | access to parameter s | Extensions.cs:7:16:7:29 | call to method Parse | semmle.label | successor |
 | Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:11:5:13:5 | {...} | semmle.label | successor |
+| Extensions.cs:10:24:10:29 | exit ToBool (normal) | Extensions.cs:10:24:10:29 | exit ToBool | semmle.label | successor |
 | Extensions.cs:11:5:13:5 | {...} | Extensions.cs:12:16:12:16 | access to parameter f | semmle.label | successor |
-| Extensions.cs:12:9:12:20 | return ...; | Extensions.cs:10:24:10:29 | exit ToBool | semmle.label | return |
+| Extensions.cs:12:9:12:20 | return ...; | Extensions.cs:10:24:10:29 | exit ToBool (normal) | semmle.label | return |
 | Extensions.cs:12:16:12:16 | access to parameter f | Extensions.cs:12:18:12:18 | access to parameter s | semmle.label | successor |
 | Extensions.cs:12:16:12:19 | delegate call | Extensions.cs:12:9:12:20 | return ...; | semmle.label | successor |
 | Extensions.cs:12:18:12:18 | access to parameter s | Extensions.cs:12:16:12:19 | delegate call | semmle.label | successor |
 | Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:48:15:50 | "0" | semmle.label | successor |
-| Extensions.cs:15:40:15:51 | call to method ToInt32 | Extensions.cs:15:23:15:33 | exit CallToInt32 | semmle.label | successor |
+| Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) | Extensions.cs:15:23:15:33 | exit CallToInt32 | semmle.label | successor |
+| Extensions.cs:15:40:15:51 | call to method ToInt32 | Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) | semmle.label | successor |
 | Extensions.cs:15:48:15:50 | "0" | Extensions.cs:15:40:15:51 | call to method ToInt32 | semmle.label | successor |
 | Extensions.cs:20:17:20:20 | enter Main | Extensions.cs:21:5:26:5 | {...} | semmle.label | successor |
+| Extensions.cs:20:17:20:20 | exit Main (normal) | Extensions.cs:20:17:20:20 | exit Main | semmle.label | successor |
 | Extensions.cs:21:5:26:5 | {...} | Extensions.cs:22:9:22:20 | ...; | semmle.label | successor |
 | Extensions.cs:22:9:22:9 | access to parameter s | Extensions.cs:22:9:22:19 | call to method ToInt32 | semmle.label | successor |
 | Extensions.cs:22:9:22:19 | call to method ToInt32 | Extensions.cs:23:9:23:31 | ...; | semmle.label | successor |
@@ -1730,11 +1836,13 @@
 | Extensions.cs:24:35:24:44 | access to method Parse | Extensions.cs:24:35:24:44 | delegate creation of type Func<String,Boolean> | semmle.label | successor |
 | Extensions.cs:24:35:24:44 | delegate creation of type Func<String,Boolean> | Extensions.cs:24:9:24:45 | call to method ToBool | semmle.label | successor |
 | Extensions.cs:25:9:25:14 | "true" | Extensions.cs:25:23:25:32 | access to method Parse | semmle.label | successor |
-| Extensions.cs:25:9:25:33 | call to method ToBool | Extensions.cs:20:17:20:20 | exit Main | semmle.label | successor |
+| Extensions.cs:25:9:25:33 | call to method ToBool | Extensions.cs:20:17:20:20 | exit Main (normal) | semmle.label | successor |
 | Extensions.cs:25:9:25:34 | ...; | Extensions.cs:25:9:25:14 | "true" | semmle.label | successor |
 | Extensions.cs:25:23:25:32 | access to method Parse | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | semmle.label | successor |
 | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | Extensions.cs:25:9:25:33 | call to method ToBool | semmle.label | successor |
 | Finally.cs:7:10:7:11 | enter M1 | Finally.cs:8:5:17:5 | {...} | semmle.label | successor |
+| Finally.cs:7:10:7:11 | exit M1 (abnormal) | Finally.cs:7:10:7:11 | exit M1 | semmle.label | successor |
+| Finally.cs:7:10:7:11 | exit M1 (normal) | Finally.cs:7:10:7:11 | exit M1 | semmle.label | successor |
 | Finally.cs:8:5:17:5 | {...} | Finally.cs:9:9:16:9 | try {...} ... | semmle.label | successor |
 | Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:10:9:12:9 | {...} | semmle.label | successor |
 | Finally.cs:10:9:12:9 | {...} | Finally.cs:11:13:11:38 | ...; | semmle.label | successor |
@@ -1746,9 +1854,9 @@
 | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} | Finally.cs:15:13:15:41 | [finally: exception(Exception)] ...; | semmle.label | successor |
 | Finally.cs:14:9:16:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:15:13:15:41 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | successor |
 | Finally.cs:14:9:16:9 | {...} | Finally.cs:15:13:15:41 | ...; | semmle.label | successor |
-| Finally.cs:15:13:15:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 | semmle.label | exception(Exception) |
-| Finally.cs:15:13:15:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 | semmle.label | exception(OutOfMemoryException) |
-| Finally.cs:15:13:15:40 | call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 | semmle.label | successor |
+| Finally.cs:15:13:15:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:15:13:15:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 (abnormal) | semmle.label | exception(OutOfMemoryException) |
+| Finally.cs:15:13:15:40 | call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 (normal) | semmle.label | successor |
 | Finally.cs:15:13:15:41 | ...; | Finally.cs:15:31:15:39 | "Finally" | semmle.label | successor |
 | Finally.cs:15:13:15:41 | [finally: exception(Exception)] ...; | Finally.cs:15:31:15:39 | [finally: exception(Exception)] "Finally" | semmle.label | successor |
 | Finally.cs:15:13:15:41 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:15:31:15:39 | [finally: exception(OutOfMemoryException)] "Finally" | semmle.label | successor |
@@ -1756,6 +1864,8 @@
 | Finally.cs:15:31:15:39 | [finally: exception(Exception)] "Finally" | Finally.cs:15:13:15:40 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
 | Finally.cs:15:31:15:39 | [finally: exception(OutOfMemoryException)] "Finally" | Finally.cs:15:13:15:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
 | Finally.cs:19:10:19:11 | enter M2 | Finally.cs:20:5:52:5 | {...} | semmle.label | successor |
+| Finally.cs:19:10:19:11 | exit M2 (abnormal) | Finally.cs:19:10:19:11 | exit M2 | semmle.label | successor |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:19:10:19:11 | exit M2 | semmle.label | successor |
 | Finally.cs:20:5:52:5 | {...} | Finally.cs:21:9:51:9 | try {...} ... | semmle.label | successor |
 | Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:22:9:25:9 | {...} | semmle.label | successor |
 | Finally.cs:22:9:25:9 | {...} | Finally.cs:23:13:23:38 | ...; | semmle.label | successor |
@@ -1793,10 +1903,10 @@
 | Finally.cs:49:9:51:9 | [finally: exception(IOException)] {...} | Finally.cs:50:13:50:41 | [finally: exception(IOException)] ...; | semmle.label | successor |
 | Finally.cs:49:9:51:9 | [finally: return] {...} | Finally.cs:50:13:50:41 | [finally: return] ...; | semmle.label | successor |
 | Finally.cs:49:9:51:9 | {...} | Finally.cs:50:13:50:41 | ...; | semmle.label | successor |
-| Finally.cs:50:13:50:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 | semmle.label | exception(Exception) |
-| Finally.cs:50:13:50:40 | [finally: exception(IOException)] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 | semmle.label | exception(IOException) |
-| Finally.cs:50:13:50:40 | [finally: return] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 | semmle.label | return |
-| Finally.cs:50:13:50:40 | call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 | semmle.label | successor |
+| Finally.cs:50:13:50:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:50:13:50:40 | [finally: exception(IOException)] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (abnormal) | semmle.label | exception(IOException) |
+| Finally.cs:50:13:50:40 | [finally: return] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (normal) | semmle.label | return |
+| Finally.cs:50:13:50:40 | call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (normal) | semmle.label | successor |
 | Finally.cs:50:13:50:41 | ...; | Finally.cs:50:31:50:39 | "Finally" | semmle.label | successor |
 | Finally.cs:50:13:50:41 | [finally: exception(Exception)] ...; | Finally.cs:50:31:50:39 | [finally: exception(Exception)] "Finally" | semmle.label | successor |
 | Finally.cs:50:13:50:41 | [finally: exception(IOException)] ...; | Finally.cs:50:31:50:39 | [finally: exception(IOException)] "Finally" | semmle.label | successor |
@@ -1806,6 +1916,8 @@
 | Finally.cs:50:31:50:39 | [finally: exception(IOException)] "Finally" | Finally.cs:50:13:50:40 | [finally: exception(IOException)] call to method WriteLine | semmle.label | successor |
 | Finally.cs:50:31:50:39 | [finally: return] "Finally" | Finally.cs:50:13:50:40 | [finally: return] call to method WriteLine | semmle.label | successor |
 | Finally.cs:54:10:54:11 | enter M3 | Finally.cs:55:5:72:5 | {...} | semmle.label | successor |
+| Finally.cs:54:10:54:11 | exit M3 (abnormal) | Finally.cs:54:10:54:11 | exit M3 | semmle.label | successor |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:54:10:54:11 | exit M3 | semmle.label | successor |
 | Finally.cs:55:5:72:5 | {...} | Finally.cs:56:9:71:9 | try {...} ... | semmle.label | successor |
 | Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:57:9:60:9 | {...} | semmle.label | successor |
 | Finally.cs:57:9:60:9 | {...} | Finally.cs:58:13:58:38 | ...; | semmle.label | successor |
@@ -1842,11 +1954,11 @@
 | Finally.cs:69:9:71:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:70:13:70:41 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | successor |
 | Finally.cs:69:9:71:9 | [finally: return] {...} | Finally.cs:70:13:70:41 | [finally: return] ...; | semmle.label | successor |
 | Finally.cs:69:9:71:9 | {...} | Finally.cs:70:13:70:41 | ...; | semmle.label | successor |
-| Finally.cs:70:13:70:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 | semmle.label | exception(Exception) |
-| Finally.cs:70:13:70:40 | [finally: exception(IOException)] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 | semmle.label | exception(IOException) |
-| Finally.cs:70:13:70:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 | semmle.label | exception(OutOfMemoryException) |
-| Finally.cs:70:13:70:40 | [finally: return] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 | semmle.label | return |
-| Finally.cs:70:13:70:40 | call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 | semmle.label | successor |
+| Finally.cs:70:13:70:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:70:13:70:40 | [finally: exception(IOException)] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (abnormal) | semmle.label | exception(IOException) |
+| Finally.cs:70:13:70:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (abnormal) | semmle.label | exception(OutOfMemoryException) |
+| Finally.cs:70:13:70:40 | [finally: return] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (normal) | semmle.label | return |
+| Finally.cs:70:13:70:40 | call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (normal) | semmle.label | successor |
 | Finally.cs:70:13:70:41 | ...; | Finally.cs:70:31:70:39 | "Finally" | semmle.label | successor |
 | Finally.cs:70:13:70:41 | [finally: exception(Exception)] ...; | Finally.cs:70:31:70:39 | [finally: exception(Exception)] "Finally" | semmle.label | successor |
 | Finally.cs:70:13:70:41 | [finally: exception(IOException)] ...; | Finally.cs:70:31:70:39 | [finally: exception(IOException)] "Finally" | semmle.label | successor |
@@ -1858,13 +1970,15 @@
 | Finally.cs:70:31:70:39 | [finally: exception(OutOfMemoryException)] "Finally" | Finally.cs:70:13:70:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
 | Finally.cs:70:31:70:39 | [finally: return] "Finally" | Finally.cs:70:13:70:40 | [finally: return] call to method WriteLine | semmle.label | successor |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:75:5:101:5 | {...} | semmle.label | successor |
+| Finally.cs:74:10:74:11 | exit M4 (abnormal) | Finally.cs:74:10:74:11 | exit M4 | semmle.label | successor |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:74:10:74:11 | exit M4 | semmle.label | successor |
 | Finally.cs:75:5:101:5 | {...} | Finally.cs:76:9:76:19 | ... ...; | semmle.label | successor |
 | Finally.cs:76:9:76:19 | ... ...; | Finally.cs:76:17:76:18 | 10 | semmle.label | successor |
 | Finally.cs:76:13:76:18 | Int32 i = ... | Finally.cs:77:9:100:9 | while (...) ... | semmle.label | successor |
 | Finally.cs:76:17:76:18 | 10 | Finally.cs:76:13:76:18 | Int32 i = ... | semmle.label | successor |
 | Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:77:16:77:16 | access to local variable i | semmle.label | successor |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:77:20:77:20 | 0 | semmle.label | successor |
-| Finally.cs:77:16:77:20 | ... > ... | Finally.cs:74:10:74:11 | exit M4 | semmle.label | false |
+| Finally.cs:77:16:77:20 | ... > ... | Finally.cs:74:10:74:11 | exit M4 (normal) | semmle.label | false |
 | Finally.cs:77:16:77:20 | ... > ... | Finally.cs:78:9:100:9 | {...} | semmle.label | true |
 | Finally.cs:77:20:77:20 | 0 | Finally.cs:77:16:77:20 | ... > ... | semmle.label | successor |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:79:13:99:13 | try {...} ... | semmle.label | successor |
@@ -1949,13 +2063,13 @@
 | Finally.cs:97:21:97:21 | [finally: return] access to local variable i | Finally.cs:97:21:97:23 | [finally: return] ...-- | semmle.label | successor |
 | Finally.cs:97:21:97:21 | access to local variable i | Finally.cs:97:21:97:23 | ...-- | semmle.label | successor |
 | Finally.cs:97:21:97:23 | ...-- | Finally.cs:77:16:77:16 | access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:23 | [finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 | semmle.label | exception(Exception) |
-| Finally.cs:97:21:97:23 | [finally: break, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 | semmle.label | exception(Exception) |
-| Finally.cs:97:21:97:23 | [finally: break] ...-- | Finally.cs:74:10:74:11 | exit M4 | semmle.label | break |
-| Finally.cs:97:21:97:23 | [finally: continue, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 | semmle.label | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally: break, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally: break] ...-- | Finally.cs:74:10:74:11 | exit M4 (normal) | semmle.label | break |
+| Finally.cs:97:21:97:23 | [finally: continue, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:97:21:97:23 | [finally: continue] ...-- | Finally.cs:77:16:77:16 | access to local variable i | semmle.label | continue |
-| Finally.cs:97:21:97:23 | [finally: return, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 | semmle.label | exception(Exception) |
-| Finally.cs:97:21:97:23 | [finally: return] ...-- | Finally.cs:74:10:74:11 | exit M4 | semmle.label | return |
+| Finally.cs:97:21:97:23 | [finally: return, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally: return] ...-- | Finally.cs:74:10:74:11 | exit M4 (normal) | semmle.label | return |
 | Finally.cs:97:21:97:24 | ...; | Finally.cs:97:21:97:21 | access to local variable i | semmle.label | successor |
 | Finally.cs:97:21:97:24 | [finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally(2): exception(Exception)] access to local variable i | semmle.label | successor |
 | Finally.cs:97:21:97:24 | [finally: break, finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: break, finally(2): exception(Exception)] access to local variable i | semmle.label | successor |
@@ -1965,6 +2079,8 @@
 | Finally.cs:97:21:97:24 | [finally: return, finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: return, finally(2): exception(Exception)] access to local variable i | semmle.label | successor |
 | Finally.cs:97:21:97:24 | [finally: return] ...; | Finally.cs:97:21:97:21 | [finally: return] access to local variable i | semmle.label | successor |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:104:5:119:5 | {...} | semmle.label | successor |
+| Finally.cs:103:10:103:11 | exit M5 (abnormal) | Finally.cs:103:10:103:11 | exit M5 | semmle.label | successor |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:103:10:103:11 | exit M5 | semmle.label | successor |
 | Finally.cs:104:5:119:5 | {...} | Finally.cs:105:9:118:9 | try {...} ... | semmle.label | successor |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:106:9:111:9 | {...} | semmle.label | successor |
 | Finally.cs:106:9:111:9 | {...} | Finally.cs:107:13:108:23 | if (...) ... | semmle.label | successor |
@@ -2077,26 +2193,26 @@
 | Finally.cs:116:17:116:28 | [finally: exception(OutOfMemoryException)] access to property Length | Finally.cs:116:32:116:32 | [finally: exception(OutOfMemoryException)] 0 | semmle.label | successor |
 | Finally.cs:116:17:116:28 | [finally: return] access to property Length | Finally.cs:116:32:116:32 | [finally: return] 0 | semmle.label | successor |
 | Finally.cs:116:17:116:28 | access to property Length | Finally.cs:116:32:116:32 | 0 | semmle.label | successor |
-| Finally.cs:116:17:116:32 | ... > ... | Finally.cs:103:10:103:11 | exit M5 | semmle.label | false |
+| Finally.cs:116:17:116:32 | ... > ... | Finally.cs:103:10:103:11 | exit M5 (normal) | semmle.label | false |
 | Finally.cs:116:17:116:32 | ... > ... | Finally.cs:117:17:117:37 | ...; | semmle.label | true |
-| Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | Finally.cs:103:10:103:11 | exit M5 | semmle.label | exception(Exception) |
+| Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; | semmle.label | true |
-| Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | Finally.cs:103:10:103:11 | exit M5 | semmle.label | exception(NullReferenceException) |
+| Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(NullReferenceException) |
 | Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; | semmle.label | true |
-| Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... | Finally.cs:103:10:103:11 | exit M5 | semmle.label | exception(OutOfMemoryException) |
+| Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(OutOfMemoryException) |
 | Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | true |
-| Finally.cs:116:17:116:32 | [finally: return] ... > ... | Finally.cs:103:10:103:11 | exit M5 | semmle.label | return |
+| Finally.cs:116:17:116:32 | [finally: return] ... > ... | Finally.cs:103:10:103:11 | exit M5 (normal) | semmle.label | return |
 | Finally.cs:116:17:116:32 | [finally: return] ... > ... | Finally.cs:117:17:117:37 | [finally: return] ...; | semmle.label | true |
 | Finally.cs:116:32:116:32 | 0 | Finally.cs:116:17:116:32 | ... > ... | semmle.label | successor |
 | Finally.cs:116:32:116:32 | [finally: exception(Exception)] 0 | Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | semmle.label | successor |
 | Finally.cs:116:32:116:32 | [finally: exception(NullReferenceException)] 0 | Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | semmle.label | successor |
 | Finally.cs:116:32:116:32 | [finally: exception(OutOfMemoryException)] 0 | Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... | semmle.label | successor |
 | Finally.cs:116:32:116:32 | [finally: return] 0 | Finally.cs:116:17:116:32 | [finally: return] ... > ... | semmle.label | successor |
-| Finally.cs:117:17:117:36 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 | semmle.label | exception(Exception) |
-| Finally.cs:117:17:117:36 | [finally: exception(NullReferenceException)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 | semmle.label | exception(NullReferenceException) |
-| Finally.cs:117:17:117:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 | semmle.label | exception(OutOfMemoryException) |
-| Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 | semmle.label | return |
-| Finally.cs:117:17:117:36 | call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 | semmle.label | successor |
+| Finally.cs:117:17:117:36 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:117:17:117:36 | [finally: exception(NullReferenceException)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(NullReferenceException) |
+| Finally.cs:117:17:117:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(OutOfMemoryException) |
+| Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (normal) | semmle.label | return |
+| Finally.cs:117:17:117:36 | call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (normal) | semmle.label | successor |
 | Finally.cs:117:17:117:37 | ...; | Finally.cs:117:35:117:35 | 1 | semmle.label | successor |
 | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; | Finally.cs:117:35:117:35 | [finally: exception(Exception)] 1 | semmle.label | successor |
 | Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; | Finally.cs:117:35:117:35 | [finally: exception(NullReferenceException)] 1 | semmle.label | successor |
@@ -2108,16 +2224,18 @@
 | Finally.cs:117:35:117:35 | [finally: exception(OutOfMemoryException)] 1 | Finally.cs:117:17:117:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
 | Finally.cs:117:35:117:35 | [finally: return] 1 | Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine | semmle.label | successor |
 | Finally.cs:121:10:121:11 | enter M6 | Finally.cs:122:5:131:5 | {...} | semmle.label | successor |
+| Finally.cs:121:10:121:11 | exit M6 (normal) | Finally.cs:121:10:121:11 | exit M6 | semmle.label | successor |
 | Finally.cs:122:5:131:5 | {...} | Finally.cs:123:9:130:9 | try {...} ... | semmle.label | successor |
 | Finally.cs:123:9:130:9 | try {...} ... | Finally.cs:124:9:126:9 | {...} | semmle.label | successor |
 | Finally.cs:124:9:126:9 | {...} | Finally.cs:125:13:125:41 | ... ...; | semmle.label | successor |
 | Finally.cs:125:13:125:41 | ... ...; | Finally.cs:125:24:125:24 | 0 | semmle.label | successor |
-| Finally.cs:125:17:125:40 | Double temp = ... | Finally.cs:121:10:121:11 | exit M6 | semmle.label | successor |
+| Finally.cs:125:17:125:40 | Double temp = ... | Finally.cs:121:10:121:11 | exit M6 (normal) | semmle.label | successor |
 | Finally.cs:125:24:125:24 | 0 | Finally.cs:125:24:125:24 | (...) ... | semmle.label | successor |
 | Finally.cs:125:24:125:24 | (...) ... | Finally.cs:125:28:125:40 | access to constant E | semmle.label | successor |
 | Finally.cs:125:24:125:40 | ... / ... | Finally.cs:125:17:125:40 | Double temp = ... | semmle.label | successor |
 | Finally.cs:125:28:125:40 | access to constant E | Finally.cs:125:24:125:40 | ... / ... | semmle.label | successor |
 | Finally.cs:133:10:133:11 | enter M7 | Finally.cs:134:5:145:5 | {...} | semmle.label | successor |
+| Finally.cs:133:10:133:11 | exit M7 (abnormal) | Finally.cs:133:10:133:11 | exit M7 | semmle.label | successor |
 | Finally.cs:134:5:145:5 | {...} | Finally.cs:135:9:143:9 | try {...} ... | semmle.label | successor |
 | Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:136:9:138:9 | {...} | semmle.label | successor |
 | Finally.cs:136:9:138:9 | {...} | Finally.cs:137:13:137:37 | ...; | semmle.label | successor |
@@ -2129,9 +2247,9 @@
 | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} | Finally.cs:141:41:141:42 | [finally: exception(Exception)] "" | semmle.label | successor |
 | Finally.cs:140:9:143:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:141:41:141:42 | [finally: exception(OutOfMemoryException)] "" | semmle.label | successor |
 | Finally.cs:140:9:143:9 | {...} | Finally.cs:141:41:141:42 | "" | semmle.label | successor |
-| Finally.cs:141:13:141:44 | [finally: exception(Exception)] throw ...; | Finally.cs:133:10:133:11 | exit M7 | semmle.label | exception(ArgumentException) |
-| Finally.cs:141:13:141:44 | [finally: exception(OutOfMemoryException)] throw ...; | Finally.cs:133:10:133:11 | exit M7 | semmle.label | exception(ArgumentException) |
-| Finally.cs:141:13:141:44 | throw ...; | Finally.cs:133:10:133:11 | exit M7 | semmle.label | exception(ArgumentException) |
+| Finally.cs:141:13:141:44 | [finally: exception(Exception)] throw ...; | Finally.cs:133:10:133:11 | exit M7 (abnormal) | semmle.label | exception(ArgumentException) |
+| Finally.cs:141:13:141:44 | [finally: exception(OutOfMemoryException)] throw ...; | Finally.cs:133:10:133:11 | exit M7 (abnormal) | semmle.label | exception(ArgumentException) |
+| Finally.cs:141:13:141:44 | throw ...; | Finally.cs:133:10:133:11 | exit M7 (abnormal) | semmle.label | exception(ArgumentException) |
 | Finally.cs:141:19:141:43 | [finally: exception(Exception)] object creation of type ArgumentException | Finally.cs:141:13:141:44 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
 | Finally.cs:141:19:141:43 | [finally: exception(OutOfMemoryException)] object creation of type ArgumentException | Finally.cs:141:13:141:44 | [finally: exception(OutOfMemoryException)] throw ...; | semmle.label | successor |
 | Finally.cs:141:19:141:43 | object creation of type ArgumentException | Finally.cs:141:13:141:44 | throw ...; | semmle.label | successor |
@@ -2139,6 +2257,8 @@
 | Finally.cs:141:41:141:42 | [finally: exception(Exception)] "" | Finally.cs:141:19:141:43 | [finally: exception(Exception)] object creation of type ArgumentException | semmle.label | successor |
 | Finally.cs:141:41:141:42 | [finally: exception(OutOfMemoryException)] "" | Finally.cs:141:19:141:43 | [finally: exception(OutOfMemoryException)] object creation of type ArgumentException | semmle.label | successor |
 | Finally.cs:147:10:147:11 | enter M8 | Finally.cs:148:5:170:5 | {...} | semmle.label | successor |
+| Finally.cs:147:10:147:11 | exit M8 (abnormal) | Finally.cs:147:10:147:11 | exit M8 | semmle.label | successor |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:147:10:147:11 | exit M8 | semmle.label | successor |
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:149:9:169:9 | try {...} ... | semmle.label | successor |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:150:9:153:9 | {...} | semmle.label | successor |
 | Finally.cs:150:9:153:9 | {...} | Finally.cs:151:13:152:50 | if (...) ... | semmle.label | successor |
@@ -2174,11 +2294,11 @@
 | Finally.cs:158:21:158:31 | access to property Length | Finally.cs:158:36:158:36 | 1 | semmle.label | successor |
 | Finally.cs:158:21:158:31 | access to property Length | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
 | Finally.cs:158:21:158:31 | access to property Length | Finally.cs:161:13:164:13 | [exception: NullReferenceException] catch (...) {...} | semmle.label | exception(NullReferenceException) |
-| Finally.cs:158:21:158:36 | ... == ... | Finally.cs:147:10:147:11 | exit M8 | semmle.label | false |
+| Finally.cs:158:21:158:36 | ... == ... | Finally.cs:147:10:147:11 | exit M8 (normal) | semmle.label | false |
 | Finally.cs:158:21:158:36 | ... == ... | Finally.cs:159:41:159:43 | "1" | semmle.label | true |
-| Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... | Finally.cs:147:10:147:11 | exit M8 | semmle.label | exception(ArgumentNullException) |
+| Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(ArgumentNullException) |
 | Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... | Finally.cs:159:41:159:43 | [finally: exception(ArgumentNullException)] "1" | semmle.label | true |
-| Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... | Finally.cs:147:10:147:11 | exit M8 | semmle.label | exception(Exception) |
+| Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... | Finally.cs:159:41:159:43 | [finally: exception(Exception)] "1" | semmle.label | true |
 | Finally.cs:158:36:158:36 | 1 | Finally.cs:158:21:158:36 | ... == ... | semmle.label | successor |
 | Finally.cs:158:36:158:36 | [finally: exception(ArgumentNullException)] 1 | Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... | semmle.label | successor |
@@ -2240,9 +2360,9 @@
 | Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:163:17:163:43 | [finally: exception(ArgumentNullException)] ...; | semmle.label | successor |
 | Finally.cs:162:13:164:13 | [finally: exception(Exception)] {...} | Finally.cs:163:17:163:43 | [finally: exception(Exception)] ...; | semmle.label | successor |
 | Finally.cs:162:13:164:13 | {...} | Finally.cs:163:17:163:43 | ...; | semmle.label | successor |
-| Finally.cs:163:17:163:42 | [finally: exception(ArgumentNullException)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 | semmle.label | exception(ArgumentNullException) |
-| Finally.cs:163:17:163:42 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 | semmle.label | exception(Exception) |
-| Finally.cs:163:17:163:42 | call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 | semmle.label | successor |
+| Finally.cs:163:17:163:42 | [finally: exception(ArgumentNullException)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(ArgumentNullException) |
+| Finally.cs:163:17:163:42 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:163:17:163:42 | call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (normal) | semmle.label | successor |
 | Finally.cs:163:17:163:43 | ...; | Finally.cs:163:35:163:38 | access to parameter args | semmle.label | successor |
 | Finally.cs:163:17:163:43 | [finally: exception(ArgumentNullException)] ...; | Finally.cs:163:35:163:38 | [finally: exception(ArgumentNullException)] access to parameter args | semmle.label | successor |
 | Finally.cs:163:17:163:43 | [finally: exception(Exception)] ...; | Finally.cs:163:35:163:38 | [finally: exception(Exception)] access to parameter args | semmle.label | successor |
@@ -2261,9 +2381,9 @@
 | Finally.cs:166:13:168:13 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:167:17:167:38 | [finally: exception(ArgumentNullException)] ...; | semmle.label | successor |
 | Finally.cs:166:13:168:13 | [finally: exception(Exception)] {...} | Finally.cs:167:17:167:38 | [finally: exception(Exception)] ...; | semmle.label | successor |
 | Finally.cs:166:13:168:13 | {...} | Finally.cs:167:17:167:38 | ...; | semmle.label | successor |
-| Finally.cs:167:17:167:37 | [finally: exception(ArgumentNullException)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 | semmle.label | exception(ArgumentNullException) |
-| Finally.cs:167:17:167:37 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 | semmle.label | exception(Exception) |
-| Finally.cs:167:17:167:37 | call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 | semmle.label | successor |
+| Finally.cs:167:17:167:37 | [finally: exception(ArgumentNullException)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(ArgumentNullException) |
+| Finally.cs:167:17:167:37 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:167:17:167:37 | call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (normal) | semmle.label | successor |
 | Finally.cs:167:17:167:38 | ...; | Finally.cs:167:35:167:36 | "" | semmle.label | successor |
 | Finally.cs:167:17:167:38 | [finally: exception(ArgumentNullException)] ...; | Finally.cs:167:35:167:36 | [finally: exception(ArgumentNullException)] "" | semmle.label | successor |
 | Finally.cs:167:17:167:38 | [finally: exception(Exception)] ...; | Finally.cs:167:35:167:36 | [finally: exception(Exception)] "" | semmle.label | successor |
@@ -2271,6 +2391,8 @@
 | Finally.cs:167:35:167:36 | [finally: exception(ArgumentNullException)] "" | Finally.cs:167:17:167:37 | [finally: exception(ArgumentNullException)] call to method WriteLine | semmle.label | successor |
 | Finally.cs:167:35:167:36 | [finally: exception(Exception)] "" | Finally.cs:167:17:167:37 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
 | Finally.cs:176:10:176:11 | enter M9 | Finally.cs:177:5:193:5 | {...} | semmle.label | successor |
+| Finally.cs:176:10:176:11 | exit M9 (abnormal) | Finally.cs:176:10:176:11 | exit M9 | semmle.label | successor |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:176:10:176:11 | exit M9 | semmle.label | successor |
 | Finally.cs:177:5:193:5 | {...} | Finally.cs:178:9:192:9 | try {...} ... | semmle.label | successor |
 | Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:179:9:181:9 | {...} | semmle.label | successor |
 | Finally.cs:179:9:181:9 | {...} | Finally.cs:180:13:180:43 | if (...) ... | semmle.label | successor |
@@ -2292,11 +2414,11 @@
 | Finally.cs:186:17:186:47 | [b1 (line 176): false] if (...) ... | Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | semmle.label | successor |
 | Finally.cs:186:17:186:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... | Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | semmle.label | successor |
 | Finally.cs:186:17:186:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... | Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | semmle.label | successor |
-| Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 | semmle.label | false |
+| Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (normal) | semmle.label | false |
 | Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB | semmle.label | true |
-| Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 | semmle.label | exception(Exception) |
+| Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | semmle.label | true |
-| Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 | semmle.label | exception(ExceptionA) |
+| Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(ExceptionA) |
 | Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | semmle.label | true |
 | Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; | Finally.cs:188:13:191:13 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | semmle.label | exception(ExceptionB) |
 | Finally.cs:186:25:186:47 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...; | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | semmle.label | exception(ExceptionB) |
@@ -2307,13 +2429,13 @@
 | Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | semmle.label | exception(Exception) |
 | Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:186:25:186:47 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...; | semmle.label | successor |
 | Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 | semmle.label | exception(Exception) |
+| Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | semmle.label | match |
 | Finally.cs:188:13:191:13 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | semmle.label | match |
-| Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 | semmle.label | exception(Exception) |
+| Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | semmle.label | match |
 | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | semmle.label | match |
-| Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 | semmle.label | exception(Exception) |
+| Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | semmle.label | match |
 | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | semmle.label | match |
 | Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | semmle.label | true |
@@ -2328,14 +2450,16 @@
 | Finally.cs:190:17:190:47 | [b1 (line 176): false] if (...) ... | Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 | semmle.label | successor |
 | Finally.cs:190:17:190:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... | Finally.cs:190:21:190:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b1 | semmle.label | successor |
 | Finally.cs:190:17:190:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... | Finally.cs:190:21:190:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1 | semmle.label | successor |
-| Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 | Finally.cs:176:10:176:11 | exit M9 | semmle.label | false |
+| Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 | Finally.cs:176:10:176:11 | exit M9 (normal) | semmle.label | false |
 | Finally.cs:190:21:190:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b1 | Finally.cs:190:31:190:46 | [finally: exception(Exception)] object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:190:21:190:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1 | Finally.cs:190:31:190:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:190:25:190:47 | [finally: exception(Exception)] throw ...; | Finally.cs:176:10:176:11 | exit M9 | semmle.label | exception(ExceptionC) |
-| Finally.cs:190:25:190:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:176:10:176:11 | exit M9 | semmle.label | exception(ExceptionC) |
+| Finally.cs:190:25:190:47 | [finally: exception(Exception)] throw ...; | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:190:25:190:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(ExceptionC) |
 | Finally.cs:190:31:190:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:190:25:190:47 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
 | Finally.cs:190:31:190:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:190:25:190:47 | [finally: exception(ExceptionA)] throw ...; | semmle.label | successor |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:196:5:214:5 | {...} | semmle.label | successor |
+| Finally.cs:195:10:195:12 | exit M10 (abnormal) | Finally.cs:195:10:195:12 | exit M10 | semmle.label | successor |
+| Finally.cs:195:10:195:12 | exit M10 (normal) | Finally.cs:195:10:195:12 | exit M10 | semmle.label | successor |
 | Finally.cs:196:5:214:5 | {...} | Finally.cs:197:9:212:9 | try {...} ... | semmle.label | successor |
 | Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:198:9:200:9 | {...} | semmle.label | successor |
 | Finally.cs:198:9:200:9 | {...} | Finally.cs:199:13:199:43 | if (...) ... | semmle.label | successor |
@@ -2390,33 +2514,33 @@
 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | semmle.label | successor |
 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | semmle.label | successor |
 | Finally.cs:209:17:209:47 | if (...) ... | Finally.cs:209:21:209:22 | access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(Exception) |
+| Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionB) |
+| Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
 | Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(Exception) |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionB) |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | semmle.label | false |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(Exception) |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionB) |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | semmle.label | false |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:211:13:211:29 | ...; | semmle.label | false |
-| Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | throw ...; | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
 | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; | semmle.label | successor |
 | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; | semmle.label | successor |
 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; | semmle.label | successor |
@@ -2430,8 +2554,8 @@
 | Finally.cs:211:13:211:16 | [finally: exception(ExceptionA)] this access | Finally.cs:211:26:211:28 | [finally: exception(ExceptionA)] "0" | semmle.label | successor |
 | Finally.cs:211:13:211:16 | this access | Finally.cs:211:26:211:28 | "0" | semmle.label | successor |
 | Finally.cs:211:13:211:28 | ... = ... | Finally.cs:213:9:213:25 | ...; | semmle.label | successor |
-| Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(Exception) |
-| Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... | Finally.cs:195:10:195:12 | exit M10 | semmle.label | exception(ExceptionA) |
+| Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionA) |
 | Finally.cs:211:13:211:29 | ...; | Finally.cs:211:13:211:16 | this access | semmle.label | successor |
 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access | semmle.label | successor |
 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:211:13:211:16 | [finally: exception(ExceptionA)] this access | semmle.label | successor |
@@ -2439,10 +2563,11 @@
 | Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" | Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... | semmle.label | successor |
 | Finally.cs:211:26:211:28 | [finally: exception(ExceptionA)] "0" | Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... | semmle.label | successor |
 | Finally.cs:213:9:213:12 | this access | Finally.cs:213:22:213:24 | "1" | semmle.label | successor |
-| Finally.cs:213:9:213:24 | ... = ... | Finally.cs:195:10:195:12 | exit M10 | semmle.label | successor |
+| Finally.cs:213:9:213:24 | ... = ... | Finally.cs:195:10:195:12 | exit M10 (normal) | semmle.label | successor |
 | Finally.cs:213:9:213:25 | ...; | Finally.cs:213:9:213:12 | this access | semmle.label | successor |
 | Finally.cs:213:22:213:24 | "1" | Finally.cs:213:9:213:24 | ... = ... | semmle.label | successor |
 | Finally.cs:216:10:216:12 | enter M11 | Finally.cs:217:5:231:5 | {...} | semmle.label | successor |
+| Finally.cs:216:10:216:12 | exit M11 (normal) | Finally.cs:216:10:216:12 | exit M11 | semmle.label | successor |
 | Finally.cs:217:5:231:5 | {...} | Finally.cs:218:9:229:9 | try {...} ... | semmle.label | successor |
 | Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:219:9:221:9 | {...} | semmle.label | successor |
 | Finally.cs:219:9:221:9 | {...} | Finally.cs:220:13:220:37 | ...; | semmle.label | successor |
@@ -2460,26 +2585,29 @@
 | Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:230:9:230:34 | ...; | semmle.label | successor |
 | Finally.cs:228:13:228:41 | ...; | Finally.cs:228:31:228:39 | "Finally" | semmle.label | successor |
 | Finally.cs:228:31:228:39 | "Finally" | Finally.cs:228:13:228:40 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | exit M11 | semmle.label | successor |
+| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | exit M11 (normal) | semmle.label | successor |
 | Finally.cs:230:9:230:34 | ...; | Finally.cs:230:27:230:32 | "Done" | semmle.label | successor |
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:33 | call to method WriteLine | semmle.label | successor |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:7:5:10:5 | {...} | semmle.label | successor |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 | semmle.label | successor |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:8:29:8:32 | access to parameter args | semmle.label | successor |
-| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 | semmle.label | empty |
+| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 (normal) | semmle.label | empty |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:22:8:24 | String arg | semmle.label | non-empty |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:9:13:9:13 | ; | semmle.label | successor |
 | Foreach.cs:8:29:8:32 | access to parameter args | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:9:13:9:13 | ; | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:13:5:16:5 | {...} | semmle.label | successor |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | exit M2 | semmle.label | successor |
 | Foreach.cs:13:5:16:5 | {...} | Foreach.cs:14:27:14:30 | access to parameter args | semmle.label | successor |
-| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 | semmle.label | empty |
+| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 (normal) | semmle.label | empty |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:22:14:22 | String _ | semmle.label | non-empty |
 | Foreach.cs:14:22:14:22 | String _ | Foreach.cs:15:13:15:13 | ; | semmle.label | successor |
 | Foreach.cs:14:27:14:30 | access to parameter args | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:15:13:15:13 | ; | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:19:5:22:5 | {...} | semmle.label | successor |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 | semmle.label | successor |
 | Foreach.cs:19:5:22:5 | {...} | Foreach.cs:20:27:20:68 | ... ?? ... | semmle.label | successor |
-| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 | semmle.label | empty |
+| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 (normal) | semmle.label | empty |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x | semmle.label | non-empty |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:21:11:21:11 | ; | semmle.label | successor |
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:29:20:38 | call to method ToArray | semmle.label | non-null |
@@ -2490,8 +2618,9 @@
 | Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:21:11:21:11 | ; | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:25:5:28:5 | {...} | semmle.label | successor |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | exit M4 | semmle.label | successor |
 | Foreach.cs:25:5:28:5 | {...} | Foreach.cs:26:36:26:39 | access to parameter args | semmle.label | successor |
-| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | exit M4 | semmle.label | empty |
+| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | exit M4 (normal) | semmle.label | empty |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:23:26:23 | String x | semmle.label | non-empty |
 | Foreach.cs:26:18:26:31 | (..., ...) | Foreach.cs:27:11:27:11 | ; | semmle.label | successor |
 | Foreach.cs:26:23:26:23 | String x | Foreach.cs:26:30:26:30 | Int32 y | semmle.label | successor |
@@ -2499,8 +2628,9 @@
 | Foreach.cs:26:36:26:39 | access to parameter args | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:27:11:27:11 | ; | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:31:5:34:5 | {...} | semmle.label | successor |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:30:10:30:11 | exit M5 | semmle.label | successor |
 | Foreach.cs:31:5:34:5 | {...} | Foreach.cs:32:32:32:35 | access to parameter args | semmle.label | successor |
-| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | exit M5 | semmle.label | empty |
+| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | exit M5 (normal) | semmle.label | empty |
 | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:23:32:23 | String x | semmle.label | non-empty |
 | Foreach.cs:32:18:32:27 | (..., ...) | Foreach.cs:33:11:33:11 | ; | semmle.label | successor |
 | Foreach.cs:32:23:32:23 | String x | Foreach.cs:32:26:32:26 | Int32 y | semmle.label | successor |
@@ -2508,8 +2638,9 @@
 | Foreach.cs:32:32:32:35 | access to parameter args | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:33:11:33:11 | ; | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:37:5:40:5 | {...} | semmle.label | successor |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | exit M6 | semmle.label | successor |
 | Foreach.cs:37:5:40:5 | {...} | Foreach.cs:38:39:38:42 | access to parameter args | semmle.label | successor |
-| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 | semmle.label | empty |
+| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 (normal) | semmle.label | empty |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:26:38:26 | String x | semmle.label | non-empty |
 | Foreach.cs:38:18:38:34 | (..., ...) | Foreach.cs:39:11:39:11 | ; | semmle.label | successor |
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:38:33:38:33 | Int32 y | semmle.label | successor |
@@ -2539,10 +2670,13 @@
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... | semmle.label | successor |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... | semmle.label | successor |
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access | semmle.label | successor |
-| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | exit Initializers | semmle.label | successor |
+| Initializers.cs:8:5:8:16 | exit Initializers (normal) | Initializers.cs:8:5:8:16 | exit Initializers | semmle.label | successor |
+| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | exit Initializers (normal) | semmle.label | successor |
 | Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access | semmle.label | successor |
-| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | exit Initializers | semmle.label | successor |
+| Initializers.cs:10:5:10:16 | exit Initializers (normal) | Initializers.cs:10:5:10:16 | exit Initializers | semmle.label | successor |
+| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | exit Initializers (normal) | semmle.label | successor |
 | Initializers.cs:12:10:12:10 | enter M | Initializers.cs:13:5:16:5 | {...} | semmle.label | successor |
+| Initializers.cs:12:10:12:10 | exit M (normal) | Initializers.cs:12:10:12:10 | exit M | semmle.label | successor |
 | Initializers.cs:13:5:16:5 | {...} | Initializers.cs:14:9:14:54 | ... ...; | semmle.label | successor |
 | Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:14:34:14:35 | "" | semmle.label | successor |
 | Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:15:9:15:64 | ... ...; | semmle.label | successor |
@@ -2555,7 +2689,7 @@
 | Initializers.cs:14:47:14:51 | ... = ... | Initializers.cs:14:38:14:53 | { ..., ... } | semmle.label | successor |
 | Initializers.cs:14:51:14:51 | 1 | Initializers.cs:14:47:14:47 | access to property G | semmle.label | successor |
 | Initializers.cs:15:9:15:64 | ... ...; | Initializers.cs:15:18:15:63 | 2 | semmle.label | successor |
-| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:12:10:12:10 | exit M | semmle.label | successor |
+| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:12:10:12:10 | exit M (normal) | semmle.label | successor |
 | Initializers.cs:15:18:15:63 | 2 | Initializers.cs:15:18:15:63 | array creation of type Initializers[] | semmle.label | successor |
 | Initializers.cs:15:18:15:63 | array creation of type Initializers[] | Initializers.cs:15:39:15:39 | access to local variable i | semmle.label | successor |
 | Initializers.cs:15:37:15:63 | { ..., ... } | Initializers.cs:15:13:15:63 | Initializers[] iz = ... | semmle.label | successor |
@@ -2564,6 +2698,7 @@
 | Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:42:15:61 | object creation of type Initializers | semmle.label | successor |
 | Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... | semmle.label | successor |
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:22:23:22:23 | this access | semmle.label | successor |
+| Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:20:11:20:23 | exit NoConstructor | semmle.label | successor |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 | semmle.label | successor |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 | semmle.label | successor |
 | Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access | semmle.label | successor |
@@ -2572,7 +2707,7 @@
 | Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... | semmle.label | successor |
 | Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 | semmle.label | successor |
 | Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 | semmle.label | successor |
-| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | exit NoConstructor | semmle.label | successor |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | semmle.label | successor |
 | Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:28:13:28:13 | this access | semmle.label | successor |
 | Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... | semmle.label | successor |
 | Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... | semmle.label | successor |
@@ -2583,28 +2718,32 @@
 | Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... | semmle.label | successor |
 | Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... | semmle.label | successor |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:17:31:20 | call to constructor NoConstructor | semmle.label | successor |
+| Initializers.cs:31:9:31:11 | exit Sub (normal) | Initializers.cs:31:9:31:11 | exit Sub | semmle.label | successor |
 | Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:28:13:28:13 | this access | semmle.label | successor |
 | Initializers.cs:31:24:31:33 | {...} | Initializers.cs:31:26:31:31 | ...; | semmle.label | successor |
 | Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:30:31:30 | 3 | semmle.label | successor |
-| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:9:31:11 | exit Sub | semmle.label | successor |
+| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:9:31:11 | exit Sub (normal) | semmle.label | successor |
 | Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:26:31:26 | this access | semmle.label | successor |
 | Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:26:31:30 | ... = ... | semmle.label | successor |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:22:33:25 | call to constructor Sub | semmle.label | successor |
+| Initializers.cs:33:9:33:11 | exit Sub (normal) | Initializers.cs:33:9:33:11 | exit Sub | semmle.label | successor |
 | Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:29:33:38 | {...} | semmle.label | successor |
 | Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:31:33:36 | ...; | semmle.label | successor |
 | Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:35:33:35 | access to parameter i | semmle.label | successor |
-| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub | semmle.label | successor |
+| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub (normal) | semmle.label | successor |
 | Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:31 | this access | semmle.label | successor |
 | Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:35 | ... = ... | semmle.label | successor |
 | Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:22:23:22:23 | this access | semmle.label | successor |
+| Initializers.cs:35:9:35:11 | exit Sub (normal) | Initializers.cs:35:9:35:11 | exit Sub | semmle.label | successor |
 | Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:29:35:38 | ...; | semmle.label | successor |
 | Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:33:35:33 | access to parameter i | semmle.label | successor |
-| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:9:35:11 | exit Sub | semmle.label | successor |
+| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:9:35:11 | exit Sub (normal) | semmle.label | successor |
 | Initializers.cs:35:29:35:38 | ...; | Initializers.cs:35:29:35:29 | this access | semmle.label | successor |
 | Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:37:35:37 | access to parameter j | semmle.label | successor |
 | Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:29:35:37 | ... = ... | semmle.label | successor |
 | Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:33:35:37 | ... + ... | semmle.label | successor |
 | Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:52:5:66:5 | {...} | semmle.label | successor |
+| Initializers.cs:51:10:51:13 | exit Test (normal) | Initializers.cs:51:10:51:13 | exit Test | semmle.label | successor |
 | Initializers.cs:52:5:66:5 | {...} | Initializers.cs:54:9:54:96 | ... ...; | semmle.label | successor |
 | Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | semmle.label | successor |
 | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:57:9:65:10 | ... ...; | semmle.label | successor |
@@ -2625,7 +2764,7 @@
 | Initializers.cs:54:84:54:84 | 2 | Initializers.cs:54:80:54:84 | ... + ... | semmle.label | successor |
 | Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:79:54:85 | access to indexer | semmle.label | successor |
 | Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:24:65:9 | object creation of type Compound | semmle.label | successor |
-| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | exit Test | semmle.label | successor |
+| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | exit Test (normal) | semmle.label | successor |
 | Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:59:34:59:34 | 0 | semmle.label | successor |
 | Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:57:13:65:9 | Compound compound = ... | semmle.label | successor |
 | Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:60:37:60:37 | 3 | semmle.label | successor |
@@ -2708,6 +2847,7 @@
 | Initializers.cs:64:54:64:54 | 0 | Initializers.cs:64:50:64:54 | ... + ... | semmle.label | successor |
 | Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:46:64:61 | ... = ... | semmle.label | successor |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:8:5:13:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | exit M1 | semmle.label | successor |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:9:9:10:19 | if (...) ... | semmle.label | successor |
 | LoopUnrolling.cs:9:9:10:19 | if (...) ... | LoopUnrolling.cs:9:13:9:16 | access to parameter args | semmle.label | successor |
 | LoopUnrolling.cs:9:13:9:16 | access to parameter args | LoopUnrolling.cs:9:13:9:23 | access to property Length | semmle.label | successor |
@@ -2715,9 +2855,9 @@
 | LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:10:13:10:19 | return ...; | semmle.label | true |
 | LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:11:29:11:32 | access to parameter args | semmle.label | false |
 | LoopUnrolling.cs:9:28:9:28 | 0 | LoopUnrolling.cs:9:13:9:28 | ... == ... | semmle.label | successor |
-| LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:7:10:7:11 | exit M1 | semmle.label | return |
+| LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | semmle.label | return |
 | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | LoopUnrolling.cs:11:22:11:24 | String arg | semmle.label | non-empty |
-| LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:7:10:7:11 | exit M1 | semmle.label | empty |
+| LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:11:22:11:24 | String arg | semmle.label | non-empty |
 | LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:12:13:12:35 | ...; | semmle.label | successor |
 | LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | semmle.label | successor |
@@ -2725,6 +2865,7 @@
 | LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | semmle.label | successor |
 | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | semmle.label | successor |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:16:5:20:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:15:10:15:11 | exit M2 | semmle.label | successor |
 | LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:17:9:17:48 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:17:18:17:47 | 3 | semmle.label | successor |
 | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:18:27:18:28 | access to local variable xs | semmle.label | successor |
@@ -2735,7 +2876,7 @@
 | LoopUnrolling.cs:17:38:17:40 | "b" | LoopUnrolling.cs:17:43:17:45 | "c" | semmle.label | successor |
 | LoopUnrolling.cs:17:43:17:45 | "c" | LoopUnrolling.cs:17:31:17:47 | { ..., ... } | semmle.label | successor |
 | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:18:22:18:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:15:10:15:11 | exit M2 | semmle.label | empty |
+| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:18:22:18:22 | String x | semmle.label | non-empty |
 | LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:19:13:19:33 | ...; | semmle.label | successor |
 | LoopUnrolling.cs:18:27:18:28 | access to local variable xs | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | semmle.label | successor |
@@ -2743,8 +2884,9 @@
 | LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:19:31:19:31 | access to local variable x | semmle.label | successor |
 | LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | semmle.label | successor |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:23:5:27:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:22:10:22:11 | exit M3 | semmle.label | successor |
 | LoopUnrolling.cs:23:5:27:5 | {...} | LoopUnrolling.cs:24:29:24:32 | access to parameter args | semmle.label | successor |
-| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 | semmle.label | empty |
+| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:22:24:24 | Char arg | semmle.label | non-empty |
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:34:25:37 | access to parameter args | semmle.label | successor |
 | LoopUnrolling.cs:24:29:24:32 | access to parameter args | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | semmle.label | successor |
@@ -2757,14 +2899,16 @@
 | LoopUnrolling.cs:26:17:26:40 | ...; | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 | semmle.label | successor |
 | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 | LoopUnrolling.cs:26:17:26:39 | call to method WriteLine | semmle.label | successor |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:30:5:34:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) | LoopUnrolling.cs:29:10:29:11 | exit M4 | semmle.label | successor |
 | LoopUnrolling.cs:30:5:34:5 | {...} | LoopUnrolling.cs:31:9:31:31 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:31:9:31:31 | ... ...; | LoopUnrolling.cs:31:29:31:29 | 0 | semmle.label | successor |
 | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | semmle.label | successor |
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | semmle.label | successor |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 | semmle.label | empty |
+| LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:37:5:43:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:36:10:36:11 | exit M5 | semmle.label | successor |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:38:9:38:48 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:38:18:38:47 | 3 | semmle.label | successor |
 | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:39:9:39:48 | ... ...; | semmle.label | successor |
@@ -2783,7 +2927,7 @@
 | LoopUnrolling.cs:39:38:39:40 | "1" | LoopUnrolling.cs:39:43:39:45 | "2" | semmle.label | successor |
 | LoopUnrolling.cs:39:43:39:45 | "2" | LoopUnrolling.cs:39:31:39:47 | { ..., ... } | semmle.label | successor |
 | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 | semmle.label | empty |
+| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x | semmle.label | non-empty |
 | LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:31:41:32 | access to local variable ys | semmle.label | successor |
 | LoopUnrolling.cs:40:27:40:28 | access to local variable xs | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | semmle.label | successor |
@@ -2817,6 +2961,7 @@
 | LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | semmle.label | successor |
 | LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:50:9:50:13 | Label: | semmle.label | goto(Label) |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:56:5:65:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:55:10:55:11 | exit M7 | semmle.label | successor |
 | LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:57:9:57:48 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:57:18:57:47 | 3 | semmle.label | successor |
 | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:58:27:58:28 | access to local variable xs | semmle.label | successor |
@@ -2826,9 +2971,9 @@
 | LoopUnrolling.cs:57:33:57:35 | "a" | LoopUnrolling.cs:57:38:57:40 | "b" | semmle.label | successor |
 | LoopUnrolling.cs:57:38:57:40 | "b" | LoopUnrolling.cs:57:43:57:45 | "c" | semmle.label | successor |
 | LoopUnrolling.cs:57:43:57:45 | "c" | LoopUnrolling.cs:57:31:57:47 | { ..., ... } | semmle.label | successor |
-| LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | exit M7 | semmle.label | empty |
+| LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | semmle.label | non-empty |
-| LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | exit M7 | semmle.label | empty |
+| LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | semmle.label | non-empty |
 | LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | String x | semmle.label | non-empty |
 | LoopUnrolling.cs:58:22:58:22 | String x | LoopUnrolling.cs:59:9:64:9 | {...} | semmle.label | successor |
@@ -2856,37 +3001,41 @@
 | LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; | LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x | semmle.label | successor |
 | LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x | LoopUnrolling.cs:63:17:63:36 | [b (line 55): true] call to method WriteLine | semmle.label | successor |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:68:5:74:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 | semmle.label | successor |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:69:9:70:19 | if (...) ... | semmle.label | successor |
 | LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:13:69:23 | !... | semmle.label | successor |
 | LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:14:69:17 | access to parameter args | semmle.label | successor |
 | LoopUnrolling.cs:69:14:69:17 | access to parameter args | LoopUnrolling.cs:69:14:69:23 | call to method Any | semmle.label | successor |
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:70:13:70:19 | return ...; | semmle.label | false |
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:71:9:71:21 | ...; | semmle.label | true |
-| LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | exit M8 | semmle.label | return |
+| LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | semmle.label | return |
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear | semmle.label | successor |
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:29:72:32 | access to parameter args | semmle.label | successor |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:12 | access to parameter args | semmle.label | successor |
-| LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | exit M8 | semmle.label | empty |
+| LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:77:5:83:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) | LoopUnrolling.cs:76:10:76:11 | exit M9 | semmle.label | successor |
 | LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:78:9:78:34 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:78:29:78:29 | 2 | semmle.label | successor |
 | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | semmle.label | successor |
 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | semmle.label | successor |
 | LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:32:78:32 | 0 | semmle.label | successor |
 | LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | semmle.label | successor |
-| LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 | semmle.label | empty |
+| LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:86:5:92:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) | LoopUnrolling.cs:85:10:85:12 | exit M10 | semmle.label | successor |
 | LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:87:9:87:34 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:87:29:87:29 | 0 | semmle.label | successor |
 | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | semmle.label | successor |
 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | semmle.label | successor |
 | LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:32:87:32 | 2 | semmle.label | successor |
 | LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | semmle.label | successor |
-| LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 | semmle.label | empty |
+| LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:95:5:101:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:94:10:94:12 | exit M11 | semmle.label | successor |
 | LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:96:9:96:34 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:96:29:96:29 | 2 | semmle.label | successor |
 | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:97:27:97:28 | access to local variable xs | semmle.label | successor |
@@ -2894,7 +3043,7 @@
 | LoopUnrolling.cs:96:29:96:29 | 2 | LoopUnrolling.cs:96:32:96:32 | 2 | semmle.label | successor |
 | LoopUnrolling.cs:96:32:96:32 | 2 | LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | semmle.label | successor |
 | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | LoopUnrolling.cs:97:22:97:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:94:10:94:12 | exit M11 | semmle.label | empty |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | semmle.label | empty |
 | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:97:22:97:22 | String x | semmle.label | non-empty |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:98:9:100:9 | {...} | semmle.label | successor |
 | LoopUnrolling.cs:97:27:97:28 | access to local variable xs | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | semmle.label | successor |
@@ -2904,25 +3053,41 @@
 | LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | semmle.label | successor |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:28:6:31 | null | semmle.label | successor |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 | semmle.label | successor |
-| MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | successor |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | semmle.label | successor |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | successor |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | semmle.label | successor |
+| MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:22:6:31 | throw ... | semmle.label | successor |
 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationA.cs:7:25:7:39 | {...} | semmle.label | successor |
 | MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationB.cs:4:25:4:37 | {...} | semmle.label | successor |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | semmle.label | successor |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | semmle.label | successor |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | semmle.label | successor |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | semmle.label | successor |
 | MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationA.cs:7:33:7:36 | null | semmle.label | successor |
-| MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationA.cs:7:33:7:36 | null | MultiImplementationA.cs:7:27:7:37 | throw ...; | semmle.label | successor |
 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationA.cs:7:45:7:59 | {...} | semmle.label | successor |
 | MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} | semmle.label | successor |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | semmle.label | successor |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | semmle.label | successor |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | semmle.label | successor |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | semmle.label | successor |
 | MultiImplementationA.cs:7:45:7:59 | {...} | MultiImplementationA.cs:7:53:7:56 | null | semmle.label | successor |
-| MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationA.cs:7:53:7:56 | null | MultiImplementationA.cs:7:47:7:57 | throw ...; | semmle.label | successor |
 | MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationA.cs:8:29:8:32 | null | semmle.label | successor |
 | MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationB.cs:5:23:5:23 | 2 | semmle.label | successor |
-| MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationA.cs:8:16:8:16 | exit M | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationB.cs:5:16:5:16 | exit M | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | MultiImplementationA.cs:8:16:8:16 | exit M | semmle.label | successor |
+| MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | MultiImplementationB.cs:5:16:5:16 | exit M | semmle.label | successor |
+| MultiImplementationA.cs:8:16:8:16 | exit M (normal) | MultiImplementationA.cs:8:16:8:16 | exit M | semmle.label | successor |
+| MultiImplementationA.cs:8:16:8:16 | exit M (normal) | MultiImplementationB.cs:5:16:5:16 | exit M | semmle.label | successor |
+| MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationA.cs:8:29:8:32 | null | MultiImplementationA.cs:8:23:8:32 | throw ... | semmle.label | successor |
 | MultiImplementationA.cs:13:16:13:16 | this access | MultiImplementationA.cs:13:20:13:20 | 0 | semmle.label | successor |
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | MultiImplementationA.cs:13:16:13:16 | this access | semmle.label | successor |
@@ -2930,50 +3095,77 @@
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | MultiImplementationB.cs:11:16:11:16 | this access | semmle.label | successor |
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | MultiImplementationB.cs:22:16:22:16 | this access | semmle.label | successor |
 | MultiImplementationA.cs:13:20:13:20 | 0 | MultiImplementationA.cs:13:16:13:20 | ... = ... | semmle.label | successor |
-| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationA.cs:14:31:14:31 | exit get_Item | semmle.label | successor |
-| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationB.cs:12:31:12:40 | exit get_Item | semmle.label | successor |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | semmle.label | successor |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) | semmle.label | successor |
 | MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i | semmle.label | successor |
 | MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationB.cs:12:37:12:40 | null | semmle.label | successor |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | MultiImplementationA.cs:14:31:14:31 | exit get_Item | semmle.label | successor |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | MultiImplementationB.cs:12:31:12:40 | exit get_Item | semmle.label | successor |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | MultiImplementationA.cs:14:31:14:31 | exit get_Item | semmle.label | successor |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | MultiImplementationB.cs:12:31:12:40 | exit get_Item | semmle.label | successor |
 | MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationA.cs:15:40:15:52 | {...} | semmle.label | successor |
 | MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationB.cs:13:40:13:54 | {...} | semmle.label | successor |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | MultiImplementationA.cs:15:36:15:38 | exit get_Item | semmle.label | successor |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | MultiImplementationB.cs:13:36:13:38 | exit get_Item | semmle.label | successor |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | MultiImplementationA.cs:15:36:15:38 | exit get_Item | semmle.label | successor |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | MultiImplementationB.cs:13:36:13:38 | exit get_Item | semmle.label | successor |
 | MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:49:15:49 | access to parameter s | semmle.label | successor |
-| MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationA.cs:15:36:15:38 | exit get_Item | semmle.label | return |
-| MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationB.cs:13:36:13:38 | exit get_Item | semmle.label | return |
+| MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | semmle.label | return |
+| MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) | semmle.label | return |
 | MultiImplementationA.cs:15:49:15:49 | access to parameter s | MultiImplementationA.cs:15:42:15:50 | return ...; | semmle.label | successor |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:58:15:60 | {...} | semmle.label | successor |
 | MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:60:13:62 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationA.cs:15:54:15:56 | exit set_Item | semmle.label | successor |
-| MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationB.cs:13:56:13:58 | exit set_Item | semmle.label | successor |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item | semmle.label | successor |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item | semmle.label | successor |
+| MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | semmle.label | successor |
+| MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | semmle.label | successor |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:17:5:19:5 | {...} | semmle.label | successor |
 | MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:15:5:17:5 | {...} | semmle.label | successor |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 | semmle.label | successor |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 | semmle.label | successor |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:18:9:18:22 | M2(...) | semmle.label | successor |
-| MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationA.cs:16:17:16:18 | exit M1 | semmle.label | successor |
-| MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationB.cs:14:17:14:18 | exit M1 | semmle.label | successor |
+| MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | semmle.label | successor |
+| MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | semmle.label | successor |
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:21:18:21 | 0 | semmle.label | successor |
-| MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | exit M2 | semmle.label | successor |
+| MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | MultiImplementationA.cs:18:9:18:22 | exit M2 | semmle.label | successor |
+| MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | semmle.label | successor |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access | semmle.label | successor |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:11:16:11:16 | this access | semmle.label | successor |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:24:20:29 | ...; | semmle.label | successor |
 | MultiImplementationA.cs:20:24:20:24 | this access | MultiImplementationA.cs:20:28:20:28 | access to parameter i | semmle.label | successor |
-| MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
-| MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
+| MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | semmle.label | successor |
+| MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | semmle.label | successor |
 | MultiImplementationA.cs:20:24:20:29 | ...; | MultiImplementationA.cs:20:24:20:24 | this access | semmle.label | successor |
 | MultiImplementationA.cs:20:28:20:28 | access to parameter i | MultiImplementationA.cs:20:24:20:28 | ... = ... | semmle.label | successor |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:24:21:24 | 0 | semmle.label | successor |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:24:19:24 | 1 | semmle.label | successor |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 | semmle.label | successor |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 | semmle.label | successor |
 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | MultiImplementationA.cs:21:27:21:29 | {...} | semmle.label | successor |
 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | MultiImplementationB.cs:19:27:19:29 | {...} | semmle.label | successor |
 | MultiImplementationA.cs:21:24:21:24 | 0 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | semmle.label | successor |
-| MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationA.cs:21:12:21:13 | exit C2 | semmle.label | successor |
-| MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationB.cs:19:12:19:13 | exit C2 | semmle.label | successor |
+| MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | semmle.label | successor |
+| MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | semmle.label | successor |
 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} | semmle.label | successor |
 | MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationB.cs:20:11:20:25 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | semmle.label | successor |
-| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | semmle.label | successor |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | semmle.label | successor |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | semmle.label | successor |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | semmle.label | successor |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | semmle.label | successor |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | semmle.label | successor |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) | semmle.label | successor |
 | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationA.cs:23:50:23:53 | null | semmle.label | successor |
 | MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationB.cs:21:56:21:59 | null | semmle.label | successor |
-| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | semmle.label | successor |
-| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | semmle.label | successor |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | semmle.label | successor |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | semmle.label | successor |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | semmle.label | successor |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | semmle.label | successor |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | semmle.label | successor |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) | semmle.label | successor |
 | MultiImplementationA.cs:24:16:24:16 | access to property P | MultiImplementationA.cs:24:32:24:34 | ... = ... | semmle.label | successor |
 | MultiImplementationA.cs:24:16:24:16 | this access | MultiImplementationA.cs:24:34:24:34 | 0 | semmle.label | successor |
 | MultiImplementationA.cs:24:32:24:34 | ... = ... | MultiImplementationA.cs:20:22:20:31 | {...} | semmle.label | successor |
@@ -2982,37 +3174,60 @@
 | MultiImplementationA.cs:24:32:24:34 | ... = ... | MultiImplementationB.cs:22:16:22:16 | this access | semmle.label | successor |
 | MultiImplementationA.cs:24:34:24:34 | 0 | MultiImplementationA.cs:24:16:24:16 | access to property P | semmle.label | successor |
 | MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationA.cs:30:34:30:37 | null | semmle.label | successor |
-| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | semmle.label | successor |
+| MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | semmle.label | successor |
+| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationA.cs:30:34:30:37 | null | MultiImplementationA.cs:30:28:30:37 | throw ... | semmle.label | successor |
 | MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationA.cs:36:14:36:28 | {...} | semmle.label | successor |
 | MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationB.cs:32:17:32:17 | 0 | semmle.label | successor |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | MultiImplementationA.cs:36:9:36:10 | exit M1 | semmle.label | successor |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | successor |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | MultiImplementationA.cs:36:9:36:10 | exit M1 | semmle.label | successor |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | successor |
 | MultiImplementationA.cs:36:14:36:28 | {...} | MultiImplementationA.cs:36:22:36:25 | null | semmle.label | successor |
-| MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationA.cs:36:9:36:10 | exit M1 | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationA.cs:36:22:36:25 | null | MultiImplementationA.cs:36:16:36:26 | throw ...; | semmle.label | successor |
 | MultiImplementationA.cs:37:9:37:10 | enter M2 | MultiImplementationA.cs:37:14:37:28 | {...} | semmle.label | successor |
+| MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) | MultiImplementationA.cs:37:9:37:10 | exit M2 | semmle.label | successor |
 | MultiImplementationA.cs:37:14:37:28 | {...} | MultiImplementationA.cs:37:22:37:25 | null | semmle.label | successor |
-| MultiImplementationA.cs:37:16:37:26 | throw ...; | MultiImplementationA.cs:37:9:37:10 | exit M2 | semmle.label | exception(NullReferenceException) |
+| MultiImplementationA.cs:37:16:37:26 | throw ...; | MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationA.cs:37:22:37:25 | null | MultiImplementationA.cs:37:16:37:26 | throw ...; | semmle.label | successor |
-| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | successor |
-| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | semmle.label | successor |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | semmle.label | successor |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) | semmle.label | successor |
 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationA.cs:6:28:6:31 | null | semmle.label | successor |
 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 | semmle.label | successor |
+| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | successor |
+| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | semmle.label | successor |
+| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | successor |
+| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | semmle.label | successor |
 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationA.cs:7:25:7:39 | {...} | semmle.label | successor |
 | MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationB.cs:4:25:4:37 | {...} | semmle.label | successor |
+| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | semmle.label | successor |
+| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | semmle.label | successor |
+| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | semmle.label | successor |
+| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | semmle.label | successor |
 | MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationB.cs:4:34:4:34 | 1 | semmle.label | successor |
-| MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | semmle.label | return |
-| MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | semmle.label | return |
+| MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | semmle.label | return |
+| MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) | semmle.label | return |
 | MultiImplementationB.cs:4:34:4:34 | 1 | MultiImplementationB.cs:4:27:4:35 | return ...; | semmle.label | successor |
 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationA.cs:7:45:7:59 | {...} | semmle.label | successor |
 | MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | semmle.label | successor |
-| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | semmle.label | successor |
+| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | semmle.label | successor |
+| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | semmle.label | successor |
+| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | semmle.label | successor |
+| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | semmle.label | successor |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | semmle.label | successor |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) | semmle.label | successor |
 | MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationA.cs:8:29:8:32 | null | semmle.label | successor |
 | MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationB.cs:5:23:5:23 | 2 | semmle.label | successor |
-| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationA.cs:8:16:8:16 | exit M | semmle.label | successor |
-| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationB.cs:5:16:5:16 | exit M | semmle.label | successor |
+| MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) | MultiImplementationA.cs:8:16:8:16 | exit M | semmle.label | successor |
+| MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) | MultiImplementationB.cs:5:16:5:16 | exit M | semmle.label | successor |
+| MultiImplementationB.cs:5:16:5:16 | exit M (normal) | MultiImplementationA.cs:8:16:8:16 | exit M | semmle.label | successor |
+| MultiImplementationB.cs:5:16:5:16 | exit M (normal) | MultiImplementationB.cs:5:16:5:16 | exit M | semmle.label | successor |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationA.cs:8:16:8:16 | exit M (normal) | semmle.label | successor |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationB.cs:5:16:5:16 | exit M (normal) | semmle.label | successor |
 | MultiImplementationB.cs:11:16:11:16 | this access | MultiImplementationB.cs:11:20:11:20 | 1 | semmle.label | successor |
 | MultiImplementationB.cs:11:16:11:20 | ... = ... | MultiImplementationA.cs:13:16:13:16 | this access | semmle.label | successor |
 | MultiImplementationB.cs:11:16:11:20 | ... = ... | MultiImplementationA.cs:24:16:24:16 | this access | semmle.label | successor |
@@ -3021,50 +3236,77 @@
 | MultiImplementationB.cs:11:20:11:20 | 1 | MultiImplementationB.cs:11:16:11:20 | ... = ... | semmle.label | successor |
 | MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i | semmle.label | successor |
 | MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationB.cs:12:37:12:40 | null | semmle.label | successor |
-| MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationA.cs:14:31:14:31 | exit get_Item | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationB.cs:12:31:12:40 | exit get_Item | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) | MultiImplementationA.cs:14:31:14:31 | exit get_Item | semmle.label | successor |
+| MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) | MultiImplementationB.cs:12:31:12:40 | exit get_Item | semmle.label | successor |
+| MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) | MultiImplementationA.cs:14:31:14:31 | exit get_Item | semmle.label | successor |
+| MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) | MultiImplementationB.cs:12:31:12:40 | exit get_Item | semmle.label | successor |
+| MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationB.cs:12:37:12:40 | null | MultiImplementationB.cs:12:31:12:40 | throw ... | semmle.label | successor |
 | MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationA.cs:15:40:15:52 | {...} | semmle.label | successor |
 | MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationB.cs:13:40:13:54 | {...} | semmle.label | successor |
+| MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) | MultiImplementationA.cs:15:36:15:38 | exit get_Item | semmle.label | successor |
+| MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) | MultiImplementationB.cs:13:36:13:38 | exit get_Item | semmle.label | successor |
+| MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) | MultiImplementationA.cs:15:36:15:38 | exit get_Item | semmle.label | successor |
+| MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) | MultiImplementationB.cs:13:36:13:38 | exit get_Item | semmle.label | successor |
 | MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationB.cs:13:48:13:51 | null | semmle.label | successor |
-| MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationA.cs:15:36:15:38 | exit get_Item | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationB.cs:13:36:13:38 | exit get_Item | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationB.cs:13:48:13:51 | null | MultiImplementationB.cs:13:42:13:52 | throw ...; | semmle.label | successor |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationA.cs:15:58:15:60 | {...} | semmle.label | successor |
 | MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:60:13:62 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationA.cs:15:54:15:56 | exit set_Item | semmle.label | successor |
-| MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationB.cs:13:56:13:58 | exit set_Item | semmle.label | successor |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item | semmle.label | successor |
+| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item | semmle.label | successor |
+| MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | semmle.label | successor |
+| MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | semmle.label | successor |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:17:5:19:5 | {...} | semmle.label | successor |
 | MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:15:5:17:5 | {...} | semmle.label | successor |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 | semmle.label | successor |
+| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 | semmle.label | successor |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:16:9:16:31 | M2(...) | semmle.label | successor |
-| MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationA.cs:16:17:16:18 | exit M1 | semmle.label | successor |
-| MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationB.cs:14:17:14:18 | exit M1 | semmle.label | successor |
+| MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | semmle.label | successor |
+| MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | semmle.label | successor |
 | MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:27:16:30 | null | semmle.label | successor |
-| MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:9:16:31 | exit M2 | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | MultiImplementationB.cs:16:9:16:31 | exit M2 | semmle.label | successor |
+| MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:21:16:30 | throw ... | semmle.label | successor |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access | semmle.label | successor |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:11:16:11:16 | this access | semmle.label | successor |
+| MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
+| MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
+| MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
+| MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
 | MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:30:18:33 | null | semmle.label | successor |
-| MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationB.cs:18:30:18:33 | null | MultiImplementationB.cs:18:24:18:34 | throw ...; | semmle.label | successor |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:24:21:24 | 0 | semmle.label | successor |
 | MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:24:19:24 | 1 | semmle.label | successor |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 | semmle.label | successor |
+| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 | semmle.label | successor |
 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | MultiImplementationA.cs:21:27:21:29 | {...} | semmle.label | successor |
 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | MultiImplementationB.cs:19:27:19:29 | {...} | semmle.label | successor |
 | MultiImplementationB.cs:19:24:19:24 | 1 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | semmle.label | successor |
-| MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationA.cs:21:12:21:13 | exit C2 | semmle.label | successor |
-| MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationB.cs:19:12:19:13 | exit C2 | semmle.label | successor |
+| MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | semmle.label | successor |
+| MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | semmle.label | successor |
 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} | semmle.label | successor |
 | MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationB.cs:20:11:20:25 | {...} | semmle.label | successor |
+| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | semmle.label | successor |
+| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | semmle.label | successor |
+| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | semmle.label | successor |
+| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | semmle.label | successor |
 | MultiImplementationB.cs:20:11:20:25 | {...} | MultiImplementationB.cs:20:19:20:22 | null | semmle.label | successor |
-| MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationB.cs:20:19:20:22 | null | MultiImplementationB.cs:20:13:20:23 | throw ...; | semmle.label | successor |
 | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationA.cs:23:50:23:53 | null | semmle.label | successor |
 | MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationB.cs:21:56:21:59 | null | semmle.label | successor |
-| MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | semmle.label | successor |
+| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | semmle.label | successor |
+| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | semmle.label | successor |
+| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | semmle.label | successor |
+| MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | semmle.label | exception(NullReferenceException) |
+| MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationB.cs:21:56:21:59 | null | MultiImplementationB.cs:21:50:21:59 | throw ... | semmle.label | successor |
 | MultiImplementationB.cs:22:16:22:16 | access to property P | MultiImplementationB.cs:22:32:22:34 | ... = ... | semmle.label | successor |
 | MultiImplementationB.cs:22:16:22:16 | this access | MultiImplementationB.cs:22:34:22:34 | 1 | semmle.label | successor |
@@ -3074,44 +3316,55 @@
 | MultiImplementationB.cs:22:32:22:34 | ... = ... | MultiImplementationB.cs:22:16:22:16 | this access | semmle.label | successor |
 | MultiImplementationB.cs:22:34:22:34 | 1 | MultiImplementationB.cs:22:16:22:16 | access to property P | semmle.label | successor |
 | MultiImplementationB.cs:27:21:27:23 | enter get_P3 | MultiImplementationA.cs:30:34:30:37 | null | semmle.label | successor |
+| MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | semmle.label | successor |
+| MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | semmle.label | successor |
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationA.cs:36:14:36:28 | {...} | semmle.label | successor |
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationB.cs:32:17:32:17 | 0 | semmle.label | successor |
-| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | exit M1 | semmle.label | successor |
-| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | successor |
+| MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) | MultiImplementationA.cs:36:9:36:10 | exit M1 | semmle.label | successor |
+| MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | successor |
+| MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | MultiImplementationA.cs:36:9:36:10 | exit M1 | semmle.label | successor |
+| MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | successor |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | semmle.label | successor |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | semmle.label | successor |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:28 | ... ?? ... | semmle.label | successor |
-| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:9:3:10 | exit M1 | semmle.label | non-null |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 | semmle.label | successor |
+| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | semmle.label | non-null |
 | NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:28:3:28 | 0 | semmle.label | null |
 | NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:23 | access to parameter i | semmle.label | successor |
-| NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:9:3:10 | exit M1 | semmle.label | successor |
+| NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | semmle.label | successor |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | semmle.label | successor |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 | semmle.label | successor |
 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:25:5:34 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:30:5:34 | false | semmle.label | null |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:39:5:39 | 0 | semmle.label | true |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:43:5:43 | 1 | semmle.label | false |
 | NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:25:5:25 | access to parameter b | semmle.label | successor |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:43:5:43 | 1 | semmle.label | false |
-| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:9:5:10 | exit M2 | semmle.label | successor |
-| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:9:5:10 | exit M2 | semmle.label | successor |
+| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | semmle.label | successor |
+| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | semmle.label | successor |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:53 | ... ?? ... | semmle.label | successor |
-| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:12:7:13 | exit M3 | semmle.label | non-null |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 | semmle.label | successor |
+| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | semmle.label | non-null |
 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | semmle.label | null |
 | NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | semmle.label | successor |
-| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:12:7:13 | exit M3 | semmle.label | non-null |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | semmle.label | non-null |
 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:52:7:53 | "" | semmle.label | null |
 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | semmle.label | successor |
-| NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:12:7:13 | exit M3 | semmle.label | successor |
+| NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | semmle.label | successor |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:36:9:58 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 | semmle.label | successor |
 | NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | semmle.label | successor |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:41:9:41 | access to parameter s | semmle.label | true |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:45:9:45 | access to parameter s | semmle.label | false |
 | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:37:9:37 | access to parameter b | semmle.label | successor |
-| NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:12:9:13 | exit M4 | semmle.label | non-null |
+| NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | semmle.label | non-null |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:51:9:58 | ... ?? ... | semmle.label | null |
-| NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:12:9:13 | exit M4 | semmle.label | non-null |
+| NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | semmle.label | non-null |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:51:9:58 | ... ?? ... | semmle.label | null |
-| NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:12:9:13 | exit M4 | semmle.label | non-null |
+| NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | semmle.label | non-null |
 | NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:52 | "" | semmle.label | successor |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | semmle.label | successor |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 | semmle.label | successor |
 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:44:11:59 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:51:11:58 | ... && ... | semmle.label | null |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:64:11:64 | 0 | semmle.label | true |
@@ -3122,9 +3375,10 @@
 | NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | semmle.label | successor |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:64:11:64 | 0 | semmle.label | true |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:68:11:68 | 1 | semmle.label | false |
-| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:9:11:10 | exit M5 | semmle.label | successor |
-| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:9:11:10 | exit M5 | semmle.label | successor |
+| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | semmle.label | successor |
+| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | semmle.label | successor |
 | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:14:5:18:5 | {...} | semmle.label | successor |
+| NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | NullCoalescing.cs:13:10:13:11 | exit M6 | semmle.label | successor |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:15:9:15:32 | ... ...; | semmle.label | successor |
 | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:17:15:31 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:16:9:16:26 | ... ...; | semmle.label | successor |
@@ -3136,12 +3390,13 @@
 | NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:17:9:17:25 | ...; | semmle.label | successor |
 | NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:13:16:25 | String s = ... | semmle.label | non-null |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" | semmle.label | successor |
-| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:13:10:13:11 | exit M6 | semmle.label | successor |
+| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | semmle.label | successor |
 | NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:13:17:24 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:9:17:24 | ... = ... | semmle.label | non-null |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:19:17:19 | access to parameter i | semmle.label | successor |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... | semmle.label | successor |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:6:5:43:5 | {...} | semmle.label | successor |
+| Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:5:10:5:13 | exit Test | semmle.label | successor |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:7:9:7:24 | ... ...; | semmle.label | successor |
 | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:20:7:23 | null | semmle.label | successor |
 | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:8:9:18:9 | if (...) ... | semmle.label | successor |
@@ -3221,41 +3476,48 @@
 | Patterns.cs:36:35:36:50 | "Something else" | Patterns.cs:36:17:36:51 | call to method WriteLine | semmle.label | successor |
 | Patterns.cs:37:17:37:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | semmle.label | break |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o | semmle.label | successor |
-| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | exit Test | semmle.label | successor |
+| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | exit Test (normal) | semmle.label | successor |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:6:5:8:5 | {...} | semmle.label | successor |
+| PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | exit M1 | semmle.label | successor |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:29 | ...; | semmle.label | successor |
-| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:5:10:5:11 | exit M1 | semmle.label | successor |
+| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:5:10:5:11 | exit M1 (normal) | semmle.label | successor |
 | PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:27:7:27 | access to parameter s | semmle.label | successor |
 | PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:7:9:7:28 | call to method WriteLine | semmle.label | successor |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:11:5:15:5 | {...} | semmle.label | successor |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 | semmle.label | successor |
 | PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:12:9:13:19 | if (...) ... | semmle.label | successor |
 | PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:12:13:12:13 | access to parameter s | semmle.label | successor |
 | PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:18:12:21 | null | semmle.label | successor |
 | PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:13:13:13:19 | return ...; | semmle.label | true |
 | PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:14:9:14:29 | ...; | semmle.label | false |
 | PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | ... is ... | semmle.label | successor |
-| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | exit M2 | semmle.label | return |
-| PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:10:10:10:11 | exit M2 | semmle.label | successor |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
+| PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:10:10:10:11 | exit M2 (normal) | semmle.label | successor |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:27:14:27 | access to parameter s | semmle.label | successor |
 | PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:9:14:28 | call to method WriteLine | semmle.label | successor |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:18:5:22:5 | {...} | semmle.label | successor |
+| PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | PostDominance.cs:17:10:17:11 | exit M3 | semmle.label | successor |
+| PostDominance.cs:17:10:17:11 | exit M3 (normal) | PostDominance.cs:17:10:17:11 | exit M3 | semmle.label | successor |
 | PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:19:9:20:55 | if (...) ... | semmle.label | successor |
 | PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:19:13:19:13 | access to parameter s | semmle.label | successor |
 | PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:18:19:21 | null | semmle.label | successor |
 | PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | semmle.label | true |
 | PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:21:9:21:29 | ...; | semmle.label | false |
 | PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | ... is ... | semmle.label | successor |
-| PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:17:10:17:11 | exit M3 | semmle.label | exception(ArgumentNullException) |
+| PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | semmle.label | exception(ArgumentNullException) |
 | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:13:20:55 | throw ...; | semmle.label | successor |
 | PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | semmle.label | successor |
-| PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:17:10:17:11 | exit M3 | semmle.label | successor |
+| PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:17:10:17:11 | exit M3 (normal) | semmle.label | successor |
 | PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:27:21:27 | access to parameter s | semmle.label | successor |
 | PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:9:21:28 | call to method WriteLine | semmle.label | successor |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:28:7:31 | null | semmle.label | successor |
-| Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | exit Method | semmle.label | successor |
+| Qualifiers.cs:7:16:7:21 | exit Method (normal) | Qualifiers.cs:7:16:7:21 | exit Method | semmle.label | successor |
+| Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | exit Method (normal) | semmle.label | successor |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:41:8:44 | null | semmle.label | successor |
-| Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:23:8:34 | exit StaticMethod | semmle.label | successor |
+| Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) | Qualifiers.cs:8:23:8:34 | exit StaticMethod | semmle.label | successor |
+| Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) | semmle.label | successor |
 | Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:11:5:31:5 | {...} | semmle.label | successor |
+| Qualifiers.cs:10:10:10:10 | exit M (normal) | Qualifiers.cs:10:10:10:10 | exit M | semmle.label | successor |
 | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:12:9:12:22 | ... ...; | semmle.label | successor |
 | Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:17:12:21 | this access | semmle.label | successor |
 | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:13:9:13:21 | ...; | semmle.label | successor |
@@ -3307,26 +3569,29 @@
 | Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:13:29:46 | access to property Property | semmle.label | successor |
 | Qualifiers.cs:29:13:29:46 | access to property Property | Qualifiers.cs:29:9:29:46 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:10:10:10:10 | exit M | semmle.label | successor |
+| Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:10:10:10:10 | exit M (normal) | semmle.label | successor |
 | Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:13:30:46 | call to method Method | semmle.label | successor |
 | Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:30:9:30:46 | ... = ... | semmle.label | successor |
 | Switch.cs:5:10:5:11 | enter M1 | Switch.cs:6:5:8:5 | {...} | semmle.label | successor |
+| Switch.cs:5:10:5:11 | exit M1 (normal) | Switch.cs:5:10:5:11 | exit M1 | semmle.label | successor |
 | Switch.cs:6:5:8:5 | {...} | Switch.cs:7:9:7:22 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:7:9:7:22 | switch (...) {...} | Switch.cs:7:17:7:17 | access to parameter o | semmle.label | successor |
-| Switch.cs:7:17:7:17 | access to parameter o | Switch.cs:5:10:5:11 | exit M1 | semmle.label | successor |
+| Switch.cs:7:17:7:17 | access to parameter o | Switch.cs:5:10:5:11 | exit M1 (normal) | semmle.label | successor |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:11:5:33:5 | {...} | semmle.label | successor |
+| Switch.cs:10:10:10:11 | exit M2 (abnormal) | Switch.cs:10:10:10:11 | exit M2 | semmle.label | successor |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:10:10:10:11 | exit M2 | semmle.label | successor |
 | Switch.cs:11:5:33:5 | {...} | Switch.cs:12:9:32:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:12:9:32:9 | switch (...) {...} | Switch.cs:12:17:12:17 | access to parameter o | semmle.label | successor |
 | Switch.cs:12:17:12:17 | access to parameter o | Switch.cs:14:13:14:21 | case ...: | semmle.label | successor |
 | Switch.cs:14:13:14:21 | case ...: | Switch.cs:14:18:14:20 | "a" | semmle.label | successor |
 | Switch.cs:14:18:14:20 | "a" | Switch.cs:15:17:15:23 | return ...; | semmle.label | match |
 | Switch.cs:14:18:14:20 | "a" | Switch.cs:16:13:16:19 | case ...: | semmle.label | no-match |
-| Switch.cs:15:17:15:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 | semmle.label | return |
+| Switch.cs:15:17:15:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:18:16:18 | 0 | semmle.label | successor |
 | Switch.cs:16:18:16:18 | 0 | Switch.cs:17:23:17:37 | object creation of type Exception | semmle.label | match |
 | Switch.cs:16:18:16:18 | 0 | Switch.cs:18:13:18:22 | case ...: | semmle.label | no-match |
-| Switch.cs:17:17:17:38 | throw ...; | Switch.cs:10:10:10:11 | exit M2 | semmle.label | exception(Exception) |
+| Switch.cs:17:17:17:38 | throw ...; | Switch.cs:10:10:10:11 | exit M2 (abnormal) | semmle.label | exception(Exception) |
 | Switch.cs:17:23:17:37 | object creation of type Exception | Switch.cs:17:17:17:38 | throw ...; | semmle.label | successor |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:18:18:18:21 | null | semmle.label | successor |
 | Switch.cs:18:18:18:21 | null | Switch.cs:19:17:19:29 | goto default; | semmle.label | match |
@@ -3340,7 +3605,7 @@
 | Switch.cs:21:21:21:29 | ... == ... | Switch.cs:22:21:22:27 | return ...; | semmle.label | true |
 | Switch.cs:21:21:21:29 | ... == ... | Switch.cs:23:27:23:27 | 0 | semmle.label | false |
 | Switch.cs:21:26:21:29 | null | Switch.cs:21:21:21:29 | ... == ... | semmle.label | successor |
-| Switch.cs:22:21:22:27 | return ...; | Switch.cs:10:10:10:11 | exit M2 | semmle.label | return |
+| Switch.cs:22:21:22:27 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
 | Switch.cs:23:17:23:28 | goto case ...; | Switch.cs:16:13:16:19 | case ...: | semmle.label | goto(0) |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:23:17:23:28 | goto case ...; | semmle.label | successor |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:18:24:25 | String s | semmle.label | successor |
@@ -3359,36 +3624,39 @@
 | Switch.cs:25:17:25:36 | call to method WriteLine | Switch.cs:26:17:26:23 | return ...; | semmle.label | successor |
 | Switch.cs:25:17:25:37 | ...; | Switch.cs:25:35:25:35 | access to local variable s | semmle.label | successor |
 | Switch.cs:25:35:25:35 | access to local variable s | Switch.cs:25:17:25:36 | call to method WriteLine | semmle.label | successor |
-| Switch.cs:26:17:26:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 | semmle.label | return |
+| Switch.cs:26:17:26:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | Double d | semmle.label | successor |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:27:32:27:38 | call to method Throw | semmle.label | match |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:30:13:30:20 | default: | semmle.label | no-match |
-| Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:10:10:10:11 | exit M2 | semmle.label | exception(Exception) |
+| Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:10:10:10:11 | exit M2 (abnormal) | semmle.label | exception(Exception) |
 | Switch.cs:28:13:28:17 | Label: | Switch.cs:29:17:29:23 | return ...; | semmle.label | successor |
-| Switch.cs:29:17:29:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 | semmle.label | return |
+| Switch.cs:29:17:29:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:31:17:31:27 | goto ...; | semmle.label | successor |
 | Switch.cs:31:17:31:27 | goto ...; | Switch.cs:28:13:28:17 | Label: | semmle.label | goto(Label) |
 | Switch.cs:35:10:35:11 | enter M3 | Switch.cs:36:5:42:5 | {...} | semmle.label | successor |
+| Switch.cs:35:10:35:11 | exit M3 (abnormal) | Switch.cs:35:10:35:11 | exit M3 | semmle.label | successor |
 | Switch.cs:36:5:42:5 | {...} | Switch.cs:37:9:41:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:37:9:41:9 | switch (...) {...} | Switch.cs:37:17:37:23 | call to method Throw | semmle.label | successor |
-| Switch.cs:37:17:37:23 | call to method Throw | Switch.cs:35:10:35:11 | exit M3 | semmle.label | exception(Exception) |
+| Switch.cs:37:17:37:23 | call to method Throw | Switch.cs:35:10:35:11 | exit M3 (abnormal) | semmle.label | exception(Exception) |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:45:5:53:5 | {...} | semmle.label | successor |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:44:10:44:11 | exit M4 | semmle.label | successor |
 | Switch.cs:45:5:53:5 | {...} | Switch.cs:46:9:52:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:46:17:46:17 | access to parameter o | semmle.label | successor |
 | Switch.cs:46:17:46:17 | access to parameter o | Switch.cs:48:13:48:23 | case ...: | semmle.label | successor |
 | Switch.cs:48:13:48:23 | case ...: | Switch.cs:48:18:48:20 | access to type Int32 | semmle.label | successor |
 | Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:49:17:49:22 | break; | semmle.label | match |
 | Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:50:13:50:39 | case ...: | semmle.label | no-match |
-| Switch.cs:49:17:49:22 | break; | Switch.cs:44:10:44:11 | exit M4 | semmle.label | break |
+| Switch.cs:49:17:49:22 | break; | Switch.cs:44:10:44:11 | exit M4 (normal) | semmle.label | break |
 | Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:18:50:21 | access to type Boolean | semmle.label | successor |
-| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:44:10:44:11 | exit M4 | semmle.label | no-match |
+| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:44:10:44:11 | exit M4 (normal) | semmle.label | no-match |
 | Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:30:50:30 | access to parameter o | semmle.label | match |
 | Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:50:35:50:38 | null | semmle.label | successor |
-| Switch.cs:50:30:50:38 | ... != ... | Switch.cs:44:10:44:11 | exit M4 | semmle.label | false |
+| Switch.cs:50:30:50:38 | ... != ... | Switch.cs:44:10:44:11 | exit M4 (normal) | semmle.label | false |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:51:17:51:22 | break; | semmle.label | true |
 | Switch.cs:50:35:50:38 | null | Switch.cs:50:30:50:38 | ... != ... | semmle.label | successor |
-| Switch.cs:51:17:51:22 | break; | Switch.cs:44:10:44:11 | exit M4 | semmle.label | break |
+| Switch.cs:51:17:51:22 | break; | Switch.cs:44:10:44:11 | exit M4 (normal) | semmle.label | break |
 | Switch.cs:55:10:55:11 | enter M5 | Switch.cs:56:5:64:5 | {...} | semmle.label | successor |
+| Switch.cs:55:10:55:11 | exit M5 (normal) | Switch.cs:55:10:55:11 | exit M5 | semmle.label | successor |
 | Switch.cs:56:5:64:5 | {...} | Switch.cs:57:9:63:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:57:17:57:17 | 1 | semmle.label | successor |
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:57:21:57:21 | 2 | semmle.label | successor |
@@ -3398,8 +3666,9 @@
 | Switch.cs:59:18:59:18 | 2 | Switch.cs:61:13:61:19 | case ...: | semmle.label | no-match |
 | Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:18:61:18 | 3 | semmle.label | successor |
 | Switch.cs:61:18:61:18 | 3 | Switch.cs:62:17:62:22 | break; | semmle.label | match |
-| Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | exit M5 | semmle.label | break |
+| Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | exit M5 (normal) | semmle.label | break |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:67:5:75:5 | {...} | semmle.label | successor |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:66:10:66:11 | exit M6 | semmle.label | successor |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:68:9:74:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:68:25:68:25 | access to parameter s | semmle.label | successor |
 | Switch.cs:68:17:68:25 | (...) ... | Switch.cs:70:13:70:23 | case ...: | semmle.label | successor |
@@ -3407,17 +3676,18 @@
 | Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 | semmle.label | successor |
 | Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:72:13:72:20 | case ...: | semmle.label | no-match |
 | Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:18:72:19 | "" | semmle.label | successor |
-| Switch.cs:72:18:72:19 | "" | Switch.cs:66:10:66:11 | exit M6 | semmle.label | no-match |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:66:10:66:11 | exit M6 (normal) | semmle.label | no-match |
 | Switch.cs:72:18:72:19 | "" | Switch.cs:73:17:73:22 | break; | semmle.label | match |
-| Switch.cs:73:17:73:22 | break; | Switch.cs:66:10:66:11 | exit M6 | semmle.label | break |
+| Switch.cs:73:17:73:22 | break; | Switch.cs:66:10:66:11 | exit M6 (normal) | semmle.label | break |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:78:5:89:5 | {...} | semmle.label | successor |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:77:10:77:11 | exit M7 | semmle.label | successor |
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:79:9:87:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:79:17:79:17 | access to parameter i | semmle.label | successor |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:81:13:81:19 | case ...: | semmle.label | successor |
 | Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:18:81:18 | 1 | semmle.label | successor |
 | Switch.cs:81:18:81:18 | 1 | Switch.cs:82:24:82:27 | true | semmle.label | match |
 | Switch.cs:81:18:81:18 | 1 | Switch.cs:83:13:83:19 | case ...: | semmle.label | no-match |
-| Switch.cs:82:17:82:28 | return ...; | Switch.cs:77:10:77:11 | exit M7 | semmle.label | return |
+| Switch.cs:82:17:82:28 | return ...; | Switch.cs:77:10:77:11 | exit M7 (normal) | semmle.label | return |
 | Switch.cs:82:24:82:27 | true | Switch.cs:82:17:82:28 | return ...; | semmle.label | successor |
 | Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:18:83:18 | 2 | semmle.label | successor |
 | Switch.cs:83:18:83:18 | 2 | Switch.cs:84:17:85:26 | if (...) ... | semmle.label | match |
@@ -3428,22 +3698,24 @@
 | Switch.cs:84:21:84:25 | ... > ... | Switch.cs:86:24:86:27 | true | semmle.label | false |
 | Switch.cs:84:25:84:25 | 2 | Switch.cs:84:21:84:25 | ... > ... | semmle.label | successor |
 | Switch.cs:85:21:85:26 | break; | Switch.cs:88:16:88:20 | false | semmle.label | break |
-| Switch.cs:86:17:86:28 | return ...; | Switch.cs:77:10:77:11 | exit M7 | semmle.label | return |
+| Switch.cs:86:17:86:28 | return ...; | Switch.cs:77:10:77:11 | exit M7 (normal) | semmle.label | return |
 | Switch.cs:86:24:86:27 | true | Switch.cs:86:17:86:28 | return ...; | semmle.label | successor |
-| Switch.cs:88:9:88:21 | return ...; | Switch.cs:77:10:77:11 | exit M7 | semmle.label | return |
+| Switch.cs:88:9:88:21 | return ...; | Switch.cs:77:10:77:11 | exit M7 (normal) | semmle.label | return |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:9:88:21 | return ...; | semmle.label | successor |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:92:5:99:5 | {...} | semmle.label | successor |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:91:10:91:11 | exit M8 | semmle.label | successor |
 | Switch.cs:92:5:99:5 | {...} | Switch.cs:93:9:97:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:93:17:93:17 | access to parameter o | semmle.label | successor |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:95:13:95:23 | case ...: | semmle.label | successor |
 | Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 | semmle.label | successor |
 | Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:96:24:96:27 | true | semmle.label | match |
 | Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:98:16:98:20 | false | semmle.label | no-match |
-| Switch.cs:96:17:96:28 | return ...; | Switch.cs:91:10:91:11 | exit M8 | semmle.label | return |
+| Switch.cs:96:17:96:28 | return ...; | Switch.cs:91:10:91:11 | exit M8 (normal) | semmle.label | return |
 | Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | return ...; | semmle.label | successor |
-| Switch.cs:98:9:98:21 | return ...; | Switch.cs:91:10:91:11 | exit M8 | semmle.label | return |
+| Switch.cs:98:9:98:21 | return ...; | Switch.cs:91:10:91:11 | exit M8 (normal) | semmle.label | return |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:9:98:21 | return ...; | semmle.label | successor |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:102:5:109:5 | {...} | semmle.label | successor |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:101:9:101:10 | exit M9 | semmle.label | successor |
 | Switch.cs:102:5:109:5 | {...} | Switch.cs:103:9:107:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:103:17:103:17 | access to parameter s | semmle.label | successor |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:19:103:25 | access to property Length | semmle.label | non-null |
@@ -3452,20 +3724,22 @@
 | Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:18:105:18 | 0 | semmle.label | successor |
 | Switch.cs:105:18:105:18 | 0 | Switch.cs:105:28:105:28 | 0 | semmle.label | match |
 | Switch.cs:105:18:105:18 | 0 | Switch.cs:106:13:106:19 | case ...: | semmle.label | no-match |
-| Switch.cs:105:21:105:29 | return ...; | Switch.cs:101:9:101:10 | exit M9 | semmle.label | return |
+| Switch.cs:105:21:105:29 | return ...; | Switch.cs:101:9:101:10 | exit M9 (normal) | semmle.label | return |
 | Switch.cs:105:28:105:28 | 0 | Switch.cs:105:21:105:29 | return ...; | semmle.label | successor |
 | Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:18:106:18 | 1 | semmle.label | successor |
 | Switch.cs:106:18:106:18 | 1 | Switch.cs:106:28:106:28 | 1 | semmle.label | match |
 | Switch.cs:106:18:106:18 | 1 | Switch.cs:108:17:108:17 | 1 | semmle.label | no-match |
-| Switch.cs:106:21:106:29 | return ...; | Switch.cs:101:9:101:10 | exit M9 | semmle.label | return |
+| Switch.cs:106:21:106:29 | return ...; | Switch.cs:101:9:101:10 | exit M9 (normal) | semmle.label | return |
 | Switch.cs:106:28:106:28 | 1 | Switch.cs:106:21:106:29 | return ...; | semmle.label | successor |
-| Switch.cs:108:9:108:18 | return ...; | Switch.cs:101:9:101:10 | exit M9 | semmle.label | return |
+| Switch.cs:108:9:108:18 | return ...; | Switch.cs:101:9:101:10 | exit M9 (normal) | semmle.label | return |
 | Switch.cs:108:16:108:17 | -... | Switch.cs:108:9:108:18 | return ...; | semmle.label | successor |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:16:108:17 | -... | semmle.label | successor |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:34:111:48 | object creation of type Exception | semmle.label | successor |
-| Switch.cs:111:28:111:48 | throw ... | Switch.cs:111:17:111:21 | exit Throw | semmle.label | exception(Exception) |
+| Switch.cs:111:17:111:21 | exit Throw (abnormal) | Switch.cs:111:17:111:21 | exit Throw | semmle.label | successor |
+| Switch.cs:111:28:111:48 | throw ... | Switch.cs:111:17:111:21 | exit Throw (abnormal) | semmle.label | exception(Exception) |
 | Switch.cs:111:34:111:48 | object creation of type Exception | Switch.cs:111:28:111:48 | throw ... | semmle.label | successor |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:114:5:121:5 | {...} | semmle.label | successor |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:113:9:113:11 | exit M10 | semmle.label | successor |
 | Switch.cs:114:5:121:5 | {...} | Switch.cs:115:9:119:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:115:17:115:17 | access to parameter s | semmle.label | successor |
 | Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:115:17:115:24 | access to property Length | semmle.label | successor |
@@ -3477,7 +3751,7 @@
 | Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:44:117:44 | 1 | semmle.label | true |
 | Switch.cs:117:25:117:34 | ... == ... | Switch.cs:118:13:118:34 | case ...: | semmle.label | false |
 | Switch.cs:117:30:117:34 | "foo" | Switch.cs:117:25:117:34 | ... == ... | semmle.label | successor |
-| Switch.cs:117:37:117:45 | return ...; | Switch.cs:113:9:113:11 | exit M10 | semmle.label | return |
+| Switch.cs:117:37:117:45 | return ...; | Switch.cs:113:9:113:11 | exit M10 (normal) | semmle.label | return |
 | Switch.cs:117:44:117:44 | 1 | Switch.cs:117:37:117:45 | return ...; | semmle.label | successor |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 | semmle.label | successor |
 | Switch.cs:118:18:118:18 | 2 | Switch.cs:118:25:118:25 | access to parameter s | semmle.label | match |
@@ -3486,12 +3760,13 @@
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:43:118:43 | 2 | semmle.label | true |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:120:17:120:17 | 1 | semmle.label | false |
 | Switch.cs:118:30:118:33 | "fu" | Switch.cs:118:25:118:33 | ... == ... | semmle.label | successor |
-| Switch.cs:118:36:118:44 | return ...; | Switch.cs:113:9:113:11 | exit M10 | semmle.label | return |
+| Switch.cs:118:36:118:44 | return ...; | Switch.cs:113:9:113:11 | exit M10 (normal) | semmle.label | return |
 | Switch.cs:118:43:118:43 | 2 | Switch.cs:118:36:118:44 | return ...; | semmle.label | successor |
-| Switch.cs:120:9:120:18 | return ...; | Switch.cs:113:9:113:11 | exit M10 | semmle.label | return |
+| Switch.cs:120:9:120:18 | return ...; | Switch.cs:113:9:113:11 | exit M10 (normal) | semmle.label | return |
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:9:120:18 | return ...; | semmle.label | successor |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:16:120:17 | -... | semmle.label | successor |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:124:5:127:5 | {...} | semmle.label | successor |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 | semmle.label | successor |
 | Switch.cs:124:5:127:5 | {...} | Switch.cs:125:9:126:19 | if (...) ... | semmle.label | successor |
 | Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:13:125:48 | ... switch { ... } | semmle.label | successor |
 | Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:24:125:34 | ... => ... | semmle.label | successor |
@@ -3499,15 +3774,16 @@
 | Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:34:125:34 | access to local variable b | semmle.label | match |
 | Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:37:125:46 | ... => ... | semmle.label | no-match |
 | Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:29 | Boolean b | semmle.label | successor |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | exit M11 | semmle.label | false |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | exit M11 (normal) | semmle.label | false |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:126:13:126:19 | return ...; | semmle.label | true |
 | Switch.cs:125:37:125:37 | _ | Switch.cs:125:42:125:46 | false | semmle.label | match |
 | Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:37 | _ | semmle.label | successor |
-| Switch.cs:125:42:125:46 | false | Switch.cs:123:10:123:12 | exit M11 | semmle.label | false |
-| Switch.cs:126:13:126:19 | return ...; | Switch.cs:123:10:123:12 | exit M11 | semmle.label | return |
+| Switch.cs:125:42:125:46 | false | Switch.cs:123:10:123:12 | exit M11 (normal) | semmle.label | false |
+| Switch.cs:126:13:126:19 | return ...; | Switch.cs:123:10:123:12 | exit M11 (normal) | semmle.label | return |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:130:5:132:5 | {...} | semmle.label | successor |
+| Switch.cs:129:12:129:14 | exit M12 (normal) | Switch.cs:129:12:129:14 | exit M12 | semmle.label | successor |
 | Switch.cs:130:5:132:5 | {...} | Switch.cs:131:17:131:53 | ... switch { ... } | semmle.label | successor |
-| Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 | semmle.label | return |
+| Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 (normal) | semmle.label | return |
 | Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:28:131:40 | ... => ... | semmle.label | successor |
 | Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:17:131:17 | access to parameter o | semmle.label | successor |
 | Switch.cs:131:28:131:35 | String s | Switch.cs:131:40:131:40 | access to local variable s | semmle.label | match |
@@ -3520,42 +3796,46 @@
 | Switch.cs:131:48:131:51 | null | Switch.cs:131:9:131:67 | return ...; | semmle.label | null |
 | Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:9:131:67 | return ...; | semmle.label | successor |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:135:5:142:5 | {...} | semmle.label | successor |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 | semmle.label | successor |
 | Switch.cs:135:5:142:5 | {...} | Switch.cs:136:9:141:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:136:9:141:9 | switch (...) {...} | Switch.cs:136:17:136:17 | access to parameter i | semmle.label | successor |
 | Switch.cs:136:17:136:17 | access to parameter i | Switch.cs:139:13:139:19 | case ...: | semmle.label | successor |
 | Switch.cs:138:13:138:20 | default: | Switch.cs:138:30:138:30 | 1 | semmle.label | successor |
-| Switch.cs:138:22:138:31 | return ...; | Switch.cs:134:9:134:11 | exit M13 | semmle.label | return |
+| Switch.cs:138:22:138:31 | return ...; | Switch.cs:134:9:134:11 | exit M13 (normal) | semmle.label | return |
 | Switch.cs:138:29:138:30 | -... | Switch.cs:138:22:138:31 | return ...; | semmle.label | successor |
 | Switch.cs:138:30:138:30 | 1 | Switch.cs:138:29:138:30 | -... | semmle.label | successor |
 | Switch.cs:139:13:139:19 | case ...: | Switch.cs:139:18:139:18 | 1 | semmle.label | successor |
 | Switch.cs:139:18:139:18 | 1 | Switch.cs:139:28:139:28 | 1 | semmle.label | match |
 | Switch.cs:139:18:139:18 | 1 | Switch.cs:140:13:140:19 | case ...: | semmle.label | no-match |
-| Switch.cs:139:21:139:29 | return ...; | Switch.cs:134:9:134:11 | exit M13 | semmle.label | return |
+| Switch.cs:139:21:139:29 | return ...; | Switch.cs:134:9:134:11 | exit M13 (normal) | semmle.label | return |
 | Switch.cs:139:28:139:28 | 1 | Switch.cs:139:21:139:29 | return ...; | semmle.label | successor |
 | Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:18:140:18 | 2 | semmle.label | successor |
 | Switch.cs:140:18:140:18 | 2 | Switch.cs:138:13:138:20 | default: | semmle.label | no-match |
 | Switch.cs:140:18:140:18 | 2 | Switch.cs:140:28:140:28 | 2 | semmle.label | match |
-| Switch.cs:140:21:140:29 | return ...; | Switch.cs:134:9:134:11 | exit M13 | semmle.label | return |
+| Switch.cs:140:21:140:29 | return ...; | Switch.cs:134:9:134:11 | exit M13 (normal) | semmle.label | return |
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:140:21:140:29 | return ...; | semmle.label | successor |
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:145:5:152:5 | {...} | semmle.label | successor |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:144:9:144:11 | exit M14 | semmle.label | successor |
 | Switch.cs:145:5:152:5 | {...} | Switch.cs:146:9:151:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:146:9:151:9 | switch (...) {...} | Switch.cs:146:17:146:17 | access to parameter i | semmle.label | successor |
 | Switch.cs:146:17:146:17 | access to parameter i | Switch.cs:148:13:148:19 | case ...: | semmle.label | successor |
 | Switch.cs:148:13:148:19 | case ...: | Switch.cs:148:18:148:18 | 1 | semmle.label | successor |
 | Switch.cs:148:18:148:18 | 1 | Switch.cs:148:28:148:28 | 1 | semmle.label | match |
 | Switch.cs:148:18:148:18 | 1 | Switch.cs:150:13:150:19 | case ...: | semmle.label | no-match |
-| Switch.cs:148:21:148:29 | return ...; | Switch.cs:144:9:144:11 | exit M14 | semmle.label | return |
+| Switch.cs:148:21:148:29 | return ...; | Switch.cs:144:9:144:11 | exit M14 (normal) | semmle.label | return |
 | Switch.cs:148:28:148:28 | 1 | Switch.cs:148:21:148:29 | return ...; | semmle.label | successor |
 | Switch.cs:149:13:149:20 | default: | Switch.cs:149:30:149:30 | 1 | semmle.label | successor |
-| Switch.cs:149:22:149:31 | return ...; | Switch.cs:144:9:144:11 | exit M14 | semmle.label | return |
+| Switch.cs:149:22:149:31 | return ...; | Switch.cs:144:9:144:11 | exit M14 (normal) | semmle.label | return |
 | Switch.cs:149:29:149:30 | -... | Switch.cs:149:22:149:31 | return ...; | semmle.label | successor |
 | Switch.cs:149:30:149:30 | 1 | Switch.cs:149:29:149:30 | -... | semmle.label | successor |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:18:150:18 | 2 | semmle.label | successor |
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:149:13:149:20 | default: | semmle.label | no-match |
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:150:28:150:28 | 2 | semmle.label | match |
-| Switch.cs:150:21:150:29 | return ...; | Switch.cs:144:9:144:11 | exit M14 | semmle.label | return |
+| Switch.cs:150:21:150:29 | return ...; | Switch.cs:144:9:144:11 | exit M14 (normal) | semmle.label | return |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; | semmle.label | successor |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:155:5:161:5 | {...} | semmle.label | successor |
+| Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | exit M15 | semmle.label | successor |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | exit M15 | semmle.label | successor |
 | Switch.cs:155:5:161:5 | {...} | Switch.cs:156:9:156:55 | ... ...; | semmle.label | successor |
 | Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:17:156:54 | ... switch { ... } | semmle.label | successor |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:157:9:160:49 | if (...) ... | semmle.label | successor |
@@ -3565,24 +3845,25 @@
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:41:156:52 | ... => ... | semmle.label | no-match |
 | Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true | semmle.label | successor |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:156:13:156:54 | String s = ... | semmle.label | successor |
-| Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | exit M15 | semmle.label | exception(InvalidOperationException) |
+| Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | exit M15 (abnormal) | semmle.label | exception(InvalidOperationException) |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" | semmle.label | match |
 | Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false | semmle.label | successor |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:13:156:54 | String s = ... | semmle.label | successor |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:13:157:13 | access to parameter b | semmle.label | successor |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; | semmle.label | true |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; | semmle.label | false |
-| Switch.cs:158:13:158:48 | call to method WriteLine | Switch.cs:154:10:154:12 | exit M15 | semmle.label | successor |
+| Switch.cs:158:13:158:48 | call to method WriteLine | Switch.cs:154:10:154:12 | exit M15 (normal) | semmle.label | successor |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:40:158:43 | "a = " | semmle.label | successor |
 | Switch.cs:158:38:158:47 | $"..." | Switch.cs:158:13:158:48 | call to method WriteLine | semmle.label | successor |
 | Switch.cs:158:40:158:43 | "a = " | Switch.cs:158:45:158:45 | access to local variable s | semmle.label | successor |
 | Switch.cs:158:45:158:45 | access to local variable s | Switch.cs:158:38:158:47 | $"..." | semmle.label | successor |
-| Switch.cs:160:13:160:48 | call to method WriteLine | Switch.cs:154:10:154:12 | exit M15 | semmle.label | successor |
+| Switch.cs:160:13:160:48 | call to method WriteLine | Switch.cs:154:10:154:12 | exit M15 (normal) | semmle.label | successor |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:40:160:43 | "b = " | semmle.label | successor |
 | Switch.cs:160:38:160:47 | $"..." | Switch.cs:160:13:160:48 | call to method WriteLine | semmle.label | successor |
 | Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:45:160:45 | access to local variable s | semmle.label | successor |
 | Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:38:160:47 | $"..." | semmle.label | successor |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:4:5:9:5 | {...} | semmle.label | successor |
+| TypeAccesses.cs:3:10:3:10 | exit M (normal) | TypeAccesses.cs:3:10:3:10 | exit M | semmle.label | successor |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:5:9:5:26 | ... ...; | semmle.label | successor |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:25:5:25 | access to parameter o | semmle.label | successor |
 | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:6:9:6:24 | ...; | semmle.label | successor |
@@ -3599,9 +3880,10 @@
 | TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | ... is ... | semmle.label | successor |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:8:9:8:28 | ... ...; | semmle.label | successor |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:17:8:27 | typeof(...) | semmle.label | successor |
-| TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:3:10:3:10 | exit M | semmle.label | successor |
+| TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:3:10:3:10 | exit M (normal) | semmle.label | successor |
 | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:13:8:27 | Type t = ... | semmle.label | successor |
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:6:5:11:5 | {...} | semmle.label | successor |
+| VarDecls.cs:5:18:5:19 | exit M1 (normal) | VarDecls.cs:5:18:5:19 | exit M1 | semmle.label | successor |
 | VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | semmle.label | successor |
 | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:27:7:33 | access to parameter strings | semmle.label | successor |
 | VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:44:7:50 | access to parameter strings | semmle.label | successor |
@@ -3615,21 +3897,23 @@
 | VarDecls.cs:7:44:7:53 | access to array element | VarDecls.cs:7:44:7:53 | (...) ... | semmle.label | successor |
 | VarDecls.cs:7:52:7:52 | 1 | VarDecls.cs:7:44:7:53 | access to array element | semmle.label | successor |
 | VarDecls.cs:8:9:10:9 | {...} | VarDecls.cs:9:27:9:28 | access to local variable c1 | semmle.label | successor |
-| VarDecls.cs:9:13:9:29 | return ...; | VarDecls.cs:5:18:5:19 | exit M1 | semmle.label | return |
+| VarDecls.cs:9:13:9:29 | return ...; | VarDecls.cs:5:18:5:19 | exit M1 (normal) | semmle.label | return |
 | VarDecls.cs:9:20:9:28 | (...) ... | VarDecls.cs:9:13:9:29 | return ...; | semmle.label | successor |
 | VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:9:20:9:28 | (...) ... | semmle.label | successor |
 | VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:14:5:17:5 | {...} | semmle.label | successor |
+| VarDecls.cs:13:12:13:13 | exit M2 (normal) | VarDecls.cs:13:12:13:13 | exit M2 | semmle.label | successor |
 | VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:15:9:15:30 | ... ...; | semmle.label | successor |
 | VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:21:15:21 | access to parameter s | semmle.label | successor |
 | VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:29:15:29 | access to parameter s | semmle.label | successor |
 | VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:16:15:21 | String s1 = ... | semmle.label | successor |
 | VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:16:16:16:17 | access to local variable s1 | semmle.label | successor |
 | VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:24:15:29 | String s2 = ... | semmle.label | successor |
-| VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:13:12:13:13 | exit M2 | semmle.label | return |
+| VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:13:12:13:13 | exit M2 (normal) | semmle.label | return |
 | VarDecls.cs:16:16:16:17 | access to local variable s1 | VarDecls.cs:16:21:16:22 | access to local variable s2 | semmle.label | successor |
 | VarDecls.cs:16:16:16:22 | ... + ... | VarDecls.cs:16:9:16:23 | return ...; | semmle.label | successor |
 | VarDecls.cs:16:21:16:22 | access to local variable s2 | VarDecls.cs:16:16:16:22 | ... + ... | semmle.label | successor |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:20:5:26:5 | {...} | semmle.label | successor |
+| VarDecls.cs:19:7:19:8 | exit M3 (normal) | VarDecls.cs:19:7:19:8 | exit M3 | semmle.label | successor |
 | VarDecls.cs:20:5:26:5 | {...} | VarDecls.cs:21:9:22:13 | using (...) {...} | semmle.label | successor |
 | VarDecls.cs:21:9:22:13 | using (...) {...} | VarDecls.cs:21:16:21:22 | object creation of type C | semmle.label | successor |
 | VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:22:13:22:13 | ; | semmle.label | successor |
@@ -3639,15 +3923,17 @@
 | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... | semmle.label | successor |
 | VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... | semmle.label | successor |
 | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:31:24:41 | C y = ... | semmle.label | successor |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 | semmle.label | return |
+| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 (normal) | semmle.label | return |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:24:25:24 | access to local variable x | semmle.label | true |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:28:25:28 | access to local variable y | semmle.label | false |
 | VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:20:25:20 | access to parameter b | semmle.label | successor |
 | VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:13:25:29 | return ...; | semmle.label | successor |
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:13:25:29 | return ...; | semmle.label | successor |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:51:28:53 | {...} | semmle.label | successor |
-| VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | exit Dispose | semmle.label | successor |
+| VarDecls.cs:28:41:28:47 | exit Dispose (normal) | VarDecls.cs:28:41:28:47 | exit Dispose | semmle.label | successor |
+| VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | exit Dispose (normal) | semmle.label | successor |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:6:5:35:5 | {...} | semmle.label | successor |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:5:17:5:20 | exit Main | semmle.label | successor |
 | cflow.cs:6:5:35:5 | {...} | cflow.cs:7:9:7:28 | ... ...; | semmle.label | successor |
 | cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:17:7:20 | access to parameter args | semmle.label | successor |
 | cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:9:9:9:40 | ...; | semmle.label | successor |
@@ -3693,7 +3979,7 @@
 | cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:25:24:25 | access to local variable i | semmle.label | successor |
 | cflow.cs:24:22:24:22 | 1 | cflow.cs:24:18:24:22 | Int32 i = ... | semmle.label | successor |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:30:24:31 | 20 | semmle.label | successor |
-| cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:5:17:5:20 | exit Main | semmle.label | false |
+| cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:5:17:5:20 | exit Main (normal) | semmle.label | false |
 | cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:25:9:34:9 | {...} | semmle.label | true |
 | cflow.cs:24:30:24:31 | 20 | cflow.cs:24:25:24:31 | ... <= ... | semmle.label | successor |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:24:34:24:36 | ...++ | semmle.label | successor |
@@ -3740,6 +4026,8 @@
 | cflow.cs:33:17:33:37 | ...; | cflow.cs:33:35:33:35 | access to local variable i | semmle.label | successor |
 | cflow.cs:33:35:33:35 | access to local variable i | cflow.cs:33:17:33:36 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:37:17:37:22 | enter Switch | cflow.cs:38:5:68:5 | {...} | semmle.label | successor |
+| cflow.cs:37:17:37:22 | exit Switch (abnormal) | cflow.cs:37:17:37:22 | exit Switch | semmle.label | successor |
+| cflow.cs:37:17:37:22 | exit Switch (normal) | cflow.cs:37:17:37:22 | exit Switch | semmle.label | successor |
 | cflow.cs:38:5:68:5 | {...} | cflow.cs:39:9:50:9 | switch (...) {...} | semmle.label | successor |
 | cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:39:17:39:17 | access to parameter a | semmle.label | successor |
 | cflow.cs:39:17:39:17 | access to parameter a | cflow.cs:41:13:41:19 | case ...: | semmle.label | successor |
@@ -3794,19 +4082,20 @@
 | cflow.cs:63:23:63:33 | ... == ... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | semmle.label | false |
 | cflow.cs:63:23:63:33 | ... == ... | cflow.cs:65:17:65:22 | break; | semmle.label | true |
 | cflow.cs:63:32:63:33 | "" | cflow.cs:63:23:63:33 | ... == ... | semmle.label | successor |
-| cflow.cs:64:21:64:55 | throw ...; | cflow.cs:37:17:37:22 | exit Switch | semmle.label | exception(NullReferenceException) |
+| cflow.cs:64:21:64:55 | throw ...; | cflow.cs:37:17:37:22 | exit Switch (abnormal) | semmle.label | exception(NullReferenceException) |
 | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:64:21:64:55 | throw ...; | semmle.label | successor |
 | cflow.cs:65:17:65:22 | break; | cflow.cs:67:16:67:16 | access to parameter a | semmle.label | break |
-| cflow.cs:67:9:67:17 | return ...; | cflow.cs:37:17:37:22 | exit Switch | semmle.label | return |
+| cflow.cs:67:9:67:17 | return ...; | cflow.cs:37:17:37:22 | exit Switch (normal) | semmle.label | return |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:67:9:67:17 | return ...; | semmle.label | successor |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:71:5:82:5 | {...} | semmle.label | successor |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | exit M | semmle.label | successor |
 | cflow.cs:71:5:82:5 | {...} | cflow.cs:72:9:73:19 | if (...) ... | semmle.label | successor |
 | cflow.cs:72:9:73:19 | if (...) ... | cflow.cs:72:13:72:13 | access to parameter s | semmle.label | successor |
 | cflow.cs:72:13:72:13 | access to parameter s | cflow.cs:72:18:72:21 | null | semmle.label | successor |
 | cflow.cs:72:13:72:21 | ... == ... | cflow.cs:73:13:73:19 | return ...; | semmle.label | true |
 | cflow.cs:72:13:72:21 | ... == ... | cflow.cs:74:9:81:9 | if (...) ... | semmle.label | false |
 | cflow.cs:72:18:72:21 | null | cflow.cs:72:13:72:21 | ... == ... | semmle.label | successor |
-| cflow.cs:73:13:73:19 | return ...; | cflow.cs:70:18:70:18 | exit M | semmle.label | return |
+| cflow.cs:73:13:73:19 | return ...; | cflow.cs:70:18:70:18 | exit M (normal) | semmle.label | return |
 | cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:74:13:74:13 | access to parameter s | semmle.label | successor |
 | cflow.cs:74:13:74:13 | access to parameter s | cflow.cs:74:13:74:20 | access to property Length | semmle.label | successor |
 | cflow.cs:74:13:74:20 | access to property Length | cflow.cs:74:24:74:24 | 0 | semmle.label | successor |
@@ -3814,37 +4103,40 @@
 | cflow.cs:74:13:74:24 | ... > ... | cflow.cs:79:9:81:9 | {...} | semmle.label | false |
 | cflow.cs:74:24:74:24 | 0 | cflow.cs:74:13:74:24 | ... > ... | semmle.label | successor |
 | cflow.cs:75:9:77:9 | {...} | cflow.cs:76:13:76:33 | ...; | semmle.label | successor |
-| cflow.cs:76:13:76:32 | call to method WriteLine | cflow.cs:70:18:70:18 | exit M | semmle.label | successor |
+| cflow.cs:76:13:76:32 | call to method WriteLine | cflow.cs:70:18:70:18 | exit M (normal) | semmle.label | successor |
 | cflow.cs:76:13:76:33 | ...; | cflow.cs:76:31:76:31 | access to parameter s | semmle.label | successor |
 | cflow.cs:76:31:76:31 | access to parameter s | cflow.cs:76:13:76:32 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:79:9:81:9 | {...} | cflow.cs:80:13:80:48 | ...; | semmle.label | successor |
-| cflow.cs:80:13:80:47 | call to method WriteLine | cflow.cs:70:18:70:18 | exit M | semmle.label | successor |
+| cflow.cs:80:13:80:47 | call to method WriteLine | cflow.cs:70:18:70:18 | exit M (normal) | semmle.label | successor |
 | cflow.cs:80:13:80:48 | ...; | cflow.cs:80:31:80:46 | "<empty string>" | semmle.label | successor |
 | cflow.cs:80:31:80:46 | "<empty string>" | cflow.cs:80:13:80:47 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:85:5:88:5 | {...} | semmle.label | successor |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 | semmle.label | successor |
 | cflow.cs:85:5:88:5 | {...} | cflow.cs:86:9:87:33 | if (...) ... | semmle.label | successor |
 | cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:13:86:37 | ... && ... | semmle.label | successor |
 | cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:18:86:21 | null | semmle.label | successor |
-| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:84:18:84:19 | exit M2 | semmle.label | false |
+| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:84:18:84:19 | exit M2 (normal) | semmle.label | false |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:26:86:26 | access to parameter s | semmle.label | true |
 | cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:13:86:13 | access to parameter s | semmle.label | successor |
 | cflow.cs:86:18:86:21 | null | cflow.cs:86:13:86:21 | ... != ... | semmle.label | successor |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:33 | access to property Length | semmle.label | successor |
 | cflow.cs:86:26:86:33 | access to property Length | cflow.cs:86:37:86:37 | 0 | semmle.label | successor |
-| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:84:18:84:19 | exit M2 | semmle.label | false |
+| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:84:18:84:19 | exit M2 (normal) | semmle.label | false |
 | cflow.cs:86:26:86:37 | ... > ... | cflow.cs:87:13:87:33 | ...; | semmle.label | true |
 | cflow.cs:86:37:86:37 | 0 | cflow.cs:86:26:86:37 | ... > ... | semmle.label | successor |
-| cflow.cs:87:13:87:32 | call to method WriteLine | cflow.cs:84:18:84:19 | exit M2 | semmle.label | successor |
+| cflow.cs:87:13:87:32 | call to method WriteLine | cflow.cs:84:18:84:19 | exit M2 (normal) | semmle.label | successor |
 | cflow.cs:87:13:87:33 | ...; | cflow.cs:87:31:87:31 | access to parameter s | semmle.label | successor |
 | cflow.cs:87:31:87:31 | access to parameter s | cflow.cs:87:13:87:32 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:91:5:104:5 | {...} | semmle.label | successor |
+| cflow.cs:90:18:90:19 | exit M3 (abnormal) | cflow.cs:90:18:90:19 | exit M3 | semmle.label | successor |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | exit M3 | semmle.label | successor |
 | cflow.cs:91:5:104:5 | {...} | cflow.cs:92:9:93:49 | if (...) ... | semmle.label | successor |
 | cflow.cs:92:9:93:49 | if (...) ... | cflow.cs:92:20:92:20 | access to parameter s | semmle.label | successor |
 | cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:93:45:93:47 | "s" | semmle.label | true |
 | cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:94:9:94:29 | ...; | semmle.label | false |
 | cflow.cs:92:20:92:20 | access to parameter s | cflow.cs:92:23:92:26 | null | semmle.label | successor |
 | cflow.cs:92:23:92:26 | null | cflow.cs:92:13:92:27 | call to method Equals | semmle.label | successor |
-| cflow.cs:93:13:93:49 | throw ...; | cflow.cs:90:18:90:19 | exit M3 | semmle.label | exception(ArgumentNullException) |
+| cflow.cs:93:13:93:49 | throw ...; | cflow.cs:90:18:90:19 | exit M3 (abnormal) | semmle.label | exception(ArgumentNullException) |
 | cflow.cs:93:19:93:48 | object creation of type ArgumentNullException | cflow.cs:93:13:93:49 | throw ...; | semmle.label | successor |
 | cflow.cs:93:45:93:47 | "s" | cflow.cs:93:19:93:48 | object creation of type ArgumentNullException | semmle.label | successor |
 | cflow.cs:94:9:94:28 | call to method WriteLine | cflow.cs:96:9:97:55 | if (...) ... | semmle.label | successor |
@@ -3873,14 +4165,15 @@
 | cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:102:13:102:16 | this access | semmle.label | successor |
 | cflow.cs:102:13:102:16 | this access | cflow.cs:102:13:102:21 | access to property Prop | semmle.label | successor |
 | cflow.cs:102:13:102:21 | access to property Prop | cflow.cs:102:26:102:29 | null | semmle.label | successor |
-| cflow.cs:102:13:102:29 | ... != ... | cflow.cs:90:18:90:19 | exit M3 | semmle.label | false |
+| cflow.cs:102:13:102:29 | ... != ... | cflow.cs:90:18:90:19 | exit M3 (normal) | semmle.label | false |
 | cflow.cs:102:13:102:29 | ... != ... | cflow.cs:103:13:103:36 | ...; | semmle.label | true |
 | cflow.cs:102:26:102:29 | null | cflow.cs:102:13:102:29 | ... != ... | semmle.label | successor |
-| cflow.cs:103:13:103:35 | call to method WriteLine | cflow.cs:90:18:90:19 | exit M3 | semmle.label | successor |
+| cflow.cs:103:13:103:35 | call to method WriteLine | cflow.cs:90:18:90:19 | exit M3 (normal) | semmle.label | successor |
 | cflow.cs:103:13:103:36 | ...; | cflow.cs:103:31:103:34 | this access | semmle.label | successor |
 | cflow.cs:103:31:103:34 | access to property Prop | cflow.cs:103:13:103:35 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:103:31:103:34 | this access | cflow.cs:103:31:103:34 | access to property Prop | semmle.label | successor |
 | cflow.cs:106:18:106:19 | enter M4 | cflow.cs:107:5:117:5 | {...} | semmle.label | successor |
+| cflow.cs:106:18:106:19 | exit M4 (normal) | cflow.cs:106:18:106:19 | exit M4 | semmle.label | successor |
 | cflow.cs:107:5:117:5 | {...} | cflow.cs:108:9:115:9 | if (...) ... | semmle.label | successor |
 | cflow.cs:108:9:115:9 | if (...) ... | cflow.cs:108:13:108:13 | access to parameter s | semmle.label | successor |
 | cflow.cs:108:13:108:13 | access to parameter s | cflow.cs:108:18:108:21 | null | semmle.label | successor |
@@ -3894,10 +4187,11 @@
 | cflow.cs:112:17:112:36 | call to method WriteLine | cflow.cs:110:20:110:23 | true | semmle.label | successor |
 | cflow.cs:112:17:112:37 | ...; | cflow.cs:112:35:112:35 | access to parameter s | semmle.label | successor |
 | cflow.cs:112:35:112:35 | access to parameter s | cflow.cs:112:17:112:36 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:116:9:116:28 | call to method WriteLine | cflow.cs:106:18:106:19 | exit M4 | semmle.label | successor |
+| cflow.cs:116:9:116:28 | call to method WriteLine | cflow.cs:106:18:106:19 | exit M4 (normal) | semmle.label | successor |
 | cflow.cs:116:9:116:29 | ...; | cflow.cs:116:27:116:27 | access to parameter s | semmle.label | successor |
 | cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:116:9:116:28 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:119:20:119:21 | enter M5 | cflow.cs:120:5:124:5 | {...} | semmle.label | successor |
+| cflow.cs:119:20:119:21 | exit M5 (normal) | cflow.cs:119:20:119:21 | exit M5 | semmle.label | successor |
 | cflow.cs:120:5:124:5 | {...} | cflow.cs:121:9:121:18 | ... ...; | semmle.label | successor |
 | cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:17:121:17 | access to parameter s | semmle.label | successor |
 | cflow.cs:121:13:121:17 | String x = ... | cflow.cs:122:9:122:20 | ...; | semmle.label | successor |
@@ -3907,11 +4201,12 @@
 | cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:17:122:19 | " " | semmle.label | successor |
 | cflow.cs:122:13:122:19 | ... + ... | cflow.cs:122:9:122:19 | ... = ... | semmle.label | successor |
 | cflow.cs:122:17:122:19 | " " | cflow.cs:122:13:122:19 | ... + ... | semmle.label | successor |
-| cflow.cs:123:9:123:17 | return ...; | cflow.cs:119:20:119:21 | exit M5 | semmle.label | return |
+| cflow.cs:123:9:123:17 | return ...; | cflow.cs:119:20:119:21 | exit M5 (normal) | semmle.label | return |
 | cflow.cs:123:16:123:16 | access to local variable x | cflow.cs:123:9:123:17 | return ...; | semmle.label | successor |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:23:127:60 | {...} | semmle.label | successor |
+| cflow.cs:127:19:127:21 | exit get_Prop (normal) | cflow.cs:127:19:127:21 | exit get_Prop | semmle.label | successor |
 | cflow.cs:127:23:127:60 | {...} | cflow.cs:127:32:127:57 | ... ? ... : ... | semmle.label | successor |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop | semmle.label | return |
+| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop (normal) | semmle.label | return |
 | cflow.cs:127:32:127:36 | access to field Field | cflow.cs:127:41:127:44 | null | semmle.label | successor |
 | cflow.cs:127:32:127:36 | this access | cflow.cs:127:32:127:36 | access to field Field | semmle.label | successor |
 | cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:48:127:49 | "" | semmle.label | true |
@@ -3922,47 +4217,55 @@
 | cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:25:127:58 | return ...; | semmle.label | successor |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field | semmle.label | successor |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:66:127:83 | {...} | semmle.label | successor |
+| cflow.cs:127:62:127:64 | exit set_Prop (normal) | cflow.cs:127:62:127:64 | exit set_Prop | semmle.label | successor |
 | cflow.cs:127:66:127:83 | {...} | cflow.cs:127:68:127:81 | ...; | semmle.label | successor |
 | cflow.cs:127:68:127:72 | this access | cflow.cs:127:76:127:80 | access to parameter value | semmle.label | successor |
-| cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | exit set_Prop | semmle.label | successor |
+| cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | exit set_Prop (normal) | semmle.label | successor |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:72 | this access | semmle.label | successor |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:80 | ... = ... | semmle.label | successor |
 | cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:130:5:132:5 | {...} | semmle.label | successor |
+| cflow.cs:129:5:129:15 | exit ControlFlow (normal) | cflow.cs:129:5:129:15 | exit ControlFlow | semmle.label | successor |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:18 | ...; | semmle.label | successor |
 | cflow.cs:131:9:131:13 | this access | cflow.cs:131:17:131:17 | access to parameter s | semmle.label | successor |
-| cflow.cs:131:9:131:17 | ... = ... | cflow.cs:129:5:129:15 | exit ControlFlow | semmle.label | successor |
+| cflow.cs:131:9:131:17 | ... = ... | cflow.cs:129:5:129:15 | exit ControlFlow (normal) | semmle.label | successor |
 | cflow.cs:131:9:131:18 | ...; | cflow.cs:131:9:131:13 | this access | semmle.label | successor |
 | cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:131:9:131:17 | ... = ... | semmle.label | successor |
 | cflow.cs:134:5:134:15 | enter ControlFlow | cflow.cs:134:31:134:31 | access to parameter i | semmle.label | successor |
+| cflow.cs:134:5:134:15 | exit ControlFlow (normal) | cflow.cs:134:5:134:15 | exit ControlFlow | semmle.label | successor |
 | cflow.cs:134:26:134:29 | call to constructor ControlFlow | cflow.cs:134:39:134:41 | {...} | semmle.label | successor |
 | cflow.cs:134:31:134:31 | (...) ... | cflow.cs:134:35:134:36 | "" | semmle.label | successor |
 | cflow.cs:134:31:134:31 | access to parameter i | cflow.cs:134:31:134:31 | (...) ... | semmle.label | successor |
 | cflow.cs:134:31:134:36 | ... + ... | cflow.cs:134:26:134:29 | call to constructor ControlFlow | semmle.label | successor |
 | cflow.cs:134:35:134:36 | "" | cflow.cs:134:31:134:36 | ... + ... | semmle.label | successor |
-| cflow.cs:134:39:134:41 | {...} | cflow.cs:134:5:134:15 | exit ControlFlow | semmle.label | successor |
+| cflow.cs:134:39:134:41 | {...} | cflow.cs:134:5:134:15 | exit ControlFlow (normal) | semmle.label | successor |
 | cflow.cs:136:12:136:22 | enter ControlFlow | cflow.cs:136:33:136:33 | 0 | semmle.label | successor |
+| cflow.cs:136:12:136:22 | exit ControlFlow (normal) | cflow.cs:136:12:136:22 | exit ControlFlow | semmle.label | successor |
 | cflow.cs:136:28:136:31 | call to constructor ControlFlow | cflow.cs:136:40:136:42 | {...} | semmle.label | successor |
 | cflow.cs:136:33:136:33 | 0 | cflow.cs:136:37:136:37 | 1 | semmle.label | successor |
 | cflow.cs:136:33:136:37 | ... + ... | cflow.cs:136:28:136:31 | call to constructor ControlFlow | semmle.label | successor |
 | cflow.cs:136:37:136:37 | 1 | cflow.cs:136:33:136:37 | ... + ... | semmle.label | successor |
-| cflow.cs:136:40:136:42 | {...} | cflow.cs:136:12:136:22 | exit ControlFlow | semmle.label | successor |
+| cflow.cs:136:40:136:42 | {...} | cflow.cs:136:12:136:22 | exit ControlFlow (normal) | semmle.label | successor |
 | cflow.cs:138:40:138:40 | enter + | cflow.cs:139:5:142:5 | {...} | semmle.label | successor |
+| cflow.cs:138:40:138:40 | exit + (normal) | cflow.cs:138:40:138:40 | exit + | semmle.label | successor |
 | cflow.cs:139:5:142:5 | {...} | cflow.cs:140:9:140:29 | ...; | semmle.label | successor |
 | cflow.cs:140:9:140:28 | call to method WriteLine | cflow.cs:141:16:141:16 | access to parameter y | semmle.label | successor |
 | cflow.cs:140:9:140:29 | ...; | cflow.cs:140:27:140:27 | access to parameter x | semmle.label | successor |
 | cflow.cs:140:27:140:27 | access to parameter x | cflow.cs:140:9:140:28 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:141:9:141:17 | return ...; | cflow.cs:138:40:138:40 | exit + | semmle.label | return |
+| cflow.cs:141:9:141:17 | return ...; | cflow.cs:138:40:138:40 | exit + (normal) | semmle.label | return |
 | cflow.cs:141:16:141:16 | access to parameter y | cflow.cs:141:9:141:17 | return ...; | semmle.label | successor |
 | cflow.cs:144:33:144:35 | enter get_Item | cflow.cs:144:37:144:54 | {...} | semmle.label | successor |
+| cflow.cs:144:33:144:35 | exit get_Item (normal) | cflow.cs:144:33:144:35 | exit get_Item | semmle.label | successor |
 | cflow.cs:144:37:144:54 | {...} | cflow.cs:144:46:144:46 | access to parameter i | semmle.label | successor |
-| cflow.cs:144:39:144:52 | return ...; | cflow.cs:144:33:144:35 | exit get_Item | semmle.label | return |
+| cflow.cs:144:39:144:52 | return ...; | cflow.cs:144:33:144:35 | exit get_Item (normal) | semmle.label | return |
 | cflow.cs:144:46:144:46 | (...) ... | cflow.cs:144:50:144:51 | "" | semmle.label | successor |
 | cflow.cs:144:46:144:46 | access to parameter i | cflow.cs:144:46:144:46 | (...) ... | semmle.label | successor |
 | cflow.cs:144:46:144:51 | ... + ... | cflow.cs:144:39:144:52 | return ...; | semmle.label | successor |
 | cflow.cs:144:50:144:51 | "" | cflow.cs:144:46:144:51 | ... + ... | semmle.label | successor |
 | cflow.cs:144:56:144:58 | enter set_Item | cflow.cs:144:60:144:62 | {...} | semmle.label | successor |
-| cflow.cs:144:60:144:62 | {...} | cflow.cs:144:56:144:58 | exit set_Item | semmle.label | successor |
+| cflow.cs:144:56:144:58 | exit set_Item (normal) | cflow.cs:144:56:144:58 | exit set_Item | semmle.label | successor |
+| cflow.cs:144:60:144:62 | {...} | cflow.cs:144:56:144:58 | exit set_Item (normal) | semmle.label | successor |
 | cflow.cs:146:10:146:12 | enter For | cflow.cs:147:5:177:5 | {...} | semmle.label | successor |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:146:10:146:12 | exit For | semmle.label | successor |
 | cflow.cs:147:5:177:5 | {...} | cflow.cs:148:9:148:18 | ... ...; | semmle.label | successor |
 | cflow.cs:148:9:148:18 | ... ...; | cflow.cs:148:17:148:17 | 0 | semmle.label | successor |
 | cflow.cs:148:13:148:17 | Int32 x = ... | cflow.cs:149:9:150:33 | for (...;...;...) ... | semmle.label | successor |
@@ -4023,7 +4326,7 @@
 | cflow.cs:173:29:173:29 | 0 | cflow.cs:173:25:173:29 | Int32 j = ... | semmle.label | successor |
 | cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:173:36:173:36 | access to local variable j | semmle.label | successor |
 | cflow.cs:173:32:173:36 | ... + ... | cflow.cs:173:40:173:41 | 10 | semmle.label | successor |
-| cflow.cs:173:32:173:41 | ... < ... | cflow.cs:146:10:146:12 | exit For | semmle.label | false |
+| cflow.cs:173:32:173:41 | ... < ... | cflow.cs:146:10:146:12 | exit For (normal) | semmle.label | false |
 | cflow.cs:173:32:173:41 | ... < ... | cflow.cs:174:9:176:9 | {...} | semmle.label | true |
 | cflow.cs:173:36:173:36 | access to local variable j | cflow.cs:173:32:173:36 | ... + ... | semmle.label | successor |
 | cflow.cs:173:40:173:41 | 10 | cflow.cs:173:32:173:41 | ... < ... | semmle.label | successor |
@@ -4038,24 +4341,28 @@
 | cflow.cs:175:31:175:35 | ... + ... | cflow.cs:175:13:175:36 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:175:35:175:35 | access to local variable j | cflow.cs:175:31:175:35 | ... + ... | semmle.label | successor |
 | cflow.cs:179:10:179:16 | enter Lambdas | cflow.cs:180:5:183:5 | {...} | semmle.label | successor |
+| cflow.cs:179:10:179:16 | exit Lambdas (normal) | cflow.cs:179:10:179:16 | exit Lambdas | semmle.label | successor |
 | cflow.cs:180:5:183:5 | {...} | cflow.cs:181:9:181:38 | ... ...; | semmle.label | successor |
 | cflow.cs:181:9:181:38 | ... ...; | cflow.cs:181:28:181:37 | (...) => ... | semmle.label | successor |
 | cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... | cflow.cs:182:9:182:62 | ... ...; | semmle.label | successor |
 | cflow.cs:181:28:181:37 | (...) => ... | cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... | semmle.label | successor |
 | cflow.cs:181:28:181:37 | enter (...) => ... | cflow.cs:181:33:181:33 | access to parameter x | semmle.label | successor |
+| cflow.cs:181:28:181:37 | exit (...) => ... (normal) | cflow.cs:181:28:181:37 | exit (...) => ... | semmle.label | successor |
 | cflow.cs:181:33:181:33 | access to parameter x | cflow.cs:181:37:181:37 | 1 | semmle.label | successor |
-| cflow.cs:181:33:181:37 | ... + ... | cflow.cs:181:28:181:37 | exit (...) => ... | semmle.label | successor |
+| cflow.cs:181:33:181:37 | ... + ... | cflow.cs:181:28:181:37 | exit (...) => ... (normal) | semmle.label | successor |
 | cflow.cs:181:37:181:37 | 1 | cflow.cs:181:33:181:37 | ... + ... | semmle.label | successor |
 | cflow.cs:182:9:182:62 | ... ...; | cflow.cs:182:28:182:61 | delegate(...) { ... } | semmle.label | successor |
-| cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... | cflow.cs:179:10:179:16 | exit Lambdas | semmle.label | successor |
+| cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... | cflow.cs:179:10:179:16 | exit Lambdas (normal) | semmle.label | successor |
 | cflow.cs:182:28:182:61 | delegate(...) { ... } | cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... | semmle.label | successor |
 | cflow.cs:182:28:182:61 | enter delegate(...) { ... } | cflow.cs:182:45:182:61 | {...} | semmle.label | successor |
+| cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) | cflow.cs:182:28:182:61 | exit delegate(...) { ... } | semmle.label | successor |
 | cflow.cs:182:45:182:61 | {...} | cflow.cs:182:54:182:54 | access to parameter x | semmle.label | successor |
-| cflow.cs:182:47:182:59 | return ...; | cflow.cs:182:28:182:61 | exit delegate(...) { ... } | semmle.label | return |
+| cflow.cs:182:47:182:59 | return ...; | cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) | semmle.label | return |
 | cflow.cs:182:54:182:54 | access to parameter x | cflow.cs:182:58:182:58 | 1 | semmle.label | successor |
 | cflow.cs:182:54:182:58 | ... + ... | cflow.cs:182:47:182:59 | return ...; | semmle.label | successor |
 | cflow.cs:182:58:182:58 | 1 | cflow.cs:182:54:182:58 | ... + ... | semmle.label | successor |
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:186:5:191:5 | {...} | semmle.label | successor |
+| cflow.cs:185:10:185:18 | exit LogicalOr (normal) | cflow.cs:185:10:185:18 | exit LogicalOr | semmle.label | successor |
 | cflow.cs:186:5:191:5 | {...} | cflow.cs:187:9:190:52 | if (...) ... | semmle.label | successor |
 | cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:187:13:187:50 | ... \|\| ... | semmle.label | successor |
 | cflow.cs:187:13:187:13 | 1 | cflow.cs:187:18:187:18 | 2 | semmle.label | successor |
@@ -4070,10 +4377,12 @@
 | cflow.cs:187:34:187:39 | ... == ... | cflow.cs:190:13:190:52 | ...; | semmle.label | false |
 | cflow.cs:187:34:187:49 | ... && ... | cflow.cs:187:34:187:34 | 1 | semmle.label | successor |
 | cflow.cs:187:39:187:39 | 3 | cflow.cs:187:34:187:39 | ... == ... | semmle.label | successor |
-| cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:185:10:185:18 | exit LogicalOr | semmle.label | successor |
+| cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:185:10:185:18 | exit LogicalOr (normal) | semmle.label | successor |
 | cflow.cs:190:13:190:52 | ...; | cflow.cs:190:31:190:50 | "This should happen" | semmle.label | successor |
 | cflow.cs:190:31:190:50 | "This should happen" | cflow.cs:190:13:190:51 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:194:5:206:5 | {...} | semmle.label | successor |
+| cflow.cs:193:10:193:17 | exit Booleans (abnormal) | cflow.cs:193:10:193:17 | exit Booleans | semmle.label | successor |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | exit Booleans | semmle.label | successor |
 | cflow.cs:194:5:206:5 | {...} | cflow.cs:195:9:195:57 | ... ...; | semmle.label | successor |
 | cflow.cs:195:9:195:57 | ... ...; | cflow.cs:195:17:195:56 | ... && ... | semmle.label | successor |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:9:198:49 | if (...) ... | semmle.label | successor |
@@ -4126,17 +4435,18 @@
 | cflow.cs:200:40:200:44 | access to field Field | cflow.cs:200:40:200:51 | access to property Length | semmle.label | successor |
 | cflow.cs:200:40:200:44 | this access | cflow.cs:200:40:200:44 | access to field Field | semmle.label | successor |
 | cflow.cs:200:40:200:51 | access to property Length | cflow.cs:200:56:200:56 | 1 | semmle.label | successor |
-| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:193:10:193:17 | exit Booleans | semmle.label | false |
+| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | semmle.label | false |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:61:200:61 | access to local variable b | semmle.label | true |
 | cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:40:200:44 | this access | semmle.label | successor |
 | cflow.cs:200:56:200:56 | 1 | cflow.cs:200:40:200:56 | ... == ... | semmle.label | successor |
-| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:193:10:193:17 | exit Booleans | semmle.label | false |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:193:10:193:17 | exit Booleans (normal) | semmle.label | false |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:201:9:205:9 | {...} | semmle.label | true |
 | cflow.cs:201:9:205:9 | {...} | cflow.cs:202:13:204:13 | {...} | semmle.label | successor |
 | cflow.cs:202:13:204:13 | {...} | cflow.cs:203:23:203:37 | object creation of type Exception | semmle.label | successor |
-| cflow.cs:203:17:203:38 | throw ...; | cflow.cs:193:10:193:17 | exit Booleans | semmle.label | exception(Exception) |
+| cflow.cs:203:17:203:38 | throw ...; | cflow.cs:193:10:193:17 | exit Booleans (abnormal) | semmle.label | exception(Exception) |
 | cflow.cs:203:23:203:37 | object creation of type Exception | cflow.cs:203:17:203:38 | throw ...; | semmle.label | successor |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:209:5:222:5 | {...} | semmle.label | successor |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | exit Do | semmle.label | successor |
 | cflow.cs:209:5:222:5 | {...} | cflow.cs:210:9:221:36 | do ... while (...); | semmle.label | successor |
 | cflow.cs:210:9:221:36 | do ... while (...); | cflow.cs:211:9:221:9 | {...} | semmle.label | successor |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:212:13:212:25 | ...; | semmle.label | successor |
@@ -4164,16 +4474,17 @@
 | cflow.cs:217:17:217:32 | ... < ... | cflow.cs:221:18:221:22 | this access | semmle.label | false |
 | cflow.cs:217:32:217:32 | 0 | cflow.cs:217:17:217:32 | ... < ... | semmle.label | successor |
 | cflow.cs:218:13:220:13 | {...} | cflow.cs:219:17:219:22 | break; | semmle.label | successor |
-| cflow.cs:219:17:219:22 | break; | cflow.cs:208:10:208:11 | exit Do | semmle.label | break |
+| cflow.cs:219:17:219:22 | break; | cflow.cs:208:10:208:11 | exit Do (normal) | semmle.label | break |
 | cflow.cs:221:18:221:22 | access to field Field | cflow.cs:221:18:221:29 | access to property Length | semmle.label | successor |
 | cflow.cs:221:18:221:22 | this access | cflow.cs:221:18:221:22 | access to field Field | semmle.label | successor |
 | cflow.cs:221:18:221:29 | access to property Length | cflow.cs:221:33:221:34 | 10 | semmle.label | successor |
-| cflow.cs:221:18:221:34 | ... < ... | cflow.cs:208:10:208:11 | exit Do | semmle.label | false |
+| cflow.cs:221:18:221:34 | ... < ... | cflow.cs:208:10:208:11 | exit Do (normal) | semmle.label | false |
 | cflow.cs:221:18:221:34 | ... < ... | cflow.cs:211:9:221:9 | {...} | semmle.label | true |
 | cflow.cs:221:33:221:34 | 10 | cflow.cs:221:18:221:34 | ... < ... | semmle.label | successor |
 | cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:225:5:238:5 | {...} | semmle.label | successor |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:224:10:224:16 | exit Foreach | semmle.label | successor |
 | cflow.cs:225:5:238:5 | {...} | cflow.cs:226:57:226:59 | "a" | semmle.label | successor |
-| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | exit Foreach | semmle.label | empty |
+| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | exit Foreach (normal) | semmle.label | empty |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:226:22:226:22 | String x | semmle.label | non-empty |
 | cflow.cs:226:22:226:22 | String x | cflow.cs:227:9:237:9 | {...} | semmle.label | successor |
 | cflow.cs:226:27:226:64 | call to method Repeat | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | semmle.label | successor |
@@ -4204,8 +4515,9 @@
 | cflow.cs:233:17:233:32 | ... < ... | cflow.cs:234:13:236:13 | {...} | semmle.label | true |
 | cflow.cs:233:32:233:32 | 0 | cflow.cs:233:17:233:32 | ... < ... | semmle.label | successor |
 | cflow.cs:234:13:236:13 | {...} | cflow.cs:235:17:235:22 | break; | semmle.label | successor |
-| cflow.cs:235:17:235:22 | break; | cflow.cs:224:10:224:16 | exit Foreach | semmle.label | break |
+| cflow.cs:235:17:235:22 | break; | cflow.cs:224:10:224:16 | exit Foreach (normal) | semmle.label | break |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:241:5:259:5 | {...} | semmle.label | successor |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto | semmle.label | successor |
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:242:9:242:13 | Label: | semmle.label | successor |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:16:242:45 | if (...) ... | semmle.label | successor |
 | cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:20:242:40 | !... | semmle.label | successor |
@@ -4242,7 +4554,7 @@
 | cflow.cs:251:17:251:36 | call to method WriteLine | cflow.cs:252:17:252:22 | break; | semmle.label | successor |
 | cflow.cs:251:17:251:37 | ...; | cflow.cs:251:35:251:35 | 1 | semmle.label | successor |
 | cflow.cs:251:35:251:35 | 1 | cflow.cs:251:17:251:36 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:252:17:252:22 | break; | cflow.cs:240:10:240:13 | exit Goto | semmle.label | break |
+| cflow.cs:252:17:252:22 | break; | cflow.cs:240:10:240:13 | exit Goto (normal) | semmle.label | break |
 | cflow.cs:253:13:253:19 | case ...: | cflow.cs:253:18:253:18 | 2 | semmle.label | successor |
 | cflow.cs:253:18:253:18 | 2 | cflow.cs:254:17:254:27 | goto ...; | semmle.label | match |
 | cflow.cs:253:18:253:18 | 2 | cflow.cs:255:13:255:20 | default: | semmle.label | no-match |
@@ -4251,8 +4563,9 @@
 | cflow.cs:256:17:256:36 | call to method WriteLine | cflow.cs:257:17:257:22 | break; | semmle.label | successor |
 | cflow.cs:256:17:256:37 | ...; | cflow.cs:256:35:256:35 | 0 | semmle.label | successor |
 | cflow.cs:256:35:256:35 | 0 | cflow.cs:256:17:256:36 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:257:17:257:22 | break; | cflow.cs:240:10:240:13 | exit Goto | semmle.label | break |
+| cflow.cs:257:17:257:22 | break; | cflow.cs:240:10:240:13 | exit Goto (normal) | semmle.label | break |
 | cflow.cs:261:49:261:53 | enter Yield | cflow.cs:262:5:277:5 | {...} | semmle.label | successor |
+| cflow.cs:261:49:261:53 | exit Yield (normal) | cflow.cs:261:49:261:53 | exit Yield | semmle.label | successor |
 | cflow.cs:262:5:277:5 | {...} | cflow.cs:263:22:263:22 | 0 | semmle.label | successor |
 | cflow.cs:263:9:263:23 | yield return ...; | cflow.cs:264:9:267:9 | for (...;...;...) ... | semmle.label | successor |
 | cflow.cs:263:22:263:22 | 0 | cflow.cs:263:9:263:23 | yield return ...; | semmle.label | successor |
@@ -4272,29 +4585,35 @@
 | cflow.cs:269:9:272:9 | {...} | cflow.cs:270:13:270:24 | yield break; | semmle.label | successor |
 | cflow.cs:270:13:270:24 | yield break; | cflow.cs:274:9:276:9 | [finally: return] {...} | semmle.label | return |
 | cflow.cs:274:9:276:9 | [finally: return] {...} | cflow.cs:275:13:275:42 | [finally: return] ...; | semmle.label | successor |
-| cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine | cflow.cs:261:49:261:53 | exit Yield | semmle.label | return |
+| cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine | cflow.cs:261:49:261:53 | exit Yield (normal) | semmle.label | return |
 | cflow.cs:275:13:275:42 | [finally: return] ...; | cflow.cs:275:31:275:40 | [finally: return] "not dead" | semmle.label | successor |
 | cflow.cs:275:31:275:40 | [finally: return] "not dead" | cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine | semmle.label | successor |
 | cflow.cs:282:5:282:18 | enter ControlFlowSub | cflow.cs:282:24:282:27 | call to constructor ControlFlow | semmle.label | successor |
+| cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) | cflow.cs:282:5:282:18 | exit ControlFlowSub | semmle.label | successor |
 | cflow.cs:282:24:282:27 | call to constructor ControlFlow | cflow.cs:282:31:282:33 | {...} | semmle.label | successor |
-| cflow.cs:282:31:282:33 | {...} | cflow.cs:282:5:282:18 | exit ControlFlowSub | semmle.label | successor |
+| cflow.cs:282:31:282:33 | {...} | cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) | semmle.label | successor |
 | cflow.cs:284:5:284:18 | enter ControlFlowSub | cflow.cs:284:32:284:35 | call to constructor ControlFlowSub | semmle.label | successor |
+| cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) | cflow.cs:284:5:284:18 | exit ControlFlowSub | semmle.label | successor |
 | cflow.cs:284:32:284:35 | call to constructor ControlFlowSub | cflow.cs:284:39:284:41 | {...} | semmle.label | successor |
-| cflow.cs:284:39:284:41 | {...} | cflow.cs:284:5:284:18 | exit ControlFlowSub | semmle.label | successor |
+| cflow.cs:284:39:284:41 | {...} | cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) | semmle.label | successor |
 | cflow.cs:286:5:286:18 | enter ControlFlowSub | cflow.cs:286:34:286:34 | access to parameter i | semmle.label | successor |
+| cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) | cflow.cs:286:5:286:18 | exit ControlFlowSub | semmle.label | successor |
 | cflow.cs:286:29:286:32 | call to constructor ControlFlowSub | cflow.cs:286:48:286:50 | {...} | semmle.label | successor |
 | cflow.cs:286:34:286:34 | access to parameter i | cflow.cs:286:34:286:45 | call to method ToString | semmle.label | successor |
 | cflow.cs:286:34:286:45 | call to method ToString | cflow.cs:286:29:286:32 | call to constructor ControlFlowSub | semmle.label | successor |
-| cflow.cs:286:48:286:50 | {...} | cflow.cs:286:5:286:18 | exit ControlFlowSub | semmle.label | successor |
+| cflow.cs:286:48:286:50 | {...} | cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) | semmle.label | successor |
 | cflow.cs:291:12:291:12 | enter M | cflow.cs:291:38:291:38 | access to parameter f | semmle.label | successor |
+| cflow.cs:291:12:291:12 | exit M (normal) | cflow.cs:291:12:291:12 | exit M | semmle.label | successor |
 | cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:40:291:40 | 0 | semmle.label | successor |
-| cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:12:291:12 | exit M | semmle.label | successor |
+| cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:12:291:12 | exit M (normal) | semmle.label | successor |
 | cflow.cs:291:40:291:40 | 0 | cflow.cs:291:38:291:41 | delegate call | semmle.label | successor |
 | cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:52:296:54 | {...} | semmle.label | successor |
-| cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | exit NegationInConstructor | semmle.label | successor |
+| cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | cflow.cs:296:5:296:25 | exit NegationInConstructor | semmle.label | successor |
+| cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | semmle.label | successor |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:299:5:301:5 | {...} | semmle.label | successor |
+| cflow.cs:298:10:298:10 | exit M (normal) | cflow.cs:298:10:298:10 | exit M | semmle.label | successor |
 | cflow.cs:299:5:301:5 | {...} | cflow.cs:300:9:300:73 | ...; | semmle.label | successor |
-| cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:298:10:298:10 | exit M | semmle.label | successor |
+| cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:298:10:298:10 | exit M (normal) | semmle.label | successor |
 | cflow.cs:300:9:300:73 | ...; | cflow.cs:300:38:300:38 | 0 | semmle.label | successor |
 | cflow.cs:300:38:300:38 | 0 | cflow.cs:300:44:300:64 | ... && ... | semmle.label | successor |
 | cflow.cs:300:44:300:51 | !... | cflow.cs:300:46:300:46 | access to parameter i | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -1162,6 +1162,9 @@ entryPoint
 | NullCoalescing.cs:11:9:11:10 | M5 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
 | NullCoalescing.cs:13:10:13:11 | M6 | NullCoalescing.cs:14:5:18:5 | {...} |
 | Patterns.cs:5:10:5:13 | Test | Patterns.cs:6:5:43:5 | {...} |
+| PostDominance.cs:5:10:5:11 | M1 | PostDominance.cs:6:5:8:5 | {...} |
+| PostDominance.cs:10:10:10:11 | M2 | PostDominance.cs:11:5:15:5 | {...} |
+| PostDominance.cs:17:10:17:11 | M3 | PostDominance.cs:18:5:22:5 | {...} |
 | Qualifiers.cs:7:16:7:21 | Method | Qualifiers.cs:7:28:7:31 | null |
 | Qualifiers.cs:8:23:8:34 | StaticMethod | Qualifiers.cs:8:41:8:44 | null |
 | Qualifiers.cs:10:10:10:10 | M | Qualifiers.cs:11:5:31:5 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/PostDominance.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/PostDominance.cs
@@ -1,0 +1,23 @@
+using System;
+
+class PostDominance
+{
+    void M1(string s)
+    {
+        Console.WriteLine(s); // post-dominates entry
+    }
+
+    void M2(string s)
+    {
+        if (s is null)
+            return;
+        Console.WriteLine(s); // does not post-dominate entry
+    }
+
+    void M3(string s)
+    {
+        if (s is null)
+            throw new ArgumentNullException(nameof(s));
+        Console.WriteLine(s); // post-dominates entry
+    }
+}

--- a/csharp/ql/test/library-tests/csharp7/IsFlow.expected
+++ b/csharp/ql/test/library-tests/csharp7/IsFlow.expected
@@ -1,16 +1,17 @@
+| CSharp7.cs:232:10:232:13 | exit Test (normal) | CSharp7.cs:232:10:232:13 | exit Test | semmle.label | successor |
 | CSharp7.cs:250:9:276:9 | switch (...) {...} | CSharp7.cs:250:17:250:17 | access to local variable o | semmle.label | successor |
 | CSharp7.cs:250:17:250:17 | access to local variable o | CSharp7.cs:252:13:252:23 | case ...: | semmle.label | successor |
 | CSharp7.cs:252:13:252:23 | case ...: | CSharp7.cs:252:18:252:22 | "xyz" | semmle.label | successor |
 | CSharp7.cs:252:18:252:22 | "xyz" | CSharp7.cs:253:17:253:22 | break; | semmle.label | match |
 | CSharp7.cs:252:18:252:22 | "xyz" | CSharp7.cs:254:13:254:31 | case ...: | semmle.label | no-match |
-| CSharp7.cs:253:17:253:22 | break; | CSharp7.cs:232:10:232:13 | exit Test | semmle.label | break |
+| CSharp7.cs:253:17:253:22 | break; | CSharp7.cs:232:10:232:13 | exit Test (normal) | semmle.label | break |
 | CSharp7.cs:254:13:254:31 | case ...: | CSharp7.cs:254:18:254:19 | "" | semmle.label | successor |
 | CSharp7.cs:254:18:254:19 | "" | CSharp7.cs:254:26:254:26 | 1 | semmle.label | match |
 | CSharp7.cs:254:18:254:19 | "" | CSharp7.cs:256:13:256:41 | case ...: | semmle.label | no-match |
 | CSharp7.cs:254:26:254:26 | 1 | CSharp7.cs:254:30:254:30 | 2 | semmle.label | successor |
 | CSharp7.cs:254:26:254:30 | ... < ... | CSharp7.cs:255:17:255:22 | break; | semmle.label | true |
 | CSharp7.cs:254:30:254:30 | 2 | CSharp7.cs:254:26:254:30 | ... < ... | semmle.label | successor |
-| CSharp7.cs:255:17:255:22 | break; | CSharp7.cs:232:10:232:13 | exit Test | semmle.label | break |
+| CSharp7.cs:255:17:255:22 | break; | CSharp7.cs:232:10:232:13 | exit Test (normal) | semmle.label | break |
 | CSharp7.cs:256:13:256:41 | case ...: | CSharp7.cs:256:18:256:20 | "x" | semmle.label | successor |
 | CSharp7.cs:256:18:256:20 | "x" | CSharp7.cs:256:27:256:27 | access to local variable o | semmle.label | match |
 | CSharp7.cs:256:18:256:20 | "x" | CSharp7.cs:259:13:259:36 | case ...: | semmle.label | no-match |
@@ -23,7 +24,7 @@
 | CSharp7.cs:257:35:257:43 | $"..." | CSharp7.cs:257:17:257:44 | call to method WriteLine | semmle.label | successor |
 | CSharp7.cs:257:37:257:38 | "x " | CSharp7.cs:257:40:257:41 | access to local variable s4 | semmle.label | successor |
 | CSharp7.cs:257:40:257:41 | access to local variable s4 | CSharp7.cs:257:35:257:43 | $"..." | semmle.label | successor |
-| CSharp7.cs:258:17:258:22 | break; | CSharp7.cs:232:10:232:13 | exit Test | semmle.label | break |
+| CSharp7.cs:258:17:258:22 | break; | CSharp7.cs:232:10:232:13 | exit Test (normal) | semmle.label | break |
 | CSharp7.cs:259:13:259:36 | case ...: | CSharp7.cs:259:18:259:23 | Int32 i2 | semmle.label | successor |
 | CSharp7.cs:259:18:259:23 | Int32 i2 | CSharp7.cs:259:30:259:31 | access to local variable i2 | semmle.label | match |
 | CSharp7.cs:259:18:259:23 | Int32 i2 | CSharp7.cs:262:13:262:24 | case ...: | semmle.label | no-match |
@@ -36,7 +37,7 @@
 | CSharp7.cs:260:35:260:50 | $"..." | CSharp7.cs:260:17:260:51 | call to method WriteLine | semmle.label | successor |
 | CSharp7.cs:260:37:260:45 | "positive " | CSharp7.cs:260:47:260:48 | access to local variable i2 | semmle.label | successor |
 | CSharp7.cs:260:47:260:48 | access to local variable i2 | CSharp7.cs:260:35:260:50 | $"..." | semmle.label | successor |
-| CSharp7.cs:261:17:261:22 | break; | CSharp7.cs:232:10:232:13 | exit Test | semmle.label | break |
+| CSharp7.cs:261:17:261:22 | break; | CSharp7.cs:232:10:232:13 | exit Test (normal) | semmle.label | break |
 | CSharp7.cs:262:13:262:24 | case ...: | CSharp7.cs:262:18:262:23 | Int32 i3 | semmle.label | successor |
 | CSharp7.cs:262:18:262:23 | Int32 i3 | CSharp7.cs:263:17:263:47 | ...; | semmle.label | match |
 | CSharp7.cs:262:18:262:23 | Int32 i3 | CSharp7.cs:265:13:265:27 | case ...: | semmle.label | no-match |
@@ -45,7 +46,7 @@
 | CSharp7.cs:263:35:263:45 | $"..." | CSharp7.cs:263:17:263:46 | call to method WriteLine | semmle.label | successor |
 | CSharp7.cs:263:37:263:40 | "int " | CSharp7.cs:263:42:263:43 | access to local variable i3 | semmle.label | successor |
 | CSharp7.cs:263:42:263:43 | access to local variable i3 | CSharp7.cs:263:35:263:45 | $"..." | semmle.label | successor |
-| CSharp7.cs:264:17:264:22 | break; | CSharp7.cs:232:10:232:13 | exit Test | semmle.label | break |
+| CSharp7.cs:264:17:264:22 | break; | CSharp7.cs:232:10:232:13 | exit Test (normal) | semmle.label | break |
 | CSharp7.cs:265:13:265:27 | case ...: | CSharp7.cs:265:18:265:26 | String s2 | semmle.label | successor |
 | CSharp7.cs:265:18:265:26 | String s2 | CSharp7.cs:266:17:266:50 | ...; | semmle.label | match |
 | CSharp7.cs:265:18:265:26 | String s2 | CSharp7.cs:268:13:268:26 | case ...: | semmle.label | no-match |
@@ -54,20 +55,20 @@
 | CSharp7.cs:266:35:266:48 | $"..." | CSharp7.cs:266:17:266:49 | call to method WriteLine | semmle.label | successor |
 | CSharp7.cs:266:37:266:43 | "string " | CSharp7.cs:266:45:266:46 | access to local variable s2 | semmle.label | successor |
 | CSharp7.cs:266:45:266:46 | access to local variable s2 | CSharp7.cs:266:35:266:48 | $"..." | semmle.label | successor |
-| CSharp7.cs:267:17:267:22 | break; | CSharp7.cs:232:10:232:13 | exit Test | semmle.label | break |
+| CSharp7.cs:267:17:267:22 | break; | CSharp7.cs:232:10:232:13 | exit Test (normal) | semmle.label | break |
 | CSharp7.cs:268:13:268:26 | case ...: | CSharp7.cs:268:18:268:23 | access to type Double | semmle.label | successor |
 | CSharp7.cs:268:18:268:23 | access to type Double | CSharp7.cs:269:17:269:44 | ...; | semmle.label | match |
 | CSharp7.cs:268:18:268:23 | access to type Double | CSharp7.cs:271:13:271:24 | case ...: | semmle.label | no-match |
 | CSharp7.cs:269:17:269:43 | call to method WriteLine | CSharp7.cs:270:17:270:22 | break; | semmle.label | successor |
 | CSharp7.cs:269:17:269:44 | ...; | CSharp7.cs:269:35:269:42 | "Double" | semmle.label | successor |
 | CSharp7.cs:269:35:269:42 | "Double" | CSharp7.cs:269:17:269:43 | call to method WriteLine | semmle.label | successor |
-| CSharp7.cs:270:17:270:22 | break; | CSharp7.cs:232:10:232:13 | exit Test | semmle.label | break |
+| CSharp7.cs:270:17:270:22 | break; | CSharp7.cs:232:10:232:13 | exit Test (normal) | semmle.label | break |
 | CSharp7.cs:271:13:271:24 | case ...: | CSharp7.cs:271:18:271:23 | Object v2 | semmle.label | successor |
 | CSharp7.cs:271:18:271:23 | Object v2 | CSharp7.cs:272:17:272:22 | break; | semmle.label | match |
 | CSharp7.cs:271:18:271:23 | Object v2 | CSharp7.cs:273:13:273:20 | default: | semmle.label | no-match |
-| CSharp7.cs:272:17:272:22 | break; | CSharp7.cs:232:10:232:13 | exit Test | semmle.label | break |
+| CSharp7.cs:272:17:272:22 | break; | CSharp7.cs:232:10:232:13 | exit Test (normal) | semmle.label | break |
 | CSharp7.cs:273:13:273:20 | default: | CSharp7.cs:274:17:274:52 | ...; | semmle.label | successor |
 | CSharp7.cs:274:17:274:51 | call to method WriteLine | CSharp7.cs:275:17:275:22 | break; | semmle.label | successor |
 | CSharp7.cs:274:17:274:52 | ...; | CSharp7.cs:274:35:274:50 | "Something else" | semmle.label | successor |
 | CSharp7.cs:274:35:274:50 | "Something else" | CSharp7.cs:274:17:274:51 | call to method WriteLine | semmle.label | successor |
-| CSharp7.cs:275:17:275:22 | break; | CSharp7.cs:232:10:232:13 | exit Test | semmle.label | break |
+| CSharp7.cs:275:17:275:22 | break; | CSharp7.cs:232:10:232:13 | exit Test (normal) | semmle.label | break |

--- a/csharp/ql/test/library-tests/csharp8/NullCoalescingControlFlow.expected
+++ b/csharp/ql/test/library-tests/csharp8/NullCoalescingControlFlow.expected
@@ -1,11 +1,12 @@
 | NullCoalescingAssignment.cs:5:10:5:23 | enter NullCoalescing | NullCoalescingAssignment.cs:6:5:9:5 | {...} | semmle.label | successor |
+| NullCoalescingAssignment.cs:5:10:5:23 | exit NullCoalescing (normal) | NullCoalescingAssignment.cs:5:10:5:23 | exit NullCoalescing | semmle.label | successor |
 | NullCoalescingAssignment.cs:6:5:9:5 | {...} | NullCoalescingAssignment.cs:7:9:7:24 | ... ...; | semmle.label | successor |
 | NullCoalescingAssignment.cs:7:9:7:24 | ... ...; | NullCoalescingAssignment.cs:7:20:7:23 | null | semmle.label | successor |
 | NullCoalescingAssignment.cs:7:16:7:23 | Object o = ... | NullCoalescingAssignment.cs:8:9:8:19 | ...; | semmle.label | successor |
 | NullCoalescingAssignment.cs:7:20:7:23 | null | NullCoalescingAssignment.cs:7:16:7:23 | Object o = ... | semmle.label | successor |
 | NullCoalescingAssignment.cs:8:9:8:9 | access to local variable o | NullCoalescingAssignment.cs:8:9:8:18 | ... = ... | semmle.label | non-null |
 | NullCoalescingAssignment.cs:8:9:8:9 | access to local variable o | NullCoalescingAssignment.cs:8:15:8:18 | this access | semmle.label | null |
-| NullCoalescingAssignment.cs:8:9:8:18 | ... = ... | NullCoalescingAssignment.cs:5:10:5:23 | exit NullCoalescing | semmle.label | successor |
+| NullCoalescingAssignment.cs:8:9:8:18 | ... = ... | NullCoalescingAssignment.cs:5:10:5:23 | exit NullCoalescing (normal) | semmle.label | successor |
 | NullCoalescingAssignment.cs:8:9:8:18 | ... ?? ... | NullCoalescingAssignment.cs:8:9:8:9 | access to local variable o | semmle.label | successor |
 | NullCoalescingAssignment.cs:8:9:8:19 | ...; | NullCoalescingAssignment.cs:8:9:8:18 | ... ?? ... | semmle.label | successor |
 | NullCoalescingAssignment.cs:8:15:8:18 | this access | NullCoalescingAssignment.cs:8:9:8:18 | ... = ... | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/NullableRefTypes.expected
+++ b/csharp/ql/test/library-tests/csharp8/NullableRefTypes.expected
@@ -14,6 +14,7 @@ nullableDataFlow
 | NullableRefTypes.cs:88:13:88:13 | access to local variable x | NullableRefTypes.cs:88:13:88:14 | ...! |
 nullableControlFlow
 | NullableRefTypes.cs:82:10:82:40 | enter TestSuppressNullableWarningExpr | NullableRefTypes.cs:83:5:89:5 | {...} | successor |
+| NullableRefTypes.cs:82:10:82:40 | exit TestSuppressNullableWarningExpr (normal) | NullableRefTypes.cs:82:10:82:40 | exit TestSuppressNullableWarningExpr | successor |
 | NullableRefTypes.cs:83:5:89:5 | {...} | NullableRefTypes.cs:84:9:84:29 | ... ...; | successor |
 | NullableRefTypes.cs:84:9:84:29 | ... ...; | NullableRefTypes.cs:84:21:84:28 | "source" | successor |
 | NullableRefTypes.cs:84:17:84:28 | String x = ... | NullableRefTypes.cs:85:9:85:22 | ... ...; | successor |
@@ -29,7 +30,7 @@ nullableControlFlow
 | NullableRefTypes.cs:87:9:87:16 | ... = ... | NullableRefTypes.cs:88:9:88:15 | ...; | successor |
 | NullableRefTypes.cs:87:9:87:17 | ...; | NullableRefTypes.cs:87:13:87:16 | null | successor |
 | NullableRefTypes.cs:87:13:87:16 | null | NullableRefTypes.cs:87:9:87:16 | ... = ... | successor |
-| NullableRefTypes.cs:88:9:88:14 | ... = ... | NullableRefTypes.cs:82:10:82:40 | exit TestSuppressNullableWarningExpr | successor |
+| NullableRefTypes.cs:88:9:88:14 | ... = ... | NullableRefTypes.cs:82:10:82:40 | exit TestSuppressNullableWarningExpr (normal) | successor |
 | NullableRefTypes.cs:88:9:88:15 | ...; | NullableRefTypes.cs:88:13:88:13 | access to local variable x | successor |
 | NullableRefTypes.cs:88:13:88:13 | access to local variable x | NullableRefTypes.cs:88:13:88:14 | ...! | successor |
 | NullableRefTypes.cs:88:13:88:14 | ...! | NullableRefTypes.cs:88:9:88:14 | ... = ... | successor |

--- a/csharp/ql/test/library-tests/csharp8/UsingControlFlow.expected
+++ b/csharp/ql/test/library-tests/csharp8/UsingControlFlow.expected
@@ -1,4 +1,5 @@
 | UsingDeclarations.cs:6:10:6:30 | enter TestUsingDeclarations | UsingDeclarations.cs:7:5:16:5 | {...} | semmle.label | successor |
+| UsingDeclarations.cs:6:10:6:30 | exit TestUsingDeclarations (normal) | UsingDeclarations.cs:6:10:6:30 | exit TestUsingDeclarations | semmle.label | successor |
 | UsingDeclarations.cs:7:5:16:5 | {...} | UsingDeclarations.cs:8:9:8:116 | using ... ...; | semmle.label | successor |
 | UsingDeclarations.cs:8:9:8:116 | using ... ...; | UsingDeclarations.cs:8:49:8:53 | "..." | semmle.label | successor |
 | UsingDeclarations.cs:8:26:8:69 | FileStream file1 = ... | UsingDeclarations.cs:8:95:8:99 | "..." | semmle.label | successor |
@@ -23,4 +24,4 @@
 | UsingDeclarations.cs:14:15:14:50 | object creation of type FileStream | UsingDeclarations.cs:15:13:15:13 | ; | semmle.label | successor |
 | UsingDeclarations.cs:14:30:14:34 | "..." | UsingDeclarations.cs:14:37:14:49 | access to constant Open | semmle.label | successor |
 | UsingDeclarations.cs:14:37:14:49 | access to constant Open | UsingDeclarations.cs:14:15:14:50 | object creation of type FileStream | semmle.label | successor |
-| UsingDeclarations.cs:15:13:15:13 | ; | UsingDeclarations.cs:6:10:6:30 | exit TestUsingDeclarations | semmle.label | successor |
+| UsingDeclarations.cs:15:13:15:13 | ; | UsingDeclarations.cs:6:10:6:30 | exit TestUsingDeclarations (normal) | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/ispatternflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/ispatternflow.expected
@@ -1,4 +1,5 @@
 | patterns.cs:5:10:5:19 | enter IsPatterns | patterns.cs:6:5:30:5 | {...} | semmle.label | successor |
+| patterns.cs:5:10:5:19 | exit IsPatterns (normal) | patterns.cs:5:10:5:19 | exit IsPatterns | semmle.label | successor |
 | patterns.cs:6:5:30:5 | {...} | patterns.cs:7:9:7:42 | ... ...; | semmle.label | successor |
 | patterns.cs:7:9:7:42 | ... ...; | patterns.cs:7:20:7:41 | object creation of type MyStruct | semmle.label | successor |
 | patterns.cs:7:16:7:41 | Object o = ... | patterns.cs:9:9:11:9 | if (...) ... | semmle.label | successor |
@@ -54,7 +55,7 @@
 | patterns.cs:23:9:24:9 | {...} | patterns.cs:27:9:29:9 | if (...) ... | semmle.label | successor |
 | patterns.cs:27:9:29:9 | if (...) ... | patterns.cs:27:13:27:13 | access to local variable o | semmle.label | successor |
 | patterns.cs:27:13:27:13 | access to local variable o | patterns.cs:27:31:27:32 | 12 | semmle.label | successor |
-| patterns.cs:27:13:27:58 | ... is ... | patterns.cs:5:10:5:19 | exit IsPatterns | semmle.label | false |
+| patterns.cs:27:13:27:58 | ... is ... | patterns.cs:5:10:5:19 | exit IsPatterns (normal) | semmle.label | false |
 | patterns.cs:27:13:27:58 | ... is ... | patterns.cs:28:9:29:9 | {...} | semmle.label | true |
 | patterns.cs:27:18:27:58 | { ... } | patterns.cs:27:13:27:58 | ... is ... | semmle.label | successor |
 | patterns.cs:27:27:27:58 | { ... } | patterns.cs:27:18:27:58 | { ... } | semmle.label | successor |
@@ -63,4 +64,4 @@
 | patterns.cs:27:38:27:56 | { ... } | patterns.cs:27:27:27:58 | { ... } | semmle.label | successor |
 | patterns.cs:27:47:27:53 | { ... } | patterns.cs:27:38:27:56 | { ... } | semmle.label | successor |
 | patterns.cs:27:51:27:51 | _ | patterns.cs:27:47:27:53 | { ... } | semmle.label | successor |
-| patterns.cs:28:9:29:9 | {...} | patterns.cs:5:10:5:19 | exit IsPatterns | semmle.label | successor |
+| patterns.cs:28:9:29:9 | {...} | patterns.cs:5:10:5:19 | exit IsPatterns (normal) | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/switchexprcontrolflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/switchexprcontrolflow.expected
@@ -1,4 +1,6 @@
 | patterns.cs:98:10:98:20 | enter Expressions | patterns.cs:99:5:121:5 | {...} | semmle.label | successor |
+| patterns.cs:98:10:98:20 | exit Expressions (abnormal) | patterns.cs:98:10:98:20 | exit Expressions | semmle.label | successor |
+| patterns.cs:98:10:98:20 | exit Expressions (normal) | patterns.cs:98:10:98:20 | exit Expressions | semmle.label | successor |
 | patterns.cs:99:5:121:5 | {...} | patterns.cs:100:9:103:10 | ... ...; | semmle.label | successor |
 | patterns.cs:100:9:103:10 | ... ...; | patterns.cs:100:20:103:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:100:13:103:9 | String size = ... | patterns.cs:105:9:105:27 | ... ...; | semmle.label | successor |
@@ -39,7 +41,7 @@
 | patterns.cs:110:23:110:23 | 1 | patterns.cs:110:25:110:25 | 0 | semmle.label | successor |
 | patterns.cs:110:25:110:25 | 0 | patterns.cs:110:22:110:26 | (..., ...) | semmle.label | successor |
 | patterns.cs:111:13:111:17 | ( ... ) | patterns.cs:111:13:111:17 | { ... } | semmle.label | successor |
-| patterns.cs:111:13:111:17 | { ... } | patterns.cs:98:10:98:20 | exit Expressions | semmle.label | exception(InvalidOperationException) |
+| patterns.cs:111:13:111:17 | { ... } | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | semmle.label | exception(InvalidOperationException) |
 | patterns.cs:111:13:111:17 | { ... } | patterns.cs:111:23:111:23 | 0 | semmle.label | match |
 | patterns.cs:111:13:111:26 | ... => ... | patterns.cs:111:14:111:14 | 1 | semmle.label | successor |
 | patterns.cs:111:14:111:14 | 1 | patterns.cs:111:16:111:16 | 0 | semmle.label | successor |
@@ -48,7 +50,7 @@
 | patterns.cs:111:23:111:23 | 0 | patterns.cs:111:25:111:25 | 1 | semmle.label | successor |
 | patterns.cs:111:25:111:25 | 1 | patterns.cs:111:22:111:26 | (..., ...) | semmle.label | successor |
 | patterns.cs:115:9:115:16 | (..., ...) | patterns.cs:115:20:120:9 | ... switch { ... } | semmle.label | successor |
-| patterns.cs:115:9:120:9 | ... = ... | patterns.cs:98:10:98:20 | exit Expressions | semmle.label | successor |
+| patterns.cs:115:9:120:9 | ... = ... | patterns.cs:98:10:98:20 | exit Expressions (normal) | semmle.label | successor |
 | patterns.cs:115:9:120:10 | ...; | patterns.cs:115:9:115:16 | (..., ...) | semmle.label | successor |
 | patterns.cs:115:20:115:27 | (..., ...) | patterns.cs:117:13:117:33 | ... => ... | semmle.label | successor |
 | patterns.cs:115:20:120:9 | ... switch { ... } | patterns.cs:115:21:115:22 | access to local variable x0 | semmle.label | successor |
@@ -73,7 +75,7 @@
 | patterns.cs:118:29:118:29 | 0 | patterns.cs:118:32:118:33 | access to local variable x2 | semmle.label | successor |
 | patterns.cs:118:32:118:33 | access to local variable x2 | patterns.cs:118:28:118:34 | (..., ...) | semmle.label | successor |
 | patterns.cs:119:13:119:28 | ( ... ) | patterns.cs:119:13:119:28 | { ... } | semmle.label | successor |
-| patterns.cs:119:13:119:28 | { ... } | patterns.cs:98:10:98:20 | exit Expressions | semmle.label | exception(InvalidOperationException) |
+| patterns.cs:119:13:119:28 | { ... } | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | semmle.label | exception(InvalidOperationException) |
 | patterns.cs:119:13:119:28 | { ... } | patterns.cs:119:34:119:34 | 0 | semmle.label | match |
 | patterns.cs:119:13:119:38 | ... => ... | patterns.cs:119:14:119:19 | Int32 x2 | semmle.label | successor |
 | patterns.cs:119:14:119:19 | Int32 x2 | patterns.cs:119:22:119:27 | Int32 y2 | semmle.label | successor |
@@ -82,6 +84,8 @@
 | patterns.cs:119:34:119:34 | 0 | patterns.cs:119:37:119:37 | 0 | semmle.label | successor |
 | patterns.cs:119:37:119:37 | 0 | patterns.cs:119:33:119:38 | (..., ...) | semmle.label | successor |
 | patterns.cs:123:10:123:21 | enter Expressions2 | patterns.cs:124:5:149:5 | {...} | semmle.label | successor |
+| patterns.cs:123:10:123:21 | exit Expressions2 (abnormal) | patterns.cs:123:10:123:21 | exit Expressions2 | semmle.label | successor |
+| patterns.cs:123:10:123:21 | exit Expressions2 (normal) | patterns.cs:123:10:123:21 | exit Expressions2 | semmle.label | successor |
 | patterns.cs:124:5:149:5 | {...} | patterns.cs:125:9:125:39 | ... ...; | semmle.label | successor |
 | patterns.cs:125:9:125:39 | ... ...; | patterns.cs:125:17:125:38 | object creation of type MyStruct | semmle.label | successor |
 | patterns.cs:125:13:125:38 | MyStruct s = ... | patterns.cs:126:9:132:10 | ... ...; | semmle.label | successor |
@@ -117,7 +121,7 @@
 | patterns.cs:130:14:130:14 | 1 | patterns.cs:130:17:130:17 | 2 | semmle.label | successor |
 | patterns.cs:130:17:130:17 | 2 | patterns.cs:130:13:130:18 | ( ... ) | semmle.label | successor |
 | patterns.cs:130:23:130:23 | 2 | patterns.cs:126:13:132:9 | Int32 r = ... | semmle.label | successor |
-| patterns.cs:131:13:131:22 | (..., ...) | patterns.cs:123:10:123:21 | exit Expressions2 | semmle.label | exception(InvalidOperationException) |
+| patterns.cs:131:13:131:22 | (..., ...) | patterns.cs:123:10:123:21 | exit Expressions2 (abnormal) | semmle.label | exception(InvalidOperationException) |
 | patterns.cs:131:13:131:22 | (..., ...) | patterns.cs:131:27:131:27 | 3 | semmle.label | match |
 | patterns.cs:131:13:131:27 | ... => ... | patterns.cs:131:18:131:18 | Int32 x | semmle.label | successor |
 | patterns.cs:131:18:131:18 | Int32 x | patterns.cs:131:21:131:21 | _ | semmle.label | successor |
@@ -125,7 +129,7 @@
 | patterns.cs:131:27:131:27 | 3 | patterns.cs:126:13:132:9 | Int32 r = ... | semmle.label | successor |
 | patterns.cs:134:9:148:9 | try {...} ... | patterns.cs:135:9:144:9 | {...} | semmle.label | successor |
 | patterns.cs:135:9:144:9 | {...} | patterns.cs:136:13:143:14 | ...; | semmle.label | successor |
-| patterns.cs:136:13:143:13 | ... = ... | patterns.cs:123:10:123:21 | exit Expressions2 | semmle.label | successor |
+| patterns.cs:136:13:143:13 | ... = ... | patterns.cs:123:10:123:21 | exit Expressions2 (normal) | semmle.label | successor |
 | patterns.cs:136:13:143:14 | ...; | patterns.cs:136:17:143:13 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:136:17:136:17 | access to parameter o | patterns.cs:138:17:138:50 | ... => ... | semmle.label | successor |
 | patterns.cs:136:17:143:13 | ... switch { ... } | patterns.cs:136:17:136:17 | access to parameter o | semmle.label | successor |
@@ -158,13 +162,13 @@
 | patterns.cs:142:26:142:34 | { ... } | patterns.cs:142:17:142:36 | { ... } | semmle.label | successor |
 | patterns.cs:142:31:142:32 | 10 | patterns.cs:142:26:142:34 | { ... } | semmle.label | successor |
 | patterns.cs:142:41:142:41 | 6 | patterns.cs:136:13:143:13 | ... = ... | semmle.label | successor |
-| patterns.cs:145:9:148:9 | [exception: ArgumentException] catch (...) {...} | patterns.cs:123:10:123:21 | exit Expressions2 | semmle.label | exception(ArgumentException) |
-| patterns.cs:145:9:148:9 | [exception: Exception] catch (...) {...} | patterns.cs:123:10:123:21 | exit Expressions2 | semmle.label | exception(Exception) |
+| patterns.cs:145:9:148:9 | [exception: ArgumentException] catch (...) {...} | patterns.cs:123:10:123:21 | exit Expressions2 (abnormal) | semmle.label | exception(ArgumentException) |
+| patterns.cs:145:9:148:9 | [exception: Exception] catch (...) {...} | patterns.cs:123:10:123:21 | exit Expressions2 (abnormal) | semmle.label | exception(Exception) |
 | patterns.cs:145:9:148:9 | [exception: Exception] catch (...) {...} | patterns.cs:145:41:145:42 | [exception: Exception] InvalidOperationException ex | semmle.label | match |
 | patterns.cs:145:9:148:9 | [exception: InvalidOperationException] catch (...) {...} | patterns.cs:145:41:145:42 | [exception: InvalidOperationException] InvalidOperationException ex | semmle.label | match |
 | patterns.cs:145:41:145:42 | [exception: Exception] InvalidOperationException ex | patterns.cs:146:9:148:9 | {...} | semmle.label | successor |
 | patterns.cs:145:41:145:42 | [exception: InvalidOperationException] InvalidOperationException ex | patterns.cs:146:9:148:9 | {...} | semmle.label | successor |
 | patterns.cs:146:9:148:9 | {...} | patterns.cs:147:13:147:51 | ...; | semmle.label | successor |
-| patterns.cs:147:13:147:50 | call to method WriteLine | patterns.cs:123:10:123:21 | exit Expressions2 | semmle.label | successor |
+| patterns.cs:147:13:147:50 | call to method WriteLine | patterns.cs:123:10:123:21 | exit Expressions2 (normal) | semmle.label | successor |
 | patterns.cs:147:13:147:51 | ...; | patterns.cs:147:31:147:49 | "Invalid operation" | semmle.label | successor |
 | patterns.cs:147:31:147:49 | "Invalid operation" | patterns.cs:147:13:147:50 | call to method WriteLine | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/switchstmtctrlflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/switchstmtctrlflow.expected
@@ -1,4 +1,5 @@
 | patterns.cs:32:10:32:25 | enter SwitchStatements | patterns.cs:33:5:96:5 | {...} | semmle.label | successor |
+| patterns.cs:32:10:32:25 | exit SwitchStatements (normal) | patterns.cs:32:10:32:25 | exit SwitchStatements | semmle.label | successor |
 | patterns.cs:33:5:96:5 | {...} | patterns.cs:34:9:34:39 | ... ...; | semmle.label | successor |
 | patterns.cs:34:9:34:39 | ... ...; | patterns.cs:34:17:34:38 | object creation of type MyStruct | semmle.label | successor |
 | patterns.cs:34:13:34:38 | MyStruct s = ... | patterns.cs:36:9:44:9 | switch (...) {...} | semmle.label | successor |
@@ -160,11 +161,11 @@
 | patterns.cs:93:18:93:27 | { ... } | patterns.cs:94:13:94:24 | case ...: | semmle.label | no-match |
 | patterns.cs:93:19:93:19 | 1 | patterns.cs:93:22:93:26 | Int32 x | semmle.label | successor |
 | patterns.cs:93:22:93:26 | Int32 x | patterns.cs:93:18:93:27 | ( ... ) | semmle.label | successor |
-| patterns.cs:93:30:93:35 | break; | patterns.cs:32:10:32:25 | exit SwitchStatements | semmle.label | break |
+| patterns.cs:93:30:93:35 | break; | patterns.cs:32:10:32:25 | exit SwitchStatements (normal) | semmle.label | break |
 | patterns.cs:94:13:94:24 | case ...: | patterns.cs:94:19:94:19 | 2 | semmle.label | successor |
 | patterns.cs:94:18:94:23 | ( ... ) | patterns.cs:94:18:94:23 | { ... } | semmle.label | successor |
-| patterns.cs:94:18:94:23 | { ... } | patterns.cs:32:10:32:25 | exit SwitchStatements | semmle.label | no-match |
+| patterns.cs:94:18:94:23 | { ... } | patterns.cs:32:10:32:25 | exit SwitchStatements (normal) | semmle.label | no-match |
 | patterns.cs:94:18:94:23 | { ... } | patterns.cs:94:26:94:31 | break; | semmle.label | match |
 | patterns.cs:94:19:94:19 | 2 | patterns.cs:94:22:94:22 | _ | semmle.label | successor |
 | patterns.cs:94:22:94:22 | _ | patterns.cs:94:18:94:23 | ( ... ) | semmle.label | successor |
-| patterns.cs:94:26:94:31 | break; | patterns.cs:32:10:32:25 | exit SwitchStatements | semmle.label | break |
+| patterns.cs:94:26:94:31 | break; | patterns.cs:32:10:32:25 | exit SwitchStatements (normal) | semmle.label | break |

--- a/csharp/ql/test/library-tests/goto/Goto1.expected
+++ b/csharp/ql/test/library-tests/goto/Goto1.expected
@@ -1,4 +1,5 @@
 | goto.cs:4:17:4:20 | enter Main | goto.cs:5:5:20:5 | {...} | semmle.label | successor |
+| goto.cs:4:17:4:20 | exit Main (normal) | goto.cs:4:17:4:20 | exit Main | semmle.label | successor |
 | goto.cs:5:5:20:5 | {...} | goto.cs:6:9:8:9 | {...} | semmle.label | successor |
 | goto.cs:6:9:8:9 | {...} | goto.cs:7:13:7:14 | s1: | semmle.label | successor |
 | goto.cs:7:13:7:14 | s1: | goto.cs:7:17:7:24 | goto ...; | semmle.label | successor |
@@ -41,4 +42,4 @@
 | goto.cs:17:26:17:40 | goto case ...; | goto.cs:12:13:12:22 | case ...: | semmle.label | goto(null) |
 | goto.cs:17:36:17:39 | null | goto.cs:17:26:17:40 | goto case ...; | semmle.label | successor |
 | goto.cs:19:9:19:10 | s9: | goto.cs:19:12:19:12 | ; | semmle.label | successor |
-| goto.cs:19:12:19:12 | ; | goto.cs:4:17:4:20 | exit Main | semmle.label | successor |
+| goto.cs:19:12:19:12 | ; | goto.cs:4:17:4:20 | exit Main (normal) | semmle.label | successor |

--- a/csharp/ql/test/library-tests/standalone/controlflow/cfg.expected
+++ b/csharp/ql/test/library-tests/standalone/controlflow/cfg.expected
@@ -1,4 +1,5 @@
 | ControlFlow.cs:7:10:7:10 | enter F | ControlFlow.cs:8:5:13:5 | {...} |
+| ControlFlow.cs:7:10:7:10 | exit F (normal) | ControlFlow.cs:7:10:7:10 | exit F |
 | ControlFlow.cs:8:5:13:5 | {...} | ControlFlow.cs:9:9:9:34 | ... ...; |
 | ControlFlow.cs:9:9:9:34 | ... ...; | ControlFlow.cs:9:17:9:33 | Call (unknown target) |
 | ControlFlow.cs:9:13:9:33 | (unknown type) v | ControlFlow.cs:10:9:10:44 | ...; |
@@ -19,7 +20,7 @@
 | ControlFlow.cs:10:29:10:42 | "This is true" | ControlFlow.cs:10:9:10:43 | call to method  |
 | ControlFlow.cs:12:9:12:86 | Call (unknown target) | ControlFlow.cs:12:51:12:62 | access to field Empty |
 | ControlFlow.cs:12:9:12:87 | ...; | ControlFlow.cs:12:9:12:86 | Call (unknown target) |
-| ControlFlow.cs:12:35:12:86 | { ..., ... } | ControlFlow.cs:7:10:7:10 | exit F |
+| ControlFlow.cs:12:35:12:86 | { ..., ... } | ControlFlow.cs:7:10:7:10 | exit F (normal) |
 | ControlFlow.cs:12:37:12:62 | ... = ... | ControlFlow.cs:12:79:12:79 | access to local variable v |
 | ControlFlow.cs:12:51:12:62 | access to field Empty | ControlFlow.cs:12:37:12:62 | ... = ... |
 | ControlFlow.cs:12:65:12:84 | ... = ... | ControlFlow.cs:12:35:12:86 | { ..., ... } |


### PR DESCRIPTION
### Overview

As discussed several times with @aschackmull, post-dominance makes more sense when restricted to paths that leave the callable normally, that is, without throwing an exception or halting.

For example, in

```csharp
void M3(string s)
{
    if (s is null)
        throw new ArgumentNullException(nameof(s));
    Console.WriteLine(s);
}
```

the call `Console.WriteLine(s)` will happen on all normal paths through `M3`, so we want it to post-dominate the entry point.

### Implementation

Before this PR, the CFG for `M3` was
<img width="735" alt="Screenshot 2020-10-29 at 14 12 57" src="https://user-images.githubusercontent.com/3667920/97578501-298f4500-19f1-11eb-9da1-57d04c4fa736.png">
and post-dominance was defined in terms of the `exit M3` node.

This PR changes the CFG for `M3` to
<img width="661" alt="Screenshot 2020-10-29 at 14 09 39" src="https://user-images.githubusercontent.com/3667920/97578555-3dd34200-19f1-11eb-8735-f2a748a40de6.png">
and redefines post-dominance with respect to the new `exit M3 (normal)` node that represents normal execution (highlighted in red).

Note that each callable will still have a unique exit node, which is reached from the two new normal/abnormal exit nodes: this is for backwards compatibility, and so that we can recover the old post-dominance logic, if needed.

CSharp-Differences [here](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/577/).