### PR TITLE
C++: Speed up PrintAST.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Element.qll
+++ b/cpp/ql/src/semmle/code/cpp/Element.qll
@@ -66,7 +66,7 @@ class ElementBase extends @element {
    * `BinaryOperation` is not.
    *
    * This predicate can have multiple results if multiple primary classes match.
-   * For some elements, this predicate may not exist.
+   * For some elements, this predicate may not have a result.
    */
   string getAPrimaryQlClass() { none() }
 }

--- a/cpp/ql/src/semmle/code/cpp/Element.qll
+++ b/cpp/ql/src/semmle/code/cpp/Element.qll
@@ -65,11 +65,10 @@ class ElementBase extends @element {
    * which they belong; for example, `AddExpr` is a primary class, but
    * `BinaryOperation` is not.
    *
-   * This predicate always has a result. If no primary class can be
-   * determined, the result is `"???"`. If multiple primary classes match,
-   * this predicate can have multiple results.
+   * This predicate can have multiple results if multiple primary classes match.
+   * For some elements, this predicate may not exist.
    */
-  string getAPrimaryQlClass() { result = "???" }
+  string getAPrimaryQlClass() { none() }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -241,7 +241,7 @@ private class PrintableElementBase extends ElementBase {
     or
     this instanceof Type
     or
-    shouldPrintFunction(this.(DeclarationEntry).getEnclosingElement+())
+    this instanceof DeclarationEntry
   }
 
   pragma[noinline]

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -91,7 +91,8 @@ private newtype TPrintASTNode =
   TDeclarationEntryNode(DeclStmt stmt, DeclarationEntry entry) {
     // We create a unique node for each pair of (stmt, entry), to avoid having one node with
     // multiple parents due to extractor bug CPP-413.
-    stmt.getADeclarationEntry() = entry
+    stmt.getADeclarationEntry() = entry and
+    shouldPrintFunction(stmt.getEnclosingFunction())
   } or
   TParametersNode(Function func) { shouldPrintFunction(func) } or
   TConstructorInitializersNode(Constructor ctor) {
@@ -236,9 +237,11 @@ class PrintASTNode extends TPrintASTNode {
 
 private class PrintableElementBase extends ElementBase {
   PrintableElementBase() {
-    not this instanceof Locatable
+    shouldPrintFunction(getEnclosingFunction(this))
     or
-    shouldPrintFunction(getEnclosingFunction(this.(Locatable)))
+    this instanceof Type
+    or
+    shouldPrintFunction(this.(DeclarationEntry).getEnclosingElement+())
   }
 
   pragma[noinline]

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -234,11 +234,22 @@ class PrintASTNode extends TPrintASTNode {
   private Function getEnclosingFunction() { result = getParent*().(FunctionNode).getFunction() }
 }
 
+private class PrintableElementBase extends ElementBase {
+  PrintableElementBase() {
+    not this instanceof Locatable
+    or
+    shouldPrintFunction(getEnclosingFunction(this.(Locatable)))
+  }
+
+  pragma[noinline]
+  string getAPrimaryQlClass0() { result = getAPrimaryQlClass() }
+}
+
 /**
  * Retrieves the canonical QL class(es) for entity `el`
  */
-private string qlClass(ElementBase el) {
-  result = "[" + concat(el.getAPrimaryQlClass(), ",") + "] "
+private string qlClass(PrintableElementBase el) {
+  result = "[" + concat(el.getAPrimaryQlClass0(), ",") + "] "
   // Alternative implementation -- do not delete. It is useful for QL class discovery.
   //result = "["+ concat(el.getAQlClass(), ",") + "] "
 }

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -235,8 +235,11 @@ class PrintASTNode extends TPrintASTNode {
   private Function getEnclosingFunction() { result = getParent*().(FunctionNode).getFunction() }
 }
 
-private class PrintableElementBase extends ElementBase {
-  PrintableElementBase() {
+/**
+ * Class that restricts the elements that we compute `qlClass` for.
+ */
+private class PrintableElement extends Element {
+  PrintableElement() {
     exists(TASTNode(this))
     or
     exists(TDeclarationEntryNode(_, this))
@@ -251,7 +254,7 @@ private class PrintableElementBase extends ElementBase {
 /**
  * Retrieves the canonical QL class(es) for entity `el`
  */
-private string qlClass(PrintableElementBase el) {
+private string qlClass(PrintableElement el) {
   result = "[" + concat(el.getAPrimaryQlClass0(), ",") + "] "
   // Alternative implementation -- do not delete. It is useful for QL class discovery.
   //result = "["+ concat(el.getAQlClass(), ",") + "] "

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -237,11 +237,11 @@ class PrintASTNode extends TPrintASTNode {
 
 private class PrintableElementBase extends ElementBase {
   PrintableElementBase() {
-    shouldPrintFunction(getEnclosingFunction(this))
+    exists(TASTNode(this))
+    or
+    exists(TDeclarationEntryNode(_, this))
     or
     this instanceof Type
-    or
-    this instanceof DeclarationEntry
   }
 
   pragma[noinline]


### PR DESCRIPTION
Performance numbers:
Using 16 threads for evaluator, with empty cache
boost, lockpool.cpp
before: total 85s, qlClass 10s, EB 30s
after: total 75s, qlClass 3s

openjdk, ad_x86.cpp
before: total 93s, qlClass 11s, EB 28
after: total 81s, qlClass 7.9s

The times for the individual predicates are from the query log, the total time is the wall time from the parallel execution.
EB is the predicate in `ElementBase` that computes the `el` that need the default implementation of `getAPrimaryQlClass`, i.e. where the predicate is not overriden.
Note: Changing this default from "???" to no result is a breaking API change.

Part of https://github.com/github/codeql-c-analysis-team/issues/129
