### PR TITLE
C++: Fix bad join order in AliasedSSA::getResultMemoryLocation

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -566,6 +566,9 @@ private Overlap getVariableMemoryLocationOverlap(
       use.getEndBitOffset())
 }
 
+bindingset[result, b]
+private boolean unbindBool(boolean b) { result != b.booleanNot() }
+
 MemoryLocation getResultMemoryLocation(Instruction instr) {
   exists(MemoryAccessKind kind, boolean isMayAccess |
     kind = instr.getResultMemoryAccess() and
@@ -578,7 +581,8 @@ MemoryLocation getResultMemoryLocation(Instruction instr) {
           exists(Allocation var, IRType type, IntValue startBitOffset, IntValue endBitOffset |
             hasResultMemoryAccess(instr, var, type, _, startBitOffset, endBitOffset, isMayAccess) and
             result =
-              TVariableMemoryLocation(var, type, _, startBitOffset, endBitOffset, isMayAccess)
+              TVariableMemoryLocation(var, type, _, startBitOffset, endBitOffset,
+                unbindBool(isMayAccess))
           )
         else result = TUnknownMemoryLocation(instr.getEnclosingIRFunction(), isMayAccess)
       )
@@ -586,7 +590,7 @@ MemoryLocation getResultMemoryLocation(Instruction instr) {
       kind instanceof EntireAllocationMemoryAccess and
       result =
         TEntireAllocationMemoryLocation(getAddressOperandAllocation(instr.getResultAddressOperand()),
-          isMayAccess)
+          unbindBool(isMayAccess))
       or
       kind instanceof EscapedMemoryAccess and
       result = TAllAliasedMemory(instr.getEnclosingIRFunction(), isMayAccess, false)


### PR DESCRIPTION
Fixes a bad join-order introduced in https://github.com/github/codeql/pull/4558. A couple of unbinds solved the problem (at least on `openjdk`). I'm not exactly sure _why_ we need the unbind in only two places, though.

Before (I stopped the evaluation after being stuck in `getResultMemoryLocation` for a couple of minutes):
```
Tuple counts for AliasedSSA::getResultMemoryLocation#ff/2@63c146:
  0          ~0%       {2} r1 = JOIN Opcode::Opcode::getWriteMemoryAccess_dispred#ff AS L WITH SSAConstruction::Cached::getInstructionOpcode#ff_10#join_rhs AS R ON FIRST 1 OUTPUT L.<1>, R.<1>
  0          ~0%       {2} r2 = r1 AND NOT AliasedSSA::getResultMemoryLocation#ff#antijoin_rhs AS R(r1.<0>, r1.<1>)
  949028     ~1%       {2} r3 = AliasedSSA::getResultMemoryLocation#ff#antijoin_rhs \/ r2
  0          ~0%       {1} r4 = JOIN r3 WITH MemoryAccessKind::EscapedInitializationMemoryAccess#class#f AS R ON FIRST 1 OUTPUT r3.<1>
  0          ~0%       {4} r5 = JOIN r4 WITH SSAConstruction::Cached::getInstructionEnclosingIRFunction#ff AS R ON FIRST 1 OUTPUT R.<1>, false, true, r4.<0>
  0          ~0%       {2} r6 = JOIN r5 WITH AliasedSSA::TAllAliasedMemory#ffff AS R ON FIRST 3 OUTPUT R.<3>, r5.<3>
  0          ~0%       {2} r7 = JOIN r6 WITH AliasedSSA::MemoryLocation#class#f AS R ON FIRST 1 OUTPUT r6.<1>, r6.<0>
  413525     ~0%       {3} r8 = JOIN Opcode::MayWriteOpcode#class#f AS L WITH AliasedSSA::getResultMemoryLocation#ff#shared AS R ON FIRST 1 OUTPUT R.<1>, R.<2>, true
  0          ~0%       {3} r9 = SCAN r2 OUTPUT r2.<0>, r2.<1>, false
  413525     ~0%       {3} r10 = r8 \/ r9
  402804     ~0%       {2} r11 = JOIN r10 WITH MemoryAccessKind::EscapedMemoryAccess#class#f AS R ON FIRST 1 OUTPUT r10.<1>, r10.<2>
  402804     ~0%       {4} r12 = JOIN r11 WITH SSAConstruction::Cached::getInstructionEnclosingIRFunction#ff AS R ON FIRST 1 OUTPUT R.<1>, r11.<1>, false, r11.<0>
  402804     ~6%       {2} r13 = JOIN r12 WITH AliasedSSA::TAllAliasedMemory#ffff AS R ON FIRST 3 OUTPUT R.<3>, r12.<3>
  402804     ~7%       {2} r14 = JOIN r13 WITH AliasedSSA::MemoryLocation#class#f AS R ON FIRST 1 OUTPUT r13.<1>, r13.<0>
  402804     ~7%       {2} r15 = r7 \/ r14
  10721      ~0%       {3} r16 = JOIN r10 WITH AliasedSSA::isIndirectOrBufferMemoryAccess#f AS R ON FIRST 1 OUTPUT r10.<0>, r10.<1>, r10.<2>
  2755       ~2%       {3} r17 = r16 AND NOT project#AliasedSSA::hasResultMemoryAccess#fffffff#6 AS R(r16.<1>)
  2755       ~0%       {2} r18 = SCAN r17 OUTPUT r17.<1>, r17.<2>
  2755       ~0%       {3} r19 = JOIN r18 WITH SSAConstruction::Cached::getInstructionEnclosingIRFunction#ff AS R ON FIRST 1 OUTPUT R.<1>, r18.<1>, r18.<0>
  2755       ~0%       {2} r20 = JOIN r19 WITH AliasedSSA::TUnknownMemoryLocation#fff AS R ON FIRST 2 OUTPUT R.<2>, r19.<2>
  2755       ~0%       {2} r21 = JOIN r20 WITH AliasedSSA::MemoryLocation#class#f AS R ON FIRST 1 OUTPUT r20.<1>, r20.<0>
  0          ~0%       {2} r22 = JOIN r10 WITH MemoryAccessKind::EntireAllocationMemoryAccess#class#f AS R ON FIRST 1 OUTPUT r10.<1>, r10.<2>
  0          ~0%       {3} r23 = JOIN r22 WITH Instruction::Instruction::getResultAddressOperand_dispred#2#ff AS R ON FIRST 1 OUTPUT r22.<1>, r22.<0>, R.<1>
  0          ~0%       {4} r24 = JOIN r23 WITH AliasedSSA::TEntireAllocationMemoryLocation#fff_102#join_rhs AS R ON FIRST 1 OUTPUT R.<2>, r23.<1>, r23.<2>, R.<1>
  0          ~0%       {4} r25 = JOIN r24 WITH AliasedSSA::MemoryLocation#class#f AS R ON FIRST 1 OUTPUT r24.<2>, r24.<3>, r24.<1>, r24.<0>
  0          ~0%       {2} r26 = JOIN r25 WITH project#AliasAnalysis::addressOperandAllocationAndOffset#2#fff AS R ON FIRST 2 OUTPUT r25.<2>, r25.<3>
  10721      ~2%       {2} r27 = JOIN r10 WITH AliasedSSA::isIndirectOrBufferMemoryAccess#f AS R ON FIRST 1 OUTPUT r10.<2>, r10.<1>
  2233402438 ~0%       {7} r28 = JOIN r27 WITH AliasedSSA::TVariableMemoryLocation#fffffff_501346#join_rhs AS R ON FIRST 1 OUTPUT R.<5>, r27.<1>, r27.<0>, R.<1>, R.<2>, R.<3>, R.<4>
  2233402438 ~0%       {7} r29 = JOIN r28 WITH AliasedSSA::MemoryLocation#class#f AS R ON FIRST 1 OUTPUT r28.<1>, r28.<3>, r28.<4>, r28.<5>, r28.<6>, r28.<2>, r28.<0>
  7969       ~5%       {2} r30 = JOIN r29 WITH project#AliasedSSA::hasResultMemoryAccess#fffffff#5 AS R ON FIRST 6 OUTPUT r29.<0>, r29.<6>
  7969       ~5%       {2} r31 = r26 \/ r30
  10724      ~6%       {2} r32 = r21 \/ r31
  413528     ~7%       {2} r33 = r15 \/ r32
                       return r33
```

After:
```
Tuple counts for AliasedSSA::getResultMemoryLocation#ff/2@4d567b:
  116454  ~0%       {2} r1 = JOIN Opcode::Opcode::getWriteMemoryAccess_dispred#ff AS L WITH SSAConstruction::Cached::getInstructionOpcode#ff_10#join_rhs AS R ON FIRST 1 OUTPUT L.<1>, R.<1>
  116454  ~0%       {2} r2 = r1 AND NOT AliasedSSA::getResultMemoryLocation#ff#antijoin_rhs AS R(r1.<0>, r1.<1>)
  1065482 ~0%       {2} r3 = AliasedSSA::getResultMemoryLocation#ff#antijoin_rhs \/ r2
  107634  ~6%       {1} r4 = JOIN r3 WITH MemoryAccessKind::EscapedInitializationMemoryAccess#class#f AS R ON FIRST 1 OUTPUT r3.<1>
  107634  ~0%       {4} r5 = JOIN r4 WITH SSAConstruction::Cached::getInstructionEnclosingIRFunction#ff AS R ON FIRST 1 OUTPUT R.<1>, false, true, r4.<0>
  107634  ~0%       {2} r6 = JOIN r5 WITH AliasedSSA::TAllAliasedMemory#ffff AS R ON FIRST 3 OUTPUT R.<3>, r5.<3>
  107634  ~3%       {2} r7 = JOIN r6 WITH AliasedSSA::MemoryLocation#class#f AS R ON FIRST 1 OUTPUT r6.<1>, r6.<0>
  949028  ~0%       {3} r8 = JOIN Opcode::MayWriteOpcode#class#f AS L WITH AliasedSSA::getResultMemoryLocation#ff#shared AS R ON FIRST 1 OUTPUT R.<1>, R.<2>, true
  116454  ~0%       {3} r9 = SCAN r2 OUTPUT r2.<0>, r2.<1>, false
  1065482 ~0%       {3} r10 = r8 \/ r9
  402804  ~0%       {2} r11 = JOIN r10 WITH MemoryAccessKind::EscapedMemoryAccess#class#f AS R ON FIRST 1 OUTPUT r10.<1>, r10.<2>
  402804  ~4%       {4} r12 = JOIN r11 WITH SSAConstruction::Cached::getInstructionEnclosingIRFunction#ff AS R ON FIRST 1 OUTPUT R.<1>, r11.<1>, false, r11.<0>
  402804  ~0%       {2} r13 = JOIN r12 WITH AliasedSSA::TAllAliasedMemory#ffff AS R ON FIRST 3 OUTPUT R.<3>, r12.<3>
  402804  ~0%       {2} r14 = JOIN r13 WITH AliasedSSA::MemoryLocation#class#f AS R ON FIRST 1 OUTPUT r13.<1>, r13.<0>
  510438  ~5%       {2} r15 = r7 \/ r14
  546224  ~0%       {3} r16 = JOIN r10 WITH AliasedSSA::isIndirectOrBufferMemoryAccess#f AS R ON FIRST 1 OUTPUT r10.<0>, r10.<1>, r10.<2>
  183799  ~2%       {3} r17 = r16 AND NOT project#AliasedSSA::hasResultMemoryAccess#fffffff#6 AS R(r16.<1>)
  183799  ~0%       {2} r18 = SCAN r17 OUTPUT r17.<1>, r17.<2>
  183799  ~4%       {3} r19 = JOIN r18 WITH SSAConstruction::Cached::getInstructionEnclosingIRFunction#ff AS R ON FIRST 1 OUTPUT R.<1>, r18.<1>, r18.<0>
  183799  ~1%       {2} r20 = JOIN r19 WITH AliasedSSA::TUnknownMemoryLocation#fff AS R ON FIRST 2 OUTPUT R.<2>, r19.<2>
  183799  ~3%       {2} r21 = JOIN r20 WITH AliasedSSA::MemoryLocation#class#f AS R ON FIRST 1 OUTPUT r20.<1>, r20.<0>
  8820    ~0%       {3} r22 = JOIN r10 WITH MemoryAccessKind::EntireAllocationMemoryAccess#class#f AS R ON FIRST 1 OUTPUT r10.<1>, r10.<0>, r10.<2>
  8820    ~3%       {5} r23 = JOIN r22 WITH Instruction::Instruction::getResultAddressOperand_dispred#2#ff AS R ON FIRST 1 OUTPUT R.<1>, r22.<1>, r22.<0>, r22.<2>, booleanNot(r22.<2>)
  8132    ~0%       {5} r24 = JOIN r23 WITH project#AliasAnalysis::addressOperandAllocationAndOffset#2#fff AS R ON FIRST 1 OUTPUT R.<1>, r23.<1>, r23.<2>, r23.<3>, r23.<4>
  16222   ~0%       {7} r25 = JOIN r24 WITH AliasedSSA::TEntireAllocationMemoryLocation#fff AS R ON FIRST 1 OUTPUT r24.<1>, r24.<2>, r24.<3>, r24.<4>, r24.<0>, R.<1>, R.<2>
  8111    ~2%       {7} r26 = SELECT r25 ON r25.<3> != r25.<5>
  8111    ~2%       {2} r27 = SCAN r26 OUTPUT r26.<6>, r26.<1>
  8111    ~0%       {2} r28 = JOIN r27 WITH AliasedSSA::MemoryLocation#class#f AS R ON FIRST 1 OUTPUT r27.<1>, r27.<0>
  546224  ~0%       {4} r29 = JOIN r10 WITH AliasedSSA::isIndirectOrBufferMemoryAccess#f AS R ON FIRST 1 OUTPUT r10.<1>, r10.<2>, r10.<0>, booleanNot(r10.<2>)
  366756  ~7%       {8} r30 = JOIN r29 WITH project#AliasedSSA::hasResultMemoryAccess#fffffff#5_051234#join_rhs AS R ON FIRST 2 OUTPUT R.<2>, R.<3>, R.<4>, R.<5>, r29.<2>, r29.<0>, r29.<1>, r29.<3>
  594569  ~2%       {11} r31 = JOIN r30 WITH AliasedSSA::TVariableMemoryLocation#fffffff_0134256#join_rhs AS R ON FIRST 4 OUTPUT r30.<4>, r30.<5>, r30.<6>, r30.<7>, r30.<0>, r30.<1>, r30.<2>, r30.<3>, R.<4>, R.<5>, R.<6>
  366756  ~1%       {11} r32 = SELECT r31 ON r31.<3> != r31.<9>
  366756  ~7%       {2} r33 = SCAN r32 OUTPUT r32.<10>, r32.<1>
  366756  ~4%       {2} r34 = JOIN r33 WITH AliasedSSA::MemoryLocation#class#f AS R ON FIRST 1 OUTPUT r33.<1>, r33.<0>
  374867  ~5%       {2} r35 = r28 \/ r34
  558666  ~4%       {2} r36 = r21 \/ r35
  1069104 ~0%       {2} r37 = r15 \/ r36
                    return r37
```

CPP-difference: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1559/