### PR TITLE
C#: Add test cases for native integers

### DIFF
--- a/csharp/ql/test/library-tests/csharp9/NativeInt.cs
+++ b/csharp/ql/test/library-tests/csharp9/NativeInt.cs
@@ -1,0 +1,27 @@
+using System;
+
+public class Class1
+{
+    public void M1(int j, uint k)
+    {
+        nint x = j;
+        nint x0 = (nint)j;
+        IntPtr x1 = (IntPtr)j;
+        nuint y = k;
+
+        const nint i = (nint)42;
+    }
+
+    public void M2()
+    {
+        nint x = 3;
+        int y = 3;
+        long v = 10;
+
+        var test3 = typeof(nint);      // System.IntPtr
+        var test4 = typeof(nuint);     // System.UIntPtr
+        var test5 = (x + 1).GetType(); // System.IntPtr
+        var test6 = (x + y).GetType(); // System.IntPtr
+        var test7 = (x + v).GetType(); // System.Int64
+    }
+}

--- a/csharp/ql/test/library-tests/csharp9/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp9/PrintAst.expected
@@ -1,0 +1,107 @@
+NativeInt.cs:
+#    3| [Class] Class1
+#    5|   5: [Method] M1
+#    5|     -1: [TypeMention] Void
+#-----|     2: (Parameters)
+#    5|       0: [Parameter] j
+#    5|         -1: [TypeMention] int
+#    5|       1: [Parameter] k
+#    5|         -1: [TypeMention] uint
+#    6|     4: [BlockStmt] {...}
+#    7|       0: [LocalVariableDeclStmt] ... ...;
+#    7|         0: [LocalVariableDeclAndInitExpr] IntPtr x = ...
+#    7|           -1: [TypeMention] IntPtr
+#    7|           0: [LocalVariableAccess] access to local variable x
+#    7|           1: [CastExpr] (...) ...
+#    7|             1: [ParameterAccess] access to parameter j
+#    8|       1: [LocalVariableDeclStmt] ... ...;
+#    8|         0: [LocalVariableDeclAndInitExpr] IntPtr x0 = ...
+#    8|           -1: [TypeMention] IntPtr
+#    8|           0: [LocalVariableAccess] access to local variable x0
+#    8|           1: [CastExpr] (...) ...
+#    8|             0: [TypeAccess] access to type IntPtr
+#    8|               0: [TypeMention] IntPtr
+#    8|             1: [ParameterAccess] access to parameter j
+#    9|       2: [LocalVariableDeclStmt] ... ...;
+#    9|         0: [LocalVariableDeclAndInitExpr] IntPtr x1 = ...
+#    9|           -1: [TypeMention] IntPtr
+#    9|           0: [LocalVariableAccess] access to local variable x1
+#    9|           1: [CastExpr] (...) ...
+#    9|             0: [TypeAccess] access to type IntPtr
+#    9|               0: [TypeMention] IntPtr
+#    9|             1: [ParameterAccess] access to parameter j
+#   10|       3: [LocalVariableDeclStmt] ... ...;
+#   10|         0: [LocalVariableDeclAndInitExpr] UIntPtr y = ...
+#   10|           -1: [TypeMention] UIntPtr
+#   10|           0: [LocalVariableAccess] access to local variable y
+#   10|           1: [CastExpr] (...) ...
+#   10|             1: [ParameterAccess] access to parameter k
+#   12|       4: [LocalConstantDeclStmt] const ... ...;
+#   12|         0: [LocalVariableDeclAndInitExpr] IntPtr i = ...
+#   12|           -1: [TypeMention] IntPtr
+#   12|           0: [LocalVariableAccess] access to local variable i
+#   12|           1: [CastExpr] (...) ...
+#   12|             0: [TypeAccess] access to type IntPtr
+#   12|               0: [TypeMention] IntPtr
+#   12|             1: [IntLiteral] 42
+#   15|   6: [Method] M2
+#   15|     -1: [TypeMention] Void
+#   16|     4: [BlockStmt] {...}
+#   17|       0: [LocalVariableDeclStmt] ... ...;
+#   17|         0: [LocalVariableDeclAndInitExpr] IntPtr x = ...
+#   17|           -1: [TypeMention] IntPtr
+#   17|           0: [LocalVariableAccess] access to local variable x
+#   17|           1: [CastExpr] (...) ...
+#   17|             1: [IntLiteral] 3
+#   18|       1: [LocalVariableDeclStmt] ... ...;
+#   18|         0: [LocalVariableDeclAndInitExpr] Int32 y = ...
+#   18|           -1: [TypeMention] int
+#   18|           0: [LocalVariableAccess] access to local variable y
+#   18|           1: [IntLiteral] 3
+#   19|       2: [LocalVariableDeclStmt] ... ...;
+#   19|         0: [LocalVariableDeclAndInitExpr] Int64 v = ...
+#   19|           -1: [TypeMention] long
+#   19|           0: [LocalVariableAccess] access to local variable v
+#   19|           1: [CastExpr] (...) ...
+#   19|             1: [IntLiteral] 10
+#   21|       3: [LocalVariableDeclStmt] ... ...;
+#   21|         0: [LocalVariableDeclAndInitExpr] Type test3 = ...
+#   21|           -1: [TypeMention] Type
+#   21|           0: [LocalVariableAccess] access to local variable test3
+#   21|           1: [TypeofExpr] typeof(...)
+#   21|             0: [TypeAccess] access to type IntPtr
+#   21|               0: [TypeMention] IntPtr
+#   22|       4: [LocalVariableDeclStmt] ... ...;
+#   22|         0: [LocalVariableDeclAndInitExpr] Type test4 = ...
+#   22|           -1: [TypeMention] Type
+#   22|           0: [LocalVariableAccess] access to local variable test4
+#   22|           1: [TypeofExpr] typeof(...)
+#   22|             0: [TypeAccess] access to type UIntPtr
+#   22|               0: [TypeMention] UIntPtr
+#   23|       5: [LocalVariableDeclStmt] ... ...;
+#   23|         0: [LocalVariableDeclAndInitExpr] Type test5 = ...
+#   23|           -1: [TypeMention] Type
+#   23|           0: [LocalVariableAccess] access to local variable test5
+#   23|           1: [MethodCall] call to method GetType
+#   23|             -1: [AddExpr] ... + ...
+#   23|               0: [LocalVariableAccess] access to local variable x
+#   23|               1: [CastExpr] (...) ...
+#   23|                 1: [IntLiteral] 1
+#   24|       6: [LocalVariableDeclStmt] ... ...;
+#   24|         0: [LocalVariableDeclAndInitExpr] Type test6 = ...
+#   24|           -1: [TypeMention] Type
+#   24|           0: [LocalVariableAccess] access to local variable test6
+#   24|           1: [MethodCall] call to method GetType
+#   24|             -1: [AddExpr] ... + ...
+#   24|               0: [LocalVariableAccess] access to local variable x
+#   24|               1: [CastExpr] (...) ...
+#   24|                 1: [LocalVariableAccess] access to local variable y
+#   25|       7: [LocalVariableDeclStmt] ... ...;
+#   25|         0: [LocalVariableDeclAndInitExpr] Type test7 = ...
+#   25|           -1: [TypeMention] Type
+#   25|           0: [LocalVariableAccess] access to local variable test7
+#   25|           1: [MethodCall] call to method GetType
+#   25|             -1: [AddExpr] ... + ...
+#   25|               0: [CastExpr] (...) ...
+#   25|                 1: [LocalVariableAccess] access to local variable x
+#   25|               1: [LocalVariableAccess] access to local variable v

--- a/csharp/ql/test/library-tests/csharp9/PrintAst.qlref
+++ b/csharp/ql/test/library-tests/csharp9/PrintAst.qlref
@@ -1,0 +1,1 @@
+semmle/code/csharp/PrintAst.ql

--- a/csharp/ql/test/library-tests/csharp9/nativeInt.expected
+++ b/csharp/ql/test/library-tests/csharp9/nativeInt.expected
@@ -1,0 +1,63 @@
+| NativeInt.cs:7:14:7:14 | access to local variable x | IntPtr |
+| NativeInt.cs:7:14:7:18 | IntPtr x = ... | IntPtr |
+| NativeInt.cs:7:18:7:18 | (...) ... | IntPtr |
+| NativeInt.cs:7:18:7:18 | access to parameter j | Int32 |
+| NativeInt.cs:8:14:8:15 | access to local variable x0 | IntPtr |
+| NativeInt.cs:8:14:8:25 | IntPtr x0 = ... | IntPtr |
+| NativeInt.cs:8:19:8:25 | (...) ... | IntPtr |
+| NativeInt.cs:8:20:8:23 | access to type IntPtr | IntPtr |
+| NativeInt.cs:8:25:8:25 | access to parameter j | Int32 |
+| NativeInt.cs:9:16:9:17 | access to local variable x1 | IntPtr |
+| NativeInt.cs:9:16:9:29 | IntPtr x1 = ... | IntPtr |
+| NativeInt.cs:9:21:9:29 | (...) ... | IntPtr |
+| NativeInt.cs:9:22:9:27 | access to type IntPtr | IntPtr |
+| NativeInt.cs:9:29:9:29 | access to parameter j | Int32 |
+| NativeInt.cs:10:15:10:15 | access to local variable y | UIntPtr |
+| NativeInt.cs:10:15:10:19 | UIntPtr y = ... | UIntPtr |
+| NativeInt.cs:10:19:10:19 | (...) ... | UIntPtr |
+| NativeInt.cs:10:19:10:19 | access to parameter k | UInt32 |
+| NativeInt.cs:12:20:12:20 | access to local variable i | IntPtr |
+| NativeInt.cs:12:20:12:31 | IntPtr i = ... | IntPtr |
+| NativeInt.cs:12:24:12:31 | (...) ... | IntPtr |
+| NativeInt.cs:12:25:12:28 | access to type IntPtr | IntPtr |
+| NativeInt.cs:12:30:12:31 | 42 | Int32 |
+| NativeInt.cs:17:14:17:14 | access to local variable x | IntPtr |
+| NativeInt.cs:17:14:17:18 | IntPtr x = ... | IntPtr |
+| NativeInt.cs:17:18:17:18 | 3 | Int32 |
+| NativeInt.cs:17:18:17:18 | (...) ... | IntPtr |
+| NativeInt.cs:18:13:18:13 | access to local variable y | Int32 |
+| NativeInt.cs:18:13:18:17 | Int32 y = ... | Int32 |
+| NativeInt.cs:18:17:18:17 | 3 | Int32 |
+| NativeInt.cs:19:14:19:14 | access to local variable v | Int64 |
+| NativeInt.cs:19:14:19:19 | Int64 v = ... | Int64 |
+| NativeInt.cs:19:18:19:19 | 10 | Int32 |
+| NativeInt.cs:19:18:19:19 | (...) ... | Int64 |
+| NativeInt.cs:21:13:21:17 | access to local variable test3 | Type |
+| NativeInt.cs:21:13:21:32 | Type test3 = ... | Type |
+| NativeInt.cs:21:21:21:32 | typeof(...) | Type |
+| NativeInt.cs:21:28:21:31 | access to type IntPtr | IntPtr |
+| NativeInt.cs:22:13:22:17 | access to local variable test4 | Type |
+| NativeInt.cs:22:13:22:33 | Type test4 = ... | Type |
+| NativeInt.cs:22:21:22:33 | typeof(...) | Type |
+| NativeInt.cs:22:28:22:32 | access to type UIntPtr | UIntPtr |
+| NativeInt.cs:23:13:23:17 | access to local variable test5 | Type |
+| NativeInt.cs:23:13:23:37 | Type test5 = ... | Type |
+| NativeInt.cs:23:21:23:37 | call to method GetType | Type |
+| NativeInt.cs:23:22:23:22 | access to local variable x | IntPtr |
+| NativeInt.cs:23:22:23:26 | ... + ... | IntPtr |
+| NativeInt.cs:23:26:23:26 | 1 | Int32 |
+| NativeInt.cs:23:26:23:26 | (...) ... | IntPtr |
+| NativeInt.cs:24:13:24:17 | access to local variable test6 | Type |
+| NativeInt.cs:24:13:24:37 | Type test6 = ... | Type |
+| NativeInt.cs:24:21:24:37 | call to method GetType | Type |
+| NativeInt.cs:24:22:24:22 | access to local variable x | IntPtr |
+| NativeInt.cs:24:22:24:26 | ... + ... | IntPtr |
+| NativeInt.cs:24:26:24:26 | (...) ... | IntPtr |
+| NativeInt.cs:24:26:24:26 | access to local variable y | Int32 |
+| NativeInt.cs:25:13:25:17 | access to local variable test7 | Type |
+| NativeInt.cs:25:13:25:37 | Type test7 = ... | Type |
+| NativeInt.cs:25:21:25:37 | call to method GetType | Type |
+| NativeInt.cs:25:22:25:22 | (...) ... | Int64 |
+| NativeInt.cs:25:22:25:22 | access to local variable x | IntPtr |
+| NativeInt.cs:25:22:25:26 | ... + ... | Int64 |
+| NativeInt.cs:25:26:25:26 | access to local variable v | Int64 |

--- a/csharp/ql/test/library-tests/csharp9/nativeInt.ql
+++ b/csharp/ql/test/library-tests/csharp9/nativeInt.ql
@@ -1,0 +1,5 @@
+import csharp
+
+from Expr e
+where e.fromSource()
+select e, e.getType().toString()


### PR DESCRIPTION
`nint` is reported as `System.IntPtr`. I think it's fine, maybe we could add some extra relations to store where type references happened through the contextual keyword, but we are not doing this for `int`s either.
There are some differences between `nint` and `IntPtr` though. For example the following works for `nint`: `nint i = 5;` whereas for `IntPtr` you would need an explicit cast: `IntPtr i = (IntPtr)5;`. In the former case there's an implicit numeric conversion, and in the latter, there's an explicit conversion operator call.