### PR TITLE
C#: C#9 add test cases for discards as lambda/delegate parameters

### DIFF
--- a/csharp/ql/test/library-tests/csharp9/Discard.cs
+++ b/csharp/ql/test/library-tests/csharp9/Discard.cs
@@ -1,0 +1,12 @@
+using System;
+
+public class Discard
+{
+    public void M1()
+    {
+        Func<int, int, int> i = (int a, int b) => 42;
+        i = (_, _) => 42;
+        i = (int _, int _) => 42;
+        i = delegate (int _, int _) { return 0; };
+    }
+}

--- a/csharp/ql/test/library-tests/csharp9/Discard.expected
+++ b/csharp/ql/test/library-tests/csharp9/Discard.expected
@@ -1,0 +1,8 @@
+| Discard.cs:7:33:7:52 | (...) => ... | Discard.cs:7:38:7:38 | a |
+| Discard.cs:7:33:7:52 | (...) => ... | Discard.cs:7:45:7:45 | b |
+| Discard.cs:8:13:8:24 | (...) => ... | Discard.cs:8:14:8:14 | _ |
+| Discard.cs:8:13:8:24 | (...) => ... | Discard.cs:8:17:8:17 | _`1 |
+| Discard.cs:9:13:9:32 | (...) => ... | Discard.cs:9:18:9:18 | _ |
+| Discard.cs:9:13:9:32 | (...) => ... | Discard.cs:9:25:9:25 | _`1 |
+| Discard.cs:10:13:10:49 | delegate(...) { ... } | Discard.cs:10:27:10:27 | _ |
+| Discard.cs:10:13:10:49 | delegate(...) { ... } | Discard.cs:10:34:10:34 | _`1 |

--- a/csharp/ql/test/library-tests/csharp9/Discard.ql
+++ b/csharp/ql/test/library-tests/csharp9/Discard.ql
@@ -1,0 +1,4 @@
+import csharp
+
+from AnonymousFunctionExpr anon
+select anon, anon.getAParameter()

--- a/csharp/ql/test/library-tests/csharp9/NativeInt.cs
+++ b/csharp/ql/test/library-tests/csharp9/NativeInt.cs
@@ -1,6 +1,6 @@
 using System;
 
-public class Class1
+public class NativeInt
 {
     public void M1(int j, uint k)
     {

--- a/csharp/ql/test/library-tests/csharp9/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp9/PrintAst.expected
@@ -1,3 +1,52 @@
+Discard.cs:
+#    3| [Class] Discard
+#    5|   5: [Method] M1
+#    5|     -1: [TypeMention] Void
+#    6|     4: [BlockStmt] {...}
+#    7|       0: [LocalVariableDeclStmt] ... ...;
+#    7|         0: [LocalVariableDeclAndInitExpr] Func<Int32,Int32,Int32> i = ...
+#    7|           -1: [TypeMention] Func<Int32, Int32, Int32>
+#    7|             1: [TypeMention] int
+#    7|             2: [TypeMention] int
+#    7|             3: [TypeMention] int
+#    7|           0: [LocalVariableAccess] access to local variable i
+#    7|           1: [LambdaExpr] (...) => ...
+#-----|             2: (Parameters)
+#    7|               0: [Parameter] a
+#    7|                 -1: [TypeMention] int
+#    7|               1: [Parameter] b
+#    7|                 -1: [TypeMention] int
+#    7|             4: [IntLiteral] 42
+#    8|       1: [ExprStmt] ...;
+#    8|         0: [AssignExpr] ... = ...
+#    8|           0: [LocalVariableAccess] access to local variable i
+#    8|           1: [LambdaExpr] (...) => ...
+#-----|             2: (Parameters)
+#    8|               0: [Parameter] _
+#    8|               1: [Parameter] _`1
+#    8|             4: [IntLiteral] 42
+#    9|       2: [ExprStmt] ...;
+#    9|         0: [AssignExpr] ... = ...
+#    9|           0: [LocalVariableAccess] access to local variable i
+#    9|           1: [LambdaExpr] (...) => ...
+#-----|             2: (Parameters)
+#    9|               0: [Parameter] _
+#    9|                 -1: [TypeMention] int
+#    9|               1: [Parameter] _`1
+#    9|                 -1: [TypeMention] int
+#    9|             4: [IntLiteral] 42
+#   10|       3: [ExprStmt] ...;
+#   10|         0: [AssignExpr] ... = ...
+#   10|           0: [LocalVariableAccess] access to local variable i
+#   10|           1: [AnonymousMethodExpr] delegate(...) { ... }
+#-----|             2: (Parameters)
+#   10|               0: [Parameter] _
+#   10|                 -1: [TypeMention] int
+#   10|               1: [Parameter] _`1
+#   10|                 -1: [TypeMention] int
+#   10|             4: [BlockStmt] {...}
+#   10|               0: [ReturnStmt] return ...;
+#   10|                 0: [IntLiteral] 0
 NativeInt.cs:
 #    3| [Class] Class1
 #    5|   5: [Method] M1

--- a/csharp/ql/test/library-tests/csharp9/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp9/PrintAst.expected
@@ -48,7 +48,7 @@ Discard.cs:
 #   10|               0: [ReturnStmt] return ...;
 #   10|                 0: [IntLiteral] 0
 NativeInt.cs:
-#    3| [Class] Class1
+#    3| [Class] NativeInt
 #    5|   5: [Method] M1
 #    5|     -1: [TypeMention] Void
 #-----|     2: (Parameters)

--- a/csharp/ql/test/library-tests/csharp9/nativeInt.expected
+++ b/csharp/ql/test/library-tests/csharp9/nativeInt.expected
@@ -1,3 +1,19 @@
+| Discard.cs:7:29:7:29 | access to local variable i | Func<Int32,Int32,Int32> |
+| Discard.cs:7:29:7:52 | Func<Int32,Int32,Int32> i = ... | Func<Int32,Int32,Int32> |
+| Discard.cs:7:33:7:52 | (...) => ... | Func<Int32,Int32,Int32> |
+| Discard.cs:7:51:7:52 | 42 | Int32 |
+| Discard.cs:8:9:8:9 | access to local variable i | Func<Int32,Int32,Int32> |
+| Discard.cs:8:9:8:24 | ... = ... | Func<Int32,Int32,Int32> |
+| Discard.cs:8:13:8:24 | (...) => ... | Func<Int32,Int32,Int32> |
+| Discard.cs:8:23:8:24 | 42 | Int32 |
+| Discard.cs:9:9:9:9 | access to local variable i | Func<Int32,Int32,Int32> |
+| Discard.cs:9:9:9:32 | ... = ... | Func<Int32,Int32,Int32> |
+| Discard.cs:9:13:9:32 | (...) => ... | Func<Int32,Int32,Int32> |
+| Discard.cs:9:31:9:32 | 42 | Int32 |
+| Discard.cs:10:9:10:9 | access to local variable i | Func<Int32,Int32,Int32> |
+| Discard.cs:10:9:10:49 | ... = ... | Func<Int32,Int32,Int32> |
+| Discard.cs:10:13:10:49 | delegate(...) { ... } | Func<Int32,Int32,Int32> |
+| Discard.cs:10:46:10:46 | 0 | Int32 |
 | NativeInt.cs:7:14:7:14 | access to local variable x | IntPtr |
 | NativeInt.cs:7:14:7:18 | IntPtr x = ... | IntPtr |
 | NativeInt.cs:7:18:7:18 | (...) ... | IntPtr |

--- a/csharp/ql/test/library-tests/csharp9/nativeInt.expected
+++ b/csharp/ql/test/library-tests/csharp9/nativeInt.expected
@@ -1,19 +1,3 @@
-| Discard.cs:7:29:7:29 | access to local variable i | Func<Int32,Int32,Int32> |
-| Discard.cs:7:29:7:52 | Func<Int32,Int32,Int32> i = ... | Func<Int32,Int32,Int32> |
-| Discard.cs:7:33:7:52 | (...) => ... | Func<Int32,Int32,Int32> |
-| Discard.cs:7:51:7:52 | 42 | Int32 |
-| Discard.cs:8:9:8:9 | access to local variable i | Func<Int32,Int32,Int32> |
-| Discard.cs:8:9:8:24 | ... = ... | Func<Int32,Int32,Int32> |
-| Discard.cs:8:13:8:24 | (...) => ... | Func<Int32,Int32,Int32> |
-| Discard.cs:8:23:8:24 | 42 | Int32 |
-| Discard.cs:9:9:9:9 | access to local variable i | Func<Int32,Int32,Int32> |
-| Discard.cs:9:9:9:32 | ... = ... | Func<Int32,Int32,Int32> |
-| Discard.cs:9:13:9:32 | (...) => ... | Func<Int32,Int32,Int32> |
-| Discard.cs:9:31:9:32 | 42 | Int32 |
-| Discard.cs:10:9:10:9 | access to local variable i | Func<Int32,Int32,Int32> |
-| Discard.cs:10:9:10:49 | ... = ... | Func<Int32,Int32,Int32> |
-| Discard.cs:10:13:10:49 | delegate(...) { ... } | Func<Int32,Int32,Int32> |
-| Discard.cs:10:46:10:46 | 0 | Int32 |
 | NativeInt.cs:7:14:7:14 | access to local variable x | IntPtr |
 | NativeInt.cs:7:14:7:18 | IntPtr x = ... | IntPtr |
 | NativeInt.cs:7:18:7:18 | (...) ... | IntPtr |

--- a/csharp/ql/test/library-tests/csharp9/nativeInt.ql
+++ b/csharp/ql/test/library-tests/csharp9/nativeInt.ql
@@ -1,5 +1,5 @@
 import csharp
 
 from Expr e
-where e.fromSource()
+where e.getFile().getStem() = "NativeInt"
 select e, e.getType().toString()


### PR DESCRIPTION
There was already some logic in place to make parameter names unique. This means that the second discard param will show up with the ``_`1`` name whereever we display the name, such as in PrintAst.