### PR TITLE
Remove unit tests for duplicate-code detection

### DIFF
--- a/csharp/ql/test/query-tests/Metrics/Dependencies/ExternalDependencies/ExternalDependencies.qlref
+++ b/csharp/ql/test/query-tests/Metrics/Dependencies/ExternalDependencies/ExternalDependencies.qlref
@@ -1,1 +1,0 @@
-Metrics/Dependencies/ExternalDependencies.ql

--- a/csharp/ql/test/query-tests/Metrics/Dependencies/ExternalDependencies/ExternalDependenciesSourceLinks.qlref
+++ b/csharp/ql/test/query-tests/Metrics/Dependencies/ExternalDependencies/ExternalDependenciesSourceLinks.qlref
@@ -1,1 +1,0 @@
-Metrics/Dependencies/ExternalDependenciesSourceLinks.ql

--- a/csharp/ql/test/query-tests/Metrics/Files/FLinesOfDuplicatedCode/flinesofduplicatedcode.qlref
+++ b/csharp/ql/test/query-tests/Metrics/Files/FLinesOfDuplicatedCode/flinesofduplicatedcode.qlref
@@ -1,1 +1,0 @@
-Metrics/Files/FLinesOfDuplicatedCode.ql

--- a/python/ql/test/query-tests/Metrics/duplicate/FLinesOfDuplicatedCode.qlref
+++ b/python/ql/test/query-tests/Metrics/duplicate/FLinesOfDuplicatedCode.qlref
@@ -1,1 +1,0 @@
-Metrics/FLinesOfDuplicatedCode.ql

--- a/python/ql/test/query-tests/Metrics/duplicate/FLinesOfSimilarCode.qlref
+++ b/python/ql/test/query-tests/Metrics/duplicate/FLinesOfSimilarCode.qlref
@@ -1,1 +1,0 @@
-Metrics/FLinesOfSimilarCode.ql


### PR DESCRIPTION
The old Semmle duplicate-code detection code has never been done when extracting databases for the CodeQL CLI, except that `codeql test run` will run it _just_ in order to support tests of the feature. With the sunsetting of Odasa there's no need to even _test_ the feature anymore.

This PR removes those tests that fail when the duplicate-code detector is turned off. Once it is merged and bumped, we can finally remove it from `codeql`.

(The underlying _queries_ are still present; I'll leave their deletion to the language teams).