### PR TITLE
C#: Fix bad join-order in `commonSubTypeGeneral/2`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -534,6 +534,11 @@ private TypeParameter getATypeParameterSubType(DataFlowTypeOrUnifiable t) {
 }
 
 pragma[noinline]
+private TypeParameter getATypeParameterSubTypeRestricted(DataFlowType t) {
+  result = getATypeParameterSubType(t)
+}
+
+pragma[noinline]
 private Gvn::GvnType getANonTypeParameterSubType(DataFlowTypeOrUnifiable t) {
   not t instanceof Gvn::TypeParameterGvnType and
   not result instanceof Gvn::TypeParameterGvnType and
@@ -542,6 +547,11 @@ private Gvn::GvnType getANonTypeParameterSubType(DataFlowTypeOrUnifiable t) {
     result = Gvn::getGlobalValueNumber(t1) and
     t = Gvn::getGlobalValueNumber(t2)
   )
+}
+
+pragma[noinline]
+private Gvn::GvnType getANonTypeParameterSubTypeRestricted(DataFlowType t) {
+  result = getANonTypeParameterSubType(t)
 }
 
 /** A collection of cached types and predicates to be evaluated in the same stage. */
@@ -793,9 +803,9 @@ private module Cached {
     not t1 instanceof Gvn::TypeParameterGvnType and
     t1 = t2
     or
-    getATypeParameterSubType(t1) = getATypeParameterSubType(t2)
+    getATypeParameterSubType(t1) = getATypeParameterSubTypeRestricted(t2)
     or
-    getANonTypeParameterSubType(t1) = getANonTypeParameterSubType(t2)
+    getANonTypeParameterSubType(t1) = getANonTypeParameterSubTypeRestricted(t2)
   }
 
   /**


### PR DESCRIPTION
Before:
```
[2020-11-01 19:42:06] (1264s) Tuple counts for DataFlowPrivate::Cached::commonSubTypeGeneral#ff:
                      61534      ~0%        {1} r1 = JOIN project#DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff AS L WITH DataFlowPrivate::DataFlowTypeOrUnifiable#f AS R ON FIRST 1 OUTPUT R.<0>
                      61533      ~0%        {1} r2 = r1 AND NOT Unification::Gvn::Cached::TTypeParameterGvnType#f@staged_ext AS R(r1.<0>)
                      61533      ~3%        {2} r3 = SCAN r2 OUTPUT r2.<0>, r2.<0>
                      68119      ~4%        {2} r4 = JOIN DataFlowPrivate::getATypeParameterSubType#ff AS L WITH DataFlowPrivate::DataFlowTypeOrUnifiable#f AS R ON FIRST 1 OUTPUT L.<1>, R.<0>
                      89969      ~2869%     {2} r5 = JOIN r4 WITH DataFlowPrivate::getATypeParameterSubType#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r4.<1>
                      88071      ~3002%     {2} r6 = JOIN r5 WITH project#DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff AS R ON FIRST 1 OUTPUT r5.<1>, r5.<0>
                      1952980    ~0%        {2} r7 = JOIN DataFlowPrivate::DataFlowTypeOrUnifiable#f AS L WITH DataFlowPrivate::getANonTypeParameterSubType#ff AS R ON FIRST 1 OUTPUT R.<1>, L.<0>
                      4897808380 ~4355%     {2} r8 = JOIN r7 WITH DataFlowPrivate::getANonTypeParameterSubType#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r7.<1>
                      1002659008 ~4352%     {2} r9 = JOIN r8 WITH project#DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff AS R ON FIRST 1 OUTPUT r8.<1>, r8.<0>
                      1002747079 ~4352%     {2} r10 = r6 \/ r9
                      1002808612 ~4353%     {2} r11 = r3 \/ r10
                                            return r11
```

After:
```
[2020-11-01 20:06:12] (541s) Tuple counts for DataFlowPrivate::Cached::commonSubTypeGeneral#ff:
                      61536      ~0%        {1} r1 = JOIN project#DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff AS L WITH DataFlowPrivate::DataFlowTypeOrUnifiable#f AS R ON FIRST 1 OUTPUT R.<0>
                      61535      ~0%        {1} r2 = r1 AND NOT Unification::Gvn::Cached::TTypeParameterGvnType#f@staged_ext AS R(r1.<0>)
                      61535      ~3%        {2} r3 = SCAN r2 OUTPUT r2.<0>, r2.<0>
                      68119      ~4%        {2} r4 = JOIN DataFlowPrivate::getATypeParameterSubType#ff AS L WITH DataFlowPrivate::DataFlowTypeOrUnifiable#f AS R ON FIRST 1 OUTPUT L.<1>, R.<0>
                      88071      ~2986%     {2} r5 = JOIN r4 WITH DataFlowPrivate::getATypeParameterSubTypeRestricted#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r4.<1>
                      88071      ~3002%     {2} r6 = JOIN r5 WITH project#DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff AS R ON FIRST 1 OUTPUT r5.<1>, r5.<0>
                      1953662    ~0%        {2} r7 = JOIN DataFlowPrivate::DataFlowTypeOrUnifiable#f AS L WITH DataFlowPrivate::getANonTypeParameterSubType#ff AS R ON FIRST 1 OUTPUT R.<1>, L.<0>
                      1002660102 ~4169%     {2} r8 = JOIN r7 WITH DataFlowPrivate::getANonTypeParameterSubTypeRestricted#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r7.<1>
                      1002660102 ~4352%     {2} r9 = JOIN r8 WITH project#DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff AS R ON FIRST 1 OUTPUT r8.<1>, r8.<0>
                      1002748173 ~4352%     {2} r10 = r6 \/ r9
                      1002809708 ~4353%     {2} r11 = r3 \/ r10
                                            return r11
```

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/587/