### PR TITLE
C++: Add support for StmtExpr to Print AST.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -342,6 +342,20 @@ class CastNode extends ConversionNode {
 }
 
 /**
+ * A node representing a `StmtExpr`.
+ */
+class StmtExprNode extends ExprNode {
+  StmtExpr stmtExpr;
+
+  StmtExprNode() { stmtExpr = expr }
+
+  override ASTNode getChildInternal(int childIndex) {
+    childIndex = 0 and
+    result.getAST() = stmtExpr.getStmt()
+  }
+}
+
+/**
  * A node representing a `DeclarationEntry`.
  */
 class DeclarationEntryNode extends BaseASTNode, TDeclarationEntryNode {

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -345,13 +345,11 @@ class CastNode extends ConversionNode {
  * A node representing a `StmtExpr`.
  */
 class StmtExprNode extends ExprNode {
-  StmtExpr stmtExpr;
-
-  StmtExprNode() { stmtExpr = expr }
+  override StmtExpr expr;
 
   override ASTNode getChildInternal(int childIndex) {
     childIndex = 0 and
-    result.getAST() = stmtExpr.getStmt()
+    result.getAST() = expr.getStmt()
   }
 }
 

--- a/cpp/ql/test/examples/expressions/PrintAST.expected
+++ b/cpp/ql/test/examples/expressions/PrintAST.expected
@@ -724,6 +724,19 @@ StatementExpr.c:
 #    2|           getExpr(): [StmtExpr] (statement expression)
 #    2|               Type = [IntType] int
 #    2|               ValueCategory = prvalue
+#    2|             getStmt(): [BlockStmt] { ... }
+#    2|               getStmt(0): [DeclStmt] declaration
+#    2|                 getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
+#    2|                     Type = [IntType] int
+#    2|                   getVariable().getInitializer(): [Initializer] initializer for i
+#    2|                     getExpr(): [Literal] 5
+#    2|                         Type = [IntType] int
+#    2|                         Value = [Literal] 5
+#    2|                         ValueCategory = prvalue
+#    2|               getStmt(1): [ExprStmt] ExprStmt
+#    2|                 getExpr(): [VariableAccess] i
+#    2|                     Type = [IntType] int
+#    2|                     ValueCategory = prvalue(load)
 #    3|     getStmt(1): [ReturnStmt] return ...
 StaticMemberAccess.cpp:
 #    1| [CopyAssignmentOperator] X& X::operator=(X const&)

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -8260,7 +8260,7 @@ ir.cpp:
 #  997|               Type = [FloatType] float
 #  997|               Value = [CStyleCast] 1.0
 #  997|               ValueCategory = prvalue
-# 1000| [TopLevelFunction] int ExprStmt(int, int, int)
+# 1000| [TopLevelFunction] int StmtExpr(int, int, int)
 # 1000|   <params>: 
 # 1000|     getParameter(0): [Parameter] b
 # 1000|         Type = [IntType] int
@@ -8276,10 +8276,53 @@ ir.cpp:
 # 1001|           getExpr(): [StmtExpr] (statement expression)
 # 1001|               Type = [IntType] int
 # 1001|               ValueCategory = prvalue
+# 1001|             getStmt(): [BlockStmt] { ... }
+# 1002|               getStmt(0): [DeclStmt] declaration
+# 1002|                 getDeclarationEntry(0): [VariableDeclarationEntry] definition of w
+# 1002|                     Type = [IntType] int
+# 1003|               getStmt(1): [IfStmt] if (...) ... 
+# 1003|                 getCondition(): [VariableAccess] b
+# 1003|                     Type = [IntType] int
+# 1003|                     ValueCategory = prvalue(load)
+# 1003|                 getThen(): [BlockStmt] { ... }
+# 1004|                   getStmt(0): [ExprStmt] ExprStmt
+# 1004|                     getExpr(): [AssignExpr] ... = ...
+# 1004|                         Type = [IntType] int
+# 1004|                         ValueCategory = lvalue
+# 1004|                       getLValue(): [VariableAccess] w
+# 1004|                           Type = [IntType] int
+# 1004|                           ValueCategory = lvalue
+# 1004|                       getRValue(): [VariableAccess] y
+# 1004|                           Type = [IntType] int
+# 1004|                           ValueCategory = prvalue(load)
+# 1005|                 getElse(): [BlockStmt] { ... }
+# 1006|                   getStmt(0): [ExprStmt] ExprStmt
+# 1006|                     getExpr(): [AssignExpr] ... = ...
+# 1006|                         Type = [IntType] int
+# 1006|                         ValueCategory = lvalue
+# 1006|                       getLValue(): [VariableAccess] w
+# 1006|                           Type = [IntType] int
+# 1006|                           ValueCategory = lvalue
+# 1006|                       getRValue(): [VariableAccess] z
+# 1006|                           Type = [IntType] int
+# 1006|                           ValueCategory = prvalue(load)
+# 1003|                 getCondition().getFullyConverted(): [CStyleCast] (bool)...
+# 1003|                     Conversion = [BoolConversion] conversion to bool
+# 1003|                     Type = [BoolType] bool
+# 1003|                     ValueCategory = prvalue
+# 1008|               getStmt(2): [ExprStmt] ExprStmt
+# 1008|                 getExpr(): [VariableAccess] w
+# 1008|                     Type = [IntType] int
+# 1008|                     ValueCategory = prvalue(load)
 # 1011|     getStmt(1): [ReturnStmt] return ...
 # 1011|       getExpr(): [StmtExpr] (statement expression)
 # 1011|           Type = [IntType] int
 # 1011|           ValueCategory = prvalue
+# 1011|         getStmt(): [BlockStmt] { ... }
+# 1011|           getStmt(0): [ExprStmt] ExprStmt
+# 1011|             getExpr(): [VariableAccess] x
+# 1011|                 Type = [IntType] int
+# 1011|                 ValueCategory = prvalue(load)
 # 1015| [TopLevelFunction] void OperatorDelete()
 # 1015|   <params>: 
 # 1015|   getEntryPoint(): [BlockStmt] { ... }

--- a/cpp/ql/test/library-tests/ir/ir/ir.cpp
+++ b/cpp/ql/test/library-tests/ir/ir/ir.cpp
@@ -997,7 +997,7 @@ int PointerDecay(int a[], int fn(float)) {
   return a[0] + fn(1.0);
 }
 
-int ExprStmt(int b, int y, int z) {
+int StmtExpr(int b, int y, int z) {
   int x = ({
     int w;
     if (b) {

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -5532,7 +5532,7 @@ ir.cpp:
 #  996|     v996_13(void)            = AliasedUse               : ~m?
 #  996|     v996_14(void)            = ExitFunction             : 
 
-# 1000| int ExprStmt(int, int, int)
+# 1000| int StmtExpr(int, int, int)
 # 1000|   Block 0
 # 1000|     v1000_1(void)       = EnterFunction          : 
 # 1000|     mu1000_2(unknown)   = AliasedDefinition      : 


### PR DESCRIPTION
Includes support for `StmtExpr` in PrintAST.