### PR TITLE
C++: Odds and ends

### DIFF
--- a/cpp/ql/src/experimental/semmle/code/cpp/security/PrivateCleartextWrite.qll
+++ b/cpp/ql/src/experimental/semmle/code/cpp/security/PrivateCleartextWrite.qll
@@ -7,7 +7,6 @@ import semmle.code.cpp.dataflow.TaintTracking
 import experimental.semmle.code.cpp.security.PrivateData
 import semmle.code.cpp.security.FileWrite
 import semmle.code.cpp.security.BufferWrite
-import semmle.code.cpp.dataflow.TaintTracking
 
 module PrivateCleartextWrite {
   /**

--- a/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
@@ -442,40 +442,6 @@ class ConstructorCall extends FunctionCall {
 }
 
 /**
- * A C++ `throw` expression.
- * ```
- * throw Exc(2);
- * ```
- */
-class ThrowExpr extends Expr, @throw_expr {
-  /**
-   * Gets the expression that will be thrown, if any. There is no result if
-   * `this` is a `ReThrowExpr`.
-   */
-  Expr getExpr() { result = this.getChild(0) }
-
-  override string getAPrimaryQlClass() { result = "ThrowExpr" }
-
-  override string toString() { result = "throw ..." }
-
-  override int getPrecedence() { result = 1 }
-}
-
-/**
- * A C++ `throw` expression with no argument (which causes the current exception to be re-thrown).
- * ```
- * throw;
- * ```
- */
-class ReThrowExpr extends ThrowExpr {
-  ReThrowExpr() { this.getType() instanceof VoidType }
-
-  override string getAPrimaryQlClass() { result = "ReThrowExpr" }
-
-  override string toString() { result = "re-throw exception " }
-}
-
-/**
  * A call to a destructor.
  * ```
  * struct S { ~S(void) {} } *s;

--- a/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
@@ -1147,6 +1147,40 @@ class BlockExpr extends Literal {
 }
 
 /**
+ * A C++ `throw` expression.
+ * ```
+ * throw Exc(2);
+ * ```
+ */
+class ThrowExpr extends Expr, @throw_expr {
+  /**
+   * Gets the expression that will be thrown, if any. There is no result if
+   * `this` is a `ReThrowExpr`.
+   */
+  Expr getExpr() { result = this.getChild(0) }
+
+  override string getAPrimaryQlClass() { result = "ThrowExpr" }
+
+  override string toString() { result = "throw ..." }
+
+  override int getPrecedence() { result = 1 }
+}
+
+/**
+ * A C++ `throw` expression with no argument (which causes the current exception to be re-thrown).
+ * ```
+ * throw;
+ * ```
+ */
+class ReThrowExpr extends ThrowExpr {
+  ReThrowExpr() { this.getType() instanceof VoidType }
+
+  override string getAPrimaryQlClass() { result = "ReThrowExpr" }
+
+  override string toString() { result = "re-throw exception " }
+}
+
+/**
  * A C++11 `noexcept` expression, returning `true` if its subexpression is guaranteed
  * not to `throw` exceptions.  For example:
  * ```

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/Iterator.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/Iterator.qll
@@ -22,7 +22,7 @@ abstract class IteratorReferenceFunction extends Function { }
 abstract class GetIteratorFunction extends Function {
   /**
    * Holds if the return value or buffer represented by `output` is an iterator over the container
-   * passd in the argument, qualifier, or buffer represented by `input`.
+   * passed in the argument, qualifier, or buffer represented by `input`.
    */
   abstract predicate getsIterator(FunctionInput input, FunctionOutput output);
 }

--- a/cpp/ql/src/semmle/code/cpp/stmts/Stmt.qll
+++ b/cpp/ql/src/semmle/code/cpp/stmts/Stmt.qll
@@ -678,7 +678,7 @@ class CoReturnStmt extends Stmt, @stmt_co_return {
   override string getAPrimaryQlClass() { result = "CoReturnStmt" }
 
   /**
-   * Gets the operand of this 'co_return' statement.
+   * Gets the operand of this `co_return` statement.
    *
    * For example, for
    * ```
@@ -693,7 +693,7 @@ class CoReturnStmt extends Stmt, @stmt_co_return {
   FunctionCall getOperand() { result = this.getChild(0) }
 
   /**
-   * Gets the expression of this 'co_return' statement, if any.
+   * Gets the expression of this `co_return` statement, if any.
    *
    * For example, for
    * ```
@@ -707,7 +707,7 @@ class CoReturnStmt extends Stmt, @stmt_co_return {
   Expr getExpr() { result = this.getOperand().getArgument(0) }
 
   /**
-   * Holds if this 'co_return' statement has an expression.
+   * Holds if this `co_return` statement has an expression.
    *
    * For example, this holds for
    * ```


### PR DESCRIPTION
Odds and ends I've been meaning to tidy up.  The biggest is moving `ThrowExpr` and `ReThrowExpr`, because I don't see why `Call.qll` should be their home.