### PR TITLE
C++: IR post dominance

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
@@ -164,6 +164,46 @@ class IRBlock extends IRBlockBase {
   }
 
   /**
+   * Holds if this block immediately post-dominates `block`.
+   *
+   * Block `A` immediate post-dominates block `B` if block `A` strictly post-dominates block `B` and
+   * block `B` is a direct successor of block `A`.
+   */
+  final predicate immediatelyPostDominates(IRBlock block) {
+    blockImmediatelyPostDominates(this, block)
+  }
+
+  /**
+   * Holds if this block strictly post-dominates `block`.
+   *
+   * Block `A` strictly post-dominates block `B` if block `A` post-dominates block `B` and blocks `A`
+   * and `B` are not the same block.
+   */
+  final predicate strictlyPostDominates(IRBlock block) {
+    blockImmediatelyPostDominates+(this, block)
+  }
+
+  /**
+   * Holds if this block is a post-dominator of `block`.
+   *
+   * Block `A` post-dominates block `B` if any control flow path from `B` to the exit block of the
+   * function must pass through block `A`. A block always post-dominates itself.
+   */
+  final predicate postDominates(IRBlock block) { strictlyPostDominates(block) or this = block }
+
+  /**
+   * Gets a block on the post-dominance frontier of this block.
+   *
+   * The post-dominance frontier of block `A` is the set of blocks `B` such that block `A` does not
+   * post-dominate block `B`, but block `A` does post-dominate an immediate successor of block `B`.
+   */
+  pragma[noinline]
+  final IRBlock postPominanceFrontier() {
+    postDominates(result.getASuccessor()) and
+    not strictlyPostDominates(result)
+  }
+
+  /**
    * Holds if this block is reachable from the entry block of its function.
    */
   final predicate isReachableFromFunctionEntry() {
@@ -280,3 +320,12 @@ private module Cached {
 }
 
 private Instruction getFirstInstruction(TIRBlock block) { block = MkIRBlock(result) }
+
+private predicate blockFunctionExit(IRBlock exit) {
+  exit.getLastInstruction() instanceof ExitFunctionInstruction
+}
+
+private predicate blockPredecessor(IRBlock src, IRBlock pred) { src.getAPredecessor() = pred }
+
+private predicate blockImmediatelyPostDominates(IRBlock postDominator, IRBlock block) =
+  idominance(blockFunctionExit/1, blockPredecessor/2)(_, postDominator, block)

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
@@ -164,6 +164,46 @@ class IRBlock extends IRBlockBase {
   }
 
   /**
+   * Holds if this block immediately post-dominates `block`.
+   *
+   * Block `A` immediate post-dominates block `B` if block `A` strictly post-dominates block `B` and
+   * block `B` is a direct successor of block `A`.
+   */
+  final predicate immediatelyPostDominates(IRBlock block) {
+    blockImmediatelyPostDominates(this, block)
+  }
+
+  /**
+   * Holds if this block strictly post-dominates `block`.
+   *
+   * Block `A` strictly post-dominates block `B` if block `A` post-dominates block `B` and blocks `A`
+   * and `B` are not the same block.
+   */
+  final predicate strictlyPostDominates(IRBlock block) {
+    blockImmediatelyPostDominates+(this, block)
+  }
+
+  /**
+   * Holds if this block is a post-dominator of `block`.
+   *
+   * Block `A` post-dominates block `B` if any control flow path from `B` to the exit block of the
+   * function must pass through block `A`. A block always post-dominates itself.
+   */
+  final predicate postDominates(IRBlock block) { strictlyPostDominates(block) or this = block }
+
+  /**
+   * Gets a block on the post-dominance frontier of this block.
+   *
+   * The post-dominance frontier of block `A` is the set of blocks `B` such that block `A` does not
+   * post-dominate block `B`, but block `A` does post-dominate an immediate successor of block `B`.
+   */
+  pragma[noinline]
+  final IRBlock postPominanceFrontier() {
+    postDominates(result.getASuccessor()) and
+    not strictlyPostDominates(result)
+  }
+
+  /**
    * Holds if this block is reachable from the entry block of its function.
    */
   final predicate isReachableFromFunctionEntry() {
@@ -280,3 +320,12 @@ private module Cached {
 }
 
 private Instruction getFirstInstruction(TIRBlock block) { block = MkIRBlock(result) }
+
+private predicate blockFunctionExit(IRBlock exit) {
+  exit.getLastInstruction() instanceof ExitFunctionInstruction
+}
+
+private predicate blockPredecessor(IRBlock src, IRBlock pred) { src.getAPredecessor() = pred }
+
+private predicate blockImmediatelyPostDominates(IRBlock postDominator, IRBlock block) =
+  idominance(blockFunctionExit/1, blockPredecessor/2)(_, postDominator, block)

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -164,6 +164,46 @@ class IRBlock extends IRBlockBase {
   }
 
   /**
+   * Holds if this block immediately post-dominates `block`.
+   *
+   * Block `A` immediate post-dominates block `B` if block `A` strictly post-dominates block `B` and
+   * block `B` is a direct successor of block `A`.
+   */
+  final predicate immediatelyPostDominates(IRBlock block) {
+    blockImmediatelyPostDominates(this, block)
+  }
+
+  /**
+   * Holds if this block strictly post-dominates `block`.
+   *
+   * Block `A` strictly post-dominates block `B` if block `A` post-dominates block `B` and blocks `A`
+   * and `B` are not the same block.
+   */
+  final predicate strictlyPostDominates(IRBlock block) {
+    blockImmediatelyPostDominates+(this, block)
+  }
+
+  /**
+   * Holds if this block is a post-dominator of `block`.
+   *
+   * Block `A` post-dominates block `B` if any control flow path from `B` to the exit block of the
+   * function must pass through block `A`. A block always post-dominates itself.
+   */
+  final predicate postDominates(IRBlock block) { strictlyPostDominates(block) or this = block }
+
+  /**
+   * Gets a block on the post-dominance frontier of this block.
+   *
+   * The post-dominance frontier of block `A` is the set of blocks `B` such that block `A` does not
+   * post-dominate block `B`, but block `A` does post-dominate an immediate successor of block `B`.
+   */
+  pragma[noinline]
+  final IRBlock postPominanceFrontier() {
+    postDominates(result.getASuccessor()) and
+    not strictlyPostDominates(result)
+  }
+
+  /**
    * Holds if this block is reachable from the entry block of its function.
    */
   final predicate isReachableFromFunctionEntry() {
@@ -280,3 +320,12 @@ private module Cached {
 }
 
 private Instruction getFirstInstruction(TIRBlock block) { block = MkIRBlock(result) }
+
+private predicate blockFunctionExit(IRBlock exit) {
+  exit.getLastInstruction() instanceof ExitFunctionInstruction
+}
+
+private predicate blockPredecessor(IRBlock src, IRBlock pred) { src.getAPredecessor() = pred }
+
+private predicate blockImmediatelyPostDominates(IRBlock postDominator, IRBlock block) =
+  idominance(blockFunctionExit/1, blockPredecessor/2)(_, postDominator, block)

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRBlock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRBlock.qll
@@ -164,6 +164,46 @@ class IRBlock extends IRBlockBase {
   }
 
   /**
+   * Holds if this block immediately post-dominates `block`.
+   *
+   * Block `A` immediate post-dominates block `B` if block `A` strictly post-dominates block `B` and
+   * block `B` is a direct successor of block `A`.
+   */
+  final predicate immediatelyPostDominates(IRBlock block) {
+    blockImmediatelyPostDominates(this, block)
+  }
+
+  /**
+   * Holds if this block strictly post-dominates `block`.
+   *
+   * Block `A` strictly post-dominates block `B` if block `A` post-dominates block `B` and blocks `A`
+   * and `B` are not the same block.
+   */
+  final predicate strictlyPostDominates(IRBlock block) {
+    blockImmediatelyPostDominates+(this, block)
+  }
+
+  /**
+   * Holds if this block is a post-dominator of `block`.
+   *
+   * Block `A` post-dominates block `B` if any control flow path from `B` to the exit block of the
+   * function must pass through block `A`. A block always post-dominates itself.
+   */
+  final predicate postDominates(IRBlock block) { strictlyPostDominates(block) or this = block }
+
+  /**
+   * Gets a block on the post-dominance frontier of this block.
+   *
+   * The post-dominance frontier of block `A` is the set of blocks `B` such that block `A` does not
+   * post-dominate block `B`, but block `A` does post-dominate an immediate successor of block `B`.
+   */
+  pragma[noinline]
+  final IRBlock postPominanceFrontier() {
+    postDominates(result.getASuccessor()) and
+    not strictlyPostDominates(result)
+  }
+
+  /**
    * Holds if this block is reachable from the entry block of its function.
    */
   final predicate isReachableFromFunctionEntry() {
@@ -280,3 +320,12 @@ private module Cached {
 }
 
 private Instruction getFirstInstruction(TIRBlock block) { block = MkIRBlock(result) }
+
+private predicate blockFunctionExit(IRBlock exit) {
+  exit.getLastInstruction() instanceof ExitFunctionInstruction
+}
+
+private predicate blockPredecessor(IRBlock src, IRBlock pred) { src.getAPredecessor() = pred }
+
+private predicate blockImmediatelyPostDominates(IRBlock postDominator, IRBlock block) =
+  idominance(blockFunctionExit/1, blockPredecessor/2)(_, postDominator, block)

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -164,6 +164,46 @@ class IRBlock extends IRBlockBase {
   }
 
   /**
+   * Holds if this block immediately post-dominates `block`.
+   *
+   * Block `A` immediate post-dominates block `B` if block `A` strictly post-dominates block `B` and
+   * block `B` is a direct successor of block `A`.
+   */
+  final predicate immediatelyPostDominates(IRBlock block) {
+    blockImmediatelyPostDominates(this, block)
+  }
+
+  /**
+   * Holds if this block strictly post-dominates `block`.
+   *
+   * Block `A` strictly post-dominates block `B` if block `A` post-dominates block `B` and blocks `A`
+   * and `B` are not the same block.
+   */
+  final predicate strictlyPostDominates(IRBlock block) {
+    blockImmediatelyPostDominates+(this, block)
+  }
+
+  /**
+   * Holds if this block is a post-dominator of `block`.
+   *
+   * Block `A` post-dominates block `B` if any control flow path from `B` to the exit block of the
+   * function must pass through block `A`. A block always post-dominates itself.
+   */
+  final predicate postDominates(IRBlock block) { strictlyPostDominates(block) or this = block }
+
+  /**
+   * Gets a block on the post-dominance frontier of this block.
+   *
+   * The post-dominance frontier of block `A` is the set of blocks `B` such that block `A` does not
+   * post-dominate block `B`, but block `A` does post-dominate an immediate successor of block `B`.
+   */
+  pragma[noinline]
+  final IRBlock postPominanceFrontier() {
+    postDominates(result.getASuccessor()) and
+    not strictlyPostDominates(result)
+  }
+
+  /**
    * Holds if this block is reachable from the entry block of its function.
    */
   final predicate isReachableFromFunctionEntry() {
@@ -280,3 +320,12 @@ private module Cached {
 }
 
 private Instruction getFirstInstruction(TIRBlock block) { block = MkIRBlock(result) }
+
+private predicate blockFunctionExit(IRBlock exit) {
+  exit.getLastInstruction() instanceof ExitFunctionInstruction
+}
+
+private predicate blockPredecessor(IRBlock src, IRBlock pred) { src.getAPredecessor() = pred }
+
+private predicate blockImmediatelyPostDominates(IRBlock postDominator, IRBlock block) =
+  idominance(blockFunctionExit/1, blockPredecessor/2)(_, postDominator, block)


### PR DESCRIPTION
Implement post dominance predicates for `IRBlock`s (which is mostly dual to the existing dominance predicates).

I added these predicates as part of https://github.com/github/codeql/pull/4644, but it turned out to not be needed. At some point, someone will want this functionality anyway, though.