### PR TITLE
Python: support psycopg

### DIFF
--- a/python/ql/src/semmle/python/Frameworks.qll
+++ b/python/ql/src/semmle/python/Frameworks.qll
@@ -9,5 +9,6 @@ private import semmle.python.frameworks.Flask
 private import semmle.python.frameworks.Invoke
 private import semmle.python.frameworks.MySQLdb
 private import semmle.python.frameworks.MysqlConnectorPython
+private import semmle.python.frameworks.Psycopg
 private import semmle.python.frameworks.Stdlib
 private import semmle.python.frameworks.Yaml

--- a/python/ql/src/semmle/python/Frameworks.qll
+++ b/python/ql/src/semmle/python/Frameworks.qll
@@ -9,6 +9,6 @@ private import semmle.python.frameworks.Flask
 private import semmle.python.frameworks.Invoke
 private import semmle.python.frameworks.MySQLdb
 private import semmle.python.frameworks.MysqlConnectorPython
-private import semmle.python.frameworks.Psycopg
+private import semmle.python.frameworks.Psycopg2
 private import semmle.python.frameworks.Stdlib
 private import semmle.python.frameworks.Yaml

--- a/python/ql/src/semmle/python/frameworks/Psycopg.qll
+++ b/python/ql/src/semmle/python/frameworks/Psycopg.qll
@@ -1,5 +1,5 @@
 /**
- * Provides classes modeling security-relevant aspects of the `Psycopg` PyPI package.
+ * Provides classes modeling security-relevant aspects of the `psycopg2` PyPI package.
  * See
  * - https://www.psycopg.org/docs/
  * - https://pypi.org/project/psycopg2/
@@ -12,7 +12,7 @@ private import semmle.python.Concepts
 private import PEP249
 
 /**
- * Provides models for the `Psycopg` PyPI package.
+ * Provides models for the `psycopg2` PyPI package.
  * See
  * - https://www.psycopg.org/docs/
  * - https://pypi.org/project/psycopg2/
@@ -21,19 +21,19 @@ module Psycopg {
   // ---------------------------------------------------------------------------
   // Psycopg
   // ---------------------------------------------------------------------------
-  /** Gets a reference to the `Psycopg` module. */
-  private DataFlow::Node modulePsycopg(DataFlow::TypeTracker t) {
+  /** Gets a reference to the `psycopg2` module. */
+  private DataFlow::Node psycopg2(DataFlow::TypeTracker t) {
     t.start() and
     result = DataFlow::importNode("psycopg2")
     or
-    exists(DataFlow::TypeTracker t2 | result = modulePsycopg(t2).track(t2, t))
+    exists(DataFlow::TypeTracker t2 | result = psycopg2(t2).track(t2, t))
   }
 
-  /** Gets a reference to the `Psycopg` module. */
-  DataFlow::Node modulePsycopg() { result = modulePsycopg(DataFlow::TypeTracker::end()) }
+  /** Gets a reference to the `psycopg2` module. */
+  DataFlow::Node psycopg2() { result = psycopg2(DataFlow::TypeTracker::end()) }
 
-  /** Psycopg implements PEP 249, providing ways to execute SQL statements against a database. */
+  /** psycopg2 implements PEP 249, providing ways to execute SQL statements against a database. */
   class Psycopg extends PEP249Module {
-    Psycopg() { this = modulePsycopg() }
+    Psycopg() { this = psycopg2() }
   }
 }

--- a/python/ql/src/semmle/python/frameworks/Psycopg.qll
+++ b/python/ql/src/semmle/python/frameworks/Psycopg.qll
@@ -1,0 +1,39 @@
+/**
+ * Provides classes modeling security-relevant aspects of the `Psycopg` PyPI package.
+ * See
+ * - https://www.psycopg.org/docs/
+ * - https://pypi.org/project/psycopg2/
+ */
+
+private import python
+private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.dataflow.new.RemoteFlowSources
+private import semmle.python.Concepts
+private import PEP249
+
+/**
+ * Provides models for the `Psycopg` PyPI package.
+ * See
+ * - https://www.psycopg.org/docs/
+ * - https://pypi.org/project/psycopg2/
+ */
+module Psycopg {
+  // ---------------------------------------------------------------------------
+  // Psycopg
+  // ---------------------------------------------------------------------------
+  /** Gets a reference to the `Psycopg` module. */
+  private DataFlow::Node modulePsycopg(DataFlow::TypeTracker t) {
+    t.start() and
+    result = DataFlow::importNode("psycopg2")
+    or
+    exists(DataFlow::TypeTracker t2 | result = modulePsycopg(t2).track(t2, t))
+  }
+
+  /** Gets a reference to the `Psycopg` module. */
+  DataFlow::Node modulePsycopg() { result = modulePsycopg(DataFlow::TypeTracker::end()) }
+
+  /** Psycopg implements PEP 249, providing ways to execute SQL statements against a database. */
+  class Psycopg extends PEP249Module {
+    Psycopg() { this = modulePsycopg() }
+  }
+}

--- a/python/ql/src/semmle/python/frameworks/Psycopg2.qll
+++ b/python/ql/src/semmle/python/frameworks/Psycopg2.qll
@@ -17,7 +17,7 @@ private import PEP249
  * - https://www.psycopg.org/docs/
  * - https://pypi.org/project/psycopg2/
  */
-module Psycopg {
+module Psycopg2 {
   // ---------------------------------------------------------------------------
   // Psycopg
   // ---------------------------------------------------------------------------
@@ -33,7 +33,7 @@ module Psycopg {
   DataFlow::Node psycopg2() { result = psycopg2(DataFlow::TypeTracker::end()) }
 
   /** psycopg2 implements PEP 249, providing ways to execute SQL statements against a database. */
-  class Psycopg extends PEP249Module {
-    Psycopg() { this = psycopg2() }
+  class Psycopg2 extends PEP249Module {
+    Psycopg2() { this = psycopg2() }
   }
 }


### PR DESCRIPTION
Psycopg is the most popular PostgreSQL database adapter for the Python programming language. Its main features are the complete implementation of the Python DB API 2.0 specification which makes it very easy for us to support.

This recovers the lost results for sql injection in https://lgtm.com/projects/g/GeoscienceAustralia/placenames-dataset/.