### PR TITLE
C#: Disable shared compilation when building with Mono+MSBuild

### DIFF
--- a/csharp/config/tracer/linux/csharp-compiler-settings
+++ b/csharp/config/tracer/linux/csharp-compiler-settings
@@ -7,3 +7,8 @@
 **/mono*:
 **/dotnet:
   invoke ${odasa_tools}/extract-csharp.sh
+**/msbuild:
+**/xbuild:
+  replace yes
+  invoke ${compiler}
+  append /p:UseSharedCompilation=false

--- a/csharp/tools/linux64/compiler-tracing.spec
+++ b/csharp/tools/linux64/compiler-tracing.spec
@@ -7,3 +7,8 @@
 **/mono*:
 **/dotnet:
   invoke ${config_dir}/extract-csharp.sh
+**/msbuild:
+**/xbuild:
+  replace yes
+  invoke ${compiler}
+  append /p:UseSharedCompilation=false

--- a/csharp/tools/osx64/compiler-tracing.spec
+++ b/csharp/tools/osx64/compiler-tracing.spec
@@ -7,6 +7,11 @@
 **/mono*:
 **/dotnet:
   invoke ${config_dir}/extract-csharp.sh
+**/msbuild:
+**/xbuild:
+  replace yes
+  invoke ${compiler}
+  append /p:UseSharedCompilation=false
 /usr/bin/codesign:
   replace yes
   invoke /usr/bin/env


### PR DESCRIPTION
We need to disable shared compilation when running with Mono+MSBuild, because the CLR tracer does not work in this case. We use the POSIX tracer to rewrite calls to `msbuild` to include `/p:UseSharedCompilation=false`.

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/594/
https://jenkins.internal.semmle.com/job/LGTM/job/Autobuild-Tests-v2/job/CSharp/536/