### PR TITLE
Fix path transformer handling of extensionless files

### DIFF
--- a/csharp/extractor/Semmle.Extraction/PathTransformer.cs
+++ b/csharp/extractor/Semmle.Extraction/PathTransformer.cs
@@ -49,14 +49,7 @@ namespace Semmle.Extraction
                 get
                 {
                     var extension = Path.GetExtension(value);
-                    if (string.IsNullOrEmpty(extension))
-                    {
-                        return "";
-                    }
-                    else
-                    {
-                        return extension.Substring(1);
-                    }
+                    return string.IsNullOrEmpty(extension) ? "" : extension.Substring(1);
                 }
             }
 

--- a/csharp/extractor/Semmle.Extraction/PathTransformer.cs
+++ b/csharp/extractor/Semmle.Extraction/PathTransformer.cs
@@ -44,7 +44,21 @@ namespace Semmle.Extraction
 
             public string Value => value;
 
-            public string Extension => Path.GetExtension(value)?.Substring(1) ?? "";
+            public string Extension
+            {
+                get
+                {
+                    var extension = Path.GetExtension(value);
+                    if (string.IsNullOrEmpty(extension))
+                    {
+                        return "";
+                    }
+                    else
+                    {
+                        return extension.Substring(1);
+                    }
+                }
+            }
 
             public string NameWithoutExtension => Path.GetFileNameWithoutExtension(value);
 


### PR DESCRIPTION
A customer hit this when using a path transformer in one of their large repos.

I'd like this to be in 1.26 and the corresponding CodeQL bundle, so I don't need to provide private bits to the customer.
