### PR TITLE
C++: Model std::vector emplace and emplace_back()

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
@@ -206,3 +206,34 @@ class StdSequenceContainerAt extends TaintFunction {
     output.isQualifierObject()
   }
 }
+
+/**
+ * The standard vector `emplace` function.
+ */
+class StdVectorEmplace extends TaintFunction {
+  StdVectorEmplace() { this.hasQualifiedName("std", "vector", "emplace") }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    // flow from any parameter except the position iterator to qualifier and return value
+    // (here we assume taint flow from any constructor parameter to the constructed object)
+    input.isParameter([1 .. getNumberOfParameters() - 1]) and
+    (
+      output.isQualifierObject() or
+      output.isReturnValue()
+    )
+  }
+}
+
+/**
+ * The standard vector `emplace_back` function.
+ */
+class StdVectorEmplaceBack extends TaintFunction {
+  StdVectorEmplaceBack() { this.hasQualifiedName("std", "vector", "emplace_back") }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    // flow from any parameter to qualifier
+    // (here we assume taint flow from any constructor parameter to the constructed object)
+    input.isParameter([0 .. getNumberOfParameters() - 1]) and
+    output.isQualifierObject()
+  }
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -3190,125 +3190,125 @@
 | stl.h:292:30:292:40 | call to allocator | stl.h:292:21:292:41 | noexcept(...) | TAINT |
 | stl.h:292:30:292:40 | call to allocator | stl.h:292:21:292:41 | noexcept(...) | TAINT |
 | stl.h:292:53:292:63 | 0 | stl.h:292:46:292:64 | (no string representation) | TAINT |
-| stl.h:385:9:385:9 | Unknown literal | stl.h:385:9:385:9 | constructor init of field first | TAINT |
-| stl.h:385:9:385:9 | Unknown literal | stl.h:385:9:385:9 | constructor init of field first | TAINT |
-| stl.h:385:9:385:9 | Unknown literal | stl.h:385:9:385:9 | constructor init of field first | TAINT |
-| stl.h:385:9:385:9 | Unknown literal | stl.h:385:9:385:9 | constructor init of field first | TAINT |
-| stl.h:385:9:385:9 | Unknown literal | stl.h:385:9:385:9 | constructor init of field first | TAINT |
-| stl.h:385:9:385:9 | Unknown literal | stl.h:385:9:385:9 | constructor init of field second | TAINT |
-| stl.h:385:9:385:9 | Unknown literal | stl.h:385:9:385:9 | constructor init of field second | TAINT |
-| stl.h:385:9:385:9 | Unknown literal | stl.h:385:9:385:9 | constructor init of field second | TAINT |
-| stl.h:385:9:385:9 | Unknown literal | stl.h:385:9:385:9 | constructor init of field second | TAINT |
-| stl.h:385:9:385:9 | Unknown literal | stl.h:385:9:385:9 | constructor init of field second | TAINT |
-| stl.h:385:9:385:9 | constructor init of field first [post-this] | stl.h:385:9:385:9 | constructor init of field second [pre-this] |  |
-| stl.h:385:9:385:9 | constructor init of field first [post-this] | stl.h:385:9:385:9 | constructor init of field second [pre-this] |  |
-| stl.h:385:9:385:9 | constructor init of field first [post-this] | stl.h:385:9:385:9 | constructor init of field second [pre-this] |  |
-| stl.h:385:9:385:9 | constructor init of field first [post-this] | stl.h:385:9:385:9 | constructor init of field second [pre-this] |  |
-| stl.h:385:9:385:9 | constructor init of field first [post-this] | stl.h:385:9:385:9 | constructor init of field second [pre-this] |  |
-| stl.h:385:9:385:9 | constructor init of field first [pre-this] | stl.h:385:9:385:9 | constructor init of field second [pre-this] |  |
-| stl.h:385:9:385:9 | constructor init of field first [pre-this] | stl.h:385:9:385:9 | constructor init of field second [pre-this] |  |
-| stl.h:385:9:385:9 | constructor init of field first [pre-this] | stl.h:385:9:385:9 | constructor init of field second [pre-this] |  |
-| stl.h:385:9:385:9 | constructor init of field first [pre-this] | stl.h:385:9:385:9 | constructor init of field second [pre-this] |  |
-| stl.h:385:9:385:9 | constructor init of field first [pre-this] | stl.h:385:9:385:9 | constructor init of field second [pre-this] |  |
-| stl.h:385:9:385:9 | this | stl.h:385:9:385:9 | constructor init of field first [pre-this] |  |
-| stl.h:385:9:385:9 | this | stl.h:385:9:385:9 | constructor init of field first [pre-this] |  |
-| stl.h:385:9:385:9 | this | stl.h:385:9:385:9 | constructor init of field first [pre-this] |  |
-| stl.h:385:9:385:9 | this | stl.h:385:9:385:9 | constructor init of field first [pre-this] |  |
-| stl.h:385:9:385:9 | this | stl.h:385:9:385:9 | constructor init of field first [pre-this] |  |
-| stl.h:392:3:392:3 | this | stl.h:392:36:392:43 | constructor init of field first [pre-this] |  |
-| stl.h:392:3:392:3 | this | stl.h:392:36:392:43 | constructor init of field first [pre-this] |  |
-| stl.h:392:3:392:3 | this | stl.h:392:36:392:43 | constructor init of field first [pre-this] |  |
-| stl.h:392:3:392:3 | this | stl.h:392:36:392:43 | constructor init of field first [pre-this] |  |
-| stl.h:392:3:392:3 | this | stl.h:392:36:392:43 | constructor init of field first [pre-this] |  |
-| stl.h:392:3:392:6 | this | stl.h:392:36:392:43 | constructor init of field first [pre-this] |  |
-| stl.h:392:18:392:18 | x | stl.h:392:42:392:42 | x |  |
-| stl.h:392:18:392:18 | x | stl.h:392:42:392:42 | x |  |
-| stl.h:392:18:392:18 | x | stl.h:392:42:392:42 | x |  |
-| stl.h:392:18:392:18 | x | stl.h:392:42:392:42 | x |  |
-| stl.h:392:18:392:18 | x | stl.h:392:42:392:42 | x |  |
-| stl.h:392:18:392:18 | x | stl.h:392:42:392:42 | x |  |
-| stl.h:392:31:392:31 | y | stl.h:392:53:392:53 | y |  |
-| stl.h:392:31:392:31 | y | stl.h:392:53:392:53 | y |  |
-| stl.h:392:31:392:31 | y | stl.h:392:53:392:53 | y |  |
-| stl.h:392:31:392:31 | y | stl.h:392:53:392:53 | y |  |
-| stl.h:392:31:392:31 | y | stl.h:392:53:392:53 | y |  |
-| stl.h:392:31:392:31 | y | stl.h:392:53:392:53 | y |  |
-| stl.h:392:36:392:43 | call to unknown function | stl.h:392:36:392:43 | constructor init of field first | TAINT |
-| stl.h:392:36:392:43 | constructor init of field first [post-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [post-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [post-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [post-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [post-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [post-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [pre-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [pre-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [pre-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [pre-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [pre-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:36:392:43 | constructor init of field first [pre-this] | stl.h:392:46:392:54 | constructor init of field second [pre-this] |  |
-| stl.h:392:42:392:42 | x | stl.h:392:36:392:43 | constructor init of field first | TAINT |
-| stl.h:392:42:392:42 | x | stl.h:392:36:392:43 | constructor init of field first | TAINT |
-| stl.h:392:42:392:42 | x | stl.h:392:36:392:43 | constructor init of field first | TAINT |
-| stl.h:392:42:392:42 | x | stl.h:392:36:392:43 | constructor init of field first | TAINT |
-| stl.h:392:42:392:42 | x | stl.h:392:36:392:43 | constructor init of field first | TAINT |
-| stl.h:392:46:392:54 | call to unknown function | stl.h:392:46:392:54 | constructor init of field second | TAINT |
-| stl.h:392:53:392:53 | y | stl.h:392:46:392:54 | constructor init of field second | TAINT |
-| stl.h:392:53:392:53 | y | stl.h:392:46:392:54 | constructor init of field second | TAINT |
-| stl.h:392:53:392:53 | y | stl.h:392:46:392:54 | constructor init of field second | TAINT |
-| stl.h:392:53:392:53 | y | stl.h:392:46:392:54 | constructor init of field second | TAINT |
-| stl.h:392:53:392:53 | y | stl.h:392:46:392:54 | constructor init of field second | TAINT |
-| stl.h:398:87:398:87 | x | stl.h:398:87:398:87 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:398:87:398:87 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:398:87:398:87 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:398:87:398:87 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:398:87:398:87 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:398:87:398:87 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:398:87:398:87 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:399:58:399:58 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:399:58:399:58 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:399:58:399:58 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:399:58:399:58 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:399:58:399:58 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:399:58:399:58 | x |  |
-| stl.h:398:87:398:87 | x | stl.h:399:58:399:58 | x |  |
-| stl.h:398:95:398:95 | y | stl.h:398:95:398:95 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:398:95:398:95 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:398:95:398:95 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:398:95:398:95 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:398:95:398:95 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:398:95:398:95 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:398:95:398:95 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:399:79:399:79 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:399:79:399:79 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:399:79:399:79 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:399:79:399:79 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:399:79:399:79 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:399:79:399:79 | y |  |
-| stl.h:398:95:398:95 | y | stl.h:399:79:399:79 | y |  |
-| stl.h:399:58:399:58 | x | stl.h:399:41:399:56 | call to forward |  |
-| stl.h:399:58:399:58 | x | stl.h:399:41:399:56 | call to forward |  |
-| stl.h:399:58:399:58 | x | stl.h:399:41:399:56 | call to forward |  |
-| stl.h:399:58:399:58 | x | stl.h:399:41:399:56 | call to forward |  |
-| stl.h:399:58:399:58 | x | stl.h:399:41:399:56 | call to forward |  |
-| stl.h:399:58:399:58 | x | stl.h:399:41:399:56 | call to forward |  |
-| stl.h:399:62:399:77 | call to forward | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:62:399:77 | call to forward | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:62:399:77 | call to forward | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:62:399:77 | call to forward | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:62:399:77 | call to forward | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:62:399:77 | call to forward | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:79:399:79 | y | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:79:399:79 | y | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:79:399:79 | y | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:79:399:79 | y | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:79:399:79 | y | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:79:399:79 | y | stl.h:399:3:399:82 | call to pair | TAINT |
-| stl.h:399:79:399:79 | y | stl.h:399:62:399:77 | call to forward |  |
-| stl.h:399:79:399:79 | y | stl.h:399:62:399:77 | call to forward |  |
-| stl.h:399:79:399:79 | y | stl.h:399:62:399:77 | call to forward |  |
-| stl.h:399:79:399:79 | y | stl.h:399:62:399:77 | call to forward |  |
-| stl.h:399:79:399:79 | y | stl.h:399:62:399:77 | call to forward |  |
-| stl.h:399:79:399:79 | y | stl.h:399:62:399:77 | call to forward |  |
+| stl.h:388:9:388:9 | Unknown literal | stl.h:388:9:388:9 | constructor init of field first | TAINT |
+| stl.h:388:9:388:9 | Unknown literal | stl.h:388:9:388:9 | constructor init of field first | TAINT |
+| stl.h:388:9:388:9 | Unknown literal | stl.h:388:9:388:9 | constructor init of field first | TAINT |
+| stl.h:388:9:388:9 | Unknown literal | stl.h:388:9:388:9 | constructor init of field first | TAINT |
+| stl.h:388:9:388:9 | Unknown literal | stl.h:388:9:388:9 | constructor init of field first | TAINT |
+| stl.h:388:9:388:9 | Unknown literal | stl.h:388:9:388:9 | constructor init of field second | TAINT |
+| stl.h:388:9:388:9 | Unknown literal | stl.h:388:9:388:9 | constructor init of field second | TAINT |
+| stl.h:388:9:388:9 | Unknown literal | stl.h:388:9:388:9 | constructor init of field second | TAINT |
+| stl.h:388:9:388:9 | Unknown literal | stl.h:388:9:388:9 | constructor init of field second | TAINT |
+| stl.h:388:9:388:9 | Unknown literal | stl.h:388:9:388:9 | constructor init of field second | TAINT |
+| stl.h:388:9:388:9 | constructor init of field first [post-this] | stl.h:388:9:388:9 | constructor init of field second [pre-this] |  |
+| stl.h:388:9:388:9 | constructor init of field first [post-this] | stl.h:388:9:388:9 | constructor init of field second [pre-this] |  |
+| stl.h:388:9:388:9 | constructor init of field first [post-this] | stl.h:388:9:388:9 | constructor init of field second [pre-this] |  |
+| stl.h:388:9:388:9 | constructor init of field first [post-this] | stl.h:388:9:388:9 | constructor init of field second [pre-this] |  |
+| stl.h:388:9:388:9 | constructor init of field first [post-this] | stl.h:388:9:388:9 | constructor init of field second [pre-this] |  |
+| stl.h:388:9:388:9 | constructor init of field first [pre-this] | stl.h:388:9:388:9 | constructor init of field second [pre-this] |  |
+| stl.h:388:9:388:9 | constructor init of field first [pre-this] | stl.h:388:9:388:9 | constructor init of field second [pre-this] |  |
+| stl.h:388:9:388:9 | constructor init of field first [pre-this] | stl.h:388:9:388:9 | constructor init of field second [pre-this] |  |
+| stl.h:388:9:388:9 | constructor init of field first [pre-this] | stl.h:388:9:388:9 | constructor init of field second [pre-this] |  |
+| stl.h:388:9:388:9 | constructor init of field first [pre-this] | stl.h:388:9:388:9 | constructor init of field second [pre-this] |  |
+| stl.h:388:9:388:9 | this | stl.h:388:9:388:9 | constructor init of field first [pre-this] |  |
+| stl.h:388:9:388:9 | this | stl.h:388:9:388:9 | constructor init of field first [pre-this] |  |
+| stl.h:388:9:388:9 | this | stl.h:388:9:388:9 | constructor init of field first [pre-this] |  |
+| stl.h:388:9:388:9 | this | stl.h:388:9:388:9 | constructor init of field first [pre-this] |  |
+| stl.h:388:9:388:9 | this | stl.h:388:9:388:9 | constructor init of field first [pre-this] |  |
+| stl.h:395:3:395:3 | this | stl.h:395:36:395:43 | constructor init of field first [pre-this] |  |
+| stl.h:395:3:395:3 | this | stl.h:395:36:395:43 | constructor init of field first [pre-this] |  |
+| stl.h:395:3:395:3 | this | stl.h:395:36:395:43 | constructor init of field first [pre-this] |  |
+| stl.h:395:3:395:3 | this | stl.h:395:36:395:43 | constructor init of field first [pre-this] |  |
+| stl.h:395:3:395:3 | this | stl.h:395:36:395:43 | constructor init of field first [pre-this] |  |
+| stl.h:395:3:395:6 | this | stl.h:395:36:395:43 | constructor init of field first [pre-this] |  |
+| stl.h:395:18:395:18 | x | stl.h:395:42:395:42 | x |  |
+| stl.h:395:18:395:18 | x | stl.h:395:42:395:42 | x |  |
+| stl.h:395:18:395:18 | x | stl.h:395:42:395:42 | x |  |
+| stl.h:395:18:395:18 | x | stl.h:395:42:395:42 | x |  |
+| stl.h:395:18:395:18 | x | stl.h:395:42:395:42 | x |  |
+| stl.h:395:18:395:18 | x | stl.h:395:42:395:42 | x |  |
+| stl.h:395:31:395:31 | y | stl.h:395:53:395:53 | y |  |
+| stl.h:395:31:395:31 | y | stl.h:395:53:395:53 | y |  |
+| stl.h:395:31:395:31 | y | stl.h:395:53:395:53 | y |  |
+| stl.h:395:31:395:31 | y | stl.h:395:53:395:53 | y |  |
+| stl.h:395:31:395:31 | y | stl.h:395:53:395:53 | y |  |
+| stl.h:395:31:395:31 | y | stl.h:395:53:395:53 | y |  |
+| stl.h:395:36:395:43 | call to unknown function | stl.h:395:36:395:43 | constructor init of field first | TAINT |
+| stl.h:395:36:395:43 | constructor init of field first [post-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [post-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [post-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [post-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [post-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [post-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [pre-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [pre-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [pre-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [pre-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [pre-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:36:395:43 | constructor init of field first [pre-this] | stl.h:395:46:395:54 | constructor init of field second [pre-this] |  |
+| stl.h:395:42:395:42 | x | stl.h:395:36:395:43 | constructor init of field first | TAINT |
+| stl.h:395:42:395:42 | x | stl.h:395:36:395:43 | constructor init of field first | TAINT |
+| stl.h:395:42:395:42 | x | stl.h:395:36:395:43 | constructor init of field first | TAINT |
+| stl.h:395:42:395:42 | x | stl.h:395:36:395:43 | constructor init of field first | TAINT |
+| stl.h:395:42:395:42 | x | stl.h:395:36:395:43 | constructor init of field first | TAINT |
+| stl.h:395:46:395:54 | call to unknown function | stl.h:395:46:395:54 | constructor init of field second | TAINT |
+| stl.h:395:53:395:53 | y | stl.h:395:46:395:54 | constructor init of field second | TAINT |
+| stl.h:395:53:395:53 | y | stl.h:395:46:395:54 | constructor init of field second | TAINT |
+| stl.h:395:53:395:53 | y | stl.h:395:46:395:54 | constructor init of field second | TAINT |
+| stl.h:395:53:395:53 | y | stl.h:395:46:395:54 | constructor init of field second | TAINT |
+| stl.h:395:53:395:53 | y | stl.h:395:46:395:54 | constructor init of field second | TAINT |
+| stl.h:401:87:401:87 | x | stl.h:401:87:401:87 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:401:87:401:87 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:401:87:401:87 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:401:87:401:87 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:401:87:401:87 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:401:87:401:87 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:401:87:401:87 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:402:58:402:58 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:402:58:402:58 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:402:58:402:58 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:402:58:402:58 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:402:58:402:58 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:402:58:402:58 | x |  |
+| stl.h:401:87:401:87 | x | stl.h:402:58:402:58 | x |  |
+| stl.h:401:95:401:95 | y | stl.h:401:95:401:95 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:401:95:401:95 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:401:95:401:95 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:401:95:401:95 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:401:95:401:95 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:401:95:401:95 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:401:95:401:95 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:402:79:402:79 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:402:79:402:79 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:402:79:402:79 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:402:79:402:79 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:402:79:402:79 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:402:79:402:79 | y |  |
+| stl.h:401:95:401:95 | y | stl.h:402:79:402:79 | y |  |
+| stl.h:402:58:402:58 | x | stl.h:402:41:402:56 | call to forward |  |
+| stl.h:402:58:402:58 | x | stl.h:402:41:402:56 | call to forward |  |
+| stl.h:402:58:402:58 | x | stl.h:402:41:402:56 | call to forward |  |
+| stl.h:402:58:402:58 | x | stl.h:402:41:402:56 | call to forward |  |
+| stl.h:402:58:402:58 | x | stl.h:402:41:402:56 | call to forward |  |
+| stl.h:402:58:402:58 | x | stl.h:402:41:402:56 | call to forward |  |
+| stl.h:402:62:402:77 | call to forward | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:62:402:77 | call to forward | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:62:402:77 | call to forward | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:62:402:77 | call to forward | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:62:402:77 | call to forward | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:62:402:77 | call to forward | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:79:402:79 | y | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:79:402:79 | y | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:79:402:79 | y | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:79:402:79 | y | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:79:402:79 | y | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:79:402:79 | y | stl.h:402:3:402:82 | call to pair | TAINT |
+| stl.h:402:79:402:79 | y | stl.h:402:62:402:77 | call to forward |  |
+| stl.h:402:79:402:79 | y | stl.h:402:62:402:77 | call to forward |  |
+| stl.h:402:79:402:79 | y | stl.h:402:62:402:77 | call to forward |  |
+| stl.h:402:79:402:79 | y | stl.h:402:62:402:77 | call to forward |  |
+| stl.h:402:79:402:79 | y | stl.h:402:62:402:77 | call to forward |  |
+| stl.h:402:79:402:79 | y | stl.h:402:62:402:77 | call to forward |  |
 | string.cpp:25:12:25:17 | call to source | string.cpp:29:7:29:7 | a |  |
 | string.cpp:26:16:26:20 | 123 | string.cpp:26:16:26:21 | call to basic_string | TAINT |
 | string.cpp:26:16:26:21 | call to basic_string | string.cpp:30:7:30:7 | b |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -7231,3 +7231,21 @@
 | vector.cpp:484:29:484:33 | call to c_str | vector.cpp:484:3:484:8 | call to memcpy | TAINT |
 | vector.cpp:484:29:484:33 | call to c_str | vector.cpp:484:10:484:22 | ref arg & ... | TAINT |
 | vector.cpp:486:8:486:9 | ref arg cs | vector.cpp:487:2:487:2 | cs |  |
+| vector.cpp:491:22:491:24 | call to vector | vector.cpp:493:2:493:3 | v1 |  |
+| vector.cpp:491:22:491:24 | call to vector | vector.cpp:494:7:494:8 | v1 |  |
+| vector.cpp:491:22:491:24 | call to vector | vector.cpp:498:1:498:1 | v1 |  |
+| vector.cpp:491:30:491:32 | call to vector | vector.cpp:496:2:496:3 | v2 |  |
+| vector.cpp:491:30:491:32 | call to vector | vector.cpp:496:13:496:14 | v2 |  |
+| vector.cpp:491:30:491:32 | call to vector | vector.cpp:497:7:497:8 | v2 |  |
+| vector.cpp:491:30:491:32 | call to vector | vector.cpp:498:1:498:1 | v2 |  |
+| vector.cpp:493:2:493:3 | ref arg v1 | vector.cpp:494:7:494:8 | v1 |  |
+| vector.cpp:493:2:493:3 | ref arg v1 | vector.cpp:498:1:498:1 | v1 |  |
+| vector.cpp:494:7:494:8 | ref arg v1 | vector.cpp:498:1:498:1 | v1 |  |
+| vector.cpp:496:2:496:3 | ref arg v2 | vector.cpp:497:7:497:8 | v2 |  |
+| vector.cpp:496:2:496:3 | ref arg v2 | vector.cpp:498:1:498:1 | v2 |  |
+| vector.cpp:496:13:496:14 | ref arg v2 | vector.cpp:496:2:496:3 | v2 |  |
+| vector.cpp:496:13:496:14 | ref arg v2 | vector.cpp:497:7:497:8 | v2 |  |
+| vector.cpp:496:13:496:14 | ref arg v2 | vector.cpp:498:1:498:1 | v2 |  |
+| vector.cpp:496:13:496:14 | v2 | vector.cpp:496:16:496:20 | call to begin | TAINT |
+| vector.cpp:496:16:496:20 | call to begin | vector.cpp:496:13:496:22 | call to iterator | TAINT |
+| vector.cpp:497:7:497:8 | ref arg v2 | vector.cpp:498:1:498:1 | v2 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -7240,6 +7240,7 @@
 | vector.cpp:491:30:491:32 | call to vector | vector.cpp:498:1:498:1 | v2 |  |
 | vector.cpp:493:2:493:3 | ref arg v1 | vector.cpp:494:7:494:8 | v1 |  |
 | vector.cpp:493:2:493:3 | ref arg v1 | vector.cpp:498:1:498:1 | v1 |  |
+| vector.cpp:493:18:493:23 | call to source | vector.cpp:493:2:493:3 | ref arg v1 | TAINT |
 | vector.cpp:494:7:494:8 | ref arg v1 | vector.cpp:498:1:498:1 | v1 |  |
 | vector.cpp:496:2:496:3 | ref arg v2 | vector.cpp:497:7:497:8 | v2 |  |
 | vector.cpp:496:2:496:3 | ref arg v2 | vector.cpp:498:1:498:1 | v2 |  |
@@ -7248,4 +7249,6 @@
 | vector.cpp:496:13:496:14 | ref arg v2 | vector.cpp:498:1:498:1 | v2 |  |
 | vector.cpp:496:13:496:14 | v2 | vector.cpp:496:16:496:20 | call to begin | TAINT |
 | vector.cpp:496:16:496:20 | call to begin | vector.cpp:496:13:496:22 | call to iterator | TAINT |
+| vector.cpp:496:25:496:30 | call to source | vector.cpp:496:2:496:3 | ref arg v2 | TAINT |
+| vector.cpp:496:25:496:30 | call to source | vector.cpp:496:5:496:11 | call to emplace | TAINT |
 | vector.cpp:497:7:497:8 | ref arg v2 | vector.cpp:498:1:498:1 | v2 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
@@ -332,6 +332,9 @@ namespace std {
 		iterator insert(const_iterator position, size_type n, const T& x);
 		template<class InputIterator> iterator insert(const_iterator position, InputIterator first, InputIterator last);
 
+		template <class... Args> iterator emplace (const_iterator position, Args&&... args);
+		template <class... Args> void emplace_back (Args&&... args);
+
 		void swap(vector&) noexcept/*(allocator_traits<Allocator>::propagate_on_container_swap::value || allocator_traits<Allocator>::is_always_equal::value)*/;
 
 		void clear() noexcept;

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -668,3 +668,5 @@
 | vector.cpp:482:8:482:10 | src | vector.cpp:478:21:478:37 | call to source |
 | vector.cpp:485:8:485:10 | src | vector.cpp:478:21:478:37 | call to source |
 | vector.cpp:486:8:486:9 | cs | vector.cpp:478:21:478:37 | call to source |
+| vector.cpp:494:7:494:8 | v1 | vector.cpp:493:18:493:23 | call to source |
+| vector.cpp:497:7:497:8 | v2 | vector.cpp:496:25:496:30 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -266,3 +266,5 @@
 | vector.cpp:450:8:450:10 | vector.cpp:449:11:449:16 | AST only |
 | vector.cpp:473:8:473:8 | vector.cpp:468:11:468:16 | AST only |
 | vector.cpp:486:8:486:9 | vector.cpp:478:21:478:37 | AST only |
+| vector.cpp:494:7:494:8 | vector.cpp:493:18:493:23 | AST only |
+| vector.cpp:497:7:497:8 | vector.cpp:496:25:496:30 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -486,3 +486,13 @@ void test_vector_memcpy()
 		sink(cs); // tainted [NOT DETECTED by IR]
 	}
 }
+
+void test_vector_emplace() {
+	std::vector<int> v1(10), v2(10);
+
+	v1.emplace_back(source());
+	sink(v1); // tainted
+
+	v2.emplace(v2.begin(), source());
+	sink(v2); // tainted
+}


### PR DESCRIPTION
Fixes https://github.com/github/codeql-c-analysis-team/issues/159.
I recommend commit-by-commit review for the test changes, as the addition to `stl.h` lead to some churn.
