### PR TITLE
JS: Improve handling of destructuring and default exports

### DIFF
--- a/javascript/ql/src/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/src/semmle/javascript/ES2015Modules.qll
@@ -41,6 +41,40 @@ class ES2015Module extends Module {
 }
 
 /**
+ * Holds if `mod` contains one or more named export declarations other than `default`.
+ */
+private predicate hasNamedExports(ES2015Module mod) {
+  mod.getAnExport().(ExportNamedDeclaration).getASpecifier().getExportedName() != "default"
+  or
+  exists(mod.getAnExport().(ExportNamedDeclaration).getAnExportedDecl())
+  or
+  // Bulk re-exports only export named bindings (not "default")
+  mod.getAnExport() instanceof BulkReExportDeclaration
+}
+
+/**
+ * Holds if this module contains a `default` export.
+ */
+private predicate hasDefaultExport(ES2015Module mod) {
+  // export default foo;
+  mod.getAnExport() instanceof ExportDefaultDeclaration
+  or
+  // export { foo as default };
+  mod.getAnExport().(ExportNamedDeclaration).getASpecifier().getExportedName() = "default"
+}
+
+/**
+ * Holds if `mod` contains both named and `default` exports.
+ *
+ * This is used to determine whether a default-import of the module should be reinterpreted
+ * as a namespace-import, to accomodate the non-standard behavior implemented by some compilers.
+ */
+private predicate hasBothNamedAndDefaultExports(ES2015Module mod) {
+  hasNamedExports(mod) and
+  hasDefaultExport(mod)
+}
+
+/**
  * An import declaration.
  *
  * Examples:
@@ -70,6 +104,10 @@ class ImportDeclaration extends Stmt, Import, @import_declaration {
       is instanceof ImportNamespaceSpecifier and
       count(getASpecifier()) = 1
       or
+      // For compatibility with the non-standard implementation of default imports,
+      // treat default imports as namespace imports in cases where it can't cause ambiguity
+      // between named exports and the properties of a default-exported object.
+      not hasBothNamedAndDefaultExports(getImportedModule()) and
       is.getImportedName() = "default"
     )
     or

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
@@ -318,7 +318,12 @@ private class AnalyzedVariableExport extends AnalyzedPropertyWrite, DataFlow::Va
   override predicate writes(AbstractValue baseVal, string propName, DataFlow::AnalyzedNode source) {
     baseVal = TAbstractExportsObject(export.getEnclosingModule()) and
     propName = name and
-    source = varDef.getSource().analyze()
+    (
+      source = varDef.getSource().analyze()
+      or
+      varDef.getTarget() instanceof DestructuringPattern and
+      source = export.getSourceNode(propName)
+    )
   }
 
   override predicate writesValue(AbstractValue baseVal, string propName, AbstractValue val) {

--- a/javascript/ql/test/library-tests/InterProceduralFlow/mixedExports.js
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/mixedExports.js
@@ -1,0 +1,7 @@
+let source = 'tainted';
+
+export const x = source;
+
+export default {
+    x: 'safe'
+};

--- a/javascript/ql/test/library-tests/InterProceduralFlow/mixedExportsClient.js
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/mixedExportsClient.js
@@ -1,0 +1,7 @@
+import defaultValue from './mixedExports';
+import { x } from './mixedExports';
+import * as ns from './mixedExports';
+
+let sink1 = defaultValue.x; // OK
+let sink2 = x; // NOT OK
+let sink3 = ns.x; // NOT OK

--- a/javascript/ql/test/library-tests/InterProceduralFlow/tests.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/tests.expected
@@ -1,6 +1,5 @@
 dataFlow
 | a.js:1:15:1:23 | "tainted" | b.js:4:13:4:40 | whoKnow ... Tainted |
-| a.js:1:15:1:23 | "tainted" | b.js:6:13:6:13 | x |
 | a.js:2:15:2:28 | "also tainted" | b.js:5:13:5:29 | notTaintedTrustMe |
 | async.js:2:16:2:23 | "source" | async.js:8:15:8:27 | await async() |
 | async.js:2:16:2:23 | "source" | async.js:13:15:13:20 | sync() |
@@ -26,6 +25,8 @@ dataFlow
 | global.js:2:15:2:24 | "tainted2" | global.js:10:13:10:22 | g(source2) |
 | global.js:5:22:5:35 | "also tainted" | global.js:9:13:9:22 | g(source1) |
 | global.js:5:22:5:35 | "also tainted" | global.js:10:13:10:22 | g(source2) |
+| mixedExports.js:1:14:1:22 | 'tainted' | mixedExportsClient.js:6:13:6:13 | x |
+| mixedExports.js:1:14:1:22 | 'tainted' | mixedExportsClient.js:7:13:7:16 | ns.x |
 | nodeJsLib.js:2:15:2:23 | "tainted" | esClient.js:7:13:7:18 | nj.foo |
 | nodeJsLib.js:2:15:2:23 | "tainted" | esClient.js:10:13:10:17 | njFoo |
 | nodeJsLib.js:2:15:2:23 | "tainted" | nodeJsClient.js:4:13:4:18 | nj.foo |
@@ -77,7 +78,6 @@ flowLabels
 | tst5.mjs:15:8:15:19 | source(flow) | tst5.mjs:16:13:16:16 | flow |
 taintTracking
 | a.js:1:15:1:23 | "tainted" | b.js:4:13:4:40 | whoKnow ... Tainted |
-| a.js:1:15:1:23 | "tainted" | b.js:6:13:6:13 | x |
 | a.js:2:15:2:28 | "also tainted" | b.js:5:13:5:29 | notTaintedTrustMe |
 | async.js:2:16:2:23 | "source" | async.js:7:14:7:20 | async() |
 | async.js:2:16:2:23 | "source" | async.js:8:15:8:27 | await async() |
@@ -106,6 +106,8 @@ taintTracking
 | global.js:2:15:2:24 | "tainted2" | global.js:10:13:10:22 | g(source2) |
 | global.js:5:22:5:35 | "also tainted" | global.js:9:13:9:22 | g(source1) |
 | global.js:5:22:5:35 | "also tainted" | global.js:10:13:10:22 | g(source2) |
+| mixedExports.js:1:14:1:22 | 'tainted' | mixedExportsClient.js:6:13:6:13 | x |
+| mixedExports.js:1:14:1:22 | 'tainted' | mixedExportsClient.js:7:13:7:16 | ns.x |
 | nodeJsLib.js:1:15:1:23 | "tainted" | esClient.js:7:13:7:18 | nj.foo |
 | nodeJsLib.js:1:15:1:23 | "tainted" | esClient.js:10:13:10:17 | njFoo |
 | nodeJsLib.js:1:15:1:23 | "tainted" | nodeJsClient.js:4:13:4:18 | nj.foo |
@@ -182,7 +184,6 @@ taintTracking
 | underscore.js:19:17:19:22 | "src5" | underscore.js:20:15:20:44 | _.map([ ... ource5) |
 germanFlow
 | a.js:1:15:1:23 | "tainted" | b.js:4:13:4:40 | whoKnow ... Tainted |
-| a.js:1:15:1:23 | "tainted" | b.js:6:13:6:13 | x |
 | a.js:2:15:2:28 | "also tainted" | b.js:5:13:5:29 | notTaintedTrustMe |
 | async.js:2:16:2:23 | "source" | async.js:8:15:8:27 | await async() |
 | async.js:2:16:2:23 | "source" | async.js:13:15:13:20 | sync() |
@@ -209,6 +210,8 @@ germanFlow
 | global.js:2:15:2:24 | "tainted2" | global.js:10:13:10:22 | g(source2) |
 | global.js:5:22:5:35 | "also tainted" | global.js:9:13:9:22 | g(source1) |
 | global.js:5:22:5:35 | "also tainted" | global.js:10:13:10:22 | g(source2) |
+| mixedExports.js:1:14:1:22 | 'tainted' | mixedExportsClient.js:6:13:6:13 | x |
+| mixedExports.js:1:14:1:22 | 'tainted' | mixedExportsClient.js:7:13:7:16 | ns.x |
 | nodeJsLib.js:2:15:2:23 | "tainted" | esClient.js:7:13:7:18 | nj.foo |
 | nodeJsLib.js:2:15:2:23 | "tainted" | esClient.js:10:13:10:17 | njFoo |
 | nodeJsLib.js:2:15:2:23 | "tainted" | nodeJsClient.js:4:13:4:18 | nj.foo |

--- a/javascript/ql/test/library-tests/InterProceduralFlow/tests.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/tests.expected
@@ -1,5 +1,6 @@
 dataFlow
 | a.js:1:15:1:23 | "tainted" | b.js:4:13:4:40 | whoKnow ... Tainted |
+| a.js:1:15:1:23 | "tainted" | b.js:6:13:6:13 | x |
 | a.js:2:15:2:28 | "also tainted" | b.js:5:13:5:29 | notTaintedTrustMe |
 | async.js:2:16:2:23 | "source" | async.js:8:15:8:27 | await async() |
 | async.js:2:16:2:23 | "source" | async.js:13:15:13:20 | sync() |
@@ -78,6 +79,7 @@ flowLabels
 | tst5.mjs:15:8:15:19 | source(flow) | tst5.mjs:16:13:16:16 | flow |
 taintTracking
 | a.js:1:15:1:23 | "tainted" | b.js:4:13:4:40 | whoKnow ... Tainted |
+| a.js:1:15:1:23 | "tainted" | b.js:6:13:6:13 | x |
 | a.js:2:15:2:28 | "also tainted" | b.js:5:13:5:29 | notTaintedTrustMe |
 | async.js:2:16:2:23 | "source" | async.js:7:14:7:20 | async() |
 | async.js:2:16:2:23 | "source" | async.js:8:15:8:27 | await async() |
@@ -184,6 +186,7 @@ taintTracking
 | underscore.js:19:17:19:22 | "src5" | underscore.js:20:15:20:44 | _.map([ ... ource5) |
 germanFlow
 | a.js:1:15:1:23 | "tainted" | b.js:4:13:4:40 | whoKnow ... Tainted |
+| a.js:1:15:1:23 | "tainted" | b.js:6:13:6:13 | x |
 | a.js:2:15:2:28 | "also tainted" | b.js:5:13:5:29 | notTaintedTrustMe |
 | async.js:2:16:2:23 | "source" | async.js:8:15:8:27 | await async() |
 | async.js:2:16:2:23 | "source" | async.js:13:15:13:20 | sync() |

--- a/javascript/ql/test/library-tests/Portals/PortalEntry.expected
+++ b/javascript/ql/test/library-tests/Portals/PortalEntry.expected
@@ -717,19 +717,13 @@
 | (parameter 0 (member log (member console (global)))) | src/m3/index.js:3:43:3:61 | m1("Hello, world!") | true |
 | (parameter 0 (member m (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:15:4:18 | "hi" | false |
 | (parameter 0 (member m (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:15:4:18 | "hi" | true |
-| (parameter 0 (member m (instance (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:15:4:18 | "hi" | false |
 | (parameter 0 (member m (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:2:5:2:8 | "hi" | false |
 | (parameter 0 (member m (return (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:15:4:18 | "hi" | false |
-| (parameter 0 (member m (return (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:15:4:18 | "hi" | false |
-| (parameter 0 (member m (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:2:5:2:8 | "hi" | false |
 | (parameter 0 (member readFileSync (root https://www.npmjs.com/package/fs))) | src/m5/index.js:5:49:5:49 | f | false |
 | (parameter 0 (member s (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:5:15:5:21 | "there" | false |
 | (parameter 0 (member s (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:5:15:5:21 | "there" | true |
-| (parameter 0 (member s (instance (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:15:5:21 | "there" | false |
 | (parameter 0 (member s (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:3:5:3:11 | "there" | false |
 | (parameter 0 (member s (return (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:5:15:5:21 | "there" | false |
-| (parameter 0 (member s (return (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:15:5:21 | "there" | false |
-| (parameter 0 (member s (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:3:5:3:11 | "there" | false |
 | (parameter 0 (parameter 0 (member f00 (member f00 (member f00 (member f00 (member f00 (member f00 (member foo (root https://www.npmjs.com/package/cyclic)))))))))) | src/cyclic/index.js:2:6:2:8 | foo | true |
 | (parameter 0 (parameter 0 (member f00 (member f00 (member f00 (member f00 (member f00 (member foo (root https://www.npmjs.com/package/cyclic))))))))) | src/cyclic/index.js:2:6:2:8 | foo | true |
 | (parameter 0 (parameter 0 (member f00 (member f00 (member f00 (member f00 (member f00 (return (member foo (root https://www.npmjs.com/package/cyclic)))))))))) | src/cyclic/index.js:2:6:2:8 | foo | true |
@@ -1020,8 +1014,6 @@
 | (parameter 0 (parameter 0 (return (return (return (return (return (return (member foo (root https://www.npmjs.com/package/cyclic)))))))))) | src/cyclic/index.js:2:6:2:8 | foo | true |
 | (parameter 0 (parameter 1 (member then (instance (member Promise (root https://www.npmjs.com/package/bluebird)))))) | src/bluebird/index.js:6:12:6:15 | null | true |
 | (parameter 0 (root https://www.npmjs.com/package/m1)) | src/m3/index.js:3:46:3:60 | "Hello, world!" | false |
-| (parameter 0 (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:4:7:4:10 | "me" | false |
-| (parameter 0 (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:5:7:5:10 | "me" | false |
 | (return (member f00 (member f00 (member f00 (member f00 (member f00 (member f00 (member f00 (member foo (root https://www.npmjs.com/package/cyclic)))))))))) | src/cyclic/index.js:3:10:3:12 | foo | true |
 | (return (member f00 (member f00 (member f00 (member f00 (member f00 (member f00 (member foo (root https://www.npmjs.com/package/cyclic))))))))) | src/cyclic/index.js:3:10:3:12 | foo | true |
 | (return (member f00 (member f00 (member f00 (member f00 (member f00 (member f00 (return (member foo (root https://www.npmjs.com/package/cyclic)))))))))) | src/cyclic/index.js:3:10:3:12 | foo | true |

--- a/javascript/ql/test/library-tests/Portals/PortalExit.expected
+++ b/javascript/ql/test/library-tests/Portals/PortalExit.expected
@@ -20,8 +20,6 @@
 | (instance (member default (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:4:1:4:11 | new A("me") | true |
 | (instance (member default (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:5:1:5:11 | new A("me") | false |
 | (instance (member default (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:5:1:5:11 | new A("me") | true |
-| (instance (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:4:1:4:11 | new A("me") | false |
-| (instance (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:5:1:5:11 | new A("me") | false |
 | (member String (global)) | src/m5/index.js:5:26:5:31 | String | true |
 | (member console (global)) | src/m2/main.js:2:3:2:9 | console | true |
 | (member console (global)) | src/m2/main.js:12:5:12:11 | console | true |
@@ -34,20 +32,14 @@
 | (member log (member console (global))) | src/m3/index.js:3:31:3:41 | console.log | true |
 | (member m (instance (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:1:4:13 | new A("me").m | false |
 | (member m (instance (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:1:4:13 | new A("me").m | true |
-| (member m (instance (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:4:1:4:13 | new A("me").m | false |
 | (member m (member default (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:2:1:2:3 | A.m | false |
 | (member m (return (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:1:4:13 | new A("me").m | false |
-| (member m (return (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:4:1:4:13 | new A("me").m | false |
-| (member m (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:2:1:2:3 | A.m | false |
 | (member name (instance (member default (root https://www.npmjs.com/package/m2)))) | src/m2/main.js:12:27:12:35 | this.name | true |
 | (member readFileSync (root https://www.npmjs.com/package/fs)) | src/m5/index.js:5:33:5:47 | fs.readFileSync | false |
 | (member s (instance (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:1:5:13 | new A("me").s | false |
 | (member s (instance (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:1:5:13 | new A("me").s | true |
-| (member s (instance (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:5:1:5:13 | new A("me").s | false |
 | (member s (member default (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:3:1:3:3 | A.s | false |
 | (member s (return (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:1:5:13 | new A("me").s | false |
-| (member s (return (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:5:1:5:13 | new A("me").s | false |
-| (member s (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:3:1:3:3 | A.s | false |
 | (member x (parameter 0 (member foo (root https://www.npmjs.com/package/m2)))) | src/m2/main.js:2:15:2:17 | p.x | true |
 | (member y (member x (parameter 0 (member foo (root https://www.npmjs.com/package/m2))))) | src/m2/main.js:2:15:2:19 | p.x.y | true |
 | (parameter 0 (member Promise (root https://www.npmjs.com/package/bluebird))) | src/bluebird/index.js:1:18:1:21 | exec | true |
@@ -764,19 +756,13 @@
 | (return (member log (member console (global)))) | src/m3/index.js:3:31:3:62 | console ... rld!")) | true |
 | (return (member m (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:1:4:19 | new A("me").m("hi") | false |
 | (return (member m (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:1:4:19 | new A("me").m("hi") | true |
-| (return (member m (instance (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:1:4:19 | new A("me").m("hi") | false |
 | (return (member m (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:2:1:2:9 | A.m("hi") | false |
 | (return (member m (return (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:1:4:19 | new A("me").m("hi") | false |
-| (return (member m (return (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:1:4:19 | new A("me").m("hi") | false |
-| (return (member m (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:2:1:2:9 | A.m("hi") | false |
 | (return (member readFileSync (root https://www.npmjs.com/package/fs))) | src/m5/index.js:5:33:5:50 | fs.readFileSync(f) | false |
 | (return (member s (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:5:1:5:22 | new A(" ... there") | false |
 | (return (member s (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:5:1:5:22 | new A(" ... there") | true |
-| (return (member s (instance (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:1:5:22 | new A(" ... there") | false |
 | (return (member s (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:3:1:3:12 | A.s("there") | false |
 | (return (member s (return (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:5:1:5:22 | new A(" ... there") | false |
-| (return (member s (return (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:1:5:22 | new A(" ... there") | false |
-| (return (member s (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:3:1:3:12 | A.s("there") | false |
 | (return (parameter 0 (member f00 (member f00 (member f00 (member f00 (member f00 (member f00 (member foo (root https://www.npmjs.com/package/cyclic)))))))))) | src/cyclic/index.js:2:3:2:9 | cb(foo) | true |
 | (return (parameter 0 (member f00 (member f00 (member f00 (member f00 (member f00 (member foo (root https://www.npmjs.com/package/cyclic))))))))) | src/cyclic/index.js:2:3:2:9 | cb(foo) | true |
 | (return (parameter 0 (member f00 (member f00 (member f00 (member f00 (member f00 (return (member foo (root https://www.npmjs.com/package/cyclic)))))))))) | src/cyclic/index.js:2:3:2:9 | cb(foo) | true |
@@ -1067,11 +1053,8 @@
 | (return (parameter 0 (return (return (return (return (return (return (member foo (root https://www.npmjs.com/package/cyclic)))))))))) | src/cyclic/index.js:2:3:2:9 | cb(foo) | true |
 | (return (parameter 1 (member then (instance (member Promise (root https://www.npmjs.com/package/bluebird)))))) | src/bluebird/index.js:6:3:6:16 | rejected(null) | true |
 | (return (root https://www.npmjs.com/package/m1)) | src/m3/index.js:3:43:3:61 | m1("Hello, world!") | false |
-| (return (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:4:1:4:11 | new A("me") | false |
-| (return (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:5:1:5:11 | new A("me") | false |
 | (root https://www.npmjs.com/package/base-64/base64.js) | src/m5/index.js:2:14:2:41 | require ... 64.js") | false |
 | (root https://www.npmjs.com/package/fs) | src/m5/index.js:1:12:1:24 | require("fs") | false |
 | (root https://www.npmjs.com/package/m1) | src/m3/index.js:1:10:1:22 | require("m1") | false |
 | (root https://www.npmjs.com/package/m2) | src/m3/tst2.js:1:1:1:25 | import  ... m "m2"; | false |
 | (root https://www.npmjs.com/package/m2) | src/m3/tst3.js:1:1:1:19 | import A from "m2"; | false |
-| (root https://www.npmjs.com/package/m2) | src/m3/tst3.js:1:8:1:8 | A | false |

--- a/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
@@ -1,2 +1,0 @@
-| destructuring-export-client.js:3:8:3:41 | // trac ... ort-foo | Failed to track destructuring-export-foo here. |
-| destructuring-export-client.js:4:8:4:41 | // trac ... ort-bar | Failed to track destructuring-export-bar here. |

--- a/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
@@ -1,0 +1,2 @@
+| destructuring-export-client.js:3:8:3:41 | // trac ... ort-foo | Failed to track destructuring-export-foo here. |
+| destructuring-export-client.js:4:8:4:41 | // trac ... ort-bar | Failed to track destructuring-export-bar here. |

--- a/javascript/ql/test/library-tests/TypeTracking/destructuring-export-client.js
+++ b/javascript/ql/test/library-tests/TypeTracking/destructuring-export-client.js
@@ -1,0 +1,4 @@
+import { foo, bar } from './destructuring-export';
+
+foo(); // track: destructuring-export-foo
+bar(); // track: destructuring-export-bar

--- a/javascript/ql/test/library-tests/TypeTracking/destructuring-export.js
+++ b/javascript/ql/test/library-tests/TypeTracking/destructuring-export.js
@@ -1,0 +1,4 @@
+export const {
+    foo, // name: destructuring-export-foo
+    bar, // name: destructuring-export-bar
+} = new Something();


### PR DESCRIPTION
Fixes two issues with export declarations.

First, the inter-module type inference relied on `VarDef.getSource()`, which only works for non-destructuring assignments, and so did not handle destructuring export declarations well:
```js
export const { foo } = bar();
```

This PR changes it to include `ExportDeclaration.getSourceNode` in case it's a destructuring export, which means `foo` is now properly exported with the RHS set to the `PropRead` generated by the binding pattern.

The second issue is that our fallback for handling the non-standard behavior of `default` exports could lead to ambiguity for modules that also have named exports. For example:
```js
// foo.js
export let x = foo();
export default { x : bar() };

import { x } from './foo'; // <--- both foo() and bar() flow here
```
In the above, both `foo()` and `bar()` could be type-tracked to the imported `x`. Even when there is no name clash between a property of the default-exported object and a named export, you could get spurious flow when tracking through arbitrary properties using `getAMember()`/`getAPropertyRead()`. Now, when a module has both named and default exports, we disable the fallback and stick to the standard behaviour of `default`. 

@max-schaefer FYI this change affects the API graphs we generate for such codebases; they should be more accurate.

[Evaluation](https://github.com/github/asgerf-dist-compare-reports/tree/js/destructuring-export_1604784715166) looks fine.