### PR TITLE
Python: Remove unnecessary cached annotation from adjacentRefUse

### DIFF
--- a/python/ql/src/semmle/python/essa/SsaCompute.qll
+++ b/python/ql/src/semmle/python/essa/SsaCompute.qll
@@ -446,7 +446,6 @@ private module SsaComputeImpl {
      * ```
      */
     pragma[nomagic]
-    cached
     private predicate adjacentRefUse(
       SsaSourceVariable v, BasicBlock b2, int i2, ControlFlowNode use1
     ) {


### PR DESCRIPTION
As discussed in https://github.com/github/codeql/pull/4544#pullrequestreview-516575676