### PR TITLE
Java/Android : Insecure Context Creation

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-691/InsecureClassLoading.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-691/InsecureClassLoading.qhelp
@@ -1,0 +1,37 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+  <overview>
+    <p>
+      Loading a class that could have been installed by another Android application will lead to arbitrary code being executed in the context of the victim application.
+      This query detects usage of code which can be maliciously abused by an adversary to create a new Android
+      <code>Context</code>
+      , which in turn, can be used to instantiate untrusted classes.
+    </p>
+  </overview>
+
+  <recommendation>
+    <p>This can be avoided in two ways. </p>
+    <ol>
+      <li> 
+        To avoid arbitrary code execution, the application should verify the signature of the package before loading it.
+      </li>
+      <li> Changing the application architecture to prevent unintended access to sensitive components.</li>
+    </ol>
+  </recommendation>
+
+  <example>
+    <p>
+      The following example shows a dangerous way of creating an Android <code>Context</code>.
+      A malicious, attacker-controlled app may have registered a package with the name
+      <code>somename.plugin.xyz</code> having a <code>pluginLoader</code> class, which the victim app will encounter and execute.
+    </p>
+    <sample src="InsecureClassLoadingBad.java" />
+    <p> Then, when the code above executes, the attacker would be able to run malicious code in the context of the applciaiton.</p>
+    <p>However, in the example shown below, the signature of the package is being verified and hence, the context creation in this case is safe.</p>
+    <sample src="InsecureClassLoadingGood.java" />
+
+  </example>
+
+  <references></references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-691/InsecureClassLoading.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-691/InsecureClassLoading.ql
@@ -1,0 +1,119 @@
+/**
+ * @name Android insecure context creation
+ * @description Using untrusted input to create a context can lead to arbitary code execution
+ * @kind path-problem
+ * @id java/android-insecure-context-creation
+ * @tags security
+ *       external/cwe/cwe-691
+ */
+
+import java
+import DataFlow::PathGraph
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.dataflow.TaintTracking
+
+/**
+ * A taint-tracking configuration for insecure context creation vulnerabilities
+ */
+class InsecureContextCreationConfig extends TaintTracking::Configuration {
+  InsecureContextCreationConfig() { this = "Android insecure context creation config" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source instanceof AndroidPackageInput or
+    source instanceof RemoteFlowSource or
+    source instanceof LocalStringSource
+  }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof InsecureContextCreationSink }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+    packageInfoAccessStep(node1, node2)
+  }
+}
+
+/**
+ * A data-flow helper configuration for tracking flow of flag field to `createPackageContext` calls
+ */
+private class FlagFlowConfig extends DataFlow2::Configuration {
+  FlagFlowConfig() { this = "Android insecure context creation config" }
+
+  override predicate isSource(DataFlow::Node source) {
+    exists(OrBitwiseExpr e |
+      forex(FieldAccess a | e.getAnOperand() = a |
+        a instanceof ContextIgnoreSecurity or a instanceof ContextIncludeCode
+      )
+    |
+      source.asExpr() = e
+    )
+    or
+    exists(IntegerLiteral i | i.getIntValue() = 3 | source.asExpr() = i)
+  }
+
+  override predicate isSink(DataFlow::Node sink) { any() }
+}
+
+/** A `java.lang.String` which can be a source for insecure context creation vulnerabilities */
+private class LocalStringSource extends DataFlow::ExprNode {
+  LocalStringSource() {
+    exists(string pattern, StringLiteral s |
+      s.getRepresentedString().matches(pattern) and
+      pattern = ["com%", "org%", "my%"]
+    |
+      s = this.asExpr()
+    )
+  }
+}
+
+/** A sink for insecure context creation vulnerabilities */
+private class InsecureContextCreationSink extends DataFlow::ExprNode {
+  InsecureContextCreationSink() {
+    exists(MethodAccess ma, Method m |
+      ma.getMethod() = m and
+      m.getDeclaringType().hasQualifiedName("android.content", "ContextWrapper") and
+      m.getName().matches("create%Context") and
+      exists(FlagFlowConfig fc | fc.hasFlowToExpr(ma.getArgument(1)))
+    |
+      this.asExpr() = ma.getArgument(0)
+    )
+  }
+}
+
+/** Holds if a taint flows from `node1` to `node2` through an access on the `PackageInfo` object */
+private predicate packageInfoAccessStep(DataFlow::Node node1, DataFlow::Node node2) {
+  exists(FieldAccess fa |
+    fa.getQualifier() = node1.asExpr() and
+    fa.getField().getDeclaringType() instanceof AndroidPackageInfo
+  |
+    fa = node2.asExpr()
+  )
+}
+
+/**  Models the `android.content.pm.PackageInfo` class. */
+private class AndroidPackageInfo extends RefType {
+  AndroidPackageInfo() { this.hasQualifiedName("android.content.pm", "PackageInfo") }
+}
+
+/**  Models the constant `CONTEXT_INCLUDE_CODE` declared in `android.content.Context`class. */
+private class ContextIncludeCode extends FieldAccess {
+  ContextIncludeCode() {
+    exists(TypeContext t |
+      this.getField().getDeclaringType().extendsOrImplements*(t) and
+      this.getField().hasName("CONTEXT_INCLUDE_CODE")
+    )
+  }
+}
+
+/**  Models the constant `CONTEXT_IGNORE_SECURITY` declared in `android.content.Context`. */
+private class ContextIgnoreSecurity extends FieldAccess {
+  ContextIgnoreSecurity() {
+    exists(TypeContext t |
+      this.getField().getDeclaringType().extendsOrImplements*(t) and
+      this.getField().hasName("CONTEXT_IGNORE_SECURITY")
+    )
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, InsecureContextCreationConfig conf
+where conf.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Arbitary code execution from $@.", source.getNode(),
+  "this user input"

--- a/java/ql/src/experimental/Security/CWE/CWE-691/InsecureClassLoadingBad.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-691/InsecureClassLoadingBad.java
@@ -1,0 +1,31 @@
+
+import android.app.Application;
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.os.Bundle;
+
+public class InsecureClassLoading extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    invokePlugins();
+  }
+
+  private void invokePlugins() {
+    // An attacker may install a package with a name matching a trusted package's
+    // name, this is bad.
+    for (PackageInfo info : getPackageManager().getInstalledPackages(0)) {
+      String packageName = info.packageName;
+      Bundle meta = info.applicationInfo.metaData;
+      if (packageName.startsWith("somename.plugin.")) {
+        try {
+          Context packageContext = createPackageContext(packageName, CONTEXT_INCLUDE_CODE | CONTEXT_IGNORE_SECURITY);
+          packageContext.getClassLoader().loadClass("somename.pluginLoader").getMethod("load", Context.class)
+              .invoke(null, this);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+  }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-691/InsecureClassLoadingGood.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-691/InsecureClassLoadingGood.java
@@ -1,0 +1,55 @@
+
+import android.app.Application;
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.os.Bundle;
+
+public class InsecureClassLoading extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    invokePlugins();
+  }
+
+  private void invokePlugins() {
+
+    PackageManager packageManager = getPackageManager();
+    List<PackageInfo> packageList = packageManager.getInstalledPackages(PackageManager.GET_SIGNATURES);
+
+    for (PackageInfo p : packageList) {
+
+      // Check the signature of the package before using it.
+      final Signature[] arrSignatures = p.signatures;
+      for (final Signature sig : arrSignatures) {
+        final byte[] rawCert = sig.toByteArray();
+        InputStream certStream = new ByteArrayInputStream(rawCert);
+
+        try {
+          CertificateFactory certFactory = CertificateFactory.getInstance("X509");
+          X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(certStream);
+
+          if (!x509Cert.getSubjectDN().equals("Trusted Subject DN")
+              || !x509Cert.getIssuerDN().equals("Trusted Issuer DN")
+              || !x509Cert.getSerialNumber().equals("Serial Number")) {
+            throw Exception("Signature mismatch");
+          }
+        } catch (Exception e) {
+          // e.printStackTrace();
+        }
+      }
+
+      // This is now safe as the signature of the package is verified
+      String packageName = info.packageName;
+      Bundle meta = info.applicationInfo.metaData;
+      if (packageName.startsWith("somename.plugin.")) {
+        try {
+          Context packageContext = createPackageContext(packageName, CONTEXT_INCLUDE_CODE | CONTEXT_IGNORE_SECURITY);
+          packageContext.getClassLoader().loadClass("somename.pluginLoader").getMethod("load", Context.class)
+              .invoke(null, this);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+  }
+}

--- a/java/ql/src/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSources.qll
@@ -342,3 +342,15 @@ class ExportedAndroidIntentInput extends RemoteFlowSource, AndroidIntentInput {
 
   override string getSourceType() { result = "Exported Android intent source" }
 }
+
+/** Android `PackageInfo` objects that may have come from a hostile application. */
+class AndroidPackageInput extends DataFlow::Node {
+  AndroidPackageInput() {
+    exists(MethodAccess ma, Method m |
+      ma.getMethod() = m and
+      m.getDeclaringType().hasQualifiedName("android.content.pm", "PackageManager") and
+      m.hasName("getInstalledPackages") and
+      this.asExpr() = ma
+    )
+  }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-691/InsecureClassLoading.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-691/InsecureClassLoading.expected
@@ -1,0 +1,21 @@
+edges
+| InsecureClassLoading.java:18:29:18:54 | getInstalledPackages(...) : List | InsecureClassLoading.java:24:60:24:70 | packageName |
+| InsecureClassLoading.java:29:25:29:29 | "com" : String | InsecureClassLoading.java:31:52:31:62 | packageName |
+| InsecureClassLoading.java:29:25:29:29 | "com" : String | InsecureClassLoading.java:33:52:33:62 | packageName |
+| InsecureClassLoading.java:35:25:35:34 | "com.test" : String | InsecureClassLoading.java:37:52:37:62 | packageName |
+| InsecureClassLoading.java:35:25:35:34 | "com.test" : String | InsecureClassLoading.java:39:52:39:62 | packageName |
+nodes
+| InsecureClassLoading.java:18:29:18:54 | getInstalledPackages(...) : List | semmle.label | getInstalledPackages(...) : List |
+| InsecureClassLoading.java:24:60:24:70 | packageName | semmle.label | packageName |
+| InsecureClassLoading.java:29:25:29:29 | "com" : String | semmle.label | "com" : String |
+| InsecureClassLoading.java:31:52:31:62 | packageName | semmle.label | packageName |
+| InsecureClassLoading.java:33:52:33:62 | packageName | semmle.label | packageName |
+| InsecureClassLoading.java:35:25:35:34 | "com.test" : String | semmle.label | "com.test" : String |
+| InsecureClassLoading.java:37:52:37:62 | packageName | semmle.label | packageName |
+| InsecureClassLoading.java:39:52:39:62 | packageName | semmle.label | packageName |
+#select
+| InsecureClassLoading.java:24:60:24:70 | packageName | InsecureClassLoading.java:18:29:18:54 | getInstalledPackages(...) : List | InsecureClassLoading.java:24:60:24:70 | packageName | Arbitary code execution from $@. | InsecureClassLoading.java:18:29:18:54 | getInstalledPackages(...) | this user input |
+| InsecureClassLoading.java:31:52:31:62 | packageName | InsecureClassLoading.java:29:25:29:29 | "com" : String | InsecureClassLoading.java:31:52:31:62 | packageName | Arbitary code execution from $@. | InsecureClassLoading.java:29:25:29:29 | "com" | this user input |
+| InsecureClassLoading.java:33:52:33:62 | packageName | InsecureClassLoading.java:29:25:29:29 | "com" : String | InsecureClassLoading.java:33:52:33:62 | packageName | Arbitary code execution from $@. | InsecureClassLoading.java:29:25:29:29 | "com" | this user input |
+| InsecureClassLoading.java:37:52:37:62 | packageName | InsecureClassLoading.java:35:25:35:34 | "com.test" : String | InsecureClassLoading.java:37:52:37:62 | packageName | Arbitary code execution from $@. | InsecureClassLoading.java:35:25:35:34 | "com.test" | this user input |
+| InsecureClassLoading.java:39:52:39:62 | packageName | InsecureClassLoading.java:35:25:35:34 | "com.test" : String | InsecureClassLoading.java:39:52:39:62 | packageName | Arbitary code execution from $@. | InsecureClassLoading.java:35:25:35:34 | "com.test" | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-691/InsecureClassLoading.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-691/InsecureClassLoading.java
@@ -1,0 +1,52 @@
+
+import android.app.Application;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+public class InsecureClassLoading extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    invokePlugins();
+  }
+
+  private void invokePlugins() {
+    PackageManager pm;
+    for (PackageInfo info : pm.getInstalledPackages(0)) {      
+      String packageName = info.packageName;
+
+      if (packageName.startsWith("somename.plugin.")) {
+        try {
+          ContextWrapper cw = new ContextWrapper();
+          Context packageContext = cw.createPackageContext(packageName, 3);
+          packageContext = cw.createPackageContext("test.test", 0);
+          packageContext = cw.createPackageContext("test.test", 3);
+          packageContext = cw.createPackageContext("test.test", Context.CONTEXT_INCLUDE_CODE | Context.CONTEXT_IGNORE_SECURITY);
+
+          packageName = "com";
+          packageName += ".test.package";
+          packageContext = cw.createPackageContext(packageName, Context.CONTEXT_INCLUDE_CODE | Context.CONTEXT_IGNORE_SECURITY);
+          packageContext = cw.createPackageContext(packageName, 0);
+          packageContext = cw.createPackageContext(packageName, 3);
+
+          packageName = "com.test";
+          packageName += ".package";
+          packageContext = cw.createPackageContext(packageName, Context.CONTEXT_INCLUDE_CODE | Context.CONTEXT_IGNORE_SECURITY);
+          packageContext = cw.createPackageContext(packageName, 0);
+          packageContext = cw.createPackageContext(packageName, 3);
+
+          int flags = Context.CONTEXT_INCLUDE_CODE | Context.CONTEXT_IGNORE_SECURITY;
+          packageContext = cw.createPackageContext(packageName, flags);
+
+          packageContext.getClassLoader().loadClass("somename.pluginLoader").getMethod("load", Context.class)
+              .invoke(null, this);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+  }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-691/InsecureClassLoading.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-691/InsecureClassLoading.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-691/InsecureClassLoading.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-691/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-691/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/google-android-9.0.0

--- a/java/ql/test/stubs/google-android-9.0.0/android/app/Application.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/app/Application.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.app;
+
+// import android.annotation.CallSuper;
+// import android.annotation.NonNull;
+// import android.annotation.Nullable;
+// import android.compat.annotation.UnsupportedAppUsage;
+// import android.content.ComponentCallbacks;
+// import android.content.ComponentCallbacks2;
+// import android.content.Context;
+import android.content.ContextWrapper;
+// import android.content.Intent;
+// import android.content.res.Configuration;
+// import android.os.Build;
+import android.os.Bundle;
+// import android.util.Log;
+// import android.view.autofill.AutofillManager;
+
+import java.util.ArrayList;
+
+/**
+ * Base class for maintaining global application state. You can provide your own
+ * implementation by creating a subclass and specifying the fully-qualified name
+ * of this subclass as the <code>"android:name"</code> attribute in your
+ * AndroidManifest.xml's <code>&lt;application&gt;</code> tag. The Application
+ * class, or your subclass of the Application class, is instantiated before any
+ * other class when the process for your application/package is created.
+ *
+ * <p class="note">
+ * <strong>Note: </strong>There is normally no need to subclass Application. In
+ * most situations, static singletons can provide the same functionality in a
+ * more modular way. If your singleton needs a global context (for example to
+ * register broadcast receivers), include
+ * {@link android.content.Context#getApplicationContext()
+ * Context.getApplicationContext()} as a {@link android.content.Context}
+ * argument when invoking your singleton's <code>getInstance()</code> method.
+ * </p>
+ */
+public class Application {
+    public interface ActivityLifecycleCallbacks {
+
+        /**
+         * Called as the first step of the Activity being created. This is always called
+         * before {@link Activity#onCreate}.
+         */
+        default void onActivityPreCreated(Activity activity, Bundle savedInstanceState) {
+        }
+
+        /**
+         * Called when the Activity calls {@link Activity#onCreate super.onCreate()}.
+         */
+        void onActivityCreated(Activity activity, Bundle savedInstanceState);
+
+        /**
+         * Called as the last step of the Activity being created. This is always called
+         * after {@link Activity#onCreate}.
+         */
+        default void onActivityPostCreated(Activity activity, Bundle savedInstanceState) {
+        }
+
+        /**
+         * Called as the first step of the Activity being started. This is always called
+         * before {@link Activity#onStart}.
+         */
+        default void onActivityPreStarted(Activity activity) {
+        }
+
+        /**
+         * Called when the Activity calls {@link Activity#onStart super.onStart()}.
+         */
+        void onActivityStarted(Activity activity);
+
+        /**
+         * Called as the last step of the Activity being started. This is always called
+         * after {@link Activity#onStart}.
+         */
+        default void onActivityPostStarted(Activity activity) {
+        }
+
+        /**
+         * Called as the first step of the Activity being resumed. This is always called
+         * before {@link Activity#onResume}.
+         */
+        default void onActivityPreResumed(Activity activity) {
+        }
+
+        /**
+         * Called when the Activity calls {@link Activity#onResume super.onResume()}.
+         */
+        void onActivityResumed(Activity activity);
+
+        /**
+         * Called as the last step of the Activity being resumed. This is always called
+         * after {@link Activity#onResume} and {@link Activity#onPostResume}.
+         */
+        default void onActivityPostResumed(Activity activity) {
+        }
+
+        /**
+         * Called as the first step of the Activity being paused. This is always called
+         * before {@link Activity#onPause}.
+         */
+        default void onActivityPrePaused(Activity activity) {
+        }
+
+        /**
+         * Called when the Activity calls {@link Activity#onPause super.onPause()}.
+         */
+        void onActivityPaused(Activity activity);
+
+        /**
+         * Called as the last step of the Activity being paused. This is always called
+         * after {@link Activity#onPause}.
+         */
+        default void onActivityPostPaused(Activity activity) {
+        }
+
+        /**
+         * Called as the first step of the Activity being stopped. This is always called
+         * before {@link Activity#onStop}.
+         */
+        default void onActivityPreStopped(Activity activity) {
+        }
+
+        /**
+         * Called when the Activity calls {@link Activity#onStop super.onStop()}.
+         */
+        void onActivityStopped(Activity activity);
+
+        /**
+         * Called as the last step of the Activity being stopped. This is always called
+         * after {@link Activity#onStop}.
+         */
+        default void onActivityPostStopped(Activity activity) {
+        }
+
+        /**
+         * Called as the first step of the Activity saving its instance state. This is
+         * always called before {@link Activity#onSaveInstanceState}.
+         */
+        default void onActivityPreSaveInstanceState(Activity activity, Bundle outState) {
+        }
+
+        /**
+         * Called when the Activity calls {@link Activity#onSaveInstanceState
+         * super.onSaveInstanceState()}.
+         */
+        void onActivitySaveInstanceState(Activity activity, Bundle outState);
+
+        /**
+         * Called as the last step of the Activity saving its instance state. This is
+         * always called after{@link Activity#onSaveInstanceState}.
+         */
+        default void onActivityPostSaveInstanceState(Activity activity, Bundle outState) {
+        }
+
+        /**
+         * Called as the first step of the Activity being destroyed. This is always
+         * called before {@link Activity#onDestroy}.
+         */
+        default void onActivityPreDestroyed(Activity activity) {
+        }
+
+        /**
+         * Called when the Activity calls {@link Activity#onDestroy super.onDestroy()}.
+         */
+        void onActivityDestroyed(Activity activity);
+
+        /**
+         * Called as the last step of the Activity being destroyed. This is always
+         * called after {@link Activity#onDestroy}.
+         */
+        default void onActivityPostDestroyed(Activity activity) {
+        }
+    }
+
+    /**
+     * Callback interface for use with
+     * {@link Application#registerOnProvideAssistDataListener} and
+     * {@link Application#unregisterOnProvideAssistDataListener}.
+     */
+    public interface OnProvideAssistDataListener {
+        /**
+         * This is called when the user is requesting an assist, to build a full
+         * {@link Intent#ACTION_ASSIST} Intent with all of the context of the current
+         * application. You can override this method to place into the bundle anything
+         * you would like to appear in the {@link Intent#EXTRA_ASSIST_CONTEXT} part of
+         * the assist Intent.
+         */
+        public void onProvideAssistData(Activity activity, Bundle data);
+    }
+
+    /**
+     * Called when the application is starting, before any activity, service, or
+     * receiver objects (excluding content providers) have been created.
+     *
+     * <p>
+     * Implementations should be as quick as possible (for example using lazy
+     * initialization of state) since the time spent in this function directly
+     * impacts the performance of starting the first activity, service, or receiver
+     * in a process.
+     * </p>
+     *
+     * <p>
+     * If you override this method, be sure to call {@code super.onCreate()}.
+     * </p>
+     *
+     * <p class="note">
+     * Be aware that direct boot may also affect callback order on Android
+     * {@link android.os.Build.VERSION_CODES#N} and later devices. Until the user
+     * unlocks the device, only direct boot aware components are allowed to run. You
+     * should consider that all direct boot unaware components, including such
+     * {@link android.content.ContentProvider}, are disabled until user unlock
+     * happens, especially when component callback order matters.
+     * </p>
+     */
+    public void onCreate() {
+    }
+
+    /**
+     * This method is for use in emulated process environments. It will never be
+     * called on a production Android device, where processes are removed by simply
+     * killing them; no user code (including this callback) is executed when doing
+     * so.
+     */
+    public void onTerminate() {
+    }
+
+    public void onLowMemory() {
+    }
+
+    public void onTrimMemory(int level) {
+    }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/content/ContextWrapper.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/content/ContextWrapper.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.content;
+
+import android.os.Bundle;
+import android.content.pm.PackageManager;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.Executor;
+
+public class ContextWrapper extends Context {
+    Context mBase;
+
+    public ContextWrapper(Context base) {
+        mBase = base;
+    }
+
+    // Created just for for the tests to pass
+    public ContextWrapper() {
+        mBase = null;
+    }
+
+    @Override
+    public PackageManager getPackageManager() {
+        return mBase.getPackageManager();
+    }
+
+    @Override
+    public Context createPackageContext(String packageName, int flags) throws Exception {
+        return mBase.createPackageContext(packageName, flags);
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return null;
+    }
+
+    @Override
+    public Context getApplicationContext() {
+        return null;
+    };
+
+    @Override
+    public void startActivity(Intent intent) {
+    };
+
+    @Override
+    public SharedPreferences getSharedPreferences(String name, int mode) {
+    };
+
+    @Override
+    public void sendOrderedBroadcast(Intent intent, String receiverPermission) {
+    };
+
+    @Override
+    public void sendBroadcast(Intent intent) {
+    };
+
+    @Override
+    public void sendBroadcast(Intent intent, String receiverPermission) {
+    };
+
+    @Override
+    public void sendBroadcast(Intent intent, String receiverPermission, Bundle options) {
+    };
+
+    @Override
+    public void sendBroadcast(Intent intent, String receiverPermission, int appOp) {
+    };
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/content/pm/PackageInfo.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/content/pm/PackageInfo.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.content.pm;
+
+// import android.annotation.Nullable;
+// import android.compat.annotation.UnsupportedAppUsage;
+// import android.os.Build;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/**
+ * Overall information about the contents of a package. This corresponds to all
+ * of the information collected from AndroidManifest.xml.
+ */
+public class PackageInfo implements Parcelable {
+    /**
+     * The name of this package. From the &lt;manifest&gt; tag's "name" attribute.
+     */
+    public String packageName;
+
+    /**
+     * The names of any installed split APKs for this package.
+     */
+    public String[] splitNames;
+
+    /**
+     * @deprecated Use {@link #getLongVersionCode()} instead, which includes both
+     *             this and the additional
+     *             {@link android.R.styleable#AndroidManifest_versionCodeMajor
+     *             versionCodeMajor} attribute. The version number of this package,
+     *             as specified by the &lt;manifest&gt; tag's
+     *             {@link android.R.styleable#AndroidManifest_versionCode
+     *             versionCode} attribute.
+     * @see #getLongVersionCode()
+     */
+    @Deprecated
+    public int versionCode;
+
+    /**
+     * @hide The major version number of this package, as specified by the
+     *       &lt;manifest&gt; tag's
+     *       {@link android.R.styleable#AndroidManifest_versionCode
+     *       versionCodeMajor} attribute.
+     * @see #getLongVersionCode()
+     */
+    public int versionCodeMajor;
+
+    /**
+     * Return {@link android.R.styleable#AndroidManifest_versionCode versionCode}
+     * and {@link android.R.styleable#AndroidManifest_versionCodeMajor
+     * versionCodeMajor} combined together as a single long value. The
+     * {@link android.R.styleable#AndroidManifest_versionCodeMajor versionCodeMajor}
+     * is placed in the upper 32 bits.
+     */
+    public long getLongVersionCode() {
+        return composeLongVersionCode(versionCodeMajor, versionCode);
+    }
+
+    /**
+     * Set the full version code in this PackageInfo, updating {@link #versionCode}
+     * with the lower bits.
+     * 
+     * @see #getLongVersionCode()
+     */
+    public void setLongVersionCode(long longVersionCode) {
+        versionCodeMajor = (int) (longVersionCode >> 32);
+        versionCode = (int) longVersionCode;
+    }
+
+    /**
+     * @hide Internal implementation for composing a minor and major version code in
+     *       to a single long version code.
+     */
+    public static long composeLongVersionCode(int major, int minor) {
+        return (((long) major) << 32) | (((long) minor) & 0xffffffffL);
+    }
+
+    /**
+     * The version name of this package, as specified by the &lt;manifest&gt; tag's
+     * {@link android.R.styleable#AndroidManifest_versionName versionName}
+     * attribute.
+     */
+    public String versionName;
+
+    /**
+     * The revision number of the base APK for this package, as specified by the
+     * &lt;manifest&gt; tag's
+     * {@link android.R.styleable#AndroidManifest_revisionCode revisionCode}
+     * attribute.
+     */
+    public int baseRevisionCode;
+
+    /**
+     * The revision number of any split APKs for this package, as specified by the
+     * &lt;manifest&gt; tag's
+     * {@link android.R.styleable#AndroidManifest_revisionCode revisionCode}
+     * attribute. Indexes are a 1:1 mapping against {@link #splitNames}.
+     */
+    public int[] splitRevisionCodes;
+
+    /**
+     * The shared user ID name of this package, as specified by the &lt;manifest&gt;
+     * tag's {@link android.R.styleable#AndroidManifest_sharedUserId sharedUserId}
+     * attribute.
+     */
+    public String sharedUserId;
+
+    /**
+     * The shared user ID label of this package, as specified by the
+     * &lt;manifest&gt; tag's
+     * {@link android.R.styleable#AndroidManifest_sharedUserLabel sharedUserLabel}
+     * attribute.
+     */
+    public int sharedUserLabel;
+
+
+    /**
+     * The time at which the app was first installed. Units are as per
+     * {@link System#currentTimeMillis()}.
+     */
+    public long firstInstallTime;
+
+    /**
+     * The time at which the app was last updated. Units are as per
+     * {@link System#currentTimeMillis()}.
+     */
+    public long lastUpdateTime;
+
+    /**
+     * All kernel group-IDs that have been assigned to this package. This is only
+     * filled in if the flag {@link PackageManager#GET_GIDS} was set.
+     */
+    public int[] gids;
+    /**
+     * Array of all {@link android.R.styleable#AndroidManifestUsesPermission
+     * &lt;uses-permission&gt;} tags included under &lt;manifest&gt;, or null if
+     * there were none. This is only filled in if the flag
+     * {@link PackageManager#GET_PERMISSIONS} was set. This list includes all
+     * permissions requested, even those that were not granted or known by the
+     * system at install time.
+     */
+    public String[] requestedPermissions;
+
+    /**
+     * Array of flags of all
+     * {@link android.R.styleable#AndroidManifestUsesPermission
+     * &lt;uses-permission&gt;} tags included under &lt;manifest&gt;, or null if
+     * there were none. This is only filled in if the flag
+     * {@link PackageManager#GET_PERMISSIONS} was set. Each value matches the
+     * corresponding entry in {@link #requestedPermissions}, and will have the flag
+     * {@link #REQUESTED_PERMISSION_GRANTED} set as appropriate.
+     */
+    public int[] requestedPermissionsFlags;
+
+    /**
+     * Flag for {@link #requestedPermissionsFlags}: the requested permission is
+     * required for the application to run; the user can not optionally disable it.
+     * Currently all permissions are required.
+     *
+     * @removed We do not support required permissions.
+     */
+    public static final int REQUESTED_PERMISSION_REQUIRED = 1 << 0;
+
+    /**
+     * Flag for {@link #requestedPermissionsFlags}: the requested permission is
+     * currently granted to the application.
+     */
+    public static final int REQUESTED_PERMISSION_GRANTED = 1 << 1;
+    /**
+     * Constant corresponding to <code>auto</code> in the
+     * {@link android.R.attr#installLocation} attribute.
+     * 
+     * @hide
+     */
+    public static final int INSTALL_LOCATION_UNSPECIFIED = -1;
+
+    /**
+     * Constant corresponding to <code>auto</code> in the
+     * {@link android.R.attr#installLocation} attribute.
+     */
+    public static final int INSTALL_LOCATION_AUTO = 0;
+
+    /**
+     * Constant corresponding to <code>internalOnly</code> in the
+     * {@link android.R.attr#installLocation} attribute.
+     */
+    public static final int INSTALL_LOCATION_INTERNAL_ONLY = 1;
+
+    /**
+     * Constant corresponding to <code>preferExternal</code> in the
+     * {@link android.R.attr#installLocation} attribute.
+     */
+    public static final int INSTALL_LOCATION_PREFER_EXTERNAL = 2;
+
+    /**
+     * The install location requested by the package. From the
+     * {@link android.R.attr#installLocation} attribute, one of
+     * {@link #INSTALL_LOCATION_AUTO}, {@link #INSTALL_LOCATION_INTERNAL_ONLY},
+     * {@link #INSTALL_LOCATION_PREFER_EXTERNAL}
+     */
+    public int installLocation = INSTALL_LOCATION_INTERNAL_ONLY;
+
+    /** @hide */
+    public boolean isStub;
+
+    /** @hide */
+    public boolean coreApp;
+
+    /** @hide */
+    public boolean requiredForAllUsers;
+
+    /** @hide */
+    public String restrictedAccountType;
+
+    /** @hide */
+    public String requiredAccountType;
+
+    /**
+     * What package, if any, this package will overlay.
+     *
+     * Package name of target package, or null.
+     * 
+     * @hide
+     */
+    public String overlayTarget;
+
+    /**
+     * The name of the overlayable set of elements package, if any, this package
+     * will overlay.
+     *
+     * Overlayable name defined within the target package, or null.
+     * 
+     * @hide
+     */
+    public String targetOverlayableName;
+
+    /**
+     * The overlay category, if any, of this package
+     *
+     * @hide
+     */
+    public String overlayCategory;
+
+    /** @hide */
+    public int overlayPriority;
+
+    /**
+     * Whether the overlay is static, meaning it cannot be enabled/disabled at
+     * runtime.
+     * 
+     * @hide
+     */
+    public boolean mOverlayIsStatic;
+
+    /**
+     * The user-visible SDK version (ex. 26) of the framework against which the
+     * application claims to have been compiled, or {@code 0} if not specified.
+     * <p>
+     * This property is the compile-time equivalent of
+     * {@link android.os.Build.VERSION#SDK_INT Build.VERSION.SDK_INT}.
+     *
+     * @hide For platform use only; we don't expect developers to need to read this
+     *       value.
+     */
+    public int compileSdkVersion;
+
+    /**
+     * The development codename (ex. "O", "REL") of the framework against which the
+     * application claims to have been compiled, or {@code null} if not specified.
+     * <p>
+     * This property is the compile-time equivalent of
+     * {@link android.os.Build.VERSION#CODENAME Build.VERSION.CODENAME}.
+     *
+     * @hide For platform use only; we don't expect developers to need to read this
+     *       value.
+     */
+    public String compileSdkVersionCodename;
+
+    /**
+     * Whether the package is an APEX package.
+     */
+    public boolean isApex;
+
+    public PackageInfo() {
+    }
+
+    public boolean isOverlayPackage() {
+        return false;
+    }
+
+    /**
+     * Returns true if the package is a valid static Runtime Overlay package. Static
+     * overlays are not updatable outside of a system update and are safe to load in
+     * the system process.
+     * 
+     * @hide
+     */
+    public boolean isStaticOverlayPackage() {
+        return false;
+    }
+
+    public String toString() {
+        return "";
+    }
+
+    public int describeContents() {
+        return 0;
+    }
+
+    public void writeToParcel(Parcel dest, int parcelableFlags) {
+    }
+
+    private PackageInfo(Parcel source) {
+
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/content/pm/PackageManager.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/content/pm/PackageManager.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.content.pm;
+
+// import android.Manifest;
+// import android.annotation.CheckResult;
+// import android.annotation.DrawableRes;
+// import android.annotation.IntDef;
+// import android.annotation.IntRange;
+// import android.annotation.NonNull;
+// import android.annotation.Nullable;
+// import android.annotation.RequiresPermission;
+// import android.annotation.SdkConstant;
+// import android.annotation.SdkConstant.SdkConstantType;
+// import android.annotation.StringRes;
+// import android.annotation.SystemApi;
+// import android.annotation.TestApi;
+// import android.annotation.UserIdInt;
+// import android.annotation.XmlRes;
+// import android.app.ActivityManager;
+// import android.app.ActivityThread;
+// import android.app.AppDetailsActivity;
+// import android.app.PackageDeleteObserver;
+// import android.app.PackageInstallObserver;
+// import android.app.PropertyInvalidatedCache;
+// import android.app.admin.DevicePolicyManager;
+// import android.app.usage.StorageStatsManager;
+// import android.compat.annotation.ChangeId;
+// import android.compat.annotation.EnabledSince;
+// import android.compat.annotation.UnsupportedAppUsage;
+// import android.content.ComponentName;
+// import android.content.Context;
+// import android.content.Intent;
+// import android.content.IntentFilter;
+// import android.content.IntentSender;
+// import android.content.pm.dex.ArtManager;
+// import android.content.pm.parsing.PackageInfoWithoutStateUtils;
+// import android.content.pm.parsing.ParsingPackage;
+// import android.content.pm.parsing.ParsingPackageUtils;
+// import android.content.pm.parsing.result.ParseInput;
+// import android.content.pm.parsing.result.ParseResult;
+// import android.content.pm.parsing.result.ParseTypeImpl;
+// import android.content.res.Resources;
+// import android.content.res.XmlResourceParser;
+// import android.graphics.Rect;
+// import android.graphics.drawable.AdaptiveIconDrawable;
+// import android.graphics.drawable.Drawable;
+// import android.net.wifi.WifiManager;
+// import android.os.Build;
+// import android.os.Bundle;
+// import android.os.Handler;
+// import android.os.PersistableBundle;
+// import android.os.RemoteException;
+// import android.os.UserHandle;
+// import android.os.UserManager;
+// import android.os.incremental.IncrementalManager;
+// import android.os.storage.StorageManager;
+// import android.os.storage.VolumeInfo;
+// import android.permission.PermissionManager;
+// import android.util.AndroidException;
+// import android.util.Log;
+
+// import com.android.internal.util.ArrayUtils;
+
+// import dalvik.system.VMRuntime;
+
+import java.io.File;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Class for retrieving various kinds of information related to the application
+ * packages that are currently installed on the device.
+ *
+ * You can find this class through {@link Context#getPackageManager}.
+ */
+public abstract class PackageManager {
+    private static final String TAG = "PackageManager";
+
+    /** {@hide} */
+    public static final boolean APPLY_DEFAULT_TO_DEVICE_PROTECTED_STORAGE = true;
+
+    /**
+     * This exception is thrown when a given package, application, or component name
+     * cannot be found.
+     */
+    public static class NameNotFoundException extends Exception {
+        public NameNotFoundException() {
+        }
+
+        public NameNotFoundException(String name) {
+            super(name);
+        }
+    }
+
+    /**
+     * Listener for changes in permissions granted to a UID.
+     *
+     * @hide
+     */
+
+    public PackageManager() {
+    }
+
+    public abstract PackageInfo getPackageInfo(String packageName, int flags) throws NameNotFoundException;
+
+    public List<PackageInfo> getInstalledPackages(int flags) {
+        return null;
+    };
+
+}


### PR DESCRIPTION
Using untrusted input to create a context can lead to arbitary code execution
This PR adds a query to detect cases where an untrusted input may be
used to instantiate a new context in the application's scope. Allowing
this results in arbitrary code execution as a malicious app would now be
able to take control of the execution flow.