### PR TITLE
C++: Clean up Type.qll, getSpecifierString() API.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Print.qll
+++ b/cpp/ql/src/semmle/code/cpp/Print.qll
@@ -304,7 +304,7 @@ private class SpecifiedDumpType extends DerivedDumpType, SpecifiedType {
       basePrefix = getBaseType().(DumpType).getDeclaratorPrefix() and
       if getBaseType().getUnspecifiedType() instanceof RoutineType
       then result = basePrefix
-      else result = basePrefix + " " + getSpecifierString().trim()
+      else result = basePrefix + " " + getSpecifierString()
     )
   }
 
@@ -312,7 +312,7 @@ private class SpecifiedDumpType extends DerivedDumpType, SpecifiedType {
     exists(string baseSuffix |
       baseSuffix = getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers() and
       if getBaseType().getUnspecifiedType() instanceof RoutineType
-      then result = baseSuffix + " " + getSpecifierString().trim()
+      then result = baseSuffix + " " + getSpecifierString()
       else result = baseSuffix
     )
   }

--- a/cpp/ql/src/semmle/code/cpp/Type.qll
+++ b/cpp/ql/src/semmle/code/cpp/Type.qll
@@ -1305,12 +1305,12 @@ class SpecifiedType extends DerivedType {
 
   /**
    * INTERNAL: Do not use.
-   * 
+   *
    * Gets all the specifiers of this type as a string in a fixed order (the order
    * only depends on the specifiers, not on the source program). This is intended
    * for debugging queries only and is an expensive operation.
    */
-  string getSpecifierString() { result = concat(this.getASpecifier().getName(), " ")}
+  string getSpecifierString() { result = concat(this.getASpecifier().getName(), " ") }
 
   override string explain() {
     result = this.getSpecifierString() + " {" + this.getBaseType().explain() + "}"

--- a/cpp/ql/src/semmle/code/cpp/Type.qll
+++ b/cpp/ql/src/semmle/code/cpp/Type.qll
@@ -1304,14 +1304,16 @@ class SpecifiedType extends DerivedType {
   }
 
   /**
+   * INTERNAL: Do not use.
+   * 
    * Gets all the specifiers of this type as a string in a fixed order (the order
    * only depends on the specifiers, not on the source program). This is intended
    * for debugging queries only and is an expensive operation.
    */
-  string getSpecifierString() { result = concat(this.getASpecifier().getName(), " ") + " " }
+  string getSpecifierString() { result = concat(this.getASpecifier().getName(), " ")}
 
   override string explain() {
-    result = this.getSpecifierString() + "{" + this.getBaseType().explain() + "}"
+    result = this.getSpecifierString() + " {" + this.getBaseType().explain() + "}"
   }
 
   override predicate isDeeplyConst() {


### PR DESCRIPTION
As discussed in #4680, a small change to the API in `Type.qll`.