### PR TITLE
Java: Factor NumberFormatException out into a library file

### DIFF
--- a/java/ql/src/Violations of Best Practice/Exception Handling/NumberFormatException.ql
+++ b/java/ql/src/Violations of Best Practice/Exception Handling/NumberFormatException.ql
@@ -11,71 +11,7 @@
  */
 
 import java
-
-private class SpecialMethodAccess extends MethodAccess {
-  predicate isValueOfMethod(string klass) {
-    this.getMethod().getName() = "valueOf" and
-    this.getQualifier().getType().(RefType).hasQualifiedName("java.lang", klass) and
-    this.getAnArgument().getType().(RefType).hasQualifiedName("java.lang", "String")
-  }
-
-  predicate isParseMethod(string klass, string name) {
-    this.getMethod().getName() = name and
-    this.getQualifier().getType().(RefType).hasQualifiedName("java.lang", klass)
-  }
-
-  predicate throwsNFE() {
-    this.isParseMethod("Byte", "parseByte") or
-    this.isParseMethod("Short", "parseShort") or
-    this.isParseMethod("Integer", "parseInt") or
-    this.isParseMethod("Long", "parseLong") or
-    this.isParseMethod("Float", "parseFloat") or
-    this.isParseMethod("Double", "parseDouble") or
-    this.isParseMethod("Byte", "decode") or
-    this.isParseMethod("Short", "decode") or
-    this.isParseMethod("Integer", "decode") or
-    this.isParseMethod("Long", "decode") or
-    this.isValueOfMethod("Byte") or
-    this.isValueOfMethod("Short") or
-    this.isValueOfMethod("Integer") or
-    this.isValueOfMethod("Long") or
-    this.isValueOfMethod("Float") or
-    this.isValueOfMethod("Double")
-  }
-}
-
-private class SpecialClassInstanceExpr extends ClassInstanceExpr {
-  predicate isStringConstructor(string klass) {
-    this.getType().(RefType).hasQualifiedName("java.lang", klass) and
-    this.getAnArgument().getType().(RefType).hasQualifiedName("java.lang", "String") and
-    this.getNumArgument() = 1
-  }
-
-  predicate throwsNFE() {
-    this.isStringConstructor("Byte") or
-    this.isStringConstructor("Short") or
-    this.isStringConstructor("Integer") or
-    this.isStringConstructor("Long") or
-    this.isStringConstructor("Float") or
-    this.isStringConstructor("Double")
-  }
-}
-
-class NumberFormatException extends RefType {
-  NumberFormatException() { this.hasQualifiedName("java.lang", "NumberFormatException") }
-}
-
-private predicate catchesNFE(TryStmt t) {
-  exists(CatchClause cc, LocalVariableDeclExpr v |
-    t.getACatchClause() = cc and
-    cc.getVariable() = v and
-    v.getType().(RefType).getASubtype*() instanceof NumberFormatException
-  )
-}
-
-private predicate throwsNFE(Expr e) {
-  e.(SpecialClassInstanceExpr).throwsNFE() or e.(SpecialMethodAccess).throwsNFE()
-}
+import semmle.code.java.NumberFormatException
 
 from Expr e
 where

--- a/java/ql/src/semmle/code/java/NumberFormatException.qll
+++ b/java/ql/src/semmle/code/java/NumberFormatException.qll
@@ -1,6 +1,8 @@
+/** Provides classes and predicates for reasoning about `java.lang.NumberFormatException`. */
+
 import java
 
-/** Calls a string to number conversion */
+/** A call to a string to number conversion. */
 private class SpecialMethodAccess extends MethodAccess {
   predicate isValueOfMethod(string klass) {
     this.getMethod().getName() = "valueOf" and
@@ -33,7 +35,7 @@ private class SpecialMethodAccess extends MethodAccess {
   }
 }
 
-/** Constructs a number from its string representation */
+/** A `ClassInstanceExpr` that constructs a number from its string representation. */
 private class SpecialClassInstanceExpr extends ClassInstanceExpr {
   predicate isStringConstructor(string klass) {
     this.getType().(RefType).hasQualifiedName("java.lang", klass) and
@@ -51,12 +53,12 @@ private class SpecialClassInstanceExpr extends ClassInstanceExpr {
   }
 }
 
-/** The class `java.lang.NumberFormatException` */
+/** The class `java.lang.NumberFormatException`. */
 class NumberFormatException extends RefType {
   NumberFormatException() { this.hasQualifiedName("java.lang", "NumberFormatException") }
 }
 
-/** Holds if `java.lang.NumberFormatException` is caught */
+/** Holds if `java.lang.NumberFormatException` is caught. */
 predicate catchesNFE(TryStmt t) {
   exists(CatchClause cc, LocalVariableDeclExpr v |
     t.getACatchClause() = cc and
@@ -65,7 +67,7 @@ predicate catchesNFE(TryStmt t) {
   )
 }
 
-/** Holds if `java.lang.NumberFormatException` is thrown */
+/** Holds if `java.lang.NumberFormatException` can be thrown. */
 predicate throwsNFE(Expr e) {
   e.(SpecialClassInstanceExpr).throwsNFE() or e.(SpecialMethodAccess).throwsNFE()
 }

--- a/java/ql/src/semmle/code/java/NumberFormatException.qll
+++ b/java/ql/src/semmle/code/java/NumberFormatException.qll
@@ -1,15 +1,3 @@
-/**
- * @name Missing catch of NumberFormatException
- * @description Calling a string to number conversion method without handling
- *              'NumberFormatException' may cause unexpected runtime exceptions.
- * @kind problem
- * @problem.severity recommendation
- * @precision high
- * @id java/uncaught-number-format-exception
- * @tags reliability
- *       external/cwe/cwe-248
- */
-
 import java
 
 /** Calls a string to number conversion */
@@ -68,7 +56,7 @@ class NumberFormatException extends RefType {
   NumberFormatException() { this.hasQualifiedName("java.lang", "NumberFormatException") }
 }
 
-/** Holds if NFE is caught */
+/** Holds if `java.lang.NumberFormatException` is caught */
 predicate catchesNFE(TryStmt t) {
   exists(CatchClause cc, LocalVariableDeclExpr v |
     t.getACatchClause() = cc and
@@ -77,7 +65,7 @@ predicate catchesNFE(TryStmt t) {
   )
 }
 
-/** Holds if NFE is thrown */
+/** Holds if `java.lang.NumberFormatException` is thrown */
 predicate throwsNFE(Expr e) {
   e.(SpecialClassInstanceExpr).throwsNFE() or e.(SpecialMethodAccess).throwsNFE()
 }

--- a/java/ql/src/semmle/code/java/NumberFormatException.qll
+++ b/java/ql/src/semmle/code/java/NumberFormatException.qll
@@ -1,0 +1,83 @@
+/**
+ * @name Missing catch of NumberFormatException
+ * @description Calling a string to number conversion method without handling
+ *              'NumberFormatException' may cause unexpected runtime exceptions.
+ * @kind problem
+ * @problem.severity recommendation
+ * @precision high
+ * @id java/uncaught-number-format-exception
+ * @tags reliability
+ *       external/cwe/cwe-248
+ */
+
+import java
+
+/** Calls a string to number conversion */
+private class SpecialMethodAccess extends MethodAccess {
+  predicate isValueOfMethod(string klass) {
+    this.getMethod().getName() = "valueOf" and
+    this.getQualifier().getType().(RefType).hasQualifiedName("java.lang", klass) and
+    this.getAnArgument().getType().(RefType).hasQualifiedName("java.lang", "String")
+  }
+
+  predicate isParseMethod(string klass, string name) {
+    this.getMethod().getName() = name and
+    this.getQualifier().getType().(RefType).hasQualifiedName("java.lang", klass)
+  }
+
+  predicate throwsNFE() {
+    this.isParseMethod("Byte", "parseByte") or
+    this.isParseMethod("Short", "parseShort") or
+    this.isParseMethod("Integer", "parseInt") or
+    this.isParseMethod("Long", "parseLong") or
+    this.isParseMethod("Float", "parseFloat") or
+    this.isParseMethod("Double", "parseDouble") or
+    this.isParseMethod("Byte", "decode") or
+    this.isParseMethod("Short", "decode") or
+    this.isParseMethod("Integer", "decode") or
+    this.isParseMethod("Long", "decode") or
+    this.isValueOfMethod("Byte") or
+    this.isValueOfMethod("Short") or
+    this.isValueOfMethod("Integer") or
+    this.isValueOfMethod("Long") or
+    this.isValueOfMethod("Float") or
+    this.isValueOfMethod("Double")
+  }
+}
+
+/** Constructs a number from its string representation */
+private class SpecialClassInstanceExpr extends ClassInstanceExpr {
+  predicate isStringConstructor(string klass) {
+    this.getType().(RefType).hasQualifiedName("java.lang", klass) and
+    this.getAnArgument().getType().(RefType).hasQualifiedName("java.lang", "String") and
+    this.getNumArgument() = 1
+  }
+
+  predicate throwsNFE() {
+    this.isStringConstructor("Byte") or
+    this.isStringConstructor("Short") or
+    this.isStringConstructor("Integer") or
+    this.isStringConstructor("Long") or
+    this.isStringConstructor("Float") or
+    this.isStringConstructor("Double")
+  }
+}
+
+/** The class `java.lang.NumberFormatException` */
+class NumberFormatException extends RefType {
+  NumberFormatException() { this.hasQualifiedName("java.lang", "NumberFormatException") }
+}
+
+/** Holds if NFE is caught */
+predicate catchesNFE(TryStmt t) {
+  exists(CatchClause cc, LocalVariableDeclExpr v |
+    t.getACatchClause() = cc and
+    cc.getVariable() = v and
+    v.getType().(RefType).getASubtype*() instanceof NumberFormatException
+  )
+}
+
+/** Holds if NFE is thrown */
+predicate throwsNFE(Expr e) {
+  e.(SpecialClassInstanceExpr).throwsNFE() or e.(SpecialMethodAccess).throwsNFE()
+}


### PR DESCRIPTION
Convert the query <code>src/Violations of\ Best Practice/Exception Handling/NumberFormatException.ql</code> to a library so that it can shared by all the queries dealing with NFEs.