### PR TITLE
C#: Represent all expressions in post-order in the CFG

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Completion.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Completion.qll
@@ -39,7 +39,7 @@ private newtype TCompletion =
   TGotoCompletion(string label) { label = any(GotoStmt gs).getLabel() } or
   TThrowCompletion(ExceptionClass ec) or
   TExitCompletion() or
-  TNestedCompletion(NormalCompletion inner, Completion outer) {
+  TNestedCompletion(ConditionalCompletion inner, Completion outer) {
     outer = TReturnCompletion()
     or
     outer = TBreakCompletion()
@@ -51,8 +51,6 @@ private newtype TCompletion =
     outer = TThrowCompletion(_)
     or
     outer = TExitCompletion()
-    or
-    exists(boolean b | inner = TBooleanCompletion(b) and outer = TBooleanCompletion(b.booleanNot()))
   }
 
 pragma[noinline]
@@ -407,126 +405,87 @@ Completion assertionCompletion(Assertion a, int i) {
  * Holds if a normal completion of `e` must be a Boolean completion.
  */
 private predicate mustHaveBooleanCompletion(Expr e) {
-  inBooleanContext(e, _) and
-  not inBooleanContext(e.getAChildExpr(), true) and
+  inBooleanContext(e) and
   not e instanceof NonReturningCall
 }
 
 /**
  * Holds if `e` is used in a Boolean context. That is, whether the value
  * that `e` evaluates to determines a true/false branch successor.
- *
- * `isBooleanCompletionForParent` indicates whether the Boolean completion
- * for `e` will be the Boolean completion for `e`'s parent. For example,
- * if `e = B` and the parent is `A && B`, then the Boolean completion of
- * `B` is the Boolean completion of `A && B`.
  */
-private predicate inBooleanContext(Expr e, boolean isBooleanCompletionForParent) {
-  exists(IfStmt is | is.getCondition() = e | isBooleanCompletionForParent = false)
+private predicate inBooleanContext(Expr e) {
+  e = any(IfStmt is).getCondition()
   or
-  exists(LoopStmt ls | ls.getCondition() = e | isBooleanCompletionForParent = false)
+  e = any(LoopStmt ls).getCondition()
   or
-  exists(Case c | c.getCondition() = e | isBooleanCompletionForParent = false)
+  e = any(Case c).getCondition()
   or
-  exists(SpecificCatchClause scc | scc.getFilterClause() = e | isBooleanCompletionForParent = false)
+  e = any(SpecificCatchClause scc).getFilterClause()
   or
   exists(BooleanAssertMethod m, int i |
     assertion(_, i, m, e) and
-    i = m.getAnAssertionIndex(_) and
-    isBooleanCompletionForParent = false
+    i = m.getAnAssertionIndex(_)
   )
   or
-  exists(LogicalNotExpr lne | lne.getAnOperand() = e |
-    inBooleanContext(lne, _) and
-    isBooleanCompletionForParent = true
-  )
+  e = any(LogicalNotExpr lne | inBooleanContext(lne)).getAnOperand()
   or
   exists(LogicalAndExpr lae |
-    lae.getLeftOperand() = e and
-    isBooleanCompletionForParent = false
+    lae.getLeftOperand() = e
     or
-    lae.getRightOperand() = e and
-    inBooleanContext(lae, _) and
-    isBooleanCompletionForParent = true
+    inBooleanContext(lae) and
+    lae.getRightOperand() = e
   )
   or
   exists(LogicalOrExpr lae |
-    lae.getLeftOperand() = e and
-    isBooleanCompletionForParent = false
+    lae.getLeftOperand() = e
     or
-    lae.getRightOperand() = e and
-    inBooleanContext(lae, _) and
-    isBooleanCompletionForParent = true
+    inBooleanContext(lae) and
+    lae.getRightOperand() = e
   )
   or
   exists(ConditionalExpr ce |
-    ce.getCondition() = e and
-    isBooleanCompletionForParent = false
+    ce.getCondition() = e
     or
-    (ce.getThen() = e or ce.getElse() = e) and
-    inBooleanContext(ce, _) and
-    isBooleanCompletionForParent = true
+    inBooleanContext(ce) and
+    e in [ce.getThen(), ce.getElse()]
   )
   or
-  exists(NullCoalescingExpr nce | nce.getAnOperand() = e |
-    inBooleanContext(nce, _) and
-    isBooleanCompletionForParent = true
-  )
+  e = any(NullCoalescingExpr nce | inBooleanContext(nce)).getAnOperand()
   or
-  exists(SwitchExpr se |
-    inBooleanContext(se, _) and
-    e = se.getACase().getBody() and
-    isBooleanCompletionForParent = true
-  )
+  e = any(SwitchExpr se | inBooleanContext(se)).getACase()
+  or
+  e = any(SwitchCaseExpr sce | inBooleanContext(sce)).getBody()
 }
 
 /**
  * Holds if a normal completion of `e` must be a nullness completion.
  */
 private predicate mustHaveNullnessCompletion(Expr e) {
-  inNullnessContext(e, _) and
-  not inNullnessContext(e.getAChildExpr(), true) and
+  inNullnessContext(e) and
   not e instanceof NonReturningCall
 }
 
 /**
  * Holds if `e` is used in a nullness context. That is, whether the value
  * that `e` evaluates to determines a `null`/non-`null` branch successor.
- *
- * `isNullnessCompletionForParent` indicates whether the nullness completion
- * for `e` will be the nullness completion for `e`'s parent. For example,
- * if `e = A` and the parent is `A ?? B`, then the nullness completion of `B`
- * is the nullness completion of `A ?? B`.
  */
-private predicate inNullnessContext(Expr e, boolean isNullnessCompletionForParent) {
-  exists(NullCoalescingExpr nce | e = nce.getLeftOperand() | isNullnessCompletionForParent = false)
+private predicate inNullnessContext(Expr e) {
+  e = any(NullCoalescingExpr nce).getLeftOperand()
   or
-  exists(QualifiableExpr qe | qe.isConditional() |
-    e = qe.getChildExpr(-1) and
-    isNullnessCompletionForParent = false
-  )
+  exists(QualifiableExpr qe | qe.isConditional() | e = qe.getChildExpr(-1))
   or
   exists(NullnessAssertMethod m, int i |
     assertion(_, i, m, e) and
-    i = m.getAnAssertionIndex(_) and
-    isNullnessCompletionForParent = false
+    i = m.getAnAssertionIndex(_)
   )
   or
-  exists(ConditionalExpr ce | inNullnessContext(ce, _) |
-    (e = ce.getThen() or e = ce.getElse()) and
-    isNullnessCompletionForParent = true
-  )
+  exists(ConditionalExpr ce | inNullnessContext(ce) | (e = ce.getThen() or e = ce.getElse()))
   or
-  exists(NullCoalescingExpr nce | inNullnessContext(nce, _) |
-    e = nce.getRightOperand() and
-    isNullnessCompletionForParent = true
-  )
+  exists(NullCoalescingExpr nce | inNullnessContext(nce) | e = nce.getRightOperand())
   or
-  exists(SwitchExpr se |
-    inNullnessContext(se, _) and
-    e = se.getACase().getBody() and
-    isNullnessCompletionForParent = true
-  )
+  e = any(SwitchExpr se | inNullnessContext(se)).getACase()
+  or
+  e = any(SwitchCaseExpr sce | inNullnessContext(sce)).getBody()
 }
 
 /**
@@ -592,18 +551,14 @@ abstract class ConditionalCompletion extends NormalCompletion { }
 class BooleanCompletion extends ConditionalCompletion {
   private boolean value;
 
-  BooleanCompletion() {
-    this = TBooleanCompletion(value) or
-    this = TNestedCompletion(_, TBooleanCompletion(value))
-  }
+  BooleanCompletion() { this = TBooleanCompletion(value) }
 
   /** Gets the Boolean value of this completion. */
   boolean getValue() { result = value }
 
-  override string toString() {
-    this = TBooleanCompletion(value) and
-    result = this.getValue().toString()
-  }
+  BooleanCompletion getDual() { result = TBooleanCompletion(value.booleanNot()) }
+
+  override string toString() { result = value.toString() }
 }
 
 /** A Boolean `true` completion. */
@@ -690,30 +645,31 @@ class BreakNormalCompletion extends NormalCompletion, TBreakNormalCompletion {
  * A nested completion. For example, in
  *
  * ```csharp
- * void M(bool b)
+ * void M(bool b1, bool b2)
  * {
  *     try
  *     {
- *         if (b)
+ *         if (b1)
  *            throw new Exception();
  *     }
  *     finally
  *     {
- *         System.Console.WriteLine("M called");
+ *         if (b2)
+ *             System.Console.WriteLine("M called");
  *     }
  * }
  * ```
  *
- * `System.Console.WriteLine("M called")` has an outer throw completion
- * from `throw new Exception` and an inner simple completion.
+ * `b2` has an outer throw completion (inherited from `throw new Exception`)
+ * and an inner `false` completion. `b2` also has a (normal) `true` completion.
  */
 class NestedCompletion extends Completion, TNestedCompletion {
-  private NormalCompletion inner;
+  private ConditionalCompletion inner;
   private Completion outer;
 
   NestedCompletion() { this = TNestedCompletion(inner, outer) }
 
-  override NormalCompletion getInnerCompletion() { result = inner }
+  override ConditionalCompletion getInnerCompletion() { result = inner }
 
   override Completion getOuterCompletion() { result = outer }
 

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
@@ -27,6 +27,7 @@ private module Cached {
   cached
   newtype TSplitKind =
     TInitializerSplitKind() or
+    TConditionalCompletionSplitKind() or
     TAssertionSplitKind() or
     TFinallySplitKind(int nestLevel) { nestLevel = FinallySplitting::nestLevel(_) } or
     TExceptionHandlerSplitKind() or
@@ -36,6 +37,7 @@ private module Cached {
   cached
   newtype TSplit =
     TInitializerSplit(Constructor c) { InitializerSplitting::constructorInitializes(c, _) } or
+    TConditionalCompletionSplit(ConditionalCompletion c) or
     TAssertionSplit(AssertionSplitting::Assertion a, int i, boolean success) {
       exists(a.getExpr(i)) and
       success in [false, true]
@@ -220,7 +222,8 @@ module InitializerSplitting {
 
     InitializedInstanceMember() {
       not this.isStatic() and
-      expr_parent_top_level_adjusted(ae, _, this)
+      expr_parent_top_level_adjusted(ae, _, this) and
+      not ae = any(Callable c).getExpressionBody()
     }
 
     /** Gets the initializer expression. */
@@ -390,6 +393,102 @@ module InitializerSplitting {
   }
 }
 
+module ConditionalCompletionSplitting {
+  /**
+   * A split for conditional completions. For example, in
+   *
+   * ```csharp
+   * void M(int i)
+   * {
+   *     if (x && !y)
+   *         System.Console.WriteLine("true")
+   * }
+   * ```
+   *
+   * we record whether `x`, `y`, and `!y` evaluate to `true` or `false`, and restrict
+   * the edges out of `!y` and `x && !y` accordingly.
+   */
+  class ConditionalCompletionSplitImpl extends SplitImpl, TConditionalCompletionSplit {
+    ConditionalCompletion completion;
+
+    ConditionalCompletionSplitImpl() { this = TConditionalCompletionSplit(completion) }
+
+    override string toString() { result = completion.toString() }
+  }
+
+  private class ConditionalCompletionSplitKind extends SplitKind, TConditionalCompletionSplitKind {
+    override int getListOrder() { result = InitializerSplitting::getNextListOrder() }
+
+    override predicate isEnabled(ControlFlowElement cfe) { this.appliesTo(cfe) }
+
+    override string toString() { result = "ConditionalCompletion" }
+  }
+
+  int getNextListOrder() { result = InitializerSplitting::getNextListOrder() + 1 }
+
+  private class ConditionalCompletionSplitInternal extends SplitInternal,
+    ConditionalCompletionSplitImpl {
+    override ConditionalCompletionSplitKind getKind() { any() }
+
+    override predicate hasEntry(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
+      succ = succ(pred, c) and
+      exists(last(succ, completion)) and
+      (
+        pred = last(succ.(LogicalNotExpr).getOperand(), c) and
+        completion.(BooleanCompletion).getDual() = c
+        or
+        pred = last(succ.(LogicalAndExpr).getAnOperand(), c) and
+        completion = c
+        or
+        pred = last(succ.(LogicalOrExpr).getAnOperand(), c) and
+        completion = c
+        or
+        succ =
+          any(ConditionalExpr ce |
+            pred = last([ce.getThen(), ce.getElse()], c) and
+            completion = c
+          )
+        or
+        succ =
+          any(NullCoalescingExpr nce |
+            exists(Expr operand |
+              pred = last(operand, c) and
+              completion = c
+            |
+              if c instanceof NullnessCompletion
+              then operand = nce.getRightOperand()
+              else operand = nce.getAnOperand()
+            )
+          )
+        or
+        pred = last(succ.(SwitchExpr).getACase(), c) and
+        completion = c
+        or
+        pred = last(succ.(SwitchCaseExpr).getBody(), c) and
+        completion = c
+      )
+    }
+
+    override predicate hasEntry(Callable c, ControlFlowElement succ) { none() }
+
+    override predicate hasExit(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
+      this.appliesTo(pred) and
+      succ = succ(pred, c) and
+      if c instanceof ConditionalCompletion then completion = c else any()
+    }
+
+    override Callable hasExit(ControlFlowElement pred, Completion c) {
+      this.appliesTo(pred) and
+      result = succExit(pred, c) and
+      if c instanceof ConditionalCompletion then completion = c else any()
+    }
+
+    override predicate hasSuccessor(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
+      none()
+    }
+  }
+}
+
 module AssertionSplitting {
   import semmle.code.csharp.commons.Assertions
   private import semmle.code.csharp.ExprOrStmtParent
@@ -435,14 +534,14 @@ module AssertionSplitting {
   }
 
   private class AssertionSplitKind extends SplitKind, TAssertionSplitKind {
-    override int getListOrder() { result = InitializerSplitting::getNextListOrder() }
+    override int getListOrder() { result = ConditionalCompletionSplitting::getNextListOrder() }
 
     override predicate isEnabled(ControlFlowElement cfe) { this.appliesTo(cfe) }
 
     override string toString() { result = "Assertion" }
   }
 
-  int getNextListOrder() { result = InitializerSplitting::getNextListOrder() + 1 }
+  int getNextListOrder() { result = ConditionalCompletionSplitting::getNextListOrder() + 1 }
 
   private class AssertionSplitInternal extends SplitInternal, AssertionSplitImpl {
     override AssertionSplitKind getKind() { any() }
@@ -1508,12 +1607,13 @@ predicate succExitSplits(ControlFlowElement pred, Splits predSplits, Callable su
  * 2. For all `split` in `predSplits`:
  *    - If `split.hasSuccessor(pred, succ, c)` then `split` in `succSplits`.
  * 3. For all `split` in `predSplits`:
- *    - If `split.hasExit(pred, succ, c)` then `split` not in `succSplits`.
- * 4. For all `split` not in `predSplits`:
+ *    - If `split.hasExit(pred, succ, c)` and not `split.hasEntry(pred, succ, c)` then
+ *      `split` not in `succSplits`.
+ * 4. For all `split` with kind not in `predSplits`:
  *    - If `split.hasEntry(pred, succ, c)` then `split` in `succSplits`.
  * 5. For all `split` in `succSplits`:
  *    - `split.hasSuccessor(pred, succ, c)` and `split` in `predSplits`, or
- *    - `split.hasEntry(pred, succ, c)` and `split` not in `predSplits`.
+ *    - `split.hasEntry(pred, succ, c)`.
  *
  * The algorithm divides into four cases:
  *
@@ -1570,10 +1670,18 @@ private module SuccSplits {
     case1b0(pred, predSplits, succ, c) and
     except = predSplits
     or
-    exists(Splits mid, SplitInternal split | case1bForall(pred, predSplits, succ, c, mid) |
-      mid = TSplitsCons(split, except) and
+    exists(SplitInternal split |
+      case1bForallCons(pred, predSplits, succ, c, split, except) and
       split.hasSuccessor(pred, succ, c)
     )
+  }
+
+  pragma[noinline]
+  private predicate case1bForallCons(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c,
+    SplitInternal exceptHead, Splits exceptTail
+  ) {
+    case1bForall(pred, predSplits, succ, c, TSplitsCons(exceptHead, exceptTail))
   }
 
   private predicate case1(
@@ -1589,6 +1697,15 @@ private module SuccSplits {
     case1bForall(pred, predSplits, succ, c, TSplitsNil())
   }
 
+  pragma[noinline]
+  private SplitInternal succInvariant1GetASplit(
+    Reachability::SameSplitsBlock b, ControlFlowElement pred, Splits predSplits,
+    ControlFlowElement succ, Completion c
+  ) {
+    succInvariant1(b, pred, predSplits, succ, c) and
+    result = predSplits.getASplit()
+  }
+
   private predicate case2aux(
     ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c
   ) {
@@ -1596,7 +1713,7 @@ private module SuccSplits {
       succInvariant1(b, pred, predSplits, succ, c) and
       (succ = b.getAnElement() implies succ = b)
     |
-      predSplits.getASplit().hasExit(pred, succ, c)
+      succInvariant1GetASplit(b, pred, predSplits, succ, c).hasExit(pred, succ, c)
       or
       any(SplitInternal split).hasEntry(pred, succ, c)
     )
@@ -1756,11 +1873,18 @@ private module SuccSplits {
     not any(SplitKind sk).appliesTo(succ) and
     except = predSplits
     or
-    exists(Splits mid, SplitInternal split | case2bForall(pred, predSplits, succ, c, mid) |
-      mid = TSplitsCons(split, except) and
+    exists(SplitInternal split | case2bForallCons(pred, predSplits, succ, c, split, except) |
       // Invariants 2 and 3
       split.hasExit(pred, succ, c)
     )
+  }
+
+  pragma[noinline]
+  private predicate case2bForallCons(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c,
+    SplitInternal exceptHead, Splits exceptTail
+  ) {
+    case2bForall(pred, predSplits, succ, c, TSplitsCons(exceptHead, exceptTail))
   }
 
   private predicate case2(

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -170,7 +170,7 @@ module LocalFlow {
         or
         e1 = e2.(NullCoalescingExpr).getAnOperand() and
         scope = e2 and
-        isSuccessor = false
+        isSuccessor = true
         or
         e1 = e2.(SuppressNullableWarningExpr).getExpr() and
         scope = e2 and
@@ -182,7 +182,7 @@ module LocalFlow {
             e1 = ce.getElse()
           ) and
         scope = e2 and
-        isSuccessor = false
+        isSuccessor = true
         or
         e1 = e2.(Cast).getExpr() and
         scope = e2 and
@@ -207,7 +207,7 @@ module LocalFlow {
         or
         e1 = e2.(SwitchExpr).getACase().getBody() and
         scope = e2 and
-        isSuccessor = false
+        isSuccessor = true
       )
     }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
@@ -37,14 +37,13 @@ private class LocalTaintExprStepConfiguration extends ControlFlowReachabilityCon
     Expr e1, Expr e2, ControlFlowElement scope, boolean exactScope, boolean isSuccessor
   ) {
     exactScope = false and
+    isSuccessor = true and
     (
       e1 = e2.(ElementAccess).getQualifier() and
-      scope = e2 and
-      isSuccessor = true
+      scope = e2
       or
       e1 = e2.(AddExpr).getAnOperand() and
-      scope = e2 and
-      isSuccessor = true
+      scope = e2
       or
       // A comparison expression where taint can flow from one of the
       // operands if the other operand is a constant value.
@@ -54,51 +53,43 @@ private class LocalTaintExprStepConfiguration extends ControlFlowReachabilityCon
         other = ct.getAnArgument() and
         other.stripCasts().hasValue() and
         e1 != other and
-        scope = e2 and
-        isSuccessor = true
+        scope = e2
       )
       or
       e1 = e2.(UnaryLogicalOperation).getAnOperand() and
-      scope = e2 and
-      isSuccessor = false
+      scope = e2
       or
       e1 = e2.(BinaryLogicalOperation).getAnOperand() and
-      scope = e2 and
-      isSuccessor = false
+      scope = e2
       or
       // Taint from tuple argument
       e2 =
         any(TupleExpr te |
           e1 = te.getAnArgument() and
           te.isReadAccess() and
-          scope = e2 and
-          isSuccessor = true
+          scope = e2
         )
       or
       e1 = e2.(InterpolatedStringExpr).getAChild() and
-      scope = e2 and
-      isSuccessor = true
+      scope = e2
       or
       // Taint from tuple expression
       e2 =
         any(MemberAccess ma |
           ma.getQualifier().getType() instanceof TupleType and
           e1 = ma.getQualifier() and
-          scope = e2 and
-          isSuccessor = true
+          scope = e2
         )
       or
       e2 =
         any(OperatorCall oc |
           oc.getTarget().(ConversionOperator).fromLibrary() and
           e1 = oc.getAnArgument() and
-          scope = e2 and
-          isSuccessor = true
+          scope = e2
         )
       or
       e1 = e2.(AwaitExpr).getExpr() and
-      scope = e2 and
-      isSuccessor = true
+      scope = e2
     )
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/RangeUtils.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/RangeUtils.qll
@@ -73,6 +73,19 @@ private module Impl {
       e2.(ExprNode::SubExpr).getRightOperand() = x and
       x.getIntValue() = -delta
     )
+    or
+    // Conditional expressions with only one branch can happen either
+    // because of pruning or because of Boolean splitting. In such cases
+    // the conditional expression has the same value as the branch.
+    delta = 0 and
+    e2 =
+      any(ExprNode::ConditionalExpr ce |
+        e1 = ce.getTrueExpr() and
+        not exists(ce.getFalseExpr())
+        or
+        e1 = ce.getFalseExpr() and
+        not exists(ce.getTrueExpr())
+      )
   }
 
   /** An expression whose value may control the execution of another element. */

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -15,88 +15,88 @@
 | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | exit M2 | 6 |
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | exit M3 | 8 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | exit M4 | 13 |
-| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:20:9:20 | access to parameter b | 5 |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:20:9:20 | access to parameter b | 4 |
 | Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | exit M1 | 1 |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:22:10:30 | ... != ... | 5 |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:10:22:10:30 | ... != ... | 6 |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null | 1 |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" | 1 |
 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | exit M1 (abnormal) | 2 |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:7:10:7:11 | exit M1 (normal) | 6 |
-| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:20:16:20 | access to parameter b | 5 |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:20:16:20 | access to parameter b | 4 |
 | Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | exit M2 | 1 |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:23:17:23 | access to local variable s | 3 |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:17:23:17:23 | access to local variable s | 4 |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null | 1 |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" | 1 |
 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 (abnormal) | 2 |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 (normal) | 6 |
-| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:20:23:20 | access to parameter b | 5 |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:20:23:20 | access to parameter b | 4 |
 | Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | exit M3 | 1 |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:26:24:26 | access to local variable s | 3 |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:24:26:24:26 | access to local variable s | 4 |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null | 1 |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" | 1 |
 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 (abnormal) | 2 |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 (normal) | 6 |
-| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:20:30:20 | access to parameter b | 5 |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:20:30:20 | access to parameter b | 4 |
 | Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | exit M4 | 1 |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:23:31:31 | ... == ... | 5 |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:31:23:31:31 | ... == ... | 6 |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null | 1 |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" | 1 |
 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 (abnormal) | 2 |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 (normal) | 6 |
-| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:20:37:20 | access to parameter b | 5 |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:20:37:20 | access to parameter b | 4 |
 | Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | exit M5 | 1 |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:23:38:31 | ... != ... | 5 |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:38:23:38:31 | ... != ... | 6 |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null | 1 |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" | 1 |
 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 (abnormal) | 2 |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 (normal) | 6 |
-| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:20:44:20 | access to parameter b | 5 |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:20:44:20 | access to parameter b | 4 |
 | Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | exit M6 | 1 |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:24:45:32 | ... != ... | 5 |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:45:24:45:32 | ... != ... | 6 |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null | 1 |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" | 1 |
 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 (abnormal) | 2 |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 (normal) | 6 |
-| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:20:51:20 | access to parameter b | 5 |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:20:51:20 | access to parameter b | 4 |
 | Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | exit M7 | 1 |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:24:52:32 | ... == ... | 5 |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:52:24:52:32 | ... == ... | 6 |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null | 1 |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" | 1 |
 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 (abnormal) | 2 |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 (normal) | 6 |
-| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:20:58:20 | access to parameter b | 5 |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:20:58:20 | access to parameter b | 4 |
 | Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | exit M8 | 1 |
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | 7 |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | 7 |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 (abnormal) | 2 |
+| Assert.cs:59:23:59:36 | [false] ... && ... | Assert.cs:56:10:56:11 | exit M8 (abnormal) | 3 |
 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | 1 |
-| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:56:10:56:11 | exit M8 (normal) | 7 |
-| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:20:65:20 | access to parameter b | 5 |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:56:10:56:11 | exit M8 (normal) | 8 |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:20:65:20 | access to parameter b | 4 |
 | Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | exit M9 | 1 |
 | Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | 7 |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | 7 |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 (abnormal) | 2 |
-| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:63:10:63:11 | exit M9 (normal) | 7 |
+| Assert.cs:66:24:66:37 | [true] ... \|\| ... | Assert.cs:63:10:63:11 | exit M9 (abnormal) | 3 |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:63:10:63:11 | exit M9 (normal) | 8 |
 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | 1 |
-| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:20:72:20 | access to parameter b | 5 |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:20:72:20 | access to parameter b | 4 |
 | Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | exit M10 | 1 |
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | 7 |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | 7 |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 (abnormal) | 2 |
+| Assert.cs:73:23:73:36 | [false] ... && ... | Assert.cs:70:10:70:12 | exit M10 (abnormal) | 3 |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | 1 |
-| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:70:10:70:12 | exit M10 (normal) | 7 |
-| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:20:79:20 | access to parameter b | 5 |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:70:10:70:12 | exit M10 (normal) | 8 |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:20:79:20 | access to parameter b | 4 |
 | Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | exit M11 | 1 |
 | Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | 7 |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | 7 |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 (abnormal) | 2 |
-| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:77:10:77:12 | exit M11 (normal) | 7 |
+| Assert.cs:80:24:80:37 | [true] ... \|\| ... | Assert.cs:77:10:77:12 | exit M11 (abnormal) | 3 |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:77:10:77:12 | exit M11 (normal) | 8 |
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | 1 |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:20:86:20 | access to parameter b | 5 |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:20:86:20 | access to parameter b | 4 |
 | Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | exit M12 | 1 |
 | Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | exit M12 (abnormal) | 1 |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | 6 |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | 6 |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | 7 |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | 7 |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | 1 |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | 1 |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | 12 |
@@ -123,18 +123,18 @@
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | 14 |
 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | 1 |
 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | 1 |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | 15 |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | 15 |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | 1 |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | 1 |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | 14 |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | 14 |
+| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | 2 |
+| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | 2 |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | 1 |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | 16 |
-| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | 1 |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | 17 |
-| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | 1 |
+| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | 2 |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | 17 |
+| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | 2 |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | 16 |
-| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | 1 |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | exit M12 (normal) | 8 |
+| Assert.cs:127:24:127:38 | [true] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | 2 |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | exit M12 (normal) | 9 |
 | Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:131:18:131:32 | exit AssertTrueFalse | 4 |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:140:25:140:26 | access to parameter b1 | 5 |
 | Assert.cs:138:10:138:12 | exit M13 | Assert.cs:138:10:138:12 | exit M13 | 1 |
@@ -187,8 +187,6 @@
 | CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:15:10:15:15 | exit Typeof | 6 |
 | CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:20:12:20:17 | exit Nameof | 6 |
 | CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:28:10:28:10 | exit M | 15 |
-| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:30:28:30:32 | ... = ... | 3 |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | 2 |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | 2 |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 | 2 |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:28:3:38 | call to method ToString | 1 |
@@ -196,12 +194,15 @@
 | ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | 2 |
 | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | exit M2 | 2 |
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:28:5:34 | access to property Length | 1 |
-| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | 3 |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | 2 |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 | 2 |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | 1 |
+| ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | 1 |
+| ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | 1 |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | 1 |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:49:7:55 | access to property Length | 1 |
-| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | 3 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 | 2 |
+| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | 2 |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:9:9:10 | exit M4 | 3 |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:27:9:33 | access to property Length | 1 |
 | ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:38:9:38 | 0 | 1 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:13:13:13:13 | access to parameter s | 4 |
@@ -214,21 +215,20 @@
 | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | exit M6 | 2 |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | 2 |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | exit M7 | 18 |
-| ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:28:30:32 | ... = ... | 3 |
-| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out | 2 |
+| ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | exit Out | 5 |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:35:9:35:12 | access to property Prop | 8 |
 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 | 2 |
 | ConditionalAccess.cs:35:14:35:24 | call to method Out | ConditionalAccess.cs:35:14:35:24 | call to method Out | 1 |
 | ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith | 8 |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:5:13:5:15 | access to parameter inc | 4 |
 | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | exit IncrOrDecr | 2 |
-| Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | 6 |
+| Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:7:13:7:16 | [false] !... | 6 |
 | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:8:13:8:15 | ...-- | 6 |
 | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:14:13:14:13 | access to parameter b | 7 |
 | Conditions.cs:15:13:15:16 | [b (line 11): true] ...; | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | 7 |
 | Conditions.cs:16:9:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | 4 |
 | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:18:17:18:19 | ...-- | 6 |
-| Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | 3 |
+| Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:17:17:17:18 | [false] !... | 3 |
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:11:9:11:10 | exit M1 | 4 |
 | Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:25:13:25:14 | access to parameter b1 | 7 |
 | Conditions.cs:26:13:27:20 | if (...) ... | Conditions.cs:26:17:26:18 | access to parameter b2 | 2 |
@@ -283,24 +283,24 @@
 | Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | 10 |
 | Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... | 5 |
 | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:109:17:109:23 | ... = ... | 8 |
-| Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | 3 |
+| Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:17:108:18 | [false] !... | 3 |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:102:12:102:13 | exit M8 | 4 |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:18:116:22 | Int32 i = ... | 8 |
 | Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | exit M9 | 2 |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:39 | ... < ... | 4 |
 | Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:44 | ...++ | 2 |
-| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:18:119:21 | access to local variable last | 12 |
-| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | 5 |
-| Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:122:17:122:24 | ... = ... | 5 |
+| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:18:119:21 | access to local variable last | 11 |
+| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | Conditions.cs:122:17:122:24 | ... = ... | 6 |
+| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | 6 |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:133:17:133:22 | access to field Field1 | 8 |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | 5 |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | 9 |
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | 4 |
 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | 14 |
-| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:17:145:17 | access to parameter b | 5 |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:17:145:17 | access to parameter b | 4 |
 | Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | exit M11 | 2 |
-| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:147:13:147:48 | call to method WriteLine | 9 |
-| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:149:13:149:48 | call to method WriteLine | 9 |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:147:13:147:48 | call to method WriteLine | 10 |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:149:13:149:48 | call to method WriteLine | 10 |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | exit M1 | 8 |
 | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | exit M2 | 8 |
 | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | exit M3 | 7 |
@@ -327,12 +327,12 @@
 | ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:86:10:86:13 | exit Exit | 7 |
 | ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:91:10:91:18 | exit ExitInTry | 9 |
 | ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit | 6 |
-| ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:111:16:111:25 | ... != ... | 7 |
+| ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:111:16:111:25 | ... != ... | 6 |
 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | 1 |
-| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) | 6 |
+| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) | 7 |
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) | 4 |
-| ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:16:116:30 | call to method Contains | 6 |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | 3 |
+| ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:16:116:30 | call to method Contains | 5 |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | 4 |
 | ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 | 1 |
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 | 1 |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | 7 |
@@ -413,20 +413,25 @@
 | Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:103:10:103:11 | exit M5 (normal) | 1 |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:107:17:107:28 | access to property Length | 1 |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:107:17:107:33 | ... == ... | 2 |
-| Finally.cs:108:17:108:23 | return ...; | Finally.cs:114:19:114:35 | [finally: return] ... == ... | 9 |
+| Finally.cs:108:17:108:23 | return ...; | Finally.cs:114:19:114:35 | [finally: return] ... == ... | 8 |
 | Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:109:17:109:21 | access to field Field | 3 |
 | Finally.cs:109:17:109:28 | access to property Length | Finally.cs:109:17:109:28 | access to property Length | 1 |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:109:17:109:33 | ... == ... | 2 |
-| Finally.cs:110:17:110:49 | throw ...; | Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | 9 |
+| Finally.cs:110:17:110:49 | throw ...; | Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | 8 |
 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | 1 |
-| Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | 8 |
-| Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | 8 |
-| Finally.cs:113:9:118:9 | {...} | Finally.cs:114:19:114:35 | ... == ... | 8 |
-| Finally.cs:115:17:115:41 | ...; | Finally.cs:115:17:115:40 | call to method WriteLine | 4 |
-| Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | Finally.cs:115:17:115:40 | [finally: exception(Exception)] call to method WriteLine | 4 |
-| Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | Finally.cs:115:17:115:40 | [finally: exception(NullReferenceException)] call to method WriteLine | 4 |
-| Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:115:17:115:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 4 |
-| Finally.cs:115:17:115:41 | [finally: return] ...; | Finally.cs:115:17:115:40 | [finally: return] call to method WriteLine | 4 |
+| Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | 7 |
+| Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | 7 |
+| Finally.cs:113:9:118:9 | {...} | Finally.cs:114:19:114:35 | ... == ... | 7 |
+| Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | 1 |
+| Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | 1 |
+| Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | 1 |
+| Finally.cs:114:17:114:36 | [false, finally: return] !... | Finally.cs:114:17:114:36 | [false, finally: return] !... | 1 |
+| Finally.cs:114:17:114:36 | [false] !... | Finally.cs:114:17:114:36 | [false] !... | 1 |
+| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:115:17:115:40 | [finally: exception(Exception)] call to method WriteLine | 5 |
+| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:115:17:115:40 | [finally: exception(NullReferenceException)] call to method WriteLine | 5 |
+| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:115:17:115:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 5 |
+| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:115:17:115:40 | [finally: return] call to method WriteLine | 5 |
+| Finally.cs:114:17:114:36 | [true] !... | Finally.cs:115:17:115:40 | call to method WriteLine | 5 |
 | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | 6 |
 | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | 6 |
 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... | 6 |
@@ -539,10 +544,11 @@
 | Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | exit M2 | 2 |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | 1 |
 | Foreach.cs:14:22:14:22 | String _ | Foreach.cs:15:13:15:13 | ; | 2 |
-| Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:27:20:27 | access to parameter e | 4 |
+| Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:27:20:27 | access to parameter e | 3 |
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 | 2 |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | 1 |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:21:11:21:11 | ; | 2 |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:27:20:68 | ... ?? ... | 1 |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:29:20:38 | call to method ToArray | 1 |
 | Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:43:20:68 | call to method Empty | 1 |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:26:36:26:39 | access to parameter args | 3 |
@@ -593,10 +599,10 @@
 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:60:17:60:17 | [b (line 55): true] access to parameter b | 4 |
 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | 9 |
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | 3 |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:69:14:69:23 | call to method Any | 6 |
+| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:69:14:69:23 | call to method Any | 5 |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 | 2 |
-| LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; | 1 |
-| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | 5 |
+| LoopUnrolling.cs:69:13:69:23 | [false] !... | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | 6 |
+| LoopUnrolling.cs:69:13:69:23 | [true] !... | LoopUnrolling.cs:70:13:70:19 | return ...; | 2 |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 | 11 |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 | 11 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | 9 |
@@ -765,29 +771,33 @@
 | MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | exit M1 | 1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | 2 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | 2 |
-| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:23 | access to parameter i | 3 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 | 2 |
+| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:23 | access to parameter i | 2 |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:9:3:10 | exit M1 | 3 |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:28:3:28 | 0 | 1 |
-| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:25:5:25 | access to parameter b | 4 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 | 2 |
+| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:25:5:25 | access to parameter b | 2 |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | exit M2 | 3 |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:43:5:43 | 1 | 2 |
+| NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | NullCoalescing.cs:5:39:5:39 | 0 | 2 |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:30:5:34 | false | 1 |
-| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:39:5:39 | 0 | 1 |
-| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:43:5:43 | 1 | 1 |
-| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | 3 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 | 2 |
-| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | 2 |
+| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | 2 |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | exit M3 | 3 |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | 1 |
+| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:53 | ... ?? ... | 1 |
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:52:7:53 | "" | 1 |
-| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:37:9:37 | access to parameter b | 4 |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 | 2 |
+| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:37:9:37 | access to parameter b | 2 |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | exit M4 | 3 |
+| NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | 1 |
+| NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | NullCoalescing.cs:9:51:9:58 | ... ?? ... | 3 |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:41:9:41 | access to parameter s | 1 |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:45:9:45 | access to parameter s | 1 |
-| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:52 | "" | 2 |
-| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | 4 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 | 2 |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | 2 |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | 2 |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | exit M5 | 3 |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:68:11:68 | 1 | 2 |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:64:11:64 | 0 | 2 |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | 1 |
+| NullCoalescing.cs:11:51:11:58 | [false] ... && ... | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | 1 |
+| NullCoalescing.cs:11:51:11:58 | [true] ... && ... | NullCoalescing.cs:11:51:11:58 | [true] ... && ... | 1 |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | 1 |
-| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:64:11:64 | 0 | 1 |
-| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:68:11:68 | 1 | 1 |
 | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:13:10:13:11 | exit M6 | 19 |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:8:13:8:23 | ... is ... | 9 |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:10:13:10:42 | call to method WriteLine | 6 |
@@ -835,9 +845,10 @@
 | Switch.cs:22:21:22:27 | return ...; | Switch.cs:22:21:22:27 | return ...; | 1 |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:23:17:23:28 | goto case ...; | 2 |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:18:24:25 | String s | 2 |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:32:24:43 | ... > ... | 5 |
+| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:43 | ... > ... | 4 |
+| Switch.cs:24:32:24:55 | [false] ... && ... | Switch.cs:24:32:24:55 | [false] ... && ... | 1 |
+| Switch.cs:24:32:24:55 | [true] ... && ... | Switch.cs:26:17:26:23 | return ...; | 5 |
 | Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:48:24:55 | ... != ... | 3 |
-| Switch.cs:25:17:25:37 | ...; | Switch.cs:26:17:26:23 | return ...; | 4 |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | Double d | 2 |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:27:32:27:38 | call to method Throw | 1 |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:29:17:29:23 | return ...; | 4 |
@@ -881,16 +892,20 @@
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:25:118:33 | ... == ... | 3 |
 | Switch.cs:118:43:118:43 | 2 | Switch.cs:118:36:118:44 | return ...; | 2 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:9:120:18 | return ...; | 3 |
-| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:24:125:29 | Boolean b | 7 |
+| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:24:125:29 | Boolean b | 5 |
 | Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 | 2 |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:125:13:125:48 | [false] ... switch { ... } | 1 |
+| Switch.cs:125:24:125:34 | [false] ... => ... | Switch.cs:125:24:125:34 | [false] ... => ... | 1 |
+| Switch.cs:125:24:125:34 | [true] ... => ... | Switch.cs:126:13:126:19 | return ...; | 3 |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:34:125:34 | access to local variable b | 1 |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:42:125:46 | false | 3 |
-| Switch.cs:126:13:126:19 | return ...; | Switch.cs:126:13:126:19 | return ...; | 1 |
-| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:28:131:35 | String s | 6 |
+| Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:46 | [false] ... => ... | 3 |
+| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:28:131:35 | String s | 4 |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 | 3 |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:131:17:131:53 | [null] ... switch { ... } | 1 |
+| Switch.cs:131:28:131:40 | [non-null] ... => ... | Switch.cs:131:56:131:66 | call to method ToString | 3 |
+| Switch.cs:131:28:131:40 | [null] ... => ... | Switch.cs:131:28:131:40 | [null] ... => ... | 1 |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:40:131:40 | access to local variable s | 1 |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:48:131:51 | null | 3 |
-| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:56:131:66 | call to method ToString | 1 |
+| Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:51 | [null] ... => ... | 3 |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:139:18:139:18 | 1 | 6 |
 | Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 | 2 |
 | Switch.cs:138:13:138:20 | default: | Switch.cs:138:22:138:31 | return ...; | 4 |
@@ -903,14 +918,14 @@
 | Switch.cs:149:13:149:20 | default: | Switch.cs:149:22:149:31 | return ...; | 4 |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:18:150:18 | 2 | 2 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; | 2 |
-| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:28:156:31 | true | 7 |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:28:156:31 | true | 5 |
 | Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | exit M15 | 1 |
 | Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | exit M15 (abnormal) | 1 |
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | exit M15 (normal) | 1 |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:157:13:157:13 | access to parameter b | 3 |
-| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" | 1 |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false | 2 |
-| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" | 1 |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:157:13:157:13 | access to parameter b | 4 |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:28:156:38 | ... => ... | 2 |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false | 1 |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:52 | ... => ... | 2 |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:48 | call to method WriteLine | 5 |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:48 | call to method WriteLine | 5 |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | ... is ... | 14 |
@@ -918,8 +933,8 @@
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | exit M | 5 |
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | exit M1 | 19 |
 | VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:13:12:13:13 | exit M2 | 13 |
-| VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:20:25:20 | access to parameter b | 12 |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 | 3 |
+| VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:20:25:20 | access to parameter b | 11 |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:19:7:19:8 | exit M3 | 4 |
 | VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:24:25:24 | access to local variable x | 1 |
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:28:25:28 | access to local variable y | 1 |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | exit Dispose | 4 |
@@ -934,10 +949,10 @@
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:18:24:22 | Int32 i = ... | 3 |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:25:24:31 | ... <= ... | 3 |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:24:34:24:36 | ...++ | 2 |
-| cflow.cs:25:9:34:9 | {...} | cflow.cs:26:17:26:26 | ... == ... | 8 |
+| cflow.cs:25:9:34:9 | {...} | cflow.cs:26:17:26:26 | ... == ... | 7 |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:28:22:28:31 | ... == ... | 7 |
+| cflow.cs:26:17:26:40 | [true] ... && ... | cflow.cs:27:17:27:45 | call to method WriteLine | 4 |
 | cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:31:26:40 | ... == ... | 5 |
-| cflow.cs:27:17:27:46 | ...; | cflow.cs:27:17:27:45 | call to method WriteLine | 3 |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:28:22:28:31 | ... == ... | 6 |
 | cflow.cs:29:17:29:42 | ...; | cflow.cs:29:17:29:41 | call to method WriteLine | 3 |
 | cflow.cs:30:18:33:37 | if (...) ... | cflow.cs:30:22:30:31 | ... == ... | 6 |
 | cflow.cs:31:17:31:42 | ...; | cflow.cs:31:17:31:41 | call to method WriteLine | 3 |
@@ -954,9 +969,9 @@
 | cflow.cs:54:17:54:48 | ...; | cflow.cs:55:17:55:22 | break; | 4 |
 | cflow.cs:56:13:56:20 | default: | cflow.cs:58:17:58:22 | break; | 5 |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:62:18:62:18 | 0 | 6 |
-| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:23:63:33 | ... == ... | 6 |
-| cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:37:17:37:22 | exit Switch (abnormal) | 3 |
-| cflow.cs:65:17:65:22 | break; | cflow.cs:65:17:65:22 | break; | 1 |
+| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:23:63:33 | ... == ... | 5 |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:65:17:65:22 | break; | 2 |
+| cflow.cs:63:21:63:34 | [true] !... | cflow.cs:37:17:37:22 | exit Switch (abnormal) | 4 |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:37:17:37:22 | exit Switch (normal) | 3 |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:72:13:72:21 | ... == ... | 6 |
 | cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | exit M | 2 |
@@ -964,10 +979,11 @@
 | cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:74:13:74:24 | ... > ... | 5 |
 | cflow.cs:75:9:77:9 | {...} | cflow.cs:76:13:76:32 | call to method WriteLine | 4 |
 | cflow.cs:79:9:81:9 | {...} | cflow.cs:80:13:80:47 | call to method WriteLine | 4 |
-| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:86:13:86:21 | ... != ... | 7 |
+| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:86:13:86:21 | ... != ... | 6 |
 | cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 | 2 |
+| cflow.cs:86:13:86:37 | [false] ... && ... | cflow.cs:86:13:86:37 | [false] ... && ... | 1 |
+| cflow.cs:86:13:86:37 | [true] ... && ... | cflow.cs:87:13:87:32 | call to method WriteLine | 4 |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:37 | ... > ... | 4 |
-| cflow.cs:87:13:87:33 | ...; | cflow.cs:87:13:87:32 | call to method WriteLine | 3 |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:92:13:92:27 | call to method Equals | 6 |
 | cflow.cs:90:18:90:19 | exit M3 | cflow.cs:90:18:90:19 | exit M3 | 1 |
 | cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | exit M3 (normal) | 1 |
@@ -983,8 +999,8 @@
 | cflow.cs:110:20:110:23 | true | cflow.cs:112:17:112:36 | call to method WriteLine | 5 |
 | cflow.cs:116:9:116:29 | ...; | cflow.cs:106:18:106:19 | exit M4 | 5 |
 | cflow.cs:119:20:119:21 | enter M5 | cflow.cs:119:20:119:21 | exit M5 | 14 |
-| cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:32:127:44 | ... == ... | 7 |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop | 3 |
+| cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:32:127:44 | ... == ... | 6 |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:19:127:21 | exit get_Prop | 4 |
 | cflow.cs:127:48:127:49 | "" | cflow.cs:127:48:127:49 | "" | 1 |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field | 2 |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:62:127:64 | exit set_Prop | 8 |
@@ -1013,20 +1029,22 @@
 | cflow.cs:181:28:181:37 | enter (...) => ... | cflow.cs:181:28:181:37 | exit (...) => ... | 6 |
 | cflow.cs:182:28:182:61 | enter delegate(...) { ... } | cflow.cs:182:28:182:61 | exit delegate(...) { ... } | 8 |
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:185:10:185:18 | exit LogicalOr | 20 |
-| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:17:195:32 | ... > ... | 9 |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:17:195:32 | ... > ... | 8 |
 | cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:193:10:193:17 | exit Booleans | 1 |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | exit Booleans (normal) | 1 |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:15:197:31 | ... == ... | 9 |
-| cflow.cs:195:37:195:56 | !... | cflow.cs:195:39:195:55 | ... == ... | 6 |
-| cflow.cs:197:35:197:39 | false | cflow.cs:198:17:198:33 | ... == ... | 8 |
-| cflow.cs:197:43:197:46 | true | cflow.cs:197:43:197:46 | true | 1 |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:198:13:198:48 | ... = ... | 1 |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:197:15:197:31 | ... == ... | 8 |
+| cflow.cs:195:39:195:43 | this access | cflow.cs:195:37:195:56 | !... | 6 |
+| cflow.cs:197:35:197:39 | false | cflow.cs:198:17:198:33 | ... == ... | 9 |
+| cflow.cs:197:43:197:46 | true | cflow.cs:197:13:197:47 | [false] !... | 3 |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:13:198:48 | ... = ... | 2 |
 | cflow.cs:198:37:198:41 | false | cflow.cs:198:37:198:41 | false | 1 |
 | cflow.cs:198:45:198:48 | true | cflow.cs:198:45:198:48 | true | 1 |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:15:200:31 | ... == ... | 8 |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:40:200:56 | ... == ... | 8 |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:15:200:31 | ... == ... | 6 |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:40:200:56 | ... == ... | 6 |
+| cflow.cs:200:13:200:32 | [true] !... | cflow.cs:200:13:200:32 | [true] !... | 1 |
+| cflow.cs:200:13:200:62 | [true] ... \|\| ... | cflow.cs:193:10:193:17 | exit Booleans (abnormal) | 6 |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | 5 |
+| cflow.cs:200:40:200:61 | [true] ... && ... | cflow.cs:200:37:200:62 | [true] !... | 3 |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:61:200:61 | access to local variable b | 1 |
-| cflow.cs:201:9:205:9 | {...} | cflow.cs:193:10:193:17 | exit Booleans (abnormal) | 5 |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:210:9:221:36 | do ... while (...); | 3 |
 | cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | exit Do | 2 |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:213:17:213:32 | ... > ... | 14 |
@@ -1043,8 +1061,9 @@
 | cflow.cs:234:13:236:13 | {...} | cflow.cs:235:17:235:22 | break; | 2 |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:241:5:259:5 | {...} | 2 |
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto | 2 |
-| cflow.cs:242:9:242:13 | Label: | cflow.cs:242:23:242:39 | ... == ... | 9 |
-| cflow.cs:242:43:242:45 | {...} | cflow.cs:242:43:242:45 | {...} | 1 |
+| cflow.cs:242:9:242:13 | Label: | cflow.cs:242:23:242:39 | ... == ... | 7 |
+| cflow.cs:242:21:242:40 | [false] !... | cflow.cs:242:43:242:45 | {...} | 3 |
+| cflow.cs:242:21:242:40 | [true] !... | cflow.cs:242:20:242:40 | [false] !... | 2 |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:13:244:28 | ... > ... | 6 |
 | cflow.cs:244:31:244:41 | goto ...; | cflow.cs:244:31:244:41 | goto ...; | 1 |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:248:18:248:18 | 0 | 8 |
@@ -1063,6 +1082,7 @@
 | cflow.cs:286:5:286:18 | enter ControlFlowSub | cflow.cs:286:5:286:18 | exit ControlFlowSub | 7 |
 | cflow.cs:291:12:291:12 | enter M | cflow.cs:291:12:291:12 | exit M | 6 |
 | cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | exit NegationInConstructor | 4 |
-| cflow.cs:298:10:298:10 | enter M | cflow.cs:300:46:300:50 | ... > ... | 9 |
-| cflow.cs:300:56:300:56 | access to parameter s | cflow.cs:300:56:300:64 | ... != ... | 3 |
-| cflow.cs:300:70:300:71 | "" | cflow.cs:298:10:298:10 | exit M | 4 |
+| cflow.cs:298:10:298:10 | enter M | cflow.cs:300:46:300:50 | ... > ... | 7 |
+| cflow.cs:300:44:300:51 | [false] !... | cflow.cs:300:44:300:51 | [false] !... | 1 |
+| cflow.cs:300:44:300:51 | [true] !... | cflow.cs:300:56:300:64 | ... != ... | 4 |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:298:10:298:10 | exit M | 5 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -1,32 +1,32 @@
 conditionBlock
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:24:9:27 | null | true |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:31:9:32 | "" | false |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | false |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | true |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | false |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | true |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:24:16:27 | null | true |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:31:16:32 | "" | false |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | false |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | true |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | false |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | true |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:24:23:27 | null | true |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:31:23:32 | "" | false |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | true |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | false |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | true |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | false |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:24:30:27 | null | true |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:31:30:32 | "" | false |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | false |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | true |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | true |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:24:37:27 | null | true |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:31:37:32 | "" | false |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | false |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | true |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | true |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:24:44:27 | null | true |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:31:44:32 | "" | false |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | false |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | false |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:24:51:27 | null | true |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:31:51:32 | "" | false |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | false |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | false |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:24:58:27 | [b (line 56): true] null | true |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | false |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | false |
@@ -81,16 +81,16 @@ conditionBlock
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | false |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:24:127:38 | [true] ... \|\| ... | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | true |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | false |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | true |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | true |
@@ -105,14 +105,14 @@ conditionBlock
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:24:127:38 | [true] ... \|\| ... | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | true |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | false |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | true |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | true |
@@ -127,7 +127,7 @@ conditionBlock
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | true |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | false |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | true |
@@ -141,7 +141,7 @@ conditionBlock
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | true |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | false |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | true |
@@ -155,14 +155,14 @@ conditionBlock
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:24:127:38 | [true] ... \|\| ... | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | true |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | true |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | false |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
@@ -173,7 +173,7 @@ conditionBlock
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | false |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | false |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | false |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | true |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | false |
@@ -185,14 +185,14 @@ conditionBlock
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | false |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | false |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | false |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | false |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | false |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | false |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | false |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:24:127:38 | [true] ... \|\| ... | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | false |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | true |
@@ -201,7 +201,7 @@ conditionBlock
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | true |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | false |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
@@ -211,21 +211,21 @@ conditionBlock
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:24:127:38 | [true] ... \|\| ... | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | false |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
@@ -233,67 +233,67 @@ conditionBlock
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:24:127:38 | [true] ... \|\| ... | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | true |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | false |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | false |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | false |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | false |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | false |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | false |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | false |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | false |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | false |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | false |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:24:127:38 | [true] ... \|\| ... | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | false |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | false |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | false |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | false |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | false |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | false |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | false |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | false |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | false |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:24:127:38 | [true] ... \|\| ... | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | false |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | false |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | true |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:24:127:38 | [true] ... \|\| ... | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | true |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | false |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | false |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | false |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:24:127:38 | [true] ... \|\| ... | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | false |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:127:24:127:38 | [true] ... \|\| ... | true |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:24:127:38 | [true] ... \|\| ... | true |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | false |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | false |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:140:29:140:30 | access to parameter b2 | true |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | true |
@@ -348,7 +348,12 @@ conditionBlock
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:40:3:49 | call to method ToLower | false |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:40:3:49 | call to method ToLower | false |
 | ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:28:5:34 | access to property Length | false |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | false |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | true |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | true |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | true |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | false |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | true |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:27:9:33 | access to property Length | false |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:13:15:13:21 | access to property Length | false |
 | ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:14:20:14:20 | 0 | true |
@@ -430,10 +435,10 @@ conditionBlock
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | exit M9 (normal) | false |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i | true |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:117:9:123:9 | {...} | true |
-| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | true |
-| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
-| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | false |
-| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | true |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | true |
+| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | true |
+| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | false |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | false |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | true |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | true |
@@ -557,29 +562,39 @@ conditionBlock
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:110:17:110:49 | throw ...; | false |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | false |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:113:9:118:9 | {...} | false |
-| Finally.cs:107:33:107:33 | 0 | Finally.cs:115:17:115:41 | ...; | false |
-| Finally.cs:107:33:107:33 | 0 | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | false |
-| Finally.cs:107:33:107:33 | 0 | Finally.cs:115:17:115:41 | [finally: return] ...; | true |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | false |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [false, finally: return] !... | true |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [false] !... | false |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | false |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [true, finally: return] !... | true |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [true] !... | false |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | false |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | true |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:116:13:117:37 | if (...) ... | false |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:117:17:117:37 | ...; | false |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; | false |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:117:17:117:37 | [finally: return] ...; | true |
-| Finally.cs:108:17:108:23 | return ...; | Finally.cs:115:17:115:41 | [finally: return] ...; | false |
+| Finally.cs:108:17:108:23 | return ...; | Finally.cs:114:17:114:36 | [false, finally: return] !... | true |
+| Finally.cs:108:17:108:23 | return ...; | Finally.cs:114:17:114:36 | [true, finally: return] !... | false |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:110:17:110:49 | throw ...; | true |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | true |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:113:9:118:9 | {...} | false |
-| Finally.cs:109:33:109:33 | 1 | Finally.cs:115:17:115:41 | ...; | false |
-| Finally.cs:109:33:109:33 | 1 | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | true |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | true |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:114:17:114:36 | [false] !... | false |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | true |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:114:17:114:36 | [true] !... | false |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | true |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:116:13:117:37 | if (...) ... | false |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:117:17:117:37 | ...; | false |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; | true |
-| Finally.cs:110:17:110:49 | throw ...; | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | false |
-| Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | false |
-| Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | false |
-| Finally.cs:113:9:118:9 | {...} | Finally.cs:115:17:115:41 | ...; | false |
+| Finally.cs:110:17:110:49 | throw ...; | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | true |
+| Finally.cs:110:17:110:49 | throw ...; | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | false |
+| Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | true |
+| Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | false |
+| Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | true |
+| Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | false |
+| Finally.cs:113:9:118:9 | {...} | Finally.cs:114:17:114:36 | [false] !... | true |
+| Finally.cs:113:9:118:9 | {...} | Finally.cs:114:17:114:36 | [true] !... | false |
 | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; | true |
 | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; | true |
 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; | true |
@@ -760,22 +775,27 @@ conditionBlock
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | false |
 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | false |
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | false |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:70:13:70:19 | return ...; | false |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:71:9:71:21 | ...; | true |
+| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:69:13:69:23 | [false] !... | true |
+| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:69:13:69:23 | [true] !... | false |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | false |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:22:97:22 | String x | false |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | true |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:28:3:28 | 0 | true |
+| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | true |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:30:5:34 | false | true |
-| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:39:5:39 | 0 | true |
+| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | true |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | true |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:52:7:53 | "" | true |
-| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:52:7:53 | "" | true |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:52:7:53 | "" | true |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:41:9:41 | access to parameter s | true |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:45:9:45 | access to parameter s | false |
-| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:51:11:58 | ... && ... | true |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | true |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | true |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... | true |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | true |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | true |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... | true |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | true |
+| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... | true |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:9:9:11:9 | {...} | true |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:12:14:18:9 | if (...) ... | false |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:13:9:15:9 | {...} | false |
@@ -826,9 +846,10 @@ conditionBlock
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:22:21:22:27 | return ...; | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:23:27:23:27 | 0 | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:13:24:56 | case ...: | false |
-| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:32:24:55 | ... && ... | false |
+| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:32:24:32 | access to local variable s | false |
+| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:32:24:55 | [false] ... && ... | false |
+| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:32:24:55 | [true] ... && ... | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:48:24:48 | access to local variable s | false |
-| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:25:17:25:37 | ...; | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:27:13:27:39 | case ...: | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:27:32:27:38 | call to method Throw | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:30:13:30:20 | default: | false |
@@ -840,9 +861,10 @@ conditionBlock
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:22:21:22:27 | return ...; | false |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:23:27:23:27 | 0 | false |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:13:24:56 | case ...: | false |
-| Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:32:24:55 | ... && ... | false |
+| Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:32:24:32 | access to local variable s | false |
+| Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:32:24:55 | [false] ... && ... | false |
+| Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:32:24:55 | [true] ... && ... | false |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:48:24:48 | access to local variable s | false |
-| Switch.cs:16:13:16:19 | case ...: | Switch.cs:25:17:25:37 | ...; | false |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:27:13:27:39 | case ...: | false |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:27:32:27:38 | call to method Throw | false |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:30:13:30:20 | default: | false |
@@ -852,28 +874,31 @@ conditionBlock
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:22:21:22:27 | return ...; | false |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:23:27:23:27 | 0 | false |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:13:24:56 | case ...: | false |
-| Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:32:24:55 | ... && ... | false |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:32:24:32 | access to local variable s | false |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:32:24:55 | [false] ... && ... | false |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:32:24:55 | [true] ... && ... | false |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:48:24:48 | access to local variable s | false |
-| Switch.cs:18:13:18:22 | case ...: | Switch.cs:25:17:25:37 | ...; | false |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:27:13:27:39 | case ...: | false |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:27:32:27:38 | call to method Throw | false |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:21:17:22:27 | if (...) ... | true |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:22:21:22:27 | return ...; | true |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:23:27:23:27 | 0 | true |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:13:24:56 | case ...: | false |
-| Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:32:24:55 | ... && ... | false |
+| Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:32:24:32 | access to local variable s | false |
+| Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:32:24:55 | [false] ... && ... | false |
+| Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:32:24:55 | [true] ... && ... | false |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:48:24:48 | access to local variable s | false |
-| Switch.cs:20:13:20:23 | case ...: | Switch.cs:25:17:25:37 | ...; | false |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:27:13:27:39 | case ...: | false |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:27:32:27:38 | call to method Throw | false |
 | Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:22:21:22:27 | return ...; | true |
 | Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:23:27:23:27 | 0 | false |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:32:24:55 | ... && ... | true |
+| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:32:24:32 | access to local variable s | true |
+| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:32:24:55 | [false] ... && ... | true |
+| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:32:24:55 | [true] ... && ... | true |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:48:24:48 | access to local variable s | true |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:25:17:25:37 | ...; | true |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:48:24:48 | access to local variable s | true |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:25:17:25:37 | ...; | true |
-| Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:25:17:25:37 | ...; | true |
+| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:55 | [true] ... && ... | true |
+| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:48:24:48 | access to local variable s | true |
+| Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:32:24:55 | [true] ... && ... | true |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:32:27:38 | call to method Throw | true |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:49:17:49:22 | break; | true |
 | Switch.cs:44:10:44:11 | enter M4 | Switch.cs:50:13:50:39 | case ...: | false |
@@ -909,14 +934,18 @@ conditionBlock
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:25:118:25 | access to parameter s | true |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:43:118:43 | 2 | true |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:43:118:43 | 2 | true |
+| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:24:125:34 | [false] ... => ... | true |
+| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:24:125:34 | [true] ... => ... | true |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:34:125:34 | access to local variable b | true |
-| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:37:125:46 | ... => ... | false |
-| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:126:13:126:19 | return ...; | true |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:126:13:126:19 | return ...; | true |
+| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:37:125:37 | _ | false |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [false] ... => ... | false |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [true] ... => ... | true |
+| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:28:131:40 | [non-null] ... => ... | true |
+| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:28:131:40 | [null] ... => ... | true |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:40:131:40 | access to local variable s | true |
-| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:43:131:51 | ... => ... | false |
-| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:56:131:66 | call to method ToString | true |
-| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:56:131:66 | call to method ToString | false |
+| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:43:131:43 | _ | false |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [non-null] ... => ... | false |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [null] ... => ... | true |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:138:13:138:20 | default: | false |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:139:28:139:28 | 1 | true |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:140:13:140:19 | case ...: | false |
@@ -931,11 +960,11 @@ conditionBlock
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:28:150:28 | 2 | true |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | exit M15 (abnormal) | false |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:36:156:38 | "a" | true |
-| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:41:156:52 | ... => ... | false |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:41:156:45 | false | false |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:50:156:52 | "b" | false |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:158:13:158:49 | ...; | true |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:160:13:160:49 | ...; | false |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:50:156:52 | "b" | true |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:158:13:158:49 | ...; | true |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:160:13:160:49 | ...; | false |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" | true |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:25:7:25 | ; | true |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:24:25:24 | access to local variable x | true |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:28:25:28 | access to local variable y | false |
@@ -948,9 +977,9 @@ conditionBlock
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:24:25:24:25 | access to local variable i | false |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:24:34:24:34 | access to local variable i | false |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:25:9:34:9 | {...} | false |
+| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:26:17:26:40 | [false] ... && ... | false |
+| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:26:17:26:40 | [true] ... && ... | false |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:26:31:26:31 | access to local variable i | false |
-| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:27:17:27:46 | ...; | false |
-| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:28:18:33:37 | if (...) ... | false |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:29:17:29:42 | ...; | false |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:30:18:33:37 | if (...) ... | false |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:31:17:31:42 | ...; | false |
@@ -960,9 +989,9 @@ conditionBlock
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:24:25:24:25 | access to local variable i | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:24:34:24:34 | access to local variable i | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:25:9:34:9 | {...} | false |
+| cflow.cs:20:9:22:9 | {...} | cflow.cs:26:17:26:40 | [false] ... && ... | false |
+| cflow.cs:20:9:22:9 | {...} | cflow.cs:26:17:26:40 | [true] ... && ... | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:26:31:26:31 | access to local variable i | false |
-| cflow.cs:20:9:22:9 | {...} | cflow.cs:27:17:27:46 | ...; | false |
-| cflow.cs:20:9:22:9 | {...} | cflow.cs:28:18:33:37 | if (...) ... | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:29:17:29:42 | ...; | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:30:18:33:37 | if (...) ... | false |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:31:17:31:42 | ...; | false |
@@ -970,20 +999,20 @@ conditionBlock
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:5:17:5:20 | exit Main (normal) | false |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:34:24:34 | access to local variable i | true |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:25:9:34:9 | {...} | true |
+| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:26:17:26:40 | [false] ... && ... | true |
+| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:26:17:26:40 | [true] ... && ... | true |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:26:31:26:31 | access to local variable i | true |
-| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:27:17:27:46 | ...; | true |
-| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:28:18:33:37 | if (...) ... | true |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:29:17:29:42 | ...; | true |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:30:18:33:37 | if (...) ... | true |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:31:17:31:42 | ...; | true |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:33:17:33:37 | ...; | true |
+| cflow.cs:25:9:34:9 | {...} | cflow.cs:26:17:26:40 | [true] ... && ... | true |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:26:31:26:31 | access to local variable i | true |
-| cflow.cs:25:9:34:9 | {...} | cflow.cs:27:17:27:46 | ...; | true |
-| cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:27:17:27:46 | ...; | true |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:29:17:29:42 | ...; | true |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:30:18:33:37 | if (...) ... | false |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:31:17:31:42 | ...; | false |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:33:17:33:37 | ...; | false |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:29:17:29:42 | ...; | true |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:30:18:33:37 | if (...) ... | false |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:31:17:31:42 | ...; | false |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:33:17:33:37 | ...; | false |
+| cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:17:26:40 | [true] ... && ... | true |
 | cflow.cs:30:18:33:37 | if (...) ... | cflow.cs:31:17:31:42 | ...; | true |
 | cflow.cs:30:18:33:37 | if (...) ... | cflow.cs:33:17:33:37 | ...; | false |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:42:17:42:39 | ...; | true |
@@ -996,26 +1025,26 @@ conditionBlock
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:56:13:56:20 | default: | false |
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:60:9:66:9 | switch (...) {...} | false |
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:63:17:64:55 | if (...) ... | false |
-| cflow.cs:44:13:44:19 | case ...: | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | false |
-| cflow.cs:44:13:44:19 | case ...: | cflow.cs:65:17:65:22 | break; | false |
+| cflow.cs:44:13:44:19 | case ...: | cflow.cs:63:21:63:34 | [false] !... | false |
+| cflow.cs:44:13:44:19 | case ...: | cflow.cs:63:21:63:34 | [true] !... | false |
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:67:16:67:16 | access to parameter a | false |
 | cflow.cs:47:13:47:19 | case ...: | cflow.cs:48:17:48:39 | ...; | true |
 | cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:54:17:54:48 | ...; | true |
 | cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:56:13:56:20 | default: | false |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:63:17:64:55 | if (...) ... | true |
-| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | true |
-| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:65:17:65:22 | break; | true |
-| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | false |
-| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:65:17:65:22 | break; | true |
+| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:63:21:63:34 | [false] !... | true |
+| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:63:21:63:34 | [true] !... | true |
+| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:21:63:34 | [false] !... | true |
+| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:21:63:34 | [true] !... | false |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:73:13:73:19 | return ...; | true |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:74:9:81:9 | if (...) ... | false |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:75:9:77:9 | {...} | false |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:79:9:81:9 | {...} | false |
 | cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:75:9:77:9 | {...} | true |
 | cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:79:9:81:9 | {...} | false |
+| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:86:13:86:37 | [true] ... && ... | true |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:86:26:86:26 | access to parameter s | true |
-| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:87:13:87:33 | ...; | true |
-| cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:87:13:87:33 | ...; | true |
+| cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:13:86:37 | [true] ... && ... | true |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | exit M3 (normal) | false |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:93:45:93:47 | "s" | true |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:94:9:94:29 | ...; | false |
@@ -1069,18 +1098,22 @@ conditionBlock
 | cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:174:9:176:9 | {...} | false |
 | cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:146:10:146:12 | exit For (normal) | false |
 | cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:174:9:176:9 | {...} | true |
-| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:37:195:56 | !... | true |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:35:197:39 | false | true |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:43:197:46 | true | false |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:198:13:198:48 | ... = ... | true |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:198:37:198:41 | false | true |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:198:45:198:48 | true | true |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:39:195:43 | this access | true |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:197:35:197:39 | false | true |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:197:43:197:46 | true | false |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:198:17:198:48 | ... ? ... : ... | true |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:198:37:198:41 | false | true |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:198:45:198:48 | true | true |
 | cflow.cs:197:35:197:39 | false | cflow.cs:198:37:198:41 | false | true |
 | cflow.cs:197:35:197:39 | false | cflow.cs:198:45:198:48 | true | false |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | true |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:37:200:62 | !... | true |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:13:200:32 | [false] !... | true |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:13:200:32 | [true] !... | false |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:40:200:61 | [false] ... && ... | true |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:40:200:61 | [true] ... && ... | true |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:61:200:61 | access to local variable b | true |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:61:200:61 | access to local variable b | true |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:40:200:61 | [true] ... && ... | true |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:61:200:61 | access to local variable b | true |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [true] ... && ... | true |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:214:13:216:13 | {...} | true |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:217:13:220:13 | if (...) ... | false |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:218:13:220:13 | {...} | false |
@@ -1093,7 +1126,8 @@ conditionBlock
 | cflow.cs:226:22:226:22 | String x | cflow.cs:233:13:236:13 | if (...) ... | false |
 | cflow.cs:226:22:226:22 | String x | cflow.cs:234:13:236:13 | {...} | false |
 | cflow.cs:233:13:236:13 | if (...) ... | cflow.cs:234:13:236:13 | {...} | true |
-| cflow.cs:242:9:242:13 | Label: | cflow.cs:242:43:242:45 | {...} | true |
+| cflow.cs:242:9:242:13 | Label: | cflow.cs:242:21:242:40 | [false] !... | true |
+| cflow.cs:242:9:242:13 | Label: | cflow.cs:242:21:242:40 | [true] !... | false |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:240:10:240:13 | exit Goto (normal) | false |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:31:244:41 | goto ...; | true |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:246:9:258:9 | switch (...) {...} | false |
@@ -1114,7 +1148,8 @@ conditionBlock
 | cflow.cs:253:13:253:19 | case ...: | cflow.cs:254:17:254:27 | goto ...; | true |
 | cflow.cs:264:25:264:25 | access to local variable i | cflow.cs:265:9:267:9 | {...} | true |
 | cflow.cs:264:25:264:25 | access to local variable i | cflow.cs:268:9:276:9 | try {...} ... | false |
-| cflow.cs:298:10:298:10 | enter M | cflow.cs:300:56:300:56 | access to parameter s | false |
+| cflow.cs:298:10:298:10 | enter M | cflow.cs:300:44:300:51 | [false] !... | true |
+| cflow.cs:298:10:298:10 | enter M | cflow.cs:300:44:300:51 | [true] !... | false |
 conditionFlow
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null | true |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" | false |
@@ -1142,36 +1177,44 @@ conditionFlow
 | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | false |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | [b (line 56): true] null | true |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | [b (line 56): false] "" | false |
-| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:23:59:36 | [false] ... && ... | false |
 | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | true |
-| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:23:59:36 | [false] ... && ... | false |
 | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | true |
-| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | false |
-| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | true |
+| Assert.cs:59:23:59:36 | [false] ... && ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:59:23:59:36 | [true] ... && ... | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | true |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:23:59:36 | [false] ... && ... | false |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:23:59:36 | [true] ... && ... | true |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | [b (line 63): true] null | true |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | [b (line 63): false] "" | false |
-| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:24:66:37 | [true] ... \|\| ... | true |
 | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | false |
-| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:24:66:37 | [true] ... \|\| ... | true |
 | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | false |
-| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | false |
-| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:66:24:66:37 | [false] ... \|\| ... | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | false |
+| Assert.cs:66:24:66:37 | [true] ... \|\| ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:24:66:37 | [false] ... \|\| ... | false |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:24:66:37 | [true] ... \|\| ... | true |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | [b (line 70): true] null | true |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | [b (line 70): false] "" | false |
-| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:23:73:36 | [false] ... && ... | false |
 | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | true |
-| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:23:73:36 | [false] ... && ... | false |
 | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | true |
-| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | false |
-| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | true |
+| Assert.cs:73:23:73:36 | [false] ... && ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:73:23:73:36 | [true] ... && ... | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | true |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:23:73:36 | [false] ... && ... | false |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:23:73:36 | [true] ... && ... | true |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | [b (line 77): true] null | true |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | [b (line 77): false] "" | false |
-| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:24:80:37 | [true] ... \|\| ... | true |
 | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | false |
-| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:24:80:37 | [true] ... \|\| ... | true |
 | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | false |
-| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | false |
-| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:80:24:80:37 | [false] ... \|\| ... | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | false |
+| Assert.cs:80:24:80:37 | [true] ... \|\| ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:24:80:37 | [false] ... \|\| ... | false |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:24:80:37 | [true] ... \|\| ... | true |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null | true |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:31:86:32 | [b (line 84): false] "" | false |
 | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | false |
@@ -1208,24 +1251,35 @@ conditionFlow
 | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
 | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:24:114:25 | [b (line 84): false] "" | false |
 | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:17:114:20 | [b (line 84): true] null | true |
-| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | false |
 | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
-| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | false |
 | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | true |
 | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null | true |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
-| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | true |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | false |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | true |
 | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null | true |
-| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | false |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | true |
 | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | [b (line 84): true] null | true |
-| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
-| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
-| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | true |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:24:127:38 | [true] ... \|\| ... | true |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:127:24:127:38 | [false] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | false |
+| Assert.cs:127:24:127:38 | [true] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:127:37:127:38 | [false] !... | Assert.cs:127:24:127:38 | [false] ... \|\| ... | false |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [false] !... | true |
 | Assert.cs:140:25:140:26 | access to parameter b1 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | false |
 | Assert.cs:140:25:140:26 | access to parameter b1 | Assert.cs:140:29:140:30 | access to parameter b2 | true |
 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | false |
@@ -1257,16 +1311,20 @@ conditionFlow
 | ConditionalAccess.cs:13:13:13:25 | ... > ... | ConditionalAccess.cs:16:20:16:20 | 1 | false |
 | Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | true |
 | Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | false |
-| Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:8:13:8:16 | ...; | false |
-| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | true |
+| Conditions.cs:7:13:7:16 | [false] !... | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | false |
+| Conditions.cs:7:13:7:16 | [true] !... | Conditions.cs:8:13:8:16 | ...; | true |
+| Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:7:13:7:16 | [true] !... | false |
+| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:7:13:7:16 | [false] !... | true |
 | Conditions.cs:14:13:14:13 | access to parameter b | Conditions.cs:15:13:15:16 | [b (line 11): true] ...; | true |
 | Conditions.cs:14:13:14:13 | access to parameter b | Conditions.cs:16:9:18:20 | [b (line 11): false] if (...) ... | false |
 | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | true |
 | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | Conditions.cs:19:16:19:16 | access to local variable x | false |
 | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | true |
 | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | Conditions.cs:19:16:19:16 | access to local variable x | false |
-| Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:18:17:18:20 | ...; | false |
-| Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | Conditions.cs:19:16:19:16 | access to local variable x | true |
+| Conditions.cs:17:17:17:18 | [false] !... | Conditions.cs:19:16:19:16 | access to local variable x | false |
+| Conditions.cs:17:17:17:18 | [true] !... | Conditions.cs:18:17:18:20 | ...; | true |
+| Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:17:17:17:18 | [true] !... | false |
+| Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | Conditions.cs:17:17:17:18 | [false] !... | true |
 | Conditions.cs:25:13:25:14 | access to parameter b1 | Conditions.cs:26:13:27:20 | if (...) ... | true |
 | Conditions.cs:25:13:25:14 | access to parameter b1 | Conditions.cs:28:9:29:16 | if (...) ... | false |
 | Conditions.cs:26:17:26:18 | access to parameter b2 | Conditions.cs:27:17:27:20 | [b2 (line 22): true] ...; | true |
@@ -1323,12 +1381,16 @@ conditionFlow
 | Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... | Conditions.cs:110:16:110:16 | access to local variable x | false |
 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | true |
 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:110:16:110:16 | access to local variable x | false |
-| Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:109:17:109:24 | ...; | false |
-| Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:110:16:110:16 | access to local variable x | true |
+| Conditions.cs:108:17:108:18 | [false] !... | Conditions.cs:110:16:110:16 | access to local variable x | false |
+| Conditions.cs:108:17:108:18 | [true] !... | Conditions.cs:109:17:109:24 | ...; | true |
+| Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:108:17:108:18 | [true] !... | false |
+| Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:108:17:108:18 | [false] !... | true |
 | Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 (normal) | false |
 | Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:117:9:123:9 | {...} | true |
-| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | false |
-| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
+| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | false |
+| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | true |
+| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | true |
+| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | false |
 | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | Conditions.cs:116:42:116:42 | access to local variable i | false |
 | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | Conditions.cs:122:17:122:25 | ...; | true |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | true |
@@ -1385,16 +1447,26 @@ conditionFlow
 | Finally.cs:107:17:107:33 | ... == ... | Finally.cs:109:13:110:49 | if (...) ... | false |
 | Finally.cs:109:17:109:33 | ... == ... | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | true |
 | Finally.cs:109:17:109:33 | ... == ... | Finally.cs:113:9:118:9 | {...} | false |
-| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:115:17:115:41 | ...; | false |
-| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:116:13:117:37 | if (...) ... | true |
-| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | false |
-| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | true |
-| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | false |
-| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | true |
-| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | false |
-| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | true |
-| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:115:17:115:41 | [finally: return] ...; | false |
-| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | true |
+| Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | false |
+| Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | false |
+| Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | false |
+| Finally.cs:114:17:114:36 | [false, finally: return] !... | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | false |
+| Finally.cs:114:17:114:36 | [false] !... | Finally.cs:116:13:117:37 | if (...) ... | false |
+| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | true |
+| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | true |
+| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | true |
+| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:115:17:115:41 | [finally: return] ...; | true |
+| Finally.cs:114:17:114:36 | [true] !... | Finally.cs:115:17:115:41 | ...; | true |
+| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:114:17:114:36 | [false] !... | true |
+| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:114:17:114:36 | [true] !... | false |
+| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | true |
+| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | false |
+| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | true |
+| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | false |
+| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | true |
+| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | false |
+| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:114:17:114:36 | [false, finally: return] !... | true |
+| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:114:17:114:36 | [true, finally: return] !... | false |
 | Finally.cs:116:17:116:32 | ... > ... | Finally.cs:103:10:103:11 | exit M5 (normal) | false |
 | Finally.cs:116:17:116:32 | ... > ... | Finally.cs:117:17:117:37 | ...; | true |
 | Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; | true |
@@ -1462,19 +1534,27 @@ conditionFlow
 | LoopUnrolling.cs:60:17:60:17 | access to parameter b | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | false |
 | LoopUnrolling.cs:62:17:62:17 | [b (line 55): false] access to parameter b | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | false |
 | LoopUnrolling.cs:62:17:62:17 | [b (line 55): true] access to parameter b | LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; | true |
-| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:70:13:70:19 | return ...; | false |
-| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:71:9:71:21 | ...; | true |
-| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:39:5:39 | 0 | true |
-| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:43:5:43 | 1 | false |
-| NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:43:5:43 | 1 | false |
+| LoopUnrolling.cs:69:13:69:23 | [false] !... | LoopUnrolling.cs:71:9:71:21 | ...; | false |
+| LoopUnrolling.cs:69:13:69:23 | [true] !... | LoopUnrolling.cs:70:13:70:19 | return ...; | true |
+| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:13:69:23 | [false] !... | true |
+| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:13:69:23 | [true] !... | false |
+| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | false |
+| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | true |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:43:5:43 | 1 | false |
+| NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | NullCoalescing.cs:5:39:5:39 | 0 | true |
+| NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | false |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:41:9:41 | access to parameter s | true |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:45:9:45 | access to parameter s | false |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:64:11:64 | 0 | true |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:68:11:68 | 1 | false |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | false |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | true |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:68:11:68 | 1 | false |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:64:11:64 | 0 | true |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | false |
 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | true |
-| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:68:11:68 | 1 | false |
-| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:64:11:64 | 0 | true |
-| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:68:11:68 | 1 | false |
+| NullCoalescing.cs:11:51:11:58 | [false] ... && ... | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | false |
+| NullCoalescing.cs:11:51:11:58 | [true] ... && ... | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | true |
+| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | false |
+| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... | true |
 | Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:9:9:11:9 | {...} | true |
 | Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:12:14:18:9 | if (...) ... | false |
 | Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:13:9:15:9 | {...} | true |
@@ -1489,10 +1569,12 @@ conditionFlow
 | PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:21:9:21:29 | ...; | false |
 | Switch.cs:21:21:21:29 | ... == ... | Switch.cs:22:21:22:27 | return ...; | true |
 | Switch.cs:21:21:21:29 | ... == ... | Switch.cs:23:27:23:27 | 0 | false |
+| Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:32:24:55 | [false] ... && ... | false |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:48:24:48 | access to local variable s | true |
-| Switch.cs:24:32:24:43 | ... > ... | Switch.cs:27:13:27:39 | case ...: | false |
-| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:25:17:25:37 | ...; | true |
-| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:27:13:27:39 | case ...: | false |
+| Switch.cs:24:32:24:55 | [false] ... && ... | Switch.cs:27:13:27:39 | case ...: | false |
+| Switch.cs:24:32:24:55 | [true] ... && ... | Switch.cs:25:17:25:37 | ...; | true |
+| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:32:24:55 | [false] ... && ... | false |
+| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:32:24:55 | [true] ... && ... | true |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:44:10:44:11 | exit M4 (normal) | false |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:51:17:51:22 | break; | true |
 | Switch.cs:84:21:84:25 | ... > ... | Switch.cs:85:21:85:26 | break; | true |
@@ -1501,9 +1583,14 @@ conditionFlow
 | Switch.cs:117:25:117:34 | ... == ... | Switch.cs:118:13:118:34 | case ...: | false |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:43:118:43 | 2 | true |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:120:17:120:17 | 1 | false |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | exit M11 (normal) | false |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:126:13:126:19 | return ...; | true |
-| Switch.cs:125:42:125:46 | false | Switch.cs:123:10:123:12 | exit M11 (normal) | false |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:123:10:123:12 | exit M11 (normal) | false |
+| Switch.cs:125:13:125:48 | [true] ... switch { ... } | Switch.cs:126:13:126:19 | return ...; | true |
+| Switch.cs:125:24:125:34 | [false] ... => ... | Switch.cs:125:13:125:48 | [false] ... switch { ... } | false |
+| Switch.cs:125:24:125:34 | [true] ... => ... | Switch.cs:125:13:125:48 | [true] ... switch { ... } | true |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [false] ... => ... | false |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [true] ... => ... | true |
+| Switch.cs:125:37:125:46 | [false] ... => ... | Switch.cs:125:13:125:48 | [false] ... switch { ... } | false |
+| Switch.cs:125:42:125:46 | false | Switch.cs:125:37:125:46 | [false] ... => ... | false |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; | true |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; | false |
 | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:7:25:7:25 | ; | true |
@@ -1518,24 +1605,30 @@ conditionFlow
 | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:24:9:34:9 | for (...;...;...) ... | false |
 | cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:5:17:5:20 | exit Main (normal) | false |
 | cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:25:9:34:9 | {...} | true |
+| cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:17:26:40 | [false] ... && ... | false |
 | cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:31:26:31 | access to local variable i | true |
-| cflow.cs:26:17:26:26 | ... == ... | cflow.cs:28:18:33:37 | if (...) ... | false |
-| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:27:17:27:46 | ...; | true |
-| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:28:18:33:37 | if (...) ... | false |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:28:18:33:37 | if (...) ... | false |
+| cflow.cs:26:17:26:40 | [true] ... && ... | cflow.cs:27:17:27:46 | ...; | true |
+| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:26:17:26:40 | [false] ... && ... | false |
+| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:26:17:26:40 | [true] ... && ... | true |
 | cflow.cs:28:22:28:31 | ... == ... | cflow.cs:29:17:29:42 | ...; | true |
 | cflow.cs:28:22:28:31 | ... == ... | cflow.cs:30:18:33:37 | if (...) ... | false |
 | cflow.cs:30:22:30:31 | ... == ... | cflow.cs:31:17:31:42 | ...; | true |
 | cflow.cs:30:22:30:31 | ... == ... | cflow.cs:33:17:33:37 | ...; | false |
-| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | false |
-| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:65:17:65:22 | break; | true |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:65:17:65:22 | break; | false |
+| cflow.cs:63:21:63:34 | [true] !... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | true |
+| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:21:63:34 | [false] !... | true |
+| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:21:63:34 | [true] !... | false |
 | cflow.cs:72:13:72:21 | ... == ... | cflow.cs:73:13:73:19 | return ...; | true |
 | cflow.cs:72:13:72:21 | ... == ... | cflow.cs:74:9:81:9 | if (...) ... | false |
 | cflow.cs:74:13:74:24 | ... > ... | cflow.cs:75:9:77:9 | {...} | true |
 | cflow.cs:74:13:74:24 | ... > ... | cflow.cs:79:9:81:9 | {...} | false |
-| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:84:18:84:19 | exit M2 (normal) | false |
+| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:13:86:37 | [false] ... && ... | false |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:26:86:26 | access to parameter s | true |
-| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:84:18:84:19 | exit M2 (normal) | false |
-| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:87:13:87:33 | ...; | true |
+| cflow.cs:86:13:86:37 | [false] ... && ... | cflow.cs:84:18:84:19 | exit M2 (normal) | false |
+| cflow.cs:86:13:86:37 | [true] ... && ... | cflow.cs:87:13:87:33 | ...; | true |
+| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:86:13:86:37 | [false] ... && ... | false |
+| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:86:13:86:37 | [true] ... && ... | true |
 | cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:93:45:93:47 | "s" | true |
 | cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:94:9:94:29 | ...; | false |
 | cflow.cs:96:13:96:25 | ... != ... | cflow.cs:97:13:97:55 | ...; | true |
@@ -1560,22 +1653,39 @@ conditionFlow
 | cflow.cs:173:32:173:41 | ... < ... | cflow.cs:146:10:146:12 | exit For (normal) | false |
 | cflow.cs:173:32:173:41 | ... < ... | cflow.cs:174:9:176:9 | {...} | true |
 | cflow.cs:187:13:187:18 | ... == ... | cflow.cs:187:23:187:23 | 2 | false |
-| cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:34:187:49 | ... && ... | false |
-| cflow.cs:187:34:187:39 | ... == ... | cflow.cs:190:13:190:52 | ...; | false |
-| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:13:195:56 | Boolean b = ... | false |
-| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:37:195:56 | !... | true |
+| cflow.cs:187:13:187:28 | [false] ... \|\| ... | cflow.cs:187:34:187:34 | 1 | false |
+| cflow.cs:187:13:187:50 | [false] ... \|\| ... | cflow.cs:190:13:190:52 | ...; | false |
+| cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:13:187:28 | [false] ... \|\| ... | false |
+| cflow.cs:187:34:187:39 | ... == ... | cflow.cs:187:34:187:49 | [false] ... && ... | false |
+| cflow.cs:187:34:187:49 | [false] ... && ... | cflow.cs:187:13:187:50 | [false] ... \|\| ... | false |
+| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:17:195:56 | ... && ... | false |
+| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:39:195:43 | this access | true |
+| cflow.cs:197:13:197:47 | [false] !... | cflow.cs:200:9:205:9 | if (...) ... | false |
+| cflow.cs:197:13:197:47 | [true] !... | cflow.cs:198:13:198:49 | ...; | true |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:35:197:39 | false | true |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:43:197:46 | true | false |
-| cflow.cs:197:35:197:39 | false | cflow.cs:198:13:198:49 | ...; | false |
-| cflow.cs:197:43:197:46 | true | cflow.cs:200:9:205:9 | if (...) ... | true |
+| cflow.cs:197:15:197:46 | [false] ... ? ... : ... | cflow.cs:197:13:197:47 | [true] !... | false |
+| cflow.cs:197:15:197:46 | [true] ... ? ... : ... | cflow.cs:197:13:197:47 | [false] !... | true |
+| cflow.cs:197:35:197:39 | false | cflow.cs:197:15:197:46 | [false] ... ? ... : ... | false |
+| cflow.cs:197:43:197:46 | true | cflow.cs:197:15:197:46 | [true] ... ? ... : ... | true |
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:37:198:41 | false | true |
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:45:198:48 | true | false |
-| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:37:200:62 | !... | true |
-| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:201:9:205:9 | {...} | false |
-| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | false |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:40:200:44 | this access | false |
+| cflow.cs:200:13:200:32 | [true] !... | cflow.cs:200:13:200:62 | [true] ... \|\| ... | true |
+| cflow.cs:200:13:200:62 | [false] ... \|\| ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | false |
+| cflow.cs:200:13:200:62 | [true] ... \|\| ... | cflow.cs:201:9:205:9 | {...} | true |
+| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:13:200:32 | [false] !... | true |
+| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:13:200:32 | [true] !... | false |
+| cflow.cs:200:37:200:62 | [false] !... | cflow.cs:200:13:200:62 | [false] ... \|\| ... | false |
+| cflow.cs:200:37:200:62 | [true] !... | cflow.cs:200:13:200:62 | [true] ... \|\| ... | true |
+| cflow.cs:200:38:200:62 | [false] !... | cflow.cs:200:37:200:62 | [true] !... | false |
+| cflow.cs:200:38:200:62 | [true] !... | cflow.cs:200:37:200:62 | [false] !... | true |
+| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:40:200:61 | [false] ... && ... | false |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:61:200:61 | access to local variable b | true |
-| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:193:10:193:17 | exit Booleans (normal) | false |
-| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:201:9:205:9 | {...} | true |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:38:200:62 | [true] !... | false |
+| cflow.cs:200:40:200:61 | [true] ... && ... | cflow.cs:200:38:200:62 | [false] !... | true |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [false] ... && ... | false |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [true] ... && ... | true |
 | cflow.cs:213:17:213:32 | ... > ... | cflow.cs:214:13:216:13 | {...} | true |
 | cflow.cs:213:17:213:32 | ... > ... | cflow.cs:217:13:220:13 | if (...) ... | false |
 | cflow.cs:217:17:217:32 | ... < ... | cflow.cs:218:13:220:13 | {...} | true |
@@ -1586,11 +1696,17 @@ conditionFlow
 | cflow.cs:229:17:229:32 | ... > ... | cflow.cs:233:13:236:13 | if (...) ... | false |
 | cflow.cs:233:17:233:32 | ... < ... | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | false |
 | cflow.cs:233:17:233:32 | ... < ... | cflow.cs:234:13:236:13 | {...} | true |
-| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:43:242:45 | {...} | true |
-| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:244:9:244:41 | if (...) ... | false |
+| cflow.cs:242:20:242:40 | [false] !... | cflow.cs:244:9:244:41 | if (...) ... | false |
+| cflow.cs:242:20:242:40 | [true] !... | cflow.cs:242:43:242:45 | {...} | true |
+| cflow.cs:242:21:242:40 | [false] !... | cflow.cs:242:20:242:40 | [true] !... | false |
+| cflow.cs:242:21:242:40 | [true] !... | cflow.cs:242:20:242:40 | [false] !... | true |
+| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:21:242:40 | [false] !... | true |
+| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:21:242:40 | [true] !... | false |
 | cflow.cs:244:13:244:28 | ... > ... | cflow.cs:244:31:244:41 | goto ...; | true |
 | cflow.cs:244:13:244:28 | ... > ... | cflow.cs:246:9:258:9 | switch (...) {...} | false |
 | cflow.cs:264:25:264:30 | ... < ... | cflow.cs:265:9:267:9 | {...} | true |
 | cflow.cs:264:25:264:30 | ... < ... | cflow.cs:268:9:276:9 | try {...} ... | false |
-| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:56:300:56 | access to parameter s | false |
-| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:70:300:71 | "" | true |
+| cflow.cs:300:44:300:51 | [false] !... | cflow.cs:300:44:300:64 | ... && ... | false |
+| cflow.cs:300:44:300:51 | [true] !... | cflow.cs:300:56:300:56 | access to parameter s | true |
+| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:44:300:51 | [false] !... | true |
+| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:44:300:51 | [true] !... | false |

--- a/csharp/ql/test/library-tests/controlflow/graph/Consistency.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Consistency.expected
@@ -3,81 +3,25 @@ nonUniqueSetRepresentation
 breakInvariant2
 breakInvariant3
 breakInvariant4
-| Assert.cs:140:29:140:30 | access to parameter b2 | assertion failure | Assert.cs:140:33:140:34 | access to parameter b3 | assertion failure | assertion failure | true |
-| Assert.cs:140:29:140:30 | access to parameter b2 | assertion failure | Assert.cs:140:33:140:34 | access to parameter b3 | assertion failure | assertion success | false |
 breakInvariant5
 multipleSuccessors
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | successor | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | successor | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
-| MultiImplementationA.cs:6:22:6:31 | enter get_P1 | successor | MultiImplementationA.cs:6:28:6:31 | null |
-| MultiImplementationA.cs:6:22:6:31 | enter get_P1 | successor | MultiImplementationB.cs:3:22:3:22 | 0 |
-| MultiImplementationA.cs:7:21:7:23 | enter get_P2 | successor | MultiImplementationA.cs:7:25:7:39 | {...} |
-| MultiImplementationA.cs:7:21:7:23 | enter get_P2 | successor | MultiImplementationB.cs:4:25:4:37 | {...} |
-| MultiImplementationA.cs:7:41:7:43 | enter set_P2 | successor | MultiImplementationA.cs:7:45:7:59 | {...} |
-| MultiImplementationA.cs:7:41:7:43 | enter set_P2 | successor | MultiImplementationB.cs:4:43:4:45 | {...} |
-| MultiImplementationA.cs:8:16:8:16 | enter M | successor | MultiImplementationA.cs:8:29:8:32 | null |
-| MultiImplementationA.cs:8:16:8:16 | enter M | successor | MultiImplementationB.cs:5:23:5:23 | 2 |
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | successor | MultiImplementationA.cs:13:16:13:16 | this access |
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | successor | MultiImplementationA.cs:24:16:24:16 | this access |
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | successor | MultiImplementationB.cs:11:16:11:16 | this access |
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | successor | MultiImplementationB.cs:22:16:22:16 | this access |
-| MultiImplementationA.cs:14:31:14:31 | enter get_Item | successor | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
-| MultiImplementationA.cs:14:31:14:31 | enter get_Item | successor | MultiImplementationB.cs:12:37:12:40 | null |
-| MultiImplementationA.cs:15:36:15:38 | enter get_Item | successor | MultiImplementationA.cs:15:40:15:52 | {...} |
-| MultiImplementationA.cs:15:36:15:38 | enter get_Item | successor | MultiImplementationB.cs:13:40:13:54 | {...} |
-| MultiImplementationA.cs:15:54:15:56 | enter set_Item | successor | MultiImplementationA.cs:15:58:15:60 | {...} |
-| MultiImplementationA.cs:15:54:15:56 | enter set_Item | successor | MultiImplementationB.cs:13:60:13:62 | {...} |
-| MultiImplementationA.cs:16:17:16:18 | enter M1 | successor | MultiImplementationA.cs:17:5:19:5 | {...} |
-| MultiImplementationA.cs:16:17:16:18 | enter M1 | successor | MultiImplementationB.cs:15:5:17:5 | {...} |
-| MultiImplementationA.cs:20:12:20:13 | enter C2 | successor | MultiImplementationA.cs:13:16:13:16 | this access |
-| MultiImplementationA.cs:20:12:20:13 | enter C2 | successor | MultiImplementationB.cs:11:16:11:16 | this access |
-| MultiImplementationA.cs:21:12:21:13 | enter C2 | successor | MultiImplementationA.cs:21:24:21:24 | 0 |
-| MultiImplementationA.cs:21:12:21:13 | enter C2 | successor | MultiImplementationB.cs:19:24:19:24 | 1 |
 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | successor | MultiImplementationA.cs:21:27:21:29 | {...} |
 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | successor | MultiImplementationB.cs:19:27:19:29 | {...} |
-| MultiImplementationA.cs:22:6:22:7 | enter ~C2 | successor | MultiImplementationA.cs:22:11:22:13 | {...} |
-| MultiImplementationA.cs:22:6:22:7 | enter ~C2 | successor | MultiImplementationB.cs:20:11:20:25 | {...} |
-| MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | successor | MultiImplementationA.cs:23:50:23:53 | null |
-| MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | successor | MultiImplementationB.cs:21:56:21:59 | null |
 | MultiImplementationA.cs:24:32:24:34 | ... = ... | successor | MultiImplementationA.cs:20:22:20:31 | {...} |
 | MultiImplementationA.cs:24:32:24:34 | ... = ... | successor | MultiImplementationA.cs:24:16:24:16 | this access |
 | MultiImplementationA.cs:24:32:24:34 | ... = ... | successor | MultiImplementationB.cs:18:22:18:36 | {...} |
 | MultiImplementationA.cs:24:32:24:34 | ... = ... | successor | MultiImplementationB.cs:22:16:22:16 | this access |
-| MultiImplementationA.cs:36:9:36:10 | enter M1 | successor | MultiImplementationA.cs:36:14:36:28 | {...} |
-| MultiImplementationA.cs:36:9:36:10 | enter M1 | successor | MultiImplementationB.cs:32:17:32:17 | 0 |
-| MultiImplementationB.cs:3:22:3:22 | enter get_P1 | successor | MultiImplementationA.cs:6:28:6:31 | null |
-| MultiImplementationB.cs:3:22:3:22 | enter get_P1 | successor | MultiImplementationB.cs:3:22:3:22 | 0 |
-| MultiImplementationB.cs:4:21:4:23 | enter get_P2 | successor | MultiImplementationA.cs:7:25:7:39 | {...} |
-| MultiImplementationB.cs:4:21:4:23 | enter get_P2 | successor | MultiImplementationB.cs:4:25:4:37 | {...} |
-| MultiImplementationB.cs:4:39:4:41 | enter set_P2 | successor | MultiImplementationA.cs:7:45:7:59 | {...} |
-| MultiImplementationB.cs:4:39:4:41 | enter set_P2 | successor | MultiImplementationB.cs:4:43:4:45 | {...} |
-| MultiImplementationB.cs:5:16:5:16 | enter M | successor | MultiImplementationA.cs:8:29:8:32 | null |
-| MultiImplementationB.cs:5:16:5:16 | enter M | successor | MultiImplementationB.cs:5:23:5:23 | 2 |
 | MultiImplementationB.cs:11:16:11:20 | ... = ... | successor | MultiImplementationA.cs:13:16:13:16 | this access |
 | MultiImplementationB.cs:11:16:11:20 | ... = ... | successor | MultiImplementationA.cs:24:16:24:16 | this access |
 | MultiImplementationB.cs:11:16:11:20 | ... = ... | successor | MultiImplementationB.cs:11:16:11:16 | this access |
 | MultiImplementationB.cs:11:16:11:20 | ... = ... | successor | MultiImplementationB.cs:22:16:22:16 | this access |
-| MultiImplementationB.cs:12:31:12:40 | enter get_Item | successor | MultiImplementationA.cs:14:31:14:31 | access to parameter i |
-| MultiImplementationB.cs:12:31:12:40 | enter get_Item | successor | MultiImplementationB.cs:12:37:12:40 | null |
-| MultiImplementationB.cs:13:36:13:38 | enter get_Item | successor | MultiImplementationA.cs:15:40:15:52 | {...} |
-| MultiImplementationB.cs:13:36:13:38 | enter get_Item | successor | MultiImplementationB.cs:13:40:13:54 | {...} |
-| MultiImplementationB.cs:13:56:13:58 | enter set_Item | successor | MultiImplementationA.cs:15:58:15:60 | {...} |
-| MultiImplementationB.cs:13:56:13:58 | enter set_Item | successor | MultiImplementationB.cs:13:60:13:62 | {...} |
-| MultiImplementationB.cs:14:17:14:18 | enter M1 | successor | MultiImplementationA.cs:17:5:19:5 | {...} |
-| MultiImplementationB.cs:14:17:14:18 | enter M1 | successor | MultiImplementationB.cs:15:5:17:5 | {...} |
-| MultiImplementationB.cs:18:12:18:13 | enter C2 | successor | MultiImplementationA.cs:13:16:13:16 | this access |
-| MultiImplementationB.cs:18:12:18:13 | enter C2 | successor | MultiImplementationB.cs:11:16:11:16 | this access |
-| MultiImplementationB.cs:19:12:19:13 | enter C2 | successor | MultiImplementationA.cs:21:24:21:24 | 0 |
-| MultiImplementationB.cs:19:12:19:13 | enter C2 | successor | MultiImplementationB.cs:19:24:19:24 | 1 |
 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | successor | MultiImplementationA.cs:21:27:21:29 | {...} |
 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | successor | MultiImplementationB.cs:19:27:19:29 | {...} |
-| MultiImplementationB.cs:20:6:20:7 | enter ~C2 | successor | MultiImplementationA.cs:22:11:22:13 | {...} |
-| MultiImplementationB.cs:20:6:20:7 | enter ~C2 | successor | MultiImplementationB.cs:20:11:20:25 | {...} |
-| MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | successor | MultiImplementationA.cs:23:50:23:53 | null |
-| MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | successor | MultiImplementationB.cs:21:56:21:59 | null |
 | MultiImplementationB.cs:22:32:22:34 | ... = ... | successor | MultiImplementationA.cs:20:22:20:31 | {...} |
 | MultiImplementationB.cs:22:32:22:34 | ... = ... | successor | MultiImplementationA.cs:24:16:24:16 | this access |
 | MultiImplementationB.cs:22:32:22:34 | ... = ... | successor | MultiImplementationB.cs:18:22:18:36 | {...} |
 | MultiImplementationB.cs:22:32:22:34 | ... = ... | successor | MultiImplementationB.cs:22:16:22:16 | this access |
-| MultiImplementationB.cs:32:9:32:10 | enter M1 | successor | MultiImplementationA.cs:36:14:36:28 | {...} |
-| MultiImplementationB.cs:32:9:32:10 | enter M1 | successor | MultiImplementationB.cs:32:17:32:17 | 0 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Consistency.ql
+++ b/csharp/ql/test/library-tests/controlflow/graph/Consistency.ql
@@ -72,6 +72,7 @@ query predicate breakInvariant3(
   succSplits(pred, predSplits, succ, succSplits, c) and
   split = predSplits.getASplit() and
   split.hasExit(pred, succ, c) and
+  not split.hasEntry(pred, succ, c) and
   split = succSplits.getASplit()
 }
 
@@ -81,7 +82,7 @@ query predicate breakInvariant4(
 ) {
   succSplits(pred, predSplits, succ, succSplits, c) and
   split.hasEntry(pred, succ, c) and
-  not split = predSplits.getASplit() and
+  not split.getKind() = predSplits.getASplit().getKind() and
   not split = succSplits.getASplit()
 }
 
@@ -92,12 +93,13 @@ query predicate breakInvariant5(
   succSplits(pred, predSplits, succ, succSplits, c) and
   split = succSplits.getASplit() and
   not (split.hasSuccessor(pred, succ, c) and split = predSplits.getASplit()) and
-  not (split.hasEntry(pred, succ, c) and not split = predSplits.getASplit())
+  not split.hasEntry(pred, succ, c)
 }
 
 query predicate multipleSuccessors(
   ControlFlow::Node node, SuccessorType t, ControlFlow::Node successor
 ) {
+  not node instanceof ControlFlow::Nodes::EntryNode and
   strictcount(node.getASuccessorByType(t)) > 1 and
   successor = node.getASuccessorByType(t)
 }

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -330,11 +330,11 @@ dominance
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:43:9:50 | { ..., ... } |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:8:5:12:5 | {...} |
 | Assert.cs:8:5:12:5 | {...} | Assert.cs:9:9:9:33 | ... ...; |
-| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:20:9:32 | ... ? ... : ... |
+| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:20:9:20 | access to parameter b |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:32 | ...; |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" |
-| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:20 | access to parameter b |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:16:9:32 | String s = ... |
 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | exit M1 (abnormal) |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:11:9:11:36 | ...; |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:10:22:10:22 | access to local variable s |
@@ -348,11 +348,11 @@ dominance
 | Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:9:11:35 | call to method WriteLine |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:15:5:19:5 | {...} |
 | Assert.cs:15:5:19:5 | {...} | Assert.cs:16:9:16:33 | ... ...; |
-| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:20:16:32 | ... ? ... : ... |
+| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:20:16:20 | access to parameter b |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:25 | ...; |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:31:16:32 | "" |
-| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:20 | access to parameter b |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:16:16:32 | String s = ... |
 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 (abnormal) |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:18:9:18:36 | ...; |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:17:23:17:23 | access to local variable s |
@@ -364,11 +364,11 @@ dominance
 | Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:9:18:35 | call to method WriteLine |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:22:5:26:5 | {...} |
 | Assert.cs:22:5:26:5 | {...} | Assert.cs:23:9:23:33 | ... ...; |
-| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:20:23:32 | ... ? ... : ... |
+| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:20:23:20 | access to parameter b |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:28 | ...; |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:31:23:32 | "" |
-| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:20 | access to parameter b |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:16:23:32 | String s = ... |
 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 (abnormal) |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:25:9:25:36 | ...; |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:24:26:24:26 | access to local variable s |
@@ -380,11 +380,11 @@ dominance
 | Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:9:25:35 | call to method WriteLine |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:29:5:33:5 | {...} |
 | Assert.cs:29:5:33:5 | {...} | Assert.cs:30:9:30:33 | ... ...; |
-| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:20:30:32 | ... ? ... : ... |
+| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:20:30:20 | access to parameter b |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:33 | ...; |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:31:30:32 | "" |
-| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:20 | access to parameter b |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:16:30:32 | String s = ... |
 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 (abnormal) |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:32:9:32:36 | ...; |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:31:23:31:23 | access to local variable s |
@@ -398,11 +398,11 @@ dominance
 | Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:9:32:35 | call to method WriteLine |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:36:5:40:5 | {...} |
 | Assert.cs:36:5:40:5 | {...} | Assert.cs:37:9:37:33 | ... ...; |
-| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:20:37:32 | ... ? ... : ... |
+| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:20:37:20 | access to parameter b |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:33 | ...; |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:31:37:32 | "" |
-| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:20 | access to parameter b |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:16:37:32 | String s = ... |
 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 (abnormal) |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:39:9:39:36 | ...; |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:38:23:38:23 | access to local variable s |
@@ -416,11 +416,11 @@ dominance
 | Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:9:39:35 | call to method WriteLine |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:43:5:47:5 | {...} |
 | Assert.cs:43:5:47:5 | {...} | Assert.cs:44:9:44:33 | ... ...; |
-| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:20:44:32 | ... ? ... : ... |
+| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:20:44:20 | access to parameter b |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:34 | ...; |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:31:44:32 | "" |
-| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:20 | access to parameter b |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:16:44:32 | String s = ... |
 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 (abnormal) |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:46:9:46:36 | ...; |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:45:24:45:24 | access to local variable s |
@@ -434,11 +434,11 @@ dominance
 | Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:9:46:35 | call to method WriteLine |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:50:5:54:5 | {...} |
 | Assert.cs:50:5:54:5 | {...} | Assert.cs:51:9:51:33 | ... ...; |
-| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:20:51:32 | ... ? ... : ... |
+| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:20:51:20 | access to parameter b |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:34 | ...; |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:31:51:32 | "" |
-| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:20 | access to parameter b |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:16:51:32 | String s = ... |
 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 (abnormal) |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:53:9:53:36 | ...; |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:52:24:52:24 | access to local variable s |
@@ -452,122 +452,127 @@ dominance
 | Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:9:53:35 | call to method WriteLine |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:57:5:61:5 | {...} |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:58:9:58:33 | ... ...; |
-| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:32 | ... ? ... : ... |
+| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:20 | access to parameter b |
 | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): false] ...; |
 | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): true] ...; |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | [b (line 56): true] null |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
-| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b |
-| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... |
-| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... |
+| Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... |
+| Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... |
 | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 (abnormal) |
 | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:60:9:60:36 | ...; |
-| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... |
-| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... |
+| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s |
+| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s |
 | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): false] null |
 | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): true] null |
 | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
 | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
-| Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s |
-| Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s |
+| Assert.cs:59:23:59:36 | [false] ... && ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:59:23:59:36 | [true] ... && ... | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue |
 | Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... |
 | Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... |
-| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:23:59:36 | [true] ... && ... |
 | Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 (normal) |
 | Assert.cs:60:9:60:36 | ...; | Assert.cs:60:27:60:27 | access to local variable s |
 | Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:34 | access to property Length |
 | Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:9:60:35 | call to method WriteLine |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:64:5:68:5 | {...} |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:65:9:65:33 | ... ...; |
-| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:32 | ... ? ... : ... |
+| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:20 | access to parameter b |
 | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): false] ...; |
 | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): true] ...; |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | [b (line 63): true] null |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
-| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b |
-| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... |
-| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... |
+| Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... |
+| Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... |
 | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 (abnormal) |
 | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:67:9:67:36 | ...; |
-| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... |
-| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... |
+| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s |
+| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s |
 | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): false] null |
 | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): true] null |
 | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
 | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
-| Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s |
-| Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s |
+| Assert.cs:66:24:66:37 | [false] ... \|\| ... | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse |
+| Assert.cs:66:24:66:37 | [true] ... \|\| ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
 | Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... |
 | Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... |
-| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:24:66:37 | [false] ... \|\| ... |
 | Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 (normal) |
 | Assert.cs:67:9:67:36 | ...; | Assert.cs:67:27:67:27 | access to local variable s |
 | Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:34 | access to property Length |
 | Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:9:67:35 | call to method WriteLine |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:71:5:75:5 | {...} |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:72:9:72:33 | ... ...; |
-| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:32 | ... ? ... : ... |
+| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:20 | access to parameter b |
 | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): false] ...; |
 | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): true] ...; |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | [b (line 70): true] null |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
-| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b |
-| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... |
-| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... |
+| Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... |
+| Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... |
 | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 (abnormal) |
 | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:74:9:74:36 | ...; |
-| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... |
-| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... |
+| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s |
+| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s |
 | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): false] null |
 | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): true] null |
 | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
 | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
-| Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s |
-| Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s |
+| Assert.cs:73:23:73:36 | [false] ... && ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:73:23:73:36 | [true] ... && ... | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue |
 | Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... |
 | Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... |
-| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:23:73:36 | [true] ... && ... |
 | Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 (normal) |
 | Assert.cs:74:9:74:36 | ...; | Assert.cs:74:27:74:27 | access to local variable s |
 | Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:34 | access to property Length |
 | Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:9:74:35 | call to method WriteLine |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:78:5:82:5 | {...} |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:79:9:79:33 | ... ...; |
-| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:32 | ... ? ... : ... |
+| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:20 | access to parameter b |
 | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): false] ...; |
 | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): true] ...; |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | [b (line 77): true] null |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
-| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b |
-| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... |
-| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... |
+| Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... |
+| Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... |
 | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 (abnormal) |
 | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:81:9:81:36 | ...; |
-| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... |
-| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... |
+| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s |
+| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s |
 | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): false] null |
 | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): true] null |
 | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
 | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
-| Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s |
-| Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s |
+| Assert.cs:80:24:80:37 | [false] ... \|\| ... | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse |
+| Assert.cs:80:24:80:37 | [true] ... \|\| ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
 | Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... |
 | Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... |
-| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:24:80:37 | [false] ... \|\| ... |
 | Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 (normal) |
 | Assert.cs:81:9:81:36 | ...; | Assert.cs:81:27:81:27 | access to local variable s |
 | Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:34 | access to property Length |
 | Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:9:81:35 | call to method WriteLine |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:85:5:129:5 | {...} |
 | Assert.cs:85:5:129:5 | {...} | Assert.cs:86:9:86:33 | ... ...; |
-| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:20:86:32 | ... ? ... : ... |
+| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:20:86:20 | access to parameter b |
 | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): false] ...; |
 | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): true] ...; |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:20 | access to parameter b |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... |
+| Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... |
+| Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): true] ...; |
 | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s |
@@ -590,14 +595,14 @@ dominance
 | Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine |
 | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): false] ...; |
 | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): true] ...; |
-| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:24:90:25 | [b (line 84): false] "" |
 | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:17:90:20 | [b (line 84): true] null |
-| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... |
-| Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... |
+| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... |
+| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... |
+| Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): true] ...; |
 | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s |
@@ -616,14 +621,14 @@ dominance
 | Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine |
 | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): false] ...; |
 | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): true] ...; |
-| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:24:94:25 | [b (line 84): false] "" |
 | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:17:94:20 | [b (line 84): true] null |
-| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... |
-| Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... |
+| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... |
+| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... |
+| Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): true] ...; |
 | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s |
@@ -642,14 +647,14 @@ dominance
 | Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine |
 | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): false] ...; |
 | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): true] ...; |
-| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:24:98:25 | [b (line 84): false] "" |
 | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:17:98:20 | [b (line 84): true] null |
-| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... |
-| Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... |
+| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... |
+| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... |
+| Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): true] ...; |
 | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s |
@@ -672,14 +677,14 @@ dominance
 | Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine |
 | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): false] ...; |
 | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): true] ...; |
-| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:24:102:25 | [b (line 84): false] "" |
 | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:17:102:20 | [b (line 84): true] null |
-| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... |
-| Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... |
+| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... |
+| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... |
+| Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): true] ...; |
 | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s |
@@ -702,14 +707,14 @@ dominance
 | Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine |
 | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): false] ...; |
 | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): true] ...; |
-| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:24:106:25 | [b (line 84): false] "" |
 | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:17:106:20 | [b (line 84): true] null |
-| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... |
-| Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... |
+| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... |
+| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... |
+| Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): true] ...; |
 | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s |
@@ -732,14 +737,14 @@ dominance
 | Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine |
 | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): false] ...; |
 | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): true] ...; |
-| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:24:110:25 | [b (line 84): false] "" |
 | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:17:110:20 | [b (line 84): true] null |
-| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... |
-| Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... |
+| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... |
+| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... |
+| Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): true] ...; |
 | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s |
@@ -762,81 +767,85 @@ dominance
 | Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine |
 | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): false] ...; |
 | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): true] ...; |
-| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:24:114:25 | [b (line 84): false] "" |
 | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:17:114:20 | [b (line 84): true] null |
-| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... |
-| Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... |
+| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... |
+| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... |
+| Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; |
-| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... |
-| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... |
+| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): false] null |
 | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): true] null |
-| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
 | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s |
-| Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... |
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... |
 | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): true] ...; |
 | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s |
 | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length |
 | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine |
 | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; |
-| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null |
-| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... |
+| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... |
+| Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; |
-| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... |
+| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s |
 | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): true] null |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
-| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [false, b (line 84): true] !... |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): true] ...; |
 | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s |
 | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length |
 | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine |
 | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; |
-| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null |
-| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... |
+| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... |
+| Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; |
-| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... |
+| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): true] null |
-| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): true] ...; |
 | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s |
 | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length |
 | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine |
 | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | Assert.cs:127:9:127:40 | [b (line 84): true] ...; |
-| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | [b (line 84): true] null |
-| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... |
+| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... |
+| Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:128:9:128:36 | ...; |
-| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... |
+| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s |
 | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:127:29:127:32 | [b (line 84): true] null |
-| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
-| Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:24:127:38 | [false] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse |
+| Assert.cs:127:24:127:38 | [true] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
 | Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
-| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse |
+| Assert.cs:127:37:127:38 | [false] !... | Assert.cs:127:24:127:38 | [false] ... \|\| ... |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [false] !... |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 (normal) |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:128:27:128:27 | access to local variable s |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:34 | access to property Length |
@@ -1039,8 +1048,6 @@ dominance
 | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | exit M (normal) |
 | CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:32:40:36 | "End" |
 | CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine |
-| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:30:32:30:32 | 0 |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:26:3:26 | access to parameter i |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 |
 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) |
@@ -1050,16 +1057,17 @@ dominance
 | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | exit M2 |
 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) |
 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:28:5:34 | access to property Length |
-| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 |
+| ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
-| ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:49:7:55 | access to property Length |
-| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 |
-| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... |
+| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:25 | access to parameter s |
 | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:27:9:33 | access to property Length |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:38:9:38 | 0 |
-| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:25:9:25 | access to parameter s |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:12:5:17:5 | {...} |
 | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | exit M5 |
 | ConditionalAccess.cs:12:5:17:5 | {...} | ConditionalAccess.cs:13:9:16:21 | if (...) ... |
@@ -1096,10 +1104,7 @@ dominance
 | ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:32:30:32 | 0 |
 | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
 | ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
-| ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:28:30:32 | ... = ... |
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:28:30:32 | ... = ... |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:33:5:36:5 | {...} |
 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 |
@@ -1127,11 +1132,11 @@ dominance
 | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ |
 | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ | Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... |
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x |
-| Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:7:13:7:16 | [inc (line 3): false] !... |
-| Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | Conditions.cs:7:13:7:16 | [inc (line 3): true] !... |
-| Conditions.cs:7:13:7:16 | [inc (line 3): false] !... | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc |
-| Conditions.cs:7:13:7:16 | [inc (line 3): true] !... | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc |
-| Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:8:13:8:16 | ...; |
+| Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc |
+| Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc |
+| Conditions.cs:7:13:7:16 | [true] !... | Conditions.cs:8:13:8:16 | ...; |
+| Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:7:13:7:16 | [true] !... |
+| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:7:13:7:16 | [false] !... |
 | Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:15 | ...-- |
 | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:13 | access to parameter x |
 | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:12:5:20:5 | {...} |
@@ -1154,11 +1159,11 @@ dominance
 | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... |
 | Conditions.cs:16:17:16:17 | [b (line 11): false] 0 | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... |
 | Conditions.cs:16:17:16:17 | [b (line 11): true] 0 | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... |
-| Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:17:17:17:18 | [b (line 11): false] !... |
-| Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:17:17:17:18 | [b (line 11): true] !... |
-| Conditions.cs:17:17:17:18 | [b (line 11): false] !... | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b |
-| Conditions.cs:17:17:17:18 | [b (line 11): true] !... | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b |
-| Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:18:17:18:20 | ...; |
+| Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b |
+| Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b |
+| Conditions.cs:17:17:17:18 | [true] !... | Conditions.cs:18:17:18:20 | ...; |
+| Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:17:17:17:18 | [true] !... |
+| Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | Conditions.cs:17:17:17:18 | [false] !... |
 | Conditions.cs:18:17:18:17 | access to local variable x | Conditions.cs:18:17:18:19 | ...-- |
 | Conditions.cs:18:17:18:20 | ...; | Conditions.cs:18:17:18:17 | access to local variable x |
 | Conditions.cs:19:9:19:17 | return ...; | Conditions.cs:11:9:11:10 | exit M1 (normal) |
@@ -1380,11 +1385,11 @@ dominance
 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... |
 | Conditions.cs:107:24:107:24 | [b (line 102): false] 0 | Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... |
 | Conditions.cs:107:24:107:24 | [b (line 102): true] 0 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... |
-| Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:108:17:108:18 | [b (line 102): false] !... |
-| Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:17:108:18 | [b (line 102): true] !... |
-| Conditions.cs:108:17:108:18 | [b (line 102): false] !... | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b |
-| Conditions.cs:108:17:108:18 | [b (line 102): true] !... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b |
-| Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:109:17:109:24 | ...; |
+| Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b |
+| Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b |
+| Conditions.cs:108:17:108:18 | [true] !... | Conditions.cs:109:17:109:24 | ...; |
+| Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:108:17:108:18 | [true] !... |
+| Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:108:17:108:18 | [false] !... |
 | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:22:109:23 | "" |
 | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:23 | ... = ... |
 | Conditions.cs:109:17:109:24 | ...; | Conditions.cs:109:17:109:17 | access to local variable x |
@@ -1415,10 +1420,11 @@ dominance
 | Conditions.cs:118:29:118:39 | access to property Length | Conditions.cs:118:43:118:43 | 1 |
 | Conditions.cs:118:29:118:43 | ... - ... | Conditions.cs:118:24:118:43 | ... == ... |
 | Conditions.cs:118:43:118:43 | 1 | Conditions.cs:118:29:118:43 | ... - ... |
-| Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:119:17:119:21 | !... |
-| Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:18:119:21 | access to local variable last |
-| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:119:18:119:21 | access to local variable last |
+| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
+| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... |
+| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... |
 | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... |
 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:21:120:22 | [last (line 118): false] "" |
 | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... |
@@ -1469,14 +1475,15 @@ dominance
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:144:5:150:5 | {...} |
 | Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | exit M11 |
 | Conditions.cs:144:5:150:5 | {...} | Conditions.cs:145:9:145:30 | ... ...; |
-| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:17:145:29 | ... ? ... : ... |
+| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:17:145:17 | access to parameter b |
 | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... |
 | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... |
 | Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
 | Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
-| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:17:145:17 | access to parameter b |
-| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... |
-| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... |
+| Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... |
+| Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... |
 | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b |
 | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b |
 | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:149:13:149:49 | ...; |
@@ -1589,29 +1596,29 @@ dominance
 | ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit (abnormal) |
 | ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:106:9:106:47 | call to method Exit |
 | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:110:5:112:5 | {...} |
-| ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
+| ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:16:111:20 | access to parameter input |
 | ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) |
 | ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:25:111:25 | 0 |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:29:111:29 | 1 |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:69:111:75 | "input" |
-| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:16:111:20 | access to parameter input |
+| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:9:111:77 | return ...; |
 | ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:25:111:25 | (...) ... |
 | ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:16:111:25 | ... != ... |
 | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | (...) ... |
 | ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:33:111:37 | access to parameter input |
-| ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:9:111:77 | return ...; |
+| ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
 | ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:29:111:37 | ... / ... |
 | ExitMethods.cs:111:41:111:76 | throw ... | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) |
 | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:41:111:76 | throw ... |
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:115:5:117:5 | {...} |
 | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall |
-| ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
+| ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:116:16:116:16 | access to parameter s |
 | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) |
 | ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:27:116:29 | - |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:34:116:34 | 0 |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:38:116:38 | 1 |
-| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:16 | access to parameter s |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:9:116:39 | return ...; |
 | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:30 | call to method Contains |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:120:5:123:5 | {...} |
 | ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) | ExitMethods.cs:119:17:119:32 | exit FailingAssertion |
@@ -1904,16 +1911,16 @@ dominance
 | Finally.cs:113:9:118:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:113:9:118:9 | [finally: return] {...} | Finally.cs:114:13:115:41 | [finally: return] if (...) ... |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:114:13:115:41 | if (...) ... |
-| Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... | Finally.cs:114:17:114:36 | [finally: exception(Exception)] !... |
-| Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:114:17:114:36 | [finally: exception(NullReferenceException)] !... |
-| Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:114:17:114:36 | [finally: exception(OutOfMemoryException)] !... |
-| Finally.cs:114:13:115:41 | [finally: return] if (...) ... | Finally.cs:114:17:114:36 | [finally: return] !... |
-| Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:114:17:114:36 | !... |
-| Finally.cs:114:17:114:36 | !... | Finally.cs:114:19:114:23 | this access |
-| Finally.cs:114:17:114:36 | [finally: exception(Exception)] !... | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access |
-| Finally.cs:114:17:114:36 | [finally: exception(NullReferenceException)] !... | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access |
-| Finally.cs:114:17:114:36 | [finally: exception(OutOfMemoryException)] !... | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access |
-| Finally.cs:114:17:114:36 | [finally: return] !... | Finally.cs:114:19:114:23 | [finally: return] this access |
+| Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access |
+| Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access |
+| Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access |
+| Finally.cs:114:13:115:41 | [finally: return] if (...) ... | Finally.cs:114:19:114:23 | [finally: return] this access |
+| Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:114:19:114:23 | this access |
+| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
+| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; |
+| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
+| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:115:17:115:41 | [finally: return] ...; |
+| Finally.cs:114:17:114:36 | [true] !... | Finally.cs:115:17:115:41 | ...; |
 | Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field | Finally.cs:114:19:114:30 | [finally: exception(Exception)] access to property Length |
 | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field |
 | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:114:19:114:30 | [finally: exception(NullReferenceException)] access to property Length |
@@ -1929,16 +1936,16 @@ dominance
 | Finally.cs:114:19:114:30 | [finally: exception(OutOfMemoryException)] access to property Length | Finally.cs:114:35:114:35 | [finally: exception(OutOfMemoryException)] 0 |
 | Finally.cs:114:19:114:30 | [finally: return] access to property Length | Finally.cs:114:35:114:35 | [finally: return] 0 |
 | Finally.cs:114:19:114:30 | access to property Length | Finally.cs:114:35:114:35 | 0 |
-| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:116:13:117:37 | if (...) ... |
-| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
-| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... |
-| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; |
-| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... |
-| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
-| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
-| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:115:17:115:41 | [finally: return] ...; |
-| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:116:13:117:37 | [finally: return] if (...) ... |
+| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:114:17:114:36 | [true] !... |
+| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... |
+| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... |
+| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... |
+| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... |
+| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:114:17:114:36 | [false, finally: return] !... |
+| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:114:17:114:36 | [true, finally: return] !... |
 | Finally.cs:114:35:114:35 | 0 | Finally.cs:114:19:114:35 | ... == ... |
 | Finally.cs:114:35:114:35 | [finally: exception(Exception)] 0 | Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... |
 | Finally.cs:114:35:114:35 | [finally: exception(NullReferenceException)] 0 | Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... |
@@ -2310,13 +2317,13 @@ dominance
 | Foreach.cs:14:27:14:30 | access to parameter args | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:19:5:22:5 | {...} |
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 |
-| Foreach.cs:19:5:22:5 | {...} | Foreach.cs:20:27:20:68 | ... ?? ... |
+| Foreach.cs:19:5:22:5 | {...} | Foreach.cs:20:27:20:27 | access to parameter e |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 (normal) |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:21:11:21:11 | ; |
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:43:20:68 | call to method Empty |
-| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:27:20:27 | access to parameter e |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:25:5:28:5 | {...} |
 | Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | exit M4 |
 | Foreach.cs:25:5:28:5 | {...} | Foreach.cs:26:36:26:39 | access to parameter args |
@@ -2687,11 +2694,12 @@ dominance
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:68:5:74:5 | {...} |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:69:9:70:19 | if (...) ... |
-| LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:13:69:23 | !... |
-| LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:14:69:17 | access to parameter args |
+| LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:14:69:17 | access to parameter args |
+| LoopUnrolling.cs:69:13:69:23 | [false] !... | LoopUnrolling.cs:71:9:71:21 | ...; |
+| LoopUnrolling.cs:69:13:69:23 | [true] !... | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:69:14:69:17 | access to parameter args | LoopUnrolling.cs:69:14:69:23 | call to method Any |
-| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:70:13:70:19 | return ...; |
-| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:71:9:71:21 | ...; |
+| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:13:69:23 | [false] !... |
+| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:13:69:23 | [true] !... |
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear |
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:29:72:32 | access to parameter args |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:12 | access to parameter args |
@@ -2895,58 +2903,61 @@ dominance
 | MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationB.cs:32:17:32:17 | 0 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) |
-| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
+| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:23 | access to parameter i |
 | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 |
-| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
+| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
 | NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:28:3:28 | 0 |
-| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:23 | access to parameter i |
-| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
+| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:25:5:25 | access to parameter b |
 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 |
-| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:25:5:34 | ... ?? ... |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) |
+| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... |
+| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:30:5:34 | false |
-| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:39:5:39 | 0 |
-| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:43:5:43 | 1 |
-| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:25:5:25 | access to parameter b |
-| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:43:5:43 | 1 |
+| NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | NullCoalescing.cs:5:39:5:39 | 0 |
+| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |
 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 |
-| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
-| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
-| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |
+| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:52:7:53 | "" |
-| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
-| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:36:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:37:9:37 | access to parameter b |
 | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 |
-| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:41:9:41 | access to parameter s |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:45:9:45 | access to parameter s |
-| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:37:9:37 | access to parameter b |
-| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:52 | "" |
-| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
+| NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | NullCoalescing.cs:9:51:9:52 | "" |
+| NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 |
 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 |
-| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:44:11:59 | ... ?? ... |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:51:11:58 | ... && ... |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:64:11:64 | 0 |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:68:11:68 | 1 |
-| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:44:11:45 | access to parameter b1 |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:68:11:68 | 1 |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:64:11:64 | 0 |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... |
 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 |
+| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... |
 | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:14:5:18:5 | {...} |
 | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | NullCoalescing.cs:13:10:13:11 | exit M6 |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:15:9:15:32 | ... ...; |
-| NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
+| NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:23:15:26 | null |
 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:16:9:16:26 | ... ...; |
 | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:31:15:31 | 0 |
-| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:23:15:26 | null |
+| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:13:15:31 | Int32 j = ... |
 | NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:17:15:26 | (...) ... |
-| NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... |
-| NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
+| NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
+| NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:17:16:18 | "" |
 | NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:17:9:17:25 | ...; |
-| NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:13:16:25 | String s = ... |
-| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" |
+| NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
+| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:13:16:25 | String s = ... |
 | NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) |
-| NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
-| NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:9:17:24 | ... = ... |
-| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
+| NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:19:17:19 | access to parameter i |
+| NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
+| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:9:17:24 | ... = ... |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:6:5:43:5 | {...} |
 | Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:5:10:5:13 | exit Test |
@@ -3140,15 +3151,16 @@ dominance
 | Switch.cs:21:26:21:29 | null | Switch.cs:21:21:21:29 | ... == ... |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:23:17:23:28 | goto case ...; |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:18:24:25 | String s |
-| Switch.cs:24:18:24:25 | String s | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:24:18:24:25 | String s | Switch.cs:24:32:24:32 | access to local variable s |
 | Switch.cs:24:18:24:25 | String s | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:39 | access to property Length |
 | Switch.cs:24:32:24:39 | access to property Length | Switch.cs:24:43:24:43 | 0 |
+| Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:32:24:55 | [false] ... && ... |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:32:24:32 | access to local variable s |
+| Switch.cs:24:32:24:55 | [true] ... && ... | Switch.cs:25:17:25:37 | ...; |
 | Switch.cs:24:43:24:43 | 0 | Switch.cs:24:32:24:43 | ... > ... |
 | Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:53:24:55 | "a" |
-| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:25:17:25:37 | ...; |
+| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:32:24:55 | [true] ... && ... |
 | Switch.cs:24:53:24:55 | "a" | Switch.cs:24:48:24:55 | ... != ... |
 | Switch.cs:25:17:25:36 | call to method WriteLine | Switch.cs:26:17:26:23 | return ...; |
 | Switch.cs:25:17:25:37 | ...; | Switch.cs:25:35:25:35 | access to local variable s |
@@ -3273,27 +3285,29 @@ dominance
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:124:5:127:5 | {...} |
 | Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 |
 | Switch.cs:124:5:127:5 | {...} | Switch.cs:125:9:126:19 | if (...) ... |
-| Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:13:125:48 | ... switch { ... } |
-| Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:24:125:34 | ... => ... |
-| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:13:125:13 | access to parameter o |
+| Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:13:125:13 | access to parameter o |
+| Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:24:125:29 | Boolean b |
+| Switch.cs:125:13:125:48 | [true] ... switch { ... } | Switch.cs:126:13:126:19 | return ...; |
 | Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:34:125:34 | access to local variable b |
-| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:37:125:46 | ... => ... |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:29 | Boolean b |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:126:13:126:19 | return ...; |
+| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:37:125:37 | _ |
+| Switch.cs:125:24:125:34 | [true] ... => ... | Switch.cs:125:13:125:48 | [true] ... switch { ... } |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [false] ... => ... |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [true] ... => ... |
 | Switch.cs:125:37:125:37 | _ | Switch.cs:125:42:125:46 | false |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:37 | _ |
+| Switch.cs:125:42:125:46 | false | Switch.cs:125:37:125:46 | [false] ... => ... |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:130:5:132:5 | {...} |
 | Switch.cs:129:12:129:14 | exit M12 (normal) | Switch.cs:129:12:129:14 | exit M12 |
-| Switch.cs:130:5:132:5 | {...} | Switch.cs:131:17:131:53 | ... switch { ... } |
+| Switch.cs:130:5:132:5 | {...} | Switch.cs:131:17:131:17 | access to parameter o |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 (normal) |
-| Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:28:131:40 | ... => ... |
-| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:17:131:17 | access to parameter o |
+| Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:28:131:35 | String s |
+| Switch.cs:131:17:131:53 | [non-null] ... switch { ... } | Switch.cs:131:56:131:66 | call to method ToString |
 | Switch.cs:131:28:131:35 | String s | Switch.cs:131:40:131:40 | access to local variable s |
-| Switch.cs:131:28:131:35 | String s | Switch.cs:131:43:131:51 | ... => ... |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:35 | String s |
-| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:56:131:66 | call to method ToString |
+| Switch.cs:131:28:131:35 | String s | Switch.cs:131:43:131:43 | _ |
+| Switch.cs:131:28:131:40 | [non-null] ... => ... | Switch.cs:131:17:131:53 | [non-null] ... switch { ... } |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [non-null] ... => ... |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [null] ... => ... |
 | Switch.cs:131:43:131:43 | _ | Switch.cs:131:48:131:51 | null |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:43 | _ |
+| Switch.cs:131:48:131:51 | null | Switch.cs:131:43:131:51 | [null] ... => ... |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:135:5:142:5 | {...} |
 | Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 |
 | Switch.cs:135:5:142:5 | {...} | Switch.cs:136:9:141:9 | switch (...) {...} |
@@ -3328,16 +3342,16 @@ dominance
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:155:5:161:5 | {...} |
 | Switch.cs:155:5:161:5 | {...} | Switch.cs:156:9:156:55 | ... ...; |
-| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:17:156:54 | ... switch { ... } |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:17:156:17 | access to parameter b |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:157:9:160:49 | if (...) ... |
-| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:28:156:38 | ... => ... |
-| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:17 | access to parameter b |
+| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:28:156:31 | true |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:13:156:54 | String s = ... |
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:36:156:38 | "a" |
-| Switch.cs:156:28:156:31 | true | Switch.cs:156:41:156:52 | ... => ... |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:41:156:45 | false |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:28:156:38 | ... => ... |
 | Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:52 | ... => ... |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:13:157:13 | access to parameter b |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; |
@@ -3407,12 +3421,12 @@ dominance
 | VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:22:24:28 | object creation of type C |
 | VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:35:24:41 | object creation of type C |
 | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... |
-| VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
+| VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:20 | access to parameter b |
 | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:31:24:41 | C y = ... |
 | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 (normal) |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:24:25:24 | access to local variable x |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:28:25:28 | access to local variable y |
-| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:20:25:20 | access to parameter b |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:13:25:29 | return ...; |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:51:28:53 | {...} |
 | VarDecls.cs:28:41:28:47 | exit Dispose (normal) | VarDecls.cs:28:41:28:47 | exit Dispose |
 | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | exit Dispose (normal) |
@@ -3465,17 +3479,18 @@ dominance
 | cflow.cs:24:30:24:31 | 20 | cflow.cs:24:25:24:31 | ... <= ... |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:24:34:24:36 | ...++ |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:26:13:33:37 | if (...) ... |
-| cflow.cs:26:13:33:37 | if (...) ... | cflow.cs:26:17:26:40 | ... && ... |
+| cflow.cs:26:13:33:37 | if (...) ... | cflow.cs:26:17:26:17 | access to local variable i |
 | cflow.cs:26:17:26:17 | access to local variable i | cflow.cs:26:21:26:21 | 3 |
 | cflow.cs:26:17:26:21 | ... % ... | cflow.cs:26:26:26:26 | 0 |
+| cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:17:26:40 | [false] ... && ... |
 | cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:26:17:26:26 | ... == ... | cflow.cs:28:18:33:37 | if (...) ... |
-| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:26:17:26:17 | access to local variable i |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:28:18:33:37 | if (...) ... |
+| cflow.cs:26:17:26:40 | [true] ... && ... | cflow.cs:27:17:27:46 | ...; |
 | cflow.cs:26:21:26:21 | 3 | cflow.cs:26:17:26:21 | ... % ... |
 | cflow.cs:26:26:26:26 | 0 | cflow.cs:26:17:26:26 | ... == ... |
 | cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:35:26:35 | 5 |
 | cflow.cs:26:31:26:35 | ... % ... | cflow.cs:26:40:26:40 | 0 |
-| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:27:17:27:46 | ...; |
+| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:26:35:26:35 | 5 | cflow.cs:26:31:26:35 | ... % ... |
 | cflow.cs:26:40:26:40 | 0 | cflow.cs:26:31:26:40 | ... == ... |
 | cflow.cs:27:17:27:46 | ...; | cflow.cs:27:35:27:44 | "FizzBuzz" |
@@ -3543,12 +3558,13 @@ dominance
 | cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:18:62:18 | 0 |
 | cflow.cs:62:18:62:18 | 0 | cflow.cs:63:17:64:55 | if (...) ... |
 | cflow.cs:62:18:62:18 | 0 | cflow.cs:67:16:67:16 | access to parameter a |
-| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:21:63:34 | !... |
-| cflow.cs:63:21:63:34 | !... | cflow.cs:63:23:63:27 | this access |
+| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:23:63:27 | this access |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:63:21:63:34 | [true] !... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
 | cflow.cs:63:23:63:27 | access to field Field | cflow.cs:63:32:63:33 | "" |
 | cflow.cs:63:23:63:27 | this access | cflow.cs:63:23:63:27 | access to field Field |
-| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:21:63:34 | [false] !... |
+| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:21:63:34 | [true] !... |
 | cflow.cs:63:32:63:33 | "" | cflow.cs:63:23:63:33 | ... == ... |
 | cflow.cs:64:21:64:55 | throw ...; | cflow.cs:37:17:37:22 | exit Switch (abnormal) |
 | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:64:21:64:55 | throw ...; |
@@ -3577,15 +3593,15 @@ dominance
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:85:5:88:5 | {...} |
 | cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 |
 | cflow.cs:85:5:88:5 | {...} | cflow.cs:86:9:87:33 | if (...) ... |
-| cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:13:86:37 | ... && ... |
+| cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:13:86:13 | access to parameter s |
 | cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:18:86:21 | null |
-| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:84:18:84:19 | exit M2 (normal) |
+| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:13:86:37 | [false] ... && ... |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:26:86:26 | access to parameter s |
-| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:13:86:13 | access to parameter s |
+| cflow.cs:86:13:86:37 | [true] ... && ... | cflow.cs:87:13:87:33 | ...; |
 | cflow.cs:86:18:86:21 | null | cflow.cs:86:13:86:21 | ... != ... |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:33 | access to property Length |
 | cflow.cs:86:26:86:33 | access to property Length | cflow.cs:86:37:86:37 | 0 |
-| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:87:13:87:33 | ...; |
+| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:86:13:86:37 | [true] ... && ... |
 | cflow.cs:86:37:86:37 | 0 | cflow.cs:86:26:86:37 | ... > ... |
 | cflow.cs:87:13:87:33 | ...; | cflow.cs:87:31:87:31 | access to parameter s |
 | cflow.cs:87:31:87:31 | access to parameter s | cflow.cs:87:13:87:32 | call to method WriteLine |
@@ -3661,13 +3677,13 @@ dominance
 | cflow.cs:123:16:123:16 | access to local variable x | cflow.cs:123:9:123:17 | return ...; |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:23:127:60 | {...} |
 | cflow.cs:127:19:127:21 | exit get_Prop (normal) | cflow.cs:127:19:127:21 | exit get_Prop |
-| cflow.cs:127:23:127:60 | {...} | cflow.cs:127:32:127:57 | ... ? ... : ... |
+| cflow.cs:127:23:127:60 | {...} | cflow.cs:127:32:127:36 | this access |
 | cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop (normal) |
 | cflow.cs:127:32:127:36 | access to field Field | cflow.cs:127:41:127:44 | null |
 | cflow.cs:127:32:127:36 | this access | cflow.cs:127:32:127:36 | access to field Field |
 | cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:48:127:49 | "" |
 | cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:53:127:57 | this access |
-| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:32:127:36 | this access |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:25:127:58 | return ...; |
 | cflow.cs:127:41:127:44 | null | cflow.cs:127:32:127:44 | ... == ... |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:66:127:83 | {...} |
@@ -3813,74 +3829,80 @@ dominance
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:186:5:191:5 | {...} |
 | cflow.cs:185:10:185:18 | exit LogicalOr (normal) | cflow.cs:185:10:185:18 | exit LogicalOr |
 | cflow.cs:186:5:191:5 | {...} | cflow.cs:187:9:190:52 | if (...) ... |
-| cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:187:13:187:50 | ... \|\| ... |
+| cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:187:13:187:13 | 1 |
 | cflow.cs:187:13:187:13 | 1 | cflow.cs:187:18:187:18 | 2 |
 | cflow.cs:187:13:187:18 | ... == ... | cflow.cs:187:23:187:23 | 2 |
-| cflow.cs:187:13:187:28 | ... \|\| ... | cflow.cs:187:13:187:13 | 1 |
-| cflow.cs:187:13:187:50 | ... \|\| ... | cflow.cs:187:13:187:28 | ... \|\| ... |
+| cflow.cs:187:13:187:28 | [false] ... \|\| ... | cflow.cs:187:34:187:34 | 1 |
+| cflow.cs:187:13:187:50 | [false] ... \|\| ... | cflow.cs:190:13:190:52 | ...; |
 | cflow.cs:187:18:187:18 | 2 | cflow.cs:187:13:187:18 | ... == ... |
 | cflow.cs:187:23:187:23 | 2 | cflow.cs:187:28:187:28 | 3 |
-| cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:34:187:49 | ... && ... |
+| cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:13:187:28 | [false] ... \|\| ... |
 | cflow.cs:187:28:187:28 | 3 | cflow.cs:187:23:187:28 | ... == ... |
 | cflow.cs:187:34:187:34 | 1 | cflow.cs:187:39:187:39 | 3 |
-| cflow.cs:187:34:187:39 | ... == ... | cflow.cs:190:13:190:52 | ...; |
-| cflow.cs:187:34:187:49 | ... && ... | cflow.cs:187:34:187:34 | 1 |
+| cflow.cs:187:34:187:39 | ... == ... | cflow.cs:187:34:187:49 | [false] ... && ... |
+| cflow.cs:187:34:187:49 | [false] ... && ... | cflow.cs:187:13:187:50 | [false] ... \|\| ... |
 | cflow.cs:187:39:187:39 | 3 | cflow.cs:187:34:187:39 | ... == ... |
 | cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:185:10:185:18 | exit LogicalOr (normal) |
 | cflow.cs:190:13:190:52 | ...; | cflow.cs:190:31:190:50 | "This should happen" |
 | cflow.cs:190:31:190:50 | "This should happen" | cflow.cs:190:13:190:51 | call to method WriteLine |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:194:5:206:5 | {...} |
 | cflow.cs:194:5:206:5 | {...} | cflow.cs:195:9:195:57 | ... ...; |
-| cflow.cs:195:9:195:57 | ... ...; | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:195:9:195:57 | ... ...; | cflow.cs:195:17:195:21 | this access |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:9:198:49 | if (...) ... |
 | cflow.cs:195:17:195:21 | access to field Field | cflow.cs:195:17:195:28 | access to property Length |
 | cflow.cs:195:17:195:21 | this access | cflow.cs:195:17:195:21 | access to field Field |
 | cflow.cs:195:17:195:28 | access to property Length | cflow.cs:195:32:195:32 | 0 |
-| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:13:195:56 | Boolean b = ... |
-| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:37:195:56 | !... |
-| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:17:195:21 | this access |
+| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:39:195:43 | this access |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:13:195:56 | Boolean b = ... |
 | cflow.cs:195:32:195:32 | 0 | cflow.cs:195:17:195:32 | ... > ... |
-| cflow.cs:195:37:195:56 | !... | cflow.cs:195:39:195:43 | this access |
 | cflow.cs:195:39:195:43 | access to field Field | cflow.cs:195:39:195:50 | access to property Length |
 | cflow.cs:195:39:195:43 | this access | cflow.cs:195:39:195:43 | access to field Field |
 | cflow.cs:195:39:195:50 | access to property Length | cflow.cs:195:55:195:55 | 1 |
+| cflow.cs:195:39:195:55 | ... == ... | cflow.cs:195:37:195:56 | !... |
 | cflow.cs:195:55:195:55 | 1 | cflow.cs:195:39:195:55 | ... == ... |
-| cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:197:13:197:47 | !... |
-| cflow.cs:197:13:197:47 | !... | cflow.cs:197:15:197:46 | ... ? ... : ... |
+| cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:197:15:197:19 | this access |
+| cflow.cs:197:13:197:47 | [true] !... | cflow.cs:198:13:198:49 | ...; |
 | cflow.cs:197:15:197:19 | access to field Field | cflow.cs:197:15:197:26 | access to property Length |
 | cflow.cs:197:15:197:19 | this access | cflow.cs:197:15:197:19 | access to field Field |
 | cflow.cs:197:15:197:26 | access to property Length | cflow.cs:197:31:197:31 | 0 |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:35:197:39 | false |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:43:197:46 | true |
-| cflow.cs:197:15:197:46 | ... ? ... : ... | cflow.cs:197:15:197:19 | this access |
+| cflow.cs:197:15:197:46 | [false] ... ? ... : ... | cflow.cs:197:13:197:47 | [true] !... |
+| cflow.cs:197:15:197:46 | [true] ... ? ... : ... | cflow.cs:197:13:197:47 | [false] !... |
 | cflow.cs:197:31:197:31 | 0 | cflow.cs:197:15:197:31 | ... == ... |
-| cflow.cs:197:35:197:39 | false | cflow.cs:198:13:198:49 | ...; |
-| cflow.cs:198:13:198:49 | ...; | cflow.cs:198:17:198:48 | ... ? ... : ... |
+| cflow.cs:197:35:197:39 | false | cflow.cs:197:15:197:46 | [false] ... ? ... : ... |
+| cflow.cs:197:43:197:46 | true | cflow.cs:197:15:197:46 | [true] ... ? ... : ... |
+| cflow.cs:198:13:198:49 | ...; | cflow.cs:198:17:198:21 | this access |
 | cflow.cs:198:17:198:21 | access to field Field | cflow.cs:198:17:198:28 | access to property Length |
 | cflow.cs:198:17:198:21 | this access | cflow.cs:198:17:198:21 | access to field Field |
 | cflow.cs:198:17:198:28 | access to property Length | cflow.cs:198:33:198:33 | 0 |
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:37:198:41 | false |
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:45:198:48 | true |
-| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:17:198:21 | this access |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:13:198:48 | ... = ... |
 | cflow.cs:198:33:198:33 | 0 | cflow.cs:198:17:198:33 | ... == ... |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:13:200:62 | ... \|\| ... |
-| cflow.cs:200:13:200:32 | !... | cflow.cs:200:15:200:19 | this access |
-| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:13:200:32 | !... |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:15:200:19 | this access |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:40:200:44 | this access |
+| cflow.cs:200:13:200:62 | [false] ... \|\| ... | cflow.cs:193:10:193:17 | exit Booleans (normal) |
+| cflow.cs:200:13:200:62 | [true] ... \|\| ... | cflow.cs:201:9:205:9 | {...} |
 | cflow.cs:200:15:200:19 | access to field Field | cflow.cs:200:15:200:26 | access to property Length |
 | cflow.cs:200:15:200:19 | this access | cflow.cs:200:15:200:19 | access to field Field |
 | cflow.cs:200:15:200:26 | access to property Length | cflow.cs:200:31:200:31 | 0 |
-| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:37:200:62 | !... |
-| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:201:9:205:9 | {...} |
+| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:13:200:32 | [false] !... |
+| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:13:200:32 | [true] !... |
 | cflow.cs:200:31:200:31 | 0 | cflow.cs:200:15:200:31 | ... == ... |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:38:200:62 | !... |
-| cflow.cs:200:38:200:62 | !... | cflow.cs:200:40:200:61 | ... && ... |
+| cflow.cs:200:37:200:62 | [false] !... | cflow.cs:200:13:200:62 | [false] ... \|\| ... |
+| cflow.cs:200:38:200:62 | [false] !... | cflow.cs:200:37:200:62 | [true] !... |
+| cflow.cs:200:38:200:62 | [true] !... | cflow.cs:200:37:200:62 | [false] !... |
 | cflow.cs:200:40:200:44 | access to field Field | cflow.cs:200:40:200:51 | access to property Length |
 | cflow.cs:200:40:200:44 | this access | cflow.cs:200:40:200:44 | access to field Field |
 | cflow.cs:200:40:200:51 | access to property Length | cflow.cs:200:56:200:56 | 1 |
-| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:193:10:193:17 | exit Booleans (normal) |
+| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:40:200:61 | [false] ... && ... |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:61:200:61 | access to local variable b |
-| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:40:200:44 | this access |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:38:200:62 | [true] !... |
+| cflow.cs:200:40:200:61 | [true] ... && ... | cflow.cs:200:38:200:62 | [false] !... |
 | cflow.cs:200:56:200:56 | 1 | cflow.cs:200:40:200:56 | ... == ... |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [true] ... && ... |
 | cflow.cs:201:9:205:9 | {...} | cflow.cs:202:13:204:13 | {...} |
 | cflow.cs:202:13:204:13 | {...} | cflow.cs:203:23:203:37 | object creation of type Exception |
 | cflow.cs:203:17:203:38 | throw ...; | cflow.cs:193:10:193:17 | exit Booleans (abnormal) |
@@ -3952,14 +3974,15 @@ dominance
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto |
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:242:9:242:13 | Label: |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:16:242:45 | if (...) ... |
-| cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:20:242:40 | !... |
-| cflow.cs:242:20:242:40 | !... | cflow.cs:242:21:242:40 | !... |
-| cflow.cs:242:21:242:40 | !... | cflow.cs:242:23:242:27 | this access |
+| cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:23:242:27 | this access |
+| cflow.cs:242:20:242:40 | [true] !... | cflow.cs:242:43:242:45 | {...} |
+| cflow.cs:242:21:242:40 | [false] !... | cflow.cs:242:20:242:40 | [true] !... |
+| cflow.cs:242:21:242:40 | [true] !... | cflow.cs:242:20:242:40 | [false] !... |
 | cflow.cs:242:23:242:27 | access to field Field | cflow.cs:242:23:242:34 | access to property Length |
 | cflow.cs:242:23:242:27 | this access | cflow.cs:242:23:242:27 | access to field Field |
 | cflow.cs:242:23:242:34 | access to property Length | cflow.cs:242:39:242:39 | 0 |
-| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:43:242:45 | {...} |
-| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:244:9:244:41 | if (...) ... |
+| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:21:242:40 | [false] !... |
+| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:21:242:40 | [true] !... |
 | cflow.cs:242:39:242:39 | 0 | cflow.cs:242:23:242:39 | ... == ... |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:13:244:17 | this access |
 | cflow.cs:244:13:244:17 | access to field Field | cflow.cs:244:13:244:24 | access to property Length |
@@ -4039,12 +4062,12 @@ dominance
 | cflow.cs:299:5:301:5 | {...} | cflow.cs:300:9:300:73 | ...; |
 | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:298:10:298:10 | exit M (normal) |
 | cflow.cs:300:9:300:73 | ...; | cflow.cs:300:38:300:38 | 0 |
-| cflow.cs:300:38:300:38 | 0 | cflow.cs:300:44:300:64 | ... && ... |
-| cflow.cs:300:44:300:51 | !... | cflow.cs:300:46:300:46 | access to parameter i |
-| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:44:300:51 | !... |
+| cflow.cs:300:38:300:38 | 0 | cflow.cs:300:46:300:46 | access to parameter i |
+| cflow.cs:300:44:300:51 | [true] !... | cflow.cs:300:56:300:56 | access to parameter s |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:70:300:71 | "" |
 | cflow.cs:300:46:300:46 | access to parameter i | cflow.cs:300:50:300:50 | 0 |
-| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:56:300:56 | access to parameter s |
-| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:70:300:71 | "" |
+| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:44:300:51 | [false] !... |
+| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:44:300:51 | [true] !... |
 | cflow.cs:300:50:300:50 | 0 | cflow.cs:300:46:300:50 | ... > ... |
 | cflow.cs:300:56:300:56 | access to parameter s | cflow.cs:300:61:300:64 | null |
 | cflow.cs:300:61:300:64 | null | cflow.cs:300:56:300:64 | ... != ... |
@@ -4383,10 +4406,10 @@ postDominance
 | Assert.cs:7:10:7:11 | exit M1 (normal) | Assert.cs:11:9:11:35 | call to method WriteLine |
 | Assert.cs:8:5:12:5 | {...} | Assert.cs:7:10:7:11 | enter M1 |
 | Assert.cs:9:9:9:33 | ... ...; | Assert.cs:8:5:12:5 | {...} |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:24:9:27 | null |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:31:9:32 | "" |
-| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:20:9:32 | ... ? ... : ... |
-| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:9:9:33 | ... ...; |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:20:9:32 | ... ? ... : ... |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:9:9:33 | ... ...; |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:24:9:27 | null |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:10:22:10:30 | ... != ... |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:9:16:9:32 | String s = ... |
 | Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:9:10:32 | ...; |
@@ -4400,10 +4423,10 @@ postDominance
 | Assert.cs:14:10:14:11 | exit M2 (normal) | Assert.cs:18:9:18:35 | call to method WriteLine |
 | Assert.cs:15:5:19:5 | {...} | Assert.cs:14:10:14:11 | enter M2 |
 | Assert.cs:16:9:16:33 | ... ...; | Assert.cs:15:5:19:5 | {...} |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:24:16:27 | null |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:31:16:32 | "" |
-| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:20:16:32 | ... ? ... : ... |
-| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:9:16:33 | ... ...; |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:20:16:32 | ... ? ... : ... |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:9:16:33 | ... ...; |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:24:16:27 | null |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:17:23:17:23 | access to local variable s |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:16:16:16:32 | String s = ... |
 | Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:25 | ...; |
@@ -4415,10 +4438,10 @@ postDominance
 | Assert.cs:21:10:21:11 | exit M3 (normal) | Assert.cs:25:9:25:35 | call to method WriteLine |
 | Assert.cs:22:5:26:5 | {...} | Assert.cs:21:10:21:11 | enter M3 |
 | Assert.cs:23:9:23:33 | ... ...; | Assert.cs:22:5:26:5 | {...} |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:24:23:27 | null |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:31:23:32 | "" |
-| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:20:23:32 | ... ? ... : ... |
-| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:9:23:33 | ... ...; |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:20:23:32 | ... ? ... : ... |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:9:23:33 | ... ...; |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:24:23:27 | null |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:24:26:24:26 | access to local variable s |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:23:16:23:32 | String s = ... |
 | Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:28 | ...; |
@@ -4430,10 +4453,10 @@ postDominance
 | Assert.cs:28:10:28:11 | exit M4 (normal) | Assert.cs:32:9:32:35 | call to method WriteLine |
 | Assert.cs:29:5:33:5 | {...} | Assert.cs:28:10:28:11 | enter M4 |
 | Assert.cs:30:9:30:33 | ... ...; | Assert.cs:29:5:33:5 | {...} |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:24:30:27 | null |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:31:30:32 | "" |
-| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:20:30:32 | ... ? ... : ... |
-| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:9:30:33 | ... ...; |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:20:30:32 | ... ? ... : ... |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:9:30:33 | ... ...; |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:24:30:27 | null |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:31:23:31:31 | ... == ... |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:30:16:30:32 | String s = ... |
 | Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:9:31:33 | ...; |
@@ -4447,10 +4470,10 @@ postDominance
 | Assert.cs:35:10:35:11 | exit M5 (normal) | Assert.cs:39:9:39:35 | call to method WriteLine |
 | Assert.cs:36:5:40:5 | {...} | Assert.cs:35:10:35:11 | enter M5 |
 | Assert.cs:37:9:37:33 | ... ...; | Assert.cs:36:5:40:5 | {...} |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:24:37:27 | null |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:31:37:32 | "" |
-| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:20:37:32 | ... ? ... : ... |
-| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:9:37:33 | ... ...; |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:20:37:32 | ... ? ... : ... |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:9:37:33 | ... ...; |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:24:37:27 | null |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:38:23:38:31 | ... != ... |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:37:16:37:32 | String s = ... |
 | Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:9:38:33 | ...; |
@@ -4464,10 +4487,10 @@ postDominance
 | Assert.cs:42:10:42:11 | exit M6 (normal) | Assert.cs:46:9:46:35 | call to method WriteLine |
 | Assert.cs:43:5:47:5 | {...} | Assert.cs:42:10:42:11 | enter M6 |
 | Assert.cs:44:9:44:33 | ... ...; | Assert.cs:43:5:47:5 | {...} |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:24:44:27 | null |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:31:44:32 | "" |
-| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:20:44:32 | ... ? ... : ... |
-| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:9:44:33 | ... ...; |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:20:44:32 | ... ? ... : ... |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:9:44:33 | ... ...; |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:24:44:27 | null |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:45:24:45:32 | ... != ... |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:44:16:44:32 | String s = ... |
 | Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:9:45:34 | ...; |
@@ -4481,10 +4504,10 @@ postDominance
 | Assert.cs:49:10:49:11 | exit M7 (normal) | Assert.cs:53:9:53:35 | call to method WriteLine |
 | Assert.cs:50:5:54:5 | {...} | Assert.cs:49:10:49:11 | enter M7 |
 | Assert.cs:51:9:51:33 | ... ...; | Assert.cs:50:5:54:5 | {...} |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:24:51:27 | null |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:31:51:32 | "" |
-| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:20:51:32 | ... ? ... : ... |
-| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:9:51:33 | ... ...; |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:20:51:32 | ... ? ... : ... |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:9:51:33 | ... ...; |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:24:51:27 | null |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:52:24:52:32 | ... == ... |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:51:16:51:32 | String s = ... |
 | Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:9:52:34 | ...; |
@@ -4498,20 +4521,21 @@ postDominance
 | Assert.cs:56:10:56:11 | exit M8 (normal) | Assert.cs:60:9:60:35 | call to method WriteLine |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:56:10:56:11 | enter M8 |
 | Assert.cs:58:9:58:33 | ... ...; | Assert.cs:57:5:61:5 | {...} |
-| Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
-| Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:58:24:58:27 | [b (line 56): true] null |
-| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:32 | ... ? ... : ... |
-| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:9:58:33 | ... ...; |
+| Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... |
+| Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:9:58:33 | ... ...; |
+| Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
+| Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... | Assert.cs:58:24:58:27 | [b (line 56): true] null |
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:20:58:20 | access to parameter b |
-| Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:23:59:36 | [false] ... && ... |
+| Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:59:23:59:36 | [true] ... && ... |
 | Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... |
 | Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... |
-| Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... |
-| Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... |
+| Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | Assert.cs:59:9:59:38 | [b (line 56): false] ...; |
+| Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:59:9:59:38 | [b (line 56): true] ...; |
 | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:28:59:31 | [b (line 56): false] null |
 | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:28:59:31 | [b (line 56): true] null |
-| Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | Assert.cs:59:9:59:38 | [b (line 56): false] ...; |
-| Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | Assert.cs:59:9:59:38 | [b (line 56): true] ...; |
+| Assert.cs:59:23:59:36 | [true] ... && ... | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
 | Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s |
 | Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... |
@@ -4523,20 +4547,21 @@ postDominance
 | Assert.cs:63:10:63:11 | exit M9 (normal) | Assert.cs:67:9:67:35 | call to method WriteLine |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:63:10:63:11 | enter M9 |
 | Assert.cs:65:9:65:33 | ... ...; | Assert.cs:64:5:68:5 | {...} |
-| Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
-| Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:65:24:65:27 | [b (line 63): true] null |
-| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... |
-| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:9:65:33 | ... ...; |
+| Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... |
+| Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:9:65:33 | ... ...; |
+| Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
+| Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... | Assert.cs:65:24:65:27 | [b (line 63): true] null |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:20:65:20 | access to parameter b |
-| Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:24:66:37 | [true] ... \|\| ... |
+| Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:66:24:66:37 | [false] ... \|\| ... |
 | Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... |
 | Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... |
-| Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... |
-| Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... |
+| Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | Assert.cs:66:9:66:39 | [b (line 63): false] ...; |
+| Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:66:9:66:39 | [b (line 63): true] ...; |
 | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:29:66:32 | [b (line 63): false] null |
 | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:29:66:32 | [b (line 63): true] null |
-| Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | Assert.cs:66:9:66:39 | [b (line 63): false] ...; |
-| Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | Assert.cs:66:9:66:39 | [b (line 63): true] ...; |
+| Assert.cs:66:24:66:37 | [false] ... \|\| ... | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
 | Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s |
 | Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... |
@@ -4548,20 +4573,21 @@ postDominance
 | Assert.cs:70:10:70:12 | exit M10 (normal) | Assert.cs:74:9:74:35 | call to method WriteLine |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:70:10:70:12 | enter M10 |
 | Assert.cs:72:9:72:33 | ... ...; | Assert.cs:71:5:75:5 | {...} |
-| Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
-| Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:72:24:72:27 | [b (line 70): true] null |
-| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... |
-| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:9:72:33 | ... ...; |
+| Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... |
+| Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:9:72:33 | ... ...; |
+| Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
+| Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... | Assert.cs:72:24:72:27 | [b (line 70): true] null |
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:20:72:20 | access to parameter b |
-| Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:23:73:36 | [false] ... && ... |
+| Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:73:23:73:36 | [true] ... && ... |
 | Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... |
 | Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... |
-| Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... |
-| Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... |
+| Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | Assert.cs:73:9:73:38 | [b (line 70): false] ...; |
+| Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:73:9:73:38 | [b (line 70): true] ...; |
 | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:28:73:31 | [b (line 70): false] null |
 | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:28:73:31 | [b (line 70): true] null |
-| Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | Assert.cs:73:9:73:38 | [b (line 70): false] ...; |
-| Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | Assert.cs:73:9:73:38 | [b (line 70): true] ...; |
+| Assert.cs:73:23:73:36 | [true] ... && ... | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
 | Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s |
 | Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... |
@@ -4573,20 +4599,21 @@ postDominance
 | Assert.cs:77:10:77:12 | exit M11 (normal) | Assert.cs:81:9:81:35 | call to method WriteLine |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:77:10:77:12 | enter M11 |
 | Assert.cs:79:9:79:33 | ... ...; | Assert.cs:78:5:82:5 | {...} |
-| Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
-| Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:79:24:79:27 | [b (line 77): true] null |
-| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... |
-| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:9:79:33 | ... ...; |
+| Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... |
+| Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:9:79:33 | ... ...; |
+| Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
+| Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... | Assert.cs:79:24:79:27 | [b (line 77): true] null |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:20:79:20 | access to parameter b |
-| Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:24:80:37 | [true] ... \|\| ... |
+| Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:80:24:80:37 | [false] ... \|\| ... |
 | Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... |
 | Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... |
-| Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... |
-| Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... |
+| Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | Assert.cs:80:9:80:39 | [b (line 77): false] ...; |
+| Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:80:9:80:39 | [b (line 77): true] ...; |
 | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:29:80:32 | [b (line 77): false] null |
 | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:29:80:32 | [b (line 77): true] null |
-| Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | Assert.cs:80:9:80:39 | [b (line 77): false] ...; |
-| Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | Assert.cs:80:9:80:39 | [b (line 77): true] ...; |
+| Assert.cs:80:24:80:37 | [false] ... \|\| ... | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
 | Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s |
 | Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... |
@@ -4597,10 +4624,11 @@ postDominance
 | Assert.cs:84:10:84:12 | exit M12 (normal) | Assert.cs:128:9:128:35 | call to method WriteLine |
 | Assert.cs:85:5:129:5 | {...} | Assert.cs:84:10:84:12 | enter M12 |
 | Assert.cs:86:9:86:33 | ... ...; | Assert.cs:85:5:129:5 | {...} |
-| Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
-| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:20:86:32 | ... ? ... : ... |
-| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:9:86:33 | ... ...; |
+| Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:9:86:33 | ... ...; |
+| Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:20:86:20 | access to parameter b |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... |
 | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... |
@@ -4619,14 +4647,14 @@ postDominance
 | Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | Assert.cs:88:9:88:36 | [b (line 84): true] ...; |
 | Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | Assert.cs:90:24:90:25 | [b (line 84): false] "" |
-| Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | Assert.cs:90:17:90:20 | [b (line 84): true] null |
+| Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:9:90:26 | [b (line 84): false] ...; |
-| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:9:90:26 | [b (line 84): true] ...; |
+| Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:9:90:26 | [b (line 84): false] ...; |
+| Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:9:90:26 | [b (line 84): true] ...; |
+| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:24:90:25 | [b (line 84): false] "" |
+| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:17:90:20 | [b (line 84): true] null |
 | Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s |
@@ -4642,14 +4670,14 @@ postDominance
 | Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | Assert.cs:92:9:92:36 | [b (line 84): true] ...; |
 | Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | Assert.cs:94:24:94:25 | [b (line 84): false] "" |
-| Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | Assert.cs:94:17:94:20 | [b (line 84): true] null |
+| Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:9:94:26 | [b (line 84): false] ...; |
-| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:9:94:26 | [b (line 84): true] ...; |
+| Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:9:94:26 | [b (line 84): false] ...; |
+| Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:9:94:26 | [b (line 84): true] ...; |
+| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:24:94:25 | [b (line 84): false] "" |
+| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:17:94:20 | [b (line 84): true] null |
 | Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s |
@@ -4665,14 +4693,14 @@ postDominance
 | Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | Assert.cs:96:9:96:36 | [b (line 84): true] ...; |
 | Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | Assert.cs:98:24:98:25 | [b (line 84): false] "" |
-| Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | Assert.cs:98:17:98:20 | [b (line 84): true] null |
+| Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:9:98:26 | [b (line 84): false] ...; |
-| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:9:98:26 | [b (line 84): true] ...; |
+| Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:9:98:26 | [b (line 84): false] ...; |
+| Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:9:98:26 | [b (line 84): true] ...; |
+| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:24:98:25 | [b (line 84): false] "" |
+| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:17:98:20 | [b (line 84): true] null |
 | Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... |
@@ -4692,14 +4720,14 @@ postDominance
 | Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | Assert.cs:100:9:100:36 | [b (line 84): true] ...; |
 | Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | Assert.cs:102:24:102:25 | [b (line 84): false] "" |
-| Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | Assert.cs:102:17:102:20 | [b (line 84): true] null |
+| Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:9:102:26 | [b (line 84): false] ...; |
-| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:9:102:26 | [b (line 84): true] ...; |
+| Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:9:102:26 | [b (line 84): false] ...; |
+| Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:9:102:26 | [b (line 84): true] ...; |
+| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:24:102:25 | [b (line 84): false] "" |
+| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:17:102:20 | [b (line 84): true] null |
 | Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... |
@@ -4719,14 +4747,14 @@ postDominance
 | Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | Assert.cs:104:9:104:36 | [b (line 84): true] ...; |
 | Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | Assert.cs:106:24:106:25 | [b (line 84): false] "" |
-| Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | Assert.cs:106:17:106:20 | [b (line 84): true] null |
+| Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:9:106:26 | [b (line 84): false] ...; |
-| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:9:106:26 | [b (line 84): true] ...; |
+| Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:9:106:26 | [b (line 84): false] ...; |
+| Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:9:106:26 | [b (line 84): true] ...; |
+| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:24:106:25 | [b (line 84): false] "" |
+| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:17:106:20 | [b (line 84): true] null |
 | Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... |
@@ -4746,14 +4774,14 @@ postDominance
 | Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | Assert.cs:108:9:108:36 | [b (line 84): true] ...; |
 | Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | Assert.cs:110:24:110:25 | [b (line 84): false] "" |
-| Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | Assert.cs:110:17:110:20 | [b (line 84): true] null |
+| Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:9:110:26 | [b (line 84): false] ...; |
-| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:9:110:26 | [b (line 84): true] ...; |
+| Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:9:110:26 | [b (line 84): false] ...; |
+| Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:9:110:26 | [b (line 84): true] ...; |
+| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:24:110:25 | [b (line 84): false] "" |
+| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:17:110:20 | [b (line 84): true] null |
 | Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... |
@@ -4773,25 +4801,26 @@ postDominance
 | Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | Assert.cs:112:9:112:36 | [b (line 84): true] ...; |
 | Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | Assert.cs:114:24:114:25 | [b (line 84): false] "" |
-| Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | Assert.cs:114:17:114:20 | [b (line 84): true] null |
+| Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... |
-| Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:9:114:26 | [b (line 84): false] ...; |
-| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:9:114:26 | [b (line 84): true] ...; |
+| Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:9:114:26 | [b (line 84): false] ...; |
+| Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:9:114:26 | [b (line 84): true] ...; |
+| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:24:114:25 | [b (line 84): false] "" |
+| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:17:114:20 | [b (line 84): true] null |
 | Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
+| Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... |
 | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... |
 | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... |
-| Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... |
-| Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... |
+| Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:9:115:38 | [b (line 84): false] ...; |
+| Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:9:115:38 | [b (line 84): true] ...; |
 | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:28:115:31 | [b (line 84): false] null |
 | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:28:115:31 | [b (line 84): true] null |
-| Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | Assert.cs:115:9:115:38 | [b (line 84): false] ...; |
-| Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:115:9:115:38 | [b (line 84): true] ...; |
+| Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
 | Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s |
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... |
@@ -4799,52 +4828,55 @@ postDominance
 | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:9:116:36 | [b (line 84): true] ...; |
 | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:118:17:118:20 | [b (line 84): true] null |
+| Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:9:118:26 | [b (line 84): true] ...; |
+| Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:9:118:26 | [b (line 84): true] ...; |
+| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:17:118:20 | [b (line 84): true] null |
 | Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... |
 | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... |
-| Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... |
+| Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:9:119:40 | [b (line 84): true] ...; |
 | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:29:119:32 | [b (line 84): true] null |
-| Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; |
+| Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | Assert.cs:119:37:119:38 | [false, b (line 84): true] !... |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... |
-| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length |
 | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:9:120:36 | [b (line 84): true] ...; |
 | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:122:17:122:20 | [b (line 84): true] null |
+| Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:9:122:26 | [b (line 84): true] ...; |
+| Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:9:122:26 | [b (line 84): true] ...; |
+| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:17:122:20 | [b (line 84): true] null |
 | Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
+| Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... |
 | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... |
-| Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... |
+| Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:9:123:38 | [b (line 84): true] ...; |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:28:123:31 | [b (line 84): true] null |
-| Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; |
+| Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length |
 | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:9:124:36 | [b (line 84): true] ...; |
 | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | Assert.cs:126:17:126:20 | [b (line 84): true] null |
+| Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... |
 | Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:9:126:26 | [b (line 84): true] ...; |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:9:126:26 | [b (line 84): true] ...; |
+| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:17:126:20 | [b (line 84): true] null |
 | Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:127:24:127:38 | [false] ... \|\| ... |
 | Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... |
-| Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... |
+| Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:127:9:127:40 | [b (line 84): true] ...; |
 | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:29:127:32 | [b (line 84): true] null |
-| Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | Assert.cs:127:9:127:40 | [b (line 84): true] ...; |
+| Assert.cs:127:24:127:38 | [false] ... \|\| ... | Assert.cs:127:37:127:38 | [false] !... |
 | Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... |
-| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:127:37:127:38 | [false] !... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:128:27:128:34 | access to property Length |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:9:128:36 | ...; |
@@ -5039,9 +5071,6 @@ postDominance
 | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:40:32:40:36 | "End" |
 | CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:9:40:11 | End: |
 | CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:40:14:40:38 | ...; |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:30:28:30:32 | ... = ... |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:30:28:30:32 | ... = ... |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:26:3:26 | access to parameter i |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:28:3:38 | call to method ToString |
@@ -5052,15 +5081,16 @@ postDominance
 | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:28:5:34 | access to property Length |
 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | enter M2 |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:49:7:55 | access to property Length |
-| ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
-| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:10:7:11 | enter M3 |
+| ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:10:7:11 | enter M3 |
+| ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... |
 | ConditionalAccess.cs:9:9:9:10 | exit M4 | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:27:9:33 | access to property Length |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:38:9:38 | 0 |
-| ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |
-| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:9:9:10 | enter M4 |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |
+| ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:9:9:10 | enter M4 |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:27:9:33 | access to property Length |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:38:9:38 | 0 |
 | ConditionalAccess.cs:11:9:11:10 | exit M5 | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) |
 | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:14:13:14:21 | return ...; |
 | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:16:13:16:21 | return ...; |
@@ -5098,8 +5128,6 @@ postDominance
 | ConditionalAccess.cs:30:10:30:12 | exit Out | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
 | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:28:30:32 | ... = ... |
 | ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:32:30:32 | 0 |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:32:30:32 | 0 |
-| ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess |
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:10:30:12 | enter Out |
 | ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) |
 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:35:9:35:12 | access to property Prop |
@@ -5119,7 +5147,7 @@ postDominance
 | ConditionalAccess.cs:41:75:41:78 | ", " | ConditionalAccess.cs:41:70:41:71 | access to parameter s1 |
 | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | ConditionalAccess.cs:41:70:41:78 | ... + ... |
 | Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:7:13:7:16 | [false] !... |
 | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:8:13:8:15 | ...-- |
 | Conditions.cs:4:5:9:5 | {...} | Conditions.cs:3:10:3:19 | enter IncrOrDecr |
 | Conditions.cs:5:9:6:16 | if (...) ... | Conditions.cs:4:5:9:5 | {...} |
@@ -5127,13 +5155,13 @@ postDominance
 | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; |
 | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x |
 | Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ |
-| Conditions.cs:7:13:7:16 | [inc (line 3): false] !... | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... |
-| Conditions.cs:7:13:7:16 | [inc (line 3): true] !... | Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... |
-| Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:7:13:7:16 | [inc (line 3): false] !... |
-| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:7:13:7:16 | [inc (line 3): true] !... |
+| Conditions.cs:7:13:7:16 | [false] !... | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc |
+| Conditions.cs:7:13:7:16 | [true] !... | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc |
+| Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... |
+| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... |
 | Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:16 | ...; |
 | Conditions.cs:8:13:8:15 | ...-- | Conditions.cs:8:13:8:13 | access to parameter x |
-| Conditions.cs:8:13:8:16 | ...; | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc |
+| Conditions.cs:8:13:8:16 | ...; | Conditions.cs:7:13:7:16 | [true] !... |
 | Conditions.cs:11:9:11:10 | exit M1 | Conditions.cs:11:9:11:10 | exit M1 (normal) |
 | Conditions.cs:11:9:11:10 | exit M1 (normal) | Conditions.cs:19:9:19:17 | return ...; |
 | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:11:9:11:10 | enter M1 |
@@ -5151,17 +5179,17 @@ postDominance
 | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | Conditions.cs:16:17:16:17 | [b (line 11): true] 0 |
 | Conditions.cs:16:17:16:17 | [b (line 11): false] 0 | Conditions.cs:16:13:16:13 | [b (line 11): false] access to local variable x |
 | Conditions.cs:16:17:16:17 | [b (line 11): true] 0 | Conditions.cs:16:13:16:13 | [b (line 11): true] access to local variable x |
-| Conditions.cs:17:17:17:18 | [b (line 11): false] !... | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... |
-| Conditions.cs:17:17:17:18 | [b (line 11): true] !... | Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... |
-| Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:17:17:17:18 | [b (line 11): false] !... |
-| Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | Conditions.cs:17:17:17:18 | [b (line 11): true] !... |
+| Conditions.cs:17:17:17:18 | [false] !... | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b |
+| Conditions.cs:17:17:17:18 | [true] !... | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b |
+| Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... |
+| Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... |
 | Conditions.cs:18:17:18:17 | access to local variable x | Conditions.cs:18:17:18:20 | ...; |
 | Conditions.cs:18:17:18:19 | ...-- | Conditions.cs:18:17:18:17 | access to local variable x |
-| Conditions.cs:18:17:18:20 | ...; | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b |
+| Conditions.cs:18:17:18:20 | ...; | Conditions.cs:17:17:17:18 | [true] !... |
 | Conditions.cs:19:9:19:17 | return ...; | Conditions.cs:19:16:19:16 | access to local variable x |
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... |
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... |
-| Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b |
+| Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:17:17:17:18 | [false] !... |
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:18:17:18:19 | ...-- |
 | Conditions.cs:22:9:22:10 | exit M2 | Conditions.cs:22:9:22:10 | exit M2 (normal) |
 | Conditions.cs:22:9:22:10 | exit M2 (normal) | Conditions.cs:30:9:30:17 | return ...; |
@@ -5376,19 +5404,19 @@ postDominance
 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:107:24:107:24 | [b (line 102): true] 0 |
 | Conditions.cs:107:24:107:24 | [b (line 102): false] 0 | Conditions.cs:107:13:107:20 | [b (line 102): false] access to property Length |
 | Conditions.cs:107:24:107:24 | [b (line 102): true] 0 | Conditions.cs:107:13:107:20 | [b (line 102): true] access to property Length |
-| Conditions.cs:108:17:108:18 | [b (line 102): false] !... | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... |
-| Conditions.cs:108:17:108:18 | [b (line 102): true] !... | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... |
-| Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:108:17:108:18 | [b (line 102): false] !... |
-| Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:108:17:108:18 | [b (line 102): true] !... |
+| Conditions.cs:108:17:108:18 | [false] !... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b |
+| Conditions.cs:108:17:108:18 | [true] !... | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b |
+| Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... |
+| Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... |
 | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:24 | ...; |
 | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:22:109:23 | "" |
 | Conditions.cs:109:17:109:23 | ... = ... | Conditions.cs:109:17:109:23 | ... + ... |
-| Conditions.cs:109:17:109:24 | ...; | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b |
+| Conditions.cs:109:17:109:24 | ...; | Conditions.cs:108:17:108:18 | [true] !... |
 | Conditions.cs:109:22:109:23 | "" | Conditions.cs:109:17:109:17 | access to local variable x |
 | Conditions.cs:110:9:110:17 | return ...; | Conditions.cs:110:16:110:16 | access to local variable x |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... |
-| Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b |
+| Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:108:17:108:18 | [false] !... |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:109:17:109:23 | ... = ... |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | exit M9 (normal) |
 | Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:116:25:116:39 | ... < ... |
@@ -5416,11 +5444,12 @@ postDominance
 | Conditions.cs:118:29:118:43 | ... - ... | Conditions.cs:118:43:118:43 | 1 |
 | Conditions.cs:118:43:118:43 | 1 | Conditions.cs:118:29:118:39 | access to property Length |
 | Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:118:17:118:43 | Boolean last = ... |
-| Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:13:120:23 | if (...) ... |
-| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | !... |
+| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:13:120:23 | if (...) ... |
 | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | Conditions.cs:120:21:120:22 | [last (line 118): false] "" |
+| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... |
 | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... |
+| Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... |
 | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... |
 | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
 | Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:122:21:122:24 | null |
@@ -5466,10 +5495,11 @@ postDominance
 | Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:149:13:149:48 | call to method WriteLine |
 | Conditions.cs:144:5:150:5 | {...} | Conditions.cs:143:10:143:12 | enter M11 |
 | Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:144:5:150:5 | {...} |
-| Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
-| Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
-| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:17:145:29 | ... ? ... : ... |
-| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:9:145:30 | ... ...; |
+| Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... |
+| Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:9:145:30 | ... ...; |
+| Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
+| Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
 | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... |
 | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... |
 | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... |
@@ -5583,10 +5613,10 @@ postDominance
 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) | ExitMethods.cs:111:41:111:76 | throw ... |
 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) | ExitMethods.cs:111:9:111:77 | return ...; |
 | ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:109:13:109:21 | enter ThrowExpr |
-| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:111:29:111:37 | ... / ... |
-| ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
+| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
+| ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:110:5:112:5 | {...} |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:25:111:25 | (...) ... |
-| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:110:5:112:5 | {...} |
+| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:29:111:37 | ... / ... |
 | ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:16:111:20 | access to parameter input |
 | ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:25:111:25 | 0 |
 | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:16:111:25 | ... != ... |
@@ -5598,11 +5628,11 @@ postDominance
 | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) |
 | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) | ExitMethods.cs:116:9:116:39 | return ...; |
 | ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:34:116:34 | 0 |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:38:116:38 | 1 |
-| ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
+| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
+| ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:115:5:117:5 | {...} |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:27:116:29 | - |
-| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:115:5:117:5 | {...} |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:34:116:34 | 0 |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:38:116:38 | 1 |
 | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:16 | access to parameter s |
 | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) |
 | ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue |
@@ -5870,21 +5900,16 @@ postDominance
 | Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:113:9:118:9 | [finally: exception(OutOfMemoryException)] {...} |
 | Finally.cs:114:13:115:41 | [finally: return] if (...) ... | Finally.cs:113:9:118:9 | [finally: return] {...} |
 | Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:114:17:114:36 | !... | Finally.cs:114:13:115:41 | if (...) ... |
-| Finally.cs:114:17:114:36 | [finally: exception(Exception)] !... | Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... |
-| Finally.cs:114:17:114:36 | [finally: exception(NullReferenceException)] !... | Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... |
-| Finally.cs:114:17:114:36 | [finally: exception(OutOfMemoryException)] !... | Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... |
-| Finally.cs:114:17:114:36 | [finally: return] !... | Finally.cs:114:13:115:41 | [finally: return] if (...) ... |
 | Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access |
-| Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | Finally.cs:114:17:114:36 | [finally: exception(Exception)] !... |
+| Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... |
 | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access |
-| Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access | Finally.cs:114:17:114:36 | [finally: exception(NullReferenceException)] !... |
+| Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access | Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... |
 | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] access to field Field | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access |
-| Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access | Finally.cs:114:17:114:36 | [finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access | Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:114:19:114:23 | [finally: return] access to field Field | Finally.cs:114:19:114:23 | [finally: return] this access |
-| Finally.cs:114:19:114:23 | [finally: return] this access | Finally.cs:114:17:114:36 | [finally: return] !... |
+| Finally.cs:114:19:114:23 | [finally: return] this access | Finally.cs:114:13:115:41 | [finally: return] if (...) ... |
 | Finally.cs:114:19:114:23 | access to field Field | Finally.cs:114:19:114:23 | this access |
-| Finally.cs:114:19:114:23 | this access | Finally.cs:114:17:114:36 | !... |
+| Finally.cs:114:19:114:23 | this access | Finally.cs:114:13:115:41 | if (...) ... |
 | Finally.cs:114:19:114:30 | [finally: exception(Exception)] access to property Length | Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field |
 | Finally.cs:114:19:114:30 | [finally: exception(NullReferenceException)] access to property Length | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] access to field Field |
 | Finally.cs:114:19:114:30 | [finally: exception(OutOfMemoryException)] access to property Length | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] access to field Field |
@@ -5905,6 +5930,11 @@ postDominance
 | Finally.cs:115:17:115:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:115:35:115:39 | [finally: exception(OutOfMemoryException)] access to field Field |
 | Finally.cs:115:17:115:40 | [finally: return] call to method WriteLine | Finally.cs:115:35:115:39 | [finally: return] access to field Field |
 | Finally.cs:115:17:115:40 | call to method WriteLine | Finally.cs:115:35:115:39 | access to field Field |
+| Finally.cs:115:17:115:41 | ...; | Finally.cs:114:17:114:36 | [true] !... |
+| Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... |
+| Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... |
+| Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:115:17:115:41 | [finally: return] ...; | Finally.cs:114:17:114:36 | [true, finally: return] !... |
 | Finally.cs:115:35:115:39 | [finally: exception(Exception)] access to field Field | Finally.cs:115:35:115:39 | [finally: exception(Exception)] this access |
 | Finally.cs:115:35:115:39 | [finally: exception(Exception)] this access | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
 | Finally.cs:115:35:115:39 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:115:35:115:39 | [finally: exception(NullReferenceException)] this access |
@@ -5915,9 +5945,9 @@ postDominance
 | Finally.cs:115:35:115:39 | [finally: return] this access | Finally.cs:115:17:115:41 | [finally: return] ...; |
 | Finally.cs:115:35:115:39 | access to field Field | Finally.cs:115:35:115:39 | this access |
 | Finally.cs:115:35:115:39 | this access | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:114:19:114:35 | [finally: return] ... == ... |
+| Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:114:17:114:36 | [false, finally: return] !... |
 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:115:17:115:40 | [finally: return] call to method WriteLine |
-| Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:114:19:114:35 | ... == ... |
+| Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:114:17:114:36 | [false] !... |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:115:17:115:40 | call to method WriteLine |
 | Finally.cs:116:17:116:21 | [finally: exception(Exception)] access to field Field | Finally.cs:116:17:116:21 | [finally: exception(Exception)] this access |
 | Finally.cs:116:17:116:21 | [finally: exception(Exception)] this access | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... |
@@ -6213,11 +6243,11 @@ postDominance
 | Foreach.cs:18:10:18:11 | exit M3 | Foreach.cs:18:10:18:11 | exit M3 (normal) |
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
 | Foreach.cs:19:5:22:5 | {...} | Foreach.cs:18:10:18:11 | enter M3 |
-| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:29:20:38 | call to method ToArray |
-| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:43:20:68 | call to method Empty |
+| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:27:20:68 | ... ?? ... |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:21:11:21:11 | ; |
-| Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:27:20:68 | ... ?? ... |
-| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:19:5:22:5 | {...} |
+| Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:19:5:22:5 | {...} |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:29:20:38 | call to method ToArray |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:21:11:21:11 | ; | Foreach.cs:20:22:20:22 | String x |
 | Foreach.cs:24:10:24:11 | exit M4 | Foreach.cs:24:10:24:11 | exit M4 (normal) |
 | Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |
@@ -6590,11 +6620,12 @@ postDominance
 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:67:10:67:11 | enter M8 |
 | LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:68:5:74:5 | {...} |
-| LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:9:70:19 | if (...) ... |
-| LoopUnrolling.cs:69:14:69:17 | access to parameter args | LoopUnrolling.cs:69:13:69:23 | !... |
+| LoopUnrolling.cs:69:14:69:17 | access to parameter args | LoopUnrolling.cs:69:9:70:19 | if (...) ... |
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:14:69:17 | access to parameter args |
+| LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:69:13:69:23 | [true] !... |
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:71:9:71:12 | access to parameter args |
+| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:69:13:69:23 | [false] !... |
 | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | LoopUnrolling.cs:72:29:72:32 | access to parameter args |
 | LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear |
 | LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) |
@@ -6777,57 +6808,59 @@ postDominance
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | enter M1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | enter M1 |
 | NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
-| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:23:3:23 | access to parameter i |
-| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:28:3:28 | 0 |
-| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
-| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:9:3:10 | enter M1 |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
+| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:9:3:10 | enter M1 |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:23 | access to parameter i |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:28:3:28 | 0 |
 | NullCoalescing.cs:5:9:5:10 | exit M2 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:39:5:39 | 0 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:43:5:43 | 1 |
-| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | enter M2 |
-| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | ... ?? ... |
-| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |
-| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:30:5:34 | false |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:39:5:39 | 0 |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:43:5:43 | 1 |
+| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:9:5:10 | enter M2 |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:30:5:34 | false |
+| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... |
+| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... |
 | NullCoalescing.cs:7:12:7:13 | exit M3 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:52:7:53 | "" |
-| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
-| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | enter M3 |
-| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:12:7:13 | enter M3 |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
+| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:9:12:9:13 | exit M4 | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:41:9:41 | access to parameter s |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:45:9:45 | access to parameter s |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:51:9:52 | "" |
-| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | enter M4 |
-| NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... |
-| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... |
-| NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:36:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:12:9:13 | enter M4 |
+| NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... |
+| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:52 | "" |
 | NullCoalescing.cs:11:9:11:10 | exit M5 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:64:11:64 | 0 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:68:11:68 | 1 |
-| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | enter M5 |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | ... ?? ... |
-| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
-| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:58 | ... && ... |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:64:11:64 | 0 |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:68:11:68 | 1 |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:9:11:10 | enter M5 |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:51:11:58 | [false] ... && ... |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:51:11:58 | [true] ... && ... |
+| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... |
+| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... |
 | NullCoalescing.cs:13:10:13:11 | exit M6 | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) |
 | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | NullCoalescing.cs:17:9:17:24 | ... = ... |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:13:10:13:11 | enter M6 |
 | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:14:5:18:5 | {...} |
-| NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:15:31:15:31 | 0 |
+| NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
 | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:23:15:26 | null |
-| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:9:15:32 | ... ...; |
-| NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
+| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:31:15:31 | 0 |
+| NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:9:15:32 | ... ...; |
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:17:15:26 | (...) ... |
 | NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:15:13:15:31 | Int32 j = ... |
-| NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:16:17:16:18 | "" |
-| NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
-| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:9:16:26 | ... ...; |
-| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:17:13:17:19 | (...) ... |
+| NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
+| NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:9:16:26 | ... ...; |
+| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" |
+| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:16:13:16:25 | String s = ... |
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
-| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:9:17:25 | ...; |
-| NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
+| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:13:17:19 | (...) ... |
+| NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:9:17:25 | ...; |
 | Patterns.cs:5:10:5:13 | exit Test | Patterns.cs:5:10:5:13 | exit Test (normal) |
 | Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:40:17:40:17 | access to local variable o |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:5:10:5:13 | enter Test |
@@ -7009,15 +7042,16 @@ postDominance
 | Switch.cs:21:26:21:29 | null | Switch.cs:21:21:21:21 | access to parameter o |
 | Switch.cs:23:17:23:28 | goto case ...; | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:24:18:24:25 | String s | Switch.cs:24:13:24:56 | case ...: |
-| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:55 | ... && ... |
 | Switch.cs:24:32:24:39 | access to property Length | Switch.cs:24:32:24:32 | access to local variable s |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:43:24:43 | 0 |
 | Switch.cs:24:43:24:43 | 0 | Switch.cs:24:32:24:39 | access to property Length |
 | Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:53:24:55 | "a" |
 | Switch.cs:24:53:24:55 | "a" | Switch.cs:24:48:24:48 | access to local variable s |
 | Switch.cs:25:17:25:36 | call to method WriteLine | Switch.cs:25:35:25:35 | access to local variable s |
+| Switch.cs:25:17:25:37 | ...; | Switch.cs:24:32:24:55 | [true] ... && ... |
 | Switch.cs:25:35:25:35 | access to local variable s | Switch.cs:25:17:25:37 | ...; |
 | Switch.cs:26:17:26:23 | return ...; | Switch.cs:25:17:25:36 | call to method WriteLine |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:24:32:24:55 | [false] ... && ... |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:28:13:28:17 | Label: | Switch.cs:31:17:31:27 | goto ...; |
 | Switch.cs:29:17:29:23 | return ...; | Switch.cs:28:13:28:17 | Label: |
@@ -7131,29 +7165,31 @@ postDominance
 | Switch.cs:120:9:120:18 | return ...; | Switch.cs:120:16:120:17 | -... |
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | exit M11 (normal) |
-| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:34:125:34 | access to local variable b |
-| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:42:125:46 | false |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:13:125:48 | [false] ... switch { ... } |
 | Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:126:13:126:19 | return ...; |
 | Switch.cs:124:5:127:5 | {...} | Switch.cs:123:10:123:12 | enter M11 |
 | Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:124:5:127:5 | {...} |
-| Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:13:125:48 | ... switch { ... } |
-| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:9:126:19 | if (...) ... |
-| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:24:125:34 | ... => ... |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:13:125:13 | access to parameter o |
-| Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:46 | ... => ... |
+| Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:9:126:19 | if (...) ... |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:125:24:125:34 | [false] ... => ... |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:125:37:125:46 | [false] ... => ... |
+| Switch.cs:125:13:125:48 | [true] ... switch { ... } | Switch.cs:125:24:125:34 | [true] ... => ... |
+| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:13:125:13 | access to parameter o |
+| Switch.cs:125:37:125:46 | [false] ... => ... | Switch.cs:125:42:125:46 | false |
 | Switch.cs:125:42:125:46 | false | Switch.cs:125:37:125:37 | _ |
+| Switch.cs:126:13:126:19 | return ...; | Switch.cs:125:13:125:48 | [true] ... switch { ... } |
 | Switch.cs:129:12:129:14 | exit M12 | Switch.cs:129:12:129:14 | exit M12 (normal) |
 | Switch.cs:129:12:129:14 | exit M12 (normal) | Switch.cs:131:9:131:67 | return ...; |
 | Switch.cs:130:5:132:5 | {...} | Switch.cs:129:12:129:14 | enter M12 |
-| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:40:131:40 | access to local variable s |
-| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:48:131:51 | null |
+| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:17:131:53 | [null] ... switch { ... } |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:56:131:66 | call to method ToString |
-| Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:17:131:53 | ... switch { ... } |
-| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:130:5:132:5 | {...} |
-| Switch.cs:131:28:131:35 | String s | Switch.cs:131:28:131:40 | ... => ... |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:17:131:17 | access to parameter o |
-| Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:51 | ... => ... |
+| Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:130:5:132:5 | {...} |
+| Switch.cs:131:17:131:53 | [non-null] ... switch { ... } | Switch.cs:131:28:131:40 | [non-null] ... => ... |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:131:28:131:40 | [null] ... => ... |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:131:43:131:51 | [null] ... => ... |
+| Switch.cs:131:28:131:35 | String s | Switch.cs:131:17:131:17 | access to parameter o |
+| Switch.cs:131:43:131:51 | [null] ... => ... | Switch.cs:131:48:131:51 | null |
 | Switch.cs:131:48:131:51 | null | Switch.cs:131:43:131:43 | _ |
+| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:17:131:53 | [non-null] ... switch { ... } |
 | Switch.cs:134:9:134:11 | exit M13 | Switch.cs:134:9:134:11 | exit M13 (normal) |
 | Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:138:22:138:31 | return ...; |
 | Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:139:21:139:29 | return ...; |
@@ -7188,13 +7224,13 @@ postDominance
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:160:13:160:48 | call to method WriteLine |
 | Switch.cs:155:5:161:5 | {...} | Switch.cs:154:10:154:12 | enter M15 |
 | Switch.cs:156:9:156:55 | ... ...; | Switch.cs:155:5:161:5 | {...} |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:36:156:38 | "a" |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:50:156:52 | "b" |
-| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:17:156:54 | ... switch { ... } |
-| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:9:156:55 | ... ...; |
-| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:38 | ... => ... |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:17:156:17 | access to parameter b |
-| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:17:156:54 | ... switch { ... } |
+| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:9:156:55 | ... ...; |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:28:156:38 | ... => ... |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:17:156:17 | access to parameter b |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:45 | false |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:156:13:156:54 | String s = ... |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:157:9:160:49 | if (...) ... |
@@ -7266,10 +7302,10 @@ postDominance
 | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:9:25:29 | using (...) {...} |
 | VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:24:35:24:41 | object creation of type C |
 | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:24:25:24 | access to local variable x |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:28:25:28 | access to local variable y |
-| VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
-| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:24:31:24:41 | C y = ... |
+| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
+| VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:24:31:24:41 | C y = ... |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:24:25:24 | access to local variable x |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:28:25:28 | access to local variable y |
 | VarDecls.cs:28:41:28:47 | exit Dispose | VarDecls.cs:28:41:28:47 | exit Dispose (normal) |
 | VarDecls.cs:28:41:28:47 | exit Dispose (normal) | VarDecls.cs:28:51:28:53 | {...} |
 | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | enter Dispose |
@@ -7326,10 +7362,9 @@ postDominance
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:33:17:33:36 | call to method WriteLine |
 | cflow.cs:24:34:24:36 | ...++ | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:26:13:33:37 | if (...) ... | cflow.cs:25:9:34:9 | {...} |
-| cflow.cs:26:17:26:17 | access to local variable i | cflow.cs:26:17:26:40 | ... && ... |
+| cflow.cs:26:17:26:17 | access to local variable i | cflow.cs:26:13:33:37 | if (...) ... |
 | cflow.cs:26:17:26:21 | ... % ... | cflow.cs:26:21:26:21 | 3 |
 | cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:26:26:26 | 0 |
-| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:26:13:33:37 | if (...) ... |
 | cflow.cs:26:21:26:21 | 3 | cflow.cs:26:17:26:17 | access to local variable i |
 | cflow.cs:26:26:26:26 | 0 | cflow.cs:26:17:26:21 | ... % ... |
 | cflow.cs:26:31:26:35 | ... % ... | cflow.cs:26:35:26:35 | 5 |
@@ -7337,7 +7372,9 @@ postDominance
 | cflow.cs:26:35:26:35 | 5 | cflow.cs:26:31:26:31 | access to local variable i |
 | cflow.cs:26:40:26:40 | 0 | cflow.cs:26:31:26:35 | ... % ... |
 | cflow.cs:27:17:27:45 | call to method WriteLine | cflow.cs:27:35:27:44 | "FizzBuzz" |
+| cflow.cs:27:17:27:46 | ...; | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:27:35:27:44 | "FizzBuzz" | cflow.cs:27:17:27:46 | ...; |
+| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:26:17:26:40 | [false] ... && ... |
 | cflow.cs:28:22:28:22 | access to local variable i | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:28:22:28:26 | ... % ... | cflow.cs:28:26:28:26 | 3 |
 | cflow.cs:28:22:28:31 | ... == ... | cflow.cs:28:31:28:31 | 0 |
@@ -7397,13 +7434,14 @@ postDominance
 | cflow.cs:60:27:60:31 | this access | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:62:13:62:19 | case ...: | cflow.cs:60:17:60:32 | call to method Parse |
 | cflow.cs:62:18:62:18 | 0 | cflow.cs:62:13:62:19 | case ...: |
-| cflow.cs:63:21:63:34 | !... | cflow.cs:63:17:64:55 | if (...) ... |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:63:23:63:33 | ... == ... |
 | cflow.cs:63:23:63:27 | access to field Field | cflow.cs:63:23:63:27 | this access |
-| cflow.cs:63:23:63:27 | this access | cflow.cs:63:21:63:34 | !... |
+| cflow.cs:63:23:63:27 | this access | cflow.cs:63:17:64:55 | if (...) ... |
 | cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:32:63:33 | "" |
 | cflow.cs:63:32:63:33 | "" | cflow.cs:63:23:63:27 | access to field Field |
 | cflow.cs:64:21:64:55 | throw ...; | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:65:17:65:22 | break; | cflow.cs:63:23:63:33 | ... == ... |
+| cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:63:21:63:34 | [true] !... |
+| cflow.cs:65:17:65:22 | break; | cflow.cs:63:21:63:34 | [false] !... |
 | cflow.cs:67:9:67:17 | return ...; | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:62:18:62:18 | 0 |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:65:17:65:22 | break; |
@@ -7427,19 +7465,18 @@ postDominance
 | cflow.cs:80:13:80:48 | ...; | cflow.cs:79:9:81:9 | {...} |
 | cflow.cs:80:31:80:46 | "<empty string>" | cflow.cs:80:13:80:48 | ...; |
 | cflow.cs:84:18:84:19 | exit M2 | cflow.cs:84:18:84:19 | exit M2 (normal) |
-| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:86:13:86:21 | ... != ... |
-| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:86:26:86:37 | ... > ... |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:86:13:86:37 | [false] ... && ... |
 | cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:87:13:87:32 | call to method WriteLine |
 | cflow.cs:85:5:88:5 | {...} | cflow.cs:84:18:84:19 | enter M2 |
 | cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:85:5:88:5 | {...} |
-| cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:13:86:37 | ... && ... |
+| cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:9:87:33 | if (...) ... |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:18:86:21 | null |
-| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:9:87:33 | if (...) ... |
 | cflow.cs:86:18:86:21 | null | cflow.cs:86:13:86:13 | access to parameter s |
 | cflow.cs:86:26:86:33 | access to property Length | cflow.cs:86:26:86:26 | access to parameter s |
 | cflow.cs:86:26:86:37 | ... > ... | cflow.cs:86:37:86:37 | 0 |
 | cflow.cs:86:37:86:37 | 0 | cflow.cs:86:26:86:33 | access to property Length |
 | cflow.cs:87:13:87:32 | call to method WriteLine | cflow.cs:87:31:87:31 | access to parameter s |
+| cflow.cs:87:13:87:33 | ...; | cflow.cs:86:13:86:37 | [true] ... && ... |
 | cflow.cs:87:31:87:31 | access to parameter s | cflow.cs:87:13:87:33 | ...; |
 | cflow.cs:90:18:90:19 | exit M3 (abnormal) | cflow.cs:93:13:93:49 | throw ...; |
 | cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:102:13:102:29 | ... != ... |
@@ -7511,12 +7548,12 @@ postDominance
 | cflow.cs:127:19:127:21 | exit get_Prop | cflow.cs:127:19:127:21 | exit get_Prop (normal) |
 | cflow.cs:127:19:127:21 | exit get_Prop (normal) | cflow.cs:127:25:127:58 | return ...; |
 | cflow.cs:127:23:127:60 | {...} | cflow.cs:127:19:127:21 | enter get_Prop |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:48:127:49 | "" |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:53:127:57 | access to field Field |
+| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:32:127:57 | ... ? ... : ... |
 | cflow.cs:127:32:127:36 | access to field Field | cflow.cs:127:32:127:36 | this access |
-| cflow.cs:127:32:127:36 | this access | cflow.cs:127:32:127:57 | ... ? ... : ... |
+| cflow.cs:127:32:127:36 | this access | cflow.cs:127:23:127:60 | {...} |
 | cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:41:127:44 | null |
-| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:23:127:60 | {...} |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:48:127:49 | "" |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:53:127:57 | access to field Field |
 | cflow.cs:127:41:127:44 | null | cflow.cs:127:32:127:36 | access to field Field |
 | cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:53:127:57 | this access |
 | cflow.cs:127:62:127:64 | exit set_Prop | cflow.cs:127:62:127:64 | exit set_Prop (normal) |
@@ -7663,73 +7700,78 @@ postDominance
 | cflow.cs:185:10:185:18 | exit LogicalOr (normal) | cflow.cs:190:13:190:51 | call to method WriteLine |
 | cflow.cs:186:5:191:5 | {...} | cflow.cs:185:10:185:18 | enter LogicalOr |
 | cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:186:5:191:5 | {...} |
-| cflow.cs:187:13:187:13 | 1 | cflow.cs:187:13:187:28 | ... \|\| ... |
+| cflow.cs:187:13:187:13 | 1 | cflow.cs:187:9:190:52 | if (...) ... |
 | cflow.cs:187:13:187:18 | ... == ... | cflow.cs:187:18:187:18 | 2 |
-| cflow.cs:187:13:187:28 | ... \|\| ... | cflow.cs:187:13:187:50 | ... \|\| ... |
-| cflow.cs:187:13:187:50 | ... \|\| ... | cflow.cs:187:9:190:52 | if (...) ... |
+| cflow.cs:187:13:187:28 | [false] ... \|\| ... | cflow.cs:187:23:187:28 | ... == ... |
+| cflow.cs:187:13:187:50 | [false] ... \|\| ... | cflow.cs:187:34:187:49 | [false] ... && ... |
 | cflow.cs:187:18:187:18 | 2 | cflow.cs:187:13:187:13 | 1 |
 | cflow.cs:187:23:187:23 | 2 | cflow.cs:187:13:187:18 | ... == ... |
 | cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:28:187:28 | 3 |
 | cflow.cs:187:28:187:28 | 3 | cflow.cs:187:23:187:23 | 2 |
-| cflow.cs:187:34:187:34 | 1 | cflow.cs:187:34:187:49 | ... && ... |
+| cflow.cs:187:34:187:34 | 1 | cflow.cs:187:13:187:28 | [false] ... \|\| ... |
 | cflow.cs:187:34:187:39 | ... == ... | cflow.cs:187:39:187:39 | 3 |
-| cflow.cs:187:34:187:49 | ... && ... | cflow.cs:187:23:187:28 | ... == ... |
+| cflow.cs:187:34:187:49 | [false] ... && ... | cflow.cs:187:34:187:39 | ... == ... |
 | cflow.cs:187:39:187:39 | 3 | cflow.cs:187:34:187:34 | 1 |
 | cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:190:31:190:50 | "This should happen" |
-| cflow.cs:190:13:190:52 | ...; | cflow.cs:187:34:187:39 | ... == ... |
+| cflow.cs:190:13:190:52 | ...; | cflow.cs:187:13:187:50 | [false] ... \|\| ... |
 | cflow.cs:190:31:190:50 | "This should happen" | cflow.cs:190:13:190:52 | ...; |
 | cflow.cs:193:10:193:17 | exit Booleans (abnormal) | cflow.cs:203:17:203:38 | throw ...; |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:40:200:56 | ... == ... |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:61:200:61 | access to local variable b |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:13:200:62 | [false] ... \|\| ... |
 | cflow.cs:194:5:206:5 | {...} | cflow.cs:193:10:193:17 | enter Booleans |
 | cflow.cs:195:9:195:57 | ... ...; | cflow.cs:194:5:206:5 | {...} |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:17:195:32 | ... > ... |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:39:195:55 | ... == ... |
+| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:17:195:56 | ... && ... |
 | cflow.cs:195:17:195:21 | access to field Field | cflow.cs:195:17:195:21 | this access |
-| cflow.cs:195:17:195:21 | this access | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:195:17:195:21 | this access | cflow.cs:195:9:195:57 | ... ...; |
 | cflow.cs:195:17:195:28 | access to property Length | cflow.cs:195:17:195:21 | access to field Field |
 | cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:32:195:32 | 0 |
-| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:9:195:57 | ... ...; |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:17:195:32 | ... > ... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:37:195:56 | !... |
 | cflow.cs:195:32:195:32 | 0 | cflow.cs:195:17:195:28 | access to property Length |
+| cflow.cs:195:37:195:56 | !... | cflow.cs:195:39:195:55 | ... == ... |
 | cflow.cs:195:39:195:43 | access to field Field | cflow.cs:195:39:195:43 | this access |
-| cflow.cs:195:39:195:43 | this access | cflow.cs:195:37:195:56 | !... |
 | cflow.cs:195:39:195:50 | access to property Length | cflow.cs:195:39:195:43 | access to field Field |
 | cflow.cs:195:39:195:55 | ... == ... | cflow.cs:195:55:195:55 | 1 |
 | cflow.cs:195:55:195:55 | 1 | cflow.cs:195:39:195:50 | access to property Length |
 | cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:195:13:195:56 | Boolean b = ... |
-| cflow.cs:197:13:197:47 | !... | cflow.cs:197:9:198:49 | if (...) ... |
+| cflow.cs:197:13:197:47 | [false] !... | cflow.cs:197:15:197:46 | [true] ... ? ... : ... |
+| cflow.cs:197:13:197:47 | [true] !... | cflow.cs:197:15:197:46 | [false] ... ? ... : ... |
 | cflow.cs:197:15:197:19 | access to field Field | cflow.cs:197:15:197:19 | this access |
-| cflow.cs:197:15:197:19 | this access | cflow.cs:197:15:197:46 | ... ? ... : ... |
+| cflow.cs:197:15:197:19 | this access | cflow.cs:197:9:198:49 | if (...) ... |
 | cflow.cs:197:15:197:26 | access to property Length | cflow.cs:197:15:197:19 | access to field Field |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:31:197:31 | 0 |
-| cflow.cs:197:15:197:46 | ... ? ... : ... | cflow.cs:197:13:197:47 | !... |
+| cflow.cs:197:15:197:46 | [false] ... ? ... : ... | cflow.cs:197:35:197:39 | false |
+| cflow.cs:197:15:197:46 | [true] ... ? ... : ... | cflow.cs:197:43:197:46 | true |
 | cflow.cs:197:31:197:31 | 0 | cflow.cs:197:15:197:26 | access to property Length |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:198:37:198:41 | false |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:198:45:198:48 | true |
-| cflow.cs:198:13:198:49 | ...; | cflow.cs:197:35:197:39 | false |
+| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:198:17:198:48 | ... ? ... : ... |
+| cflow.cs:198:13:198:49 | ...; | cflow.cs:197:13:197:47 | [true] !... |
 | cflow.cs:198:17:198:21 | access to field Field | cflow.cs:198:17:198:21 | this access |
-| cflow.cs:198:17:198:21 | this access | cflow.cs:198:17:198:48 | ... ? ... : ... |
+| cflow.cs:198:17:198:21 | this access | cflow.cs:198:13:198:49 | ...; |
 | cflow.cs:198:17:198:28 | access to property Length | cflow.cs:198:17:198:21 | access to field Field |
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:33:198:33 | 0 |
-| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:13:198:49 | ...; |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:37:198:41 | false |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:45:198:48 | true |
 | cflow.cs:198:33:198:33 | 0 | cflow.cs:198:17:198:28 | access to property Length |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:197:43:197:46 | true |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:197:13:197:47 | [false] !... |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:198:13:198:48 | ... = ... |
-| cflow.cs:200:13:200:32 | !... | cflow.cs:200:13:200:62 | ... \|\| ... |
-| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:9:205:9 | if (...) ... |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:15:200:31 | ... == ... |
+| cflow.cs:200:13:200:62 | [false] ... \|\| ... | cflow.cs:200:37:200:62 | [false] !... |
 | cflow.cs:200:15:200:19 | access to field Field | cflow.cs:200:15:200:19 | this access |
-| cflow.cs:200:15:200:19 | this access | cflow.cs:200:13:200:32 | !... |
+| cflow.cs:200:15:200:19 | this access | cflow.cs:200:9:205:9 | if (...) ... |
 | cflow.cs:200:15:200:26 | access to property Length | cflow.cs:200:15:200:19 | access to field Field |
 | cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:31:200:31 | 0 |
 | cflow.cs:200:31:200:31 | 0 | cflow.cs:200:15:200:26 | access to property Length |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:15:200:31 | ... == ... |
-| cflow.cs:200:38:200:62 | !... | cflow.cs:200:37:200:62 | !... |
+| cflow.cs:200:37:200:62 | [false] !... | cflow.cs:200:38:200:62 | [true] !... |
+| cflow.cs:200:37:200:62 | [true] !... | cflow.cs:200:38:200:62 | [false] !... |
+| cflow.cs:200:38:200:62 | [false] !... | cflow.cs:200:40:200:61 | [true] ... && ... |
+| cflow.cs:200:38:200:62 | [true] !... | cflow.cs:200:40:200:61 | [false] ... && ... |
 | cflow.cs:200:40:200:44 | access to field Field | cflow.cs:200:40:200:44 | this access |
-| cflow.cs:200:40:200:44 | this access | cflow.cs:200:40:200:61 | ... && ... |
+| cflow.cs:200:40:200:44 | this access | cflow.cs:200:13:200:32 | [false] !... |
 | cflow.cs:200:40:200:51 | access to property Length | cflow.cs:200:40:200:44 | access to field Field |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:56:200:56 | 1 |
-| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:38:200:62 | !... |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:40:200:56 | ... == ... |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:61:200:61 | access to local variable b |
 | cflow.cs:200:56:200:56 | 1 | cflow.cs:200:40:200:51 | access to property Length |
+| cflow.cs:201:9:205:9 | {...} | cflow.cs:200:13:200:62 | [true] ... \|\| ... |
 | cflow.cs:202:13:204:13 | {...} | cflow.cs:201:9:205:9 | {...} |
 | cflow.cs:203:17:203:38 | throw ...; | cflow.cs:203:23:203:37 | object creation of type Exception |
 | cflow.cs:203:23:203:37 | object creation of type Exception | cflow.cs:202:13:204:13 | {...} |
@@ -7802,14 +7844,15 @@ postDominance
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:244:31:244:41 | goto ...; |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:254:17:254:27 | goto ...; |
 | cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:9:242:13 | Label: |
-| cflow.cs:242:20:242:40 | !... | cflow.cs:242:16:242:45 | if (...) ... |
-| cflow.cs:242:21:242:40 | !... | cflow.cs:242:20:242:40 | !... |
+| cflow.cs:242:20:242:40 | [false] !... | cflow.cs:242:21:242:40 | [true] !... |
+| cflow.cs:242:20:242:40 | [true] !... | cflow.cs:242:21:242:40 | [false] !... |
 | cflow.cs:242:23:242:27 | access to field Field | cflow.cs:242:23:242:27 | this access |
-| cflow.cs:242:23:242:27 | this access | cflow.cs:242:21:242:40 | !... |
+| cflow.cs:242:23:242:27 | this access | cflow.cs:242:16:242:45 | if (...) ... |
 | cflow.cs:242:23:242:34 | access to property Length | cflow.cs:242:23:242:27 | access to field Field |
 | cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:39:242:39 | 0 |
 | cflow.cs:242:39:242:39 | 0 | cflow.cs:242:23:242:34 | access to property Length |
-| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:242:23:242:39 | ... == ... |
+| cflow.cs:242:43:242:45 | {...} | cflow.cs:242:20:242:40 | [true] !... |
+| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:242:20:242:40 | [false] !... |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:242:43:242:45 | {...} |
 | cflow.cs:244:13:244:17 | access to field Field | cflow.cs:244:13:244:17 | this access |
 | cflow.cs:244:13:244:17 | this access | cflow.cs:244:9:244:41 | if (...) ... |
@@ -7885,15 +7928,15 @@ postDominance
 | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:300:70:300:71 | "" |
 | cflow.cs:300:9:300:73 | ...; | cflow.cs:299:5:301:5 | {...} |
 | cflow.cs:300:38:300:38 | 0 | cflow.cs:300:9:300:73 | ...; |
-| cflow.cs:300:44:300:51 | !... | cflow.cs:300:44:300:64 | ... && ... |
-| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:38:300:38 | 0 |
-| cflow.cs:300:46:300:46 | access to parameter i | cflow.cs:300:44:300:51 | !... |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:44:300:51 | [false] !... |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:56:300:64 | ... != ... |
+| cflow.cs:300:46:300:46 | access to parameter i | cflow.cs:300:38:300:38 | 0 |
 | cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:50:300:50 | 0 |
 | cflow.cs:300:50:300:50 | 0 | cflow.cs:300:46:300:46 | access to parameter i |
+| cflow.cs:300:56:300:56 | access to parameter s | cflow.cs:300:44:300:51 | [true] !... |
 | cflow.cs:300:56:300:64 | ... != ... | cflow.cs:300:61:300:64 | null |
 | cflow.cs:300:61:300:64 | null | cflow.cs:300:56:300:56 | access to parameter s |
-| cflow.cs:300:70:300:71 | "" | cflow.cs:300:46:300:50 | ... > ... |
-| cflow.cs:300:70:300:71 | "" | cflow.cs:300:56:300:64 | ... != ... |
+| cflow.cs:300:70:300:71 | "" | cflow.cs:300:44:300:64 | ... && ... |
 blockDominance
 | AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:23:5:25 | enter get_Item |
 | AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:33:5:35 | enter set_Item |
@@ -7914,112 +7957,112 @@ blockDominance
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | enter M4 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | enter M1 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | exit M1 |
-| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:16:9:32 | String s = ... |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:20:9:32 | ... ? ... : ... |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:24:9:27 | null |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | exit M1 |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | exit M1 |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:16:9:32 | String s = ... |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:7:10:7:11 | exit M1 |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:32 | ... ? ... : ... |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | enter M2 |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | exit M2 |
-| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:16:16:32 | String s = ... |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:20:16:32 | ... ? ... : ... |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:24:16:27 | null |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | exit M2 |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | exit M2 |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:16:16:32 | String s = ... |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:14:10:14:11 | exit M2 |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:32 | ... ? ... : ... |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | enter M3 |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | exit M3 |
-| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:16:23:32 | String s = ... |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:20:23:32 | ... ? ... : ... |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:24:23:27 | null |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | exit M3 |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | exit M3 |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:16:23:32 | String s = ... |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:21:10:21:11 | exit M3 |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:32 | ... ? ... : ... |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | enter M4 |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | exit M4 |
-| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:16:30:32 | String s = ... |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:20:30:32 | ... ? ... : ... |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:24:30:27 | null |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | exit M4 |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | exit M4 |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:16:30:32 | String s = ... |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:28:10:28:11 | exit M4 |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:32 | ... ? ... : ... |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | enter M5 |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | exit M5 |
-| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:16:37:32 | String s = ... |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:20:37:32 | ... ? ... : ... |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:24:37:27 | null |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | exit M5 |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | exit M5 |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:16:37:32 | String s = ... |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:35:10:35:11 | exit M5 |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:32 | ... ? ... : ... |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | enter M6 |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | exit M6 |
-| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:16:44:32 | String s = ... |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:20:44:32 | ... ? ... : ... |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:24:44:27 | null |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | exit M6 |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | exit M6 |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:16:44:32 | String s = ... |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:42:10:42:11 | exit M6 |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:32 | ... ? ... : ... |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | enter M7 |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | exit M7 |
-| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:16:51:32 | String s = ... |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:20:51:32 | ... ? ... : ... |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:24:51:27 | null |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | exit M7 |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | exit M7 |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:16:51:32 | String s = ... |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:49:10:49:11 | exit M7 |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:32 | ... ? ... : ... |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
@@ -8028,7 +8071,7 @@ blockDominance
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | exit M8 |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:24:58:27 | [b (line 56): true] null |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
-| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:23:59:36 | [false] ... && ... |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
 | Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | exit M8 |
@@ -8036,14 +8079,14 @@ blockDominance
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:59:23:59:36 | [false] ... && ... | Assert.cs:59:23:59:36 | [false] ... && ... |
 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | enter M9 |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | exit M9 |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:24:65:27 | [b (line 63): true] null |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
-| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:24:66:37 | [true] ... \|\| ... |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
 | Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | exit M9 |
@@ -8051,14 +8094,14 @@ blockDominance
 | Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:66:24:66:37 | [true] ... \|\| ... | Assert.cs:66:24:66:37 | [true] ... \|\| ... |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | enter M10 |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | exit M10 |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:24:72:27 | [b (line 70): true] null |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
-| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:23:73:36 | [false] ... && ... |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
 | Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | exit M10 |
@@ -8066,14 +8109,14 @@ blockDominance
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:73:23:73:36 | [false] ... && ... | Assert.cs:73:23:73:36 | [false] ... && ... |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | enter M11 |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | exit M11 |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:24:79:27 | [b (line 77): true] null |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
-| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:24:80:37 | [true] ... \|\| ... |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
 | Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | exit M11 |
@@ -8081,7 +8124,7 @@ blockDominance
 | Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:80:24:80:37 | [true] ... \|\| ... | Assert.cs:80:24:80:37 | [true] ... \|\| ... |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | enter M12 |
@@ -8117,16 +8160,16 @@ blockDominance
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | exit M12 |
 | Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | exit M12 (abnormal) |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:24:86:27 | [b (line 84): true] null |
@@ -8144,14 +8187,14 @@ blockDominance
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert |
@@ -8167,7 +8210,7 @@ blockDominance
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
@@ -8184,7 +8227,7 @@ blockDominance
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
@@ -8199,14 +8242,14 @@ blockDominance
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
@@ -8220,7 +8263,7 @@ blockDominance
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
@@ -8233,14 +8276,14 @@ blockDominance
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
@@ -8252,7 +8295,7 @@ blockDominance
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
@@ -8263,14 +8306,14 @@ blockDominance
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
@@ -8280,7 +8323,7 @@ blockDominance
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
@@ -8289,14 +8332,14 @@ blockDominance
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
@@ -8304,75 +8347,75 @@ blockDominance
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
+| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
-| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
-| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
-| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:24:127:38 | [true] ... \|\| ... | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:131:18:131:32 | enter AssertTrueFalse |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:138:10:138:12 | enter M13 |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:138:10:138:12 | exit M13 |
@@ -8511,9 +8554,6 @@ blockDominance
 | CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:15:10:15:15 | enter Typeof |
 | CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:20:12:20:17 | enter Nameof |
 | CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:28:10:28:10 | enter M |
-| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | enter M1 |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:28:3:38 | call to method ToString |
@@ -8529,16 +8569,24 @@ blockDominance
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:28:5:34 | access to property Length |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:10:7:11 | enter M3 |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:49:7:55 | access to property Length |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
+| ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... |
+| ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:49:7:55 | access to property Length |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | enter M4 |
-| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) |
+| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:27:9:33 | access to property Length |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:38:9:38 | 0 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:27:9:33 | access to property Length |
 | ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:38:9:38 | 0 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:11:9:11:10 | enter M5 |
@@ -8561,10 +8609,7 @@ blockDominance
 | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | enter M7 |
-| ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | enter Out |
-| ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
-| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | enter M8 |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:35:14:35:24 | call to method Out |
@@ -8751,22 +8796,22 @@ blockDominance
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:25:116:25 | access to local variable i |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... |
+| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... |
 | Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | exit M9 (normal) |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | exit M9 (normal) |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:25 | access to local variable i |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... |
 | Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
-| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... |
+| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... |
+| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... |
+| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:129:10:129:12 | enter M10 |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
@@ -8831,10 +8876,10 @@ blockDominance
 | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | 1 |
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:69:111:75 | "input" |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
-| ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:9:116:39 | return ...; |
+| ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:34:116:34 | 0 |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:38:116:38 | 1 |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:9:116:39 | return ...; |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
 | ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 |
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | enter FailingAssertion |
@@ -9109,11 +9154,16 @@ blockDominance
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
-| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; |
-| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
-| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:115:17:115:41 | [finally: return] ...; |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:114:17:114:36 | [false, finally: return] !... |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:114:17:114:36 | [true, finally: return] !... |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
@@ -9138,10 +9188,14 @@ blockDominance
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
-| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
-| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:115:17:115:41 | [finally: return] ...; |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:114:17:114:36 | [false, finally: return] !... |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:114:17:114:36 | [true, finally: return] !... |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:107:17:107:28 | access to property Length | Finally.cs:116:13:117:37 | [finally: return] if (...) ... |
@@ -9159,9 +9213,12 @@ blockDominance
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:110:17:110:49 | throw ...; |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:107:33:107:33 | 0 | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:107:33:107:33 | 0 | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
-| Finally.cs:107:33:107:33 | 0 | Finally.cs:115:17:115:41 | [finally: return] ...; |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [false, finally: return] !... |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [true, finally: return] !... |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:116:13:117:37 | if (...) ... |
@@ -9169,7 +9226,8 @@ blockDominance
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:117:17:117:37 | [finally: return] ...; |
 | Finally.cs:108:17:108:23 | return ...; | Finally.cs:108:17:108:23 | return ...; |
-| Finally.cs:108:17:108:23 | return ...; | Finally.cs:115:17:115:41 | [finally: return] ...; |
+| Finally.cs:108:17:108:23 | return ...; | Finally.cs:114:17:114:36 | [false, finally: return] !... |
+| Finally.cs:108:17:108:23 | return ...; | Finally.cs:114:17:114:36 | [true, finally: return] !... |
 | Finally.cs:108:17:108:23 | return ...; | Finally.cs:116:13:117:37 | [finally: return] if (...) ... |
 | Finally.cs:108:17:108:23 | return ...; | Finally.cs:117:17:117:37 | [finally: return] ...; |
 | Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:109:13:110:49 | if (...) ... |
@@ -9178,8 +9236,10 @@ blockDominance
 | Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:110:17:110:49 | throw ...; |
 | Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException |
 | Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
+| Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:116:13:117:37 | if (...) ... |
 | Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:117:17:117:37 | ...; |
@@ -9189,8 +9249,10 @@ blockDominance
 | Finally.cs:109:17:109:28 | access to property Length | Finally.cs:110:17:110:49 | throw ...; |
 | Finally.cs:109:17:109:28 | access to property Length | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException |
 | Finally.cs:109:17:109:28 | access to property Length | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
+| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:109:17:109:28 | access to property Length | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:109:17:109:28 | access to property Length | Finally.cs:116:13:117:37 | if (...) ... |
 | Finally.cs:109:17:109:28 | access to property Length | Finally.cs:117:17:117:37 | ...; |
@@ -9199,38 +9261,50 @@ blockDominance
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:110:17:110:49 | throw ...; |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:109:33:109:33 | 1 | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:109:33:109:33 | 1 | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:116:13:117:37 | if (...) ... |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:117:17:117:37 | ...; |
 | Finally.cs:109:33:109:33 | 1 | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:110:17:110:49 | throw ...; | Finally.cs:110:17:110:49 | throw ...; |
-| Finally.cs:110:17:110:49 | throw ...; | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
+| Finally.cs:110:17:110:49 | throw ...; | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:110:17:110:49 | throw ...; | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
 | Finally.cs:110:17:110:49 | throw ...; | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:110:17:110:49 | throw ...; | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:110:17:110:49 | throw ...; |
 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException |
-| Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
+| Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; |
 | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} |
-| Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
+| Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... |
+| Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... |
 | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... |
 | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; |
 | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} |
-| Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; |
+| Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... |
+| Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... |
 | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... |
 | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:113:9:118:9 | {...} | Finally.cs:115:17:115:41 | ...; |
+| Finally.cs:113:9:118:9 | {...} | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:113:9:118:9 | {...} | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:116:13:117:37 | if (...) ... |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:117:17:117:37 | ...; |
-| Finally.cs:115:17:115:41 | ...; | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
-| Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; |
-| Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
-| Finally.cs:115:17:115:41 | [finally: return] ...; | Finally.cs:115:17:115:41 | [finally: return] ...; |
+| Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... |
+| Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... |
+| Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:114:17:114:36 | [false, finally: return] !... | Finally.cs:114:17:114:36 | [false, finally: return] !... |
+| Finally.cs:114:17:114:36 | [false] !... | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... |
+| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... |
+| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:114:17:114:36 | [true, finally: return] !... |
+| Finally.cs:114:17:114:36 | [true] !... | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... |
 | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; |
 | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... |
@@ -9609,6 +9683,7 @@ blockDominance
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:18:10:18:11 | exit M3 (normal) |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:22:20:22 | String x |
+| Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:27:20:68 | ... ?? ... |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 (normal) |
@@ -9616,6 +9691,10 @@ blockDominance
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:20:22:20:22 | String x |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:18:10:18:11 | exit M3 (normal) |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:22:20:22 | String x |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:27:20:68 | ... ?? ... |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:24:10:24:11 | enter M4 |
@@ -9717,11 +9796,11 @@ blockDominance
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | enter M8 |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:70:13:70:19 | return ...; |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:71:9:71:21 | ...; |
+| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:69:13:69:23 | [false] !... |
+| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:69:13:69:23 | [true] !... |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) |
-| LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; |
-| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:21 | ...; |
+| LoopUnrolling.cs:69:13:69:23 | [false] !... | LoopUnrolling.cs:69:13:69:23 | [false] !... |
+| LoopUnrolling.cs:69:13:69:23 | [true] !... | LoopUnrolling.cs:69:13:69:23 | [true] !... |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | enter M9 |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | enter M10 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
@@ -9990,48 +10069,60 @@ blockDominance
 | MultiImplementationB.cs:32:9:32:10 | exit M1 | MultiImplementationB.cs:32:9:32:10 | exit M1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:17:32:17 | 0 |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:9:3:10 | enter M1 |
-| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
+| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:28:3:28 | 0 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:28:3:28 | 0 |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:9:5:10 | enter M2 |
-| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) |
+| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |
+| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... |
+| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:30:5:34 | false |
-| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:39:5:39 | 0 |
-| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:43:5:43 | 1 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... |
+| NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:30:5:34 | false |
-| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:39:5:39 | 0 |
-| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:43:5:43 | 1 |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:12:7:13 | enter M3 |
-| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
+| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:52:7:53 | "" |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
-| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:12:9:13 | enter M4 |
-| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) |
+| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:36:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... |
+| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:41:9:41 | access to parameter s |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:45:9:45 | access to parameter s |
-| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... |
+| NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:41:9:41 | access to parameter s |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:45:9:45 | access to parameter s |
-| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:9:11:10 | enter M5 |
-| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) |
-| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:51:11:58 | ... && ... |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
-| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:64:11:64 | 0 |
-| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:68:11:68 | 1 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:58 | ... && ... |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
+| NullCoalescing.cs:11:51:11:58 | [false] ... && ... | NullCoalescing.cs:11:51:11:58 | [false] ... && ... |
+| NullCoalescing.cs:11:51:11:58 | [true] ... && ... | NullCoalescing.cs:11:51:11:58 | [true] ... && ... |
+| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
-| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:64:11:64 | 0 |
-| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:68:11:68 | 1 |
 | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:13:10:13:11 | enter M6 |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:5:10:5:13 | enter Test |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:9:9:11:9 | {...} |
@@ -10141,9 +10232,10 @@ blockDominance
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:22:21:22:27 | return ...; |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:13:24:56 | case ...: |
-| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:32:24:32 | access to local variable s |
+| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:32:24:55 | [false] ... && ... |
+| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:32:24:55 | [true] ... && ... |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:25:17:25:37 | ...; |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:27:32:27:38 | call to method Throw |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:30:13:30:20 | default: |
@@ -10161,9 +10253,10 @@ blockDominance
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:22:21:22:27 | return ...; |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:13:24:56 | case ...: |
-| Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:32:24:32 | access to local variable s |
+| Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:32:24:55 | [false] ... && ... |
+| Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:32:24:55 | [true] ... && ... |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:16:13:16:19 | case ...: | Switch.cs:25:17:25:37 | ...; |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:27:32:27:38 | call to method Throw |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:30:13:30:20 | default: |
@@ -10175,9 +10268,10 @@ blockDominance
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:22:21:22:27 | return ...; |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:13:24:56 | case ...: |
-| Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:32:24:32 | access to local variable s |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:32:24:55 | [false] ... && ... |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:32:24:55 | [true] ... && ... |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:18:13:18:22 | case ...: | Switch.cs:25:17:25:37 | ...; |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:27:32:27:38 | call to method Throw |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:30:13:30:20 | default: |
@@ -10187,9 +10281,10 @@ blockDominance
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:22:21:22:27 | return ...; |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:13:24:56 | case ...: |
-| Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:32:24:32 | access to local variable s |
+| Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:32:24:55 | [false] ... && ... |
+| Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:32:24:55 | [true] ... && ... |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:20:13:20:23 | case ...: | Switch.cs:25:17:25:37 | ...; |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:27:32:27:38 | call to method Throw |
 | Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:21:17:22:27 | if (...) ... |
@@ -10198,17 +10293,20 @@ blockDominance
 | Switch.cs:22:21:22:27 | return ...; | Switch.cs:22:21:22:27 | return ...; |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:13:24:56 | case ...: |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:32:24:32 | access to local variable s |
+| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:32:24:55 | [false] ... && ... |
+| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:32:24:55 | [true] ... && ... |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:25:17:25:37 | ...; |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:27:32:27:38 | call to method Throw |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:32:24:55 | ... && ... |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:25:17:25:37 | ...; |
+| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:32 | access to local variable s |
+| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:55 | [false] ... && ... |
+| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:55 | [true] ... && ... |
+| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:48:24:48 | access to local variable s |
+| Switch.cs:24:32:24:55 | [false] ... && ... | Switch.cs:24:32:24:55 | [false] ... && ... |
+| Switch.cs:24:32:24:55 | [true] ... && ... | Switch.cs:24:32:24:55 | [true] ... && ... |
+| Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:32:24:55 | [true] ... && ... |
 | Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:25:17:25:37 | ...; |
-| Switch.cs:25:17:25:37 | ...; | Switch.cs:25:17:25:37 | ...; |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:32:27:38 | call to method Throw |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:27:32:27:38 | call to method Throw |
@@ -10307,24 +10405,34 @@ blockDominance
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | enter M11 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | exit M11 (normal) |
+| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:13:125:48 | [false] ... switch { ... } |
+| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:24:125:34 | [false] ... => ... |
+| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:24:125:34 | [true] ... => ... |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:34:125:34 | access to local variable b |
-| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:37:125:46 | ... => ... |
-| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:126:13:126:19 | return ...; |
+| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:37:125:37 | _ |
 | Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 (normal) |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:125:13:125:48 | [false] ... switch { ... } |
+| Switch.cs:125:24:125:34 | [false] ... => ... | Switch.cs:125:24:125:34 | [false] ... => ... |
+| Switch.cs:125:24:125:34 | [true] ... => ... | Switch.cs:125:24:125:34 | [true] ... => ... |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [false] ... => ... |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [true] ... => ... |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:34:125:34 | access to local variable b |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:126:13:126:19 | return ...; |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:46 | ... => ... |
-| Switch.cs:126:13:126:19 | return ...; | Switch.cs:126:13:126:19 | return ...; |
+| Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:37 | _ |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:129:12:129:14 | enter M12 |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:9:131:67 | return ...; |
+| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:17:131:53 | [null] ... switch { ... } |
+| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:28:131:40 | [non-null] ... => ... |
+| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:28:131:40 | [null] ... => ... |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:40:131:40 | access to local variable s |
-| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:43:131:51 | ... => ... |
-| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:56:131:66 | call to method ToString |
+| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:131:43:131:43 | _ |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:9:131:67 | return ...; |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:131:17:131:53 | [null] ... switch { ... } |
+| Switch.cs:131:28:131:40 | [non-null] ... => ... | Switch.cs:131:28:131:40 | [non-null] ... => ... |
+| Switch.cs:131:28:131:40 | [null] ... => ... | Switch.cs:131:28:131:40 | [null] ... => ... |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [non-null] ... => ... |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [null] ... => ... |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:40:131:40 | access to local variable s |
-| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:56:131:66 | call to method ToString |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:51 | ... => ... |
-| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:56:131:66 | call to method ToString |
+| Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:43 | _ |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | enter M13 |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | exit M13 (normal) |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:138:13:138:20 | default: |
@@ -10355,23 +10463,23 @@ blockDominance
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | exit M15 |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | exit M15 (normal) |
-| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:13:156:54 | String s = ... |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:17:156:54 | ... switch { ... } |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:36:156:38 | "a" |
-| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:41:156:45 | false |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:154:10:154:12 | enter M15 | Switch.cs:160:13:160:49 | ...; |
 | Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | exit M15 |
 | Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | exit M15 (normal) |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:154:10:154:12 | exit M15 (normal) |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:13:156:54 | String s = ... |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:158:13:158:49 | ...; |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:154:10:154:12 | exit M15 (normal) |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:54 | ... switch { ... } |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:158:13:158:49 | ...; |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:160:13:160:49 | ...; |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | ... => ... |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:49 | ...; |
@@ -10383,10 +10491,10 @@ blockDominance
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | enter M1 |
 | VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:13:12:13:13 | enter M2 |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:19:7:19:8 | enter M3 |
-| VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:13:25:29 | return ...; |
+| VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:24:25:24 | access to local variable x |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:28:25:28 | access to local variable y |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:13:25:29 | return ...; |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
 | VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:24:25:24 | access to local variable x |
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:28:25:28 | access to local variable y |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | enter Dispose |
@@ -10402,9 +10510,9 @@ blockDominance
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:5:17:5:20 | enter Main | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:5:17:5:20 | enter Main | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:5:17:5:20 | enter Main | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:5:17:5:20 | enter Main | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:31:17:31:42 | ...; |
@@ -10421,9 +10529,9 @@ blockDominance
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:31:17:31:42 | ...; |
@@ -10437,9 +10545,9 @@ blockDominance
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:31:17:31:42 | ...; |
@@ -10452,9 +10560,9 @@ blockDominance
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:31:17:31:42 | ...; |
@@ -10465,9 +10573,9 @@ blockDominance
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:20:9:22:9 | {...} | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:20:9:22:9 | {...} | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:20:9:22:9 | {...} | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:20:9:22:9 | {...} | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:31:17:31:42 | ...; |
@@ -10477,9 +10585,9 @@ blockDominance
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:31:17:31:42 | ...; |
@@ -10488,9 +10596,9 @@ blockDominance
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:31:17:31:42 | ...; |
@@ -10498,21 +10606,21 @@ blockDominance
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:25:9:34:9 | {...} | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:25:9:34:9 | {...} | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:25:9:34:9 | {...} | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:25:9:34:9 | {...} | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:33:17:33:37 | ...; |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:29:17:29:42 | ...; |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:30:18:33:37 | if (...) ... |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:31:17:31:42 | ...; |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:33:17:33:37 | ...; |
+| cflow.cs:26:17:26:40 | [true] ... && ... | cflow.cs:26:17:26:40 | [true] ... && ... |
+| cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:27:17:27:46 | ...; | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:28:18:33:37 | if (...) ... |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:29:17:29:42 | ...; |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:30:18:33:37 | if (...) ... |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:31:17:31:42 | ...; |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:33:17:33:37 | ...; |
 | cflow.cs:29:17:29:42 | ...; | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:30:18:33:37 | if (...) ... | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:30:18:33:37 | if (...) ... | cflow.cs:31:17:31:42 | ...; |
@@ -10532,8 +10640,8 @@ blockDominance
 | cflow.cs:37:17:37:22 | enter Switch | cflow.cs:56:13:56:20 | default: |
 | cflow.cs:37:17:37:22 | enter Switch | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:37:17:37:22 | enter Switch | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:37:17:37:22 | enter Switch | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:37:17:37:22 | enter Switch | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:37:17:37:22 | enter Switch | cflow.cs:63:21:63:34 | [false] !... |
+| cflow.cs:37:17:37:22 | enter Switch | cflow.cs:63:21:63:34 | [true] !... |
 | cflow.cs:37:17:37:22 | enter Switch | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:37:17:37:22 | exit Switch | cflow.cs:37:17:37:22 | exit Switch |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:37:17:37:22 | exit Switch |
@@ -10548,8 +10656,8 @@ blockDominance
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:56:13:56:20 | default: |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:41:13:41:19 | case ...: | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:41:13:41:19 | case ...: | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:41:13:41:19 | case ...: | cflow.cs:63:21:63:34 | [false] !... |
+| cflow.cs:41:13:41:19 | case ...: | cflow.cs:63:21:63:34 | [true] !... |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:42:17:42:39 | ...; | cflow.cs:42:17:42:39 | ...; |
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:37:17:37:22 | exit Switch |
@@ -10562,8 +10670,8 @@ blockDominance
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:56:13:56:20 | default: |
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:44:13:44:19 | case ...: | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:44:13:44:19 | case ...: | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:44:13:44:19 | case ...: | cflow.cs:63:21:63:34 | [false] !... |
+| cflow.cs:44:13:44:19 | case ...: | cflow.cs:63:21:63:34 | [true] !... |
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:45:17:45:39 | ...; | cflow.cs:45:17:45:39 | ...; |
 | cflow.cs:47:13:47:19 | case ...: | cflow.cs:37:17:37:22 | exit Switch |
@@ -10574,8 +10682,8 @@ blockDominance
 | cflow.cs:47:13:47:19 | case ...: | cflow.cs:56:13:56:20 | default: |
 | cflow.cs:47:13:47:19 | case ...: | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:47:13:47:19 | case ...: | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:47:13:47:19 | case ...: | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:47:13:47:19 | case ...: | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:47:13:47:19 | case ...: | cflow.cs:63:21:63:34 | [false] !... |
+| cflow.cs:47:13:47:19 | case ...: | cflow.cs:63:21:63:34 | [true] !... |
 | cflow.cs:47:13:47:19 | case ...: | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:48:17:48:39 | ...; | cflow.cs:48:17:48:39 | ...; |
 | cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:37:17:37:22 | exit Switch |
@@ -10584,22 +10692,22 @@ blockDominance
 | cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:56:13:56:20 | default: |
 | cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:63:21:63:34 | [false] !... |
+| cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:63:21:63:34 | [true] !... |
 | cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:54:17:54:48 | ...; | cflow.cs:54:17:54:48 | ...; |
 | cflow.cs:56:13:56:20 | default: | cflow.cs:56:13:56:20 | default: |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:37:17:37:22 | exit Switch |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:63:21:63:34 | [false] !... |
+| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:63:21:63:34 | [true] !... |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:65:17:65:22 | break; |
-| cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:65:17:65:22 | break; | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:21:63:34 | [false] !... |
+| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:21:63:34 | [true] !... |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:63:21:63:34 | [false] !... |
+| cflow.cs:63:21:63:34 | [true] !... | cflow.cs:63:21:63:34 | [true] !... |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:70:18:70:18 | enter M |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:70:18:70:18 | exit M (normal) |
@@ -10616,12 +10724,14 @@ blockDominance
 | cflow.cs:79:9:81:9 | {...} | cflow.cs:79:9:81:9 | {...} |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:84:18:84:19 | enter M2 |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:84:18:84:19 | exit M2 (normal) |
+| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:86:13:86:37 | [false] ... && ... |
+| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:86:13:86:37 | [true] ... && ... |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:86:26:86:26 | access to parameter s |
-| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:87:13:87:33 | ...; |
 | cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 (normal) |
+| cflow.cs:86:13:86:37 | [false] ... && ... | cflow.cs:86:13:86:37 | [false] ... && ... |
+| cflow.cs:86:13:86:37 | [true] ... && ... | cflow.cs:86:13:86:37 | [true] ... && ... |
+| cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:13:86:37 | [true] ... && ... |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:26 | access to parameter s |
-| cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:87:13:87:33 | ...; |
-| cflow.cs:87:13:87:33 | ...; | cflow.cs:87:13:87:33 | ...; |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | enter M3 |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | exit M3 |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | exit M3 (normal) |
@@ -10663,10 +10773,10 @@ blockDominance
 | cflow.cs:116:9:116:29 | ...; | cflow.cs:116:9:116:29 | ...; |
 | cflow.cs:119:20:119:21 | enter M5 | cflow.cs:119:20:119:21 | enter M5 |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:19:127:21 | enter get_Prop |
-| cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:25:127:58 | return ...; |
+| cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:32:127:57 | ... ? ... : ... |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:48:127:49 | "" |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:53:127:57 | this access |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:25:127:58 | return ...; |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:32:127:57 | ... ? ... : ... |
 | cflow.cs:127:48:127:49 | "" | cflow.cs:127:48:127:49 | "" |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | this access |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:62:127:64 | enter set_Prop |
@@ -10776,52 +10886,62 @@ blockDominance
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:185:10:185:18 | enter LogicalOr |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | enter Booleans |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | exit Booleans |
-| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | exit Booleans (normal) |
-| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:13:195:56 | Boolean b = ... |
-| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:37:195:56 | !... |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:195:39:195:43 | this access |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:197:35:197:39 | false |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:197:43:197:46 | true |
-| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:198:13:198:48 | ... = ... |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:198:17:198:48 | ... ? ... : ... |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:198:37:198:41 | false |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:198:45:198:48 | true |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:200:9:205:9 | if (...) ... |
-| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:200:37:200:62 | !... |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:200:13:200:32 | [false] !... |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:200:13:200:32 | [true] !... |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:200:13:200:62 | [true] ... \|\| ... |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:200:40:200:61 | [false] ... && ... |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:200:40:200:61 | [true] ... && ... |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:200:61:200:61 | access to local variable b |
-| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:201:9:205:9 | {...} |
 | cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:193:10:193:17 | exit Booleans |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | exit Booleans (normal) |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:193:10:193:17 | exit Booleans |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:193:10:193:17 | exit Booleans (normal) |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:13:195:56 | Boolean b = ... |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:35:197:39 | false |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:43:197:46 | true |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:198:13:198:48 | ... = ... |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:198:37:198:41 | false |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:198:45:198:48 | true |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:200:9:205:9 | if (...) ... |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:200:37:200:62 | !... |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:200:61:200:61 | access to local variable b |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:201:9:205:9 | {...} |
-| cflow.cs:195:37:195:56 | !... | cflow.cs:195:37:195:56 | !... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:193:10:193:17 | exit Booleans |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:197:35:197:39 | false |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:197:43:197:46 | true |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:198:17:198:48 | ... ? ... : ... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:198:37:198:41 | false |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:198:45:198:48 | true |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:200:9:205:9 | if (...) ... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:200:13:200:32 | [false] !... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:200:13:200:32 | [true] !... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:200:13:200:62 | [true] ... \|\| ... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:200:40:200:61 | [false] ... && ... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:200:40:200:61 | [true] ... && ... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:200:61:200:61 | access to local variable b |
+| cflow.cs:195:39:195:43 | this access | cflow.cs:195:39:195:43 | this access |
 | cflow.cs:197:35:197:39 | false | cflow.cs:197:35:197:39 | false |
-| cflow.cs:197:35:197:39 | false | cflow.cs:198:13:198:48 | ... = ... |
+| cflow.cs:197:35:197:39 | false | cflow.cs:198:17:198:48 | ... ? ... : ... |
 | cflow.cs:197:35:197:39 | false | cflow.cs:198:37:198:41 | false |
 | cflow.cs:197:35:197:39 | false | cflow.cs:198:45:198:48 | true |
 | cflow.cs:197:43:197:46 | true | cflow.cs:197:43:197:46 | true |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:198:13:198:48 | ... = ... |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:17:198:48 | ... ? ... : ... |
 | cflow.cs:198:37:198:41 | false | cflow.cs:198:37:198:41 | false |
 | cflow.cs:198:45:198:48 | true | cflow.cs:198:45:198:48 | true |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:193:10:193:17 | exit Booleans |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:193:10:193:17 | exit Booleans (normal) |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:9:205:9 | if (...) ... |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:37:200:62 | !... |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:13:200:32 | [false] !... |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:13:200:32 | [true] !... |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:13:200:62 | [true] ... \|\| ... |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:40:200:61 | [false] ... && ... |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:40:200:61 | [true] ... && ... |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:61:200:61 | access to local variable b |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:201:9:205:9 | {...} |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:193:10:193:17 | exit Booleans (normal) |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:37:200:62 | !... |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:61:200:61 | access to local variable b |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:13:200:32 | [false] !... |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:40:200:61 | [false] ... && ... |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:40:200:61 | [true] ... && ... |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:61:200:61 | access to local variable b |
+| cflow.cs:200:13:200:32 | [true] !... | cflow.cs:200:13:200:32 | [true] !... |
+| cflow.cs:200:13:200:62 | [true] ... \|\| ... | cflow.cs:200:13:200:62 | [true] ... \|\| ... |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:40:200:61 | [false] ... && ... |
+| cflow.cs:200:40:200:61 | [true] ... && ... | cflow.cs:200:40:200:61 | [true] ... && ... |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [true] ... && ... |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:61:200:61 | access to local variable b |
-| cflow.cs:201:9:205:9 | {...} | cflow.cs:201:9:205:9 | {...} |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:208:10:208:11 | enter Do |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:208:10:208:11 | exit Do (normal) |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:211:9:221:9 | {...} |
@@ -10866,7 +10986,8 @@ blockDominance
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:240:10:240:13 | enter Goto |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:240:10:240:13 | exit Goto (normal) |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:242:9:242:13 | Label: |
-| cflow.cs:240:10:240:13 | enter Goto | cflow.cs:242:43:242:45 | {...} |
+| cflow.cs:240:10:240:13 | enter Goto | cflow.cs:242:21:242:40 | [false] !... |
+| cflow.cs:240:10:240:13 | enter Goto | cflow.cs:242:21:242:40 | [true] !... |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:244:9:244:41 | if (...) ... |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:244:31:244:41 | goto ...; |
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:246:9:258:9 | switch (...) {...} |
@@ -10879,7 +11000,8 @@ blockDominance
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto (normal) |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:240:10:240:13 | exit Goto (normal) |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:9:242:13 | Label: |
-| cflow.cs:242:9:242:13 | Label: | cflow.cs:242:43:242:45 | {...} |
+| cflow.cs:242:9:242:13 | Label: | cflow.cs:242:21:242:40 | [false] !... |
+| cflow.cs:242:9:242:13 | Label: | cflow.cs:242:21:242:40 | [true] !... |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:244:9:244:41 | if (...) ... |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:244:31:244:41 | goto ...; |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:246:9:258:9 | switch (...) {...} |
@@ -10889,7 +11011,8 @@ blockDominance
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:253:13:253:19 | case ...: |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:254:17:254:27 | goto ...; |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:255:13:255:20 | default: |
-| cflow.cs:242:43:242:45 | {...} | cflow.cs:242:43:242:45 | {...} |
+| cflow.cs:242:21:242:40 | [false] !... | cflow.cs:242:21:242:40 | [false] !... |
+| cflow.cs:242:21:242:40 | [true] !... | cflow.cs:242:21:242:40 | [true] !... |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:240:10:240:13 | exit Goto (normal) |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:9:244:41 | if (...) ... |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:31:244:41 | goto ...; |
@@ -10934,10 +11057,12 @@ blockDominance
 | cflow.cs:291:12:291:12 | enter M | cflow.cs:291:12:291:12 | enter M |
 | cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | enter NegationInConstructor |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:298:10:298:10 | enter M |
-| cflow.cs:298:10:298:10 | enter M | cflow.cs:300:56:300:56 | access to parameter s |
-| cflow.cs:298:10:298:10 | enter M | cflow.cs:300:70:300:71 | "" |
-| cflow.cs:300:56:300:56 | access to parameter s | cflow.cs:300:56:300:56 | access to parameter s |
-| cflow.cs:300:70:300:71 | "" | cflow.cs:300:70:300:71 | "" |
+| cflow.cs:298:10:298:10 | enter M | cflow.cs:300:44:300:51 | [false] !... |
+| cflow.cs:298:10:298:10 | enter M | cflow.cs:300:44:300:51 | [true] !... |
+| cflow.cs:298:10:298:10 | enter M | cflow.cs:300:44:300:64 | ... && ... |
+| cflow.cs:300:44:300:51 | [false] !... | cflow.cs:300:44:300:51 | [false] !... |
+| cflow.cs:300:44:300:51 | [true] !... | cflow.cs:300:44:300:51 | [true] !... |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:44:300:64 | ... && ... |
 postBlockDominance
 | AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:23:5:25 | enter get_Item |
 | AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:33:5:35 | enter set_Item |
@@ -10958,99 +11083,99 @@ postBlockDominance
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | enter M4 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | enter M1 |
 | Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | exit M1 |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | enter M1 |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:16:9:32 | String s = ... |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:24:9:27 | null |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:7:10:7:11 | enter M1 |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:32 | ... ? ... : ... |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:24:9:27 | null |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:7:10:7:11 | enter M1 |
-| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:9:16:9:32 | String s = ... |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:9:20:9:32 | ... ? ... : ... |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:9:24:9:27 | null |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | enter M2 |
 | Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | exit M2 |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | enter M2 |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:16:16:32 | String s = ... |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:24:16:27 | null |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:14:10:14:11 | enter M2 |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:32 | ... ? ... : ... |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:24:16:27 | null |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:14:10:14:11 | enter M2 |
-| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:16:16:16:32 | String s = ... |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:16:20:16:32 | ... ? ... : ... |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:16:24:16:27 | null |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | enter M3 |
 | Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | exit M3 |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | enter M3 |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:16:23:32 | String s = ... |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:24:23:27 | null |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:21:10:21:11 | enter M3 |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:32 | ... ? ... : ... |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:24:23:27 | null |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:21:10:21:11 | enter M3 |
-| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:23:16:23:32 | String s = ... |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:23:20:23:32 | ... ? ... : ... |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:23:24:23:27 | null |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | enter M4 |
 | Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | exit M4 |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | enter M4 |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:16:30:32 | String s = ... |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:24:30:27 | null |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:28:10:28:11 | enter M4 |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:32 | ... ? ... : ... |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:24:30:27 | null |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:28:10:28:11 | enter M4 |
-| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:30:16:30:32 | String s = ... |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:30:20:30:32 | ... ? ... : ... |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:30:24:30:27 | null |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | enter M5 |
 | Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | exit M5 |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | enter M5 |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:16:37:32 | String s = ... |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:24:37:27 | null |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:35:10:35:11 | enter M5 |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:32 | ... ? ... : ... |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:24:37:27 | null |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:35:10:35:11 | enter M5 |
-| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:37:16:37:32 | String s = ... |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:37:20:37:32 | ... ? ... : ... |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:37:24:37:27 | null |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | enter M6 |
 | Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | exit M6 |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | enter M6 |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:16:44:32 | String s = ... |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:24:44:27 | null |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:42:10:42:11 | enter M6 |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:32 | ... ? ... : ... |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:24:44:27 | null |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:42:10:42:11 | enter M6 |
-| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:44:16:44:32 | String s = ... |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:44:20:44:32 | ... ? ... : ... |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:44:24:44:27 | null |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | enter M7 |
 | Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | exit M7 |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | enter M7 |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:16:51:32 | String s = ... |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:24:51:27 | null |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:49:10:49:11 | enter M7 |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:32 | ... ? ... : ... |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:24:51:27 | null |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:49:10:49:11 | enter M7 |
-| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:51:16:51:32 | String s = ... |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:51:20:51:32 | ... ? ... : ... |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:51:24:51:27 | null |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
@@ -11059,7 +11184,7 @@ postBlockDominance
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:56:10:56:11 | enter M8 |
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:24:58:27 | [b (line 56): true] null |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:59:23:59:36 | [false] ... && ... | Assert.cs:59:23:59:36 | [false] ... && ... |
 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:56:10:56:11 | enter M8 |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:58:24:58:27 | [b (line 56): true] null |
@@ -11069,7 +11194,7 @@ postBlockDominance
 | Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:24:65:27 | [b (line 63): true] null |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:63:10:63:11 | enter M9 |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:66:24:66:37 | [true] ... \|\| ... | Assert.cs:66:24:66:37 | [true] ... \|\| ... |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:63:10:63:11 | enter M9 |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
@@ -11079,7 +11204,7 @@ postBlockDominance
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:70:10:70:12 | enter M10 |
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:24:72:27 | [b (line 70): true] null |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:73:23:73:36 | [false] ... && ... | Assert.cs:73:23:73:36 | [false] ... && ... |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:70:10:70:12 | enter M10 |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:72:24:72:27 | [b (line 70): true] null |
@@ -11089,7 +11214,7 @@ postBlockDominance
 | Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:24:79:27 | [b (line 77): true] null |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:77:10:77:12 | enter M11 |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:80:24:80:37 | [true] ... \|\| ... | Assert.cs:80:24:80:37 | [true] ... \|\| ... |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:77:10:77:12 | enter M11 |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
@@ -11163,8 +11288,8 @@ postBlockDominance
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... |
+| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | enter M12 |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null |
@@ -11176,19 +11301,19 @@ postBlockDominance
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | enter M12 |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | enter M12 |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
@@ -11199,22 +11324,22 @@ postBlockDominance
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | enter M12 |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:127:24:127:38 | [true] ... \|\| ... | Assert.cs:127:24:127:38 | [true] ... \|\| ... |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:131:18:131:32 | enter AssertTrueFalse |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:138:10:138:12 | enter M13 |
 | Assert.cs:138:10:138:12 | exit M13 | Assert.cs:138:10:138:12 | exit M13 |
@@ -11318,10 +11443,6 @@ postBlockDominance
 | CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:15:10:15:15 | enter Typeof |
 | CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:20:12:20:17 | enter Nameof |
 | CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:28:10:28:10 | enter M |
-| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:30:10:30:12 | enter Out |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | enter M1 |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | enter M1 |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) |
@@ -11337,15 +11458,22 @@ postBlockDominance
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:10:7:11 | enter M3 |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | enter M3 |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:49:7:55 | access to property Length |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
+| ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... |
+| ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
+| ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:49:7:55 | access to property Length |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | enter M4 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | enter M4 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:27:9:33 | access to property Length |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:38:9:38 | 0 |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:9:9:10 | enter M4 |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:27:9:33 | access to property Length |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:38:9:38 | 0 |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:27:9:33 | access to property Length |
 | ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:38:9:38 | 0 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:11:9:11:10 | enter M5 |
@@ -11368,8 +11496,6 @@ postBlockDominance
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | enter M7 |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | enter Out |
-| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | enter Out |
-| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | enter M8 |
 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | enter M8 |
 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) |
@@ -11543,21 +11669,21 @@ postBlockDominance
 | Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:116:25:116:25 | access to local variable i |
 | Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | enter M9 |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:25 | access to local variable i |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... |
 | Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... |
+| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:129:10:129:12 | enter M10 |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
@@ -11609,10 +11735,10 @@ postBlockDominance
 | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | 1 |
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:69:111:75 | "input" |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:9:116:39 | return ...; |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:34:116:34 | 0 |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:38:116:38 | 1 |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:34:116:34 | 0 |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:38:116:38 | 1 |
 | ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 |
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | enter FailingAssertion |
@@ -11751,8 +11877,10 @@ postBlockDominance
 | Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:109:17:109:28 | access to property Length |
 | Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:109:33:109:33 | 1 |
 | Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:115:17:115:41 | [finally: return] ...; |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:114:17:114:36 | [false, finally: return] !... |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:114:17:114:36 | [true, finally: return] !... |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:116:13:117:37 | [finally: return] if (...) ... |
 | Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:116:13:117:37 | if (...) ... |
 | Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:117:17:117:37 | ...; |
@@ -11777,22 +11905,29 @@ postBlockDominance
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:109:17:109:28 | access to property Length |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:109:33:109:33 | 1 |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:115:17:115:41 | ...; | Finally.cs:115:17:115:41 | ...; |
-| Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; |
-| Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; |
-| Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; |
-| Finally.cs:115:17:115:41 | [finally: return] ...; | Finally.cs:115:17:115:41 | [finally: return] ...; |
+| Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... |
+| Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... |
+| Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:114:17:114:36 | [false, finally: return] !... | Finally.cs:114:17:114:36 | [false, finally: return] !... |
+| Finally.cs:114:17:114:36 | [false] !... | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... |
+| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... |
+| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... |
+| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:114:17:114:36 | [true, finally: return] !... |
+| Finally.cs:114:17:114:36 | [true] !... | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... |
 | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... |
 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:108:17:108:23 | return ...; |
-| Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:115:17:115:41 | [finally: return] ...; |
+| Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:114:17:114:36 | [false, finally: return] !... |
+| Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:114:17:114:36 | [true, finally: return] !... |
 | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:116:13:117:37 | [finally: return] if (...) ... |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:109:13:110:49 | if (...) ... |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:109:17:109:28 | access to property Length |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:109:33:109:33 | 1 |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:113:9:118:9 | {...} |
-| Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:115:17:115:41 | ...; |
+| Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:114:17:114:36 | [false] !... |
+| Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:114:17:114:36 | [true] !... |
 | Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:116:13:117:37 | if (...) ... |
 | Finally.cs:117:17:117:37 | ...; | Finally.cs:117:17:117:37 | ...; |
 | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; |
@@ -11950,14 +12085,20 @@ postBlockDominance
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 (normal) |
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:22:20:22 | String x |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:27:20:68 | ... ?? ... |
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | enter M3 |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x |
+| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:27:20:68 | ... ?? ... |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:20:22:20:22 | String x |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:18:10:18:11 | enter M3 |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:27:20:68 | ... ?? ... |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:29:20:38 | call to method ToArray |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:29:20:38 | call to method ToArray |
 | Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:24:10:24:11 | enter M4 |
@@ -12059,10 +12200,10 @@ postBlockDominance
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | enter M8 |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | enter M8 |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:70:13:70:19 | return ...; |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:71:9:71:21 | ...; |
-| LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; |
-| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:21 | ...; |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:69:13:69:23 | [false] !... |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:69:13:69:23 | [true] !... |
+| LoopUnrolling.cs:69:13:69:23 | [false] !... | LoopUnrolling.cs:69:13:69:23 | [false] !... |
+| LoopUnrolling.cs:69:13:69:23 | [true] !... | LoopUnrolling.cs:69:13:69:23 | [true] !... |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | enter M9 |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | enter M10 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
@@ -12267,47 +12408,59 @@ postBlockDominance
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | enter M1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:17:32:17 | 0 |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:9:3:10 | enter M1 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | enter M1 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |
-| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:28:3:28 | 0 |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:9:3:10 | enter M1 |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:28:3:28 | 0 |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:28:3:28 | 0 |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:9:5:10 | enter M2 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | enter M2 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:30:5:34 | false |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:39:5:39 | 0 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:43:5:43 | 1 |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | enter M2 |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:30:5:34 | false |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:30:5:34 | false |
+| NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:30:5:34 | false |
-| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:39:5:39 | 0 |
-| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:30:5:34 | false |
-| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:43:5:43 | 1 |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:12:7:13 | enter M3 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | enter M3 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:52:7:53 | "" |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | enter M3 |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:52:7:53 | "" |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
+| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:52:7:53 | "" |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:12:9:13 | enter M4 |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | enter M4 |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:41:9:41 | access to parameter s |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:45:9:45 | access to parameter s |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | enter M4 |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:41:9:41 | access to parameter s |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:45:9:45 | access to parameter s |
+| NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... |
+| NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:41:9:41 | access to parameter s |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:45:9:45 | access to parameter s |
-| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:9:11:10 | enter M5 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | enter M5 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:51:11:58 | ... && ... |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:64:11:64 | 0 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:68:11:68 | 1 |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:58 | ... && ... |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | enter M5 |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:51:11:58 | [false] ... && ... |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:51:11:58 | [true] ... && ... |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:51:11:58 | [false] ... && ... |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:51:11:58 | [true] ... && ... |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 |
+| NullCoalescing.cs:11:51:11:58 | [false] ... && ... | NullCoalescing.cs:11:51:11:58 | [false] ... && ... |
+| NullCoalescing.cs:11:51:11:58 | [true] ... && ... | NullCoalescing.cs:11:51:11:58 | [true] ... && ... |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
-| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:64:11:64 | 0 |
-| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:68:11:68 | 1 |
 | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:13:10:13:11 | enter M6 |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:5:10:5:13 | enter Test |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:9:9:11:9 | {...} |
@@ -12383,9 +12536,10 @@ postBlockDominance
 | Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:22:21:22:27 | return ...; |
 | Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:24:13:24:56 | case ...: |
-| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:24:32:24:32 | access to local variable s |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:24:32:24:55 | [false] ... && ... |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:24:32:24:55 | [true] ... && ... |
 | Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:25:17:25:37 | ...; |
 | Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:30:13:30:20 | default: |
 | Switch.cs:15:17:15:23 | return ...; | Switch.cs:15:17:15:23 | return ...; |
@@ -12401,12 +12555,15 @@ postBlockDominance
 | Switch.cs:22:21:22:27 | return ...; | Switch.cs:22:21:22:27 | return ...; |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:13:24:56 | case ...: |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:32 | access to local variable s |
+| Switch.cs:24:32:24:55 | [false] ... && ... | Switch.cs:24:32:24:55 | [false] ... && ... |
+| Switch.cs:24:32:24:55 | [true] ... && ... | Switch.cs:24:32:24:55 | [true] ... && ... |
 | Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:48:24:48 | access to local variable s |
-| Switch.cs:25:17:25:37 | ...; | Switch.cs:25:17:25:37 | ...; |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:24:32:24:55 | [false] ... && ... |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:27:32:27:38 | call to method Throw |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:19:17:19:29 | goto default; |
+| Switch.cs:30:13:30:20 | default: | Switch.cs:24:32:24:55 | [false] ... && ... |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:30:13:30:20 | default: |
 | Switch.cs:35:10:35:11 | enter M3 | Switch.cs:35:10:35:11 | enter M3 |
@@ -12486,21 +12643,33 @@ postBlockDominance
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | enter M11 |
 | Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | enter M11 |
 | Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 (normal) |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:13:125:48 | [false] ... switch { ... } |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:24:125:34 | [false] ... => ... |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:24:125:34 | [true] ... => ... |
 | Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:34:125:34 | access to local variable b |
-| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:37:125:46 | ... => ... |
-| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:126:13:126:19 | return ...; |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:125:37:125:37 | _ |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:125:13:125:48 | [false] ... switch { ... } |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:125:24:125:34 | [false] ... => ... |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:125:37:125:37 | _ |
+| Switch.cs:125:24:125:34 | [false] ... => ... | Switch.cs:125:24:125:34 | [false] ... => ... |
+| Switch.cs:125:24:125:34 | [true] ... => ... | Switch.cs:125:24:125:34 | [true] ... => ... |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:34:125:34 | access to local variable b |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:46 | ... => ... |
-| Switch.cs:126:13:126:19 | return ...; | Switch.cs:126:13:126:19 | return ...; |
+| Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:37 | _ |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:129:12:129:14 | enter M12 |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | enter M12 |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:9:131:67 | return ...; |
+| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:17:131:53 | [null] ... switch { ... } |
+| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:28:131:40 | [non-null] ... => ... |
+| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:28:131:40 | [null] ... => ... |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:40:131:40 | access to local variable s |
-| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:43:131:51 | ... => ... |
-| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:56:131:66 | call to method ToString |
+| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:43:131:43 | _ |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:131:17:131:53 | [null] ... switch { ... } |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:131:28:131:40 | [null] ... => ... |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:131:43:131:43 | _ |
+| Switch.cs:131:28:131:40 | [non-null] ... => ... | Switch.cs:131:28:131:40 | [non-null] ... => ... |
+| Switch.cs:131:28:131:40 | [null] ... => ... | Switch.cs:131:28:131:40 | [null] ... => ... |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:40:131:40 | access to local variable s |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:51 | ... => ... |
-| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:56:131:66 | call to method ToString |
+| Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:43 | _ |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | enter M13 |
 | Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | enter M13 |
 | Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 (normal) |
@@ -12528,20 +12697,20 @@ postBlockDominance
 | Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | exit M15 (abnormal) |
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | enter M15 |
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | exit M15 (normal) |
-| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:156:13:156:54 | String s = ... |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:156:17:156:54 | ... switch { ... } |
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:156:36:156:38 | "a" |
-| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:156:41:156:45 | false |
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:160:13:160:49 | ...; |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:154:10:154:12 | enter M15 |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:13:156:54 | String s = ... |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:36:156:38 | "a" |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:41:156:52 | ... => ... |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:154:10:154:12 | enter M15 |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:54 | ... switch { ... } |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:41:156:45 | false |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | ... => ... |
-| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:45 | false |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:49 | ...; |
@@ -12553,10 +12722,10 @@ postBlockDominance
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | enter M1 |
 | VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:13:12:13:13 | enter M2 |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:19:7:19:8 | enter M3 |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | enter M3 |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:13:25:29 | return ...; |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:24:25:24 | access to local variable x |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:28:25:28 | access to local variable y |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:19:7:19:8 | enter M3 |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:24:25:24 | access to local variable x |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:28:25:28 | access to local variable y |
 | VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:24:25:24 | access to local variable x |
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:28:25:28 | access to local variable y |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | enter Dispose |
@@ -12573,9 +12742,9 @@ postBlockDominance
 | cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:31:17:31:42 | ...; |
@@ -12622,26 +12791,26 @@ postBlockDominance
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:33:17:33:37 | ...; |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:24:34:24:34 | access to local variable i |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:31:17:31:42 | ...; |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:33:17:33:37 | ...; |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:25:9:34:9 | {...} |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:26:17:26:40 | [false] ... && ... |
+| cflow.cs:26:17:26:40 | [true] ... && ... | cflow.cs:26:17:26:40 | [true] ... && ... |
 | cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:31:26:31 | access to local variable i |
-| cflow.cs:27:17:27:46 | ...; | cflow.cs:27:17:27:46 | ...; |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:28:18:33:37 | if (...) ... |
 | cflow.cs:29:17:29:42 | ...; | cflow.cs:29:17:29:42 | ...; |
 | cflow.cs:30:18:33:37 | if (...) ... | cflow.cs:30:18:33:37 | if (...) ... |
 | cflow.cs:31:17:31:42 | ...; | cflow.cs:31:17:31:42 | ...; |
@@ -12687,9 +12856,9 @@ postBlockDominance
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:56:13:56:20 | default: |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:64:27:64:54 | object creation of type NullReferenceException |
-| cflow.cs:65:17:65:22 | break; | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:65:17:65:22 | break; | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:63:17:64:55 | if (...) ... |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:63:21:63:34 | [false] !... |
+| cflow.cs:63:21:63:34 | [true] !... | cflow.cs:63:21:63:34 | [true] !... |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:37:17:37:22 | enter Switch |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:41:13:41:19 | case ...: |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:42:17:42:39 | ...; |
@@ -12702,7 +12871,7 @@ postBlockDominance
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:56:13:56:20 | default: |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:65:17:65:22 | break; |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:63:21:63:34 | [false] !... |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:67:16:67:16 | access to parameter a |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:70:18:70:18 | enter M |
 | cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | enter M |
@@ -12718,10 +12887,12 @@ postBlockDominance
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:84:18:84:19 | enter M2 |
 | cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | enter M2 |
 | cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 (normal) |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:86:13:86:37 | [false] ... && ... |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:86:13:86:37 | [true] ... && ... |
 | cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:86:26:86:26 | access to parameter s |
-| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:87:13:87:33 | ...; |
+| cflow.cs:86:13:86:37 | [false] ... && ... | cflow.cs:86:13:86:37 | [false] ... && ... |
+| cflow.cs:86:13:86:37 | [true] ... && ... | cflow.cs:86:13:86:37 | [true] ... && ... |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:26 | access to parameter s |
-| cflow.cs:87:13:87:33 | ...; | cflow.cs:87:13:87:33 | ...; |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | enter M3 |
 | cflow.cs:90:18:90:19 | exit M3 | cflow.cs:90:18:90:19 | exit M3 |
 | cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | enter M3 |
@@ -12755,10 +12926,10 @@ postBlockDominance
 | cflow.cs:116:9:116:29 | ...; | cflow.cs:116:9:116:29 | ...; |
 | cflow.cs:119:20:119:21 | enter M5 | cflow.cs:119:20:119:21 | enter M5 |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:19:127:21 | enter get_Prop |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | enter get_Prop |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:25:127:58 | return ...; |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:48:127:49 | "" |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:53:127:57 | this access |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:19:127:21 | enter get_Prop |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:32:127:57 | ... ? ... : ... |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:48:127:49 | "" |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:53:127:57 | this access |
 | cflow.cs:127:48:127:49 | "" | cflow.cs:127:48:127:49 | "" |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | this access |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:62:127:64 | enter set_Prop |
@@ -12868,51 +13039,53 @@ postBlockDominance
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:185:10:185:18 | enter LogicalOr |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | enter Booleans |
 | cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:193:10:193:17 | exit Booleans |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | enter Booleans |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | exit Booleans (normal) |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:195:13:195:56 | Boolean b = ... |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:195:37:195:56 | !... |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:197:35:197:39 | false |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:197:43:197:46 | true |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:198:13:198:48 | ... = ... |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:198:37:198:41 | false |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:198:45:198:48 | true |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:9:205:9 | if (...) ... |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:37:200:62 | !... |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:200:61:200:61 | access to local variable b |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:193:10:193:17 | enter Booleans |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:13:195:56 | Boolean b = ... |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:37:195:56 | !... |
-| cflow.cs:195:37:195:56 | !... | cflow.cs:195:37:195:56 | !... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:193:10:193:17 | enter Booleans |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:39:195:43 | this access |
+| cflow.cs:195:39:195:43 | this access | cflow.cs:195:39:195:43 | this access |
 | cflow.cs:197:35:197:39 | false | cflow.cs:197:35:197:39 | false |
 | cflow.cs:197:43:197:46 | true | cflow.cs:197:43:197:46 | true |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:197:35:197:39 | false |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:198:13:198:48 | ... = ... |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:198:37:198:41 | false |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:198:45:198:48 | true |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:197:35:197:39 | false |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:17:198:48 | ... ? ... : ... |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:37:198:41 | false |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:45:198:48 | true |
 | cflow.cs:198:37:198:41 | false | cflow.cs:198:37:198:41 | false |
 | cflow.cs:198:45:198:48 | true | cflow.cs:198:45:198:48 | true |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:193:10:193:17 | enter Booleans |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:195:13:195:56 | Boolean b = ... |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:195:37:195:56 | !... |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:195:39:195:43 | this access |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:197:35:197:39 | false |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:197:43:197:46 | true |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:198:13:198:48 | ... = ... |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:198:17:198:48 | ... ? ... : ... |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:198:37:198:41 | false |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:198:45:198:48 | true |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:9:205:9 | if (...) ... |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:193:10:193:17 | enter Booleans |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:195:13:195:56 | Boolean b = ... |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:195:37:195:56 | !... |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:197:35:197:39 | false |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:197:43:197:46 | true |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:198:13:198:48 | ... = ... |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:198:37:198:41 | false |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:198:45:198:48 | true |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:9:205:9 | if (...) ... |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:37:200:62 | !... |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:193:10:193:17 | enter Booleans |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:195:39:195:43 | this access |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:197:35:197:39 | false |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:197:43:197:46 | true |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:198:17:198:48 | ... ? ... : ... |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:198:37:198:41 | false |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:198:45:198:48 | true |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:9:205:9 | if (...) ... |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:13:200:32 | [false] !... |
+| cflow.cs:200:13:200:32 | [true] !... | cflow.cs:200:13:200:32 | [true] !... |
+| cflow.cs:200:13:200:62 | [true] ... \|\| ... | cflow.cs:200:13:200:62 | [true] ... \|\| ... |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:193:10:193:17 | enter Booleans |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:195:39:195:43 | this access |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:197:35:197:39 | false |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:197:43:197:46 | true |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:198:17:198:48 | ... ? ... : ... |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:198:37:198:41 | false |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:198:45:198:48 | true |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:9:205:9 | if (...) ... |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:13:200:32 | [false] !... |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:40:200:61 | [false] ... && ... |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:61:200:61 | access to local variable b |
+| cflow.cs:200:40:200:61 | [true] ... && ... | cflow.cs:200:40:200:61 | [true] ... && ... |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:61:200:61 | access to local variable b |
-| cflow.cs:201:9:205:9 | {...} | cflow.cs:201:9:205:9 | {...} |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:208:10:208:11 | enter Do |
 | cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | enter Do |
 | cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | exit Do (normal) |
@@ -12947,7 +13120,8 @@ postBlockDominance
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | enter Goto |
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto (normal) |
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:242:9:242:13 | Label: |
-| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:242:43:242:45 | {...} |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:242:21:242:40 | [false] !... |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:242:21:242:40 | [true] !... |
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:244:9:244:41 | if (...) ... |
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:244:31:244:41 | goto ...; |
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:246:9:258:9 | switch (...) {...} |
@@ -12961,17 +13135,20 @@ postBlockDominance
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:9:242:13 | Label: |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:244:31:244:41 | goto ...; |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:254:17:254:27 | goto ...; |
-| cflow.cs:242:43:242:45 | {...} | cflow.cs:242:43:242:45 | {...} |
+| cflow.cs:242:21:242:40 | [false] !... | cflow.cs:242:21:242:40 | [false] !... |
+| cflow.cs:242:21:242:40 | [true] !... | cflow.cs:242:21:242:40 | [true] !... |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:240:10:240:13 | enter Goto |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:242:9:242:13 | Label: |
-| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:242:43:242:45 | {...} |
+| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:242:21:242:40 | [false] !... |
+| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:242:21:242:40 | [true] !... |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:9:244:41 | if (...) ... |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:31:244:41 | goto ...; |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:254:17:254:27 | goto ...; |
 | cflow.cs:244:31:244:41 | goto ...; | cflow.cs:244:31:244:41 | goto ...; |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:240:10:240:13 | enter Goto |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:242:9:242:13 | Label: |
-| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:242:43:242:45 | {...} |
+| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:242:21:242:40 | [false] !... |
+| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:242:21:242:40 | [true] !... |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:244:9:244:41 | if (...) ... |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:244:31:244:41 | goto ...; |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:246:9:258:9 | switch (...) {...} |
@@ -12998,7 +13175,9 @@ postBlockDominance
 | cflow.cs:291:12:291:12 | enter M | cflow.cs:291:12:291:12 | enter M |
 | cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | enter NegationInConstructor |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:298:10:298:10 | enter M |
-| cflow.cs:300:56:300:56 | access to parameter s | cflow.cs:300:56:300:56 | access to parameter s |
-| cflow.cs:300:70:300:71 | "" | cflow.cs:298:10:298:10 | enter M |
-| cflow.cs:300:70:300:71 | "" | cflow.cs:300:56:300:56 | access to parameter s |
-| cflow.cs:300:70:300:71 | "" | cflow.cs:300:70:300:71 | "" |
+| cflow.cs:300:44:300:51 | [false] !... | cflow.cs:300:44:300:51 | [false] !... |
+| cflow.cs:300:44:300:51 | [true] !... | cflow.cs:300:44:300:51 | [true] !... |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:298:10:298:10 | enter M |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:44:300:51 | [false] !... |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:44:300:51 | [true] !... |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:44:300:64 | ... && ... |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -497,7 +497,8 @@ nodeEnclosing
 | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | M8 |
@@ -508,8 +509,8 @@ nodeEnclosing
 | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:36 | [false] ... && ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:36 | [true] ... && ... | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:56:10:56:11 | M8 |
@@ -527,7 +528,8 @@ nodeEnclosing
 | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | M9 |
@@ -538,8 +540,8 @@ nodeEnclosing
 | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:37 | [false] ... \|\| ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:37 | [true] ... \|\| ... | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:63:10:63:11 | M9 |
@@ -557,7 +559,8 @@ nodeEnclosing
 | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | M10 |
@@ -568,8 +571,8 @@ nodeEnclosing
 | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:36 | [false] ... && ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:36 | [true] ... && ... | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:70:10:70:12 | M10 |
@@ -587,7 +590,8 @@ nodeEnclosing
 | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | M11 |
@@ -598,8 +602,8 @@ nodeEnclosing
 | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:37 | [false] ... \|\| ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:37 | [true] ... \|\| ... | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:77:10:77:12 | M11 |
@@ -617,7 +621,8 @@ nodeEnclosing
 | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | M12 |
@@ -831,8 +836,9 @@ nodeEnclosing
 | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
@@ -851,9 +857,10 @@ nodeEnclosing
 | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
@@ -869,7 +876,8 @@ nodeEnclosing
 | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
@@ -886,9 +894,10 @@ nodeEnclosing
 | Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:24:127:38 | [false] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:24:127:38 | [true] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:37:127:38 | [false] !... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:84:10:84:12 | M12 |
@@ -1110,9 +1119,6 @@ nodeEnclosing
 | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | M |
 | CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:28:10:28:10 | M |
 | CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:28:10:28:10 | M |
-| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | M1 |
@@ -1129,6 +1135,8 @@ nodeEnclosing
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:10:7:11 | M3 |
+| ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | ConditionalAccess.cs:7:10:7:11 | M3 |
+| ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | M4 |
@@ -1179,11 +1187,7 @@ nodeEnclosing
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | Out |
 | ConditionalAccess.cs:30:10:30:12 | exit Out | ConditionalAccess.cs:30:10:30:12 | Out |
 | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | Out |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
 | ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | Out |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | Out |
-| ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
-| ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:10:30:12 | Out |
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:10:30:12 | Out |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | M8 |
 | ConditionalAccess.cs:32:10:32:11 | exit M8 | ConditionalAccess.cs:32:10:32:11 | M8 |
@@ -1215,8 +1219,8 @@ nodeEnclosing
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | Conditions.cs:3:10:3:19 | IncrOrDecr |
-| Conditions.cs:7:13:7:16 | [inc (line 3): false] !... | Conditions.cs:3:10:3:19 | IncrOrDecr |
-| Conditions.cs:7:13:7:16 | [inc (line 3): true] !... | Conditions.cs:3:10:3:19 | IncrOrDecr |
+| Conditions.cs:7:13:7:16 | [false] !... | Conditions.cs:3:10:3:19 | IncrOrDecr |
+| Conditions.cs:7:13:7:16 | [true] !... | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:3:10:3:19 | IncrOrDecr |
 | Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:3:10:3:19 | IncrOrDecr |
@@ -1244,8 +1248,8 @@ nodeEnclosing
 | Conditions.cs:16:17:16:17 | [b (line 11): true] 0 | Conditions.cs:11:9:11:10 | M1 |
 | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:11:9:11:10 | M1 |
 | Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:11:9:11:10 | M1 |
-| Conditions.cs:17:17:17:18 | [b (line 11): false] !... | Conditions.cs:11:9:11:10 | M1 |
-| Conditions.cs:17:17:17:18 | [b (line 11): true] !... | Conditions.cs:11:9:11:10 | M1 |
+| Conditions.cs:17:17:17:18 | [false] !... | Conditions.cs:11:9:11:10 | M1 |
+| Conditions.cs:17:17:17:18 | [true] !... | Conditions.cs:11:9:11:10 | M1 |
 | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:11:9:11:10 | M1 |
 | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | Conditions.cs:11:9:11:10 | M1 |
 | Conditions.cs:18:17:18:17 | access to local variable x | Conditions.cs:11:9:11:10 | M1 |
@@ -1483,8 +1487,8 @@ nodeEnclosing
 | Conditions.cs:107:24:107:24 | [b (line 102): true] 0 | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:102:12:102:13 | M8 |
-| Conditions.cs:108:17:108:18 | [b (line 102): false] !... | Conditions.cs:102:12:102:13 | M8 |
-| Conditions.cs:108:17:108:18 | [b (line 102): true] !... | Conditions.cs:102:12:102:13 | M8 |
+| Conditions.cs:108:17:108:18 | [false] !... | Conditions.cs:102:12:102:13 | M8 |
+| Conditions.cs:108:17:108:18 | [true] !... | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:102:12:102:13 | M8 |
@@ -1520,7 +1524,8 @@ nodeEnclosing
 | Conditions.cs:118:29:118:43 | ... - ... | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:118:43:118:43 | 1 | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:119:17:119:21 | !... | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:113:10:113:11 | M9 |
@@ -1580,7 +1585,8 @@ nodeEnclosing
 | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:143:10:143:12 | M11 |
-| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:143:10:143:12 | M11 |
 | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | Conditions.cs:143:10:143:12 | M11 |
@@ -2064,11 +2070,16 @@ nodeEnclosing
 | Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:114:13:115:41 | [finally: return] if (...) ... | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:103:10:103:11 | M5 |
-| Finally.cs:114:17:114:36 | !... | Finally.cs:103:10:103:11 | M5 |
-| Finally.cs:114:17:114:36 | [finally: exception(Exception)] !... | Finally.cs:103:10:103:11 | M5 |
-| Finally.cs:114:17:114:36 | [finally: exception(NullReferenceException)] !... | Finally.cs:103:10:103:11 | M5 |
-| Finally.cs:114:17:114:36 | [finally: exception(OutOfMemoryException)] !... | Finally.cs:103:10:103:11 | M5 |
-| Finally.cs:114:17:114:36 | [finally: return] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [false, finally: return] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [false] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [true] !... | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:103:10:103:11 | M5 |
@@ -2896,7 +2907,8 @@ nodeEnclosing
 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:69:13:69:23 | [false] !... | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:69:13:69:23 | [true] !... | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:69:14:69:17 | access to parameter args | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
@@ -3322,7 +3334,8 @@ nodeEnclosing
 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:9:5:10 | M2 |
-| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:9:5:10 | M2 |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:9:5:10 | M2 |
+| NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:9:5:10 | M2 |
@@ -3339,7 +3352,8 @@ nodeEnclosing
 | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:12:9:13 | M4 |
-| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:12:9:13 | M4 |
+| NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | NullCoalescing.cs:9:12:9:13 | M4 |
+| NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:12:9:13 | M4 |
@@ -3349,9 +3363,11 @@ nodeEnclosing
 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:9:11:10 | M5 |
-| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:9:11:10 | M5 |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:51:11:58 | [false] ... && ... | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:51:11:58 | [true] ... && ... | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:9:11:10 | M5 |
@@ -3585,7 +3601,8 @@ nodeEnclosing
 | Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:32:24:39 | access to property Length | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:24:32:24:55 | [false] ... && ... | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:24:32:24:55 | [true] ... && ... | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:43:24:43 | 0 | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:48:24:55 | ... != ... | Switch.cs:10:10:10:11 | M2 |
@@ -3733,12 +3750,14 @@ nodeEnclosing
 | Switch.cs:124:5:127:5 | {...} | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:123:10:123:12 | M11 |
-| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:13:125:48 | [true] ... switch { ... } | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:24:125:29 | Boolean b | Switch.cs:123:10:123:12 | M11 |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:24:125:34 | [false] ... => ... | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:24:125:34 | [true] ... => ... | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:37:125:37 | _ | Switch.cs:123:10:123:12 | M11 |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:37:125:46 | [false] ... => ... | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:42:125:46 | false | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:126:13:126:19 | return ...; | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:129:12:129:14 | M12 |
@@ -3747,12 +3766,14 @@ nodeEnclosing
 | Switch.cs:130:5:132:5 | {...} | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:129:12:129:14 | M12 |
-| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:17:131:53 | [non-null] ... switch { ... } | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:28:131:35 | String s | Switch.cs:129:12:129:14 | M12 |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:28:131:40 | [non-null] ... => ... | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:28:131:40 | [null] ... => ... | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:43:131:43 | _ | Switch.cs:129:12:129:14 | M12 |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:43:131:51 | [null] ... => ... | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:48:131:51 | null | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | M13 |
@@ -3945,7 +3966,8 @@ nodeEnclosing
 | cflow.cs:26:17:26:17 | access to local variable i | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:26:17:26:21 | ... % ... | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:26:17:26:26 | ... == ... | cflow.cs:5:17:5:20 | Main |
-| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:5:17:5:20 | Main |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:5:17:5:20 | Main |
+| cflow.cs:26:17:26:40 | [true] ... && ... | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:26:21:26:21 | 3 | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:26:26:26:26 | 0 | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:5:17:5:20 | Main |
@@ -4024,7 +4046,8 @@ nodeEnclosing
 | cflow.cs:62:13:62:19 | case ...: | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:62:18:62:18 | 0 | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:63:21:63:34 | !... | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:63:21:63:34 | [true] !... | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:63:23:63:27 | access to field Field | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:63:23:63:27 | this access | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:63:23:63:33 | ... == ... | cflow.cs:37:17:37:22 | Switch |
@@ -4063,7 +4086,8 @@ nodeEnclosing
 | cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:84:18:84:19 | M2 |
-| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:84:18:84:19 | M2 |
+| cflow.cs:86:13:86:37 | [false] ... && ... | cflow.cs:84:18:84:19 | M2 |
+| cflow.cs:86:13:86:37 | [true] ... && ... | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:86:18:86:21 | null | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:86:26:86:33 | access to property Length | cflow.cs:84:18:84:19 | M2 |
@@ -4317,15 +4341,15 @@ nodeEnclosing
 | cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:13:187:13 | 1 | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:13:187:18 | ... == ... | cflow.cs:185:10:185:18 | LogicalOr |
-| cflow.cs:187:13:187:28 | ... \|\| ... | cflow.cs:185:10:185:18 | LogicalOr |
-| cflow.cs:187:13:187:50 | ... \|\| ... | cflow.cs:185:10:185:18 | LogicalOr |
+| cflow.cs:187:13:187:28 | [false] ... \|\| ... | cflow.cs:185:10:185:18 | LogicalOr |
+| cflow.cs:187:13:187:50 | [false] ... \|\| ... | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:18:187:18 | 2 | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:23:187:23 | 2 | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:23:187:28 | ... == ... | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:28:187:28 | 3 | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:34:187:34 | 1 | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:34:187:39 | ... == ... | cflow.cs:185:10:185:18 | LogicalOr |
-| cflow.cs:187:34:187:49 | ... && ... | cflow.cs:185:10:185:18 | LogicalOr |
+| cflow.cs:187:34:187:49 | [false] ... && ... | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:187:39:187:39 | 3 | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:190:13:190:52 | ...; | cflow.cs:185:10:185:18 | LogicalOr |
@@ -4350,12 +4374,14 @@ nodeEnclosing
 | cflow.cs:195:39:195:55 | ... == ... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:195:55:195:55 | 1 | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:197:13:197:47 | !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:197:13:197:47 | [false] !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:197:13:197:47 | [true] !... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:15:197:19 | access to field Field | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:15:197:19 | this access | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:15:197:26 | access to property Length | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:197:15:197:46 | ... ? ... : ... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:197:15:197:46 | [false] ... ? ... : ... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:197:15:197:46 | [true] ... ? ... : ... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:31:197:31 | 0 | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:35:197:39 | false | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:43:197:46 | true | cflow.cs:193:10:193:17 | Booleans |
@@ -4370,20 +4396,25 @@ nodeEnclosing
 | cflow.cs:198:37:198:41 | false | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:198:45:198:48 | true | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:200:13:200:32 | !... | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:13:200:32 | [true] !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:13:200:62 | [false] ... \|\| ... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:13:200:62 | [true] ... \|\| ... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:15:200:19 | access to field Field | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:15:200:19 | this access | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:15:200:26 | access to property Length | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:15:200:31 | ... == ... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:31:200:31 | 0 | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:200:38:200:62 | !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:37:200:62 | [false] !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:37:200:62 | [true] !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:38:200:62 | [false] !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:38:200:62 | [true] !... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:40:200:44 | access to field Field | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:40:200:44 | this access | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:40:200:51 | access to property Length | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:40:200:61 | [true] ... && ... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:56:200:56 | 1 | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:201:9:205:9 | {...} | cflow.cs:193:10:193:17 | Booleans |
@@ -4463,8 +4494,10 @@ nodeEnclosing
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:240:10:240:13 | Goto |
-| cflow.cs:242:20:242:40 | !... | cflow.cs:240:10:240:13 | Goto |
-| cflow.cs:242:21:242:40 | !... | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:242:20:242:40 | [false] !... | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:242:20:242:40 | [true] !... | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:242:21:242:40 | [false] !... | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:242:21:242:40 | [true] !... | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:242:23:242:27 | access to field Field | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:242:23:242:27 | this access | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:242:23:242:34 | access to property Length | cflow.cs:240:10:240:13 | Goto |
@@ -4559,7 +4592,8 @@ nodeEnclosing
 | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:298:10:298:10 | M |
 | cflow.cs:300:9:300:73 | ...; | cflow.cs:298:10:298:10 | M |
 | cflow.cs:300:38:300:38 | 0 | cflow.cs:298:10:298:10 | M |
-| cflow.cs:300:44:300:51 | !... | cflow.cs:298:10:298:10 | M |
+| cflow.cs:300:44:300:51 | [false] !... | cflow.cs:298:10:298:10 | M |
+| cflow.cs:300:44:300:51 | [true] !... | cflow.cs:298:10:298:10 | M |
 | cflow.cs:300:44:300:64 | ... && ... | cflow.cs:298:10:298:10 | M |
 | cflow.cs:300:46:300:46 | access to parameter i | cflow.cs:298:10:298:10 | M |
 | cflow.cs:300:46:300:50 | ... > ... | cflow.cs:298:10:298:10 | M |
@@ -4588,49 +4622,49 @@ blockEnclosing
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | M4 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | M1 |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:9:24:9:27 | null | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | M2 |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:16:24:16:27 | null | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | M3 |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:23:24:23:27 | null | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | M4 |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:30:24:30:27 | null | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | M5 |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:37:24:37:27 | null | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | M6 |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:44:24:44:27 | null | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | M7 |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:51:24:51:27 | null | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | M7 |
@@ -4639,28 +4673,28 @@ blockEnclosing
 | Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:36 | [false] ... && ... | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:37 | [true] ... \|\| ... | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:36 | [false] ... && ... | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:37 | [true] ... \|\| ... | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | M12 |
@@ -4696,16 +4730,16 @@ blockEnclosing
 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:24:127:38 | [true] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:131:18:131:32 | AssertTrueFalse |
 | Assert.cs:138:10:138:12 | enter M13 | Assert.cs:138:10:138:12 | M13 |
 | Assert.cs:138:10:138:12 | exit M13 | Assert.cs:138:10:138:12 | M13 |
@@ -4758,8 +4792,6 @@ blockEnclosing
 | CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:15:10:15:15 | Typeof |
 | CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:20:12:20:17 | Nameof |
 | CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:28:10:28:10 | M |
-| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | ConditionalAccess |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | M1 |
 | ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:12:3:13 | M1 |
@@ -4769,10 +4801,13 @@ blockEnclosing
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:10:5:11 | M2 |
 | ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | M3 |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:10:7:11 | M3 |
+| ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | ConditionalAccess.cs:7:10:7:11 | M3 |
+| ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:10:7:11 | M3 |
 | ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:9:9:10 | M4 |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | M4 |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:9:9:10 | M4 |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:11:9:11:10 | M5 |
@@ -4786,7 +4821,6 @@ blockEnclosing
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:12:19:13 | M6 |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | M7 |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:10:30:12 | Out |
-| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | Out |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:32:10:32:11 | M8 |
 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | M8 |
 | ConditionalAccess.cs:35:14:35:24 | call to method Out | ConditionalAccess.cs:32:10:32:11 | M8 |
@@ -4861,8 +4895,8 @@ blockEnclosing
 | Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:129:10:129:12 | M10 |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:129:10:129:12 | M10 |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:129:10:129:12 | M10 |
@@ -4903,7 +4937,7 @@ blockEnclosing
 | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:109:13:109:21 | ThrowExpr |
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:109:13:109:21 | ThrowExpr |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
 | ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:114:16:114:34 | ExtensionMethodCall |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | FailingAssertion |
@@ -4993,11 +5027,16 @@ blockEnclosing
 | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:103:10:103:11 | M5 |
-| Finally.cs:115:17:115:41 | ...; | Finally.cs:103:10:103:11 | M5 |
-| Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | Finally.cs:103:10:103:11 | M5 |
-| Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | Finally.cs:103:10:103:11 | M5 |
-| Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:103:10:103:11 | M5 |
-| Finally.cs:115:17:115:41 | [finally: return] ...; | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [false, finally: return] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [false] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:103:10:103:11 | M5 |
+| Finally.cs:114:17:114:36 | [true] !... | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:103:10:103:11 | M5 |
@@ -5114,6 +5153,7 @@ blockEnclosing
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:18:10:18:11 | M3 |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:18:10:18:11 | M3 |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:24:10:24:11 | M4 |
@@ -5165,8 +5205,8 @@ blockEnclosing
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:69:13:69:23 | [false] !... | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:69:13:69:23 | [true] !... | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
@@ -5348,28 +5388,32 @@ blockEnclosing
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | M1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | M1 |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:9:3:10 | M1 |
-| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | M1 |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:9:3:10 | M1 |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:9:3:10 | M1 |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:9:5:10 | M2 |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | M2 |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | M2 |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:9:5:10 | M2 |
+| NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:9:5:10 | M2 |
-| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:9:5:10 | M2 |
-| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:9:5:10 | M2 |
 | NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:12:7:13 | M3 |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | M3 |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | M3 |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:12:7:13 | M3 |
 | NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:12:9:13 | M4 |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | M4 |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | M4 |
+| NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | NullCoalescing.cs:9:12:9:13 | M4 |
+| NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:12:9:13 | M4 |
-| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | M4 |
 | NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:9:11:10 | M5 |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | M5 |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:51:11:58 | [false] ... && ... | NullCoalescing.cs:11:9:11:10 | M5 |
+| NullCoalescing.cs:11:51:11:58 | [true] ... && ... | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:9:11:10 | M5 |
-| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:9:11:10 | M5 |
-| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:9:11:10 | M5 |
 | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:13:10:13:11 | M6 |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:5:10:5:13 | Test |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:5:10:5:13 | Test |
@@ -5417,9 +5461,10 @@ blockEnclosing
 | Switch.cs:22:21:22:27 | return ...; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:24:32:24:55 | [false] ... && ... | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:24:32:24:55 | [true] ... && ... | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:25:17:25:37 | ...; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:10:10:10:11 | M2 |
@@ -5465,14 +5510,18 @@ blockEnclosing
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:24:125:34 | [false] ... => ... | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:24:125:34 | [true] ... => ... | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | M11 |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:123:10:123:12 | M11 |
-| Switch.cs:126:13:126:19 | return ...; | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:37:125:37 | _ | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:28:131:40 | [non-null] ... => ... | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:28:131:40 | [null] ... => ... | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:129:12:129:14 | M12 |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:129:12:129:14 | M12 |
-| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:43:131:43 | _ | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:138:13:138:20 | default: | Switch.cs:134:9:134:11 | M13 |
@@ -5489,9 +5538,9 @@ blockEnclosing
 | Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | M15 |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:154:10:154:12 | M15 |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:154:10:154:12 | M15 |
@@ -5501,7 +5550,7 @@ blockEnclosing
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | M1 |
 | VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:13:12:13:13 | M2 |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:19:7:19:8 | M3 |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | M3 |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:19:7:19:8 | M3 |
 | VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:19:7:19:8 | M3 |
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:19:7:19:8 | M3 |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | Dispose |
@@ -5517,9 +5566,9 @@ blockEnclosing
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:5:17:5:20 | Main |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:5:17:5:20 | Main |
+| cflow.cs:26:17:26:40 | [true] ... && ... | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:5:17:5:20 | Main |
-| cflow.cs:27:17:27:46 | ...; | cflow.cs:5:17:5:20 | Main |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:29:17:29:42 | ...; | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:30:18:33:37 | if (...) ... | cflow.cs:5:17:5:20 | Main |
 | cflow.cs:31:17:31:42 | ...; | cflow.cs:5:17:5:20 | Main |
@@ -5537,8 +5586,8 @@ blockEnclosing
 | cflow.cs:56:13:56:20 | default: | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:65:17:65:22 | break; | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:63:21:63:34 | [true] !... | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:70:18:70:18 | enter M | cflow.cs:70:18:70:18 | M |
 | cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | M |
@@ -5548,8 +5597,9 @@ blockEnclosing
 | cflow.cs:79:9:81:9 | {...} | cflow.cs:70:18:70:18 | M |
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | M2 |
+| cflow.cs:86:13:86:37 | [false] ... && ... | cflow.cs:84:18:84:19 | M2 |
+| cflow.cs:86:13:86:37 | [true] ... && ... | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:84:18:84:19 | M2 |
-| cflow.cs:87:13:87:33 | ...; | cflow.cs:84:18:84:19 | M2 |
 | cflow.cs:90:18:90:19 | enter M3 | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:90:18:90:19 | exit M3 | cflow.cs:90:18:90:19 | M3 |
 | cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | M3 |
@@ -5566,7 +5616,7 @@ blockEnclosing
 | cflow.cs:116:9:116:29 | ...; | cflow.cs:106:18:106:19 | M4 |
 | cflow.cs:119:20:119:21 | enter M5 | cflow.cs:119:20:119:21 | M5 |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:19:127:21 | get_Prop |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | get_Prop |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:19:127:21 | get_Prop |
 | cflow.cs:127:48:127:49 | "" | cflow.cs:127:19:127:21 | get_Prop |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:19:127:21 | get_Prop |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:62:127:64 | set_Prop |
@@ -5597,18 +5647,20 @@ blockEnclosing
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:185:10:185:18 | LogicalOr |
 | cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:193:10:193:17 | exit Booleans | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:195:37:195:56 | !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:195:39:195:43 | this access | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:35:197:39 | false | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:197:43:197:46 | true | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:198:37:198:41 | false | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:198:45:198:48 | true | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:13:200:32 | [true] !... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:13:200:62 | [true] ... \|\| ... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:193:10:193:17 | Booleans |
+| cflow.cs:200:40:200:61 | [true] ... && ... | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:193:10:193:17 | Booleans |
-| cflow.cs:201:9:205:9 | {...} | cflow.cs:193:10:193:17 | Booleans |
 | cflow.cs:208:10:208:11 | enter Do | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | Do |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:208:10:208:11 | Do |
@@ -5626,7 +5678,8 @@ blockEnclosing
 | cflow.cs:240:10:240:13 | enter Goto | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:240:10:240:13 | Goto |
-| cflow.cs:242:43:242:45 | {...} | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:242:21:242:40 | [false] !... | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:242:21:242:40 | [true] !... | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:244:31:244:41 | goto ...; | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:240:10:240:13 | Goto |
@@ -5646,5 +5699,6 @@ blockEnclosing
 | cflow.cs:291:12:291:12 | enter M | cflow.cs:291:12:291:12 | M |
 | cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | NegationInConstructor |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:298:10:298:10 | M |
-| cflow.cs:300:56:300:56 | access to parameter s | cflow.cs:298:10:298:10 | M |
-| cflow.cs:300:70:300:71 | "" | cflow.cs:298:10:298:10 | M |
+| cflow.cs:300:44:300:51 | [false] !... | cflow.cs:298:10:298:10 | M |
+| cflow.cs:300:44:300:51 | [true] !... | cflow.cs:298:10:298:10 | M |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:298:10:298:10 | M |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -310,9 +310,9 @@
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:48:9:48 | 3 |
 | Assert.cs:8:5:12:5 | {...} | Assert.cs:8:5:12:5 | {...} |
 | Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:9:9:33 | ... ...; |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:20:9:32 | ... ? ... : ... |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:20:9:20 | access to parameter b |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:20:9:20 | access to parameter b |
-| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:32 | ... ? ... : ... |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:20 | access to parameter b |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:10:22:10:22 | access to local variable s |
@@ -326,9 +326,9 @@
 | Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:27:11:27 | access to local variable s |
 | Assert.cs:15:5:19:5 | {...} | Assert.cs:15:5:19:5 | {...} |
 | Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:9:16:33 | ... ...; |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:20:16:32 | ... ? ... : ... |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:20:16:20 | access to parameter b |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:20:16:20 | access to parameter b |
-| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:32 | ... ? ... : ... |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:20 | access to parameter b |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:17:23:17:23 | access to local variable s |
@@ -340,9 +340,9 @@
 | Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:27:18:27 | access to local variable s |
 | Assert.cs:22:5:26:5 | {...} | Assert.cs:22:5:26:5 | {...} |
 | Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:9:23:33 | ... ...; |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:20:23:32 | ... ? ... : ... |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:20:23:20 | access to parameter b |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:20:23:20 | access to parameter b |
-| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:32 | ... ? ... : ... |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:20 | access to parameter b |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:24:26:24:26 | access to local variable s |
@@ -354,9 +354,9 @@
 | Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:27:25:27 | access to local variable s |
 | Assert.cs:29:5:33:5 | {...} | Assert.cs:29:5:33:5 | {...} |
 | Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:9:30:33 | ... ...; |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:20:30:32 | ... ? ... : ... |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:20:30:20 | access to parameter b |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:20:30:20 | access to parameter b |
-| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:32 | ... ? ... : ... |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:20 | access to parameter b |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:31:23:31:23 | access to local variable s |
@@ -370,9 +370,9 @@
 | Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:27:32:27 | access to local variable s |
 | Assert.cs:36:5:40:5 | {...} | Assert.cs:36:5:40:5 | {...} |
 | Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:9:37:33 | ... ...; |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:20:37:32 | ... ? ... : ... |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:20:37:20 | access to parameter b |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:20:37:20 | access to parameter b |
-| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:32 | ... ? ... : ... |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:20 | access to parameter b |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:38:23:38:23 | access to local variable s |
@@ -386,9 +386,9 @@
 | Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:27:39:27 | access to local variable s |
 | Assert.cs:43:5:47:5 | {...} | Assert.cs:43:5:47:5 | {...} |
 | Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:9:44:33 | ... ...; |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:20:44:32 | ... ? ... : ... |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:20:44:20 | access to parameter b |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:20:44:20 | access to parameter b |
-| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:32 | ... ? ... : ... |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:20 | access to parameter b |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:45:24:45:24 | access to local variable s |
@@ -402,9 +402,9 @@
 | Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:27:46:27 | access to local variable s |
 | Assert.cs:50:5:54:5 | {...} | Assert.cs:50:5:54:5 | {...} |
 | Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:9:51:33 | ... ...; |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:20:51:32 | ... ? ... : ... |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:20:51:20 | access to parameter b |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:20:51:20 | access to parameter b |
-| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:32 | ... ? ... : ... |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:20 | access to parameter b |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:52:24:52:24 | access to local variable s |
@@ -418,16 +418,16 @@
 | Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:27:53:27 | access to local variable s |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:57:5:61:5 | {...} |
 | Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:9:58:33 | ... ...; |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:20:58:32 | ... ? ... : ... |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:20:58:20 | access to parameter b |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b |
-| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:32 | ... ? ... : ... |
+| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b |
 | Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null |
 | Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:23:59:36 | ... && ... |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:23:59:23 | access to local variable s |
 | Assert.cs:59:9:59:38 | ...; | Assert.cs:59:9:59:38 | ...; |
 | Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s |
 | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:23 | access to local variable s |
-| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:36 | ... && ... |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:23 | access to local variable s |
 | Assert.cs:59:28:59:31 | null | Assert.cs:59:28:59:31 | null |
 | Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b |
 | Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:60:27:60:27 | access to local variable s |
@@ -436,16 +436,16 @@
 | Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:27:60:27 | access to local variable s |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:64:5:68:5 | {...} |
 | Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:9:65:33 | ... ...; |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:20:65:32 | ... ? ... : ... |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:20:65:20 | access to parameter b |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b |
-| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:32 | ... ? ... : ... |
+| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b |
 | Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null |
 | Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:24:66:37 | ... \|\| ... |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:24:66:24 | access to local variable s |
 | Assert.cs:66:9:66:39 | ...; | Assert.cs:66:9:66:39 | ...; |
 | Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s |
 | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:24 | access to local variable s |
-| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:37 | ... \|\| ... |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:24 | access to local variable s |
 | Assert.cs:66:29:66:32 | null | Assert.cs:66:29:66:32 | null |
 | Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b |
 | Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:67:27:67:27 | access to local variable s |
@@ -454,16 +454,16 @@
 | Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:27:67:27 | access to local variable s |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:71:5:75:5 | {...} |
 | Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:9:72:33 | ... ...; |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:20:72:32 | ... ? ... : ... |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:20:72:20 | access to parameter b |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b |
-| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:32 | ... ? ... : ... |
+| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b |
 | Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null |
 | Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:23:73:36 | ... && ... |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:23:73:23 | access to local variable s |
 | Assert.cs:73:9:73:38 | ...; | Assert.cs:73:9:73:38 | ...; |
 | Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s |
 | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:23 | access to local variable s |
-| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:36 | ... && ... |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:23 | access to local variable s |
 | Assert.cs:73:28:73:31 | null | Assert.cs:73:28:73:31 | null |
 | Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b |
 | Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:74:27:74:27 | access to local variable s |
@@ -472,16 +472,16 @@
 | Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:27:74:27 | access to local variable s |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:78:5:82:5 | {...} |
 | Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:9:79:33 | ... ...; |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:20:79:32 | ... ? ... : ... |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:20:79:20 | access to parameter b |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b |
-| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:32 | ... ? ... : ... |
+| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b |
 | Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null |
 | Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:24:80:37 | ... \|\| ... |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:24:80:24 | access to local variable s |
 | Assert.cs:80:9:80:39 | ...; | Assert.cs:80:9:80:39 | ...; |
 | Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s |
 | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:24 | access to local variable s |
-| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:37 | ... \|\| ... |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:24 | access to local variable s |
 | Assert.cs:80:29:80:32 | null | Assert.cs:80:29:80:32 | null |
 | Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b |
 | Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:81:27:81:27 | access to local variable s |
@@ -490,9 +490,9 @@
 | Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:27:81:27 | access to local variable s |
 | Assert.cs:85:5:129:5 | {...} | Assert.cs:85:5:129:5 | {...} |
 | Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:9:86:33 | ... ...; |
-| Assert.cs:86:16:86:32 | String s = ... | Assert.cs:86:20:86:32 | ... ? ... : ... |
+| Assert.cs:86:16:86:32 | String s = ... | Assert.cs:86:20:86:20 | access to parameter b |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:20:86:20 | access to parameter b |
-| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:32 | ... ? ... : ... |
+| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:20 | access to parameter b |
 | Assert.cs:86:24:86:27 | null | Assert.cs:86:24:86:27 | null |
 | Assert.cs:86:31:86:32 | "" | Assert.cs:86:31:86:32 | "" |
 | Assert.cs:87:9:87:31 | call to method Assert | Assert.cs:87:22:87:22 | access to local variable s |
@@ -504,10 +504,10 @@
 | Assert.cs:88:9:88:36 | ...; | Assert.cs:88:9:88:36 | ...; |
 | Assert.cs:88:27:88:27 | access to local variable s | Assert.cs:88:27:88:27 | access to local variable s |
 | Assert.cs:88:27:88:34 | access to property Length | Assert.cs:88:27:88:27 | access to local variable s |
-| Assert.cs:90:9:90:25 | ... = ... | Assert.cs:90:13:90:25 | ... ? ... : ... |
+| Assert.cs:90:9:90:25 | ... = ... | Assert.cs:90:13:90:13 | access to parameter b |
 | Assert.cs:90:9:90:26 | ...; | Assert.cs:90:9:90:26 | ...; |
 | Assert.cs:90:13:90:13 | access to parameter b | Assert.cs:90:13:90:13 | access to parameter b |
-| Assert.cs:90:13:90:25 | ... ? ... : ... | Assert.cs:90:13:90:25 | ... ? ... : ... |
+| Assert.cs:90:13:90:25 | ... ? ... : ... | Assert.cs:90:13:90:13 | access to parameter b |
 | Assert.cs:90:17:90:20 | null | Assert.cs:90:17:90:20 | null |
 | Assert.cs:90:24:90:25 | "" | Assert.cs:90:24:90:25 | "" |
 | Assert.cs:91:9:91:24 | call to method IsNull | Assert.cs:91:23:91:23 | access to local variable s |
@@ -517,10 +517,10 @@
 | Assert.cs:92:9:92:36 | ...; | Assert.cs:92:9:92:36 | ...; |
 | Assert.cs:92:27:92:27 | access to local variable s | Assert.cs:92:27:92:27 | access to local variable s |
 | Assert.cs:92:27:92:34 | access to property Length | Assert.cs:92:27:92:27 | access to local variable s |
-| Assert.cs:94:9:94:25 | ... = ... | Assert.cs:94:13:94:25 | ... ? ... : ... |
+| Assert.cs:94:9:94:25 | ... = ... | Assert.cs:94:13:94:13 | access to parameter b |
 | Assert.cs:94:9:94:26 | ...; | Assert.cs:94:9:94:26 | ...; |
 | Assert.cs:94:13:94:13 | access to parameter b | Assert.cs:94:13:94:13 | access to parameter b |
-| Assert.cs:94:13:94:25 | ... ? ... : ... | Assert.cs:94:13:94:25 | ... ? ... : ... |
+| Assert.cs:94:13:94:25 | ... ? ... : ... | Assert.cs:94:13:94:13 | access to parameter b |
 | Assert.cs:94:17:94:20 | null | Assert.cs:94:17:94:20 | null |
 | Assert.cs:94:24:94:25 | "" | Assert.cs:94:24:94:25 | "" |
 | Assert.cs:95:9:95:27 | call to method IsNotNull | Assert.cs:95:26:95:26 | access to local variable s |
@@ -530,10 +530,10 @@
 | Assert.cs:96:9:96:36 | ...; | Assert.cs:96:9:96:36 | ...; |
 | Assert.cs:96:27:96:27 | access to local variable s | Assert.cs:96:27:96:27 | access to local variable s |
 | Assert.cs:96:27:96:34 | access to property Length | Assert.cs:96:27:96:27 | access to local variable s |
-| Assert.cs:98:9:98:25 | ... = ... | Assert.cs:98:13:98:25 | ... ? ... : ... |
+| Assert.cs:98:9:98:25 | ... = ... | Assert.cs:98:13:98:13 | access to parameter b |
 | Assert.cs:98:9:98:26 | ...; | Assert.cs:98:9:98:26 | ...; |
 | Assert.cs:98:13:98:13 | access to parameter b | Assert.cs:98:13:98:13 | access to parameter b |
-| Assert.cs:98:13:98:25 | ... ? ... : ... | Assert.cs:98:13:98:25 | ... ? ... : ... |
+| Assert.cs:98:13:98:25 | ... ? ... : ... | Assert.cs:98:13:98:13 | access to parameter b |
 | Assert.cs:98:17:98:20 | null | Assert.cs:98:17:98:20 | null |
 | Assert.cs:98:24:98:25 | "" | Assert.cs:98:24:98:25 | "" |
 | Assert.cs:99:9:99:32 | call to method IsTrue | Assert.cs:99:23:99:23 | access to local variable s |
@@ -545,10 +545,10 @@
 | Assert.cs:100:9:100:36 | ...; | Assert.cs:100:9:100:36 | ...; |
 | Assert.cs:100:27:100:27 | access to local variable s | Assert.cs:100:27:100:27 | access to local variable s |
 | Assert.cs:100:27:100:34 | access to property Length | Assert.cs:100:27:100:27 | access to local variable s |
-| Assert.cs:102:9:102:25 | ... = ... | Assert.cs:102:13:102:25 | ... ? ... : ... |
+| Assert.cs:102:9:102:25 | ... = ... | Assert.cs:102:13:102:13 | access to parameter b |
 | Assert.cs:102:9:102:26 | ...; | Assert.cs:102:9:102:26 | ...; |
 | Assert.cs:102:13:102:13 | access to parameter b | Assert.cs:102:13:102:13 | access to parameter b |
-| Assert.cs:102:13:102:25 | ... ? ... : ... | Assert.cs:102:13:102:25 | ... ? ... : ... |
+| Assert.cs:102:13:102:25 | ... ? ... : ... | Assert.cs:102:13:102:13 | access to parameter b |
 | Assert.cs:102:17:102:20 | null | Assert.cs:102:17:102:20 | null |
 | Assert.cs:102:24:102:25 | "" | Assert.cs:102:24:102:25 | "" |
 | Assert.cs:103:9:103:32 | call to method IsTrue | Assert.cs:103:23:103:23 | access to local variable s |
@@ -560,10 +560,10 @@
 | Assert.cs:104:9:104:36 | ...; | Assert.cs:104:9:104:36 | ...; |
 | Assert.cs:104:27:104:27 | access to local variable s | Assert.cs:104:27:104:27 | access to local variable s |
 | Assert.cs:104:27:104:34 | access to property Length | Assert.cs:104:27:104:27 | access to local variable s |
-| Assert.cs:106:9:106:25 | ... = ... | Assert.cs:106:13:106:25 | ... ? ... : ... |
+| Assert.cs:106:9:106:25 | ... = ... | Assert.cs:106:13:106:13 | access to parameter b |
 | Assert.cs:106:9:106:26 | ...; | Assert.cs:106:9:106:26 | ...; |
 | Assert.cs:106:13:106:13 | access to parameter b | Assert.cs:106:13:106:13 | access to parameter b |
-| Assert.cs:106:13:106:25 | ... ? ... : ... | Assert.cs:106:13:106:25 | ... ? ... : ... |
+| Assert.cs:106:13:106:25 | ... ? ... : ... | Assert.cs:106:13:106:13 | access to parameter b |
 | Assert.cs:106:17:106:20 | null | Assert.cs:106:17:106:20 | null |
 | Assert.cs:106:24:106:25 | "" | Assert.cs:106:24:106:25 | "" |
 | Assert.cs:107:9:107:33 | call to method IsFalse | Assert.cs:107:24:107:24 | access to local variable s |
@@ -575,10 +575,10 @@
 | Assert.cs:108:9:108:36 | ...; | Assert.cs:108:9:108:36 | ...; |
 | Assert.cs:108:27:108:27 | access to local variable s | Assert.cs:108:27:108:27 | access to local variable s |
 | Assert.cs:108:27:108:34 | access to property Length | Assert.cs:108:27:108:27 | access to local variable s |
-| Assert.cs:110:9:110:25 | ... = ... | Assert.cs:110:13:110:25 | ... ? ... : ... |
+| Assert.cs:110:9:110:25 | ... = ... | Assert.cs:110:13:110:13 | access to parameter b |
 | Assert.cs:110:9:110:26 | ...; | Assert.cs:110:9:110:26 | ...; |
 | Assert.cs:110:13:110:13 | access to parameter b | Assert.cs:110:13:110:13 | access to parameter b |
-| Assert.cs:110:13:110:25 | ... ? ... : ... | Assert.cs:110:13:110:25 | ... ? ... : ... |
+| Assert.cs:110:13:110:25 | ... ? ... : ... | Assert.cs:110:13:110:13 | access to parameter b |
 | Assert.cs:110:17:110:20 | null | Assert.cs:110:17:110:20 | null |
 | Assert.cs:110:24:110:25 | "" | Assert.cs:110:24:110:25 | "" |
 | Assert.cs:111:9:111:33 | call to method IsFalse | Assert.cs:111:24:111:24 | access to local variable s |
@@ -590,71 +590,71 @@
 | Assert.cs:112:9:112:36 | ...; | Assert.cs:112:9:112:36 | ...; |
 | Assert.cs:112:27:112:27 | access to local variable s | Assert.cs:112:27:112:27 | access to local variable s |
 | Assert.cs:112:27:112:34 | access to property Length | Assert.cs:112:27:112:27 | access to local variable s |
-| Assert.cs:114:9:114:25 | ... = ... | Assert.cs:114:13:114:25 | ... ? ... : ... |
+| Assert.cs:114:9:114:25 | ... = ... | Assert.cs:114:13:114:13 | access to parameter b |
 | Assert.cs:114:9:114:26 | ...; | Assert.cs:114:9:114:26 | ...; |
 | Assert.cs:114:13:114:13 | access to parameter b | Assert.cs:114:13:114:13 | access to parameter b |
-| Assert.cs:114:13:114:25 | ... ? ... : ... | Assert.cs:114:13:114:25 | ... ? ... : ... |
+| Assert.cs:114:13:114:25 | ... ? ... : ... | Assert.cs:114:13:114:13 | access to parameter b |
 | Assert.cs:114:17:114:20 | null | Assert.cs:114:17:114:20 | null |
 | Assert.cs:114:24:114:25 | "" | Assert.cs:114:24:114:25 | "" |
-| Assert.cs:115:9:115:37 | call to method IsTrue | Assert.cs:115:23:115:36 | ... && ... |
+| Assert.cs:115:9:115:37 | call to method IsTrue | Assert.cs:115:23:115:23 | access to local variable s |
 | Assert.cs:115:9:115:38 | ...; | Assert.cs:115:9:115:38 | ...; |
 | Assert.cs:115:23:115:23 | access to local variable s | Assert.cs:115:23:115:23 | access to local variable s |
 | Assert.cs:115:23:115:31 | ... != ... | Assert.cs:115:23:115:23 | access to local variable s |
-| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:23:115:36 | ... && ... |
+| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:23:115:23 | access to local variable s |
 | Assert.cs:115:28:115:31 | null | Assert.cs:115:28:115:31 | null |
 | Assert.cs:115:36:115:36 | access to parameter b | Assert.cs:115:36:115:36 | access to parameter b |
 | Assert.cs:116:9:116:35 | call to method WriteLine | Assert.cs:116:27:116:27 | access to local variable s |
 | Assert.cs:116:9:116:36 | ...; | Assert.cs:116:9:116:36 | ...; |
 | Assert.cs:116:27:116:27 | access to local variable s | Assert.cs:116:27:116:27 | access to local variable s |
 | Assert.cs:116:27:116:34 | access to property Length | Assert.cs:116:27:116:27 | access to local variable s |
-| Assert.cs:118:9:118:25 | ... = ... | Assert.cs:118:13:118:25 | ... ? ... : ... |
+| Assert.cs:118:9:118:25 | ... = ... | Assert.cs:118:13:118:13 | access to parameter b |
 | Assert.cs:118:9:118:26 | ...; | Assert.cs:118:9:118:26 | ...; |
 | Assert.cs:118:13:118:13 | access to parameter b | Assert.cs:118:13:118:13 | access to parameter b |
-| Assert.cs:118:13:118:25 | ... ? ... : ... | Assert.cs:118:13:118:25 | ... ? ... : ... |
+| Assert.cs:118:13:118:25 | ... ? ... : ... | Assert.cs:118:13:118:13 | access to parameter b |
 | Assert.cs:118:17:118:20 | null | Assert.cs:118:17:118:20 | null |
 | Assert.cs:118:24:118:25 | "" | Assert.cs:118:24:118:25 | "" |
-| Assert.cs:119:9:119:39 | call to method IsFalse | Assert.cs:119:24:119:38 | ... \|\| ... |
+| Assert.cs:119:9:119:39 | call to method IsFalse | Assert.cs:119:24:119:24 | access to local variable s |
 | Assert.cs:119:9:119:40 | ...; | Assert.cs:119:9:119:40 | ...; |
 | Assert.cs:119:24:119:24 | access to local variable s | Assert.cs:119:24:119:24 | access to local variable s |
 | Assert.cs:119:24:119:32 | ... == ... | Assert.cs:119:24:119:24 | access to local variable s |
-| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:24:119:38 | ... \|\| ... |
+| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:24:119:24 | access to local variable s |
 | Assert.cs:119:29:119:32 | null | Assert.cs:119:29:119:32 | null |
-| Assert.cs:119:37:119:38 | !... | Assert.cs:119:37:119:38 | !... |
+| Assert.cs:119:37:119:38 | !... | Assert.cs:119:38:119:38 | access to parameter b |
 | Assert.cs:119:38:119:38 | access to parameter b | Assert.cs:119:38:119:38 | access to parameter b |
 | Assert.cs:120:9:120:35 | call to method WriteLine | Assert.cs:120:27:120:27 | access to local variable s |
 | Assert.cs:120:9:120:36 | ...; | Assert.cs:120:9:120:36 | ...; |
 | Assert.cs:120:27:120:27 | access to local variable s | Assert.cs:120:27:120:27 | access to local variable s |
 | Assert.cs:120:27:120:34 | access to property Length | Assert.cs:120:27:120:27 | access to local variable s |
-| Assert.cs:122:9:122:25 | ... = ... | Assert.cs:122:13:122:25 | ... ? ... : ... |
+| Assert.cs:122:9:122:25 | ... = ... | Assert.cs:122:13:122:13 | access to parameter b |
 | Assert.cs:122:9:122:26 | ...; | Assert.cs:122:9:122:26 | ...; |
 | Assert.cs:122:13:122:13 | access to parameter b | Assert.cs:122:13:122:13 | access to parameter b |
-| Assert.cs:122:13:122:25 | ... ? ... : ... | Assert.cs:122:13:122:25 | ... ? ... : ... |
+| Assert.cs:122:13:122:25 | ... ? ... : ... | Assert.cs:122:13:122:13 | access to parameter b |
 | Assert.cs:122:17:122:20 | null | Assert.cs:122:17:122:20 | null |
 | Assert.cs:122:24:122:25 | "" | Assert.cs:122:24:122:25 | "" |
-| Assert.cs:123:9:123:37 | call to method IsTrue | Assert.cs:123:23:123:36 | ... && ... |
+| Assert.cs:123:9:123:37 | call to method IsTrue | Assert.cs:123:23:123:23 | access to local variable s |
 | Assert.cs:123:9:123:38 | ...; | Assert.cs:123:9:123:38 | ...; |
 | Assert.cs:123:23:123:23 | access to local variable s | Assert.cs:123:23:123:23 | access to local variable s |
 | Assert.cs:123:23:123:31 | ... == ... | Assert.cs:123:23:123:23 | access to local variable s |
-| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:23:123:36 | ... && ... |
+| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:23:123:23 | access to local variable s |
 | Assert.cs:123:28:123:31 | null | Assert.cs:123:28:123:31 | null |
 | Assert.cs:123:36:123:36 | access to parameter b | Assert.cs:123:36:123:36 | access to parameter b |
 | Assert.cs:124:9:124:35 | call to method WriteLine | Assert.cs:124:27:124:27 | access to local variable s |
 | Assert.cs:124:9:124:36 | ...; | Assert.cs:124:9:124:36 | ...; |
 | Assert.cs:124:27:124:27 | access to local variable s | Assert.cs:124:27:124:27 | access to local variable s |
 | Assert.cs:124:27:124:34 | access to property Length | Assert.cs:124:27:124:27 | access to local variable s |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:13:126:25 | ... ? ... : ... |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:13:126:13 | access to parameter b |
 | Assert.cs:126:9:126:26 | ...; | Assert.cs:126:9:126:26 | ...; |
 | Assert.cs:126:13:126:13 | access to parameter b | Assert.cs:126:13:126:13 | access to parameter b |
-| Assert.cs:126:13:126:25 | ... ? ... : ... | Assert.cs:126:13:126:25 | ... ? ... : ... |
+| Assert.cs:126:13:126:25 | ... ? ... : ... | Assert.cs:126:13:126:13 | access to parameter b |
 | Assert.cs:126:17:126:20 | null | Assert.cs:126:17:126:20 | null |
 | Assert.cs:126:24:126:25 | "" | Assert.cs:126:24:126:25 | "" |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:24:127:38 | ... \|\| ... |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:24:127:24 | access to local variable s |
 | Assert.cs:127:9:127:40 | ...; | Assert.cs:127:9:127:40 | ...; |
 | Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:24:127:24 | access to local variable s |
 | Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:24:127:24 | access to local variable s |
-| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:38 | ... \|\| ... |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:24 | access to local variable s |
 | Assert.cs:127:29:127:32 | null | Assert.cs:127:29:127:32 | null |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b |
 | Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:38:127:38 | access to parameter b |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:128:27:128:27 | access to local variable s |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:128:9:128:36 | ...; |
@@ -820,11 +820,11 @@
 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:26:5:26 | access to parameter s |
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:26:5:26 | access to parameter s |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 |
-| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 |
-| ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
+| ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:25:9:25 | access to parameter s |
-| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:25:9:25 | access to parameter s |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:25:9:25 | access to parameter s |
 | ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:38:9:38 | 0 |
 | ConditionalAccess.cs:12:5:17:5 | {...} | ConditionalAccess.cs:12:5:17:5 | {...} |
@@ -879,7 +879,7 @@
 | Conditions.cs:6:13:6:15 | ...++ | Conditions.cs:6:13:6:13 | access to parameter x |
 | Conditions.cs:6:13:6:16 | ...; | Conditions.cs:6:13:6:16 | ...; |
 | Conditions.cs:7:9:8:16 | if (...) ... | Conditions.cs:7:9:8:16 | if (...) ... |
-| Conditions.cs:7:13:7:16 | !... | Conditions.cs:7:13:7:16 | !... |
+| Conditions.cs:7:13:7:16 | !... | Conditions.cs:7:14:7:16 | access to parameter inc |
 | Conditions.cs:7:14:7:16 | access to parameter inc | Conditions.cs:7:14:7:16 | access to parameter inc |
 | Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:13 | access to parameter x |
 | Conditions.cs:8:13:8:15 | ...-- | Conditions.cs:8:13:8:13 | access to parameter x |
@@ -898,7 +898,7 @@
 | Conditions.cs:16:13:16:17 | ... > ... | Conditions.cs:16:13:16:13 | access to local variable x |
 | Conditions.cs:16:17:16:17 | 0 | Conditions.cs:16:17:16:17 | 0 |
 | Conditions.cs:17:13:18:20 | if (...) ... | Conditions.cs:17:13:18:20 | if (...) ... |
-| Conditions.cs:17:17:17:18 | !... | Conditions.cs:17:17:17:18 | !... |
+| Conditions.cs:17:17:17:18 | !... | Conditions.cs:17:18:17:18 | access to parameter b |
 | Conditions.cs:17:18:17:18 | access to parameter b | Conditions.cs:17:18:17:18 | access to parameter b |
 | Conditions.cs:18:17:18:17 | access to local variable x | Conditions.cs:18:17:18:17 | access to local variable x |
 | Conditions.cs:18:17:18:19 | ...-- | Conditions.cs:18:17:18:17 | access to local variable x |
@@ -1071,7 +1071,7 @@
 | Conditions.cs:107:13:107:24 | ... > ... | Conditions.cs:107:13:107:13 | access to local variable x |
 | Conditions.cs:107:24:107:24 | 0 | Conditions.cs:107:24:107:24 | 0 |
 | Conditions.cs:108:13:109:24 | if (...) ... | Conditions.cs:108:13:109:24 | if (...) ... |
-| Conditions.cs:108:17:108:18 | !... | Conditions.cs:108:17:108:18 | !... |
+| Conditions.cs:108:17:108:18 | !... | Conditions.cs:108:18:108:18 | access to parameter b |
 | Conditions.cs:108:18:108:18 | access to parameter b | Conditions.cs:108:18:108:18 | access to parameter b |
 | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:17 | access to local variable x |
 | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:17 | access to local variable x |
@@ -1104,7 +1104,7 @@
 | Conditions.cs:118:29:118:43 | ... - ... | Conditions.cs:118:29:118:32 | access to parameter args |
 | Conditions.cs:118:43:118:43 | 1 | Conditions.cs:118:43:118:43 | 1 |
 | Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:119:13:120:23 | if (...) ... |
-| Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:17:119:21 | !... |
+| Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:18:119:21 | access to local variable last |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:18:119:21 | access to local variable last |
 | Conditions.cs:120:17:120:22 | ... = ... | Conditions.cs:120:21:120:22 | "" |
 | Conditions.cs:120:17:120:23 | ...; | Conditions.cs:120:17:120:23 | ...; |
@@ -1132,9 +1132,9 @@
 | Conditions.cs:137:21:137:38 | ...; | Conditions.cs:137:21:137:38 | ...; |
 | Conditions.cs:144:5:150:5 | {...} | Conditions.cs:144:5:150:5 | {...} |
 | Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:9:145:30 | ... ...; |
-| Conditions.cs:145:13:145:29 | String s = ... | Conditions.cs:145:17:145:29 | ... ? ... : ... |
+| Conditions.cs:145:13:145:29 | String s = ... | Conditions.cs:145:17:145:17 | access to parameter b |
 | Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:17:145:17 | access to parameter b |
-| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:17:145:29 | ... ? ... : ... |
+| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:17:145:17 | access to parameter b |
 | Conditions.cs:145:21:145:23 | "a" | Conditions.cs:145:21:145:23 | "a" |
 | Conditions.cs:145:27:145:29 | "b" | Conditions.cs:145:27:145:29 | "b" |
 | Conditions.cs:146:9:149:49 | if (...) ... | Conditions.cs:146:9:149:49 | if (...) ... |
@@ -1230,10 +1230,10 @@
 | ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:106:9:106:47 | call to method Exit |
 | ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:106:9:106:48 | ...; |
 | ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:110:5:112:5 | {...} |
-| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
+| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:111:16:111:20 | access to parameter input |
 | ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:16:111:20 | access to parameter input |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:16:111:20 | access to parameter input |
-| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
+| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:16:111:20 | access to parameter input |
 | ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:25:111:25 | 0 |
 | ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:25:111:25 | 0 |
 | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | 1 |
@@ -1244,10 +1244,10 @@
 | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:69:111:75 | "input" |
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:69:111:75 | "input" |
 | ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:115:5:117:5 | {...} |
-| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
+| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:16:116:16 | access to parameter s |
 | ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:16:116:16 | access to parameter s |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:16:116:16 | access to parameter s |
-| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:16 | access to parameter s |
 | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:27:116:29 | - |
 | ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 |
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 |
@@ -1428,7 +1428,7 @@
 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:113:9:118:9 | {...} |
 | Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:114:13:115:41 | if (...) ... |
-| Finally.cs:114:17:114:36 | !... | Finally.cs:114:17:114:36 | !... |
+| Finally.cs:114:17:114:36 | !... | Finally.cs:114:19:114:23 | this access |
 | Finally.cs:114:19:114:23 | access to field Field | Finally.cs:114:19:114:23 | this access |
 | Finally.cs:114:19:114:23 | this access | Finally.cs:114:19:114:23 | this access |
 | Finally.cs:114:19:114:30 | access to property Length | Finally.cs:114:19:114:23 | this access |
@@ -1591,10 +1591,10 @@
 | Foreach.cs:14:27:14:30 | access to parameter args | Foreach.cs:14:27:14:30 | access to parameter args |
 | Foreach.cs:15:13:15:13 | ; | Foreach.cs:15:13:15:13 | ; |
 | Foreach.cs:19:5:22:5 | {...} | Foreach.cs:19:5:22:5 | {...} |
-| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:27:20:68 | ... ?? ... |
+| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:27:20:27 | access to parameter e |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:20:22:20:22 | String x |
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:27:20:27 | access to parameter e |
-| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:27:20:68 | ... ?? ... |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:27:20:27 | access to parameter e |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:27:20:27 | access to parameter e |
 | Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:43:20:68 | call to method Empty |
 | Foreach.cs:21:11:21:11 | ; | Foreach.cs:21:11:21:11 | ; |
@@ -1916,7 +1916,7 @@
 | LoopUnrolling.cs:63:35:63:35 | access to local variable x | LoopUnrolling.cs:63:35:63:35 | access to local variable x |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:68:5:74:5 | {...} |
 | LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:9:70:19 | if (...) ... |
-| LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:13:69:23 | !... |
+| LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:14:69:17 | access to parameter args |
 | LoopUnrolling.cs:69:14:69:17 | access to parameter args | LoopUnrolling.cs:69:14:69:17 | access to parameter args |
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:14:69:17 | access to parameter args |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; |
@@ -2052,51 +2052,51 @@
 | MultiImplementationB.cs:22:34:22:34 | 1 | MultiImplementationB.cs:22:34:22:34 | 1 |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:17:32:17 | 0 |
 | NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:23:3:23 | access to parameter i |
-| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:23 | access to parameter i |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:28:3:28 | 0 |
-| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:25:5:25 | access to parameter b |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:25 | access to parameter b |
-| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:25:5:34 | ... ?? ... |
+| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:25:5:25 | access to parameter b |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:30:5:34 | false |
 | NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:39:5:39 | 0 |
 | NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:43:5:43 | 1 |
 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |
-| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |
 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
-| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:53 | ... ?? ... |
+| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 |
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:52:7:53 | "" |
-| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:37:9:37 | access to parameter b |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:37:9:37 | access to parameter b |
-| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... |
+| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:37:9:37 | access to parameter b |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:41:9:41 | access to parameter s |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:45:9:45 | access to parameter s |
 | NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:51:9:52 | "" |
-| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:58 | ... ?? ... |
+| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:52 | "" |
 | NullCoalescing.cs:9:57:9:58 | "" | NullCoalescing.cs:9:57:9:58 | "" |
-| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:44:11:45 | access to parameter b1 |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 |
-| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:44:11:59 | ... ?? ... |
+| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:44:11:45 | access to parameter b1 |
 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:58 | ... && ... |
+| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 |
 | NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:64:11:64 | 0 |
 | NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:68:11:68 | 1 |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:14:5:18:5 | {...} |
 | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:9:15:32 | ... ...; |
-| NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
+| NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:15:23:15:26 | null |
 | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:23:15:26 | null |
-| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
+| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:23:15:26 | null |
 | NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:23:15:26 | null |
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:31:15:31 | 0 |
 | NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:9:16:26 | ... ...; |
-| NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
+| NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:16:17:16:18 | "" |
 | NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:17:16:18 | "" |
-| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
+| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" |
 | NullCoalescing.cs:16:23:16:25 | "a" | NullCoalescing.cs:16:23:16:25 | "a" |
-| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
+| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
 | NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:9:17:25 | ...; |
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
-| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
+| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:19:17:19 | access to parameter i |
 | NullCoalescing.cs:17:24:17:24 | 1 | NullCoalescing.cs:17:24:17:24 | 1 |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:6:5:43:5 | {...} |
@@ -2282,7 +2282,7 @@
 | Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:32 | access to local variable s |
 | Switch.cs:24:32:24:39 | access to property Length | Switch.cs:24:32:24:32 | access to local variable s |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:32:24:32 | access to local variable s |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:32:24:32 | access to local variable s |
 | Switch.cs:24:43:24:43 | 0 | Switch.cs:24:43:24:43 | 0 |
 | Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:48:24:48 | access to local variable s |
 | Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:48:24:48 | access to local variable s |
@@ -2404,25 +2404,25 @@
 | Switch.cs:124:5:127:5 | {...} | Switch.cs:124:5:127:5 | {...} |
 | Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:9:126:19 | if (...) ... |
 | Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:13:125:13 | access to parameter o |
-| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:13:125:48 | ... switch { ... } |
+| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:13:125:13 | access to parameter o |
 | Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:24:125:29 | Boolean b |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:34 | ... => ... |
+| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:29 | Boolean b |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:34:125:34 | access to local variable b |
 | Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:37 | _ |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:46 | ... => ... |
+| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:37 | _ |
 | Switch.cs:125:42:125:46 | false | Switch.cs:125:42:125:46 | false |
 | Switch.cs:126:13:126:19 | return ...; | Switch.cs:126:13:126:19 | return ...; |
 | Switch.cs:130:5:132:5 | {...} | Switch.cs:130:5:132:5 | {...} |
-| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:17:131:53 | ... switch { ... } |
+| Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:17:131:17 | access to parameter o |
 | Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:17:131:17 | access to parameter o |
-| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:17:131:53 | ... switch { ... } |
+| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:17:131:17 | access to parameter o |
 | Switch.cs:131:28:131:35 | String s | Switch.cs:131:28:131:35 | String s |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:40 | ... => ... |
+| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:35 | String s |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:40:131:40 | access to local variable s |
 | Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:43 | _ |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:51 | ... => ... |
+| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:43 | _ |
 | Switch.cs:131:48:131:51 | null | Switch.cs:131:48:131:51 | null |
-| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:17:131:53 | ... switch { ... } |
+| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:17:131:17 | access to parameter o |
 | Switch.cs:135:5:142:5 | {...} | Switch.cs:135:5:142:5 | {...} |
 | Switch.cs:136:9:141:9 | switch (...) {...} | Switch.cs:136:9:141:9 | switch (...) {...} |
 | Switch.cs:136:17:136:17 | access to parameter i | Switch.cs:136:17:136:17 | access to parameter i |
@@ -2455,14 +2455,14 @@
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:28:150:28 | 2 |
 | Switch.cs:155:5:161:5 | {...} | Switch.cs:155:5:161:5 | {...} |
 | Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:9:156:55 | ... ...; |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:17:156:54 | ... switch { ... } |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:17:156:17 | access to parameter b |
 | Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:17:156:17 | access to parameter b |
-| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:54 | ... switch { ... } |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:17 | access to parameter b |
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | true |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:38 | ... => ... |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:9:160:49 | if (...) ... |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:157:13:157:13 | access to parameter b |
@@ -2528,9 +2528,9 @@
 | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:22:24:28 | object creation of type C |
 | VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:24:35:24:41 | object creation of type C |
 | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:35:24:41 | object creation of type C |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
+| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:20:25:20 | access to parameter b |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:20:25:20 | access to parameter b |
-| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:20:25:20 | access to parameter b |
 | VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:24:25:24 | access to local variable x |
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:28:25:28 | access to local variable y |
 | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:51:28:53 | {...} |
@@ -2585,7 +2585,7 @@
 | cflow.cs:26:17:26:17 | access to local variable i | cflow.cs:26:17:26:17 | access to local variable i |
 | cflow.cs:26:17:26:21 | ... % ... | cflow.cs:26:17:26:17 | access to local variable i |
 | cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:17:26:17 | access to local variable i |
-| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:26:17:26:40 | ... && ... |
+| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:26:17:26:17 | access to local variable i |
 | cflow.cs:26:21:26:21 | 3 | cflow.cs:26:21:26:21 | 3 |
 | cflow.cs:26:26:26:26 | 0 | cflow.cs:26:26:26:26 | 0 |
 | cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:31:26:31 | access to local variable i |
@@ -2660,7 +2660,7 @@
 | cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:13:62:19 | case ...: |
 | cflow.cs:62:18:62:18 | 0 | cflow.cs:62:18:62:18 | 0 |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:17:64:55 | if (...) ... |
-| cflow.cs:63:21:63:34 | !... | cflow.cs:63:21:63:34 | !... |
+| cflow.cs:63:21:63:34 | !... | cflow.cs:63:23:63:27 | this access |
 | cflow.cs:63:23:63:27 | access to field Field | cflow.cs:63:23:63:27 | this access |
 | cflow.cs:63:23:63:27 | this access | cflow.cs:63:23:63:27 | this access |
 | cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:23:63:27 | this access |
@@ -2693,7 +2693,7 @@
 | cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:9:87:33 | if (...) ... |
 | cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:13:86:13 | access to parameter s |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:13:86:13 | access to parameter s |
-| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:13:86:37 | ... && ... |
+| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:13:86:13 | access to parameter s |
 | cflow.cs:86:18:86:21 | null | cflow.cs:86:18:86:21 | null |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:26 | access to parameter s |
 | cflow.cs:86:26:86:33 | access to property Length | cflow.cs:86:26:86:26 | access to parameter s |
@@ -2770,11 +2770,11 @@
 | cflow.cs:123:9:123:17 | return ...; | cflow.cs:123:16:123:16 | access to local variable x |
 | cflow.cs:123:16:123:16 | access to local variable x | cflow.cs:123:16:123:16 | access to local variable x |
 | cflow.cs:127:23:127:60 | {...} | cflow.cs:127:23:127:60 | {...} |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:32:127:57 | ... ? ... : ... |
+| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:32:127:36 | this access |
 | cflow.cs:127:32:127:36 | access to field Field | cflow.cs:127:32:127:36 | this access |
 | cflow.cs:127:32:127:36 | this access | cflow.cs:127:32:127:36 | this access |
 | cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:32:127:36 | this access |
-| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:32:127:57 | ... ? ... : ... |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:32:127:36 | this access |
 | cflow.cs:127:41:127:44 | null | cflow.cs:127:41:127:44 | null |
 | cflow.cs:127:48:127:49 | "" | cflow.cs:127:48:127:49 | "" |
 | cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:53:127:57 | this access |
@@ -2903,15 +2903,15 @@
 | cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:187:9:190:52 | if (...) ... |
 | cflow.cs:187:13:187:13 | 1 | cflow.cs:187:13:187:13 | 1 |
 | cflow.cs:187:13:187:18 | ... == ... | cflow.cs:187:13:187:13 | 1 |
-| cflow.cs:187:13:187:28 | ... \|\| ... | cflow.cs:187:13:187:28 | ... \|\| ... |
-| cflow.cs:187:13:187:50 | ... \|\| ... | cflow.cs:187:13:187:50 | ... \|\| ... |
+| cflow.cs:187:13:187:28 | ... \|\| ... | cflow.cs:187:13:187:13 | 1 |
+| cflow.cs:187:13:187:50 | ... \|\| ... | cflow.cs:187:13:187:13 | 1 |
 | cflow.cs:187:18:187:18 | 2 | cflow.cs:187:18:187:18 | 2 |
 | cflow.cs:187:23:187:23 | 2 | cflow.cs:187:23:187:23 | 2 |
 | cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:23:187:23 | 2 |
 | cflow.cs:187:28:187:28 | 3 | cflow.cs:187:28:187:28 | 3 |
 | cflow.cs:187:34:187:34 | 1 | cflow.cs:187:34:187:34 | 1 |
 | cflow.cs:187:34:187:39 | ... == ... | cflow.cs:187:34:187:34 | 1 |
-| cflow.cs:187:34:187:49 | ... && ... | cflow.cs:187:34:187:49 | ... && ... |
+| cflow.cs:187:34:187:49 | ... && ... | cflow.cs:187:34:187:34 | 1 |
 | cflow.cs:187:39:187:39 | 3 | cflow.cs:187:39:187:39 | 3 |
 | cflow.cs:187:44:187:44 | 3 | cflow.cs:187:44:187:44 | 3 |
 | cflow.cs:187:44:187:49 | ... == ... | cflow.cs:187:44:187:44 | 3 |
@@ -2924,54 +2924,54 @@
 | cflow.cs:190:31:190:50 | "This should happen" | cflow.cs:190:31:190:50 | "This should happen" |
 | cflow.cs:194:5:206:5 | {...} | cflow.cs:194:5:206:5 | {...} |
 | cflow.cs:195:9:195:57 | ... ...; | cflow.cs:195:9:195:57 | ... ...; |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:17:195:21 | this access |
 | cflow.cs:195:17:195:21 | access to field Field | cflow.cs:195:17:195:21 | this access |
 | cflow.cs:195:17:195:21 | this access | cflow.cs:195:17:195:21 | this access |
 | cflow.cs:195:17:195:28 | access to property Length | cflow.cs:195:17:195:21 | this access |
 | cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:17:195:21 | this access |
-| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:17:195:56 | ... && ... |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:17:195:21 | this access |
 | cflow.cs:195:32:195:32 | 0 | cflow.cs:195:32:195:32 | 0 |
-| cflow.cs:195:37:195:56 | !... | cflow.cs:195:37:195:56 | !... |
+| cflow.cs:195:37:195:56 | !... | cflow.cs:195:39:195:43 | this access |
 | cflow.cs:195:39:195:43 | access to field Field | cflow.cs:195:39:195:43 | this access |
 | cflow.cs:195:39:195:43 | this access | cflow.cs:195:39:195:43 | this access |
 | cflow.cs:195:39:195:50 | access to property Length | cflow.cs:195:39:195:43 | this access |
 | cflow.cs:195:39:195:55 | ... == ... | cflow.cs:195:39:195:43 | this access |
 | cflow.cs:195:55:195:55 | 1 | cflow.cs:195:55:195:55 | 1 |
 | cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:197:9:198:49 | if (...) ... |
-| cflow.cs:197:13:197:47 | !... | cflow.cs:197:13:197:47 | !... |
+| cflow.cs:197:13:197:47 | !... | cflow.cs:197:15:197:19 | this access |
 | cflow.cs:197:15:197:19 | access to field Field | cflow.cs:197:15:197:19 | this access |
 | cflow.cs:197:15:197:19 | this access | cflow.cs:197:15:197:19 | this access |
 | cflow.cs:197:15:197:26 | access to property Length | cflow.cs:197:15:197:19 | this access |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:15:197:19 | this access |
-| cflow.cs:197:15:197:46 | ... ? ... : ... | cflow.cs:197:15:197:46 | ... ? ... : ... |
+| cflow.cs:197:15:197:46 | ... ? ... : ... | cflow.cs:197:15:197:19 | this access |
 | cflow.cs:197:31:197:31 | 0 | cflow.cs:197:31:197:31 | 0 |
 | cflow.cs:197:35:197:39 | false | cflow.cs:197:35:197:39 | false |
 | cflow.cs:197:43:197:46 | true | cflow.cs:197:43:197:46 | true |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:198:17:198:48 | ... ? ... : ... |
+| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:198:17:198:21 | this access |
 | cflow.cs:198:13:198:49 | ...; | cflow.cs:198:13:198:49 | ...; |
 | cflow.cs:198:17:198:21 | access to field Field | cflow.cs:198:17:198:21 | this access |
 | cflow.cs:198:17:198:21 | this access | cflow.cs:198:17:198:21 | this access |
 | cflow.cs:198:17:198:28 | access to property Length | cflow.cs:198:17:198:21 | this access |
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:17:198:21 | this access |
-| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:17:198:48 | ... ? ... : ... |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:17:198:21 | this access |
 | cflow.cs:198:33:198:33 | 0 | cflow.cs:198:33:198:33 | 0 |
 | cflow.cs:198:37:198:41 | false | cflow.cs:198:37:198:41 | false |
 | cflow.cs:198:45:198:48 | true | cflow.cs:198:45:198:48 | true |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:9:205:9 | if (...) ... |
-| cflow.cs:200:13:200:32 | !... | cflow.cs:200:13:200:32 | !... |
-| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:13:200:62 | ... \|\| ... |
+| cflow.cs:200:13:200:32 | !... | cflow.cs:200:15:200:19 | this access |
+| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:15:200:19 | this access |
 | cflow.cs:200:15:200:19 | access to field Field | cflow.cs:200:15:200:19 | this access |
 | cflow.cs:200:15:200:19 | this access | cflow.cs:200:15:200:19 | this access |
 | cflow.cs:200:15:200:26 | access to property Length | cflow.cs:200:15:200:19 | this access |
 | cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:15:200:19 | this access |
 | cflow.cs:200:31:200:31 | 0 | cflow.cs:200:31:200:31 | 0 |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:37:200:62 | !... |
-| cflow.cs:200:38:200:62 | !... | cflow.cs:200:38:200:62 | !... |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:200:40:200:44 | this access |
+| cflow.cs:200:38:200:62 | !... | cflow.cs:200:40:200:44 | this access |
 | cflow.cs:200:40:200:44 | access to field Field | cflow.cs:200:40:200:44 | this access |
 | cflow.cs:200:40:200:44 | this access | cflow.cs:200:40:200:44 | this access |
 | cflow.cs:200:40:200:51 | access to property Length | cflow.cs:200:40:200:44 | this access |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:40:200:44 | this access |
-| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:40:200:61 | ... && ... |
+| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:40:200:44 | this access |
 | cflow.cs:200:56:200:56 | 1 | cflow.cs:200:56:200:56 | 1 |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:61:200:61 | access to local variable b |
 | cflow.cs:201:9:205:9 | {...} | cflow.cs:201:9:205:9 | {...} |
@@ -3046,8 +3046,8 @@
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:241:5:259:5 | {...} |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:9:242:13 | Label: |
 | cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:16:242:45 | if (...) ... |
-| cflow.cs:242:20:242:40 | !... | cflow.cs:242:20:242:40 | !... |
-| cflow.cs:242:21:242:40 | !... | cflow.cs:242:21:242:40 | !... |
+| cflow.cs:242:20:242:40 | !... | cflow.cs:242:23:242:27 | this access |
+| cflow.cs:242:21:242:40 | !... | cflow.cs:242:23:242:27 | this access |
 | cflow.cs:242:23:242:27 | access to field Field | cflow.cs:242:23:242:27 | this access |
 | cflow.cs:242:23:242:27 | this access | cflow.cs:242:23:242:27 | this access |
 | cflow.cs:242:23:242:34 | access to property Length | cflow.cs:242:23:242:27 | this access |
@@ -3124,8 +3124,8 @@
 | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:300:38:300:38 | 0 |
 | cflow.cs:300:9:300:73 | ...; | cflow.cs:300:9:300:73 | ...; |
 | cflow.cs:300:38:300:38 | 0 | cflow.cs:300:38:300:38 | 0 |
-| cflow.cs:300:44:300:51 | !... | cflow.cs:300:44:300:51 | !... |
-| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:44:300:64 | ... && ... |
+| cflow.cs:300:44:300:51 | !... | cflow.cs:300:46:300:46 | access to parameter i |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:46:300:46 | access to parameter i |
 | cflow.cs:300:46:300:46 | access to parameter i | cflow.cs:300:46:300:46 | access to parameter i |
 | cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:46:300:46 | access to parameter i |
 | cflow.cs:300:50:300:50 | 0 | cflow.cs:300:50:300:50 | 0 |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -314,8 +314,7 @@
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:16:9:32 | String s = ... | normal |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:20:9:20 | access to parameter b | false |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:20:9:20 | access to parameter b | true |
-| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:24:9:27 | null | normal |
-| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:31:9:32 | "" | normal |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:32 | ... ? ... : ... | normal |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null | normal |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" | normal |
 | Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:10:9:10:31 | call to method Assert | exit |
@@ -336,8 +335,7 @@
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:16:16:32 | String s = ... | normal |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:20:16:20 | access to parameter b | false |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:20:16:20 | access to parameter b | true |
-| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:24:16:27 | null | normal |
-| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:31:16:32 | "" | normal |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:32 | ... ? ... : ... | normal |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null | normal |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" | normal |
 | Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:17:9:17:24 | call to method IsNull | normal |
@@ -356,8 +354,7 @@
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:16:23:32 | String s = ... | normal |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:20:23:20 | access to parameter b | false |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:20:23:20 | access to parameter b | true |
-| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:24:23:27 | null | normal |
-| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:31:23:32 | "" | normal |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:32 | ... ? ... : ... | normal |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null | normal |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" | normal |
 | Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:24:9:24:27 | call to method IsNotNull | normal |
@@ -376,8 +373,7 @@
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:16:30:32 | String s = ... | normal |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:20:30:20 | access to parameter b | false |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:20:30:20 | access to parameter b | true |
-| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:24:30:27 | null | normal |
-| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:31:30:32 | "" | normal |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:32 | ... ? ... : ... | normal |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null | normal |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" | normal |
 | Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:31:9:31:32 | call to method IsTrue | normal |
@@ -398,8 +394,7 @@
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:16:37:32 | String s = ... | normal |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:20:37:20 | access to parameter b | false |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:20:37:20 | access to parameter b | true |
-| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:24:37:27 | null | normal |
-| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:31:37:32 | "" | normal |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:32 | ... ? ... : ... | normal |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null | normal |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" | normal |
 | Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:38:9:38:32 | call to method IsTrue | normal |
@@ -420,8 +415,7 @@
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:16:44:32 | String s = ... | normal |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:20:44:20 | access to parameter b | false |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:20:44:20 | access to parameter b | true |
-| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:24:44:27 | null | normal |
-| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:31:44:32 | "" | normal |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:32 | ... ? ... : ... | normal |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null | normal |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" | normal |
 | Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:45:9:45:33 | call to method IsFalse | normal |
@@ -442,8 +436,7 @@
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:16:51:32 | String s = ... | normal |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:20:51:20 | access to parameter b | false |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:20:51:20 | access to parameter b | true |
-| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:24:51:27 | null | normal |
-| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:31:51:32 | "" | normal |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:32 | ... ? ... : ... | normal |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null | normal |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" | normal |
 | Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:52:9:52:33 | call to method IsFalse | normal |
@@ -464,8 +457,7 @@
 | Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:16:58:32 | String s = ... | normal |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | false |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | true |
-| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:24:58:27 | null | normal |
-| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:31:58:32 | "" | normal |
+| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:32 | ... ? ... : ... | normal |
 | Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null | normal |
 | Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" | normal |
 | Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:9:59:37 | call to method IsTrue | normal |
@@ -475,9 +467,8 @@
 | Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | normal |
 | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:31 | ... != ... | false |
 | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:31 | ... != ... | true |
-| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:31 | ... != ... | false |
-| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:36:59:36 | access to parameter b | false |
-| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:36:59:36 | access to parameter b | true |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:36 | ... && ... | false |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:36 | ... && ... | true |
 | Assert.cs:59:28:59:31 | null | Assert.cs:59:28:59:31 | null | normal |
 | Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b | false |
 | Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b | true |
@@ -491,8 +482,7 @@
 | Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:16:65:32 | String s = ... | normal |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | true |
-| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:24:65:27 | null | normal |
-| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:31:65:32 | "" | normal |
+| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:32 | ... ? ... : ... | normal |
 | Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null | normal |
 | Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" | normal |
 | Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:9:66:38 | call to method IsFalse | normal |
@@ -502,9 +492,8 @@
 | Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | normal |
 | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:32 | ... == ... | false |
 | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:32 | ... == ... | true |
-| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:32 | ... == ... | true |
-| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:37:66:37 | access to parameter b | false |
-| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:37:66:37 | access to parameter b | true |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:37 | ... \|\| ... | false |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:37 | ... \|\| ... | true |
 | Assert.cs:66:29:66:32 | null | Assert.cs:66:29:66:32 | null | normal |
 | Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b | false |
 | Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b | true |
@@ -518,8 +507,7 @@
 | Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:16:72:32 | String s = ... | normal |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | false |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
-| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:24:72:27 | null | normal |
-| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:31:72:32 | "" | normal |
+| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:32 | ... ? ... : ... | normal |
 | Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null | normal |
 | Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" | normal |
 | Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:9:73:37 | call to method IsTrue | normal |
@@ -529,9 +517,8 @@
 | Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | normal |
 | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:31 | ... == ... | false |
 | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:31 | ... == ... | true |
-| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:31 | ... == ... | false |
-| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:36:73:36 | access to parameter b | false |
-| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:36:73:36 | access to parameter b | true |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:36 | ... && ... | false |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:36 | ... && ... | true |
 | Assert.cs:73:28:73:31 | null | Assert.cs:73:28:73:31 | null | normal |
 | Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b | false |
 | Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b | true |
@@ -545,8 +532,7 @@
 | Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:16:79:32 | String s = ... | normal |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | false |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
-| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:24:79:27 | null | normal |
-| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:31:79:32 | "" | normal |
+| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:32 | ... ? ... : ... | normal |
 | Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null | normal |
 | Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" | normal |
 | Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:9:80:38 | call to method IsFalse | normal |
@@ -556,9 +542,8 @@
 | Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | normal |
 | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:32 | ... != ... | false |
 | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:32 | ... != ... | true |
-| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:32 | ... != ... | true |
-| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:37:80:37 | access to parameter b | false |
-| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:37:80:37 | access to parameter b | true |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:37 | ... \|\| ... | false |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:37 | ... \|\| ... | true |
 | Assert.cs:80:29:80:32 | null | Assert.cs:80:29:80:32 | null | normal |
 | Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b | false |
 | Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b | true |
@@ -582,8 +567,7 @@
 | Assert.cs:86:16:86:32 | String s = ... | Assert.cs:86:16:86:32 | String s = ... | normal |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:20:86:20 | access to parameter b | false |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:20:86:20 | access to parameter b | true |
-| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:24:86:27 | null | normal |
-| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:31:86:32 | "" | normal |
+| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:32 | ... ? ... : ... | normal |
 | Assert.cs:86:24:86:27 | null | Assert.cs:86:24:86:27 | null | normal |
 | Assert.cs:86:31:86:32 | "" | Assert.cs:86:31:86:32 | "" | normal |
 | Assert.cs:87:9:87:31 | call to method Assert | Assert.cs:87:9:87:31 | call to method Assert | exit |
@@ -602,8 +586,7 @@
 | Assert.cs:90:9:90:26 | ...; | Assert.cs:90:9:90:25 | ... = ... | normal |
 | Assert.cs:90:13:90:13 | access to parameter b | Assert.cs:90:13:90:13 | access to parameter b | false |
 | Assert.cs:90:13:90:13 | access to parameter b | Assert.cs:90:13:90:13 | access to parameter b | true |
-| Assert.cs:90:13:90:25 | ... ? ... : ... | Assert.cs:90:17:90:20 | null | normal |
-| Assert.cs:90:13:90:25 | ... ? ... : ... | Assert.cs:90:24:90:25 | "" | normal |
+| Assert.cs:90:13:90:25 | ... ? ... : ... | Assert.cs:90:13:90:25 | ... ? ... : ... | normal |
 | Assert.cs:90:17:90:20 | null | Assert.cs:90:17:90:20 | null | normal |
 | Assert.cs:90:24:90:25 | "" | Assert.cs:90:24:90:25 | "" | normal |
 | Assert.cs:91:9:91:24 | call to method IsNull | Assert.cs:91:9:91:24 | call to method IsNull | normal |
@@ -620,8 +603,7 @@
 | Assert.cs:94:9:94:26 | ...; | Assert.cs:94:9:94:25 | ... = ... | normal |
 | Assert.cs:94:13:94:13 | access to parameter b | Assert.cs:94:13:94:13 | access to parameter b | false |
 | Assert.cs:94:13:94:13 | access to parameter b | Assert.cs:94:13:94:13 | access to parameter b | true |
-| Assert.cs:94:13:94:25 | ... ? ... : ... | Assert.cs:94:17:94:20 | null | normal |
-| Assert.cs:94:13:94:25 | ... ? ... : ... | Assert.cs:94:24:94:25 | "" | normal |
+| Assert.cs:94:13:94:25 | ... ? ... : ... | Assert.cs:94:13:94:25 | ... ? ... : ... | normal |
 | Assert.cs:94:17:94:20 | null | Assert.cs:94:17:94:20 | null | normal |
 | Assert.cs:94:24:94:25 | "" | Assert.cs:94:24:94:25 | "" | normal |
 | Assert.cs:95:9:95:27 | call to method IsNotNull | Assert.cs:95:9:95:27 | call to method IsNotNull | normal |
@@ -638,8 +620,7 @@
 | Assert.cs:98:9:98:26 | ...; | Assert.cs:98:9:98:25 | ... = ... | normal |
 | Assert.cs:98:13:98:13 | access to parameter b | Assert.cs:98:13:98:13 | access to parameter b | false |
 | Assert.cs:98:13:98:13 | access to parameter b | Assert.cs:98:13:98:13 | access to parameter b | true |
-| Assert.cs:98:13:98:25 | ... ? ... : ... | Assert.cs:98:17:98:20 | null | normal |
-| Assert.cs:98:13:98:25 | ... ? ... : ... | Assert.cs:98:24:98:25 | "" | normal |
+| Assert.cs:98:13:98:25 | ... ? ... : ... | Assert.cs:98:13:98:25 | ... ? ... : ... | normal |
 | Assert.cs:98:17:98:20 | null | Assert.cs:98:17:98:20 | null | normal |
 | Assert.cs:98:24:98:25 | "" | Assert.cs:98:24:98:25 | "" | normal |
 | Assert.cs:99:9:99:32 | call to method IsTrue | Assert.cs:99:9:99:32 | call to method IsTrue | normal |
@@ -658,8 +639,7 @@
 | Assert.cs:102:9:102:26 | ...; | Assert.cs:102:9:102:25 | ... = ... | normal |
 | Assert.cs:102:13:102:13 | access to parameter b | Assert.cs:102:13:102:13 | access to parameter b | false |
 | Assert.cs:102:13:102:13 | access to parameter b | Assert.cs:102:13:102:13 | access to parameter b | true |
-| Assert.cs:102:13:102:25 | ... ? ... : ... | Assert.cs:102:17:102:20 | null | normal |
-| Assert.cs:102:13:102:25 | ... ? ... : ... | Assert.cs:102:24:102:25 | "" | normal |
+| Assert.cs:102:13:102:25 | ... ? ... : ... | Assert.cs:102:13:102:25 | ... ? ... : ... | normal |
 | Assert.cs:102:17:102:20 | null | Assert.cs:102:17:102:20 | null | normal |
 | Assert.cs:102:24:102:25 | "" | Assert.cs:102:24:102:25 | "" | normal |
 | Assert.cs:103:9:103:32 | call to method IsTrue | Assert.cs:103:9:103:32 | call to method IsTrue | normal |
@@ -678,8 +658,7 @@
 | Assert.cs:106:9:106:26 | ...; | Assert.cs:106:9:106:25 | ... = ... | normal |
 | Assert.cs:106:13:106:13 | access to parameter b | Assert.cs:106:13:106:13 | access to parameter b | false |
 | Assert.cs:106:13:106:13 | access to parameter b | Assert.cs:106:13:106:13 | access to parameter b | true |
-| Assert.cs:106:13:106:25 | ... ? ... : ... | Assert.cs:106:17:106:20 | null | normal |
-| Assert.cs:106:13:106:25 | ... ? ... : ... | Assert.cs:106:24:106:25 | "" | normal |
+| Assert.cs:106:13:106:25 | ... ? ... : ... | Assert.cs:106:13:106:25 | ... ? ... : ... | normal |
 | Assert.cs:106:17:106:20 | null | Assert.cs:106:17:106:20 | null | normal |
 | Assert.cs:106:24:106:25 | "" | Assert.cs:106:24:106:25 | "" | normal |
 | Assert.cs:107:9:107:33 | call to method IsFalse | Assert.cs:107:9:107:33 | call to method IsFalse | normal |
@@ -698,8 +677,7 @@
 | Assert.cs:110:9:110:26 | ...; | Assert.cs:110:9:110:25 | ... = ... | normal |
 | Assert.cs:110:13:110:13 | access to parameter b | Assert.cs:110:13:110:13 | access to parameter b | false |
 | Assert.cs:110:13:110:13 | access to parameter b | Assert.cs:110:13:110:13 | access to parameter b | true |
-| Assert.cs:110:13:110:25 | ... ? ... : ... | Assert.cs:110:17:110:20 | null | normal |
-| Assert.cs:110:13:110:25 | ... ? ... : ... | Assert.cs:110:24:110:25 | "" | normal |
+| Assert.cs:110:13:110:25 | ... ? ... : ... | Assert.cs:110:13:110:25 | ... ? ... : ... | normal |
 | Assert.cs:110:17:110:20 | null | Assert.cs:110:17:110:20 | null | normal |
 | Assert.cs:110:24:110:25 | "" | Assert.cs:110:24:110:25 | "" | normal |
 | Assert.cs:111:9:111:33 | call to method IsFalse | Assert.cs:111:9:111:33 | call to method IsFalse | normal |
@@ -718,8 +696,7 @@
 | Assert.cs:114:9:114:26 | ...; | Assert.cs:114:9:114:25 | ... = ... | normal |
 | Assert.cs:114:13:114:13 | access to parameter b | Assert.cs:114:13:114:13 | access to parameter b | false |
 | Assert.cs:114:13:114:13 | access to parameter b | Assert.cs:114:13:114:13 | access to parameter b | true |
-| Assert.cs:114:13:114:25 | ... ? ... : ... | Assert.cs:114:17:114:20 | null | normal |
-| Assert.cs:114:13:114:25 | ... ? ... : ... | Assert.cs:114:24:114:25 | "" | normal |
+| Assert.cs:114:13:114:25 | ... ? ... : ... | Assert.cs:114:13:114:25 | ... ? ... : ... | normal |
 | Assert.cs:114:17:114:20 | null | Assert.cs:114:17:114:20 | null | normal |
 | Assert.cs:114:24:114:25 | "" | Assert.cs:114:24:114:25 | "" | normal |
 | Assert.cs:115:9:115:37 | call to method IsTrue | Assert.cs:115:9:115:37 | call to method IsTrue | normal |
@@ -729,9 +706,8 @@
 | Assert.cs:115:23:115:23 | access to local variable s | Assert.cs:115:23:115:23 | access to local variable s | normal |
 | Assert.cs:115:23:115:31 | ... != ... | Assert.cs:115:23:115:31 | ... != ... | false |
 | Assert.cs:115:23:115:31 | ... != ... | Assert.cs:115:23:115:31 | ... != ... | true |
-| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:23:115:31 | ... != ... | false |
-| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:36:115:36 | access to parameter b | false |
-| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:36:115:36 | access to parameter b | true |
+| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:23:115:36 | ... && ... | false |
+| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:23:115:36 | ... && ... | true |
 | Assert.cs:115:28:115:31 | null | Assert.cs:115:28:115:31 | null | normal |
 | Assert.cs:115:36:115:36 | access to parameter b | Assert.cs:115:36:115:36 | access to parameter b | false |
 | Assert.cs:115:36:115:36 | access to parameter b | Assert.cs:115:36:115:36 | access to parameter b | true |
@@ -743,8 +719,7 @@
 | Assert.cs:118:9:118:26 | ...; | Assert.cs:118:9:118:25 | ... = ... | normal |
 | Assert.cs:118:13:118:13 | access to parameter b | Assert.cs:118:13:118:13 | access to parameter b | false |
 | Assert.cs:118:13:118:13 | access to parameter b | Assert.cs:118:13:118:13 | access to parameter b | true |
-| Assert.cs:118:13:118:25 | ... ? ... : ... | Assert.cs:118:17:118:20 | null | normal |
-| Assert.cs:118:13:118:25 | ... ? ... : ... | Assert.cs:118:24:118:25 | "" | normal |
+| Assert.cs:118:13:118:25 | ... ? ... : ... | Assert.cs:118:13:118:25 | ... ? ... : ... | normal |
 | Assert.cs:118:17:118:20 | null | Assert.cs:118:17:118:20 | null | normal |
 | Assert.cs:118:24:118:25 | "" | Assert.cs:118:24:118:25 | "" | normal |
 | Assert.cs:119:9:119:39 | call to method IsFalse | Assert.cs:119:9:119:39 | call to method IsFalse | normal |
@@ -754,12 +729,11 @@
 | Assert.cs:119:24:119:24 | access to local variable s | Assert.cs:119:24:119:24 | access to local variable s | normal |
 | Assert.cs:119:24:119:32 | ... == ... | Assert.cs:119:24:119:32 | ... == ... | false |
 | Assert.cs:119:24:119:32 | ... == ... | Assert.cs:119:24:119:32 | ... == ... | true |
-| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:24:119:32 | ... == ... | true |
-| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:38:119:38 | access to parameter b | false [true] |
-| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:38:119:38 | access to parameter b | true [false] |
+| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:24:119:38 | ... \|\| ... | false |
+| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:24:119:38 | ... \|\| ... | true |
 | Assert.cs:119:29:119:32 | null | Assert.cs:119:29:119:32 | null | normal |
-| Assert.cs:119:37:119:38 | !... | Assert.cs:119:38:119:38 | access to parameter b | false [true] |
-| Assert.cs:119:37:119:38 | !... | Assert.cs:119:38:119:38 | access to parameter b | true [false] |
+| Assert.cs:119:37:119:38 | !... | Assert.cs:119:37:119:38 | !... | false |
+| Assert.cs:119:37:119:38 | !... | Assert.cs:119:37:119:38 | !... | true |
 | Assert.cs:119:38:119:38 | access to parameter b | Assert.cs:119:38:119:38 | access to parameter b | false |
 | Assert.cs:119:38:119:38 | access to parameter b | Assert.cs:119:38:119:38 | access to parameter b | true |
 | Assert.cs:120:9:120:35 | call to method WriteLine | Assert.cs:120:9:120:35 | call to method WriteLine | normal |
@@ -770,8 +744,7 @@
 | Assert.cs:122:9:122:26 | ...; | Assert.cs:122:9:122:25 | ... = ... | normal |
 | Assert.cs:122:13:122:13 | access to parameter b | Assert.cs:122:13:122:13 | access to parameter b | false |
 | Assert.cs:122:13:122:13 | access to parameter b | Assert.cs:122:13:122:13 | access to parameter b | true |
-| Assert.cs:122:13:122:25 | ... ? ... : ... | Assert.cs:122:17:122:20 | null | normal |
-| Assert.cs:122:13:122:25 | ... ? ... : ... | Assert.cs:122:24:122:25 | "" | normal |
+| Assert.cs:122:13:122:25 | ... ? ... : ... | Assert.cs:122:13:122:25 | ... ? ... : ... | normal |
 | Assert.cs:122:17:122:20 | null | Assert.cs:122:17:122:20 | null | normal |
 | Assert.cs:122:24:122:25 | "" | Assert.cs:122:24:122:25 | "" | normal |
 | Assert.cs:123:9:123:37 | call to method IsTrue | Assert.cs:123:9:123:37 | call to method IsTrue | normal |
@@ -781,9 +754,8 @@
 | Assert.cs:123:23:123:23 | access to local variable s | Assert.cs:123:23:123:23 | access to local variable s | normal |
 | Assert.cs:123:23:123:31 | ... == ... | Assert.cs:123:23:123:31 | ... == ... | false |
 | Assert.cs:123:23:123:31 | ... == ... | Assert.cs:123:23:123:31 | ... == ... | true |
-| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:23:123:31 | ... == ... | false |
-| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:36:123:36 | access to parameter b | false |
-| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:36:123:36 | access to parameter b | true |
+| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:23:123:36 | ... && ... | false |
+| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:23:123:36 | ... && ... | true |
 | Assert.cs:123:28:123:31 | null | Assert.cs:123:28:123:31 | null | normal |
 | Assert.cs:123:36:123:36 | access to parameter b | Assert.cs:123:36:123:36 | access to parameter b | false |
 | Assert.cs:123:36:123:36 | access to parameter b | Assert.cs:123:36:123:36 | access to parameter b | true |
@@ -795,8 +767,7 @@
 | Assert.cs:126:9:126:26 | ...; | Assert.cs:126:9:126:25 | ... = ... | normal |
 | Assert.cs:126:13:126:13 | access to parameter b | Assert.cs:126:13:126:13 | access to parameter b | false |
 | Assert.cs:126:13:126:13 | access to parameter b | Assert.cs:126:13:126:13 | access to parameter b | true |
-| Assert.cs:126:13:126:25 | ... ? ... : ... | Assert.cs:126:17:126:20 | null | normal |
-| Assert.cs:126:13:126:25 | ... ? ... : ... | Assert.cs:126:24:126:25 | "" | normal |
+| Assert.cs:126:13:126:25 | ... ? ... : ... | Assert.cs:126:13:126:25 | ... ? ... : ... | normal |
 | Assert.cs:126:17:126:20 | null | Assert.cs:126:17:126:20 | null | normal |
 | Assert.cs:126:24:126:25 | "" | Assert.cs:126:24:126:25 | "" | normal |
 | Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:9:127:39 | call to method IsFalse | normal |
@@ -806,12 +777,11 @@
 | Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:24:127:24 | access to local variable s | normal |
 | Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:24:127:32 | ... != ... | false |
 | Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:24:127:32 | ... != ... | true |
-| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:32 | ... != ... | true |
-| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:38:127:38 | access to parameter b | false [true] |
-| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:38:127:38 | access to parameter b | true [false] |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:38 | ... \|\| ... | false |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:38 | ... \|\| ... | true |
 | Assert.cs:127:29:127:32 | null | Assert.cs:127:29:127:32 | null | normal |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b | false [true] |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b | true [false] |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:37:127:38 | !... | false |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:37:127:38 | !... | true |
 | Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:38:127:38 | access to parameter b | false |
 | Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:38:127:38 | access to parameter b | true |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:128:9:128:35 | call to method WriteLine | normal |
@@ -873,9 +843,13 @@
 | Assignments.cs:19:9:19:17 | return ...; | Assignments.cs:19:9:19:17 | return ...; | return |
 | Assignments.cs:19:16:19:16 | access to parameter x | Assignments.cs:19:16:19:16 | access to parameter x | normal |
 | BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:15:17:15:28 | ... == ... | false |
+| BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:16:17:16:17 | ; | empty |
 | BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:16:17:16:17 | ; | normal |
+| BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:16:17:16:17 | ; | normal (break) |
 | BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:15:17:15:28 | ... == ... | false |
+| BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:16:17:16:17 | ; | empty |
 | BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:16:17:16:17 | ; | normal |
+| BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:16:17:16:17 | ; | normal (break) |
 | BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | empty |
 | BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:10:21:10:26 | break; | normal (break) |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | empty |
@@ -908,11 +882,13 @@
 | BreakInTry.cs:22:29:22:32 | access to parameter args | BreakInTry.cs:22:29:22:32 | access to parameter args | normal |
 | BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:31:21:31:32 | ... == ... | break [false] |
 | BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:31:21:31:32 | ... == ... | false |
-| BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:32:21:32:21 | ; | break [normal] |
+| BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:32:21:32:21 | ; | break |
+| BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:32:21:32:21 | ; | false |
 | BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:32:21:32:21 | ; | normal |
 | BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:21:31:32 | ... == ... | break [false] |
 | BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:21:31:32 | ... == ... | false |
-| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:32:21:32:21 | ; | break [normal] |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:32:21:32:21 | ; | break |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:32:21:32:21 | ; | false |
 | BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:32:21:32:21 | ; | normal |
 | BreakInTry.cs:25:13:28:13 | {...} | BreakInTry.cs:26:21:26:31 | ... == ... | false |
 | BreakInTry.cs:25:13:28:13 | {...} | BreakInTry.cs:27:21:27:26 | break; | break |
@@ -934,12 +910,13 @@
 | BreakInTry.cs:32:21:32:21 | ; | BreakInTry.cs:32:21:32:21 | ; | normal |
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:35:7:35:7 | ; | normal |
 | BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | return [empty] |
-| BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:50:21:50:26 | break; | return [normal (break)] |
+| BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:50:21:50:26 | break; | return |
 | BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:53:7:53:7 | ; | normal |
 | BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | empty |
 | BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | return [empty] |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:50:21:50:26 | break; | false |
 | BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:50:21:50:26 | break; | normal (break) |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:50:21:50:26 | break; | return [normal (break)] |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:50:21:50:26 | break; | return |
 | BreakInTry.cs:41:9:44:9 | {...} | BreakInTry.cs:42:17:42:28 | ... == ... | false |
 | BreakInTry.cs:41:9:44:9 | {...} | BreakInTry.cs:43:17:43:23 | return ...; | return |
 | BreakInTry.cs:42:13:43:23 | if (...) ... | BreakInTry.cs:42:17:42:28 | ... == ... | false |
@@ -967,12 +944,14 @@
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:53:7:53:7 | ; | normal |
 | BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | empty |
 | BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | return [empty] |
+| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:68:21:68:26 | break; | false |
 | BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:68:21:68:26 | break; | normal (break) |
-| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:68:21:68:26 | break; | return [normal (break)] |
+| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:68:21:68:26 | break; | return |
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | empty |
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | return [empty] |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | break; | false |
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | break; | normal (break) |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | break; | return [normal (break)] |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | break; | return |
 | BreakInTry.cs:59:9:62:9 | {...} | BreakInTry.cs:60:17:60:28 | ... == ... | false |
 | BreakInTry.cs:59:9:62:9 | {...} | BreakInTry.cs:61:17:61:23 | return ...; | return |
 | BreakInTry.cs:60:13:61:23 | if (...) ... | BreakInTry.cs:60:17:60:28 | ... == ... | false |
@@ -1010,14 +989,14 @@
 | CompileTimeOperators.cs:22:9:22:25 | return ...; | CompileTimeOperators.cs:22:9:22:25 | return ...; | return |
 | CompileTimeOperators.cs:22:16:22:24 | nameof(...) | CompileTimeOperators.cs:22:16:22:24 | nameof(...) | normal |
 | CompileTimeOperators.cs:22:23:22:23 | access to parameter i | CompileTimeOperators.cs:22:23:22:23 | access to parameter i | normal |
-| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | goto(End) [normal] |
-| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(Exception) [normal] |
-| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | goto(End) |
+| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(Exception) |
+| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(OutOfMemoryException) |
 | CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | normal |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | goto(End) [normal] |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | goto(End) |
 | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | normal |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(Exception) [normal] |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(Exception) |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(OutOfMemoryException) |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:32:13:32:21 | goto ...; | goto(End) |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:33:13:33:37 | call to method WriteLine | normal |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:33:13:33:37 | call to method WriteLine | throw(Exception) |
@@ -1056,17 +1035,15 @@
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:28:5:34 | access to property Length | normal |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | non-null |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | null |
-| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | non-null |
-| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | non-null |
-| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | null |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | non-null |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | null |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | non-null |
 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | null |
-| ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | null |
+| ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | null |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:49:7:55 | access to property Length | normal |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:25:9:25 | access to parameter s | non-null |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:25:9:25 | access to parameter s | null |
-| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:27:9:33 | access to property Length | non-null |
-| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:38:9:38 | 0 | normal |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | normal |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:25:9:25 | access to parameter s | null |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:27:9:33 | access to property Length | non-null |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:27:9:33 | access to property Length | null |
@@ -1128,7 +1105,7 @@
 | ConditionalAccess.cs:41:70:41:83 | ... + ... | ConditionalAccess.cs:41:70:41:83 | ... + ... | normal |
 | ConditionalAccess.cs:41:75:41:78 | ", " | ConditionalAccess.cs:41:75:41:78 | ", " | normal |
 | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | normal |
-| Conditions.cs:4:5:9:5 | {...} | Conditions.cs:7:14:7:16 | access to parameter inc | false [true] |
+| Conditions.cs:4:5:9:5 | {...} | Conditions.cs:7:13:7:16 | !... | false |
 | Conditions.cs:4:5:9:5 | {...} | Conditions.cs:8:13:8:15 | ...-- | normal |
 | Conditions.cs:5:9:6:16 | if (...) ... | Conditions.cs:5:13:5:15 | access to parameter inc | false |
 | Conditions.cs:5:9:6:16 | if (...) ... | Conditions.cs:6:13:6:15 | ...++ | normal |
@@ -1137,10 +1114,10 @@
 | Conditions.cs:6:13:6:13 | access to parameter x | Conditions.cs:6:13:6:13 | access to parameter x | normal |
 | Conditions.cs:6:13:6:15 | ...++ | Conditions.cs:6:13:6:15 | ...++ | normal |
 | Conditions.cs:6:13:6:16 | ...; | Conditions.cs:6:13:6:15 | ...++ | normal |
-| Conditions.cs:7:9:8:16 | if (...) ... | Conditions.cs:7:14:7:16 | access to parameter inc | false [true] |
+| Conditions.cs:7:9:8:16 | if (...) ... | Conditions.cs:7:13:7:16 | !... | false |
 | Conditions.cs:7:9:8:16 | if (...) ... | Conditions.cs:8:13:8:15 | ...-- | normal |
-| Conditions.cs:7:13:7:16 | !... | Conditions.cs:7:14:7:16 | access to parameter inc | false [true] |
-| Conditions.cs:7:13:7:16 | !... | Conditions.cs:7:14:7:16 | access to parameter inc | true [false] |
+| Conditions.cs:7:13:7:16 | !... | Conditions.cs:7:13:7:16 | !... | false |
+| Conditions.cs:7:13:7:16 | !... | Conditions.cs:7:13:7:16 | !... | true |
 | Conditions.cs:7:14:7:16 | access to parameter inc | Conditions.cs:7:14:7:16 | access to parameter inc | false |
 | Conditions.cs:7:14:7:16 | access to parameter inc | Conditions.cs:7:14:7:16 | access to parameter inc | true |
 | Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:13 | access to parameter x | normal |
@@ -1158,16 +1135,16 @@
 | Conditions.cs:15:13:15:15 | ...++ | Conditions.cs:15:13:15:15 | ...++ | normal |
 | Conditions.cs:15:13:15:16 | ...; | Conditions.cs:15:13:15:15 | ...++ | normal |
 | Conditions.cs:16:9:18:20 | if (...) ... | Conditions.cs:16:13:16:17 | ... > ... | false |
-| Conditions.cs:16:9:18:20 | if (...) ... | Conditions.cs:17:18:17:18 | access to parameter b | false [true] |
+| Conditions.cs:16:9:18:20 | if (...) ... | Conditions.cs:17:17:17:18 | !... | false |
 | Conditions.cs:16:9:18:20 | if (...) ... | Conditions.cs:18:17:18:19 | ...-- | normal |
 | Conditions.cs:16:13:16:13 | access to local variable x | Conditions.cs:16:13:16:13 | access to local variable x | normal |
 | Conditions.cs:16:13:16:17 | ... > ... | Conditions.cs:16:13:16:17 | ... > ... | false |
 | Conditions.cs:16:13:16:17 | ... > ... | Conditions.cs:16:13:16:17 | ... > ... | true |
 | Conditions.cs:16:17:16:17 | 0 | Conditions.cs:16:17:16:17 | 0 | normal |
-| Conditions.cs:17:13:18:20 | if (...) ... | Conditions.cs:17:18:17:18 | access to parameter b | false [true] |
+| Conditions.cs:17:13:18:20 | if (...) ... | Conditions.cs:17:17:17:18 | !... | false |
 | Conditions.cs:17:13:18:20 | if (...) ... | Conditions.cs:18:17:18:19 | ...-- | normal |
-| Conditions.cs:17:17:17:18 | !... | Conditions.cs:17:18:17:18 | access to parameter b | false [true] |
-| Conditions.cs:17:17:17:18 | !... | Conditions.cs:17:18:17:18 | access to parameter b | true [false] |
+| Conditions.cs:17:17:17:18 | !... | Conditions.cs:17:17:17:18 | !... | false |
+| Conditions.cs:17:17:17:18 | !... | Conditions.cs:17:17:17:18 | !... | true |
 | Conditions.cs:17:18:17:18 | access to parameter b | Conditions.cs:17:18:17:18 | access to parameter b | false |
 | Conditions.cs:17:18:17:18 | access to parameter b | Conditions.cs:17:18:17:18 | access to parameter b | true |
 | Conditions.cs:18:17:18:17 | access to local variable x | Conditions.cs:18:17:18:17 | access to local variable x | normal |
@@ -1375,17 +1352,17 @@
 | Conditions.cs:106:13:106:20 | ...; | Conditions.cs:106:13:106:19 | ... = ... | normal |
 | Conditions.cs:106:18:106:19 | "" | Conditions.cs:106:18:106:19 | "" | normal |
 | Conditions.cs:107:9:109:24 | if (...) ... | Conditions.cs:107:13:107:24 | ... > ... | false |
-| Conditions.cs:107:9:109:24 | if (...) ... | Conditions.cs:108:18:108:18 | access to parameter b | false [true] |
+| Conditions.cs:107:9:109:24 | if (...) ... | Conditions.cs:108:17:108:18 | !... | false |
 | Conditions.cs:107:9:109:24 | if (...) ... | Conditions.cs:109:17:109:23 | ... = ... | normal |
 | Conditions.cs:107:13:107:13 | access to local variable x | Conditions.cs:107:13:107:13 | access to local variable x | normal |
 | Conditions.cs:107:13:107:20 | access to property Length | Conditions.cs:107:13:107:20 | access to property Length | normal |
 | Conditions.cs:107:13:107:24 | ... > ... | Conditions.cs:107:13:107:24 | ... > ... | false |
 | Conditions.cs:107:13:107:24 | ... > ... | Conditions.cs:107:13:107:24 | ... > ... | true |
 | Conditions.cs:107:24:107:24 | 0 | Conditions.cs:107:24:107:24 | 0 | normal |
-| Conditions.cs:108:13:109:24 | if (...) ... | Conditions.cs:108:18:108:18 | access to parameter b | false [true] |
+| Conditions.cs:108:13:109:24 | if (...) ... | Conditions.cs:108:17:108:18 | !... | false |
 | Conditions.cs:108:13:109:24 | if (...) ... | Conditions.cs:109:17:109:23 | ... = ... | normal |
-| Conditions.cs:108:17:108:18 | !... | Conditions.cs:108:18:108:18 | access to parameter b | false [true] |
-| Conditions.cs:108:17:108:18 | !... | Conditions.cs:108:18:108:18 | access to parameter b | true [false] |
+| Conditions.cs:108:17:108:18 | !... | Conditions.cs:108:17:108:18 | !... | false |
+| Conditions.cs:108:17:108:18 | !... | Conditions.cs:108:17:108:18 | !... | true |
 | Conditions.cs:108:18:108:18 | access to parameter b | Conditions.cs:108:18:108:18 | access to parameter b | false |
 | Conditions.cs:108:18:108:18 | access to parameter b | Conditions.cs:108:18:108:18 | access to parameter b | true |
 | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:17 | access to local variable x | normal |
@@ -1420,10 +1397,10 @@
 | Conditions.cs:118:29:118:39 | access to property Length | Conditions.cs:118:29:118:39 | access to property Length | normal |
 | Conditions.cs:118:29:118:43 | ... - ... | Conditions.cs:118:29:118:43 | ... - ... | normal |
 | Conditions.cs:118:43:118:43 | 1 | Conditions.cs:118:43:118:43 | 1 | normal |
-| Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:119:18:119:21 | access to local variable last | false [true] |
+| Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:119:17:119:21 | !... | false |
 | Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:120:17:120:22 | ... = ... | normal |
-| Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:18:119:21 | access to local variable last | false [true] |
-| Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:18:119:21 | access to local variable last | true [false] |
+| Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:17:119:21 | !... | false |
+| Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:17:119:21 | !... | true |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:18:119:21 | access to local variable last | false |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:18:119:21 | access to local variable last | true |
 | Conditions.cs:120:17:120:22 | ... = ... | Conditions.cs:120:17:120:22 | ... = ... | normal |
@@ -1464,8 +1441,7 @@
 | Conditions.cs:145:13:145:29 | String s = ... | Conditions.cs:145:13:145:29 | String s = ... | normal |
 | Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:17:145:17 | access to parameter b | false |
 | Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:17:145:17 | access to parameter b | true |
-| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:21:145:23 | "a" | normal |
-| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:27:145:29 | "b" | normal |
+| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:17:145:29 | ... ? ... : ... | normal |
 | Conditions.cs:145:21:145:23 | "a" | Conditions.cs:145:21:145:23 | "a" | normal |
 | Conditions.cs:145:27:145:29 | "b" | Conditions.cs:145:27:145:29 | "b" | normal |
 | Conditions.cs:146:9:149:49 | if (...) ... | Conditions.cs:147:13:147:48 | call to method WriteLine | normal |
@@ -1570,9 +1546,9 @@
 | ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:88:9:88:27 | call to method Exit | exit |
 | ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:26:88:26 | 0 | normal |
 | ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
-| ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:100:13:100:40 | call to method WriteLine | exit [normal] |
+| ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:100:13:100:40 | call to method WriteLine | exit |
 | ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
-| ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:100:13:100:40 | call to method WriteLine | exit [normal] |
+| ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:100:13:100:40 | call to method WriteLine | exit |
 | ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
 | ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
 | ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:18 | this access | normal |
@@ -1591,7 +1567,7 @@
 | ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:16:111:20 | access to parameter input | normal |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:16:111:25 | ... != ... | false |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:16:111:25 | ... != ... | true |
-| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:29:111:37 | ... / ... | normal |
+| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:16:111:76 | ... ? ... : ... | normal |
 | ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:41:111:76 | throw ... | throw(ArgumentException) |
 | ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:25:111:25 | 0 | normal |
 | ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:25:111:25 | (...) ... | normal |
@@ -1607,8 +1583,7 @@
 | ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:16:116:16 | access to parameter s | normal |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:16:116:30 | call to method Contains | false |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:16:116:30 | call to method Contains | true |
-| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:34:116:34 | 0 | normal |
-| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:38:116:38 | 1 | normal |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | normal |
 | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:27:116:29 | - | normal |
 | ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 | normal |
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 | normal |
@@ -1670,11 +1645,11 @@
 | Extensions.cs:25:23:25:32 | access to method Parse | Extensions.cs:25:23:25:32 | access to method Parse | normal |
 | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | normal |
 | Finally.cs:8:5:17:5 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | normal |
-| Finally.cs:8:5:17:5 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:8:5:17:5 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:8:5:17:5 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | throw(Exception) |
+| Finally.cs:8:5:17:5 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | throw(OutOfMemoryException) |
 | Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:15:13:15:40 | call to method WriteLine | normal |
-| Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:15:13:15:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:15:13:15:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:15:13:15:40 | call to method WriteLine | throw(Exception) |
+| Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:15:13:15:40 | call to method WriteLine | throw(OutOfMemoryException) |
 | Finally.cs:10:9:12:9 | {...} | Finally.cs:11:13:11:37 | call to method WriteLine | normal |
 | Finally.cs:10:9:12:9 | {...} | Finally.cs:11:13:11:37 | call to method WriteLine | throw(Exception) |
 | Finally.cs:10:9:12:9 | {...} | Finally.cs:11:31:11:36 | "Try1" | throw(OutOfMemoryException) |
@@ -1691,13 +1666,13 @@
 | Finally.cs:15:13:15:41 | ...; | Finally.cs:15:13:15:40 | call to method WriteLine | normal |
 | Finally.cs:15:31:15:39 | "Finally" | Finally.cs:15:31:15:39 | "Finally" | normal |
 | Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | normal |
-| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | return [normal] |
-| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | throw(IOException) [normal] |
+| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | return |
+| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | throw(Exception) |
+| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | throw(IOException) |
 | Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | normal |
-| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | return [normal] |
-| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | throw(IOException) [normal] |
+| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | return |
+| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | throw(Exception) |
+| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | throw(IOException) |
 | Finally.cs:22:9:25:9 | {...} | Finally.cs:23:13:23:37 | call to method WriteLine | throw(Exception) |
 | Finally.cs:22:9:25:9 | {...} | Finally.cs:23:31:23:36 | "Try2" | throw(OutOfMemoryException) |
 | Finally.cs:22:9:25:9 | {...} | Finally.cs:24:13:24:19 | return ...; | return |
@@ -1740,15 +1715,15 @@
 | Finally.cs:50:13:50:41 | ...; | Finally.cs:50:13:50:40 | call to method WriteLine | normal |
 | Finally.cs:50:31:50:39 | "Finally" | Finally.cs:50:31:50:39 | "Finally" | normal |
 | Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | normal |
-| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | return [normal] |
-| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(IOException) [normal] |
-| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | return |
+| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(Exception) |
+| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(IOException) |
+| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(OutOfMemoryException) |
 | Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | normal |
-| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | return [normal] |
-| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(IOException) [normal] |
-| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | return |
+| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(Exception) |
+| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(IOException) |
+| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(OutOfMemoryException) |
 | Finally.cs:57:9:60:9 | {...} | Finally.cs:58:13:58:37 | call to method WriteLine | throw(Exception) |
 | Finally.cs:57:9:60:9 | {...} | Finally.cs:58:31:58:36 | "Try3" | throw(OutOfMemoryException) |
 | Finally.cs:57:9:60:9 | {...} | Finally.cs:59:13:59:19 | return ...; | return |
@@ -1785,29 +1760,39 @@
 | Finally.cs:70:31:70:39 | "Finally" | Finally.cs:70:31:70:39 | "Finally" | normal |
 | Finally.cs:75:5:101:5 | {...} | Finally.cs:77:16:77:20 | ... > ... | false |
 | Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | normal (break) |
-| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | return [normal] |
-| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
+| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | return |
+| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | return [false] |
+| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) |
 | Finally.cs:76:9:76:19 | ... ...; | Finally.cs:76:13:76:18 | Int32 i = ... | normal |
 | Finally.cs:76:13:76:18 | Int32 i = ... | Finally.cs:76:13:76:18 | Int32 i = ... | normal |
 | Finally.cs:76:17:76:18 | 10 | Finally.cs:76:17:76:18 | 10 | normal |
 | Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:77:16:77:20 | ... > ... | false |
 | Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | normal (break) |
-| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | return [normal] |
-| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
+| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | return |
+| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | return [false] |
+| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:77:16:77:16 | access to local variable i | normal |
 | Finally.cs:77:16:77:20 | ... > ... | Finally.cs:77:16:77:20 | ... > ... | false |
 | Finally.cs:77:16:77:20 | ... > ... | Finally.cs:77:16:77:20 | ... > ... | true |
 | Finally.cs:77:20:77:20 | 0 | Finally.cs:77:20:77:20 | 0 | normal |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | break [normal] |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | continue [normal] |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | break |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | break [false] |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | continue |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | continue [false] |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | false |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | normal |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | return [normal] |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
-| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | break [normal] |
-| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | continue [normal] |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | return |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | return [false] |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | break |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | break [false] |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | continue |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | continue [false] |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | false |
 | Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | normal |
-| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | return [normal] |
-| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | return |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | return [false] |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) |
 | Finally.cs:80:13:87:13 | {...} | Finally.cs:82:21:82:27 | return ...; | return |
 | Finally.cs:80:13:87:13 | {...} | Finally.cs:84:21:84:29 | continue; | continue |
 | Finally.cs:80:13:87:13 | {...} | Finally.cs:85:21:85:26 | ... == ... | false |
@@ -1833,10 +1818,12 @@
 | Finally.cs:85:21:85:26 | ... == ... | Finally.cs:85:21:85:26 | ... == ... | true |
 | Finally.cs:85:26:85:26 | 2 | Finally.cs:85:26:85:26 | 2 | normal |
 | Finally.cs:86:21:86:26 | break; | Finally.cs:86:21:86:26 | break; | break |
+| Finally.cs:89:13:99:13 | {...} | Finally.cs:97:21:97:23 | ...-- | false |
 | Finally.cs:89:13:99:13 | {...} | Finally.cs:97:21:97:23 | ...-- | normal |
-| Finally.cs:89:13:99:13 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
+| Finally.cs:89:13:99:13 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) |
+| Finally.cs:90:17:98:17 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | false |
 | Finally.cs:90:17:98:17 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | normal |
-| Finally.cs:90:17:98:17 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
+| Finally.cs:90:17:98:17 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) |
 | Finally.cs:91:17:94:17 | {...} | Finally.cs:92:25:92:30 | ... == ... | false |
 | Finally.cs:91:17:94:17 | {...} | Finally.cs:93:25:93:46 | throw ...; | throw(Exception) |
 | Finally.cs:91:17:94:17 | {...} | Finally.cs:93:31:93:45 | object creation of type Exception | throw(Exception) |
@@ -1860,21 +1847,23 @@
 | Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | throw(Exception) [false] |
 | Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | throw(NullReferenceException) [false] |
 | Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | throw(OutOfMemoryException) [false] |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | false |
 | Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | normal |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | return [normal] |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(NullReferenceException) [normal] |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | return |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(Exception) |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(NullReferenceException) |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(OutOfMemoryException) |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | false |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | return [false] |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | throw(Exception) [false] |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | throw(NullReferenceException) [false] |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | throw(OutOfMemoryException) [false] |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | false |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | normal |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | return [normal] |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(NullReferenceException) [normal] |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | return |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(Exception) |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(NullReferenceException) |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(OutOfMemoryException) |
 | Finally.cs:106:9:111:9 | {...} | Finally.cs:107:17:107:21 | access to field Field | throw(NullReferenceException) |
 | Finally.cs:106:9:111:9 | {...} | Finally.cs:107:17:107:28 | access to property Length | throw(Exception) |
 | Finally.cs:106:9:111:9 | {...} | Finally.cs:107:17:107:28 | access to property Length | throw(NullReferenceException) |
@@ -1929,10 +1918,10 @@
 | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | throw(Exception) |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:116:17:116:32 | ... > ... | false |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | normal |
-| Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:114:19:114:35 | ... == ... | false [true] |
+| Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:114:17:114:36 | !... | false |
 | Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:115:17:115:40 | call to method WriteLine | normal |
-| Finally.cs:114:17:114:36 | !... | Finally.cs:114:19:114:35 | ... == ... | false [true] |
-| Finally.cs:114:17:114:36 | !... | Finally.cs:114:19:114:35 | ... == ... | true [false] |
+| Finally.cs:114:17:114:36 | !... | Finally.cs:114:17:114:36 | !... | false |
+| Finally.cs:114:17:114:36 | !... | Finally.cs:114:17:114:36 | !... | true |
 | Finally.cs:114:19:114:23 | access to field Field | Finally.cs:114:19:114:23 | access to field Field | normal |
 | Finally.cs:114:19:114:23 | this access | Finally.cs:114:19:114:23 | this access | normal |
 | Finally.cs:114:19:114:30 | access to property Length | Finally.cs:114:19:114:30 | access to property Length | normal |
@@ -1969,13 +1958,13 @@
 | Finally.cs:128:9:130:9 | {...} | Finally.cs:129:13:129:13 | ; | normal |
 | Finally.cs:129:13:129:13 | ; | Finally.cs:129:13:129:13 | ; | normal |
 | Finally.cs:134:5:145:5 | {...} | Finally.cs:141:13:141:44 | throw ...; | throw(ArgumentException) |
-| Finally.cs:134:5:145:5 | {...} | Finally.cs:142:13:142:37 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:134:5:145:5 | {...} | Finally.cs:142:13:142:37 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:134:5:145:5 | {...} | Finally.cs:142:13:142:37 | call to method WriteLine | throw(Exception) |
+| Finally.cs:134:5:145:5 | {...} | Finally.cs:142:13:142:37 | call to method WriteLine | throw(OutOfMemoryException) |
 | Finally.cs:134:5:145:5 | {...} | Finally.cs:144:9:144:33 | call to method WriteLine | normal |
 | Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:141:13:141:44 | throw ...; | throw(ArgumentException) |
 | Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:142:13:142:37 | call to method WriteLine | normal |
-| Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:142:13:142:37 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:142:13:142:37 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:142:13:142:37 | call to method WriteLine | throw(Exception) |
+| Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:142:13:142:37 | call to method WriteLine | throw(OutOfMemoryException) |
 | Finally.cs:136:9:138:9 | {...} | Finally.cs:137:13:137:36 | call to method WriteLine | normal |
 | Finally.cs:136:9:138:9 | {...} | Finally.cs:137:13:137:36 | call to method WriteLine | throw(Exception) |
 | Finally.cs:136:9:138:9 | {...} | Finally.cs:137:31:137:35 | "Try" | throw(OutOfMemoryException) |
@@ -2001,21 +1990,25 @@
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:158:21:158:36 | ... == ... | false |
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:158:21:158:36 | ... == ... | throw(ArgumentNullException) [false] |
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:158:21:158:36 | ... == ... | throw(Exception) [false] |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | false |
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | normal |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | throw(ArgumentNullException) [normal] |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | throw(ArgumentNullException) |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | throw(Exception) |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | false |
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | normal |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | throw(ArgumentNullException) [normal] |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | throw(ArgumentNullException) |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | throw(Exception) |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:158:21:158:36 | ... == ... | false |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:158:21:158:36 | ... == ... | throw(ArgumentNullException) [false] |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:158:21:158:36 | ... == ... | throw(Exception) [false] |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | false |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | normal |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | throw(ArgumentNullException) [normal] |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | throw(ArgumentNullException) |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | throw(Exception) |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | false |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | normal |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | throw(ArgumentNullException) [normal] |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | throw(ArgumentNullException) |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | throw(Exception) |
 | Finally.cs:150:9:153:9 | {...} | Finally.cs:151:17:151:28 | ... == ... | false |
 | Finally.cs:150:9:153:9 | {...} | Finally.cs:152:17:152:50 | throw ...; | throw(ArgumentNullException) |
 | Finally.cs:150:9:153:9 | {...} | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | throw(Exception) |
@@ -2160,15 +2153,16 @@
 | Finally.cs:196:5:214:5 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | throw(Exception) [false] |
 | Finally.cs:196:5:214:5 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | throw(ExceptionB) [false] |
 | Finally.cs:196:5:214:5 | {...} | Finally.cs:209:25:209:47 | throw ...; | throw(ExceptionC) |
-| Finally.cs:196:5:214:5 | {...} | Finally.cs:211:13:211:28 | ... = ... | throw(Exception) [normal] |
-| Finally.cs:196:5:214:5 | {...} | Finally.cs:211:13:211:28 | ... = ... | throw(ExceptionA) [normal] |
+| Finally.cs:196:5:214:5 | {...} | Finally.cs:211:13:211:28 | ... = ... | throw(Exception) |
+| Finally.cs:196:5:214:5 | {...} | Finally.cs:211:13:211:28 | ... = ... | throw(ExceptionA) |
 | Finally.cs:196:5:214:5 | {...} | Finally.cs:213:9:213:24 | ... = ... | normal |
 | Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | throw(Exception) [false] |
 | Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | throw(ExceptionB) [false] |
 | Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:209:25:209:47 | throw ...; | throw(ExceptionC) |
+| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | false |
 | Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | normal |
-| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | throw(Exception) [normal] |
-| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | throw(ExceptionA) [normal] |
+| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | throw(Exception) |
+| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | throw(ExceptionA) |
 | Finally.cs:198:9:200:9 | {...} | Finally.cs:199:17:199:18 | access to parameter b1 | false |
 | Finally.cs:198:9:200:9 | {...} | Finally.cs:199:21:199:43 | throw ...; | throw(ExceptionA) |
 | Finally.cs:198:9:200:9 | {...} | Finally.cs:199:27:199:42 | object creation of type ExceptionA | throw(Exception) |
@@ -2259,8 +2253,7 @@
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:20:22:20:22 | String x | normal |
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:27:20:27 | access to parameter e | non-null |
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:27:20:27 | access to parameter e | null |
-| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:29:20:38 | call to method ToArray | non-null |
-| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:43:20:68 | call to method Empty | normal |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:27:20:68 | ... ?? ... | normal |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:27:20:27 | access to parameter e | null |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:29:20:38 | call to method ToArray | non-null |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:29:20:38 | call to method ToArray | null |
@@ -2594,10 +2587,10 @@
 | LoopUnrolling.cs:63:35:63:35 | access to local variable x | LoopUnrolling.cs:63:35:63:35 | access to local variable x | normal |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:70:13:70:19 | return ...; | return |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:14:69:23 | call to method Any | false [true] |
+| LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:13:69:23 | !... | false |
 | LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:70:13:70:19 | return ...; | return |
-| LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:14:69:23 | call to method Any | false [true] |
-| LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:14:69:23 | call to method Any | true [false] |
+| LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:13:69:23 | !... | false |
+| LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:13:69:23 | !... | true |
 | LoopUnrolling.cs:69:14:69:17 | access to parameter args | LoopUnrolling.cs:69:14:69:17 | access to parameter args | normal |
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:14:69:23 | call to method Any | false |
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:14:69:23 | call to method Any | true |
@@ -2735,63 +2728,46 @@
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:17:32:17 | 0 | normal |
 | NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:23:3:23 | access to parameter i | non-null |
 | NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:23:3:23 | access to parameter i | null |
-| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:23 | access to parameter i | non-null |
-| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:28:3:28 | 0 | normal |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:28 | ... ?? ... | normal |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:28:3:28 | 0 | normal |
-| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:39:5:39 | 0 | normal |
-| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:43:5:43 | 1 | normal |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | normal |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:25 | access to parameter b | false |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:25 | access to parameter b | null |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:25 | access to parameter b | true |
-| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:25:5:25 | access to parameter b | false |
-| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:25:5:25 | access to parameter b | true |
-| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:30:5:34 | false | false |
+| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:25:5:34 | ... ?? ... | false |
+| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:25:5:34 | ... ?? ... | true |
 | NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:30:5:34 | false | false |
 | NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:39:5:39 | 0 | normal |
 | NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:43:5:43 | 1 | normal |
 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | non-null |
 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | null |
-| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | non-null |
-| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | non-null |
-| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:52:7:53 | "" | normal |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:53 | ... ?? ... | normal |
 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | non-null |
 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | null |
-| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | non-null |
-| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:52:7:53 | "" | normal |
+| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:53 | ... ?? ... | normal |
 | NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:52:7:53 | "" | normal |
-| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:41:9:41 | access to parameter s | non-null |
-| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:45:9:45 | access to parameter s | non-null |
-| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:52 | "" | non-null |
-| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:57:9:58 | "" | normal |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... | normal |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:37:9:37 | access to parameter b | false |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:37:9:37 | access to parameter b | true |
-| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:41:9:41 | access to parameter s | non-null |
-| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:41:9:41 | access to parameter s | null |
-| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:45:9:45 | access to parameter s | non-null |
-| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:45:9:45 | access to parameter s | null |
+| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | non-null |
+| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | null |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:41:9:41 | access to parameter s | non-null |
 | NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:41:9:41 | access to parameter s | null |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:45:9:45 | access to parameter s | non-null |
 | NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:45:9:45 | access to parameter s | null |
 | NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:51:9:52 | "" | non-null |
-| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:52 | "" | non-null |
-| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:57:9:58 | "" | normal |
+| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:58 | ... ?? ... | normal |
 | NullCoalescing.cs:9:57:9:58 | "" | NullCoalescing.cs:9:57:9:58 | "" | normal |
-| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:64:11:64 | 0 | normal |
-| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:68:11:68 | 1 | normal |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | normal |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | false |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | null |
 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | true |
-| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | false |
-| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | true |
-| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | false |
-| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | false |
-| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | true |
+| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:44:11:59 | ... ?? ... | false |
+| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:44:11:59 | ... ?? ... | true |
 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | false |
 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | true |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | false |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | false |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | true |
+| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:58 | ... && ... | false |
+| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:58 | ... && ... | true |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | false |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | true |
 | NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:64:11:64 | 0 | normal |
@@ -2800,20 +2776,18 @@
 | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | normal |
 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | normal |
 | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:17:15:26 | (...) ... | null |
-| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:31:15:31 | 0 | normal |
+| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:17:15:31 | ... ?? ... | normal |
 | NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:23:15:26 | null | normal |
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:31:15:31 | 0 | normal |
 | NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:13:16:25 | String s = ... | normal |
 | NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:16:13:16:25 | String s = ... | normal |
 | NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:17:16:18 | "" | non-null |
-| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" | non-null |
-| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:23:16:25 | "a" | normal |
+| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:25 | ... ?? ... | normal |
 | NullCoalescing.cs:16:23:16:25 | "a" | NullCoalescing.cs:16:23:16:25 | "a" | normal |
 | NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:17:9:17:24 | ... = ... | normal |
 | NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:9:17:24 | ... = ... | normal |
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:13:17:19 | (...) ... | non-null |
-| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:13:17:19 | (...) ... | non-null |
-| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:24:17:24 | 1 | normal |
+| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... | normal |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:19:17:19 | access to parameter i | normal |
 | NullCoalescing.cs:17:24:17:24 | 1 | NullCoalescing.cs:17:24:17:24 | 1 | normal |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:40:17:40:17 | access to local variable o | normal |
@@ -3050,8 +3024,7 @@
 | Switch.cs:23:17:23:28 | goto case ...; | Switch.cs:23:17:23:28 | goto case ...; | goto(0) |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:23:27:23:27 | 0 | normal |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:18:24:25 | String s | no-match |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:32:24:43 | ... > ... | false |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:48:24:55 | ... != ... | false |
+| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:32:24:55 | ... && ... | false |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:25:17:25:36 | call to method WriteLine | normal |
 | Switch.cs:24:18:24:25 | String s | Switch.cs:24:18:24:25 | String s | match |
 | Switch.cs:24:18:24:25 | String s | Switch.cs:24:18:24:25 | String s | no-match |
@@ -3059,9 +3032,8 @@
 | Switch.cs:24:32:24:39 | access to property Length | Switch.cs:24:32:24:39 | access to property Length | normal |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:32:24:43 | ... > ... | false |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:32:24:43 | ... > ... | true |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:32:24:43 | ... > ... | false |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:48:24:55 | ... != ... | false |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:48:24:55 | ... != ... | true |
+| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:32:24:55 | ... && ... | false |
+| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:32:24:55 | ... && ... | true |
 | Switch.cs:24:43:24:43 | 0 | Switch.cs:24:43:24:43 | 0 | normal |
 | Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:48:24:48 | access to local variable s | normal |
 | Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:48:24:55 | ... != ... | false |
@@ -3247,45 +3219,40 @@
 | Switch.cs:120:9:120:18 | return ...; | Switch.cs:120:9:120:18 | return ...; | return |
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:16:120:17 | -... | normal |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:17:120:17 | 1 | normal |
-| Switch.cs:124:5:127:5 | {...} | Switch.cs:125:34:125:34 | access to local variable b | false |
-| Switch.cs:124:5:127:5 | {...} | Switch.cs:125:42:125:46 | false | false |
+| Switch.cs:124:5:127:5 | {...} | Switch.cs:125:13:125:48 | ... switch { ... } | false |
 | Switch.cs:124:5:127:5 | {...} | Switch.cs:126:13:126:19 | return ...; | return |
-| Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:34:125:34 | access to local variable b | false |
-| Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:42:125:46 | false | false |
+| Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:13:125:48 | ... switch { ... } | false |
 | Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:126:13:126:19 | return ...; | return |
 | Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:13:125:13 | access to parameter o | normal |
-| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:34:125:34 | access to local variable b | false |
-| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:34:125:34 | access to local variable b | true |
-| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:42:125:46 | false | false |
+| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:13:125:48 | ... switch { ... } | false |
+| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:13:125:48 | ... switch { ... } | true |
 | Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:24:125:29 | Boolean b | match |
 | Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:24:125:29 | Boolean b | no-match |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:29 | Boolean b | no-match |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:34:125:34 | access to local variable b | false |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:34:125:34 | access to local variable b | true |
+| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:34 | ... => ... | false |
+| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:34 | ... => ... | true |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:34:125:34 | access to local variable b | false |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:34:125:34 | access to local variable b | true |
 | Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:37 | _ | match |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:42:125:46 | false | false |
+| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:46 | ... => ... | false |
+| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:46 | ... => ... | true |
 | Switch.cs:125:42:125:46 | false | Switch.cs:125:42:125:46 | false | false |
 | Switch.cs:126:13:126:19 | return ...; | Switch.cs:126:13:126:19 | return ...; | return |
 | Switch.cs:130:5:132:5 | {...} | Switch.cs:131:9:131:67 | return ...; | return |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:131:9:131:67 | return ...; | return |
 | Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:17:131:17 | access to parameter o | normal |
-| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:40:131:40 | access to local variable s | non-null |
-| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:40:131:40 | access to local variable s | null |
-| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:48:131:51 | null | null |
+| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:17:131:53 | ... switch { ... } | non-null |
+| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:17:131:53 | ... switch { ... } | null |
 | Switch.cs:131:28:131:35 | String s | Switch.cs:131:28:131:35 | String s | match |
 | Switch.cs:131:28:131:35 | String s | Switch.cs:131:28:131:35 | String s | no-match |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:35 | String s | no-match |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:40:131:40 | access to local variable s | non-null |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:40:131:40 | access to local variable s | null |
+| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:40 | ... => ... | non-null |
+| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:40 | ... => ... | null |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:40:131:40 | access to local variable s | non-null |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:40:131:40 | access to local variable s | null |
 | Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:43 | _ | match |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:48:131:51 | null | null |
+| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:51 | ... => ... | non-null |
+| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:51 | ... => ... | null |
 | Switch.cs:131:48:131:51 | null | Switch.cs:131:48:131:51 | null | null |
-| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:40:131:40 | access to local variable s | null |
-| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:48:131:51 | null | null |
+| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:17:131:53 | ... switch { ... } | null |
 | Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:56:131:66 | call to method ToString | normal |
 | Switch.cs:135:5:142:5 | {...} | Switch.cs:138:22:138:31 | return ...; | return |
 | Switch.cs:135:5:142:5 | {...} | Switch.cs:139:21:139:29 | return ...; | return |
@@ -3341,18 +3308,15 @@
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:13:156:54 | String s = ... | normal |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
 | Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:17:156:17 | access to parameter b | normal |
-| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:36:156:38 | "a" | normal |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:54 | ... switch { ... } | normal |
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
-| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:50:156:52 | "b" | normal |
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | true | match |
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | true | no-match |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true | no-match |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:36:156:38 | "a" | normal |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:38 | ... => ... | normal |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" | normal |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false | match |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false | no-match |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false | no-match |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:50:156:52 | "b" | normal |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | ... => ... | normal |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" | normal |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:158:13:158:48 | call to method WriteLine | normal |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:160:13:160:48 | call to method WriteLine | normal |
@@ -3425,8 +3389,7 @@
 | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:13:25:29 | return ...; | return |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:20:25:20 | access to parameter b | false |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:20:25:20 | access to parameter b | true |
-| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:24:25:24 | access to local variable x | normal |
-| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:28:25:28 | access to local variable y | normal |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... | normal |
 | VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:24:25:24 | access to local variable x | normal |
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:28:25:28 | access to local variable y | normal |
 | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:51:28:53 | {...} | normal |
@@ -3493,9 +3456,8 @@
 | cflow.cs:26:17:26:21 | ... % ... | cflow.cs:26:17:26:21 | ... % ... | normal |
 | cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:17:26:26 | ... == ... | false |
 | cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:17:26:26 | ... == ... | true |
-| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:26:17:26:26 | ... == ... | false |
-| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:26:31:26:40 | ... == ... | false |
-| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:26:31:26:40 | ... == ... | true |
+| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:26:17:26:40 | ... && ... | false |
+| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:26:17:26:40 | ... && ... | true |
 | cflow.cs:26:21:26:21 | 3 | cflow.cs:26:21:26:21 | 3 | normal |
 | cflow.cs:26:26:26:26 | 0 | cflow.cs:26:26:26:26 | 0 | normal |
 | cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:31:26:31 | access to local variable i | normal |
@@ -3587,14 +3549,14 @@
 | cflow.cs:60:27:60:31 | access to field Field | cflow.cs:60:27:60:31 | access to field Field | normal |
 | cflow.cs:60:27:60:31 | this access | cflow.cs:60:27:60:31 | this access | normal |
 | cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:18:62:18 | 0 | no-match |
-| cflow.cs:62:13:62:19 | case ...: | cflow.cs:63:23:63:33 | ... == ... | false [true] |
+| cflow.cs:62:13:62:19 | case ...: | cflow.cs:63:21:63:34 | !... | false |
 | cflow.cs:62:13:62:19 | case ...: | cflow.cs:64:21:64:55 | throw ...; | throw(NullReferenceException) |
 | cflow.cs:62:18:62:18 | 0 | cflow.cs:62:18:62:18 | 0 | match |
 | cflow.cs:62:18:62:18 | 0 | cflow.cs:62:18:62:18 | 0 | no-match |
-| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:23:63:33 | ... == ... | false [true] |
+| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:21:63:34 | !... | false |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:64:21:64:55 | throw ...; | throw(NullReferenceException) |
-| cflow.cs:63:21:63:34 | !... | cflow.cs:63:23:63:33 | ... == ... | false [true] |
-| cflow.cs:63:21:63:34 | !... | cflow.cs:63:23:63:33 | ... == ... | true [false] |
+| cflow.cs:63:21:63:34 | !... | cflow.cs:63:21:63:34 | !... | false |
+| cflow.cs:63:21:63:34 | !... | cflow.cs:63:21:63:34 | !... | true |
 | cflow.cs:63:23:63:27 | access to field Field | cflow.cs:63:23:63:27 | access to field Field | normal |
 | cflow.cs:63:23:63:27 | this access | cflow.cs:63:23:63:27 | this access | normal |
 | cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:23:63:33 | ... == ... | false |
@@ -3630,18 +3592,15 @@
 | cflow.cs:80:13:80:47 | call to method WriteLine | cflow.cs:80:13:80:47 | call to method WriteLine | normal |
 | cflow.cs:80:13:80:48 | ...; | cflow.cs:80:13:80:47 | call to method WriteLine | normal |
 | cflow.cs:80:31:80:46 | "<empty string>" | cflow.cs:80:31:80:46 | "<empty string>" | normal |
-| cflow.cs:85:5:88:5 | {...} | cflow.cs:86:13:86:21 | ... != ... | false |
-| cflow.cs:85:5:88:5 | {...} | cflow.cs:86:26:86:37 | ... > ... | false |
+| cflow.cs:85:5:88:5 | {...} | cflow.cs:86:13:86:37 | ... && ... | false |
 | cflow.cs:85:5:88:5 | {...} | cflow.cs:87:13:87:32 | call to method WriteLine | normal |
-| cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:13:86:21 | ... != ... | false |
-| cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:26:86:37 | ... > ... | false |
+| cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:13:86:37 | ... && ... | false |
 | cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:87:13:87:32 | call to method WriteLine | normal |
 | cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:13:86:13 | access to parameter s | normal |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:13:86:21 | ... != ... | false |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:13:86:21 | ... != ... | true |
-| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:13:86:21 | ... != ... | false |
-| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:26:86:37 | ... > ... | false |
-| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:26:86:37 | ... > ... | true |
+| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:13:86:37 | ... && ... | false |
+| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:13:86:37 | ... && ... | true |
 | cflow.cs:86:18:86:21 | null | cflow.cs:86:18:86:21 | null | normal |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:26 | access to parameter s | normal |
 | cflow.cs:86:26:86:33 | access to property Length | cflow.cs:86:26:86:33 | access to property Length | normal |
@@ -3735,8 +3694,7 @@
 | cflow.cs:127:32:127:36 | this access | cflow.cs:127:32:127:36 | this access | normal |
 | cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:32:127:44 | ... == ... | false |
 | cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:32:127:44 | ... == ... | true |
-| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:48:127:49 | "" | normal |
-| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:53:127:57 | access to field Field | normal |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:32:127:57 | ... ? ... : ... | normal |
 | cflow.cs:127:41:127:44 | null | cflow.cs:127:41:127:44 | null | normal |
 | cflow.cs:127:48:127:49 | "" | cflow.cs:127:48:127:49 | "" | normal |
 | cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:53:127:57 | access to field Field | normal |
@@ -3876,17 +3834,15 @@
 | cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:190:13:190:51 | call to method WriteLine | normal |
 | cflow.cs:187:13:187:13 | 1 | cflow.cs:187:13:187:13 | 1 | normal |
 | cflow.cs:187:13:187:18 | ... == ... | cflow.cs:187:13:187:18 | ... == ... | false |
-| cflow.cs:187:13:187:28 | ... \|\| ... | cflow.cs:187:23:187:28 | ... == ... | false |
-| cflow.cs:187:13:187:50 | ... \|\| ... | cflow.cs:187:34:187:39 | ... == ... | false |
-| cflow.cs:187:13:187:50 | ... \|\| ... | cflow.cs:187:44:187:49 | ... == ... | false |
+| cflow.cs:187:13:187:28 | ... \|\| ... | cflow.cs:187:13:187:28 | ... \|\| ... | false |
+| cflow.cs:187:13:187:50 | ... \|\| ... | cflow.cs:187:13:187:50 | ... \|\| ... | false |
 | cflow.cs:187:18:187:18 | 2 | cflow.cs:187:18:187:18 | 2 | normal |
 | cflow.cs:187:23:187:23 | 2 | cflow.cs:187:23:187:23 | 2 | normal |
 | cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:23:187:28 | ... == ... | false |
 | cflow.cs:187:28:187:28 | 3 | cflow.cs:187:28:187:28 | 3 | normal |
 | cflow.cs:187:34:187:34 | 1 | cflow.cs:187:34:187:34 | 1 | normal |
 | cflow.cs:187:34:187:39 | ... == ... | cflow.cs:187:34:187:39 | ... == ... | false |
-| cflow.cs:187:34:187:49 | ... && ... | cflow.cs:187:34:187:39 | ... == ... | false |
-| cflow.cs:187:34:187:49 | ... && ... | cflow.cs:187:44:187:49 | ... == ... | false |
+| cflow.cs:187:34:187:49 | ... && ... | cflow.cs:187:34:187:49 | ... && ... | false |
 | cflow.cs:187:39:187:39 | 3 | cflow.cs:187:39:187:39 | 3 | normal |
 | cflow.cs:187:44:187:44 | 3 | cflow.cs:187:44:187:44 | 3 | normal |
 | cflow.cs:187:44:187:49 | ... == ... | cflow.cs:187:44:187:49 | ... == ... | false |
@@ -3897,8 +3853,7 @@
 | cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:190:13:190:51 | call to method WriteLine | normal |
 | cflow.cs:190:13:190:52 | ...; | cflow.cs:190:13:190:51 | call to method WriteLine | normal |
 | cflow.cs:190:31:190:50 | "This should happen" | cflow.cs:190:31:190:50 | "This should happen" | normal |
-| cflow.cs:194:5:206:5 | {...} | cflow.cs:200:40:200:56 | ... == ... | false |
-| cflow.cs:194:5:206:5 | {...} | cflow.cs:200:61:200:61 | access to local variable b | false |
+| cflow.cs:194:5:206:5 | {...} | cflow.cs:200:13:200:62 | ... \|\| ... | false |
 | cflow.cs:194:5:206:5 | {...} | cflow.cs:203:17:203:38 | throw ...; | throw(Exception) |
 | cflow.cs:195:9:195:57 | ... ...; | cflow.cs:195:13:195:56 | Boolean b = ... | normal |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:195:13:195:56 | Boolean b = ... | normal |
@@ -3907,26 +3862,25 @@
 | cflow.cs:195:17:195:28 | access to property Length | cflow.cs:195:17:195:28 | access to property Length | normal |
 | cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:17:195:32 | ... > ... | false |
 | cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:17:195:32 | ... > ... | true |
-| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:17:195:32 | ... > ... | false |
-| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:39:195:55 | ... == ... | normal |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:17:195:56 | ... && ... | normal |
 | cflow.cs:195:32:195:32 | 0 | cflow.cs:195:32:195:32 | 0 | normal |
-| cflow.cs:195:37:195:56 | !... | cflow.cs:195:39:195:55 | ... == ... | normal |
+| cflow.cs:195:37:195:56 | !... | cflow.cs:195:37:195:56 | !... | normal |
 | cflow.cs:195:39:195:43 | access to field Field | cflow.cs:195:39:195:43 | access to field Field | normal |
 | cflow.cs:195:39:195:43 | this access | cflow.cs:195:39:195:43 | this access | normal |
 | cflow.cs:195:39:195:50 | access to property Length | cflow.cs:195:39:195:50 | access to property Length | normal |
 | cflow.cs:195:39:195:55 | ... == ... | cflow.cs:195:39:195:55 | ... == ... | normal |
 | cflow.cs:195:55:195:55 | 1 | cflow.cs:195:55:195:55 | 1 | normal |
-| cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:197:43:197:46 | true | false [true] |
+| cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:197:13:197:47 | !... | false |
 | cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:198:13:198:48 | ... = ... | normal |
-| cflow.cs:197:13:197:47 | !... | cflow.cs:197:35:197:39 | false | true [false] |
-| cflow.cs:197:13:197:47 | !... | cflow.cs:197:43:197:46 | true | false [true] |
+| cflow.cs:197:13:197:47 | !... | cflow.cs:197:13:197:47 | !... | false |
+| cflow.cs:197:13:197:47 | !... | cflow.cs:197:13:197:47 | !... | true |
 | cflow.cs:197:15:197:19 | access to field Field | cflow.cs:197:15:197:19 | access to field Field | normal |
 | cflow.cs:197:15:197:19 | this access | cflow.cs:197:15:197:19 | this access | normal |
 | cflow.cs:197:15:197:26 | access to property Length | cflow.cs:197:15:197:26 | access to property Length | normal |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:15:197:31 | ... == ... | false |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:15:197:31 | ... == ... | true |
-| cflow.cs:197:15:197:46 | ... ? ... : ... | cflow.cs:197:35:197:39 | false | false |
-| cflow.cs:197:15:197:46 | ... ? ... : ... | cflow.cs:197:43:197:46 | true | true |
+| cflow.cs:197:15:197:46 | ... ? ... : ... | cflow.cs:197:15:197:46 | ... ? ... : ... | false |
+| cflow.cs:197:15:197:46 | ... ? ... : ... | cflow.cs:197:15:197:46 | ... ? ... : ... | true |
 | cflow.cs:197:31:197:31 | 0 | cflow.cs:197:31:197:31 | 0 | normal |
 | cflow.cs:197:35:197:39 | false | cflow.cs:197:35:197:39 | false | false |
 | cflow.cs:197:43:197:46 | true | cflow.cs:197:43:197:46 | true | true |
@@ -3937,40 +3891,33 @@
 | cflow.cs:198:17:198:28 | access to property Length | cflow.cs:198:17:198:28 | access to property Length | normal |
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:17:198:33 | ... == ... | false |
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:17:198:33 | ... == ... | true |
-| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:37:198:41 | false | normal |
-| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:45:198:48 | true | normal |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:17:198:48 | ... ? ... : ... | normal |
 | cflow.cs:198:33:198:33 | 0 | cflow.cs:198:33:198:33 | 0 | normal |
 | cflow.cs:198:37:198:41 | false | cflow.cs:198:37:198:41 | false | normal |
 | cflow.cs:198:45:198:48 | true | cflow.cs:198:45:198:48 | true | normal |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:40:200:56 | ... == ... | false |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:61:200:61 | access to local variable b | false |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:13:200:62 | ... \|\| ... | false |
 | cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:203:17:203:38 | throw ...; | throw(Exception) |
-| cflow.cs:200:13:200:32 | !... | cflow.cs:200:15:200:31 | ... == ... | false [true] |
-| cflow.cs:200:13:200:32 | !... | cflow.cs:200:15:200:31 | ... == ... | true [false] |
-| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:15:200:31 | ... == ... | true [false] |
-| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:40:200:56 | ... == ... | false |
-| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:61:200:61 | access to local variable b | false |
-| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:61:200:61 | access to local variable b | true |
+| cflow.cs:200:13:200:32 | !... | cflow.cs:200:13:200:32 | !... | false |
+| cflow.cs:200:13:200:32 | !... | cflow.cs:200:13:200:32 | !... | true |
+| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:13:200:62 | ... \|\| ... | false |
+| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:13:200:62 | ... \|\| ... | true |
 | cflow.cs:200:15:200:19 | access to field Field | cflow.cs:200:15:200:19 | access to field Field | normal |
 | cflow.cs:200:15:200:19 | this access | cflow.cs:200:15:200:19 | this access | normal |
 | cflow.cs:200:15:200:26 | access to property Length | cflow.cs:200:15:200:26 | access to property Length | normal |
 | cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:15:200:31 | ... == ... | false |
 | cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:15:200:31 | ... == ... | true |
 | cflow.cs:200:31:200:31 | 0 | cflow.cs:200:31:200:31 | 0 | normal |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:40:200:56 | ... == ... | false |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:61:200:61 | access to local variable b | false |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:61:200:61 | access to local variable b | true |
-| cflow.cs:200:38:200:62 | !... | cflow.cs:200:40:200:56 | ... == ... | true [false] |
-| cflow.cs:200:38:200:62 | !... | cflow.cs:200:61:200:61 | access to local variable b | false [true] |
-| cflow.cs:200:38:200:62 | !... | cflow.cs:200:61:200:61 | access to local variable b | true [false] |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:200:37:200:62 | !... | false |
+| cflow.cs:200:37:200:62 | !... | cflow.cs:200:37:200:62 | !... | true |
+| cflow.cs:200:38:200:62 | !... | cflow.cs:200:38:200:62 | !... | false |
+| cflow.cs:200:38:200:62 | !... | cflow.cs:200:38:200:62 | !... | true |
 | cflow.cs:200:40:200:44 | access to field Field | cflow.cs:200:40:200:44 | access to field Field | normal |
 | cflow.cs:200:40:200:44 | this access | cflow.cs:200:40:200:44 | this access | normal |
 | cflow.cs:200:40:200:51 | access to property Length | cflow.cs:200:40:200:51 | access to property Length | normal |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:40:200:56 | ... == ... | false |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:40:200:56 | ... == ... | true |
-| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:40:200:56 | ... == ... | false |
-| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:61:200:61 | access to local variable b | false |
-| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:61:200:61 | access to local variable b | true |
+| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:40:200:61 | ... && ... | false |
+| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:40:200:61 | ... && ... | true |
 | cflow.cs:200:56:200:56 | 1 | cflow.cs:200:56:200:56 | 1 | normal |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:61:200:61 | access to local variable b | false |
 | cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:61:200:61 | access to local variable b | true |
@@ -4065,12 +4012,12 @@
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:254:17:254:27 | goto ...; | goto(Label) |
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:257:17:257:22 | break; | normal (break) |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:9:242:13 | Label: | normal |
-| cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:23:242:39 | ... == ... | false |
+| cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:20:242:40 | !... | false |
 | cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:43:242:45 | {...} | normal |
-| cflow.cs:242:20:242:40 | !... | cflow.cs:242:23:242:39 | ... == ... | false |
-| cflow.cs:242:20:242:40 | !... | cflow.cs:242:23:242:39 | ... == ... | true |
-| cflow.cs:242:21:242:40 | !... | cflow.cs:242:23:242:39 | ... == ... | false [true] |
-| cflow.cs:242:21:242:40 | !... | cflow.cs:242:23:242:39 | ... == ... | true [false] |
+| cflow.cs:242:20:242:40 | !... | cflow.cs:242:20:242:40 | !... | false |
+| cflow.cs:242:20:242:40 | !... | cflow.cs:242:20:242:40 | !... | true |
+| cflow.cs:242:21:242:40 | !... | cflow.cs:242:21:242:40 | !... | false |
+| cflow.cs:242:21:242:40 | !... | cflow.cs:242:21:242:40 | !... | true |
 | cflow.cs:242:23:242:27 | access to field Field | cflow.cs:242:23:242:27 | access to field Field | normal |
 | cflow.cs:242:23:242:27 | this access | cflow.cs:242:23:242:27 | this access | normal |
 | cflow.cs:242:23:242:34 | access to property Length | cflow.cs:242:23:242:34 | access to property Length | normal |
@@ -4119,9 +4066,9 @@
 | cflow.cs:256:35:256:35 | 0 | cflow.cs:256:35:256:35 | 0 | normal |
 | cflow.cs:257:17:257:22 | break; | cflow.cs:257:17:257:22 | break; | break |
 | cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | normal |
-| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | return [normal] |
-| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | throw(Exception) [normal] |
-| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | return |
+| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | throw(Exception) |
+| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | throw(OutOfMemoryException) |
 | cflow.cs:263:9:263:23 | yield return ...; | cflow.cs:263:9:263:23 | yield return ...; | normal |
 | cflow.cs:263:22:263:22 | 0 | cflow.cs:263:22:263:22 | 0 | normal |
 | cflow.cs:264:9:267:9 | for (...;...;...) ... | cflow.cs:264:25:264:30 | ... < ... | false |
@@ -4137,9 +4084,9 @@
 | cflow.cs:266:13:266:27 | yield return ...; | cflow.cs:266:13:266:27 | yield return ...; | normal |
 | cflow.cs:266:26:266:26 | access to local variable i | cflow.cs:266:26:266:26 | access to local variable i | normal |
 | cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | normal |
-| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | return [normal] |
-| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | throw(Exception) [normal] |
-| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | return |
+| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | throw(Exception) |
+| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | throw(OutOfMemoryException) |
 | cflow.cs:269:9:272:9 | {...} | cflow.cs:270:13:270:24 | yield break; | return |
 | cflow.cs:269:9:272:9 | {...} | cflow.cs:271:13:271:42 | call to method WriteLine | normal |
 | cflow.cs:269:9:272:9 | {...} | cflow.cs:271:13:271:42 | call to method WriteLine | throw(Exception) |
@@ -4173,10 +4120,9 @@
 | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | normal |
 | cflow.cs:300:9:300:73 | ...; | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | normal |
 | cflow.cs:300:38:300:38 | 0 | cflow.cs:300:38:300:38 | 0 | normal |
-| cflow.cs:300:44:300:51 | !... | cflow.cs:300:46:300:50 | ... > ... | false [true] |
-| cflow.cs:300:44:300:51 | !... | cflow.cs:300:46:300:50 | ... > ... | true [false] |
-| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:46:300:50 | ... > ... | false [true] |
-| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:56:300:64 | ... != ... | normal |
+| cflow.cs:300:44:300:51 | !... | cflow.cs:300:44:300:51 | !... | false |
+| cflow.cs:300:44:300:51 | !... | cflow.cs:300:44:300:51 | !... | true |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:44:300:64 | ... && ... | normal |
 | cflow.cs:300:46:300:46 | access to parameter i | cflow.cs:300:46:300:46 | access to parameter i | normal |
 | cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:46:300:50 | ... > ... | false |
 | cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:46:300:50 | ... > ... | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -331,13 +331,13 @@
 | Assert.cs:7:10:7:11 | exit M1 (abnormal) | Assert.cs:7:10:7:11 | exit M1 | semmle.label | successor |
 | Assert.cs:7:10:7:11 | exit M1 (normal) | Assert.cs:7:10:7:11 | exit M1 | semmle.label | successor |
 | Assert.cs:8:5:12:5 | {...} | Assert.cs:9:9:9:33 | ... ...; | semmle.label | successor |
-| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:20:9:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:20:9:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:32 | ...; | semmle.label | successor |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null | semmle.label | true |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" | semmle.label | false |
-| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:9:24:9:27 | null | Assert.cs:9:16:9:32 | String s = ... | semmle.label | successor |
-| Assert.cs:9:31:9:32 | "" | Assert.cs:9:16:9:32 | String s = ... | semmle.label | successor |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:16:9:32 | String s = ... | semmle.label | successor |
+| Assert.cs:9:24:9:27 | null | Assert.cs:9:20:9:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:9:31:9:32 | "" | Assert.cs:9:20:9:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | exit M1 (abnormal) | semmle.label | exit |
 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:11:9:11:36 | ...; | semmle.label | successor |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:10:22:10:22 | access to local variable s | semmle.label | successor |
@@ -353,13 +353,13 @@
 | Assert.cs:14:10:14:11 | exit M2 (abnormal) | Assert.cs:14:10:14:11 | exit M2 | semmle.label | successor |
 | Assert.cs:14:10:14:11 | exit M2 (normal) | Assert.cs:14:10:14:11 | exit M2 | semmle.label | successor |
 | Assert.cs:15:5:19:5 | {...} | Assert.cs:16:9:16:33 | ... ...; | semmle.label | successor |
-| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:20:16:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:20:16:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:25 | ...; | semmle.label | successor |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:24:16:27 | null | semmle.label | true |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:31:16:32 | "" | semmle.label | false |
-| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:16:24:16:27 | null | Assert.cs:16:16:16:32 | String s = ... | semmle.label | successor |
-| Assert.cs:16:31:16:32 | "" | Assert.cs:16:16:16:32 | String s = ... | semmle.label | successor |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:16:16:32 | String s = ... | semmle.label | successor |
+| Assert.cs:16:24:16:27 | null | Assert.cs:16:20:16:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:16:31:16:32 | "" | Assert.cs:16:20:16:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:18:9:18:36 | ...; | semmle.label | successor |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:17:23:17:23 | access to local variable s | semmle.label | successor |
@@ -373,13 +373,13 @@
 | Assert.cs:21:10:21:11 | exit M3 (abnormal) | Assert.cs:21:10:21:11 | exit M3 | semmle.label | successor |
 | Assert.cs:21:10:21:11 | exit M3 (normal) | Assert.cs:21:10:21:11 | exit M3 | semmle.label | successor |
 | Assert.cs:22:5:26:5 | {...} | Assert.cs:23:9:23:33 | ... ...; | semmle.label | successor |
-| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:20:23:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:20:23:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:28 | ...; | semmle.label | successor |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:24:23:27 | null | semmle.label | true |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:31:23:32 | "" | semmle.label | false |
-| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:23:24:23:27 | null | Assert.cs:23:16:23:32 | String s = ... | semmle.label | successor |
-| Assert.cs:23:31:23:32 | "" | Assert.cs:23:16:23:32 | String s = ... | semmle.label | successor |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:16:23:32 | String s = ... | semmle.label | successor |
+| Assert.cs:23:24:23:27 | null | Assert.cs:23:20:23:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:23:31:23:32 | "" | Assert.cs:23:20:23:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:25:9:25:36 | ...; | semmle.label | successor |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:24:26:24:26 | access to local variable s | semmle.label | successor |
@@ -393,13 +393,13 @@
 | Assert.cs:28:10:28:11 | exit M4 (abnormal) | Assert.cs:28:10:28:11 | exit M4 | semmle.label | successor |
 | Assert.cs:28:10:28:11 | exit M4 (normal) | Assert.cs:28:10:28:11 | exit M4 | semmle.label | successor |
 | Assert.cs:29:5:33:5 | {...} | Assert.cs:30:9:30:33 | ... ...; | semmle.label | successor |
-| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:20:30:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:20:30:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:33 | ...; | semmle.label | successor |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:24:30:27 | null | semmle.label | true |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:31:30:32 | "" | semmle.label | false |
-| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:30:24:30:27 | null | Assert.cs:30:16:30:32 | String s = ... | semmle.label | successor |
-| Assert.cs:30:31:30:32 | "" | Assert.cs:30:16:30:32 | String s = ... | semmle.label | successor |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:16:30:32 | String s = ... | semmle.label | successor |
+| Assert.cs:30:24:30:27 | null | Assert.cs:30:20:30:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:30:31:30:32 | "" | Assert.cs:30:20:30:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:32:9:32:36 | ...; | semmle.label | successor |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:31:23:31:23 | access to local variable s | semmle.label | successor |
@@ -415,13 +415,13 @@
 | Assert.cs:35:10:35:11 | exit M5 (abnormal) | Assert.cs:35:10:35:11 | exit M5 | semmle.label | successor |
 | Assert.cs:35:10:35:11 | exit M5 (normal) | Assert.cs:35:10:35:11 | exit M5 | semmle.label | successor |
 | Assert.cs:36:5:40:5 | {...} | Assert.cs:37:9:37:33 | ... ...; | semmle.label | successor |
-| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:20:37:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:20:37:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:33 | ...; | semmle.label | successor |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:24:37:27 | null | semmle.label | true |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:31:37:32 | "" | semmle.label | false |
-| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:37:24:37:27 | null | Assert.cs:37:16:37:32 | String s = ... | semmle.label | successor |
-| Assert.cs:37:31:37:32 | "" | Assert.cs:37:16:37:32 | String s = ... | semmle.label | successor |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:16:37:32 | String s = ... | semmle.label | successor |
+| Assert.cs:37:24:37:27 | null | Assert.cs:37:20:37:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:37:31:37:32 | "" | Assert.cs:37:20:37:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:39:9:39:36 | ...; | semmle.label | successor |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:38:23:38:23 | access to local variable s | semmle.label | successor |
@@ -437,13 +437,13 @@
 | Assert.cs:42:10:42:11 | exit M6 (abnormal) | Assert.cs:42:10:42:11 | exit M6 | semmle.label | successor |
 | Assert.cs:42:10:42:11 | exit M6 (normal) | Assert.cs:42:10:42:11 | exit M6 | semmle.label | successor |
 | Assert.cs:43:5:47:5 | {...} | Assert.cs:44:9:44:33 | ... ...; | semmle.label | successor |
-| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:20:44:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:20:44:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:34 | ...; | semmle.label | successor |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:24:44:27 | null | semmle.label | true |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:31:44:32 | "" | semmle.label | false |
-| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:44:24:44:27 | null | Assert.cs:44:16:44:32 | String s = ... | semmle.label | successor |
-| Assert.cs:44:31:44:32 | "" | Assert.cs:44:16:44:32 | String s = ... | semmle.label | successor |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:16:44:32 | String s = ... | semmle.label | successor |
+| Assert.cs:44:24:44:27 | null | Assert.cs:44:20:44:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:44:31:44:32 | "" | Assert.cs:44:20:44:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:46:9:46:36 | ...; | semmle.label | successor |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:45:24:45:24 | access to local variable s | semmle.label | successor |
@@ -459,13 +459,13 @@
 | Assert.cs:49:10:49:11 | exit M7 (abnormal) | Assert.cs:49:10:49:11 | exit M7 | semmle.label | successor |
 | Assert.cs:49:10:49:11 | exit M7 (normal) | Assert.cs:49:10:49:11 | exit M7 | semmle.label | successor |
 | Assert.cs:50:5:54:5 | {...} | Assert.cs:51:9:51:33 | ... ...; | semmle.label | successor |
-| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:20:51:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:20:51:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:34 | ...; | semmle.label | successor |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:24:51:27 | null | semmle.label | true |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:31:51:32 | "" | semmle.label | false |
-| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:51:24:51:27 | null | Assert.cs:51:16:51:32 | String s = ... | semmle.label | successor |
-| Assert.cs:51:31:51:32 | "" | Assert.cs:51:16:51:32 | String s = ... | semmle.label | successor |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:16:51:32 | String s = ... | semmle.label | successor |
+| Assert.cs:51:24:51:27 | null | Assert.cs:51:20:51:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:51:31:51:32 | "" | Assert.cs:51:20:51:32 | ... ? ... : ... | semmle.label | successor |
 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:53:9:53:36 | ...; | semmle.label | successor |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:52:24:52:24 | access to local variable s | semmle.label | successor |
@@ -481,30 +481,31 @@
 | Assert.cs:56:10:56:11 | exit M8 (abnormal) | Assert.cs:56:10:56:11 | exit M8 | semmle.label | successor |
 | Assert.cs:56:10:56:11 | exit M8 (normal) | Assert.cs:56:10:56:11 | exit M8 | semmle.label | successor |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:58:9:58:33 | ... ...; | semmle.label | successor |
-| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): false] ...; | semmle.label | successor |
 | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): true] ...; | semmle.label | successor |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | [b (line 56): true] null | semmle.label | true |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | [b (line 56): false] "" | semmle.label | false |
-| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | semmle.label | successor |
-| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | semmle.label | successor |
+| Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | semmle.label | successor |
+| Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | semmle.label | successor |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:60:9:60:36 | ...; | semmle.label | successor |
-| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | semmle.label | successor |
-| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | semmle.label | successor |
+| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | semmle.label | successor |
+| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | semmle.label | successor |
 | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): false] null | semmle.label | successor |
 | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): true] null | semmle.label | successor |
-| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:23:59:36 | [false] ... && ... | semmle.label | false |
 | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | semmle.label | true |
-| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:23:59:36 | [false] ... && ... | semmle.label | false |
 | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | semmle.label | true |
-| Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | semmle.label | successor |
-| Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | semmle.label | successor |
+| Assert.cs:59:23:59:36 | [false] ... && ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:59:23:59:36 | [true] ... && ... | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | semmle.label | true |
 | Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | semmle.label | successor |
 | Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | semmle.label | successor |
-| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | semmle.label | false |
-| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | semmle.label | true |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:23:59:36 | [false] ... && ... | semmle.label | false |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:23:59:36 | [true] ... && ... | semmle.label | true |
 | Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 (normal) | semmle.label | successor |
 | Assert.cs:60:9:60:36 | ...; | Assert.cs:60:27:60:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:34 | access to property Length | semmle.label | successor |
@@ -513,30 +514,31 @@
 | Assert.cs:63:10:63:11 | exit M9 (abnormal) | Assert.cs:63:10:63:11 | exit M9 | semmle.label | successor |
 | Assert.cs:63:10:63:11 | exit M9 (normal) | Assert.cs:63:10:63:11 | exit M9 | semmle.label | successor |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:65:9:65:33 | ... ...; | semmle.label | successor |
-| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): false] ...; | semmle.label | successor |
 | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): true] ...; | semmle.label | successor |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | [b (line 63): true] null | semmle.label | true |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | [b (line 63): false] "" | semmle.label | false |
-| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | semmle.label | successor |
-| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | semmle.label | successor |
+| Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | semmle.label | successor |
+| Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | semmle.label | successor |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:67:9:67:36 | ...; | semmle.label | successor |
-| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | semmle.label | successor |
-| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | semmle.label | successor |
+| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | semmle.label | successor |
+| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | semmle.label | successor |
 | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): false] null | semmle.label | successor |
 | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): true] null | semmle.label | successor |
-| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:24:66:37 | [true] ... \|\| ... | semmle.label | true |
 | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | semmle.label | false |
-| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:24:66:37 | [true] ... \|\| ... | semmle.label | true |
 | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | semmle.label | false |
-| Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | semmle.label | successor |
-| Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | semmle.label | successor |
+| Assert.cs:66:24:66:37 | [false] ... \|\| ... | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | semmle.label | false |
+| Assert.cs:66:24:66:37 | [true] ... \|\| ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | semmle.label | true |
 | Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | semmle.label | successor |
 | Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | semmle.label | successor |
-| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | semmle.label | false |
-| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:24:66:37 | [false] ... \|\| ... | semmle.label | false |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:24:66:37 | [true] ... \|\| ... | semmle.label | true |
 | Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 (normal) | semmle.label | successor |
 | Assert.cs:67:9:67:36 | ...; | Assert.cs:67:27:67:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:34 | access to property Length | semmle.label | successor |
@@ -545,30 +547,31 @@
 | Assert.cs:70:10:70:12 | exit M10 (abnormal) | Assert.cs:70:10:70:12 | exit M10 | semmle.label | successor |
 | Assert.cs:70:10:70:12 | exit M10 (normal) | Assert.cs:70:10:70:12 | exit M10 | semmle.label | successor |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:72:9:72:33 | ... ...; | semmle.label | successor |
-| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): false] ...; | semmle.label | successor |
 | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): true] ...; | semmle.label | successor |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | [b (line 70): true] null | semmle.label | true |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | [b (line 70): false] "" | semmle.label | false |
-| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | semmle.label | successor |
-| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | semmle.label | successor |
+| Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | semmle.label | successor |
+| Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | semmle.label | successor |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:74:9:74:36 | ...; | semmle.label | successor |
-| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | semmle.label | successor |
-| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | semmle.label | successor |
+| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | semmle.label | successor |
+| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | semmle.label | successor |
 | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): false] null | semmle.label | successor |
 | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): true] null | semmle.label | successor |
-| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:23:73:36 | [false] ... && ... | semmle.label | false |
 | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | semmle.label | true |
-| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:23:73:36 | [false] ... && ... | semmle.label | false |
 | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | semmle.label | true |
-| Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | semmle.label | successor |
-| Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | semmle.label | successor |
+| Assert.cs:73:23:73:36 | [false] ... && ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:73:23:73:36 | [true] ... && ... | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | semmle.label | true |
 | Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | semmle.label | successor |
 | Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | semmle.label | successor |
-| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | semmle.label | false |
-| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | semmle.label | true |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:23:73:36 | [false] ... && ... | semmle.label | false |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:23:73:36 | [true] ... && ... | semmle.label | true |
 | Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 (normal) | semmle.label | successor |
 | Assert.cs:74:9:74:36 | ...; | Assert.cs:74:27:74:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:34 | access to property Length | semmle.label | successor |
@@ -577,30 +580,31 @@
 | Assert.cs:77:10:77:12 | exit M11 (abnormal) | Assert.cs:77:10:77:12 | exit M11 | semmle.label | successor |
 | Assert.cs:77:10:77:12 | exit M11 (normal) | Assert.cs:77:10:77:12 | exit M11 | semmle.label | successor |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:79:9:79:33 | ... ...; | semmle.label | successor |
-| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): false] ...; | semmle.label | successor |
 | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): true] ...; | semmle.label | successor |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | [b (line 77): true] null | semmle.label | true |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | [b (line 77): false] "" | semmle.label | false |
-| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | semmle.label | successor |
-| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | semmle.label | successor |
+| Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | semmle.label | successor |
+| Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | semmle.label | successor |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:81:9:81:36 | ...; | semmle.label | successor |
-| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | semmle.label | successor |
-| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | semmle.label | successor |
+| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | semmle.label | successor |
+| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | semmle.label | successor |
 | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): false] null | semmle.label | successor |
 | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): true] null | semmle.label | successor |
-| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:24:80:37 | [true] ... \|\| ... | semmle.label | true |
 | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | semmle.label | false |
-| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:24:80:37 | [true] ... \|\| ... | semmle.label | true |
 | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | semmle.label | false |
-| Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | semmle.label | successor |
-| Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | semmle.label | successor |
+| Assert.cs:80:24:80:37 | [false] ... \|\| ... | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | semmle.label | false |
+| Assert.cs:80:24:80:37 | [true] ... \|\| ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | semmle.label | true |
 | Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | semmle.label | successor |
 | Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | semmle.label | successor |
-| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | semmle.label | false |
-| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:24:80:37 | [false] ... \|\| ... | semmle.label | false |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:24:80:37 | [true] ... \|\| ... | semmle.label | true |
 | Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 (normal) | semmle.label | successor |
 | Assert.cs:81:9:81:36 | ...; | Assert.cs:81:27:81:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:34 | access to property Length | semmle.label | successor |
@@ -609,14 +613,15 @@
 | Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | exit M12 | semmle.label | successor |
 | Assert.cs:84:10:84:12 | exit M12 (normal) | Assert.cs:84:10:84:12 | exit M12 | semmle.label | successor |
 | Assert.cs:85:5:129:5 | {...} | Assert.cs:86:9:86:33 | ... ...; | semmle.label | successor |
-| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:20:86:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:20:86:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null | semmle.label | true |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:31:86:32 | [b (line 84): false] "" | semmle.label | false |
-| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | semmle.label | successor |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | semmle.label | successor |
+| Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | semmle.label | successor |
+| Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | semmle.label | successor |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exit |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exit |
 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; | semmle.label | successor |
@@ -641,14 +646,14 @@
 | Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
 | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:24:90:25 | [b (line 84): false] "" | semmle.label | false |
 | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:17:90:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; | semmle.label | successor |
@@ -669,14 +674,14 @@
 | Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
 | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:24:94:25 | [b (line 84): false] "" | semmle.label | false |
 | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:17:94:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; | semmle.label | successor |
@@ -697,14 +702,14 @@
 | Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
 | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:24:98:25 | [b (line 84): false] "" | semmle.label | false |
 | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:17:98:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; | semmle.label | successor |
@@ -729,14 +734,14 @@
 | Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
 | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:24:102:25 | [b (line 84): false] "" | semmle.label | false |
 | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:17:102:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; | semmle.label | successor |
@@ -761,14 +766,14 @@
 | Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
 | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:24:106:25 | [b (line 84): false] "" | semmle.label | false |
 | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:17:106:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; | semmle.label | successor |
@@ -793,14 +798,14 @@
 | Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
 | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:24:110:25 | [b (line 84): false] "" | semmle.label | false |
 | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:17:110:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; | semmle.label | successor |
@@ -825,87 +830,91 @@
 | Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
 | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:24:114:25 | [b (line 84): false] "" | semmle.label | false |
 | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:17:114:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | semmle.label | successor |
-| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | semmle.label | successor |
+| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): false] null | semmle.label | successor |
 | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | semmle.label | false |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | semmle.label | false |
 | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | semmle.label | true |
-| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | semmle.label | false |
 | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | semmle.label | true |
-| Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | semmle.label | false |
+| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
+| Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
 | Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | semmle.label | successor |
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | semmle.label | successor |
-| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | semmle.label | false |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | semmle.label | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | semmle.label | true |
 | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | semmle.label | successor |
 | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
 | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | semmle.label | successor |
+| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | semmle.label | true |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... | semmle.label | false |
-| Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | semmle.label | true |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | semmle.label | false |
+| Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | semmle.label | false |
+| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | semmle.label | true |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | semmle.label | successor |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | semmle.label | true |
+| Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | semmle.label | false |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | semmle.label | true |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | semmle.label | successor |
 | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
 | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | semmle.label | successor |
+| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | semmle.label | false |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | semmle.label | true |
-| Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
+| Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | semmle.label | successor |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | semmle.label | true |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | semmle.label | successor |
 | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
 | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | Assert.cs:127:9:127:40 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
 | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:128:9:128:36 | ...; | semmle.label | successor |
-| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | semmle.label | successor |
+| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:127:29:127:32 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | semmle.label | true |
-| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:37:127:38 | [b (line 84): true] !... | semmle.label | false |
-| Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:24:127:38 | [true] ... \|\| ... | semmle.label | true |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | semmle.label | false |
+| Assert.cs:127:24:127:38 | [false] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | semmle.label | false |
+| Assert.cs:127:24:127:38 | [true] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | semmle.label | true |
 | Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | semmle.label | successor |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | semmle.label | true |
+| Assert.cs:127:37:127:38 | [false] !... | Assert.cs:127:24:127:38 | [false] ... \|\| ... | semmle.label | false |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [false] !... | semmle.label | true |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 (normal) | semmle.label | successor |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:128:27:128:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:34 | access to property Length | semmle.label | successor |
@@ -1132,8 +1141,6 @@
 | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | exit M (normal) | semmle.label | successor |
 | CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:32:40:36 | "End" | semmle.label | successor |
 | CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | semmle.label | successor |
-| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:30:32:30:32 | 0 | semmle.label | successor |
-| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess | semmle.label | successor |
 | ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | semmle.label | successor |
 | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 | semmle.label | successor |
 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | semmle.label | null |
@@ -1146,22 +1153,25 @@
 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | semmle.label | null |
 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:28:5:34 | access to property Length | semmle.label | non-null |
 | ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | semmle.label | successor |
-| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | semmle.label | successor |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | semmle.label | successor |
 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 | semmle.label | successor |
+| ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | semmle.label | non-null |
 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | semmle.label | null |
-| ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:49:7:55 | access to property Length | semmle.label | non-null |
-| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | semmle.label | successor |
-| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | semmle.label | null |
-| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:49:7:55 | access to property Length | semmle.label | non-null |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | semmle.label | null |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:49:7:55 | access to property Length | semmle.label | non-null |
+| ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | ConditionalAccess.cs:7:49:7:55 | access to property Length | semmle.label | non-null |
+| ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | semmle.label | null |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | semmle.label | non-null |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | semmle.label | null |
 | ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | semmle.label | successor |
-| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | semmle.label | successor |
+| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | semmle.label | successor |
 | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 | semmle.label | successor |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:27:9:33 | access to property Length | semmle.label | non-null |
 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:38:9:38 | 0 | semmle.label | null |
-| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:25:9:25 | access to parameter s | semmle.label | successor |
-| ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | semmle.label | non-null |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | semmle.label | successor |
+| ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | semmle.label | non-null |
 | ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:38:9:38 | 0 | semmle.label | null |
-| ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | semmle.label | successor |
+| ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | semmle.label | successor |
 | ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:12:5:17:5 | {...} | semmle.label | successor |
 | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | exit M5 | semmle.label | successor |
 | ConditionalAccess.cs:12:5:17:5 | {...} | ConditionalAccess.cs:13:9:16:21 | if (...) ... | semmle.label | successor |
@@ -1202,10 +1212,7 @@
 | ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | semmle.label | successor |
 | ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:32:30:32 | 0 | semmle.label | successor |
 | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out | semmle.label | successor |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | semmle.label | successor |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | semmle.label | successor |
 | ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | semmle.label | successor |
-| ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:28:30:32 | ... = ... | semmle.label | successor |
 | ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:28:30:32 | ... = ... | semmle.label | successor |
 | ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:33:5:36:5 | {...} | semmle.label | successor |
 | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 | semmle.label | successor |
@@ -1234,12 +1241,12 @@
 | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ | semmle.label | successor |
 | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ | Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | semmle.label | successor |
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x | semmle.label | successor |
-| Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:7:13:7:16 | [inc (line 3): false] !... | semmle.label | successor |
-| Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | Conditions.cs:7:13:7:16 | [inc (line 3): true] !... | semmle.label | successor |
-| Conditions.cs:7:13:7:16 | [inc (line 3): false] !... | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | semmle.label | successor |
-| Conditions.cs:7:13:7:16 | [inc (line 3): true] !... | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | semmle.label | successor |
-| Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:8:13:8:16 | ...; | semmle.label | false |
-| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | semmle.label | true |
+| Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | semmle.label | successor |
+| Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | semmle.label | successor |
+| Conditions.cs:7:13:7:16 | [false] !... | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | semmle.label | false |
+| Conditions.cs:7:13:7:16 | [true] !... | Conditions.cs:8:13:8:16 | ...; | semmle.label | true |
+| Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:7:13:7:16 | [true] !... | semmle.label | false |
+| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:7:13:7:16 | [false] !... | semmle.label | true |
 | Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:15 | ...-- | semmle.label | successor |
 | Conditions.cs:8:13:8:15 | ...-- | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | semmle.label | successor |
 | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:13 | access to parameter x | semmle.label | successor |
@@ -1265,12 +1272,12 @@
 | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | Conditions.cs:19:16:19:16 | access to local variable x | semmle.label | false |
 | Conditions.cs:16:17:16:17 | [b (line 11): false] 0 | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | semmle.label | successor |
 | Conditions.cs:16:17:16:17 | [b (line 11): true] 0 | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | semmle.label | successor |
-| Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:17:17:17:18 | [b (line 11): false] !... | semmle.label | successor |
-| Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:17:17:17:18 | [b (line 11): true] !... | semmle.label | successor |
-| Conditions.cs:17:17:17:18 | [b (line 11): false] !... | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | semmle.label | successor |
-| Conditions.cs:17:17:17:18 | [b (line 11): true] !... | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | semmle.label | successor |
-| Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:18:17:18:20 | ...; | semmle.label | false |
-| Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | Conditions.cs:19:16:19:16 | access to local variable x | semmle.label | true |
+| Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | semmle.label | successor |
+| Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | semmle.label | successor |
+| Conditions.cs:17:17:17:18 | [false] !... | Conditions.cs:19:16:19:16 | access to local variable x | semmle.label | false |
+| Conditions.cs:17:17:17:18 | [true] !... | Conditions.cs:18:17:18:20 | ...; | semmle.label | true |
+| Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:17:17:17:18 | [true] !... | semmle.label | false |
+| Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | Conditions.cs:17:17:17:18 | [false] !... | semmle.label | true |
 | Conditions.cs:18:17:18:17 | access to local variable x | Conditions.cs:18:17:18:19 | ...-- | semmle.label | successor |
 | Conditions.cs:18:17:18:19 | ...-- | Conditions.cs:19:16:19:16 | access to local variable x | semmle.label | successor |
 | Conditions.cs:18:17:18:20 | ...; | Conditions.cs:18:17:18:17 | access to local variable x | semmle.label | successor |
@@ -1522,12 +1529,12 @@
 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | false |
 | Conditions.cs:107:24:107:24 | [b (line 102): false] 0 | Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... | semmle.label | successor |
 | Conditions.cs:107:24:107:24 | [b (line 102): true] 0 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | semmle.label | successor |
-| Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:108:17:108:18 | [b (line 102): false] !... | semmle.label | successor |
-| Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:17:108:18 | [b (line 102): true] !... | semmle.label | successor |
-| Conditions.cs:108:17:108:18 | [b (line 102): false] !... | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | semmle.label | successor |
-| Conditions.cs:108:17:108:18 | [b (line 102): true] !... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | semmle.label | successor |
-| Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:109:17:109:24 | ...; | semmle.label | false |
-| Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | true |
+| Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | semmle.label | successor |
+| Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | semmle.label | successor |
+| Conditions.cs:108:17:108:18 | [false] !... | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | false |
+| Conditions.cs:108:17:108:18 | [true] !... | Conditions.cs:109:17:109:24 | ...; | semmle.label | true |
+| Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:108:17:108:18 | [true] !... | semmle.label | false |
+| Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:108:17:108:18 | [false] !... | semmle.label | true |
 | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:22:109:23 | "" | semmle.label | successor |
 | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:23 | ... = ... | semmle.label | successor |
 | Conditions.cs:109:17:109:23 | ... = ... | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | successor |
@@ -1560,10 +1567,11 @@
 | Conditions.cs:118:29:118:39 | access to property Length | Conditions.cs:118:43:118:43 | 1 | semmle.label | successor |
 | Conditions.cs:118:29:118:43 | ... - ... | Conditions.cs:118:24:118:43 | ... == ... | semmle.label | successor |
 | Conditions.cs:118:43:118:43 | 1 | Conditions.cs:118:29:118:43 | ... - ... | semmle.label | successor |
-| Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:119:17:119:21 | !... | semmle.label | successor |
-| Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:18:119:21 | access to local variable last | semmle.label | successor |
-| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | semmle.label | false |
-| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | semmle.label | true |
+| Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:119:18:119:21 | access to local variable last | semmle.label | successor |
+| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | semmle.label | false |
+| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | semmle.label | true |
+| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | semmle.label | true |
+| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | semmle.label | false |
 | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... | semmle.label | successor |
 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | semmle.label | successor |
 | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | semmle.label | successor |
@@ -1619,14 +1627,15 @@
 | Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:144:5:150:5 | {...} | semmle.label | successor |
 | Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | exit M11 | semmle.label | successor |
 | Conditions.cs:144:5:150:5 | {...} | Conditions.cs:145:9:145:30 | ... ...; | semmle.label | successor |
-| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:17:145:29 | ... ? ... : ... | semmle.label | successor |
+| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:17:145:17 | access to parameter b | semmle.label | successor |
 | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | semmle.label | successor |
 | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | semmle.label | successor |
 | Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | semmle.label | true |
 | Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | semmle.label | false |
-| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:17:145:17 | access to parameter b | semmle.label | successor |
-| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | semmle.label | successor |
-| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | semmle.label | successor |
+| Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | semmle.label | successor |
+| Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | semmle.label | successor |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... | semmle.label | successor |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... | semmle.label | successor |
 | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | semmle.label | successor |
 | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | semmle.label | successor |
 | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:149:13:149:49 | ...; | semmle.label | false |
@@ -1752,32 +1761,32 @@
 | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:110:5:112:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | semmle.label | successor |
 | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | semmle.label | successor |
-| ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:16:111:76 | ... ? ... : ... | semmle.label | successor |
+| ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:16:111:20 | access to parameter input | semmle.label | successor |
 | ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (normal) | semmle.label | return |
 | ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:25:111:25 | 0 | semmle.label | successor |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:29:111:29 | 1 | semmle.label | true |
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:69:111:75 | "input" | semmle.label | false |
-| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:16:111:20 | access to parameter input | semmle.label | successor |
+| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:9:111:77 | return ...; | semmle.label | successor |
 | ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:25:111:25 | (...) ... | semmle.label | successor |
 | ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:16:111:25 | ... != ... | semmle.label | successor |
 | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | (...) ... | semmle.label | successor |
 | ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:33:111:37 | access to parameter input | semmle.label | successor |
-| ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:9:111:77 | return ...; | semmle.label | successor |
+| ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:16:111:76 | ... ? ... : ... | semmle.label | successor |
 | ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:29:111:37 | ... / ... | semmle.label | successor |
 | ExitMethods.cs:111:41:111:76 | throw ... | ExitMethods.cs:109:13:109:21 | exit ThrowExpr (abnormal) | semmle.label | exception(ArgumentException) |
 | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:41:111:76 | throw ... | semmle.label | successor |
 | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | semmle.label | successor |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:115:5:117:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | semmle.label | successor |
-| ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | semmle.label | successor |
+| ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:116:16:116:16 | access to parameter s | semmle.label | successor |
 | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall (normal) | semmle.label | return |
 | ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:27:116:29 | - | semmle.label | successor |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:34:116:34 | 0 | semmle.label | true |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:38:116:38 | 1 | semmle.label | false |
-| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:16 | access to parameter s | semmle.label | successor |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:9:116:39 | return ...; | semmle.label | successor |
 | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:30 | call to method Contains | semmle.label | successor |
-| ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:9:116:39 | return ...; | semmle.label | successor |
-| ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:9:116:39 | return ...; | semmle.label | successor |
+| ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | semmle.label | successor |
+| ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | semmle.label | successor |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:120:5:123:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:119:17:119:32 | exit FailingAssertion (abnormal) | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | semmle.label | successor |
 | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:121:9:121:29 | ...; | semmle.label | successor |
@@ -2113,16 +2122,21 @@
 | Finally.cs:113:9:118:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | semmle.label | successor |
 | Finally.cs:113:9:118:9 | [finally: return] {...} | Finally.cs:114:13:115:41 | [finally: return] if (...) ... | semmle.label | successor |
 | Finally.cs:113:9:118:9 | {...} | Finally.cs:114:13:115:41 | if (...) ... | semmle.label | successor |
-| Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... | Finally.cs:114:17:114:36 | [finally: exception(Exception)] !... | semmle.label | successor |
-| Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:114:17:114:36 | [finally: exception(NullReferenceException)] !... | semmle.label | successor |
-| Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:114:17:114:36 | [finally: exception(OutOfMemoryException)] !... | semmle.label | successor |
-| Finally.cs:114:13:115:41 | [finally: return] if (...) ... | Finally.cs:114:17:114:36 | [finally: return] !... | semmle.label | successor |
-| Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:114:17:114:36 | !... | semmle.label | successor |
-| Finally.cs:114:17:114:36 | !... | Finally.cs:114:19:114:23 | this access | semmle.label | successor |
-| Finally.cs:114:17:114:36 | [finally: exception(Exception)] !... | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | semmle.label | successor |
-| Finally.cs:114:17:114:36 | [finally: exception(NullReferenceException)] !... | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access | semmle.label | successor |
-| Finally.cs:114:17:114:36 | [finally: exception(OutOfMemoryException)] !... | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access | semmle.label | successor |
-| Finally.cs:114:17:114:36 | [finally: return] !... | Finally.cs:114:19:114:23 | [finally: return] this access | semmle.label | successor |
+| Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | semmle.label | successor |
+| Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access | semmle.label | successor |
+| Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access | semmle.label | successor |
+| Finally.cs:114:13:115:41 | [finally: return] if (...) ... | Finally.cs:114:19:114:23 | [finally: return] this access | semmle.label | successor |
+| Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:114:19:114:23 | this access | semmle.label | successor |
+| Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | semmle.label | false |
+| Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | semmle.label | false |
+| Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | semmle.label | false |
+| Finally.cs:114:17:114:36 | [false, finally: return] !... | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | semmle.label | false |
+| Finally.cs:114:17:114:36 | [false] !... | Finally.cs:116:13:117:37 | if (...) ... | semmle.label | false |
+| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | semmle.label | true |
+| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | semmle.label | true |
+| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | true |
+| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:115:17:115:41 | [finally: return] ...; | semmle.label | true |
+| Finally.cs:114:17:114:36 | [true] !... | Finally.cs:115:17:115:41 | ...; | semmle.label | true |
 | Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field | Finally.cs:114:19:114:30 | [finally: exception(Exception)] access to property Length | semmle.label | successor |
 | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field | semmle.label | successor |
 | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:114:19:114:30 | [finally: exception(NullReferenceException)] access to property Length | semmle.label | successor |
@@ -2138,16 +2152,16 @@
 | Finally.cs:114:19:114:30 | [finally: exception(OutOfMemoryException)] access to property Length | Finally.cs:114:35:114:35 | [finally: exception(OutOfMemoryException)] 0 | semmle.label | successor |
 | Finally.cs:114:19:114:30 | [finally: return] access to property Length | Finally.cs:114:35:114:35 | [finally: return] 0 | semmle.label | successor |
 | Finally.cs:114:19:114:30 | access to property Length | Finally.cs:114:35:114:35 | 0 | semmle.label | successor |
-| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:115:17:115:41 | ...; | semmle.label | false |
-| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:116:13:117:37 | if (...) ... | semmle.label | true |
-| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | semmle.label | false |
-| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | semmle.label | true |
-| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | semmle.label | false |
-| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | semmle.label | true |
-| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | false |
-| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | semmle.label | true |
-| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:115:17:115:41 | [finally: return] ...; | semmle.label | false |
-| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | semmle.label | true |
+| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:114:17:114:36 | [false] !... | semmle.label | true |
+| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:114:17:114:36 | [true] !... | semmle.label | false |
+| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | semmle.label | true |
+| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | semmle.label | false |
+| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | semmle.label | true |
+| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | semmle.label | false |
+| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | semmle.label | true |
+| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | semmle.label | false |
+| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:114:17:114:36 | [false, finally: return] !... | semmle.label | true |
+| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:114:17:114:36 | [true, finally: return] !... | semmle.label | false |
 | Finally.cs:114:35:114:35 | 0 | Finally.cs:114:19:114:35 | ... == ... | semmle.label | successor |
 | Finally.cs:114:35:114:35 | [finally: exception(Exception)] 0 | Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | semmle.label | successor |
 | Finally.cs:114:35:114:35 | [finally: exception(NullReferenceException)] 0 | Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | semmle.label | successor |
@@ -2606,16 +2620,16 @@
 | Foreach.cs:15:13:15:13 | ; | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:19:5:22:5 | {...} | semmle.label | successor |
 | Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 | semmle.label | successor |
-| Foreach.cs:19:5:22:5 | {...} | Foreach.cs:20:27:20:68 | ... ?? ... | semmle.label | successor |
+| Foreach.cs:19:5:22:5 | {...} | Foreach.cs:20:27:20:27 | access to parameter e | semmle.label | successor |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 (normal) | semmle.label | empty |
 | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x | semmle.label | non-empty |
 | Foreach.cs:20:22:20:22 | String x | Foreach.cs:21:11:21:11 | ; | semmle.label | successor |
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:29:20:38 | call to method ToArray | semmle.label | non-null |
 | Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:43:20:68 | call to method Empty | semmle.label | null |
-| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:27:20:27 | access to parameter e | semmle.label | successor |
-| Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | semmle.label | non-null |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | semmle.label | successor |
+| Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:27:20:68 | ... ?? ... | semmle.label | non-null |
 | Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:43:20:68 | call to method Empty | semmle.label | null |
-| Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | semmle.label | successor |
+| Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:27:20:68 | ... ?? ... | semmle.label | successor |
 | Foreach.cs:21:11:21:11 | ; | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:25:5:28:5 | {...} | semmle.label | successor |
 | Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | exit M4 | semmle.label | successor |
@@ -3003,11 +3017,12 @@
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:68:5:74:5 | {...} | semmle.label | successor |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 | semmle.label | successor |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:69:9:70:19 | if (...) ... | semmle.label | successor |
-| LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:13:69:23 | !... | semmle.label | successor |
-| LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:14:69:17 | access to parameter args | semmle.label | successor |
+| LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:14:69:17 | access to parameter args | semmle.label | successor |
+| LoopUnrolling.cs:69:13:69:23 | [false] !... | LoopUnrolling.cs:71:9:71:21 | ...; | semmle.label | false |
+| LoopUnrolling.cs:69:13:69:23 | [true] !... | LoopUnrolling.cs:70:13:70:19 | return ...; | semmle.label | true |
 | LoopUnrolling.cs:69:14:69:17 | access to parameter args | LoopUnrolling.cs:69:14:69:23 | call to method Any | semmle.label | successor |
-| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:70:13:70:19 | return ...; | semmle.label | false |
-| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:71:9:71:21 | ...; | semmle.label | true |
+| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:13:69:23 | [false] !... | semmle.label | true |
+| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:13:69:23 | [true] !... | semmle.label | false |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | semmle.label | return |
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear | semmle.label | successor |
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:29:72:32 | access to parameter args | semmle.label | successor |
@@ -3326,74 +3341,78 @@
 | MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | successor |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | semmle.label | successor |
 | MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | semmle.label | successor |
-| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:28 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:23 | access to parameter i | semmle.label | successor |
 | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 | semmle.label | successor |
-| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | semmle.label | non-null |
+| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:23:3:28 | ... ?? ... | semmle.label | non-null |
 | NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:28:3:28 | 0 | semmle.label | null |
-| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:23:3:23 | access to parameter i | semmle.label | successor |
-| NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | semmle.label | successor |
-| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | semmle.label | successor |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | semmle.label | successor |
+| NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:23:3:28 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:25:5:25 | access to parameter b | semmle.label | successor |
 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 | semmle.label | successor |
-| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:25:5:34 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | semmle.label | successor |
+| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | semmle.label | false |
+| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | semmle.label | true |
 | NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:30:5:34 | false | semmle.label | null |
-| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:39:5:39 | 0 | semmle.label | true |
-| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:43:5:43 | 1 | semmle.label | false |
-| NullCoalescing.cs:5:25:5:34 | ... ?? ... | NullCoalescing.cs:5:25:5:25 | access to parameter b | semmle.label | successor |
-| NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:43:5:43 | 1 | semmle.label | false |
-| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | semmle.label | successor |
-| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | semmle.label | successor |
-| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:53 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:43:5:43 | 1 | semmle.label | false |
+| NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | NullCoalescing.cs:5:39:5:39 | 0 | semmle.label | true |
+| NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | semmle.label | false |
+| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | semmle.label | successor |
+| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | semmle.label | successor |
+| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | semmle.label | successor |
 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 | semmle.label | successor |
-| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | semmle.label | non-null |
-| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | semmle.label | null |
-| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | semmle.label | successor |
-| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | semmle.label | non-null |
+| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:40:7:53 | ... ?? ... | semmle.label | non-null |
+| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | semmle.label | null |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | semmle.label | successor |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | semmle.label | non-null |
 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:52:7:53 | "" | semmle.label | null |
-| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | semmle.label | successor |
-| NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | semmle.label | successor |
-| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:36:9:58 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:53 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:46:7:53 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:37:9:37 | access to parameter b | semmle.label | successor |
 | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 | semmle.label | successor |
-| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | semmle.label | successor |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | semmle.label | successor |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:41:9:41 | access to parameter s | semmle.label | true |
 | NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:45:9:45 | access to parameter s | semmle.label | false |
-| NullCoalescing.cs:9:37:9:45 | ... ? ... : ... | NullCoalescing.cs:9:37:9:37 | access to parameter b | semmle.label | successor |
-| NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | semmle.label | non-null |
-| NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:51:9:58 | ... ?? ... | semmle.label | null |
-| NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | semmle.label | non-null |
-| NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:51:9:58 | ... ?? ... | semmle.label | null |
-| NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | semmle.label | non-null |
-| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:51:9:52 | "" | semmle.label | successor |
-| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | semmle.label | successor |
+| NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... | semmle.label | non-null |
+| NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | NullCoalescing.cs:9:51:9:52 | "" | semmle.label | null |
+| NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | semmle.label | non-null |
+| NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | semmle.label | null |
+| NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | semmle.label | non-null |
+| NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | semmle.label | null |
+| NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:51:9:58 | ... ?? ... | semmle.label | non-null |
+| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | semmle.label | successor |
 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 | semmle.label | successor |
-| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:44:11:59 | ... ?? ... | semmle.label | successor |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:51:11:58 | ... && ... | semmle.label | null |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:64:11:64 | 0 | semmle.label | true |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:68:11:68 | 1 | semmle.label | false |
-| NullCoalescing.cs:11:44:11:59 | ... ?? ... | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | semmle.label | successor |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | semmle.label | successor |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | semmle.label | false |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | semmle.label | true |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | semmle.label | null |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:68:11:68 | 1 | semmle.label | false |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:64:11:64 | 0 | semmle.label | true |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | semmle.label | false |
 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | semmle.label | true |
-| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:68:11:68 | 1 | semmle.label | false |
-| NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | semmle.label | successor |
-| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:64:11:64 | 0 | semmle.label | true |
-| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:68:11:68 | 1 | semmle.label | false |
-| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | semmle.label | successor |
-| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | semmle.label | successor |
+| NullCoalescing.cs:11:51:11:58 | [false] ... && ... | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | semmle.label | false |
+| NullCoalescing.cs:11:51:11:58 | [true] ... && ... | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | semmle.label | true |
+| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | semmle.label | false |
+| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... | semmle.label | true |
+| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | semmle.label | successor |
+| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | semmle.label | successor |
 | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:14:5:18:5 | {...} | semmle.label | successor |
 | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | NullCoalescing.cs:13:10:13:11 | exit M6 | semmle.label | successor |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:15:9:15:32 | ... ...; | semmle.label | successor |
-| NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:17:15:31 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:23:15:26 | null | semmle.label | successor |
 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:16:9:16:26 | ... ...; | semmle.label | successor |
 | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:31:15:31 | 0 | semmle.label | null |
-| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:23:15:26 | null | semmle.label | successor |
+| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | semmle.label | successor |
 | NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:17:15:26 | (...) ... | semmle.label | successor |
-| NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | semmle.label | successor |
-| NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:17:16:25 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:17:15:31 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:17:16:18 | "" | semmle.label | successor |
 | NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:17:9:17:25 | ...; | semmle.label | successor |
-| NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:13:16:25 | String s = ... | semmle.label | non-null |
-| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" | semmle.label | successor |
+| NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:17:16:25 | ... ?? ... | semmle.label | non-null |
+| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:13:16:25 | String s = ... | semmle.label | successor |
 | NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | semmle.label | successor |
-| NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:13:17:24 | ... ?? ... | semmle.label | successor |
-| NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:9:17:24 | ... = ... | semmle.label | non-null |
-| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:19:17:19 | access to parameter i | semmle.label | successor |
+| NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:19:17:19 | access to parameter i | semmle.label | successor |
+| NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... | semmle.label | non-null |
+| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:9:17:24 | ... = ... | semmle.label | successor |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... | semmle.label | successor |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:6:5:43:5 | {...} | semmle.label | successor |
 | Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:5:10:5:13 | exit Test | semmle.label | successor |
@@ -3609,17 +3628,18 @@
 | Switch.cs:23:17:23:28 | goto case ...; | Switch.cs:16:13:16:19 | case ...: | semmle.label | goto(0) |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:23:17:23:28 | goto case ...; | semmle.label | successor |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:18:24:25 | String s | semmle.label | successor |
-| Switch.cs:24:18:24:25 | String s | Switch.cs:24:32:24:55 | ... && ... | semmle.label | match |
+| Switch.cs:24:18:24:25 | String s | Switch.cs:24:32:24:32 | access to local variable s | semmle.label | match |
 | Switch.cs:24:18:24:25 | String s | Switch.cs:27:13:27:39 | case ...: | semmle.label | no-match |
 | Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:39 | access to property Length | semmle.label | successor |
 | Switch.cs:24:32:24:39 | access to property Length | Switch.cs:24:43:24:43 | 0 | semmle.label | successor |
+| Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:32:24:55 | [false] ... && ... | semmle.label | false |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:48:24:48 | access to local variable s | semmle.label | true |
-| Switch.cs:24:32:24:43 | ... > ... | Switch.cs:27:13:27:39 | case ...: | semmle.label | false |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:32:24:32 | access to local variable s | semmle.label | successor |
+| Switch.cs:24:32:24:55 | [false] ... && ... | Switch.cs:27:13:27:39 | case ...: | semmle.label | false |
+| Switch.cs:24:32:24:55 | [true] ... && ... | Switch.cs:25:17:25:37 | ...; | semmle.label | true |
 | Switch.cs:24:43:24:43 | 0 | Switch.cs:24:32:24:43 | ... > ... | semmle.label | successor |
 | Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:53:24:55 | "a" | semmle.label | successor |
-| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:25:17:25:37 | ...; | semmle.label | true |
-| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:27:13:27:39 | case ...: | semmle.label | false |
+| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:32:24:55 | [false] ... && ... | semmle.label | false |
+| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:32:24:55 | [true] ... && ... | semmle.label | true |
 | Switch.cs:24:53:24:55 | "a" | Switch.cs:24:48:24:55 | ... != ... | semmle.label | successor |
 | Switch.cs:25:17:25:36 | call to method WriteLine | Switch.cs:26:17:26:23 | return ...; | semmle.label | successor |
 | Switch.cs:25:17:25:37 | ...; | Switch.cs:25:35:25:35 | access to local variable s | semmle.label | successor |
@@ -3768,32 +3788,36 @@
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:124:5:127:5 | {...} | semmle.label | successor |
 | Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 | semmle.label | successor |
 | Switch.cs:124:5:127:5 | {...} | Switch.cs:125:9:126:19 | if (...) ... | semmle.label | successor |
-| Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:13:125:48 | ... switch { ... } | semmle.label | successor |
-| Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:24:125:34 | ... => ... | semmle.label | successor |
-| Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:13:125:13 | access to parameter o | semmle.label | successor |
+| Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:13:125:13 | access to parameter o | semmle.label | successor |
+| Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:24:125:29 | Boolean b | semmle.label | successor |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:123:10:123:12 | exit M11 (normal) | semmle.label | false |
+| Switch.cs:125:13:125:48 | [true] ... switch { ... } | Switch.cs:126:13:126:19 | return ...; | semmle.label | true |
 | Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:34:125:34 | access to local variable b | semmle.label | match |
-| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:37:125:46 | ... => ... | semmle.label | no-match |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:29 | Boolean b | semmle.label | successor |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | exit M11 (normal) | semmle.label | false |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:126:13:126:19 | return ...; | semmle.label | true |
+| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:37:125:37 | _ | semmle.label | no-match |
+| Switch.cs:125:24:125:34 | [false] ... => ... | Switch.cs:125:13:125:48 | [false] ... switch { ... } | semmle.label | false |
+| Switch.cs:125:24:125:34 | [true] ... => ... | Switch.cs:125:13:125:48 | [true] ... switch { ... } | semmle.label | true |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [false] ... => ... | semmle.label | false |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [true] ... => ... | semmle.label | true |
 | Switch.cs:125:37:125:37 | _ | Switch.cs:125:42:125:46 | false | semmle.label | match |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:37 | _ | semmle.label | successor |
-| Switch.cs:125:42:125:46 | false | Switch.cs:123:10:123:12 | exit M11 (normal) | semmle.label | false |
+| Switch.cs:125:37:125:46 | [false] ... => ... | Switch.cs:125:13:125:48 | [false] ... switch { ... } | semmle.label | false |
+| Switch.cs:125:42:125:46 | false | Switch.cs:125:37:125:46 | [false] ... => ... | semmle.label | false |
 | Switch.cs:126:13:126:19 | return ...; | Switch.cs:123:10:123:12 | exit M11 (normal) | semmle.label | return |
 | Switch.cs:129:12:129:14 | enter M12 | Switch.cs:130:5:132:5 | {...} | semmle.label | successor |
 | Switch.cs:129:12:129:14 | exit M12 (normal) | Switch.cs:129:12:129:14 | exit M12 | semmle.label | successor |
-| Switch.cs:130:5:132:5 | {...} | Switch.cs:131:17:131:53 | ... switch { ... } | semmle.label | successor |
+| Switch.cs:130:5:132:5 | {...} | Switch.cs:131:17:131:17 | access to parameter o | semmle.label | successor |
 | Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 (normal) | semmle.label | return |
-| Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:28:131:40 | ... => ... | semmle.label | successor |
-| Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:17:131:17 | access to parameter o | semmle.label | successor |
+| Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:28:131:35 | String s | semmle.label | successor |
+| Switch.cs:131:17:131:53 | [non-null] ... switch { ... } | Switch.cs:131:56:131:66 | call to method ToString | semmle.label | non-null |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:131:9:131:67 | return ...; | semmle.label | null |
 | Switch.cs:131:28:131:35 | String s | Switch.cs:131:40:131:40 | access to local variable s | semmle.label | match |
-| Switch.cs:131:28:131:35 | String s | Switch.cs:131:43:131:51 | ... => ... | semmle.label | no-match |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:35 | String s | semmle.label | successor |
-| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:9:131:67 | return ...; | semmle.label | null |
-| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:56:131:66 | call to method ToString | semmle.label | non-null |
+| Switch.cs:131:28:131:35 | String s | Switch.cs:131:43:131:43 | _ | semmle.label | no-match |
+| Switch.cs:131:28:131:40 | [non-null] ... => ... | Switch.cs:131:17:131:53 | [non-null] ... switch { ... } | semmle.label | non-null |
+| Switch.cs:131:28:131:40 | [null] ... => ... | Switch.cs:131:17:131:53 | [null] ... switch { ... } | semmle.label | null |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [non-null] ... => ... | semmle.label | non-null |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [null] ... => ... | semmle.label | null |
 | Switch.cs:131:43:131:43 | _ | Switch.cs:131:48:131:51 | null | semmle.label | match |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:43 | _ | semmle.label | successor |
-| Switch.cs:131:48:131:51 | null | Switch.cs:131:9:131:67 | return ...; | semmle.label | null |
+| Switch.cs:131:43:131:51 | [null] ... => ... | Switch.cs:131:17:131:53 | [null] ... switch { ... } | semmle.label | null |
+| Switch.cs:131:48:131:51 | null | Switch.cs:131:43:131:51 | [null] ... => ... | semmle.label | null |
 | Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:9:131:67 | return ...; | semmle.label | successor |
 | Switch.cs:134:9:134:11 | enter M13 | Switch.cs:135:5:142:5 | {...} | semmle.label | successor |
 | Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 | semmle.label | successor |
@@ -3837,18 +3861,18 @@
 | Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | exit M15 | semmle.label | successor |
 | Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | exit M15 | semmle.label | successor |
 | Switch.cs:155:5:161:5 | {...} | Switch.cs:156:9:156:55 | ... ...; | semmle.label | successor |
-| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:17:156:54 | ... switch { ... } | semmle.label | successor |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:17:156:17 | access to parameter b | semmle.label | successor |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:157:9:160:49 | if (...) ... | semmle.label | successor |
-| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:28:156:38 | ... => ... | semmle.label | successor |
-| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:17 | access to parameter b | semmle.label | successor |
+| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:28:156:31 | true | semmle.label | successor |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:13:156:54 | String s = ... | semmle.label | successor |
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:36:156:38 | "a" | semmle.label | match |
-| Switch.cs:156:28:156:31 | true | Switch.cs:156:41:156:52 | ... => ... | semmle.label | no-match |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true | semmle.label | successor |
-| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:13:156:54 | String s = ... | semmle.label | successor |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:41:156:45 | false | semmle.label | no-match |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:17:156:54 | ... switch { ... } | semmle.label | successor |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:28:156:38 | ... => ... | semmle.label | successor |
 | Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | exit M15 (abnormal) | semmle.label | exception(InvalidOperationException) |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" | semmle.label | match |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false | semmle.label | successor |
-| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:13:156:54 | String s = ... | semmle.label | successor |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:17:156:54 | ... switch { ... } | semmle.label | successor |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:52 | ... => ... | semmle.label | successor |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:13:157:13 | access to parameter b | semmle.label | successor |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; | semmle.label | true |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; | semmle.label | false |
@@ -3921,14 +3945,14 @@
 | VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:22:24:28 | object creation of type C | semmle.label | successor |
 | VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:35:24:41 | object creation of type C | semmle.label | successor |
 | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... | semmle.label | successor |
-| VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... | semmle.label | successor |
+| VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:20 | access to parameter b | semmle.label | successor |
 | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:31:24:41 | C y = ... | semmle.label | successor |
 | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 (normal) | semmle.label | return |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:24:25:24 | access to local variable x | semmle.label | true |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:28:25:28 | access to local variable y | semmle.label | false |
-| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:20:25:20 | access to parameter b | semmle.label | successor |
-| VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:13:25:29 | return ...; | semmle.label | successor |
-| VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:13:25:29 | return ...; | semmle.label | successor |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:13:25:29 | return ...; | semmle.label | successor |
+| VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:20:25:28 | ... ? ... : ... | semmle.label | successor |
+| VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:20:25:28 | ... ? ... : ... | semmle.label | successor |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:51:28:53 | {...} | semmle.label | successor |
 | VarDecls.cs:28:41:28:47 | exit Dispose (normal) | VarDecls.cs:28:41:28:47 | exit Dispose | semmle.label | successor |
 | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | exit Dispose (normal) | semmle.label | successor |
@@ -3985,18 +4009,19 @@
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:24:34:24:36 | ...++ | semmle.label | successor |
 | cflow.cs:24:34:24:36 | ...++ | cflow.cs:24:25:24:25 | access to local variable i | semmle.label | successor |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:26:13:33:37 | if (...) ... | semmle.label | successor |
-| cflow.cs:26:13:33:37 | if (...) ... | cflow.cs:26:17:26:40 | ... && ... | semmle.label | successor |
+| cflow.cs:26:13:33:37 | if (...) ... | cflow.cs:26:17:26:17 | access to local variable i | semmle.label | successor |
 | cflow.cs:26:17:26:17 | access to local variable i | cflow.cs:26:21:26:21 | 3 | semmle.label | successor |
 | cflow.cs:26:17:26:21 | ... % ... | cflow.cs:26:26:26:26 | 0 | semmle.label | successor |
+| cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:17:26:40 | [false] ... && ... | semmle.label | false |
 | cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:31:26:31 | access to local variable i | semmle.label | true |
-| cflow.cs:26:17:26:26 | ... == ... | cflow.cs:28:18:33:37 | if (...) ... | semmle.label | false |
-| cflow.cs:26:17:26:40 | ... && ... | cflow.cs:26:17:26:17 | access to local variable i | semmle.label | successor |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:28:18:33:37 | if (...) ... | semmle.label | false |
+| cflow.cs:26:17:26:40 | [true] ... && ... | cflow.cs:27:17:27:46 | ...; | semmle.label | true |
 | cflow.cs:26:21:26:21 | 3 | cflow.cs:26:17:26:21 | ... % ... | semmle.label | successor |
 | cflow.cs:26:26:26:26 | 0 | cflow.cs:26:17:26:26 | ... == ... | semmle.label | successor |
 | cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:35:26:35 | 5 | semmle.label | successor |
 | cflow.cs:26:31:26:35 | ... % ... | cflow.cs:26:40:26:40 | 0 | semmle.label | successor |
-| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:27:17:27:46 | ...; | semmle.label | true |
-| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:28:18:33:37 | if (...) ... | semmle.label | false |
+| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:26:17:26:40 | [false] ... && ... | semmle.label | false |
+| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:26:17:26:40 | [true] ... && ... | semmle.label | true |
 | cflow.cs:26:35:26:35 | 5 | cflow.cs:26:31:26:35 | ... % ... | semmle.label | successor |
 | cflow.cs:26:40:26:40 | 0 | cflow.cs:26:31:26:40 | ... == ... | semmle.label | successor |
 | cflow.cs:27:17:27:45 | call to method WriteLine | cflow.cs:24:34:24:34 | access to local variable i | semmle.label | successor |
@@ -4075,12 +4100,13 @@
 | cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:18:62:18 | 0 | semmle.label | successor |
 | cflow.cs:62:18:62:18 | 0 | cflow.cs:63:17:64:55 | if (...) ... | semmle.label | match |
 | cflow.cs:62:18:62:18 | 0 | cflow.cs:67:16:67:16 | access to parameter a | semmle.label | no-match |
-| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:21:63:34 | !... | semmle.label | successor |
-| cflow.cs:63:21:63:34 | !... | cflow.cs:63:23:63:27 | this access | semmle.label | successor |
+| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:23:63:27 | this access | semmle.label | successor |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:65:17:65:22 | break; | semmle.label | false |
+| cflow.cs:63:21:63:34 | [true] !... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | semmle.label | true |
 | cflow.cs:63:23:63:27 | access to field Field | cflow.cs:63:32:63:33 | "" | semmle.label | successor |
 | cflow.cs:63:23:63:27 | this access | cflow.cs:63:23:63:27 | access to field Field | semmle.label | successor |
-| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | semmle.label | false |
-| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:65:17:65:22 | break; | semmle.label | true |
+| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:21:63:34 | [false] !... | semmle.label | true |
+| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:21:63:34 | [true] !... | semmle.label | false |
 | cflow.cs:63:32:63:33 | "" | cflow.cs:63:23:63:33 | ... == ... | semmle.label | successor |
 | cflow.cs:64:21:64:55 | throw ...; | cflow.cs:37:17:37:22 | exit Switch (abnormal) | semmle.label | exception(NullReferenceException) |
 | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:64:21:64:55 | throw ...; | semmle.label | successor |
@@ -4113,16 +4139,17 @@
 | cflow.cs:84:18:84:19 | enter M2 | cflow.cs:85:5:88:5 | {...} | semmle.label | successor |
 | cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 | semmle.label | successor |
 | cflow.cs:85:5:88:5 | {...} | cflow.cs:86:9:87:33 | if (...) ... | semmle.label | successor |
-| cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:13:86:37 | ... && ... | semmle.label | successor |
+| cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:13:86:13 | access to parameter s | semmle.label | successor |
 | cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:18:86:21 | null | semmle.label | successor |
-| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:84:18:84:19 | exit M2 (normal) | semmle.label | false |
+| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:13:86:37 | [false] ... && ... | semmle.label | false |
 | cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:26:86:26 | access to parameter s | semmle.label | true |
-| cflow.cs:86:13:86:37 | ... && ... | cflow.cs:86:13:86:13 | access to parameter s | semmle.label | successor |
+| cflow.cs:86:13:86:37 | [false] ... && ... | cflow.cs:84:18:84:19 | exit M2 (normal) | semmle.label | false |
+| cflow.cs:86:13:86:37 | [true] ... && ... | cflow.cs:87:13:87:33 | ...; | semmle.label | true |
 | cflow.cs:86:18:86:21 | null | cflow.cs:86:13:86:21 | ... != ... | semmle.label | successor |
 | cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:33 | access to property Length | semmle.label | successor |
 | cflow.cs:86:26:86:33 | access to property Length | cflow.cs:86:37:86:37 | 0 | semmle.label | successor |
-| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:84:18:84:19 | exit M2 (normal) | semmle.label | false |
-| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:87:13:87:33 | ...; | semmle.label | true |
+| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:86:13:86:37 | [false] ... && ... | semmle.label | false |
+| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:86:13:86:37 | [true] ... && ... | semmle.label | true |
 | cflow.cs:86:37:86:37 | 0 | cflow.cs:86:26:86:37 | ... > ... | semmle.label | successor |
 | cflow.cs:87:13:87:32 | call to method WriteLine | cflow.cs:84:18:84:19 | exit M2 (normal) | semmle.label | successor |
 | cflow.cs:87:13:87:33 | ...; | cflow.cs:87:31:87:31 | access to parameter s | semmle.label | successor |
@@ -4205,16 +4232,16 @@
 | cflow.cs:123:16:123:16 | access to local variable x | cflow.cs:123:9:123:17 | return ...; | semmle.label | successor |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:23:127:60 | {...} | semmle.label | successor |
 | cflow.cs:127:19:127:21 | exit get_Prop (normal) | cflow.cs:127:19:127:21 | exit get_Prop | semmle.label | successor |
-| cflow.cs:127:23:127:60 | {...} | cflow.cs:127:32:127:57 | ... ? ... : ... | semmle.label | successor |
+| cflow.cs:127:23:127:60 | {...} | cflow.cs:127:32:127:36 | this access | semmle.label | successor |
 | cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop (normal) | semmle.label | return |
 | cflow.cs:127:32:127:36 | access to field Field | cflow.cs:127:41:127:44 | null | semmle.label | successor |
 | cflow.cs:127:32:127:36 | this access | cflow.cs:127:32:127:36 | access to field Field | semmle.label | successor |
 | cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:48:127:49 | "" | semmle.label | true |
 | cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:53:127:57 | this access | semmle.label | false |
-| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:32:127:36 | this access | semmle.label | successor |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:25:127:58 | return ...; | semmle.label | successor |
 | cflow.cs:127:41:127:44 | null | cflow.cs:127:32:127:44 | ... == ... | semmle.label | successor |
-| cflow.cs:127:48:127:49 | "" | cflow.cs:127:25:127:58 | return ...; | semmle.label | successor |
-| cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:25:127:58 | return ...; | semmle.label | successor |
+| cflow.cs:127:48:127:49 | "" | cflow.cs:127:32:127:57 | ... ? ... : ... | semmle.label | successor |
+| cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:32:127:57 | ... ? ... : ... | semmle.label | successor |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field | semmle.label | successor |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:66:127:83 | {...} | semmle.label | successor |
 | cflow.cs:127:62:127:64 | exit set_Prop (normal) | cflow.cs:127:62:127:64 | exit set_Prop | semmle.label | successor |
@@ -4364,18 +4391,18 @@
 | cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:186:5:191:5 | {...} | semmle.label | successor |
 | cflow.cs:185:10:185:18 | exit LogicalOr (normal) | cflow.cs:185:10:185:18 | exit LogicalOr | semmle.label | successor |
 | cflow.cs:186:5:191:5 | {...} | cflow.cs:187:9:190:52 | if (...) ... | semmle.label | successor |
-| cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:187:13:187:50 | ... \|\| ... | semmle.label | successor |
+| cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:187:13:187:13 | 1 | semmle.label | successor |
 | cflow.cs:187:13:187:13 | 1 | cflow.cs:187:18:187:18 | 2 | semmle.label | successor |
 | cflow.cs:187:13:187:18 | ... == ... | cflow.cs:187:23:187:23 | 2 | semmle.label | false |
-| cflow.cs:187:13:187:28 | ... \|\| ... | cflow.cs:187:13:187:13 | 1 | semmle.label | successor |
-| cflow.cs:187:13:187:50 | ... \|\| ... | cflow.cs:187:13:187:28 | ... \|\| ... | semmle.label | successor |
+| cflow.cs:187:13:187:28 | [false] ... \|\| ... | cflow.cs:187:34:187:34 | 1 | semmle.label | false |
+| cflow.cs:187:13:187:50 | [false] ... \|\| ... | cflow.cs:190:13:190:52 | ...; | semmle.label | false |
 | cflow.cs:187:18:187:18 | 2 | cflow.cs:187:13:187:18 | ... == ... | semmle.label | successor |
 | cflow.cs:187:23:187:23 | 2 | cflow.cs:187:28:187:28 | 3 | semmle.label | successor |
-| cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:34:187:49 | ... && ... | semmle.label | false |
+| cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:13:187:28 | [false] ... \|\| ... | semmle.label | false |
 | cflow.cs:187:28:187:28 | 3 | cflow.cs:187:23:187:28 | ... == ... | semmle.label | successor |
 | cflow.cs:187:34:187:34 | 1 | cflow.cs:187:39:187:39 | 3 | semmle.label | successor |
-| cflow.cs:187:34:187:39 | ... == ... | cflow.cs:190:13:190:52 | ...; | semmle.label | false |
-| cflow.cs:187:34:187:49 | ... && ... | cflow.cs:187:34:187:34 | 1 | semmle.label | successor |
+| cflow.cs:187:34:187:39 | ... == ... | cflow.cs:187:34:187:49 | [false] ... && ... | semmle.label | false |
+| cflow.cs:187:34:187:49 | [false] ... && ... | cflow.cs:187:13:187:50 | [false] ... \|\| ... | semmle.label | false |
 | cflow.cs:187:39:187:39 | 3 | cflow.cs:187:34:187:39 | ... == ... | semmle.label | successor |
 | cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:185:10:185:18 | exit LogicalOr (normal) | semmle.label | successor |
 | cflow.cs:190:13:190:52 | ...; | cflow.cs:190:31:190:50 | "This should happen" | semmle.label | successor |
@@ -4384,63 +4411,70 @@
 | cflow.cs:193:10:193:17 | exit Booleans (abnormal) | cflow.cs:193:10:193:17 | exit Booleans | semmle.label | successor |
 | cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | exit Booleans | semmle.label | successor |
 | cflow.cs:194:5:206:5 | {...} | cflow.cs:195:9:195:57 | ... ...; | semmle.label | successor |
-| cflow.cs:195:9:195:57 | ... ...; | cflow.cs:195:17:195:56 | ... && ... | semmle.label | successor |
+| cflow.cs:195:9:195:57 | ... ...; | cflow.cs:195:17:195:21 | this access | semmle.label | successor |
 | cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:9:198:49 | if (...) ... | semmle.label | successor |
 | cflow.cs:195:17:195:21 | access to field Field | cflow.cs:195:17:195:28 | access to property Length | semmle.label | successor |
 | cflow.cs:195:17:195:21 | this access | cflow.cs:195:17:195:21 | access to field Field | semmle.label | successor |
 | cflow.cs:195:17:195:28 | access to property Length | cflow.cs:195:32:195:32 | 0 | semmle.label | successor |
-| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:13:195:56 | Boolean b = ... | semmle.label | false |
-| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:37:195:56 | !... | semmle.label | true |
-| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:17:195:21 | this access | semmle.label | successor |
+| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:17:195:56 | ... && ... | semmle.label | false |
+| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:39:195:43 | this access | semmle.label | true |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:13:195:56 | Boolean b = ... | semmle.label | successor |
 | cflow.cs:195:32:195:32 | 0 | cflow.cs:195:17:195:32 | ... > ... | semmle.label | successor |
-| cflow.cs:195:37:195:56 | !... | cflow.cs:195:39:195:43 | this access | semmle.label | successor |
+| cflow.cs:195:37:195:56 | !... | cflow.cs:195:17:195:56 | ... && ... | semmle.label | successor |
 | cflow.cs:195:39:195:43 | access to field Field | cflow.cs:195:39:195:50 | access to property Length | semmle.label | successor |
 | cflow.cs:195:39:195:43 | this access | cflow.cs:195:39:195:43 | access to field Field | semmle.label | successor |
 | cflow.cs:195:39:195:50 | access to property Length | cflow.cs:195:55:195:55 | 1 | semmle.label | successor |
-| cflow.cs:195:39:195:55 | ... == ... | cflow.cs:195:13:195:56 | Boolean b = ... | semmle.label | successor |
+| cflow.cs:195:39:195:55 | ... == ... | cflow.cs:195:37:195:56 | !... | semmle.label | successor |
 | cflow.cs:195:55:195:55 | 1 | cflow.cs:195:39:195:55 | ... == ... | semmle.label | successor |
-| cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:197:13:197:47 | !... | semmle.label | successor |
-| cflow.cs:197:13:197:47 | !... | cflow.cs:197:15:197:46 | ... ? ... : ... | semmle.label | successor |
+| cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:197:15:197:19 | this access | semmle.label | successor |
+| cflow.cs:197:13:197:47 | [false] !... | cflow.cs:200:9:205:9 | if (...) ... | semmle.label | false |
+| cflow.cs:197:13:197:47 | [true] !... | cflow.cs:198:13:198:49 | ...; | semmle.label | true |
 | cflow.cs:197:15:197:19 | access to field Field | cflow.cs:197:15:197:26 | access to property Length | semmle.label | successor |
 | cflow.cs:197:15:197:19 | this access | cflow.cs:197:15:197:19 | access to field Field | semmle.label | successor |
 | cflow.cs:197:15:197:26 | access to property Length | cflow.cs:197:31:197:31 | 0 | semmle.label | successor |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:35:197:39 | false | semmle.label | true |
 | cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:43:197:46 | true | semmle.label | false |
-| cflow.cs:197:15:197:46 | ... ? ... : ... | cflow.cs:197:15:197:19 | this access | semmle.label | successor |
+| cflow.cs:197:15:197:46 | [false] ... ? ... : ... | cflow.cs:197:13:197:47 | [true] !... | semmle.label | false |
+| cflow.cs:197:15:197:46 | [true] ... ? ... : ... | cflow.cs:197:13:197:47 | [false] !... | semmle.label | true |
 | cflow.cs:197:31:197:31 | 0 | cflow.cs:197:15:197:31 | ... == ... | semmle.label | successor |
-| cflow.cs:197:35:197:39 | false | cflow.cs:198:13:198:49 | ...; | semmle.label | false |
-| cflow.cs:197:43:197:46 | true | cflow.cs:200:9:205:9 | if (...) ... | semmle.label | true |
+| cflow.cs:197:35:197:39 | false | cflow.cs:197:15:197:46 | [false] ... ? ... : ... | semmle.label | false |
+| cflow.cs:197:43:197:46 | true | cflow.cs:197:15:197:46 | [true] ... ? ... : ... | semmle.label | true |
 | cflow.cs:198:13:198:48 | ... = ... | cflow.cs:200:9:205:9 | if (...) ... | semmle.label | successor |
-| cflow.cs:198:13:198:49 | ...; | cflow.cs:198:17:198:48 | ... ? ... : ... | semmle.label | successor |
+| cflow.cs:198:13:198:49 | ...; | cflow.cs:198:17:198:21 | this access | semmle.label | successor |
 | cflow.cs:198:17:198:21 | access to field Field | cflow.cs:198:17:198:28 | access to property Length | semmle.label | successor |
 | cflow.cs:198:17:198:21 | this access | cflow.cs:198:17:198:21 | access to field Field | semmle.label | successor |
 | cflow.cs:198:17:198:28 | access to property Length | cflow.cs:198:33:198:33 | 0 | semmle.label | successor |
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:37:198:41 | false | semmle.label | true |
 | cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:45:198:48 | true | semmle.label | false |
-| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:17:198:21 | this access | semmle.label | successor |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:13:198:48 | ... = ... | semmle.label | successor |
 | cflow.cs:198:33:198:33 | 0 | cflow.cs:198:17:198:33 | ... == ... | semmle.label | successor |
-| cflow.cs:198:37:198:41 | false | cflow.cs:198:13:198:48 | ... = ... | semmle.label | successor |
-| cflow.cs:198:45:198:48 | true | cflow.cs:198:13:198:48 | ... = ... | semmle.label | successor |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:13:200:62 | ... \|\| ... | semmle.label | successor |
-| cflow.cs:200:13:200:32 | !... | cflow.cs:200:15:200:19 | this access | semmle.label | successor |
-| cflow.cs:200:13:200:62 | ... \|\| ... | cflow.cs:200:13:200:32 | !... | semmle.label | successor |
+| cflow.cs:198:37:198:41 | false | cflow.cs:198:17:198:48 | ... ? ... : ... | semmle.label | successor |
+| cflow.cs:198:45:198:48 | true | cflow.cs:198:17:198:48 | ... ? ... : ... | semmle.label | successor |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:15:200:19 | this access | semmle.label | successor |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:40:200:44 | this access | semmle.label | false |
+| cflow.cs:200:13:200:32 | [true] !... | cflow.cs:200:13:200:62 | [true] ... \|\| ... | semmle.label | true |
+| cflow.cs:200:13:200:62 | [false] ... \|\| ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | semmle.label | false |
+| cflow.cs:200:13:200:62 | [true] ... \|\| ... | cflow.cs:201:9:205:9 | {...} | semmle.label | true |
 | cflow.cs:200:15:200:19 | access to field Field | cflow.cs:200:15:200:26 | access to property Length | semmle.label | successor |
 | cflow.cs:200:15:200:19 | this access | cflow.cs:200:15:200:19 | access to field Field | semmle.label | successor |
 | cflow.cs:200:15:200:26 | access to property Length | cflow.cs:200:31:200:31 | 0 | semmle.label | successor |
-| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:37:200:62 | !... | semmle.label | true |
-| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:201:9:205:9 | {...} | semmle.label | false |
+| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:13:200:32 | [false] !... | semmle.label | true |
+| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:13:200:32 | [true] !... | semmle.label | false |
 | cflow.cs:200:31:200:31 | 0 | cflow.cs:200:15:200:31 | ... == ... | semmle.label | successor |
-| cflow.cs:200:37:200:62 | !... | cflow.cs:200:38:200:62 | !... | semmle.label | successor |
-| cflow.cs:200:38:200:62 | !... | cflow.cs:200:40:200:61 | ... && ... | semmle.label | successor |
+| cflow.cs:200:37:200:62 | [false] !... | cflow.cs:200:13:200:62 | [false] ... \|\| ... | semmle.label | false |
+| cflow.cs:200:37:200:62 | [true] !... | cflow.cs:200:13:200:62 | [true] ... \|\| ... | semmle.label | true |
+| cflow.cs:200:38:200:62 | [false] !... | cflow.cs:200:37:200:62 | [true] !... | semmle.label | false |
+| cflow.cs:200:38:200:62 | [true] !... | cflow.cs:200:37:200:62 | [false] !... | semmle.label | true |
 | cflow.cs:200:40:200:44 | access to field Field | cflow.cs:200:40:200:51 | access to property Length | semmle.label | successor |
 | cflow.cs:200:40:200:44 | this access | cflow.cs:200:40:200:44 | access to field Field | semmle.label | successor |
 | cflow.cs:200:40:200:51 | access to property Length | cflow.cs:200:56:200:56 | 1 | semmle.label | successor |
-| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | semmle.label | false |
+| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:40:200:61 | [false] ... && ... | semmle.label | false |
 | cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:61:200:61 | access to local variable b | semmle.label | true |
-| cflow.cs:200:40:200:61 | ... && ... | cflow.cs:200:40:200:44 | this access | semmle.label | successor |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:38:200:62 | [true] !... | semmle.label | false |
+| cflow.cs:200:40:200:61 | [true] ... && ... | cflow.cs:200:38:200:62 | [false] !... | semmle.label | true |
 | cflow.cs:200:56:200:56 | 1 | cflow.cs:200:40:200:56 | ... == ... | semmle.label | successor |
-| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:193:10:193:17 | exit Booleans (normal) | semmle.label | false |
-| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:201:9:205:9 | {...} | semmle.label | true |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [false] ... && ... | semmle.label | false |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [true] ... && ... | semmle.label | true |
 | cflow.cs:201:9:205:9 | {...} | cflow.cs:202:13:204:13 | {...} | semmle.label | successor |
 | cflow.cs:202:13:204:13 | {...} | cflow.cs:203:23:203:37 | object creation of type Exception | semmle.label | successor |
 | cflow.cs:203:17:203:38 | throw ...; | cflow.cs:193:10:193:17 | exit Booleans (abnormal) | semmle.label | exception(Exception) |
@@ -4520,14 +4554,16 @@
 | cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto | semmle.label | successor |
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:242:9:242:13 | Label: | semmle.label | successor |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:16:242:45 | if (...) ... | semmle.label | successor |
-| cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:20:242:40 | !... | semmle.label | successor |
-| cflow.cs:242:20:242:40 | !... | cflow.cs:242:21:242:40 | !... | semmle.label | successor |
-| cflow.cs:242:21:242:40 | !... | cflow.cs:242:23:242:27 | this access | semmle.label | successor |
+| cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:23:242:27 | this access | semmle.label | successor |
+| cflow.cs:242:20:242:40 | [false] !... | cflow.cs:244:9:244:41 | if (...) ... | semmle.label | false |
+| cflow.cs:242:20:242:40 | [true] !... | cflow.cs:242:43:242:45 | {...} | semmle.label | true |
+| cflow.cs:242:21:242:40 | [false] !... | cflow.cs:242:20:242:40 | [true] !... | semmle.label | false |
+| cflow.cs:242:21:242:40 | [true] !... | cflow.cs:242:20:242:40 | [false] !... | semmle.label | true |
 | cflow.cs:242:23:242:27 | access to field Field | cflow.cs:242:23:242:34 | access to property Length | semmle.label | successor |
 | cflow.cs:242:23:242:27 | this access | cflow.cs:242:23:242:27 | access to field Field | semmle.label | successor |
 | cflow.cs:242:23:242:34 | access to property Length | cflow.cs:242:39:242:39 | 0 | semmle.label | successor |
-| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:43:242:45 | {...} | semmle.label | true |
-| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:244:9:244:41 | if (...) ... | semmle.label | false |
+| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:21:242:40 | [false] !... | semmle.label | true |
+| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:21:242:40 | [true] !... | semmle.label | false |
 | cflow.cs:242:39:242:39 | 0 | cflow.cs:242:23:242:39 | ... == ... | semmle.label | successor |
 | cflow.cs:242:43:242:45 | {...} | cflow.cs:244:9:244:41 | if (...) ... | semmle.label | successor |
 | cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:13:244:17 | this access | semmle.label | successor |
@@ -4615,14 +4651,15 @@
 | cflow.cs:299:5:301:5 | {...} | cflow.cs:300:9:300:73 | ...; | semmle.label | successor |
 | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:298:10:298:10 | exit M (normal) | semmle.label | successor |
 | cflow.cs:300:9:300:73 | ...; | cflow.cs:300:38:300:38 | 0 | semmle.label | successor |
-| cflow.cs:300:38:300:38 | 0 | cflow.cs:300:44:300:64 | ... && ... | semmle.label | successor |
-| cflow.cs:300:44:300:51 | !... | cflow.cs:300:46:300:46 | access to parameter i | semmle.label | successor |
-| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:44:300:51 | !... | semmle.label | successor |
+| cflow.cs:300:38:300:38 | 0 | cflow.cs:300:46:300:46 | access to parameter i | semmle.label | successor |
+| cflow.cs:300:44:300:51 | [false] !... | cflow.cs:300:44:300:64 | ... && ... | semmle.label | false |
+| cflow.cs:300:44:300:51 | [true] !... | cflow.cs:300:56:300:56 | access to parameter s | semmle.label | true |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:70:300:71 | "" | semmle.label | successor |
 | cflow.cs:300:46:300:46 | access to parameter i | cflow.cs:300:50:300:50 | 0 | semmle.label | successor |
-| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:56:300:56 | access to parameter s | semmle.label | false |
-| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:70:300:71 | "" | semmle.label | true |
+| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:44:300:51 | [false] !... | semmle.label | true |
+| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:44:300:51 | [true] !... | semmle.label | false |
 | cflow.cs:300:50:300:50 | 0 | cflow.cs:300:46:300:50 | ... > ... | semmle.label | successor |
 | cflow.cs:300:56:300:56 | access to parameter s | cflow.cs:300:61:300:64 | null | semmle.label | successor |
-| cflow.cs:300:56:300:64 | ... != ... | cflow.cs:300:70:300:71 | "" | semmle.label | successor |
+| cflow.cs:300:56:300:64 | ... != ... | cflow.cs:300:44:300:64 | ... && ... | semmle.label | successor |
 | cflow.cs:300:61:300:64 | null | cflow.cs:300:56:300:64 | ... != ... | semmle.label | successor |
 | cflow.cs:300:70:300:71 | "" | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -1,6 +1,8 @@
 booleanNode
 | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | b (line 56): false |
 | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | b (line 56): true |
+| Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... | b (line 56): false |
+| Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... | b (line 56): true |
 | Assert.cs:58:24:58:27 | [b (line 56): true] null | b (line 56): true |
 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | b (line 56): false |
 | Assert.cs:59:9:59:38 | [b (line 56): false] ...; | b (line 56): false |
@@ -9,14 +11,14 @@ booleanNode
 | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | b (line 56): true |
 | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | b (line 56): false |
 | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | b (line 56): true |
-| Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | b (line 56): false |
-| Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | b (line 56): true |
 | Assert.cs:59:28:59:31 | [b (line 56): false] null | b (line 56): false |
 | Assert.cs:59:28:59:31 | [b (line 56): true] null | b (line 56): true |
 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | b (line 56): false |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | b (line 56): true |
 | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | b (line 63): false |
 | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | b (line 63): true |
+| Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... | b (line 63): false |
+| Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... | b (line 63): true |
 | Assert.cs:65:24:65:27 | [b (line 63): true] null | b (line 63): true |
 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | b (line 63): false |
 | Assert.cs:66:9:66:39 | [b (line 63): false] ...; | b (line 63): false |
@@ -25,14 +27,14 @@ booleanNode
 | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | b (line 63): true |
 | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | b (line 63): false |
 | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | b (line 63): true |
-| Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | b (line 63): false |
-| Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | b (line 63): true |
 | Assert.cs:66:29:66:32 | [b (line 63): false] null | b (line 63): false |
 | Assert.cs:66:29:66:32 | [b (line 63): true] null | b (line 63): true |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | b (line 63): false |
 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | b (line 63): true |
 | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | b (line 70): false |
 | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | b (line 70): true |
+| Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... | b (line 70): false |
+| Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... | b (line 70): true |
 | Assert.cs:72:24:72:27 | [b (line 70): true] null | b (line 70): true |
 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | b (line 70): false |
 | Assert.cs:73:9:73:38 | [b (line 70): false] ...; | b (line 70): false |
@@ -41,14 +43,14 @@ booleanNode
 | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | b (line 70): true |
 | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | b (line 70): false |
 | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | b (line 70): true |
-| Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | b (line 70): false |
-| Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | b (line 70): true |
 | Assert.cs:73:28:73:31 | [b (line 70): false] null | b (line 70): false |
 | Assert.cs:73:28:73:31 | [b (line 70): true] null | b (line 70): true |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | b (line 70): false |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | b (line 70): true |
 | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | b (line 77): false |
 | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | b (line 77): true |
+| Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... | b (line 77): false |
+| Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... | b (line 77): true |
 | Assert.cs:79:24:79:27 | [b (line 77): true] null | b (line 77): true |
 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | b (line 77): false |
 | Assert.cs:80:9:80:39 | [b (line 77): false] ...; | b (line 77): false |
@@ -57,14 +59,14 @@ booleanNode
 | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | b (line 77): true |
 | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | b (line 77): false |
 | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | b (line 77): true |
-| Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | b (line 77): false |
-| Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | b (line 77): true |
 | Assert.cs:80:29:80:32 | [b (line 77): false] null | b (line 77): false |
 | Assert.cs:80:29:80:32 | [b (line 77): true] null | b (line 77): true |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | b (line 77): false |
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | b (line 77): true |
 | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | b (line 84): false |
 | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | b (line 84): true |
+| Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | b (line 84): false |
 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | b (line 84): false |
@@ -278,8 +280,9 @@ booleanNode
 | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | b (line 84): true |
 | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | b (line 84): false |
 | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | b (line 84): true |
-| Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | b (line 84): false |
-| Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | b (line 84): true |
+| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | b (line 84): false |
+| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | b (line 84): true |
+| Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | b (line 84): true |
 | Assert.cs:115:28:115:31 | [b (line 84): false] null | b (line 84): false |
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | b (line 84): false |
@@ -298,9 +301,10 @@ booleanNode
 | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | b (line 84): true |
 | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | b (line 84): true |
-| Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | b (line 84): true |
+| Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | b (line 84): true |
+| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | b (line 84): true |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | b (line 84): true |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | b (line 84): true |
+| Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | b (line 84): true |
 | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | b (line 84): true |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
 | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | b (line 84): true |
@@ -316,7 +320,8 @@ booleanNode
 | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | b (line 84): true |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | b (line 84): true |
-| Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | b (line 84): true |
+| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | b (line 84): true |
+| Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | b (line 84): true |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | b (line 84): true |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
@@ -331,17 +336,13 @@ booleanNode
 | Assert.cs:127:9:127:40 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | b (line 84): true |
 | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | b (line 84): true |
-| Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | b (line 84): true |
 | Assert.cs:127:29:127:32 | [b (line 84): true] null | b (line 84): true |
-| Assert.cs:127:37:127:38 | [b (line 84): true] !... | b (line 84): true |
 | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | b (line 84): true |
 | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x | inc (line 3): true |
 | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ | inc (line 3): true |
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | inc (line 3): true |
 | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | inc (line 3): false |
 | Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | inc (line 3): true |
-| Conditions.cs:7:13:7:16 | [inc (line 3): false] !... | inc (line 3): false |
-| Conditions.cs:7:13:7:16 | [inc (line 3): true] !... | inc (line 3): true |
 | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | inc (line 3): false |
 | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | inc (line 3): true |
 | Conditions.cs:15:13:15:13 | [b (line 11): true] access to local variable x | b (line 11): true |
@@ -357,8 +358,6 @@ booleanNode
 | Conditions.cs:16:17:16:17 | [b (line 11): true] 0 | b (line 11): true |
 | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | b (line 11): false |
 | Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | b (line 11): true |
-| Conditions.cs:17:17:17:18 | [b (line 11): false] !... | b (line 11): false |
-| Conditions.cs:17:17:17:18 | [b (line 11): true] !... | b (line 11): true |
 | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | b (line 11): false |
 | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | b (line 11): true |
 | Conditions.cs:27:17:27:17 | [b2 (line 22): true] access to local variable x | b2 (line 22): true |
@@ -430,10 +429,10 @@ booleanNode
 | Conditions.cs:107:24:107:24 | [b (line 102): true] 0 | b (line 102): true |
 | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | b (line 102): false |
 | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | b (line 102): true |
-| Conditions.cs:108:17:108:18 | [b (line 102): false] !... | b (line 102): false |
-| Conditions.cs:108:17:108:18 | [b (line 102): true] !... | b (line 102): true |
 | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | b (line 102): false |
 | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | b (line 102): true |
+| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | last (line 118): true |
+| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | last (line 118): false |
 | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | last (line 118): false |
 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | last (line 118): false |
 | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | last (line 118): false |
@@ -498,6 +497,8 @@ booleanNode
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Field2 (line 129): true |
 | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | b (line 143): false |
 | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | b (line 143): true |
+| Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... | b (line 143): false |
+| Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... | b (line 143): true |
 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | b (line 143): true |
 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | b (line 143): false |
 | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | b (line 143): false |
@@ -720,10 +721,14 @@ finallyNode
 | Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:105:9:118:9 | try {...} ... |
 | Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:105:9:118:9 | try {...} ... |
 | Finally.cs:114:13:115:41 | [finally: return] if (...) ... | Finally.cs:105:9:118:9 | try {...} ... |
-| Finally.cs:114:17:114:36 | [finally: exception(Exception)] !... | Finally.cs:105:9:118:9 | try {...} ... |
-| Finally.cs:114:17:114:36 | [finally: exception(NullReferenceException)] !... | Finally.cs:105:9:118:9 | try {...} ... |
-| Finally.cs:114:17:114:36 | [finally: exception(OutOfMemoryException)] !... | Finally.cs:105:9:118:9 | try {...} ... |
-| Finally.cs:114:17:114:36 | [finally: return] !... | Finally.cs:105:9:118:9 | try {...} ... |
+| Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | Finally.cs:105:9:118:9 | try {...} ... |
+| Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | Finally.cs:105:9:118:9 | try {...} ... |
+| Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | Finally.cs:105:9:118:9 | try {...} ... |
+| Finally.cs:114:17:114:36 | [false, finally: return] !... | Finally.cs:105:9:118:9 | try {...} ... |
+| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:105:9:118:9 | try {...} ... |
+| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:105:9:118:9 | try {...} ... |
+| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:105:9:118:9 | try {...} ... |
+| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:105:9:118:9 | try {...} ... |
 | Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field | Finally.cs:105:9:118:9 | try {...} ... |
 | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | Finally.cs:105:9:118:9 | try {...} ... |
 | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:105:9:118:9 | try {...} ... |
@@ -1014,11 +1019,10 @@ entryPoint
 | CompileTimeOperators.cs:15:10:15:15 | Typeof | CompileTimeOperators.cs:16:5:18:5 | {...} |
 | CompileTimeOperators.cs:20:12:20:17 | Nameof | CompileTimeOperators.cs:21:5:23:5 | {...} |
 | CompileTimeOperators.cs:28:10:28:10 | M | CompileTimeOperators.cs:29:5:41:5 | {...} |
-| ConditionalAccess.cs:1:7:1:23 | ConditionalAccess | ConditionalAccess.cs:30:32:30:32 | 0 |
 | ConditionalAccess.cs:3:12:3:13 | M1 | ConditionalAccess.cs:3:26:3:26 | access to parameter i |
 | ConditionalAccess.cs:5:10:5:11 | M2 | ConditionalAccess.cs:5:26:5:26 | access to parameter s |
-| ConditionalAccess.cs:7:10:7:11 | M3 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... |
-| ConditionalAccess.cs:9:9:9:10 | M4 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |
+| ConditionalAccess.cs:7:10:7:11 | M3 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 |
+| ConditionalAccess.cs:9:9:9:10 | M4 | ConditionalAccess.cs:9:25:9:25 | access to parameter s |
 | ConditionalAccess.cs:11:9:11:10 | M5 | ConditionalAccess.cs:12:5:17:5 | {...} |
 | ConditionalAccess.cs:19:12:19:13 | M6 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 |
 | ConditionalAccess.cs:21:10:21:11 | M7 | ConditionalAccess.cs:22:5:26:5 | {...} |
@@ -1155,11 +1159,11 @@ entryPoint
 | MultiImplementationB.cs:27:21:27:23 | get_P3 | MultiImplementationA.cs:30:34:30:37 | null |
 | MultiImplementationB.cs:32:9:32:10 | M1 | MultiImplementationA.cs:36:14:36:28 | {...} |
 | MultiImplementationB.cs:32:9:32:10 | M1 | MultiImplementationB.cs:32:17:32:17 | 0 |
-| NullCoalescing.cs:3:9:3:10 | M1 | NullCoalescing.cs:3:23:3:28 | ... ?? ... |
-| NullCoalescing.cs:5:9:5:10 | M2 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |
-| NullCoalescing.cs:7:12:7:13 | M3 | NullCoalescing.cs:7:40:7:53 | ... ?? ... |
-| NullCoalescing.cs:9:12:9:13 | M4 | NullCoalescing.cs:9:36:9:58 | ... ?? ... |
-| NullCoalescing.cs:11:9:11:10 | M5 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |
+| NullCoalescing.cs:3:9:3:10 | M1 | NullCoalescing.cs:3:23:3:23 | access to parameter i |
+| NullCoalescing.cs:5:9:5:10 | M2 | NullCoalescing.cs:5:25:5:25 | access to parameter b |
+| NullCoalescing.cs:7:12:7:13 | M3 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |
+| NullCoalescing.cs:9:12:9:13 | M4 | NullCoalescing.cs:9:37:9:37 | access to parameter b |
+| NullCoalescing.cs:11:9:11:10 | M5 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 |
 | NullCoalescing.cs:13:10:13:11 | M6 | NullCoalescing.cs:14:5:18:5 | {...} |
 | Patterns.cs:5:10:5:13 | Test | Patterns.cs:6:5:43:5 | {...} |
 | PostDominance.cs:5:10:5:11 | M1 | PostDominance.cs:6:5:8:5 | {...} |

--- a/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
+++ b/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
@@ -14,7 +14,6 @@
 | CSharp7.cs:33:16:33:16 | access to parameter i | CSharp7.cs:33:16:33:20 | ... > ... |
 | CSharp7.cs:33:16:33:16 | access to parameter i | CSharp7.cs:33:24:33:24 | access to parameter i |
 | CSharp7.cs:33:24:33:24 | access to parameter i | CSharp7.cs:33:16:33:59 | ... ? ... : ... |
-| CSharp7.cs:33:28:33:59 | throw ... | CSharp7.cs:33:16:33:59 | ... ? ... : ... |
 | CSharp7.cs:41:13:41:21 | "tainted" | CSharp7.cs:41:9:41:21 | SSA def(x) |
 | CSharp7.cs:44:19:44:19 | x | CSharp7.cs:46:13:46:13 | access to parameter x |
 | CSharp7.cs:46:13:46:13 | access to parameter x | CSharp7.cs:46:9:46:13 | SSA def(y) |
@@ -191,11 +190,13 @@
 | CSharp7.cs:235:13:235:13 | access to local variable o | CSharp7.cs:235:18:235:23 | SSA def(i1) |
 | CSharp7.cs:235:13:235:13 | access to local variable o | CSharp7.cs:239:18:239:18 | access to local variable o |
 | CSharp7.cs:235:13:235:13 | access to local variable o | CSharp7.cs:250:17:250:17 | access to local variable o |
-| CSharp7.cs:235:13:235:23 | ... is ... | CSharp7.cs:235:13:235:33 | ... && ... |
+| CSharp7.cs:235:13:235:23 | ... is ... | CSharp7.cs:235:13:235:33 | [false] ... && ... |
+| CSharp7.cs:235:13:235:23 | ... is ... | CSharp7.cs:235:13:235:33 | [true] ... && ... |
 | CSharp7.cs:235:18:235:23 | SSA def(i1) | CSharp7.cs:235:28:235:29 | access to local variable i1 |
 | CSharp7.cs:235:28:235:29 | access to local variable i1 | CSharp7.cs:235:28:235:33 | ... > ... |
 | CSharp7.cs:235:28:235:29 | access to local variable i1 | CSharp7.cs:237:38:237:39 | access to local variable i1 |
-| CSharp7.cs:235:28:235:33 | ... > ... | CSharp7.cs:235:13:235:33 | ... && ... |
+| CSharp7.cs:235:28:235:33 | ... > ... | CSharp7.cs:235:13:235:33 | [false] ... && ... |
+| CSharp7.cs:235:28:235:33 | ... > ... | CSharp7.cs:235:13:235:33 | [true] ... && ... |
 | CSharp7.cs:237:33:237:36 | "int " | CSharp7.cs:237:31:237:41 | $"..." |
 | CSharp7.cs:237:38:237:39 | access to local variable i1 | CSharp7.cs:237:31:237:41 | $"..." |
 | CSharp7.cs:239:18:239:18 | access to local variable o | CSharp7.cs:239:23:239:31 | SSA def(s1) |
@@ -238,14 +239,16 @@
 | CSharp7.cs:285:51:285:60 | access to property Value | CSharp7.cs:285:40:285:61 | (..., ...) |
 | CSharp7.cs:287:39:287:42 | access to local variable list | CSharp7.cs:289:36:289:39 | access to local variable list |
 | CSharp7.cs:289:36:289:39 | access to local variable list | CSharp7.cs:291:32:291:35 | access to local variable list |
-| CSharp7.cs:299:18:299:22 | SSA def(x) | CSharp7.cs:299:25:299:44 | SSA phi(x) |
+| CSharp7.cs:299:18:299:22 | SSA def(x) | CSharp7.cs:299:25:299:25 | SSA phi(x) |
 | CSharp7.cs:299:22:299:22 | 0 | CSharp7.cs:299:18:299:22 | SSA def(x) |
+| CSharp7.cs:299:25:299:25 | SSA phi(x) | CSharp7.cs:299:25:299:25 | access to local variable x |
 | CSharp7.cs:299:25:299:25 | access to local variable x | CSharp7.cs:299:25:299:30 | ... < ... |
 | CSharp7.cs:299:25:299:25 | access to local variable x | CSharp7.cs:299:35:299:35 | access to local variable x |
-| CSharp7.cs:299:25:299:30 | ... < ... | CSharp7.cs:299:25:299:44 | ... && ... |
-| CSharp7.cs:299:25:299:44 | SSA phi(x) | CSharp7.cs:299:25:299:25 | access to local variable x |
+| CSharp7.cs:299:25:299:30 | ... < ... | CSharp7.cs:299:25:299:44 | [false] ... && ... |
+| CSharp7.cs:299:25:299:30 | ... < ... | CSharp7.cs:299:25:299:44 | [true] ... && ... |
 | CSharp7.cs:299:35:299:35 | access to local variable x | CSharp7.cs:299:40:299:44 | SSA def(y) |
 | CSharp7.cs:299:35:299:35 | access to local variable x | CSharp7.cs:299:49:299:49 | access to local variable x |
-| CSharp7.cs:299:35:299:44 | ... is ... | CSharp7.cs:299:25:299:44 | ... && ... |
+| CSharp7.cs:299:35:299:44 | ... is ... | CSharp7.cs:299:25:299:44 | [false] ... && ... |
+| CSharp7.cs:299:35:299:44 | ... is ... | CSharp7.cs:299:25:299:44 | [true] ... && ... |
 | CSharp7.cs:299:40:299:44 | SSA def(y) | CSharp7.cs:301:31:301:31 | access to local variable y |
-| CSharp7.cs:299:47:299:49 | SSA def(x) | CSharp7.cs:299:25:299:44 | SSA phi(x) |
+| CSharp7.cs:299:47:299:49 | SSA def(x) | CSharp7.cs:299:25:299:25 | SSA phi(x) |

--- a/csharp/ql/test/library-tests/csharp8/NullCoalescingControlFlow.expected
+++ b/csharp/ql/test/library-tests/csharp8/NullCoalescingControlFlow.expected
@@ -4,9 +4,9 @@
 | NullCoalescingAssignment.cs:7:9:7:24 | ... ...; | NullCoalescingAssignment.cs:7:20:7:23 | null | semmle.label | successor |
 | NullCoalescingAssignment.cs:7:16:7:23 | Object o = ... | NullCoalescingAssignment.cs:8:9:8:19 | ...; | semmle.label | successor |
 | NullCoalescingAssignment.cs:7:20:7:23 | null | NullCoalescingAssignment.cs:7:16:7:23 | Object o = ... | semmle.label | successor |
-| NullCoalescingAssignment.cs:8:9:8:9 | access to local variable o | NullCoalescingAssignment.cs:8:9:8:18 | ... = ... | semmle.label | non-null |
+| NullCoalescingAssignment.cs:8:9:8:9 | access to local variable o | NullCoalescingAssignment.cs:8:9:8:18 | ... ?? ... | semmle.label | non-null |
 | NullCoalescingAssignment.cs:8:9:8:9 | access to local variable o | NullCoalescingAssignment.cs:8:15:8:18 | this access | semmle.label | null |
 | NullCoalescingAssignment.cs:8:9:8:18 | ... = ... | NullCoalescingAssignment.cs:5:10:5:23 | exit NullCoalescing (normal) | semmle.label | successor |
-| NullCoalescingAssignment.cs:8:9:8:18 | ... ?? ... | NullCoalescingAssignment.cs:8:9:8:9 | access to local variable o | semmle.label | successor |
-| NullCoalescingAssignment.cs:8:9:8:19 | ...; | NullCoalescingAssignment.cs:8:9:8:18 | ... ?? ... | semmle.label | successor |
-| NullCoalescingAssignment.cs:8:15:8:18 | this access | NullCoalescingAssignment.cs:8:9:8:18 | ... = ... | semmle.label | successor |
+| NullCoalescingAssignment.cs:8:9:8:18 | ... ?? ... | NullCoalescingAssignment.cs:8:9:8:18 | ... = ... | semmle.label | successor |
+| NullCoalescingAssignment.cs:8:9:8:19 | ...; | NullCoalescingAssignment.cs:8:9:8:9 | access to local variable o | semmle.label | successor |
+| NullCoalescingAssignment.cs:8:15:8:18 | this access | NullCoalescingAssignment.cs:8:9:8:18 | ... ?? ... | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/ispatternflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/ispatternflow.expected
@@ -14,24 +14,26 @@
 | patterns.cs:9:13:9:29 | ... is ... | patterns.cs:13:9:15:9 | if (...) ... | semmle.label | false |
 | patterns.cs:9:18:9:29 | MyStruct ms1 | patterns.cs:9:13:9:29 | ... is ... | semmle.label | successor |
 | patterns.cs:10:9:11:9 | {...} | patterns.cs:13:9:15:9 | if (...) ... | semmle.label | successor |
-| patterns.cs:13:9:15:9 | if (...) ... | patterns.cs:13:13:13:56 | ... && ... | semmle.label | successor |
+| patterns.cs:13:9:15:9 | if (...) ... | patterns.cs:13:13:13:13 | access to local variable o | semmle.label | successor |
 | patterns.cs:13:13:13:13 | access to local variable o | patterns.cs:13:18:13:40 | MyStruct s | semmle.label | successor |
+| patterns.cs:13:13:13:40 | ... is ... | patterns.cs:13:13:13:47 | [false] ... && ... | semmle.label | false |
 | patterns.cs:13:13:13:40 | ... is ... | patterns.cs:13:45:13:45 | access to local variable x | semmle.label | true |
-| patterns.cs:13:13:13:40 | ... is ... | patterns.cs:17:9:19:9 | if (...) ... | semmle.label | false |
-| patterns.cs:13:13:13:47 | ... && ... | patterns.cs:13:13:13:13 | access to local variable o | semmle.label | successor |
-| patterns.cs:13:13:13:56 | ... && ... | patterns.cs:13:13:13:47 | ... && ... | semmle.label | successor |
+| patterns.cs:13:13:13:47 | [false] ... && ... | patterns.cs:13:13:13:56 | [false] ... && ... | semmle.label | false |
+| patterns.cs:13:13:13:47 | [true] ... && ... | patterns.cs:13:52:13:52 | access to local variable s | semmle.label | true |
+| patterns.cs:13:13:13:56 | [false] ... && ... | patterns.cs:17:9:19:9 | if (...) ... | semmle.label | false |
+| patterns.cs:13:13:13:56 | [true] ... && ... | patterns.cs:14:9:15:9 | {...} | semmle.label | true |
 | patterns.cs:13:18:13:40 | MyStruct s | patterns.cs:13:32:13:36 | Int32 x | semmle.label | successor |
 | patterns.cs:13:18:13:40 | { ... } | patterns.cs:13:13:13:40 | ... is ... | semmle.label | successor |
 | patterns.cs:13:27:13:38 | { ... } | patterns.cs:13:18:13:40 | { ... } | semmle.label | successor |
 | patterns.cs:13:32:13:36 | Int32 x | patterns.cs:13:27:13:38 | { ... } | semmle.label | successor |
 | patterns.cs:13:45:13:45 | access to local variable x | patterns.cs:13:47:13:47 | 4 | semmle.label | successor |
-| patterns.cs:13:45:13:47 | ... < ... | patterns.cs:13:52:13:52 | access to local variable s | semmle.label | true |
-| patterns.cs:13:45:13:47 | ... < ... | patterns.cs:17:9:19:9 | if (...) ... | semmle.label | false |
+| patterns.cs:13:45:13:47 | ... < ... | patterns.cs:13:13:13:47 | [false] ... && ... | semmle.label | false |
+| patterns.cs:13:45:13:47 | ... < ... | patterns.cs:13:13:13:47 | [true] ... && ... | semmle.label | true |
 | patterns.cs:13:47:13:47 | 4 | patterns.cs:13:45:13:47 | ... < ... | semmle.label | successor |
 | patterns.cs:13:52:13:52 | access to local variable s | patterns.cs:13:52:13:54 | access to property Y | semmle.label | successor |
 | patterns.cs:13:52:13:54 | access to property Y | patterns.cs:13:56:13:56 | 2 | semmle.label | successor |
-| patterns.cs:13:52:13:56 | ... < ... | patterns.cs:14:9:15:9 | {...} | semmle.label | true |
-| patterns.cs:13:52:13:56 | ... < ... | patterns.cs:17:9:19:9 | if (...) ... | semmle.label | false |
+| patterns.cs:13:52:13:56 | ... < ... | patterns.cs:13:13:13:56 | [false] ... && ... | semmle.label | false |
+| patterns.cs:13:52:13:56 | ... < ... | patterns.cs:13:13:13:56 | [true] ... && ... | semmle.label | true |
 | patterns.cs:13:56:13:56 | 2 | patterns.cs:13:52:13:56 | ... < ... | semmle.label | successor |
 | patterns.cs:14:9:15:9 | {...} | patterns.cs:17:9:19:9 | if (...) ... | semmle.label | successor |
 | patterns.cs:17:9:19:9 | if (...) ... | patterns.cs:17:13:17:13 | access to local variable o | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/switchexprcontrolflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/switchexprcontrolflow.expected
@@ -2,85 +2,85 @@
 | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | patterns.cs:98:10:98:20 | exit Expressions | semmle.label | successor |
 | patterns.cs:98:10:98:20 | exit Expressions (normal) | patterns.cs:98:10:98:20 | exit Expressions | semmle.label | successor |
 | patterns.cs:99:5:121:5 | {...} | patterns.cs:100:9:103:10 | ... ...; | semmle.label | successor |
-| patterns.cs:100:9:103:10 | ... ...; | patterns.cs:100:20:103:9 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:100:9:103:10 | ... ...; | patterns.cs:100:20:100:20 | access to parameter x | semmle.label | successor |
 | patterns.cs:100:13:103:9 | String size = ... | patterns.cs:105:9:105:27 | ... ...; | semmle.label | successor |
-| patterns.cs:100:20:100:20 | access to parameter x | patterns.cs:101:13:101:40 | ... => ... | semmle.label | successor |
-| patterns.cs:100:20:103:9 | ... switch { ... } | patterns.cs:100:20:100:20 | access to parameter x | semmle.label | successor |
+| patterns.cs:100:20:100:20 | access to parameter x | patterns.cs:101:13:101:17 | Int32 y | semmle.label | successor |
+| patterns.cs:100:20:103:9 | ... switch { ... } | patterns.cs:100:13:103:9 | String size = ... | semmle.label | successor |
 | patterns.cs:101:13:101:17 | Int32 y | patterns.cs:101:24:101:24 | access to local variable y | semmle.label | match |
-| patterns.cs:101:13:101:17 | Int32 y | patterns.cs:102:13:102:24 | ... => ... | semmle.label | no-match |
-| patterns.cs:101:13:101:40 | ... => ... | patterns.cs:101:13:101:17 | Int32 y | semmle.label | successor |
+| patterns.cs:101:13:101:17 | Int32 y | patterns.cs:102:13:102:13 | _ | semmle.label | no-match |
+| patterns.cs:101:13:101:40 | ... => ... | patterns.cs:100:20:103:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:101:24:101:24 | access to local variable y | patterns.cs:101:28:101:29 | 10 | semmle.label | successor |
 | patterns.cs:101:24:101:29 | ... > ... | patterns.cs:101:34:101:40 | "large" | semmle.label | true |
-| patterns.cs:101:24:101:29 | ... > ... | patterns.cs:102:13:102:24 | ... => ... | semmle.label | false |
+| patterns.cs:101:24:101:29 | ... > ... | patterns.cs:102:13:102:13 | _ | semmle.label | false |
 | patterns.cs:101:28:101:29 | 10 | patterns.cs:101:24:101:29 | ... > ... | semmle.label | successor |
-| patterns.cs:101:34:101:40 | "large" | patterns.cs:100:13:103:9 | String size = ... | semmle.label | successor |
+| patterns.cs:101:34:101:40 | "large" | patterns.cs:101:13:101:40 | ... => ... | semmle.label | successor |
 | patterns.cs:102:13:102:13 | _ | patterns.cs:102:18:102:24 | "small" | semmle.label | match |
-| patterns.cs:102:13:102:24 | ... => ... | patterns.cs:102:13:102:13 | _ | semmle.label | successor |
-| patterns.cs:102:18:102:24 | "small" | patterns.cs:100:13:103:9 | String size = ... | semmle.label | successor |
+| patterns.cs:102:13:102:24 | ... => ... | patterns.cs:100:20:103:9 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:102:18:102:24 | "small" | patterns.cs:102:13:102:24 | ... => ... | semmle.label | successor |
 | patterns.cs:105:9:105:27 | ... ...; | patterns.cs:105:18:105:18 | 0 | semmle.label | successor |
 | patterns.cs:105:13:105:18 | Int32 x0 = ... | patterns.cs:105:26:105:26 | 0 | semmle.label | successor |
 | patterns.cs:105:18:105:18 | 0 | patterns.cs:105:13:105:18 | Int32 x0 = ... | semmle.label | successor |
 | patterns.cs:105:21:105:26 | Int32 y0 = ... | patterns.cs:108:9:112:10 | ...; | semmle.label | successor |
 | patterns.cs:105:26:105:26 | 0 | patterns.cs:105:21:105:26 | Int32 y0 = ... | semmle.label | successor |
-| patterns.cs:108:9:108:20 | (..., ...) | patterns.cs:108:24:112:9 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:108:9:108:20 | (..., ...) | patterns.cs:108:25:108:26 | access to local variable x0 | semmle.label | successor |
 | patterns.cs:108:9:112:9 | ... = ... | patterns.cs:115:9:120:10 | ...; | semmle.label | successor |
 | patterns.cs:108:9:112:10 | ...; | patterns.cs:108:14:108:15 | Int32 x1 | semmle.label | successor |
 | patterns.cs:108:14:108:15 | Int32 x1 | patterns.cs:108:18:108:19 | Int32 y1 | semmle.label | successor |
 | patterns.cs:108:18:108:19 | Int32 y1 | patterns.cs:108:9:108:20 | (..., ...) | semmle.label | successor |
-| patterns.cs:108:24:108:31 | (..., ...) | patterns.cs:110:13:110:26 | ... => ... | semmle.label | successor |
-| patterns.cs:108:24:112:9 | ... switch { ... } | patterns.cs:108:25:108:26 | access to local variable x0 | semmle.label | successor |
+| patterns.cs:108:24:108:31 | (..., ...) | patterns.cs:110:14:110:14 | 0 | semmle.label | successor |
+| patterns.cs:108:24:112:9 | ... switch { ... } | patterns.cs:108:9:112:9 | ... = ... | semmle.label | successor |
 | patterns.cs:108:25:108:26 | access to local variable x0 | patterns.cs:108:29:108:30 | access to local variable y0 | semmle.label | successor |
 | patterns.cs:108:29:108:30 | access to local variable y0 | patterns.cs:108:24:108:31 | (..., ...) | semmle.label | successor |
 | patterns.cs:110:13:110:17 | ( ... ) | patterns.cs:110:13:110:17 | { ... } | semmle.label | successor |
 | patterns.cs:110:13:110:17 | { ... } | patterns.cs:110:23:110:23 | 1 | semmle.label | match |
-| patterns.cs:110:13:110:17 | { ... } | patterns.cs:111:13:111:26 | ... => ... | semmle.label | no-match |
-| patterns.cs:110:13:110:26 | ... => ... | patterns.cs:110:14:110:14 | 0 | semmle.label | successor |
+| patterns.cs:110:13:110:17 | { ... } | patterns.cs:111:14:111:14 | 1 | semmle.label | no-match |
+| patterns.cs:110:13:110:26 | ... => ... | patterns.cs:108:24:112:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:110:14:110:14 | 0 | patterns.cs:110:16:110:16 | 1 | semmle.label | successor |
 | patterns.cs:110:16:110:16 | 1 | patterns.cs:110:13:110:17 | ( ... ) | semmle.label | successor |
-| patterns.cs:110:22:110:26 | (..., ...) | patterns.cs:108:9:112:9 | ... = ... | semmle.label | successor |
+| patterns.cs:110:22:110:26 | (..., ...) | patterns.cs:110:13:110:26 | ... => ... | semmle.label | successor |
 | patterns.cs:110:23:110:23 | 1 | patterns.cs:110:25:110:25 | 0 | semmle.label | successor |
 | patterns.cs:110:25:110:25 | 0 | patterns.cs:110:22:110:26 | (..., ...) | semmle.label | successor |
 | patterns.cs:111:13:111:17 | ( ... ) | patterns.cs:111:13:111:17 | { ... } | semmle.label | successor |
 | patterns.cs:111:13:111:17 | { ... } | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | semmle.label | exception(InvalidOperationException) |
 | patterns.cs:111:13:111:17 | { ... } | patterns.cs:111:23:111:23 | 0 | semmle.label | match |
-| patterns.cs:111:13:111:26 | ... => ... | patterns.cs:111:14:111:14 | 1 | semmle.label | successor |
+| patterns.cs:111:13:111:26 | ... => ... | patterns.cs:108:24:112:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:111:14:111:14 | 1 | patterns.cs:111:16:111:16 | 0 | semmle.label | successor |
 | patterns.cs:111:16:111:16 | 0 | patterns.cs:111:13:111:17 | ( ... ) | semmle.label | successor |
-| patterns.cs:111:22:111:26 | (..., ...) | patterns.cs:108:9:112:9 | ... = ... | semmle.label | successor |
+| patterns.cs:111:22:111:26 | (..., ...) | patterns.cs:111:13:111:26 | ... => ... | semmle.label | successor |
 | patterns.cs:111:23:111:23 | 0 | patterns.cs:111:25:111:25 | 1 | semmle.label | successor |
 | patterns.cs:111:25:111:25 | 1 | patterns.cs:111:22:111:26 | (..., ...) | semmle.label | successor |
-| patterns.cs:115:9:115:16 | (..., ...) | patterns.cs:115:20:120:9 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:115:9:115:16 | (..., ...) | patterns.cs:115:21:115:22 | access to local variable x0 | semmle.label | successor |
 | patterns.cs:115:9:120:9 | ... = ... | patterns.cs:98:10:98:20 | exit Expressions (normal) | semmle.label | successor |
 | patterns.cs:115:9:120:10 | ...; | patterns.cs:115:9:115:16 | (..., ...) | semmle.label | successor |
-| patterns.cs:115:20:115:27 | (..., ...) | patterns.cs:117:13:117:33 | ... => ... | semmle.label | successor |
-| patterns.cs:115:20:120:9 | ... switch { ... } | patterns.cs:115:21:115:22 | access to local variable x0 | semmle.label | successor |
+| patterns.cs:115:20:115:27 | (..., ...) | patterns.cs:117:14:117:14 | 0 | semmle.label | successor |
+| patterns.cs:115:20:120:9 | ... switch { ... } | patterns.cs:115:9:120:9 | ... = ... | semmle.label | successor |
 | patterns.cs:115:21:115:22 | access to local variable x0 | patterns.cs:115:25:115:26 | access to local variable y0 | semmle.label | successor |
 | patterns.cs:115:25:115:26 | access to local variable y0 | patterns.cs:115:20:115:27 | (..., ...) | semmle.label | successor |
 | patterns.cs:117:13:117:22 | ( ... ) | patterns.cs:117:13:117:22 | { ... } | semmle.label | successor |
 | patterns.cs:117:13:117:22 | { ... } | patterns.cs:117:28:117:29 | access to local variable y2 | semmle.label | match |
-| patterns.cs:117:13:117:22 | { ... } | patterns.cs:118:13:118:34 | ... => ... | semmle.label | no-match |
-| patterns.cs:117:13:117:33 | ... => ... | patterns.cs:117:14:117:14 | 0 | semmle.label | successor |
+| patterns.cs:117:13:117:22 | { ... } | patterns.cs:118:14:118:19 | Int32 x2 | semmle.label | no-match |
+| patterns.cs:117:13:117:33 | ... => ... | patterns.cs:115:20:120:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:117:14:117:14 | 0 | patterns.cs:117:16:117:21 | Int32 y2 | semmle.label | successor |
 | patterns.cs:117:16:117:21 | Int32 y2 | patterns.cs:117:13:117:22 | ( ... ) | semmle.label | successor |
-| patterns.cs:117:27:117:33 | (..., ...) | patterns.cs:115:9:120:9 | ... = ... | semmle.label | successor |
+| patterns.cs:117:27:117:33 | (..., ...) | patterns.cs:117:13:117:33 | ... => ... | semmle.label | successor |
 | patterns.cs:117:28:117:29 | access to local variable y2 | patterns.cs:117:32:117:32 | 0 | semmle.label | successor |
 | patterns.cs:117:32:117:32 | 0 | patterns.cs:117:27:117:33 | (..., ...) | semmle.label | successor |
 | patterns.cs:118:13:118:23 | ( ... ) | patterns.cs:118:13:118:23 | { ... } | semmle.label | successor |
 | patterns.cs:118:13:118:23 | { ... } | patterns.cs:118:29:118:29 | 0 | semmle.label | match |
-| patterns.cs:118:13:118:23 | { ... } | patterns.cs:119:13:119:38 | ... => ... | semmle.label | no-match |
-| patterns.cs:118:13:118:34 | ... => ... | patterns.cs:118:14:118:19 | Int32 x2 | semmle.label | successor |
+| patterns.cs:118:13:118:23 | { ... } | patterns.cs:119:14:119:19 | Int32 x2 | semmle.label | no-match |
+| patterns.cs:118:13:118:34 | ... => ... | patterns.cs:115:20:120:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:118:14:118:19 | Int32 x2 | patterns.cs:118:22:118:22 | 0 | semmle.label | successor |
 | patterns.cs:118:22:118:22 | 0 | patterns.cs:118:13:118:23 | ( ... ) | semmle.label | successor |
-| patterns.cs:118:28:118:34 | (..., ...) | patterns.cs:115:9:120:9 | ... = ... | semmle.label | successor |
+| patterns.cs:118:28:118:34 | (..., ...) | patterns.cs:118:13:118:34 | ... => ... | semmle.label | successor |
 | patterns.cs:118:29:118:29 | 0 | patterns.cs:118:32:118:33 | access to local variable x2 | semmle.label | successor |
 | patterns.cs:118:32:118:33 | access to local variable x2 | patterns.cs:118:28:118:34 | (..., ...) | semmle.label | successor |
 | patterns.cs:119:13:119:28 | ( ... ) | patterns.cs:119:13:119:28 | { ... } | semmle.label | successor |
 | patterns.cs:119:13:119:28 | { ... } | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | semmle.label | exception(InvalidOperationException) |
 | patterns.cs:119:13:119:28 | { ... } | patterns.cs:119:34:119:34 | 0 | semmle.label | match |
-| patterns.cs:119:13:119:38 | ... => ... | patterns.cs:119:14:119:19 | Int32 x2 | semmle.label | successor |
+| patterns.cs:119:13:119:38 | ... => ... | patterns.cs:115:20:120:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:119:14:119:19 | Int32 x2 | patterns.cs:119:22:119:27 | Int32 y2 | semmle.label | successor |
 | patterns.cs:119:22:119:27 | Int32 y2 | patterns.cs:119:13:119:28 | ( ... ) | semmle.label | successor |
-| patterns.cs:119:33:119:38 | (..., ...) | patterns.cs:115:9:120:9 | ... = ... | semmle.label | successor |
+| patterns.cs:119:33:119:38 | (..., ...) | patterns.cs:119:13:119:38 | ... => ... | semmle.label | successor |
 | patterns.cs:119:34:119:34 | 0 | patterns.cs:119:37:119:37 | 0 | semmle.label | successor |
 | patterns.cs:119:37:119:37 | 0 | patterns.cs:119:33:119:38 | (..., ...) | semmle.label | successor |
 | patterns.cs:123:10:123:21 | enter Expressions2 | patterns.cs:124:5:149:5 | {...} | semmle.label | successor |
@@ -93,75 +93,74 @@
 | patterns.cs:125:30:125:38 | { ..., ... } | patterns.cs:125:13:125:38 | MyStruct s = ... | semmle.label | successor |
 | patterns.cs:125:32:125:36 | ... = ... | patterns.cs:125:30:125:38 | { ..., ... } | semmle.label | successor |
 | patterns.cs:125:36:125:36 | 0 | patterns.cs:125:32:125:36 | ... = ... | semmle.label | successor |
-| patterns.cs:126:9:132:10 | ... ...; | patterns.cs:126:17:132:9 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:126:9:132:10 | ... ...; | patterns.cs:126:17:126:17 | access to local variable s | semmle.label | successor |
 | patterns.cs:126:13:132:9 | Int32 r = ... | patterns.cs:134:9:148:9 | try {...} ... | semmle.label | successor |
-| patterns.cs:126:17:126:17 | access to local variable s | patterns.cs:128:13:128:49 | ... => ... | semmle.label | successor |
-| patterns.cs:126:17:132:9 | ... switch { ... } | patterns.cs:126:17:126:17 | access to local variable s | semmle.label | successor |
+| patterns.cs:126:17:126:17 | access to local variable s | patterns.cs:128:27:128:31 | Int32 x | semmle.label | successor |
+| patterns.cs:126:17:132:9 | ... switch { ... } | patterns.cs:126:13:132:9 | Int32 r = ... | semmle.label | successor |
 | patterns.cs:128:13:128:33 | { ... } | patterns.cs:128:40:128:40 | access to local variable x | semmle.label | match |
-| patterns.cs:128:13:128:33 | { ... } | patterns.cs:129:13:129:38 | ... => ... | semmle.label | no-match |
-| patterns.cs:128:13:128:49 | ... => ... | patterns.cs:128:27:128:31 | Int32 x | semmle.label | successor |
+| patterns.cs:128:13:128:33 | { ... } | patterns.cs:129:13:129:33 | MyStruct ms | semmle.label | no-match |
+| patterns.cs:128:13:128:49 | ... => ... | patterns.cs:126:17:132:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:128:22:128:33 | { ... } | patterns.cs:128:13:128:33 | { ... } | semmle.label | successor |
 | patterns.cs:128:27:128:31 | Int32 x | patterns.cs:128:22:128:33 | { ... } | semmle.label | successor |
 | patterns.cs:128:40:128:40 | access to local variable x | patterns.cs:128:44:128:44 | 2 | semmle.label | successor |
 | patterns.cs:128:40:128:44 | ... > ... | patterns.cs:128:49:128:49 | 0 | semmle.label | true |
-| patterns.cs:128:40:128:44 | ... > ... | patterns.cs:129:13:129:38 | ... => ... | semmle.label | false |
+| patterns.cs:128:40:128:44 | ... > ... | patterns.cs:129:13:129:33 | MyStruct ms | semmle.label | false |
 | patterns.cs:128:44:128:44 | 2 | patterns.cs:128:40:128:44 | ... > ... | semmle.label | successor |
-| patterns.cs:128:49:128:49 | 0 | patterns.cs:126:13:132:9 | Int32 r = ... | semmle.label | successor |
+| patterns.cs:128:49:128:49 | 0 | patterns.cs:128:13:128:49 | ... => ... | semmle.label | successor |
 | patterns.cs:129:13:129:33 | MyStruct ms | patterns.cs:129:27:129:28 | 10 | semmle.label | successor |
 | patterns.cs:129:13:129:33 | { ... } | patterns.cs:129:38:129:38 | 1 | semmle.label | match |
-| patterns.cs:129:13:129:33 | { ... } | patterns.cs:130:13:130:23 | ... => ... | semmle.label | no-match |
-| patterns.cs:129:13:129:38 | ... => ... | patterns.cs:129:13:129:33 | MyStruct ms | semmle.label | successor |
+| patterns.cs:129:13:129:33 | { ... } | patterns.cs:130:14:130:14 | 1 | semmle.label | no-match |
+| patterns.cs:129:13:129:38 | ... => ... | patterns.cs:126:17:132:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:129:22:129:30 | { ... } | patterns.cs:129:13:129:33 | { ... } | semmle.label | successor |
 | patterns.cs:129:27:129:28 | 10 | patterns.cs:129:22:129:30 | { ... } | semmle.label | successor |
-| patterns.cs:129:38:129:38 | 1 | patterns.cs:126:13:132:9 | Int32 r = ... | semmle.label | successor |
+| patterns.cs:129:38:129:38 | 1 | patterns.cs:129:13:129:38 | ... => ... | semmle.label | successor |
 | patterns.cs:130:13:130:18 | ( ... ) | patterns.cs:130:13:130:18 | { ... } | semmle.label | successor |
 | patterns.cs:130:13:130:18 | { ... } | patterns.cs:130:23:130:23 | 2 | semmle.label | match |
-| patterns.cs:130:13:130:18 | { ... } | patterns.cs:131:13:131:27 | ... => ... | semmle.label | no-match |
-| patterns.cs:130:13:130:23 | ... => ... | patterns.cs:130:14:130:14 | 1 | semmle.label | successor |
+| patterns.cs:130:13:130:18 | { ... } | patterns.cs:131:18:131:18 | Int32 x | semmle.label | no-match |
+| patterns.cs:130:13:130:23 | ... => ... | patterns.cs:126:17:132:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:130:14:130:14 | 1 | patterns.cs:130:17:130:17 | 2 | semmle.label | successor |
 | patterns.cs:130:17:130:17 | 2 | patterns.cs:130:13:130:18 | ( ... ) | semmle.label | successor |
-| patterns.cs:130:23:130:23 | 2 | patterns.cs:126:13:132:9 | Int32 r = ... | semmle.label | successor |
+| patterns.cs:130:23:130:23 | 2 | patterns.cs:130:13:130:23 | ... => ... | semmle.label | successor |
 | patterns.cs:131:13:131:22 | (..., ...) | patterns.cs:123:10:123:21 | exit Expressions2 (abnormal) | semmle.label | exception(InvalidOperationException) |
 | patterns.cs:131:13:131:22 | (..., ...) | patterns.cs:131:27:131:27 | 3 | semmle.label | match |
-| patterns.cs:131:13:131:27 | ... => ... | patterns.cs:131:18:131:18 | Int32 x | semmle.label | successor |
+| patterns.cs:131:13:131:27 | ... => ... | patterns.cs:126:17:132:9 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:131:18:131:18 | Int32 x | patterns.cs:131:21:131:21 | _ | semmle.label | successor |
 | patterns.cs:131:21:131:21 | _ | patterns.cs:131:13:131:22 | (..., ...) | semmle.label | successor |
-| patterns.cs:131:27:131:27 | 3 | patterns.cs:126:13:132:9 | Int32 r = ... | semmle.label | successor |
+| patterns.cs:131:27:131:27 | 3 | patterns.cs:131:13:131:27 | ... => ... | semmle.label | successor |
 | patterns.cs:134:9:148:9 | try {...} ... | patterns.cs:135:9:144:9 | {...} | semmle.label | successor |
 | patterns.cs:135:9:144:9 | {...} | patterns.cs:136:13:143:14 | ...; | semmle.label | successor |
 | patterns.cs:136:13:143:13 | ... = ... | patterns.cs:123:10:123:21 | exit Expressions2 (normal) | semmle.label | successor |
-| patterns.cs:136:13:143:14 | ...; | patterns.cs:136:17:143:13 | ... switch { ... } | semmle.label | successor |
-| patterns.cs:136:17:136:17 | access to parameter o | patterns.cs:138:17:138:50 | ... => ... | semmle.label | successor |
-| patterns.cs:136:17:143:13 | ... switch { ... } | patterns.cs:136:17:136:17 | access to parameter o | semmle.label | successor |
+| patterns.cs:136:13:143:14 | ...; | patterns.cs:136:17:136:17 | access to parameter o | semmle.label | successor |
+| patterns.cs:136:17:136:17 | access to parameter o | patterns.cs:138:17:138:17 | 1 | semmle.label | successor |
+| patterns.cs:136:17:143:13 | ... switch { ... } | patterns.cs:136:13:143:13 | ... = ... | semmle.label | successor |
 | patterns.cs:138:17:138:17 | 1 | patterns.cs:138:28:138:50 | object creation of type ArgumentException | semmle.label | match |
-| patterns.cs:138:17:138:17 | 1 | patterns.cs:139:17:139:22 | ... => ... | semmle.label | no-match |
-| patterns.cs:138:17:138:50 | ... => ... | patterns.cs:138:17:138:17 | 1 | semmle.label | successor |
+| patterns.cs:138:17:138:17 | 1 | patterns.cs:139:17:139:17 | 2 | semmle.label | no-match |
 | patterns.cs:138:22:138:50 | throw ... | patterns.cs:145:9:148:9 | [exception: ArgumentException] catch (...) {...} | semmle.label | exception(ArgumentException) |
 | patterns.cs:138:28:138:50 | object creation of type ArgumentException | patterns.cs:138:22:138:50 | throw ... | semmle.label | successor |
 | patterns.cs:138:28:138:50 | object creation of type ArgumentException | patterns.cs:145:9:148:9 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
 | patterns.cs:139:17:139:17 | 2 | patterns.cs:139:22:139:22 | 3 | semmle.label | match |
-| patterns.cs:139:17:139:17 | 2 | patterns.cs:140:17:140:42 | ... => ... | semmle.label | no-match |
-| patterns.cs:139:17:139:22 | ... => ... | patterns.cs:139:17:139:17 | 2 | semmle.label | successor |
-| patterns.cs:139:22:139:22 | 3 | patterns.cs:136:13:143:13 | ... = ... | semmle.label | successor |
+| patterns.cs:139:17:139:17 | 2 | patterns.cs:140:17:140:24 | Object y | semmle.label | no-match |
+| patterns.cs:139:17:139:22 | ... => ... | patterns.cs:136:17:143:13 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:139:22:139:22 | 3 | patterns.cs:139:17:139:22 | ... => ... | semmle.label | successor |
 | patterns.cs:140:17:140:24 | Object y | patterns.cs:140:31:140:31 | access to local variable y | semmle.label | match |
-| patterns.cs:140:17:140:24 | Object y | patterns.cs:141:17:141:29 | ... => ... | semmle.label | no-match |
-| patterns.cs:140:17:140:42 | ... => ... | patterns.cs:140:17:140:24 | Object y | semmle.label | successor |
+| patterns.cs:140:17:140:24 | Object y | patterns.cs:141:17:141:22 | access to type String | semmle.label | no-match |
+| patterns.cs:140:17:140:42 | ... => ... | patterns.cs:136:17:143:13 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:140:31:140:31 | access to local variable y | patterns.cs:140:36:140:37 | { ... } | semmle.label | successor |
 | patterns.cs:140:31:140:37 | ... is ... | patterns.cs:140:42:140:42 | 4 | semmle.label | true |
-| patterns.cs:140:31:140:37 | ... is ... | patterns.cs:141:17:141:29 | ... => ... | semmle.label | false |
+| patterns.cs:140:31:140:37 | ... is ... | patterns.cs:141:17:141:22 | access to type String | semmle.label | false |
 | patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:31:140:37 | ... is ... | semmle.label | successor |
 | patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:36:140:37 | { ... } | semmle.label | successor |
-| patterns.cs:140:42:140:42 | 4 | patterns.cs:136:13:143:13 | ... = ... | semmle.label | successor |
+| patterns.cs:140:42:140:42 | 4 | patterns.cs:140:17:140:42 | ... => ... | semmle.label | successor |
 | patterns.cs:141:17:141:22 | access to type String | patterns.cs:141:29:141:29 | 5 | semmle.label | match |
-| patterns.cs:141:17:141:22 | access to type String | patterns.cs:142:17:142:41 | ... => ... | semmle.label | no-match |
-| patterns.cs:141:17:141:29 | ... => ... | patterns.cs:141:17:141:22 | access to type String | semmle.label | successor |
-| patterns.cs:141:29:141:29 | 5 | patterns.cs:136:13:143:13 | ... = ... | semmle.label | successor |
+| patterns.cs:141:17:141:22 | access to type String | patterns.cs:142:31:142:32 | 10 | semmle.label | no-match |
+| patterns.cs:141:17:141:29 | ... => ... | patterns.cs:136:17:143:13 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:141:29:141:29 | 5 | patterns.cs:141:17:141:29 | ... => ... | semmle.label | successor |
 | patterns.cs:142:17:142:36 | { ... } | patterns.cs:142:41:142:41 | 6 | semmle.label | match |
 | patterns.cs:142:17:142:36 | { ... } | patterns.cs:145:9:148:9 | [exception: InvalidOperationException] catch (...) {...} | semmle.label | exception(InvalidOperationException) |
-| patterns.cs:142:17:142:41 | ... => ... | patterns.cs:142:31:142:32 | 10 | semmle.label | successor |
+| patterns.cs:142:17:142:41 | ... => ... | patterns.cs:136:17:143:13 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:142:26:142:34 | { ... } | patterns.cs:142:17:142:36 | { ... } | semmle.label | successor |
 | patterns.cs:142:31:142:32 | 10 | patterns.cs:142:26:142:34 | { ... } | semmle.label | successor |
-| patterns.cs:142:41:142:41 | 6 | patterns.cs:136:13:143:13 | ... = ... | semmle.label | successor |
+| patterns.cs:142:41:142:41 | 6 | patterns.cs:142:17:142:41 | ... => ... | semmle.label | successor |
 | patterns.cs:145:9:148:9 | [exception: ArgumentException] catch (...) {...} | patterns.cs:123:10:123:21 | exit Expressions2 (abnormal) | semmle.label | exception(ArgumentException) |
 | patterns.cs:145:9:148:9 | [exception: Exception] catch (...) {...} | patterns.cs:123:10:123:21 | exit Expressions2 (abnormal) | semmle.label | exception(Exception) |
 | patterns.cs:145:9:148:9 | [exception: Exception] catch (...) {...} | patterns.cs:145:41:145:42 | [exception: Exception] InvalidOperationException ex | semmle.label | match |

--- a/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
@@ -1,8 +1,10 @@
 edges
 | CallSensitivityFlow.cs:19:39:19:39 | o : Object | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o |
 | CallSensitivityFlow.cs:27:40:27:40 | o : Object | CallSensitivityFlow.cs:31:18:31:18 | access to parameter o |
+| CallSensitivityFlow.cs:27:40:27:40 | o : Object | CallSensitivityFlow.cs:31:18:31:18 | access to parameter o |
 | CallSensitivityFlow.cs:35:41:35:41 | o : Object | CallSensitivityFlow.cs:39:18:39:18 | [cond (line 35): true] access to parameter o |
 | CallSensitivityFlow.cs:43:45:43:45 | o : Object | CallSensitivityFlow.cs:53:14:53:15 | access to local variable o3 |
+| CallSensitivityFlow.cs:56:46:56:46 | o : Object | CallSensitivityFlow.cs:66:14:66:15 | access to local variable o3 |
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | CallSensitivityFlow.cs:66:14:66:15 | access to local variable o3 |
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | CallSensitivityFlow.cs:66:14:66:15 | access to local variable o3 |
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | CallSensitivityFlow.cs:66:14:66:15 | access to local variable o3 |
@@ -36,11 +38,13 @@ nodes
 | CallSensitivityFlow.cs:19:39:19:39 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | semmle.label | access to parameter o |
 | CallSensitivityFlow.cs:27:40:27:40 | o : Object | semmle.label | o : Object |
+| CallSensitivityFlow.cs:27:40:27:40 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:31:18:31:18 | access to parameter o | semmle.label | access to parameter o |
 | CallSensitivityFlow.cs:35:41:35:41 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:39:18:39:18 | [cond (line 35): true] access to parameter o | semmle.label | [cond (line 35): true] access to parameter o |
 | CallSensitivityFlow.cs:43:45:43:45 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:53:14:53:15 | access to local variable o3 | semmle.label | access to local variable o3 |
+| CallSensitivityFlow.cs:56:46:56:46 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:56:46:56:46 | o : Object | semmle.label | o : Object |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -60,6 +60,5 @@
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x |
 | Splitting.cs:41:19:41:19 | access to local variable s |
-| Splitting.cs:43:19:43:19 | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -250,7 +250,6 @@ edges
 | Splitting.cs:31:19:31:25 | [b (line 24): false] access to parameter tainted : String | Splitting.cs:31:17:31:26 | [b (line 24): false] dynamic access to element : String |
 | Splitting.cs:31:19:31:25 | [b (line 24): true] access to parameter tainted : String | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element : String |
 | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s |
-| Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s |
 | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s |
 | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s |
 nodes
@@ -468,7 +467,6 @@ nodes
 | Splitting.cs:34:19:34:19 | access to local variable x | semmle.label | access to local variable x |
 | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | semmle.label | [b (line 37): true] "taint source" : String |
 | Splitting.cs:41:19:41:19 | access to local variable s | semmle.label | access to local variable s |
-| Splitting.cs:43:19:43:19 | access to local variable s | semmle.label | access to local variable s |
 | Splitting.cs:48:36:48:49 | "taint source" : String | semmle.label | "taint source" : String |
 | Splitting.cs:50:19:50:19 | access to local variable s | semmle.label | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | semmle.label | access to local variable s |
@@ -479,7 +477,6 @@ nodes
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | access to field SinkField0 |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
-| Splitting.cs:43:19:43:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |
 | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 | access to local variable sink0 |

--- a/csharp/ql/test/library-tests/dataflow/global/Splitting.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/Splitting.cs
@@ -40,7 +40,7 @@ class Splitting
         if (b)
             Check(s); // flow
         else
-            Check(s); // no flow [FALSE POSITIVE]
+            Check(s); // no flow
     }
 
     void M4(bool b)

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -66,6 +66,5 @@
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x |
 | Splitting.cs:41:19:41:19 | access to local variable s |
-| Splitting.cs:43:19:43:19 | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -270,7 +270,6 @@ edges
 | Splitting.cs:31:19:31:25 | [b (line 24): false] access to parameter tainted : String | Splitting.cs:31:17:31:26 | [b (line 24): false] dynamic access to element : String |
 | Splitting.cs:31:19:31:25 | [b (line 24): true] access to parameter tainted : String | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element : String |
 | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s |
-| Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s |
 | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s |
 | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s |
 nodes
@@ -510,7 +509,6 @@ nodes
 | Splitting.cs:34:19:34:19 | access to local variable x | semmle.label | access to local variable x |
 | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | semmle.label | [b (line 37): true] "taint source" : String |
 | Splitting.cs:41:19:41:19 | access to local variable s | semmle.label | access to local variable s |
-| Splitting.cs:43:19:43:19 | access to local variable s | semmle.label | access to local variable s |
 | Splitting.cs:48:36:48:49 | "taint source" : String | semmle.label | "taint source" : String |
 | Splitting.cs:50:19:50:19 | access to local variable s | semmle.label | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | semmle.label | access to local variable s |
@@ -583,6 +581,5 @@ nodes
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | [b (line 24): true] access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:34:19:34:19 | access to local variable x | access to local variable x |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
-| Splitting.cs:43:19:43:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -59,18 +59,17 @@
 | LocalDataFlow.cs:84:13:84:35 | [b (line 48): true] SSA def(sink7) | LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 |
 | LocalDataFlow.cs:84:21:84:21 | access to parameter b | LocalDataFlow.cs:88:20:88:20 | [b (line 48): false] access to parameter b |
 | LocalDataFlow.cs:84:21:84:21 | access to parameter b | LocalDataFlow.cs:88:20:88:20 | [b (line 48): true] access to parameter b |
-| LocalDataFlow.cs:84:21:84:35 | ... ? ... : ... | LocalDataFlow.cs:84:13:84:35 | [b (line 48): false] SSA def(sink7) |
-| LocalDataFlow.cs:84:21:84:35 | ... ? ... : ... | LocalDataFlow.cs:84:13:84:35 | [b (line 48): true] SSA def(sink7) |
-| LocalDataFlow.cs:84:25:84:27 | [b (line 48): true] "a" | LocalDataFlow.cs:84:21:84:35 | ... ? ... : ... |
-| LocalDataFlow.cs:84:31:84:35 | [b (line 48): false] access to local variable sink6 | LocalDataFlow.cs:84:21:84:35 | ... ? ... : ... |
-| LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:9:88:36 | SSA phi(sink7) |
-| LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:9:88:36 | SSA phi(sink7) |
+| LocalDataFlow.cs:84:21:84:35 | [b (line 48): false] ... ? ... : ... | LocalDataFlow.cs:84:13:84:35 | [b (line 48): false] SSA def(sink7) |
+| LocalDataFlow.cs:84:21:84:35 | [b (line 48): true] ... ? ... : ... | LocalDataFlow.cs:84:13:84:35 | [b (line 48): true] SSA def(sink7) |
+| LocalDataFlow.cs:84:25:84:27 | [b (line 48): true] "a" | LocalDataFlow.cs:84:21:84:35 | [b (line 48): true] ... ? ... : ... |
+| LocalDataFlow.cs:84:31:84:35 | [b (line 48): false] access to local variable sink6 | LocalDataFlow.cs:84:21:84:35 | [b (line 48): false] ... ? ... : ... |
+| LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
 | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) | LocalDataFlow.cs:89:15:89:22 | access to local variable nonSink0 |
-| LocalDataFlow.cs:88:9:88:36 | SSA phi(sink7) | LocalDataFlow.cs:92:29:92:33 | access to local variable sink7 |
-| LocalDataFlow.cs:88:20:88:36 | [b (line 48): false] ... ? ... : ... | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) |
-| LocalDataFlow.cs:88:20:88:36 | [b (line 48): true] ... ? ... : ... | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) |
-| LocalDataFlow.cs:88:24:88:28 | "abc" | LocalDataFlow.cs:88:20:88:36 | [b (line 48): true] ... ? ... : ... |
-| LocalDataFlow.cs:88:32:88:36 | "def" | LocalDataFlow.cs:88:20:88:36 | [b (line 48): false] ... ? ... : ... |
+| LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) |
+| LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) | LocalDataFlow.cs:92:29:92:33 | access to local variable sink7 |
+| LocalDataFlow.cs:88:24:88:28 | "abc" | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... |
+| LocalDataFlow.cs:88:32:88:36 | "def" | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... |
 | LocalDataFlow.cs:89:15:89:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:96:32:96:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:89:15:89:22 | access to local variable nonSink0 | LocalDataFlow.cs:96:32:96:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:92:13:92:33 | SSA def(sink8) | LocalDataFlow.cs:93:15:93:19 | access to local variable sink8 |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTracking.expected
@@ -3,7 +3,6 @@
 | LocalDataFlow.cs:69:15:69:19 | access to local variable sink5 |
 | LocalDataFlow.cs:77:15:77:19 | access to local variable sink6 |
 | LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 |
-| LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 |
 | LocalDataFlow.cs:93:15:93:19 | access to local variable sink8 |
 | LocalDataFlow.cs:101:15:101:19 | access to local variable sink9 |
 | LocalDataFlow.cs:109:15:109:20 | access to local variable sink15 |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
@@ -67,18 +67,17 @@
 | LocalDataFlow.cs:84:13:84:35 | [b (line 48): true] SSA def(sink7) | LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 |
 | LocalDataFlow.cs:84:21:84:21 | access to parameter b | LocalDataFlow.cs:88:20:88:20 | [b (line 48): false] access to parameter b |
 | LocalDataFlow.cs:84:21:84:21 | access to parameter b | LocalDataFlow.cs:88:20:88:20 | [b (line 48): true] access to parameter b |
-| LocalDataFlow.cs:84:21:84:35 | ... ? ... : ... | LocalDataFlow.cs:84:13:84:35 | [b (line 48): false] SSA def(sink7) |
-| LocalDataFlow.cs:84:21:84:35 | ... ? ... : ... | LocalDataFlow.cs:84:13:84:35 | [b (line 48): true] SSA def(sink7) |
-| LocalDataFlow.cs:84:25:84:27 | [b (line 48): true] "a" | LocalDataFlow.cs:84:21:84:35 | ... ? ... : ... |
-| LocalDataFlow.cs:84:31:84:35 | [b (line 48): false] access to local variable sink6 | LocalDataFlow.cs:84:21:84:35 | ... ? ... : ... |
-| LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:9:88:36 | SSA phi(sink7) |
-| LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:9:88:36 | SSA phi(sink7) |
+| LocalDataFlow.cs:84:21:84:35 | [b (line 48): false] ... ? ... : ... | LocalDataFlow.cs:84:13:84:35 | [b (line 48): false] SSA def(sink7) |
+| LocalDataFlow.cs:84:21:84:35 | [b (line 48): true] ... ? ... : ... | LocalDataFlow.cs:84:13:84:35 | [b (line 48): true] SSA def(sink7) |
+| LocalDataFlow.cs:84:25:84:27 | [b (line 48): true] "a" | LocalDataFlow.cs:84:21:84:35 | [b (line 48): true] ... ? ... : ... |
+| LocalDataFlow.cs:84:31:84:35 | [b (line 48): false] access to local variable sink6 | LocalDataFlow.cs:84:21:84:35 | [b (line 48): false] ... ? ... : ... |
+| LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
 | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) | LocalDataFlow.cs:89:15:89:22 | access to local variable nonSink0 |
-| LocalDataFlow.cs:88:9:88:36 | SSA phi(sink7) | LocalDataFlow.cs:92:29:92:33 | access to local variable sink7 |
-| LocalDataFlow.cs:88:20:88:36 | [b (line 48): false] ... ? ... : ... | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) |
-| LocalDataFlow.cs:88:20:88:36 | [b (line 48): true] ... ? ... : ... | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) |
-| LocalDataFlow.cs:88:24:88:28 | "abc" | LocalDataFlow.cs:88:20:88:36 | [b (line 48): true] ... ? ... : ... |
-| LocalDataFlow.cs:88:32:88:36 | "def" | LocalDataFlow.cs:88:20:88:36 | [b (line 48): false] ... ? ... : ... |
+| LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) |
+| LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) | LocalDataFlow.cs:92:29:92:33 | access to local variable sink7 |
+| LocalDataFlow.cs:88:24:88:28 | "abc" | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... |
+| LocalDataFlow.cs:88:32:88:36 | "def" | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... |
 | LocalDataFlow.cs:89:15:89:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:96:32:96:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:89:15:89:22 | access to local variable nonSink0 | LocalDataFlow.cs:96:32:96:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:92:13:92:33 | SSA def(sink8) | LocalDataFlow.cs:93:15:93:19 | access to local variable sink8 |

--- a/csharp/ql/test/library-tests/dataflow/modulusanalysis/ModulusAnalysis.cs
+++ b/csharp/ql/test/library-tests/dataflow/modulusanalysis/ModulusAnalysis.cs
@@ -81,7 +81,7 @@ class ModulusAnalysis
             ? i * 4 + 3
             : i * 8 + 7;
         if (!cond3)
-            System.Console.WriteLine(j); // congruent 3 mod 4
+            System.Console.WriteLine(j); // congruent 7 mod 8
     }
 
     void For(int cap)

--- a/csharp/ql/test/library-tests/dataflow/modulusanalysis/ModulusAnalysis.cs
+++ b/csharp/ql/test/library-tests/dataflow/modulusanalysis/ModulusAnalysis.cs
@@ -6,7 +6,7 @@ class ModulusAnalysis
     const int c1 = 42;
     const int c2 = 43;
 
-    void M(int i, bool cond, int x, int y, int[] arr, int otherSeven)
+    void M(int i, bool cond1, bool cond2, bool cond3, int x, int y, int[] arr, int otherSeven)
     {
         var eq = i + 3;
 
@@ -26,7 +26,7 @@ class ModulusAnalysis
             }
         }
 
-        var j = cond
+        var j = cond1
             ? i * 4 + 3
             : i * 8 + 7;
         System.Console.WriteLine(j); // congruent 3 mod 4
@@ -47,7 +47,7 @@ class ModulusAnalysis
         l = GetArray().Length * 4 - 11;
         System.Console.WriteLine(l); // congruent 1 mod 4
 
-        if (cond)
+        if (cond2)
         {
             j = i * 4 + 3;
         }
@@ -57,7 +57,7 @@ class ModulusAnalysis
         }
         System.Console.WriteLine(j); // congruent 3 mod 4 (cond = true) or 7 mod 8 (cond = false)
 
-        if (cond)
+        if (cond2)
         {
             System.Console.WriteLine(j); // congruent 3 mod 4
         }
@@ -76,6 +76,12 @@ class ModulusAnalysis
         {
             System.Console.WriteLine(x); // congruent 3 mod 16
         }
+
+        j = cond3
+            ? i * 4 + 3
+            : i * 8 + 7;
+        if (!cond3)
+            System.Console.WriteLine(j); // congruent 3 mod 4
     }
 
     void For(int cap)

--- a/csharp/ql/test/library-tests/dataflow/modulusanalysis/ModulusAnalysis.expected
+++ b/csharp/ql/test/library-tests/dataflow/modulusanalysis/ModulusAnalysis.expected
@@ -33,110 +33,82 @@
 | ModulusAnalysis.cs:25:42:25:44 | access to local variable mul | 0 | 3 | 42 |
 | ModulusAnalysis.cs:25:42:25:44 | access to local variable mul | SSA def(mul) | 0 | 0 |
 | ModulusAnalysis.cs:29:17:31:23 | ... ? ... : ... | 0 | 3 | 4 |
-| ModulusAnalysis.cs:30:15:30:15 | [cond (line 9): true] access to parameter i | SSA param(i) | 0 | 0 |
-| ModulusAnalysis.cs:30:15:30:19 | [cond (line 9): true] ... * ... | 0 | 0 | 4 |
-| ModulusAnalysis.cs:30:15:30:23 | [cond (line 9): true] ... + ... | 0 | 3 | 4 |
-| ModulusAnalysis.cs:30:19:30:19 | [cond (line 9): true] 4 | 0 | 4 | 0 |
-| ModulusAnalysis.cs:30:23:30:23 | [cond (line 9): true] 3 | 0 | 3 | 0 |
-| ModulusAnalysis.cs:31:15:31:15 | [cond (line 9): false] access to parameter i | SSA param(i) | 0 | 0 |
-| ModulusAnalysis.cs:31:15:31:19 | [cond (line 9): false] ... * ... | 0 | 0 | 8 |
-| ModulusAnalysis.cs:31:15:31:23 | [cond (line 9): false] ... + ... | 0 | 7 | 8 |
-| ModulusAnalysis.cs:31:19:31:19 | [cond (line 9): false] 8 | 0 | 8 | 0 |
-| ModulusAnalysis.cs:31:23:31:23 | [cond (line 9): false] 7 | 0 | 7 | 0 |
-| ModulusAnalysis.cs:32:34:32:34 | [cond (line 9): false] access to local variable j | 0 | 3 | 4 |
-| ModulusAnalysis.cs:32:34:32:34 | [cond (line 9): false] access to local variable j | [cond (line 9): false] SSA def(j) | 0 | 0 |
-| ModulusAnalysis.cs:32:34:32:34 | [cond (line 9): true] access to local variable j | 0 | 3 | 4 |
-| ModulusAnalysis.cs:32:34:32:34 | [cond (line 9): true] access to local variable j | [cond (line 9): true] SSA def(j) | 0 | 0 |
-| ModulusAnalysis.cs:34:13:34:13 | [cond (line 9): false] access to parameter x | SSA param(x) | 0 | 0 |
-| ModulusAnalysis.cs:34:13:34:13 | [cond (line 9): true] access to parameter x | SSA param(x) | 0 | 0 |
-| ModulusAnalysis.cs:34:17:34:18 | [cond (line 9): false] access to constant c1 | 0 | 42 | 0 |
-| ModulusAnalysis.cs:34:17:34:18 | [cond (line 9): false] access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
-| ModulusAnalysis.cs:34:17:34:18 | [cond (line 9): true] access to constant c1 | 0 | 42 | 0 |
-| ModulusAnalysis.cs:34:17:34:18 | [cond (line 9): true] access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
-| ModulusAnalysis.cs:34:23:34:23 | [cond (line 9): false] 3 | 0 | 3 | 0 |
-| ModulusAnalysis.cs:34:23:34:23 | [cond (line 9): true] 3 | 0 | 3 | 0 |
-| ModulusAnalysis.cs:34:28:34:28 | [cond (line 9): false] access to parameter y | SSA param(y) | 0 | 0 |
-| ModulusAnalysis.cs:34:28:34:28 | [cond (line 9): true] access to parameter y | SSA param(y) | 0 | 0 |
-| ModulusAnalysis.cs:34:32:34:33 | [cond (line 9): false] access to constant c1 | 0 | 42 | 0 |
-| ModulusAnalysis.cs:34:32:34:33 | [cond (line 9): false] access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
-| ModulusAnalysis.cs:34:32:34:33 | [cond (line 9): true] access to constant c1 | 0 | 42 | 0 |
-| ModulusAnalysis.cs:34:32:34:33 | [cond (line 9): true] access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
-| ModulusAnalysis.cs:34:38:34:38 | [cond (line 9): false] 7 | 0 | 7 | 0 |
-| ModulusAnalysis.cs:34:38:34:38 | [cond (line 9): true] 7 | 0 | 7 | 0 |
-| ModulusAnalysis.cs:36:38:36:38 | [cond (line 9): false] access to parameter x | SSA param(x) | 0 | 0 |
-| ModulusAnalysis.cs:36:38:36:38 | [cond (line 9): true] access to parameter x | SSA param(x) | 0 | 0 |
-| ModulusAnalysis.cs:36:42:36:42 | [cond (line 9): false] access to parameter y | SSA param(y) | 0 | 0 |
-| ModulusAnalysis.cs:36:42:36:42 | [cond (line 9): true] access to parameter y | SSA param(y) | 0 | 0 |
-| ModulusAnalysis.cs:39:13:39:13 | [cond (line 9): false] access to parameter x | SSA param(x) | 0 | 0 |
-| ModulusAnalysis.cs:39:13:39:13 | [cond (line 9): true] access to parameter x | SSA param(x) | 0 | 0 |
-| ModulusAnalysis.cs:39:17:39:18 | [cond (line 9): false] access to constant c1 | 0 | 42 | 0 |
-| ModulusAnalysis.cs:39:17:39:18 | [cond (line 9): false] access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
-| ModulusAnalysis.cs:39:17:39:18 | [cond (line 9): true] access to constant c1 | 0 | 42 | 0 |
-| ModulusAnalysis.cs:39:17:39:18 | [cond (line 9): true] access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
-| ModulusAnalysis.cs:39:23:39:23 | [cond (line 9): false] 3 | 0 | 3 | 0 |
-| ModulusAnalysis.cs:39:23:39:23 | [cond (line 9): true] 3 | 0 | 3 | 0 |
-| ModulusAnalysis.cs:39:28:39:28 | [cond (line 9): false] access to parameter y | SSA param(y) | 0 | 0 |
-| ModulusAnalysis.cs:39:28:39:28 | [cond (line 9): true] access to parameter y | SSA param(y) | 0 | 0 |
-| ModulusAnalysis.cs:39:32:39:33 | [cond (line 9): false] access to constant c1 | 0 | 42 | 0 |
-| ModulusAnalysis.cs:39:32:39:33 | [cond (line 9): false] access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
-| ModulusAnalysis.cs:39:32:39:33 | [cond (line 9): true] access to constant c1 | 0 | 42 | 0 |
-| ModulusAnalysis.cs:39:32:39:33 | [cond (line 9): true] access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
-| ModulusAnalysis.cs:39:38:39:38 | [cond (line 9): false] 7 | 0 | 7 | 0 |
-| ModulusAnalysis.cs:39:38:39:38 | [cond (line 9): true] 7 | 0 | 7 | 0 |
-| ModulusAnalysis.cs:41:38:41:38 | [cond (line 9): false] access to parameter x | SSA param(x) | 0 | 0 |
-| ModulusAnalysis.cs:41:38:41:38 | [cond (line 9): true] access to parameter x | SSA param(x) | 0 | 0 |
-| ModulusAnalysis.cs:41:42:41:42 | [cond (line 9): false] access to parameter y | SSA param(y) | 0 | 0 |
-| ModulusAnalysis.cs:41:42:41:42 | [cond (line 9): true] access to parameter y | SSA param(y) | 0 | 0 |
-| ModulusAnalysis.cs:44:17:44:26 | [cond (line 9): false] access to property Length | [cond (line 9): false] access to property Length | 0 | 0 |
-| ModulusAnalysis.cs:44:17:44:26 | [cond (line 9): true] access to property Length | [cond (line 9): true] access to property Length | 0 | 0 |
-| ModulusAnalysis.cs:44:17:44:30 | [cond (line 9): false] ... * ... | 0 | 0 | 4 |
-| ModulusAnalysis.cs:44:17:44:30 | [cond (line 9): true] ... * ... | 0 | 0 | 4 |
-| ModulusAnalysis.cs:44:17:44:35 | [cond (line 9): false] ... - ... | 0 | 1 | 4 |
-| ModulusAnalysis.cs:44:17:44:35 | [cond (line 9): true] ... - ... | 0 | 1 | 4 |
-| ModulusAnalysis.cs:44:30:44:30 | [cond (line 9): false] 4 | 0 | 4 | 0 |
-| ModulusAnalysis.cs:44:30:44:30 | [cond (line 9): true] 4 | 0 | 4 | 0 |
-| ModulusAnalysis.cs:44:34:44:35 | [cond (line 9): false] 11 | 0 | 11 | 0 |
-| ModulusAnalysis.cs:44:34:44:35 | [cond (line 9): true] 11 | 0 | 11 | 0 |
-| ModulusAnalysis.cs:45:34:45:34 | [cond (line 9): false] access to local variable l | 0 | 1 | 4 |
-| ModulusAnalysis.cs:45:34:45:34 | [cond (line 9): false] access to local variable l | [cond (line 9): false] SSA def(l) | 0 | 0 |
-| ModulusAnalysis.cs:45:34:45:34 | [cond (line 9): true] access to local variable l | 0 | 1 | 4 |
-| ModulusAnalysis.cs:45:34:45:34 | [cond (line 9): true] access to local variable l | [cond (line 9): true] SSA def(l) | 0 | 0 |
-| ModulusAnalysis.cs:47:9:47:38 | [cond (line 9): false] ... = ... | 0 | 1 | 4 |
-| ModulusAnalysis.cs:47:9:47:38 | [cond (line 9): true] ... = ... | 0 | 1 | 4 |
-| ModulusAnalysis.cs:47:13:47:29 | [cond (line 9): false] access to property Length | [cond (line 9): false] access to property Length | 0 | 0 |
-| ModulusAnalysis.cs:47:13:47:29 | [cond (line 9): true] access to property Length | [cond (line 9): true] access to property Length | 0 | 0 |
-| ModulusAnalysis.cs:47:13:47:33 | [cond (line 9): false] ... * ... | 0 | 0 | 4 |
-| ModulusAnalysis.cs:47:13:47:33 | [cond (line 9): true] ... * ... | 0 | 0 | 4 |
-| ModulusAnalysis.cs:47:13:47:38 | [cond (line 9): false] ... - ... | 0 | 1 | 4 |
-| ModulusAnalysis.cs:47:13:47:38 | [cond (line 9): true] ... - ... | 0 | 1 | 4 |
-| ModulusAnalysis.cs:47:33:47:33 | [cond (line 9): false] 4 | 0 | 4 | 0 |
-| ModulusAnalysis.cs:47:33:47:33 | [cond (line 9): true] 4 | 0 | 4 | 0 |
-| ModulusAnalysis.cs:47:37:47:38 | [cond (line 9): false] 11 | 0 | 11 | 0 |
-| ModulusAnalysis.cs:47:37:47:38 | [cond (line 9): true] 11 | 0 | 11 | 0 |
-| ModulusAnalysis.cs:48:34:48:34 | [cond (line 9): false] access to local variable l | 0 | 1 | 4 |
-| ModulusAnalysis.cs:48:34:48:34 | [cond (line 9): false] access to local variable l | [cond (line 9): false] SSA def(l) | 0 | 0 |
-| ModulusAnalysis.cs:48:34:48:34 | [cond (line 9): true] access to local variable l | 0 | 1 | 4 |
-| ModulusAnalysis.cs:48:34:48:34 | [cond (line 9): true] access to local variable l | [cond (line 9): true] SSA def(l) | 0 | 0 |
-| ModulusAnalysis.cs:52:13:52:25 | [cond (line 9): true] ... = ... | 0 | 3 | 4 |
-| ModulusAnalysis.cs:52:17:52:17 | [cond (line 9): true] access to parameter i | SSA param(i) | 0 | 0 |
-| ModulusAnalysis.cs:52:17:52:21 | [cond (line 9): true] ... * ... | 0 | 0 | 4 |
-| ModulusAnalysis.cs:52:17:52:25 | [cond (line 9): true] ... + ... | 0 | 3 | 4 |
-| ModulusAnalysis.cs:52:21:52:21 | [cond (line 9): true] 4 | 0 | 4 | 0 |
-| ModulusAnalysis.cs:52:25:52:25 | [cond (line 9): true] 3 | 0 | 3 | 0 |
-| ModulusAnalysis.cs:56:13:56:25 | [cond (line 9): false] ... = ... | 0 | 7 | 8 |
-| ModulusAnalysis.cs:56:17:56:17 | [cond (line 9): false] access to parameter i | SSA param(i) | 0 | 0 |
-| ModulusAnalysis.cs:56:17:56:21 | [cond (line 9): false] ... * ... | 0 | 0 | 8 |
-| ModulusAnalysis.cs:56:17:56:25 | [cond (line 9): false] ... + ... | 0 | 7 | 8 |
-| ModulusAnalysis.cs:56:21:56:21 | [cond (line 9): false] 8 | 0 | 8 | 0 |
-| ModulusAnalysis.cs:56:25:56:25 | [cond (line 9): false] 7 | 0 | 7 | 0 |
-| ModulusAnalysis.cs:58:34:58:34 | [cond (line 9): false] access to local variable j | 0 | 7 | 8 |
-| ModulusAnalysis.cs:58:34:58:34 | [cond (line 9): false] access to local variable j | [cond (line 9): false] SSA def(j) | 0 | 0 |
-| ModulusAnalysis.cs:58:34:58:34 | [cond (line 9): true] access to local variable j | 0 | 3 | 4 |
-| ModulusAnalysis.cs:58:34:58:34 | [cond (line 9): true] access to local variable j | [cond (line 9): true] SSA def(j) | 0 | 0 |
+| ModulusAnalysis.cs:30:15:30:15 | access to parameter i | SSA param(i) | 0 | 0 |
+| ModulusAnalysis.cs:30:15:30:19 | ... * ... | 0 | 0 | 4 |
+| ModulusAnalysis.cs:30:15:30:23 | ... + ... | 0 | 3 | 4 |
+| ModulusAnalysis.cs:30:19:30:19 | 4 | 0 | 4 | 0 |
+| ModulusAnalysis.cs:30:23:30:23 | 3 | 0 | 3 | 0 |
+| ModulusAnalysis.cs:31:15:31:15 | access to parameter i | SSA param(i) | 0 | 0 |
+| ModulusAnalysis.cs:31:15:31:19 | ... * ... | 0 | 0 | 8 |
+| ModulusAnalysis.cs:31:15:31:23 | ... + ... | 0 | 7 | 8 |
+| ModulusAnalysis.cs:31:19:31:19 | 8 | 0 | 8 | 0 |
+| ModulusAnalysis.cs:31:23:31:23 | 7 | 0 | 7 | 0 |
+| ModulusAnalysis.cs:32:34:32:34 | access to local variable j | 0 | 3 | 4 |
+| ModulusAnalysis.cs:32:34:32:34 | access to local variable j | SSA def(j) | 0 | 0 |
+| ModulusAnalysis.cs:34:13:34:13 | access to parameter x | SSA param(x) | 0 | 0 |
+| ModulusAnalysis.cs:34:17:34:18 | access to constant c1 | 0 | 42 | 0 |
+| ModulusAnalysis.cs:34:17:34:18 | access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
+| ModulusAnalysis.cs:34:23:34:23 | 3 | 0 | 3 | 0 |
+| ModulusAnalysis.cs:34:28:34:28 | access to parameter y | SSA param(y) | 0 | 0 |
+| ModulusAnalysis.cs:34:32:34:33 | access to constant c1 | 0 | 42 | 0 |
+| ModulusAnalysis.cs:34:32:34:33 | access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
+| ModulusAnalysis.cs:34:38:34:38 | 7 | 0 | 7 | 0 |
+| ModulusAnalysis.cs:36:38:36:38 | access to parameter x | 0 | 3 | 42 |
+| ModulusAnalysis.cs:36:38:36:38 | access to parameter x | SSA param(x) | 0 | 0 |
+| ModulusAnalysis.cs:36:38:36:42 | ... + ... | 0 | 10 | 42 |
+| ModulusAnalysis.cs:36:38:36:42 | ... + ... | SSA param(x) | 7 | 42 |
+| ModulusAnalysis.cs:36:38:36:42 | ... + ... | SSA param(y) | 3 | 42 |
+| ModulusAnalysis.cs:36:42:36:42 | access to parameter y | 0 | 7 | 42 |
+| ModulusAnalysis.cs:36:42:36:42 | access to parameter y | SSA param(y) | 0 | 0 |
+| ModulusAnalysis.cs:39:13:39:13 | access to parameter x | SSA param(x) | 0 | 0 |
+| ModulusAnalysis.cs:39:17:39:18 | access to constant c1 | 0 | 42 | 0 |
+| ModulusAnalysis.cs:39:17:39:18 | access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
+| ModulusAnalysis.cs:39:23:39:23 | 3 | 0 | 3 | 0 |
+| ModulusAnalysis.cs:39:28:39:28 | access to parameter y | SSA param(y) | 0 | 0 |
+| ModulusAnalysis.cs:39:32:39:33 | access to constant c1 | 0 | 42 | 0 |
+| ModulusAnalysis.cs:39:32:39:33 | access to constant c1 | SSA entry def(ModulusAnalysis.c1) | 0 | 0 |
+| ModulusAnalysis.cs:39:38:39:38 | 7 | 0 | 7 | 0 |
+| ModulusAnalysis.cs:41:38:41:38 | access to parameter x | 0 | 3 | 42 |
+| ModulusAnalysis.cs:41:38:41:38 | access to parameter x | SSA param(x) | 0 | 0 |
+| ModulusAnalysis.cs:41:38:41:42 | ... - ... | 0 | 38 | 42 |
+| ModulusAnalysis.cs:41:38:41:42 | ... - ... | SSA param(x) | 35 | 42 |
+| ModulusAnalysis.cs:41:42:41:42 | access to parameter y | 0 | 7 | 42 |
+| ModulusAnalysis.cs:41:42:41:42 | access to parameter y | SSA param(y) | 0 | 0 |
+| ModulusAnalysis.cs:44:17:44:26 | access to property Length | access to property Length | 0 | 0 |
+| ModulusAnalysis.cs:44:17:44:30 | ... * ... | 0 | 0 | 4 |
+| ModulusAnalysis.cs:44:17:44:35 | ... - ... | 0 | 1 | 4 |
+| ModulusAnalysis.cs:44:30:44:30 | 4 | 0 | 4 | 0 |
+| ModulusAnalysis.cs:44:34:44:35 | 11 | 0 | 11 | 0 |
+| ModulusAnalysis.cs:45:34:45:34 | access to local variable l | 0 | 1 | 4 |
+| ModulusAnalysis.cs:45:34:45:34 | access to local variable l | SSA def(l) | 0 | 0 |
+| ModulusAnalysis.cs:47:9:47:38 | ... = ... | 0 | 1 | 4 |
+| ModulusAnalysis.cs:47:13:47:29 | access to property Length | access to property Length | 0 | 0 |
+| ModulusAnalysis.cs:47:13:47:33 | ... * ... | 0 | 0 | 4 |
+| ModulusAnalysis.cs:47:13:47:38 | ... - ... | 0 | 1 | 4 |
+| ModulusAnalysis.cs:47:33:47:33 | 4 | 0 | 4 | 0 |
+| ModulusAnalysis.cs:47:37:47:38 | 11 | 0 | 11 | 0 |
+| ModulusAnalysis.cs:48:34:48:34 | access to local variable l | 0 | 1 | 4 |
+| ModulusAnalysis.cs:48:34:48:34 | access to local variable l | SSA def(l) | 0 | 0 |
+| ModulusAnalysis.cs:52:13:52:25 | [cond2 (line 9): true] ... = ... | 0 | 3 | 4 |
+| ModulusAnalysis.cs:52:17:52:17 | [cond2 (line 9): true] access to parameter i | SSA param(i) | 0 | 0 |
+| ModulusAnalysis.cs:52:17:52:21 | [cond2 (line 9): true] ... * ... | 0 | 0 | 4 |
+| ModulusAnalysis.cs:52:17:52:25 | [cond2 (line 9): true] ... + ... | 0 | 3 | 4 |
+| ModulusAnalysis.cs:52:21:52:21 | [cond2 (line 9): true] 4 | 0 | 4 | 0 |
+| ModulusAnalysis.cs:52:25:52:25 | [cond2 (line 9): true] 3 | 0 | 3 | 0 |
+| ModulusAnalysis.cs:56:13:56:25 | [cond2 (line 9): false] ... = ... | 0 | 7 | 8 |
+| ModulusAnalysis.cs:56:17:56:17 | [cond2 (line 9): false] access to parameter i | SSA param(i) | 0 | 0 |
+| ModulusAnalysis.cs:56:17:56:21 | [cond2 (line 9): false] ... * ... | 0 | 0 | 8 |
+| ModulusAnalysis.cs:56:17:56:25 | [cond2 (line 9): false] ... + ... | 0 | 7 | 8 |
+| ModulusAnalysis.cs:56:21:56:21 | [cond2 (line 9): false] 8 | 0 | 8 | 0 |
+| ModulusAnalysis.cs:56:25:56:25 | [cond2 (line 9): false] 7 | 0 | 7 | 0 |
+| ModulusAnalysis.cs:58:34:58:34 | [cond2 (line 9): false] access to local variable j | 0 | 7 | 8 |
+| ModulusAnalysis.cs:58:34:58:34 | [cond2 (line 9): false] access to local variable j | [cond2 (line 9): false] SSA def(j) | 0 | 0 |
+| ModulusAnalysis.cs:58:34:58:34 | [cond2 (line 9): true] access to local variable j | 0 | 3 | 4 |
+| ModulusAnalysis.cs:58:34:58:34 | [cond2 (line 9): true] access to local variable j | [cond2 (line 9): true] SSA def(j) | 0 | 0 |
 | ModulusAnalysis.cs:62:38:62:38 | access to local variable j | 0 | 3 | 4 |
-| ModulusAnalysis.cs:62:38:62:38 | access to local variable j | [cond (line 9): true] SSA def(j) | 0 | 0 |
+| ModulusAnalysis.cs:62:38:62:38 | access to local variable j | [cond2 (line 9): true] SSA def(j) | 0 | 0 |
 | ModulusAnalysis.cs:66:38:66:38 | access to local variable j | 0 | 7 | 8 |
-| ModulusAnalysis.cs:66:38:66:38 | access to local variable j | [cond (line 9): false] SSA def(j) | 0 | 0 |
+| ModulusAnalysis.cs:66:38:66:38 | access to local variable j | [cond2 (line 9): false] SSA def(j) | 0 | 0 |
 | ModulusAnalysis.cs:69:17:69:18 | 64 | 0 | 64 | 0 |
 | ModulusAnalysis.cs:70:34:70:34 | access to local variable t | 0 | 64 | 0 |
 | ModulusAnalysis.cs:70:34:70:34 | access to local variable t | SSA def(t) | 0 | 0 |
@@ -159,36 +131,51 @@
 | ModulusAnalysis.cs:75:25:75:25 | 3 | 0 | 3 | 0 |
 | ModulusAnalysis.cs:77:38:77:38 | access to parameter x | 0 | 3 | 16 |
 | ModulusAnalysis.cs:77:38:77:38 | access to parameter x | SSA param(x) | 0 | 0 |
-| ModulusAnalysis.cs:83:22:83:22 | 0 | 0 | 0 | 0 |
-| ModulusAnalysis.cs:83:25:83:25 | access to local variable i | SSA phi(i) | 0 | 0 |
-| ModulusAnalysis.cs:83:29:83:31 | access to parameter cap | SSA param(cap) | 0 | 0 |
-| ModulusAnalysis.cs:83:34:83:34 | access to local variable i | SSA phi(i) | 0 | 0 |
-| ModulusAnalysis.cs:83:34:83:36 | ...++ | SSA phi(i) | 0 | 0 |
-| ModulusAnalysis.cs:84:38:84:38 | access to local variable i | SSA phi(i) | 0 | 0 |
-| ModulusAnalysis.cs:86:22:86:22 | 0 | 0 | 0 | 0 |
-| ModulusAnalysis.cs:86:25:86:25 | access to local variable j | SSA phi(j) | 0 | 0 |
-| ModulusAnalysis.cs:86:29:86:31 | access to parameter cap | SSA param(cap) | 0 | 0 |
-| ModulusAnalysis.cs:86:34:86:34 | access to local variable j | SSA phi(j) | 0 | 0 |
-| ModulusAnalysis.cs:86:34:86:39 | ... + ... | SSA phi(j) | 1 | 0 |
-| ModulusAnalysis.cs:86:34:86:39 | ... = ... | SSA phi(j) | 1 | 0 |
-| ModulusAnalysis.cs:86:39:86:39 | 1 | 0 | 1 | 0 |
-| ModulusAnalysis.cs:87:38:87:38 | access to local variable j | SSA phi(j) | 0 | 0 |
+| ModulusAnalysis.cs:80:9:82:23 | [cond3 (line 9): false] ... = ... | 0 | 3 | 4 |
+| ModulusAnalysis.cs:80:9:82:23 | [cond3 (line 9): true] ... = ... | 0 | 3 | 4 |
+| ModulusAnalysis.cs:80:13:82:23 | ... ? ... : ... | 0 | 3 | 4 |
+| ModulusAnalysis.cs:81:15:81:15 | [cond3 (line 9): true] access to parameter i | SSA param(i) | 0 | 0 |
+| ModulusAnalysis.cs:81:15:81:19 | [cond3 (line 9): true] ... * ... | 0 | 0 | 4 |
+| ModulusAnalysis.cs:81:15:81:23 | [cond3 (line 9): true] ... + ... | 0 | 3 | 4 |
+| ModulusAnalysis.cs:81:19:81:19 | [cond3 (line 9): true] 4 | 0 | 4 | 0 |
+| ModulusAnalysis.cs:81:23:81:23 | [cond3 (line 9): true] 3 | 0 | 3 | 0 |
+| ModulusAnalysis.cs:82:15:82:15 | [cond3 (line 9): false] access to parameter i | SSA param(i) | 0 | 0 |
+| ModulusAnalysis.cs:82:15:82:19 | [cond3 (line 9): false] ... * ... | 0 | 0 | 8 |
+| ModulusAnalysis.cs:82:15:82:23 | [cond3 (line 9): false] ... + ... | 0 | 7 | 8 |
+| ModulusAnalysis.cs:82:19:82:19 | [cond3 (line 9): false] 8 | 0 | 8 | 0 |
+| ModulusAnalysis.cs:82:23:82:23 | [cond3 (line 9): false] 7 | 0 | 7 | 0 |
+| ModulusAnalysis.cs:84:38:84:38 | access to local variable j | 0 | 3 | 4 |
+| ModulusAnalysis.cs:84:38:84:38 | access to local variable j | [cond3 (line 9): false] SSA def(j) | 0 | 0 |
 | ModulusAnalysis.cs:89:22:89:22 | 0 | 0 | 0 | 0 |
-| ModulusAnalysis.cs:89:25:89:25 | access to local variable k | 0 | 0 | 3 |
-| ModulusAnalysis.cs:89:25:89:25 | access to local variable k | SSA def(k) | 0 | 3 |
-| ModulusAnalysis.cs:89:25:89:25 | access to local variable k | SSA phi(k) | 0 | 0 |
+| ModulusAnalysis.cs:89:25:89:25 | access to local variable i | SSA phi(i) | 0 | 0 |
 | ModulusAnalysis.cs:89:29:89:31 | access to parameter cap | SSA param(cap) | 0 | 0 |
-| ModulusAnalysis.cs:89:34:89:34 | access to local variable k | 0 | 0 | 3 |
-| ModulusAnalysis.cs:89:34:89:34 | access to local variable k | SSA def(k) | 0 | 3 |
-| ModulusAnalysis.cs:89:34:89:34 | access to local variable k | SSA phi(k) | 0 | 0 |
-| ModulusAnalysis.cs:89:34:89:39 | ... + ... | 0 | 0 | 3 |
-| ModulusAnalysis.cs:89:34:89:39 | ... + ... | SSA def(k) | 0 | 3 |
-| ModulusAnalysis.cs:89:34:89:39 | ... + ... | SSA phi(k) | 3 | 0 |
-| ModulusAnalysis.cs:89:34:89:39 | ... = ... | 0 | 0 | 3 |
-| ModulusAnalysis.cs:89:34:89:39 | ... = ... | SSA def(k) | 0 | 3 |
-| ModulusAnalysis.cs:89:34:89:39 | ... = ... | SSA phi(k) | 3 | 0 |
-| ModulusAnalysis.cs:89:39:89:39 | 3 | 0 | 3 | 0 |
-| ModulusAnalysis.cs:90:38:90:38 | access to local variable k | 0 | 0 | 3 |
-| ModulusAnalysis.cs:90:38:90:38 | access to local variable k | SSA def(k) | 0 | 3 |
-| ModulusAnalysis.cs:90:38:90:38 | access to local variable k | SSA phi(k) | 0 | 0 |
-| ModulusAnalysis.cs:94:39:94:40 | 42 | 0 | 42 | 0 |
+| ModulusAnalysis.cs:89:34:89:34 | access to local variable i | SSA phi(i) | 0 | 0 |
+| ModulusAnalysis.cs:89:34:89:36 | ...++ | SSA phi(i) | 0 | 0 |
+| ModulusAnalysis.cs:90:38:90:38 | access to local variable i | SSA phi(i) | 0 | 0 |
+| ModulusAnalysis.cs:92:22:92:22 | 0 | 0 | 0 | 0 |
+| ModulusAnalysis.cs:92:25:92:25 | access to local variable j | SSA phi(j) | 0 | 0 |
+| ModulusAnalysis.cs:92:29:92:31 | access to parameter cap | SSA param(cap) | 0 | 0 |
+| ModulusAnalysis.cs:92:34:92:34 | access to local variable j | SSA phi(j) | 0 | 0 |
+| ModulusAnalysis.cs:92:34:92:39 | ... + ... | SSA phi(j) | 1 | 0 |
+| ModulusAnalysis.cs:92:34:92:39 | ... = ... | SSA phi(j) | 1 | 0 |
+| ModulusAnalysis.cs:92:39:92:39 | 1 | 0 | 1 | 0 |
+| ModulusAnalysis.cs:93:38:93:38 | access to local variable j | SSA phi(j) | 0 | 0 |
+| ModulusAnalysis.cs:95:22:95:22 | 0 | 0 | 0 | 0 |
+| ModulusAnalysis.cs:95:25:95:25 | access to local variable k | 0 | 0 | 3 |
+| ModulusAnalysis.cs:95:25:95:25 | access to local variable k | SSA def(k) | 0 | 3 |
+| ModulusAnalysis.cs:95:25:95:25 | access to local variable k | SSA phi(k) | 0 | 0 |
+| ModulusAnalysis.cs:95:29:95:31 | access to parameter cap | SSA param(cap) | 0 | 0 |
+| ModulusAnalysis.cs:95:34:95:34 | access to local variable k | 0 | 0 | 3 |
+| ModulusAnalysis.cs:95:34:95:34 | access to local variable k | SSA def(k) | 0 | 3 |
+| ModulusAnalysis.cs:95:34:95:34 | access to local variable k | SSA phi(k) | 0 | 0 |
+| ModulusAnalysis.cs:95:34:95:39 | ... + ... | 0 | 0 | 3 |
+| ModulusAnalysis.cs:95:34:95:39 | ... + ... | SSA def(k) | 0 | 3 |
+| ModulusAnalysis.cs:95:34:95:39 | ... + ... | SSA phi(k) | 3 | 0 |
+| ModulusAnalysis.cs:95:34:95:39 | ... = ... | 0 | 0 | 3 |
+| ModulusAnalysis.cs:95:34:95:39 | ... = ... | SSA def(k) | 0 | 3 |
+| ModulusAnalysis.cs:95:34:95:39 | ... = ... | SSA phi(k) | 3 | 0 |
+| ModulusAnalysis.cs:95:39:95:39 | 3 | 0 | 3 | 0 |
+| ModulusAnalysis.cs:96:38:96:38 | access to local variable k | 0 | 0 | 3 |
+| ModulusAnalysis.cs:96:38:96:38 | access to local variable k | SSA def(k) | 0 | 3 |
+| ModulusAnalysis.cs:96:38:96:38 | access to local variable k | SSA phi(k) | 0 | 0 |
+| ModulusAnalysis.cs:100:39:100:40 | 42 | 0 | 42 | 0 |

--- a/csharp/ql/test/library-tests/dataflow/modulusanalysis/ModulusAnalysis.expected
+++ b/csharp/ql/test/library-tests/dataflow/modulusanalysis/ModulusAnalysis.expected
@@ -131,9 +131,10 @@
 | ModulusAnalysis.cs:75:25:75:25 | 3 | 0 | 3 | 0 |
 | ModulusAnalysis.cs:77:38:77:38 | access to parameter x | 0 | 3 | 16 |
 | ModulusAnalysis.cs:77:38:77:38 | access to parameter x | SSA param(x) | 0 | 0 |
-| ModulusAnalysis.cs:80:9:82:23 | [cond3 (line 9): false] ... = ... | 0 | 3 | 4 |
+| ModulusAnalysis.cs:80:9:82:23 | [cond3 (line 9): false] ... = ... | 0 | 7 | 8 |
 | ModulusAnalysis.cs:80:9:82:23 | [cond3 (line 9): true] ... = ... | 0 | 3 | 4 |
-| ModulusAnalysis.cs:80:13:82:23 | ... ? ... : ... | 0 | 3 | 4 |
+| ModulusAnalysis.cs:80:13:82:23 | [cond3 (line 9): false] ... ? ... : ... | 0 | 7 | 8 |
+| ModulusAnalysis.cs:80:13:82:23 | [cond3 (line 9): true] ... ? ... : ... | 0 | 3 | 4 |
 | ModulusAnalysis.cs:81:15:81:15 | [cond3 (line 9): true] access to parameter i | SSA param(i) | 0 | 0 |
 | ModulusAnalysis.cs:81:15:81:19 | [cond3 (line 9): true] ... * ... | 0 | 0 | 4 |
 | ModulusAnalysis.cs:81:15:81:23 | [cond3 (line 9): true] ... + ... | 0 | 3 | 4 |
@@ -144,7 +145,7 @@
 | ModulusAnalysis.cs:82:15:82:23 | [cond3 (line 9): false] ... + ... | 0 | 7 | 8 |
 | ModulusAnalysis.cs:82:19:82:19 | [cond3 (line 9): false] 8 | 0 | 8 | 0 |
 | ModulusAnalysis.cs:82:23:82:23 | [cond3 (line 9): false] 7 | 0 | 7 | 0 |
-| ModulusAnalysis.cs:84:38:84:38 | access to local variable j | 0 | 3 | 4 |
+| ModulusAnalysis.cs:84:38:84:38 | access to local variable j | 0 | 7 | 8 |
 | ModulusAnalysis.cs:84:38:84:38 | access to local variable j | [cond3 (line 9): false] SSA def(j) | 0 | 0 |
 | ModulusAnalysis.cs:89:22:89:22 | 0 | 0 | 0 | 0 |
 | ModulusAnalysis.cs:89:25:89:25 | access to local variable i | SSA phi(i) | 0 | 0 |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SSAPhi.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SSAPhi.expected
@@ -4,8 +4,8 @@
 | DefUse.cs:6:14:6:14 | y | DefUse.cs:23:9:23:15 | SSA phi(y) | DefUse.cs:18:13:18:18 | SSA def(y) |
 | DefUse.cs:6:14:6:14 | y | DefUse.cs:42:9:42:15 | SSA phi(y) | DefUse.cs:28:13:28:18 | SSA def(y) |
 | DefUse.cs:6:14:6:14 | y | DefUse.cs:42:9:42:15 | SSA phi(y) | DefUse.cs:39:13:39:18 | SSA def(y) |
-| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:16:80:46 | SSA phi(x1) | DefUse.cs:79:13:79:18 | SSA def(x1) |
-| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:16:80:46 | SSA phi(x1) | DefUse.cs:80:30:80:31 | SSA def(x1) |
+| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA phi(x1) | DefUse.cs:79:13:79:18 | SSA def(x1) |
+| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA phi(x1) | DefUse.cs:80:30:80:31 | SSA def(x1) |
 | DefUse.cs:97:13:97:14 | x5 | DefUse.cs:98:16:98:17 | SSA phi(x5) | DefUse.cs:97:13:97:18 | SSA def(x5) |
 | DefUse.cs:97:13:97:14 | x5 | DefUse.cs:98:16:98:17 | SSA phi(x5) | DefUse.cs:101:13:101:23 | SSA def(x5) |
 | Example.cs:8:9:8:18 | this.Field | Example.cs:14:9:14:24 | SSA phi(this.Field) | Example.cs:8:9:8:22 | SSA def(this.Field) |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaDef.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaDef.expected
@@ -125,8 +125,8 @@
 | DefUse.cs:66:9:66:14 | this.Field3 | DefUse.cs:66:9:66:18 | SSA def(this.Field3) |
 | DefUse.cs:67:19:67:20 | tc | DefUse.cs:67:19:67:27 | SSA def(tc) |
 | DefUse.cs:79:13:79:14 | x1 | DefUse.cs:79:13:79:18 | SSA def(x1) |
-| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:16:80:46 | SSA phi(x1) |
 | DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA def(x1) |
+| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA phi(x1) |
 | DefUse.cs:83:13:83:14 | x2 | DefUse.cs:83:13:83:18 | SSA def(x2) |
 | DefUse.cs:83:13:83:14 | x2 | DefUse.cs:85:15:85:16 | SSA def(x2) |
 | DefUse.cs:89:13:89:14 | x3 | DefUse.cs:89:13:89:18 | SSA def(x3) |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaDefLastRead.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaDefLastRead.expected
@@ -96,8 +96,8 @@
 | DefUse.cs:63:9:63:14 | this.Field2 | DefUse.cs:63:9:63:18 | SSA def(this.Field2) | DefUse.cs:80:37:80:42 | access to field Field2 |
 | DefUse.cs:66:9:66:14 | this.Field3 | DefUse.cs:66:9:66:18 | SSA def(this.Field3) | DefUse.cs:69:13:69:18 | access to field Field3 |
 | DefUse.cs:67:19:67:20 | tc | DefUse.cs:67:19:67:27 | SSA def(tc) | DefUse.cs:68:9:68:10 | access to local variable tc |
-| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:16:80:46 | SSA phi(x1) | DefUse.cs:80:30:80:31 | access to local variable x1 |
 | DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA def(x1) | DefUse.cs:81:13:81:14 | access to local variable x1 |
+| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA phi(x1) | DefUse.cs:80:30:80:31 | access to local variable x1 |
 | DefUse.cs:83:13:83:14 | x2 | DefUse.cs:83:13:83:18 | SSA def(x2) | DefUse.cs:85:15:85:16 | access to local variable x2 |
 | DefUse.cs:83:13:83:14 | x2 | DefUse.cs:85:15:85:16 | SSA def(x2) | DefUse.cs:87:13:87:14 | access to local variable x2 |
 | DefUse.cs:89:13:89:14 | x3 | DefUse.cs:89:13:89:18 | SSA def(x3) | DefUse.cs:92:15:92:16 | access to local variable x3 |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaRead.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaRead.expected
@@ -111,8 +111,8 @@
 | DefUse.cs:63:9:63:14 | this.Field2 | DefUse.cs:63:9:63:18 | SSA def(this.Field2) | DefUse.cs:80:37:80:42 | access to field Field2 |
 | DefUse.cs:66:9:66:14 | this.Field3 | DefUse.cs:66:9:66:18 | SSA def(this.Field3) | DefUse.cs:69:13:69:18 | access to field Field3 |
 | DefUse.cs:67:19:67:20 | tc | DefUse.cs:67:19:67:27 | SSA def(tc) | DefUse.cs:68:9:68:10 | access to local variable tc |
-| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:16:80:46 | SSA phi(x1) | DefUse.cs:80:30:80:31 | access to local variable x1 |
 | DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA def(x1) | DefUse.cs:81:13:81:14 | access to local variable x1 |
+| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA phi(x1) | DefUse.cs:80:30:80:31 | access to local variable x1 |
 | DefUse.cs:83:13:83:14 | x2 | DefUse.cs:83:13:83:18 | SSA def(x2) | DefUse.cs:85:15:85:16 | access to local variable x2 |
 | DefUse.cs:83:13:83:14 | x2 | DefUse.cs:85:15:85:16 | SSA def(x2) | DefUse.cs:87:13:87:14 | access to local variable x2 |
 | DefUse.cs:89:13:89:14 | x3 | DefUse.cs:89:13:89:18 | SSA def(x3) | DefUse.cs:92:15:92:16 | access to local variable x3 |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaUltimateDef.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaUltimateDef.expected
@@ -139,9 +139,9 @@
 | DefUse.cs:66:9:66:14 | this.Field3 | DefUse.cs:66:9:66:18 | SSA def(this.Field3) | DefUse.cs:66:9:66:18 | SSA def(this.Field3) |
 | DefUse.cs:67:19:67:20 | tc | DefUse.cs:67:19:67:27 | SSA def(tc) | DefUse.cs:67:19:67:27 | SSA def(tc) |
 | DefUse.cs:79:13:79:14 | x1 | DefUse.cs:79:13:79:18 | SSA def(x1) | DefUse.cs:79:13:79:18 | SSA def(x1) |
-| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:16:80:46 | SSA phi(x1) | DefUse.cs:79:13:79:18 | SSA def(x1) |
-| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:16:80:46 | SSA phi(x1) | DefUse.cs:80:30:80:31 | SSA def(x1) |
 | DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA def(x1) | DefUse.cs:80:30:80:31 | SSA def(x1) |
+| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA phi(x1) | DefUse.cs:79:13:79:18 | SSA def(x1) |
+| DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:30:80:31 | SSA phi(x1) | DefUse.cs:80:30:80:31 | SSA def(x1) |
 | DefUse.cs:83:13:83:14 | x2 | DefUse.cs:83:13:83:18 | SSA def(x2) | DefUse.cs:83:13:83:18 | SSA def(x2) |
 | DefUse.cs:83:13:83:14 | x2 | DefUse.cs:85:15:85:16 | SSA def(x2) | DefUse.cs:85:15:85:16 | SSA def(x2) |
 | DefUse.cs:89:13:89:14 | x3 | DefUse.cs:89:13:89:18 | SSA def(x3) | DefUse.cs:89:13:89:18 | SSA def(x3) |

--- a/csharp/ql/test/query-tests/Bad Practices/Control-Flow/ConstantCondition/ConstantCondition.cs
+++ b/csharp/ql/test/query-tests/Bad Practices/Control-Flow/ConstantCondition/ConstantCondition.cs
@@ -106,6 +106,15 @@ class ConstantMatching
             _ => o.ToString() // GOOD
         };
     }
+
+    void M6(bool b1, bool b2) {
+        if (!b1)
+            return;
+        if (!b2)
+            return;
+        if (b1 && b2) // BAD
+            return;
+    }
 }
 
 class Assertions

--- a/csharp/ql/test/query-tests/Bad Practices/Control-Flow/ConstantCondition/ConstantCondition.expected
+++ b/csharp/ql/test/query-tests/Bad Practices/Control-Flow/ConstantCondition/ConstantCondition.expected
@@ -8,6 +8,8 @@
 | ConstantCondition.cs:66:18:66:18 | 3 | Pattern always matches. |
 | ConstantCondition.cs:77:18:77:20 | access to type Int32 | Pattern never matches. |
 | ConstantCondition.cs:97:13:97:13 | _ | Pattern always matches. |
+| ConstantCondition.cs:115:13:115:14 | access to parameter b1 | Condition always evaluates to 'true'. |
+| ConstantCondition.cs:115:19:115:20 | access to parameter b2 | Condition always evaluates to 'true'. |
 | ConstantConditionBad.cs:5:16:5:20 | ... > ... | Condition always evaluates to 'false'. |
 | ConstantConditionalExpressionCondition.cs:11:22:11:34 | ... == ... | Condition always evaluates to 'true'. |
 | ConstantConditionalExpressionCondition.cs:12:21:12:25 | false | Condition always evaluates to 'false'. |

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -1085,13 +1085,15 @@
 | E.cs:85:18:85:29 | ... != ... | true | E.cs:85:18:85:21 | access to parameter vals | non-null |
 | E.cs:85:18:85:35 | ... && ... | true | E.cs:85:18:85:29 | ... != ... | true |
 | E.cs:85:18:85:35 | ... && ... | true | E.cs:85:34:85:35 | access to parameter b2 | true |
-| E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_A | E.cs:83:13:83:24 | ... != ... | true |
-| E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_A | E.cs:83:29:83:30 | access to parameter b1 | true |
+| E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_A | E.cs:83:13:83:30 | ... && ... | true |
 | E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_A | E.cs:90:17:90:27 | access to local variable switchguard | 1 |
-| E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_B | E.cs:85:18:85:29 | ... != ... | true |
-| E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_B | E.cs:85:34:85:35 | access to parameter b2 | true |
+| E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_B | E.cs:83:13:83:30 | ... && ... | false |
+| E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_B | E.cs:85:18:85:35 | ... && ... | true |
 | E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_B | E.cs:90:17:90:27 | access to local variable switchguard | 2 |
+| E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_C | E.cs:83:13:83:30 | ... && ... | false |
+| E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_C | E.cs:85:18:85:35 | ... && ... | false |
 | E.cs:90:17:90:27 | access to local variable switchguard | match access to constant MY_CONST_C | E.cs:90:17:90:27 | access to local variable switchguard | 3 |
+| E.cs:90:17:90:27 | access to local variable switchguard | non-match access to constant MY_CONST_A | E.cs:83:13:83:30 | ... && ... | false |
 | E.cs:108:13:108:27 | ... > ... | true | E.cs:108:13:108:16 | access to parameter arr1 | non-empty |
 | E.cs:120:16:120:20 | !... | false | E.cs:120:17:120:20 | access to local variable stop | true |
 | E.cs:120:16:120:20 | !... | true | E.cs:120:17:120:20 | access to local variable stop | false |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -46,6 +46,7 @@ nodes
 | B.cs:22:9:24:37 | if (...) ... |
 | B.cs:24:13:24:25 | access to local variable neqCallAlways |
 | C.cs:10:16:10:23 | SSA def(o) |
+| C.cs:11:17:11:28 | [false] !... |
 | C.cs:16:9:19:9 | if (...) ... |
 | C.cs:18:13:18:13 | access to local variable o |
 | C.cs:40:13:40:35 | SSA def(s) |
@@ -107,10 +108,10 @@ nodes
 | D.cs:61:9:62:26 | if (...) ... |
 | D.cs:62:13:62:14 | access to local variable o5 |
 | D.cs:68:13:68:34 | SSA def(o7) |
-| D.cs:69:13:69:36 | Boolean ok = ... |
+| D.cs:69:18:69:36 | ... && ... |
 | D.cs:73:13:73:14 | access to local variable o7 |
 | D.cs:75:13:75:34 | SSA def(o8) |
-| D.cs:76:13:76:43 | Int32 track = ... |
+| D.cs:76:21:76:43 | ... ? ... : ... |
 | D.cs:76:34:76:35 | 42 |
 | D.cs:79:9:80:26 | if (...) ... |
 | D.cs:81:9:82:26 | if (...) ... |
@@ -140,13 +141,13 @@ nodes
 | D.cs:125:35:125:35 | SSA param(a) |
 | D.cs:125:35:125:35 | SSA param(a) |
 | D.cs:125:44:125:44 | SSA param(b) |
-| D.cs:127:13:127:43 | Int32 alen = ... |
-| D.cs:127:13:127:43 | Int32 alen = ... |
+| D.cs:127:20:127:43 | ... ? ... : ... |
+| D.cs:127:20:127:43 | ... ? ... : ... |
 | D.cs:127:32:127:32 | 0 |
 | D.cs:127:32:127:32 | 0 |
 | D.cs:127:36:127:36 | access to parameter a |
-| D.cs:128:13:128:43 | Int32 blen = ... |
-| D.cs:128:13:128:43 | Int32 blen = ... |
+| D.cs:128:20:128:43 | ... ? ... : ... |
+| D.cs:128:20:128:43 | ... ? ... : ... |
 | D.cs:128:32:128:32 | 0 |
 | D.cs:128:32:128:32 | 0 |
 | D.cs:128:36:128:36 | access to parameter b |
@@ -170,7 +171,7 @@ nodes
 | D.cs:168:9:170:9 | [exception: Exception] catch (...) {...} |
 | D.cs:171:9:171:11 | access to local variable obj |
 | D.cs:240:9:240:16 | SSA def(o) |
-| D.cs:241:13:241:37 | String other = ... |
+| D.cs:241:21:241:37 | ... ? ... : ... |
 | D.cs:241:29:241:32 | null |
 | D.cs:241:36:241:37 | "" |
 | D.cs:244:9:247:25 | if (...) ... |
@@ -203,7 +204,7 @@ nodes
 | D.cs:312:13:313:29 | if (...) ... |
 | D.cs:313:17:313:17 | access to local variable s |
 | D.cs:316:16:316:23 | SSA def(r) |
-| D.cs:318:16:318:62 | ... && ... |
+| D.cs:318:16:318:19 | access to local variable stat |
 | D.cs:318:41:318:44 | access to local variable stat |
 | D.cs:324:9:324:9 | access to local variable r |
 | D.cs:351:15:351:22 | SSA def(a) |
@@ -215,7 +216,7 @@ nodes
 | D.cs:361:29:361:29 | access to local variable i |
 | D.cs:363:13:363:16 | access to local variable last |
 | D.cs:366:15:366:47 | SSA def(b) |
-| D.cs:370:9:373:9 | for (...;...;...) ... |
+| D.cs:367:13:367:56 | [false] ... && ... |
 | D.cs:370:25:370:25 | access to local variable i |
 | D.cs:371:9:373:9 | {...} |
 | D.cs:372:13:372:13 | access to local variable b |
@@ -224,8 +225,8 @@ nodes
 | D.cs:385:13:385:15 | access to local variable ioe |
 | D.cs:388:36:388:36 | SSA param(a) |
 | D.cs:388:45:388:45 | SSA param(b) |
-| D.cs:390:13:390:43 | Int32 alen = ... |
-| D.cs:390:13:390:43 | Int32 alen = ... |
+| D.cs:390:20:390:43 | ... ? ... : ... |
+| D.cs:390:20:390:43 | ... ? ... : ... |
 | D.cs:390:32:390:32 | 0 |
 | D.cs:390:32:390:32 | 0 |
 | D.cs:390:36:390:36 | access to parameter a |
@@ -235,7 +236,7 @@ nodes
 | D.cs:394:9:396:9 | {...} |
 | D.cs:395:20:395:20 | access to parameter a |
 | D.cs:397:9:397:44 | ... ...; |
-| D.cs:397:13:397:43 | Int32 blen = ... |
+| D.cs:397:20:397:43 | ... ? ... : ... |
 | D.cs:397:32:397:32 | 0 |
 | D.cs:398:21:398:21 | access to local variable i |
 | D.cs:399:9:401:9 | {...} |
@@ -246,23 +247,23 @@ nodes
 | D.cs:405:45:405:45 | SSA param(y) |
 | D.cs:405:45:405:45 | SSA param(y) |
 | D.cs:405:45:405:45 | SSA param(y) |
-| D.cs:407:42:407:63 | ... && ... |
-| D.cs:407:42:407:63 | ... && ... |
+| D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:407:42:407:63 | [false] ... && ... |
+| D.cs:407:42:407:63 | [false] ... && ... |
 | D.cs:407:55:407:55 | access to parameter y |
 | D.cs:407:55:407:55 | access to parameter y |
-| D.cs:409:9:410:25 | if (...) ... |
-| D.cs:409:9:410:25 | if (...) ... |
 | D.cs:410:13:410:13 | access to parameter y |
 | D.cs:411:9:412:25 | if (...) ... |
 | D.cs:412:13:412:13 | access to parameter x |
 | E.cs:9:18:9:26 | SSA def(a2) |
-| E.cs:10:13:10:54 | Boolean haveA2 = ... |
+| E.cs:10:22:10:54 | ... && ... |
 | E.cs:11:16:11:24 | SSA def(a3) |
-| E.cs:12:13:12:52 | Boolean haveA3 = ... |
+| E.cs:12:22:12:52 | ... && ... |
 | E.cs:12:38:12:39 | access to local variable a2 |
 | E.cs:14:13:14:14 | access to local variable a3 |
 | E.cs:23:13:23:30 | SSA def(s1) |
-| E.cs:24:13:24:41 | ... = ... |
+| E.cs:24:18:24:41 | ... ? ... : ... |
 | E.cs:24:33:24:36 | null |
 | E.cs:26:9:27:26 | if (...) ... |
 | E.cs:27:13:27:14 | access to local variable s1 |
@@ -272,8 +273,8 @@ nodes
 | E.cs:61:13:61:17 | access to local variable slice |
 | E.cs:61:13:61:27 | ...; |
 | E.cs:66:40:66:42 | SSA param(arr) |
-| E.cs:70:13:70:49 | ... = ... |
 | E.cs:70:13:70:50 | ...; |
+| E.cs:70:22:70:49 | ... ? ... : ... |
 | E.cs:70:36:70:36 | 0 |
 | E.cs:72:9:73:23 | if (...) ... |
 | E.cs:73:13:73:15 | access to parameter arr |
@@ -282,21 +283,24 @@ nodes
 | E.cs:111:25:111:25 | access to local variable i |
 | E.cs:112:13:112:16 | access to local variable arr2 |
 | E.cs:112:13:112:30 | ...; |
-| E.cs:120:16:120:20 | !... |
-| E.cs:121:9:143:9 | {...} |
-| E.cs:123:20:123:35 | ... && ... |
-| E.cs:123:29:123:29 | access to local variable j |
-| E.cs:124:13:142:13 | {...} |
+| E.cs:120:16:120:20 | [true] !... |
+| E.cs:120:17:120:20 | access to local variable stop |
+| E.cs:123:20:123:24 | [false] !... |
+| E.cs:123:20:123:24 | [true] !... |
+| E.cs:123:20:123:35 | [false] ... && ... |
+| E.cs:123:20:123:35 | [true] ... && ... |
+| E.cs:123:21:123:24 | access to local variable stop |
 | E.cs:125:33:125:35 | access to local variable obj |
 | E.cs:128:21:128:23 | access to local variable obj |
 | E.cs:137:25:137:34 | SSA def(obj) |
 | E.cs:139:21:139:29 | continue; |
 | E.cs:141:17:141:26 | ...; |
 | E.cs:152:16:152:26 | SSA def(obj2) |
+| E.cs:153:13:153:54 | [false] ... && ... |
 | E.cs:158:9:159:28 | if (...) ... |
 | E.cs:159:13:159:16 | access to local variable obj2 |
 | E.cs:162:28:162:28 | SSA param(a) |
-| E.cs:164:13:164:40 | Int32 n = ... |
+| E.cs:164:17:164:40 | ... ? ... : ... |
 | E.cs:164:29:164:29 | 0 |
 | E.cs:165:25:165:25 | access to local variable i |
 | E.cs:165:32:165:32 | access to local variable i |
@@ -304,7 +308,7 @@ nodes
 | E.cs:167:21:167:21 | access to parameter a |
 | E.cs:173:29:173:31 | SSA param(obj) |
 | E.cs:173:29:173:31 | SSA param(obj) |
-| E.cs:175:14:175:42 | Boolean b2 = ... |
+| E.cs:175:19:175:42 | ... ? ... : ... |
 | E.cs:175:33:175:37 | false |
 | E.cs:177:9:179:9 | {...} |
 | E.cs:178:13:178:15 | access to parameter obj |
@@ -337,8 +341,8 @@ nodes
 | E.cs:301:13:301:27 | SSA def(s) |
 | E.cs:302:9:302:9 | access to local variable s |
 | E.cs:319:29:319:30 | SSA param(s1) |
+| E.cs:321:14:321:21 | ... ?? ... |
 | E.cs:321:20:321:21 | access to parameter s2 |
-| E.cs:321:27:321:30 | null |
 | E.cs:323:13:323:14 | access to parameter s1 |
 | E.cs:330:13:330:36 | SSA def(x) |
 | E.cs:331:9:331:9 | access to local variable x |
@@ -356,12 +360,12 @@ nodes
 | E.cs:380:30:380:31 | SSA param(e2) |
 | E.cs:380:30:380:31 | SSA param(e2) |
 | E.cs:380:30:380:31 | SSA param(e2) |
+| E.cs:382:14:382:37 | [false] ... && ... |
+| E.cs:382:14:382:37 | [false] ... && ... |
 | E.cs:382:28:382:29 | access to parameter e2 |
 | E.cs:382:28:382:29 | access to parameter e2 |
-| E.cs:382:44:382:67 | ... && ... |
-| E.cs:382:44:382:67 | ... && ... |
-| E.cs:384:9:385:24 | if (...) ... |
-| E.cs:384:9:385:24 | if (...) ... |
+| E.cs:382:44:382:67 | [false] ... && ... |
+| E.cs:382:44:382:67 | [false] ... && ... |
 | E.cs:384:27:384:28 | access to parameter e2 |
 | E.cs:386:16:386:17 | access to parameter e1 |
 | E.cs:386:27:386:28 | access to parameter e2 |
@@ -369,8 +373,10 @@ nodes
 | E.cs:404:9:404:18 | SSA def(i) |
 | E.cs:405:16:405:16 | access to local variable i |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
+| Forwarding.cs:9:13:9:30 | [false] !... |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... |
+| Forwarding.cs:19:13:19:23 | [false] !... |
 | Forwarding.cs:24:9:27:9 | if (...) ... |
 | Forwarding.cs:29:9:32:9 | if (...) ... |
 | Forwarding.cs:34:9:37:9 | if (...) ... |
@@ -378,7 +384,9 @@ nodes
 | Forwarding.cs:36:31:36:31 | access to local variable s |
 | Forwarding.cs:40:27:40:27 | access to local variable s |
 | GuardedString.cs:7:16:7:32 | SSA def(s) |
+| GuardedString.cs:9:13:9:36 | [false] !... |
 | GuardedString.cs:14:9:17:9 | if (...) ... |
+| GuardedString.cs:14:13:14:41 | [false] !... |
 | GuardedString.cs:19:9:20:40 | if (...) ... |
 | GuardedString.cs:19:26:19:26 | 0 |
 | GuardedString.cs:22:9:23:40 | if (...) ... |
@@ -432,7 +440,8 @@ edges
 | B.cs:18:25:18:27 | {...} | B.cs:22:9:24:37 | if (...) ... |
 | B.cs:20:13:20:26 | ...; | B.cs:22:9:24:37 | if (...) ... |
 | B.cs:22:9:24:37 | if (...) ... | B.cs:24:13:24:25 | access to local variable neqCallAlways |
-| C.cs:10:16:10:23 | SSA def(o) | C.cs:16:9:19:9 | if (...) ... |
+| C.cs:10:16:10:23 | SSA def(o) | C.cs:11:17:11:28 | [false] !... |
+| C.cs:11:17:11:28 | [false] !... | C.cs:16:9:19:9 | if (...) ... |
 | C.cs:16:9:19:9 | if (...) ... | C.cs:18:13:18:13 | access to local variable o |
 | C.cs:40:13:40:35 | SSA def(s) | C.cs:42:9:42:9 | access to local variable s |
 | C.cs:55:13:55:36 | SSA def(o2) | C.cs:57:9:57:10 | access to local variable o2 |
@@ -471,11 +480,11 @@ edges
 | D.cs:26:32:26:36 | SSA param(param) | D.cs:32:9:32:13 | access to parameter param |
 | D.cs:58:13:58:41 | SSA def(o5) | D.cs:61:9:62:26 | if (...) ... |
 | D.cs:61:9:62:26 | if (...) ... | D.cs:62:13:62:14 | access to local variable o5 |
-| D.cs:68:13:68:34 | SSA def(o7) | D.cs:69:13:69:36 | Boolean ok = ... |
-| D.cs:69:13:69:36 | Boolean ok = ... | D.cs:73:13:73:14 | access to local variable o7 |
+| D.cs:68:13:68:34 | SSA def(o7) | D.cs:69:18:69:36 | ... && ... |
+| D.cs:69:18:69:36 | ... && ... | D.cs:73:13:73:14 | access to local variable o7 |
 | D.cs:75:13:75:34 | SSA def(o8) | D.cs:76:34:76:35 | 42 |
-| D.cs:76:13:76:43 | Int32 track = ... | D.cs:79:9:80:26 | if (...) ... |
-| D.cs:76:34:76:35 | 42 | D.cs:76:13:76:43 | Int32 track = ... |
+| D.cs:76:21:76:43 | ... ? ... : ... | D.cs:79:9:80:26 | if (...) ... |
+| D.cs:76:34:76:35 | 42 | D.cs:76:21:76:43 | ... ? ... : ... |
 | D.cs:79:9:80:26 | if (...) ... | D.cs:81:9:82:26 | if (...) ... |
 | D.cs:81:9:82:26 | if (...) ... | D.cs:82:13:82:14 | access to local variable o8 |
 | D.cs:81:9:82:26 | if (...) ... | D.cs:82:13:82:26 | ...; |
@@ -508,18 +517,18 @@ edges
 | D.cs:125:35:125:35 | SSA param(a) | D.cs:127:32:127:32 | 0 |
 | D.cs:125:44:125:44 | SSA param(b) | D.cs:127:32:127:32 | 0 |
 | D.cs:125:44:125:44 | SSA param(b) | D.cs:127:36:127:36 | access to parameter a |
-| D.cs:127:13:127:43 | Int32 alen = ... | D.cs:128:32:128:32 | 0 |
-| D.cs:127:13:127:43 | Int32 alen = ... | D.cs:128:32:128:32 | 0 |
-| D.cs:127:13:127:43 | Int32 alen = ... | D.cs:128:36:128:36 | access to parameter b |
-| D.cs:127:32:127:32 | 0 | D.cs:127:13:127:43 | Int32 alen = ... |
-| D.cs:127:32:127:32 | 0 | D.cs:127:13:127:43 | Int32 alen = ... |
-| D.cs:127:36:127:36 | access to parameter a | D.cs:127:13:127:43 | Int32 alen = ... |
-| D.cs:128:13:128:43 | Int32 blen = ... | D.cs:131:9:137:9 | {...} |
-| D.cs:128:13:128:43 | Int32 blen = ... | D.cs:131:9:137:9 | {...} |
-| D.cs:128:13:128:43 | Int32 blen = ... | D.cs:138:9:138:18 | ... ...; |
-| D.cs:128:32:128:32 | 0 | D.cs:128:13:128:43 | Int32 blen = ... |
-| D.cs:128:32:128:32 | 0 | D.cs:128:13:128:43 | Int32 blen = ... |
-| D.cs:128:36:128:36 | access to parameter b | D.cs:128:13:128:43 | Int32 blen = ... |
+| D.cs:127:20:127:43 | ... ? ... : ... | D.cs:128:32:128:32 | 0 |
+| D.cs:127:20:127:43 | ... ? ... : ... | D.cs:128:32:128:32 | 0 |
+| D.cs:127:20:127:43 | ... ? ... : ... | D.cs:128:36:128:36 | access to parameter b |
+| D.cs:127:32:127:32 | 0 | D.cs:127:20:127:43 | ... ? ... : ... |
+| D.cs:127:32:127:32 | 0 | D.cs:127:20:127:43 | ... ? ... : ... |
+| D.cs:127:36:127:36 | access to parameter a | D.cs:127:20:127:43 | ... ? ... : ... |
+| D.cs:128:20:128:43 | ... ? ... : ... | D.cs:131:9:137:9 | {...} |
+| D.cs:128:20:128:43 | ... ? ... : ... | D.cs:131:9:137:9 | {...} |
+| D.cs:128:20:128:43 | ... ? ... : ... | D.cs:138:9:138:18 | ... ...; |
+| D.cs:128:32:128:32 | 0 | D.cs:128:20:128:43 | ... ? ... : ... |
+| D.cs:128:32:128:32 | 0 | D.cs:128:20:128:43 | ... ? ... : ... |
+| D.cs:128:36:128:36 | access to parameter b | D.cs:128:20:128:43 | ... ? ... : ... |
 | D.cs:131:9:137:9 | {...} | D.cs:132:29:132:29 | access to local variable i |
 | D.cs:131:9:137:9 | {...} | D.cs:132:29:132:29 | access to local variable i |
 | D.cs:132:29:132:29 | access to local variable i | D.cs:133:13:136:13 | {...} |
@@ -540,9 +549,9 @@ edges
 | D.cs:168:9:170:9 | [exception: Exception] catch (...) {...} | D.cs:171:9:171:11 | access to local variable obj |
 | D.cs:240:9:240:16 | SSA def(o) | D.cs:241:29:241:32 | null |
 | D.cs:240:9:240:16 | SSA def(o) | D.cs:241:36:241:37 | "" |
-| D.cs:241:13:241:37 | String other = ... | D.cs:244:9:247:25 | if (...) ... |
-| D.cs:241:29:241:32 | null | D.cs:241:13:241:37 | String other = ... |
-| D.cs:241:36:241:37 | "" | D.cs:241:13:241:37 | String other = ... |
+| D.cs:241:21:241:37 | ... ? ... : ... | D.cs:244:9:247:25 | if (...) ... |
+| D.cs:241:29:241:32 | null | D.cs:241:21:241:37 | ... ? ... : ... |
+| D.cs:241:36:241:37 | "" | D.cs:241:21:241:37 | ... ? ... : ... |
 | D.cs:244:9:247:25 | if (...) ... | D.cs:245:13:245:13 | access to local variable o |
 | D.cs:244:9:247:25 | if (...) ... | D.cs:247:13:247:13 | access to local variable o |
 | D.cs:249:13:249:38 | SSA def(o2) | D.cs:253:13:253:14 | access to local variable o2 |
@@ -569,9 +578,9 @@ edges
 | D.cs:304:16:304:23 | SSA def(s) | D.cs:307:13:311:13 | foreach (... ... in ...) ... |
 | D.cs:307:13:311:13 | foreach (... ... in ...) ... | D.cs:312:13:313:29 | if (...) ... |
 | D.cs:312:13:313:29 | if (...) ... | D.cs:313:17:313:17 | access to local variable s |
-| D.cs:316:16:316:23 | SSA def(r) | D.cs:318:16:318:62 | ... && ... |
-| D.cs:318:16:318:62 | ... && ... | D.cs:318:41:318:44 | access to local variable stat |
-| D.cs:318:16:318:62 | ... && ... | D.cs:324:9:324:9 | access to local variable r |
+| D.cs:316:16:316:23 | SSA def(r) | D.cs:318:16:318:19 | access to local variable stat |
+| D.cs:318:16:318:19 | access to local variable stat | D.cs:318:41:318:44 | access to local variable stat |
+| D.cs:318:16:318:19 | access to local variable stat | D.cs:324:9:324:9 | access to local variable r |
 | D.cs:318:41:318:44 | access to local variable stat | D.cs:324:9:324:9 | access to local variable r |
 | D.cs:351:15:351:22 | SSA def(a) | D.cs:355:9:356:21 | for (...;...;...) ... |
 | D.cs:355:9:356:21 | for (...;...;...) ... | D.cs:355:25:355:25 | access to local variable i |
@@ -580,8 +589,8 @@ edges
 | D.cs:356:13:356:21 | ...; | D.cs:355:25:355:25 | access to local variable i |
 | D.cs:360:20:360:30 | SSA def(last) | D.cs:361:29:361:29 | access to local variable i |
 | D.cs:361:29:361:29 | access to local variable i | D.cs:363:13:363:16 | access to local variable last |
-| D.cs:366:15:366:47 | SSA def(b) | D.cs:370:9:373:9 | for (...;...;...) ... |
-| D.cs:370:9:373:9 | for (...;...;...) ... | D.cs:370:25:370:25 | access to local variable i |
+| D.cs:366:15:366:47 | SSA def(b) | D.cs:367:13:367:56 | [false] ... && ... |
+| D.cs:367:13:367:56 | [false] ... && ... | D.cs:370:25:370:25 | access to local variable i |
 | D.cs:370:25:370:25 | access to local variable i | D.cs:371:9:373:9 | {...} |
 | D.cs:370:25:370:25 | access to local variable i | D.cs:372:13:372:13 | access to local variable b |
 | D.cs:371:9:373:9 | {...} | D.cs:370:25:370:25 | access to local variable i |
@@ -590,11 +599,11 @@ edges
 | D.cs:388:36:388:36 | SSA param(a) | D.cs:390:32:390:32 | 0 |
 | D.cs:388:45:388:45 | SSA param(b) | D.cs:390:32:390:32 | 0 |
 | D.cs:388:45:388:45 | SSA param(b) | D.cs:390:36:390:36 | access to parameter a |
-| D.cs:390:13:390:43 | Int32 alen = ... | D.cs:393:21:393:21 | access to local variable i |
-| D.cs:390:13:390:43 | Int32 alen = ... | D.cs:393:21:393:21 | access to local variable i |
-| D.cs:390:32:390:32 | 0 | D.cs:390:13:390:43 | Int32 alen = ... |
-| D.cs:390:32:390:32 | 0 | D.cs:390:13:390:43 | Int32 alen = ... |
-| D.cs:390:36:390:36 | access to parameter a | D.cs:390:13:390:43 | Int32 alen = ... |
+| D.cs:390:20:390:43 | ... ? ... : ... | D.cs:393:21:393:21 | access to local variable i |
+| D.cs:390:20:390:43 | ... ? ... : ... | D.cs:393:21:393:21 | access to local variable i |
+| D.cs:390:32:390:32 | 0 | D.cs:390:20:390:43 | ... ? ... : ... |
+| D.cs:390:32:390:32 | 0 | D.cs:390:20:390:43 | ... ? ... : ... |
+| D.cs:390:36:390:36 | access to parameter a | D.cs:390:20:390:43 | ... ? ... : ... |
 | D.cs:393:21:393:21 | access to local variable i | D.cs:394:9:396:9 | {...} |
 | D.cs:393:21:393:21 | access to local variable i | D.cs:394:9:396:9 | {...} |
 | D.cs:393:21:393:21 | access to local variable i | D.cs:395:20:395:20 | access to parameter a |
@@ -602,32 +611,32 @@ edges
 | D.cs:394:9:396:9 | {...} | D.cs:393:21:393:21 | access to local variable i |
 | D.cs:394:9:396:9 | {...} | D.cs:393:21:393:21 | access to local variable i |
 | D.cs:397:9:397:44 | ... ...; | D.cs:397:32:397:32 | 0 |
-| D.cs:397:13:397:43 | Int32 blen = ... | D.cs:398:21:398:21 | access to local variable i |
-| D.cs:397:32:397:32 | 0 | D.cs:397:13:397:43 | Int32 blen = ... |
+| D.cs:397:20:397:43 | ... ? ... : ... | D.cs:398:21:398:21 | access to local variable i |
+| D.cs:397:32:397:32 | 0 | D.cs:397:20:397:43 | ... ? ... : ... |
 | D.cs:398:21:398:21 | access to local variable i | D.cs:399:9:401:9 | {...} |
 | D.cs:398:21:398:21 | access to local variable i | D.cs:400:20:400:20 | access to parameter b |
 | D.cs:399:9:401:9 | {...} | D.cs:398:21:398:21 | access to local variable i |
-| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:42:407:63 | ... && ... |
-| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:42:407:63 | ... && ... |
-| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:42:407:63 | ... && ... |
-| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:42:407:63 | ... && ... |
-| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:42:407:63 | ... && ... |
-| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:42:407:63 | ... && ... |
-| D.cs:407:42:407:63 | ... && ... | D.cs:407:55:407:55 | access to parameter y |
-| D.cs:407:42:407:63 | ... && ... | D.cs:407:55:407:55 | access to parameter y |
-| D.cs:407:42:407:63 | ... && ... | D.cs:409:9:410:25 | if (...) ... |
-| D.cs:407:55:407:55 | access to parameter y | D.cs:409:9:410:25 | if (...) ... |
-| D.cs:407:55:407:55 | access to parameter y | D.cs:409:9:410:25 | if (...) ... |
-| D.cs:409:9:410:25 | if (...) ... | D.cs:410:13:410:13 | access to parameter y |
-| D.cs:409:9:410:25 | if (...) ... | D.cs:411:9:412:25 | if (...) ... |
+| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:407:14:407:35 | [false] ... && ... | D.cs:407:42:407:63 | [false] ... && ... |
+| D.cs:407:14:407:35 | [false] ... && ... | D.cs:407:55:407:55 | access to parameter y |
+| D.cs:407:14:407:35 | [false] ... && ... | D.cs:407:55:407:55 | access to parameter y |
+| D.cs:407:42:407:63 | [false] ... && ... | D.cs:410:13:410:13 | access to parameter y |
+| D.cs:407:42:407:63 | [false] ... && ... | D.cs:411:9:412:25 | if (...) ... |
+| D.cs:407:55:407:55 | access to parameter y | D.cs:407:42:407:63 | [false] ... && ... |
+| D.cs:407:55:407:55 | access to parameter y | D.cs:407:42:407:63 | [false] ... && ... |
 | D.cs:411:9:412:25 | if (...) ... | D.cs:412:13:412:13 | access to parameter x |
-| E.cs:9:18:9:26 | SSA def(a2) | E.cs:10:13:10:54 | Boolean haveA2 = ... |
-| E.cs:10:13:10:54 | Boolean haveA2 = ... | E.cs:12:38:12:39 | access to local variable a2 |
-| E.cs:11:16:11:24 | SSA def(a3) | E.cs:12:13:12:52 | Boolean haveA3 = ... |
-| E.cs:12:13:12:52 | Boolean haveA3 = ... | E.cs:14:13:14:14 | access to local variable a3 |
+| E.cs:9:18:9:26 | SSA def(a2) | E.cs:10:22:10:54 | ... && ... |
+| E.cs:10:22:10:54 | ... && ... | E.cs:12:38:12:39 | access to local variable a2 |
+| E.cs:11:16:11:24 | SSA def(a3) | E.cs:12:22:12:52 | ... && ... |
+| E.cs:12:22:12:52 | ... && ... | E.cs:14:13:14:14 | access to local variable a3 |
 | E.cs:23:13:23:30 | SSA def(s1) | E.cs:24:33:24:36 | null |
-| E.cs:24:13:24:41 | ... = ... | E.cs:26:9:27:26 | if (...) ... |
-| E.cs:24:33:24:36 | null | E.cs:24:13:24:41 | ... = ... |
+| E.cs:24:18:24:41 | ... ? ... : ... | E.cs:26:9:27:26 | if (...) ... |
+| E.cs:24:33:24:36 | null | E.cs:24:18:24:41 | ... ? ... : ... |
 | E.cs:26:9:27:26 | if (...) ... | E.cs:27:13:27:14 | access to local variable s1 |
 | E.cs:51:22:51:33 | SSA def(slice) | E.cs:53:16:53:19 | access to local variable iter |
 | E.cs:53:16:53:19 | access to local variable iter | E.cs:54:9:63:9 | {...} |
@@ -636,42 +645,45 @@ edges
 | E.cs:61:13:61:27 | ...; | E.cs:53:16:53:19 | access to local variable iter |
 | E.cs:66:40:66:42 | SSA param(arr) | E.cs:70:13:70:50 | ...; |
 | E.cs:66:40:66:42 | SSA param(arr) | E.cs:72:9:73:23 | if (...) ... |
-| E.cs:70:13:70:49 | ... = ... | E.cs:72:9:73:23 | if (...) ... |
 | E.cs:70:13:70:50 | ...; | E.cs:70:36:70:36 | 0 |
-| E.cs:70:36:70:36 | 0 | E.cs:70:13:70:49 | ... = ... |
+| E.cs:70:22:70:49 | ... ? ... : ... | E.cs:72:9:73:23 | if (...) ... |
+| E.cs:70:36:70:36 | 0 | E.cs:70:22:70:49 | ... ? ... : ... |
 | E.cs:72:9:73:23 | if (...) ... | E.cs:73:13:73:15 | access to parameter arr |
 | E.cs:107:15:107:25 | SSA def(arr2) | E.cs:111:9:112:30 | for (...;...;...) ... |
 | E.cs:111:9:112:30 | for (...;...;...) ... | E.cs:111:25:111:25 | access to local variable i |
 | E.cs:111:25:111:25 | access to local variable i | E.cs:112:13:112:16 | access to local variable arr2 |
 | E.cs:111:25:111:25 | access to local variable i | E.cs:112:13:112:30 | ...; |
 | E.cs:112:13:112:30 | ...; | E.cs:111:25:111:25 | access to local variable i |
-| E.cs:120:16:120:20 | !... | E.cs:121:9:143:9 | {...} |
-| E.cs:121:9:143:9 | {...} | E.cs:123:20:123:35 | ... && ... |
-| E.cs:123:20:123:35 | ... && ... | E.cs:120:16:120:20 | !... |
-| E.cs:123:20:123:35 | ... && ... | E.cs:123:29:123:29 | access to local variable j |
-| E.cs:123:29:123:29 | access to local variable j | E.cs:120:16:120:20 | !... |
-| E.cs:123:29:123:29 | access to local variable j | E.cs:124:13:142:13 | {...} |
-| E.cs:123:29:123:29 | access to local variable j | E.cs:125:33:125:35 | access to local variable obj |
-| E.cs:124:13:142:13 | {...} | E.cs:128:21:128:23 | access to local variable obj |
-| E.cs:124:13:142:13 | {...} | E.cs:141:17:141:26 | ...; |
+| E.cs:120:16:120:20 | [true] !... | E.cs:123:21:123:24 | access to local variable stop |
+| E.cs:120:17:120:20 | access to local variable stop | E.cs:120:16:120:20 | [true] !... |
+| E.cs:123:20:123:24 | [false] !... | E.cs:123:20:123:35 | [false] ... && ... |
+| E.cs:123:20:123:24 | [true] !... | E.cs:123:20:123:35 | [false] ... && ... |
+| E.cs:123:20:123:24 | [true] !... | E.cs:123:20:123:35 | [true] ... && ... |
+| E.cs:123:20:123:24 | [true] !... | E.cs:125:33:125:35 | access to local variable obj |
+| E.cs:123:20:123:35 | [false] ... && ... | E.cs:120:17:120:20 | access to local variable stop |
+| E.cs:123:20:123:35 | [true] ... && ... | E.cs:128:21:128:23 | access to local variable obj |
+| E.cs:123:20:123:35 | [true] ... && ... | E.cs:141:17:141:26 | ...; |
+| E.cs:123:21:123:24 | access to local variable stop | E.cs:123:20:123:24 | [false] !... |
+| E.cs:123:21:123:24 | access to local variable stop | E.cs:123:20:123:24 | [true] !... |
 | E.cs:137:25:137:34 | SSA def(obj) | E.cs:139:21:139:29 | continue; |
-| E.cs:139:21:139:29 | continue; | E.cs:123:20:123:35 | ... && ... |
-| E.cs:141:17:141:26 | ...; | E.cs:123:20:123:35 | ... && ... |
-| E.cs:152:16:152:26 | SSA def(obj2) | E.cs:158:9:159:28 | if (...) ... |
+| E.cs:139:21:139:29 | continue; | E.cs:123:21:123:24 | access to local variable stop |
+| E.cs:141:17:141:26 | ...; | E.cs:123:21:123:24 | access to local variable stop |
+| E.cs:152:16:152:26 | SSA def(obj2) | E.cs:153:13:153:54 | [false] ... && ... |
+| E.cs:153:13:153:54 | [false] ... && ... | E.cs:158:9:159:28 | if (...) ... |
 | E.cs:158:9:159:28 | if (...) ... | E.cs:159:13:159:16 | access to local variable obj2 |
 | E.cs:162:28:162:28 | SSA param(a) | E.cs:164:29:164:29 | 0 |
-| E.cs:164:13:164:40 | Int32 n = ... | E.cs:165:25:165:25 | access to local variable i |
-| E.cs:164:29:164:29 | 0 | E.cs:164:13:164:40 | Int32 n = ... |
+| E.cs:164:17:164:40 | ... ? ... : ... | E.cs:165:25:165:25 | access to local variable i |
+| E.cs:164:29:164:29 | 0 | E.cs:164:17:164:40 | ... ? ... : ... |
 | E.cs:165:25:165:25 | access to local variable i | E.cs:166:9:170:9 | {...} |
 | E.cs:165:25:165:25 | access to local variable i | E.cs:167:21:167:21 | access to parameter a |
 | E.cs:165:32:165:32 | access to local variable i | E.cs:165:25:165:25 | access to local variable i |
 | E.cs:166:9:170:9 | {...} | E.cs:165:32:165:32 | access to local variable i |
 | E.cs:173:29:173:31 | SSA param(obj) | E.cs:175:33:175:37 | false |
 | E.cs:173:29:173:31 | SSA param(obj) | E.cs:175:33:175:37 | false |
-| E.cs:175:14:175:42 | Boolean b2 = ... | E.cs:177:9:179:9 | {...} |
-| E.cs:175:14:175:42 | Boolean b2 = ... | E.cs:178:13:178:15 | access to parameter obj |
-| E.cs:175:14:175:42 | Boolean b2 = ... | E.cs:180:9:183:9 | if (...) ... |
-| E.cs:175:33:175:37 | false | E.cs:175:14:175:42 | Boolean b2 = ... |
+| E.cs:175:19:175:42 | ... ? ... : ... | E.cs:177:9:179:9 | {...} |
+| E.cs:175:19:175:42 | ... ? ... : ... | E.cs:178:13:178:15 | access to parameter obj |
+| E.cs:175:19:175:42 | ... ? ... : ... | E.cs:180:9:183:9 | if (...) ... |
+| E.cs:175:33:175:37 | false | E.cs:175:19:175:42 | ... ? ... : ... |
 | E.cs:177:9:179:9 | {...} | E.cs:180:9:183:9 | if (...) ... |
 | E.cs:180:9:183:9 | if (...) ... | E.cs:181:9:183:9 | {...} |
 | E.cs:181:9:183:9 | {...} | E.cs:184:9:187:9 | if (...) ... |
@@ -690,8 +702,8 @@ edges
 | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s |
 | E.cs:319:29:319:30 | SSA param(s1) | E.cs:321:20:321:21 | access to parameter s2 |
-| E.cs:321:20:321:21 | access to parameter s2 | E.cs:321:27:321:30 | null |
-| E.cs:321:27:321:30 | null | E.cs:323:13:323:14 | access to parameter s1 |
+| E.cs:321:14:321:21 | ... ?? ... | E.cs:323:13:323:14 | access to parameter s1 |
+| E.cs:321:20:321:21 | access to parameter s2 | E.cs:321:14:321:21 | ... ?? ... |
 | E.cs:330:13:330:36 | SSA def(x) | E.cs:331:9:331:9 | access to local variable x |
 | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x |
 | E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x |
@@ -700,31 +712,35 @@ edges
 | E.cs:380:24:380:25 | SSA param(e1) | E.cs:382:28:382:29 | access to parameter e2 |
 | E.cs:380:24:380:25 | SSA param(e1) | E.cs:382:28:382:29 | access to parameter e2 |
 | E.cs:380:24:380:25 | SSA param(e1) | E.cs:382:28:382:29 | access to parameter e2 |
+| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:14:382:37 | [false] ... && ... |
+| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:14:382:37 | [false] ... && ... |
+| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:14:382:37 | [false] ... && ... |
 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:28:382:29 | access to parameter e2 |
 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:28:382:29 | access to parameter e2 |
 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:28:382:29 | access to parameter e2 |
-| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:44:382:67 | ... && ... |
-| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:44:382:67 | ... && ... |
-| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:44:382:67 | ... && ... |
-| E.cs:382:28:382:29 | access to parameter e2 | E.cs:382:44:382:67 | ... && ... |
-| E.cs:382:28:382:29 | access to parameter e2 | E.cs:382:44:382:67 | ... && ... |
-| E.cs:382:44:382:67 | ... && ... | E.cs:384:9:385:24 | if (...) ... |
-| E.cs:382:44:382:67 | ... && ... | E.cs:384:9:385:24 | if (...) ... |
-| E.cs:384:9:385:24 | if (...) ... | E.cs:384:27:384:28 | access to parameter e2 |
-| E.cs:384:9:385:24 | if (...) ... | E.cs:386:27:386:28 | access to parameter e2 |
+| E.cs:382:14:382:37 | [false] ... && ... | E.cs:382:44:382:67 | [false] ... && ... |
+| E.cs:382:14:382:37 | [false] ... && ... | E.cs:382:44:382:67 | [false] ... && ... |
+| E.cs:382:28:382:29 | access to parameter e2 | E.cs:382:14:382:37 | [false] ... && ... |
+| E.cs:382:28:382:29 | access to parameter e2 | E.cs:382:14:382:37 | [false] ... && ... |
+| E.cs:382:44:382:67 | [false] ... && ... | E.cs:384:27:384:28 | access to parameter e2 |
+| E.cs:382:44:382:67 | [false] ... && ... | E.cs:386:27:386:28 | access to parameter e2 |
 | E.cs:384:27:384:28 | access to parameter e2 | E.cs:386:16:386:17 | access to parameter e1 |
 | E.cs:404:9:404:18 | SSA def(i) | E.cs:405:16:405:16 | access to local variable i |
 | E.cs:404:9:404:18 | SSA def(i) | E.cs:405:16:405:16 | access to local variable i |
-| Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
+| Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:9:13:9:30 | [false] !... |
+| Forwarding.cs:9:13:9:30 | [false] !... | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
-| Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:24:9:27:9 | if (...) ... |
+| Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:19:13:19:23 | [false] !... |
+| Forwarding.cs:19:13:19:23 | [false] !... | Forwarding.cs:24:9:27:9 | if (...) ... |
 | Forwarding.cs:24:9:27:9 | if (...) ... | Forwarding.cs:29:9:32:9 | if (...) ... |
 | Forwarding.cs:29:9:32:9 | if (...) ... | Forwarding.cs:34:9:37:9 | if (...) ... |
 | Forwarding.cs:34:9:37:9 | if (...) ... | Forwarding.cs:35:9:37:9 | {...} |
 | Forwarding.cs:34:9:37:9 | if (...) ... | Forwarding.cs:36:31:36:31 | access to local variable s |
 | Forwarding.cs:35:9:37:9 | {...} | Forwarding.cs:40:27:40:27 | access to local variable s |
-| GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:14:9:17:9 | if (...) ... |
-| GuardedString.cs:14:9:17:9 | if (...) ... | GuardedString.cs:19:9:20:40 | if (...) ... |
+| GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:9:13:9:36 | [false] !... |
+| GuardedString.cs:9:13:9:36 | [false] !... | GuardedString.cs:14:9:17:9 | if (...) ... |
+| GuardedString.cs:14:9:17:9 | if (...) ... | GuardedString.cs:14:13:14:41 | [false] !... |
+| GuardedString.cs:14:13:14:41 | [false] !... | GuardedString.cs:19:9:20:40 | if (...) ... |
 | GuardedString.cs:19:9:20:40 | if (...) ... | GuardedString.cs:19:26:19:26 | 0 |
 | GuardedString.cs:19:26:19:26 | 0 | GuardedString.cs:22:9:23:40 | if (...) ... |
 | GuardedString.cs:22:9:23:40 | if (...) ... | GuardedString.cs:22:25:22:25 | 0 |


### PR DESCRIPTION
This PR changes the CFG construction for expressions so they are all visited in post order. The motivation for doing this is consistency, as well as to eliminate false positives (see https://github.com/github/codeql-csharp-team/issues/87).

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/618/ (excluding last commit).
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/621/ (including last commit).

<details>
  <summary>Example 1</summary>

```csharp
void M1(bool b1, bool b2)
{
    if (b1 && b2)
        return;
}
```

#### Before

<img width="293" alt="Screenshot 2020-11-12 at 20 23 54" src="https://user-images.githubusercontent.com/3667920/98986333-0e5e2280-2525-11eb-9642-8093f4e360b3.png">

#### After

<img width="327" alt="Screenshot 2020-11-12 at 20 18 32" src="https://user-images.githubusercontent.com/3667920/98985715-3f8a2300-2524-11eb-8ccf-086af64220fb.png">

</details>

<details>
  <summary>Example 2</summary>

```csharp
void M2(bool b)
{
    var s = b ? "taint source" : "not tainted";
    if (b)
        Sink(s);
    else
        Sink(s);
}
```

#### Before

<img width="560" alt="Screenshot 2020-11-12 at 20 22 22" src="https://user-images.githubusercontent.com/3667920/98986132-c7702d00-2524-11eb-96e1-38d985ed1997.png">

#### After

<img width="450" alt="Screenshot 2020-11-12 at 20 20 13" src="https://user-images.githubusercontent.com/3667920/98985896-7a8c5680-2524-11eb-9b5b-81ecc3e8d976.png">
</details>