### PR TITLE
Java: add some improvements to the bean validation query

### DIFF
--- a/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
+++ b/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
@@ -14,6 +14,9 @@ import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.FlowSources
 import DataFlow::PathGraph
 
+/** 
+ * A message interpolator Type that perform Expression Language (EL) evaluations
+ */
 class ELMessageInterpolatorType extends RefType {
   ELMessageInterpolatorType() {
     this
@@ -46,6 +49,10 @@ class SetSafeMessageInterpolatorCall extends MethodAccess {
   }
 }
 
+/**
+  * A method named `buildConstraintViolationWithTemplate` declared on a subtype
+  * of `javax.validation.ConstraintValidatorContext`.
+  */
 class BuildConstraintViolationWithTemplateMethod extends Method {
   BuildConstraintViolationWithTemplateMethod() {
     this
@@ -56,6 +63,10 @@ class BuildConstraintViolationWithTemplateMethod extends Method {
   }
 }
 
+/**
+ * Taint tracking BeanValidationConfiguration describing the flow of data from user input
+ * to the argument of a method that builds constraint error messages.
+ */
 class BeanValidationConfig extends TaintTracking::Configuration {
   BeanValidationConfig() { this = "BeanValidationConfig" }
 

--- a/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
+++ b/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
@@ -85,7 +85,11 @@ class BeanValidationConfig extends TaintTracking::Configuration {
 
 from BeanValidationConfig cfg, DataFlow::PathNode source, DataFlow::PathNode sink
 where
-  not forall(SetMessageInterpolatorCall c | c.isSafe()) and
+  (
+    not exists(SetMessageInterpolatorCall c)
+    or
+    exists(SetMessageInterpolatorCall c | not c.isSafe())
+  ) and
   cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink,
   "Custom constraint error message contains unsanitized user data"

--- a/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
+++ b/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
@@ -27,11 +27,10 @@ class ELMessageInterpolatorType extends RefType {
 }
 
 /**
- * A method call that sets the application's default message interpolator to an interpolator type that is likely to be safe,
- * because it does not process Java Expression Language expressions.
+ * A method call that sets the application's default message interpolator.
  */
-class SetSafeMessageInterpolatorCall extends MethodAccess {
-  SetSafeMessageInterpolatorCall() {
+class SetMessageInterpolatorCall extends MethodAccess {
+  SetMessageInterpolatorCall() {
     exists(Method m, RefType t |
       this.getMethod() = m and
       m.getDeclaringType().getASourceSupertype*() = t and
@@ -44,7 +43,13 @@ class SetSafeMessageInterpolatorCall extends MethodAccess {
               ["CustomValidatorBean", "LocalValidatorFactoryBean"]) and
         m.getName() = "setMessageInterpolator"
       )
-    ) and
+    )
+  }
+
+  /**
+  * The message interpolator is likely to be safe, because it does not process Java Expression Language expressions.
+  */
+  predicate isSafe() {
     not this.getAnArgument().getType() instanceof ELMessageInterpolatorType
   }
 }
@@ -82,7 +87,7 @@ class BeanValidationConfig extends TaintTracking::Configuration {
 
 from BeanValidationConfig cfg, DataFlow::PathNode source, DataFlow::PathNode sink
 where
-  not exists(SetSafeMessageInterpolatorCall ma) and
+  not forall(SetMessageInterpolatorCall c | c.isSafe()) and
   cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink,
   "Custom constraint error message contains unsanitized user data"

--- a/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
+++ b/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
@@ -47,11 +47,9 @@ class SetMessageInterpolatorCall extends MethodAccess {
   }
 
   /**
-  * The message interpolator is likely to be safe, because it does not process Java Expression Language expressions.
-  */
-  predicate isSafe() {
-    not this.getAnArgument().getType() instanceof ELMessageInterpolatorType
-  }
+   * The message interpolator is likely to be safe, because it does not process Java Expression Language expressions.
+   */
+  predicate isSafe() { not this.getAnArgument().getType() instanceof ELMessageInterpolatorType }
 }
 
 /**

--- a/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
+++ b/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
@@ -14,7 +14,7 @@ import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.FlowSources
 import DataFlow::PathGraph
 
-/** 
+/**
  * A message interpolator Type that perform Expression Language (EL) evaluations
  */
 class ELMessageInterpolatorType extends RefType {
@@ -50,9 +50,9 @@ class SetSafeMessageInterpolatorCall extends MethodAccess {
 }
 
 /**
-  * A method named `buildConstraintViolationWithTemplate` declared on a subtype
-  * of `javax.validation.ConstraintValidatorContext`.
-  */
+ * A method named `buildConstraintViolationWithTemplate` declared on a subtype
+ * of `javax.validation.ConstraintValidatorContext`.
+ */
 class BuildConstraintViolationWithTemplateMethod extends Method {
   BuildConstraintViolationWithTemplateMethod() {
     this


### PR DESCRIPTION
This improvements try to address those cases where the vulnerability is fixed by setting a default message interpolator that  does not interpolate Expression Language expressions.
This can lead to False negatives though since it may be the case where the project scanned has more than one application and the secure configuration may not be applied to all of them. Because we are just checking that there is a call to `setMessasgeInterpolator` with a non-EL interpolator somewhere in the scanned code, we may consider that it protects all the uses of Bean validation which may not be the case.

In the opposite hand, if we do not apply an improvement like this, projects fixing the issue with this approach (which is the recommended one) will not get rid of the alert.

/cc @adityasharad 