### PR TITLE
Replace getEncodedFile with shared getFileBySourceArchiveName predicate

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -409,5 +409,12 @@
     "java/ql/src/Metrics/Files/CommentedOutCodeReferences.qhelp",
     "javascript/ql/src/Comments/CommentedOutCodeReferences.qhelp",
     "python/ql/src/Lexical/CommentedOutCodeReferences.qhelp"
+  ],
+  "IDE Contextual Queries": [
+    "cpp/ql/src/IDEContextual.qll",
+    "csharp/ql/src/IDEContextual.qll",
+    "java/ql/src/IDEContextual.qll",
+    "javascript/ql/src/IDEContextual.qll",
+    "python/ql/src/analysis/IDEContextual.qll"
   ]
 }

--- a/cpp/ql/src/IDEContextual.qll
+++ b/cpp/ql/src/IDEContextual.qll
@@ -1,4 +1,4 @@
-/*
+/**
  * Provides shared predicates related to contextual queries in the code viewer.
  */
 

--- a/cpp/ql/src/IDEContextual.qll
+++ b/cpp/ql/src/IDEContextual.qll
@@ -1,0 +1,22 @@
+/*
+ * Provides shared predicates related to contextual queries in the code viewer.
+ */
+
+import semmle.files.FileSystem
+
+/**
+ * Returns the `File` matching the given source file name as encoded by the VS
+ * Code extension.
+ */
+cached
+File getFileBySourceArchiveName(string name) {
+  // The name provided for a file in the source archive by the VS Code extension
+  // has some differences from the absolute path in the database:
+  // 1. colons are replaced by underscores
+  // 2. there's a leading slash, even for Windows paths: "C:/foo/bar" ->
+  //    "/C_/foo/bar"
+  // 3. double slashes in UNC prefixes are replaced with a single slash
+  // We can handle 2 and 3 together by unconditionally adding a leading slash
+  // before replacing double slashes.
+  name = ("/" + result.getAbsolutePath().replaceAll(":", "_")).replaceAll("//", "/")
+}

--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -4,6 +4,7 @@
  */
 
 import cpp
+import IDEContextual
 
 /**
  * Any element that might be the source or target of a jump-to-definition
@@ -207,11 +208,3 @@ Top definitionOf(Top e, string kind) {
   // later on.
   strictcount(result.getLocation()) < 10
 }
-
-/**
- * Returns an appropriately encoded version of a filename `name`
- * passed by the VS Code extension in order to coincide with the
- * output of `.getFile()` on locatable entities.
- */
-cached
-File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }

--- a/cpp/ql/src/localDefinitions.ql
+++ b/cpp/ql/src/localDefinitions.ql
@@ -12,5 +12,5 @@ import definitions
 external string selectedSourceFile();
 
 from Top e, Top def, string kind
-where def = definitionOf(e, kind) and e.getFile() = getEncodedFile(selectedSourceFile())
+where def = definitionOf(e, kind) and e.getFile() = getFileBySourceArchiveName(selectedSourceFile())
 select e, def, kind

--- a/cpp/ql/src/localReferences.ql
+++ b/cpp/ql/src/localReferences.ql
@@ -12,5 +12,6 @@ import definitions
 external string selectedSourceFile();
 
 from Top e, Top def, string kind
-where def = definitionOf(e, kind) and def.getFile() = getEncodedFile(selectedSourceFile())
+where
+  def = definitionOf(e, kind) and def.getFile() = getFileBySourceArchiveName(selectedSourceFile())
 select e, def, kind

--- a/cpp/ql/src/printAst.ql
+++ b/cpp/ql/src/printAst.ql
@@ -22,6 +22,6 @@ class Cfg extends PrintASTConfiguration {
    * Print All functions from the selected file.
    */
   override predicate shouldPrintFunction(Function func) {
-    func.getFile() = getEncodedFile(selectedSourceFile())
+    func.getFile() = getFileBySourceArchiveName(selectedSourceFile())
   }
 }

--- a/csharp/ql/src/IDEContextual.qll
+++ b/csharp/ql/src/IDEContextual.qll
@@ -1,4 +1,4 @@
-/*
+/**
  * Provides shared predicates related to contextual queries in the code viewer.
  */
 

--- a/csharp/ql/src/IDEContextual.qll
+++ b/csharp/ql/src/IDEContextual.qll
@@ -1,0 +1,22 @@
+/*
+ * Provides shared predicates related to contextual queries in the code viewer.
+ */
+
+import semmle.files.FileSystem
+
+/**
+ * Returns the `File` matching the given source file name as encoded by the VS
+ * Code extension.
+ */
+cached
+File getFileBySourceArchiveName(string name) {
+  // The name provided for a file in the source archive by the VS Code extension
+  // has some differences from the absolute path in the database:
+  // 1. colons are replaced by underscores
+  // 2. there's a leading slash, even for Windows paths: "C:/foo/bar" ->
+  //    "/C_/foo/bar"
+  // 3. double slashes in UNC prefixes are replaced with a single slash
+  // We can handle 2 and 3 together by unconditionally adding a leading slash
+  // before replacing double slashes.
+  name = ("/" + result.getAbsolutePath().replaceAll(":", "_")).replaceAll("//", "/")
+}

--- a/csharp/ql/src/definitions.qll
+++ b/csharp/ql/src/definitions.qll
@@ -4,6 +4,7 @@
  */
 
 import csharp
+import IDEContextual
 
 /** An element with an associated definition. */
 abstract class Use extends @type_mention_parent {
@@ -188,11 +189,3 @@ Declaration definitionOf(Use use, string kind) {
   result.fromSource() and
   kind = use.getUseType()
 }
-
-/**
- * Returns an appropriately encoded version of a filename `name`
- * passed by the VS Code extension in order to coincide with the
- * output of `.getFile()` on locatable entities.
- */
-cached
-File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }

--- a/csharp/ql/src/localDefinitions.ql
+++ b/csharp/ql/src/localDefinitions.ql
@@ -15,5 +15,5 @@ from Use e, Declaration def, string kind, string filepath
 where
   def = definitionOf(e, kind) and
   e.hasLocationInfo(filepath, _, _, _, _) and
-  filepath = getEncodedFile(selectedSourceFile()).getAbsolutePath()
+  filepath = getFileBySourceArchiveName(selectedSourceFile()).getAbsolutePath()
 select e, def, kind

--- a/csharp/ql/src/localReferences.ql
+++ b/csharp/ql/src/localReferences.ql
@@ -12,5 +12,6 @@ import definitions
 external string selectedSourceFile();
 
 from Use e, Declaration def, string kind
-where def = definitionOf(e, kind) and def.getFile() = getEncodedFile(selectedSourceFile())
+where
+  def = definitionOf(e, kind) and def.getFile() = getFileBySourceArchiveName(selectedSourceFile())
 select e, def, kind

--- a/csharp/ql/src/printAst.ql
+++ b/csharp/ql/src/printAst.ql
@@ -23,6 +23,6 @@ class PrintAstConfigurationOverride extends PrintAstConfiguration {
    */
   override predicate shouldPrint(Element e, Location l) {
     super.shouldPrint(e, l) and
-    l.getFile() = getEncodedFile(selectedSourceFile())
+    l.getFile() = getFileBySourceArchiveName(selectedSourceFile())
   }
 }

--- a/java/ql/src/IDEContextual.qll
+++ b/java/ql/src/IDEContextual.qll
@@ -1,4 +1,4 @@
-/*
+/**
  * Provides shared predicates related to contextual queries in the code viewer.
  */
 

--- a/java/ql/src/IDEContextual.qll
+++ b/java/ql/src/IDEContextual.qll
@@ -1,0 +1,22 @@
+/*
+ * Provides shared predicates related to contextual queries in the code viewer.
+ */
+
+import semmle.files.FileSystem
+
+/**
+ * Returns the `File` matching the given source file name as encoded by the VS
+ * Code extension.
+ */
+cached
+File getFileBySourceArchiveName(string name) {
+  // The name provided for a file in the source archive by the VS Code extension
+  // has some differences from the absolute path in the database:
+  // 1. colons are replaced by underscores
+  // 2. there's a leading slash, even for Windows paths: "C:/foo/bar" ->
+  //    "/C_/foo/bar"
+  // 3. double slashes in UNC prefixes are replaced with a single slash
+  // We can handle 2 and 3 together by unconditionally adding a leading slash
+  // before replacing double slashes.
+  name = ("/" + result.getAbsolutePath().replaceAll(":", "_")).replaceAll("//", "/")
+}

--- a/java/ql/src/definitions.qll
+++ b/java/ql/src/definitions.qll
@@ -4,6 +4,7 @@
  */
 
 import java
+import IDEContextual
 
 /**
  * Restricts the location of a method access to the method identifier only,
@@ -202,11 +203,3 @@ Element definitionOf(Element e, string kind) {
   not dummyVarAccess(e) and
   not dummyTypeAccess(e)
 }
-
-/**
- * Returns an appropriately encoded version of a filename `name`
- * passed by the VS Code extension in order to coincide with the
- * output of `.getFile()` on locatable entities.
- */
-cached
-File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }

--- a/java/ql/src/localDefinitions.ql
+++ b/java/ql/src/localDefinitions.ql
@@ -12,5 +12,5 @@ import definitions
 external string selectedSourceFile();
 
 from Element e, Element def, string kind
-where def = definitionOf(e, kind) and e.getFile() = getEncodedFile(selectedSourceFile())
+where def = definitionOf(e, kind) and e.getFile() = getFileBySourceArchiveName(selectedSourceFile())
 select e, def, kind

--- a/java/ql/src/localReferences.ql
+++ b/java/ql/src/localReferences.ql
@@ -12,5 +12,6 @@ import definitions
 external string selectedSourceFile();
 
 from Element e, Element def, string kind
-where def = definitionOf(e, kind) and def.getFile() = getEncodedFile(selectedSourceFile())
+where
+  def = definitionOf(e, kind) and def.getFile() = getFileBySourceArchiveName(selectedSourceFile())
 select e, def, kind

--- a/java/ql/src/printAst.ql
+++ b/java/ql/src/printAst.ql
@@ -23,6 +23,6 @@ class PrintAstConfigurationOverride extends PrintAstConfiguration {
    */
   override predicate shouldPrint(Element e, Location l) {
     super.shouldPrint(e, l) and
-    l.getFile() = getEncodedFile(selectedSourceFile())
+    l.getFile() = getFileBySourceArchiveName(selectedSourceFile())
   }
 }

--- a/javascript/ql/src/IDEContextual.qll
+++ b/javascript/ql/src/IDEContextual.qll
@@ -1,4 +1,4 @@
-/*
+/**
  * Provides shared predicates related to contextual queries in the code viewer.
  */
 

--- a/javascript/ql/src/IDEContextual.qll
+++ b/javascript/ql/src/IDEContextual.qll
@@ -1,0 +1,22 @@
+/*
+ * Provides shared predicates related to contextual queries in the code viewer.
+ */
+
+import semmle.files.FileSystem
+
+/**
+ * Returns the `File` matching the given source file name as encoded by the VS
+ * Code extension.
+ */
+cached
+File getFileBySourceArchiveName(string name) {
+  // The name provided for a file in the source archive by the VS Code extension
+  // has some differences from the absolute path in the database:
+  // 1. colons are replaced by underscores
+  // 2. there's a leading slash, even for Windows paths: "C:/foo/bar" ->
+  //    "/C_/foo/bar"
+  // 3. double slashes in UNC prefixes are replaced with a single slash
+  // We can handle 2 and 3 together by unconditionally adding a leading slash
+  // before replacing double slashes.
+  name = ("/" + result.getAbsolutePath().replaceAll(":", "_")).replaceAll("//", "/")
+}

--- a/javascript/ql/src/definitions.qll
+++ b/javascript/ql/src/definitions.qll
@@ -4,6 +4,7 @@
  */
 
 import javascript
+import IDEContextual
 private import Declarations.Declarations
 
 /**
@@ -178,11 +179,3 @@ ASTNode definitionOf(Locatable e, string kind) {
   or
   jsdocTypeLookup(e, result, kind)
 }
-
-/**
- * Returns an appropriately encoded version of a filename `name`
- * passed by the VS Code extension in order to coincide with the
- * output of `.getFile()` on locatable entities.
- */
-cached
-File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }

--- a/javascript/ql/src/localDefinitions.ql
+++ b/javascript/ql/src/localDefinitions.ql
@@ -12,5 +12,5 @@ import definitions
 external string selectedSourceFile();
 
 from Locatable e, ASTNode def, string kind
-where def = definitionOf(e, kind) and e.getFile() = getEncodedFile(selectedSourceFile())
+where def = definitionOf(e, kind) and e.getFile() = getFileBySourceArchiveName(selectedSourceFile())
 select e, def, kind

--- a/javascript/ql/src/localReferences.ql
+++ b/javascript/ql/src/localReferences.ql
@@ -12,5 +12,6 @@ import definitions
 external string selectedSourceFile();
 
 from Locatable e, ASTNode def, string kind
-where def = definitionOf(e, kind) and def.getFile() = getEncodedFile(selectedSourceFile())
+where
+  def = definitionOf(e, kind) and def.getFile() = getFileBySourceArchiveName(selectedSourceFile())
 select e, def, kind

--- a/javascript/ql/src/printAst.ql
+++ b/javascript/ql/src/printAst.ql
@@ -23,6 +23,6 @@ class PrintAstConfigurationOverride extends PrintAstConfiguration {
    */
   override predicate shouldPrint(Locatable e, Location l) {
     super.shouldPrint(e, l) and
-    l.getFile() = getEncodedFile(selectedSourceFile())
+    l.getFile() = getFileBySourceArchiveName(selectedSourceFile())
   }
 }

--- a/python/ql/src/analysis/DefinitionTracking.qll
+++ b/python/ql/src/analysis/DefinitionTracking.qll
@@ -4,6 +4,7 @@
 
 import python
 import semmle.python.pointsto.PointsTo
+import IDEContextual
 
 private newtype TDefinition =
   TLocalDefinition(AstNode a) { a instanceof Expr or a instanceof Stmt or a instanceof Module }
@@ -513,11 +514,3 @@ Definition definitionOf(NiceLocationExpr use, string kind) {
     not result.getLocation().hasLocationInfo(f, l, _, _, _)
   )
 }
-
-/**
- * Returns an appropriately encoded version of a filename `name`
- * passed by the VS Code extension in order to coincide with the
- * output of `.getFile()` on locatable entities.
- */
-cached
-File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }

--- a/python/ql/src/analysis/IDEContextual.qll
+++ b/python/ql/src/analysis/IDEContextual.qll
@@ -1,4 +1,4 @@
-/*
+/**
  * Provides shared predicates related to contextual queries in the code viewer.
  */
 

--- a/python/ql/src/analysis/IDEContextual.qll
+++ b/python/ql/src/analysis/IDEContextual.qll
@@ -1,0 +1,22 @@
+/*
+ * Provides shared predicates related to contextual queries in the code viewer.
+ */
+
+import semmle.files.FileSystem
+
+/**
+ * Returns the `File` matching the given source file name as encoded by the VS
+ * Code extension.
+ */
+cached
+File getFileBySourceArchiveName(string name) {
+  // The name provided for a file in the source archive by the VS Code extension
+  // has some differences from the absolute path in the database:
+  // 1. colons are replaced by underscores
+  // 2. there's a leading slash, even for Windows paths: "C:/foo/bar" ->
+  //    "/C_/foo/bar"
+  // 3. double slashes in UNC prefixes are replaced with a single slash
+  // We can handle 2 and 3 together by unconditionally adding a leading slash
+  // before replacing double slashes.
+  name = ("/" + result.getAbsolutePath().replaceAll(":", "_")).replaceAll("//", "/")
+}

--- a/python/ql/src/analysis/LocalDefinitions.ql
+++ b/python/ql/src/analysis/LocalDefinitions.ql
@@ -16,5 +16,5 @@ from NiceLocationExpr use, Definition defn, string kind, string f
 where
   defn = definitionOf(use, kind) and
   use.hasLocationInfo(f, _, _, _, _) and
-  getEncodedFile(selectedSourceFile()).getAbsolutePath() = f
+  getFileBySourceArchiveName(selectedSourceFile()).getAbsolutePath() = f
 select use, defn, kind

--- a/python/ql/src/analysis/LocalReferences.ql
+++ b/python/ql/src/analysis/LocalReferences.ql
@@ -15,5 +15,5 @@ external string selectedSourceFile();
 from NiceLocationExpr use, Definition defn, string kind
 where
   defn = definitionOf(use, kind) and
-  defn.getLocation().getFile() = getEncodedFile(selectedSourceFile())
+  defn.getLocation().getFile() = getFileBySourceArchiveName(selectedSourceFile())
 select use, defn, kind

--- a/python/ql/src/printAst.ql
+++ b/python/ql/src/printAst.ql
@@ -23,6 +23,6 @@ class PrintAstConfigurationOverride extends PrintAstConfiguration {
    */
   override predicate shouldPrint(AstNode e, Location l) {
     super.shouldPrint(e, l) and
-    l.getFile() = getEncodedFile(selectedSourceFile())
+    l.getFile() = getFileBySourceArchiveName(selectedSourceFile())
   }
 }


### PR DESCRIPTION
While also making it work with paths for databases created on Windows.