### PR TITLE
Python: Use default `getEnclosingCallable` for `RetrunNode`

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -739,10 +739,6 @@ class ReturnNode extends CfgNode {
 
   /** Gets the kind of this return node. */
   ReturnKind getKind() { any() }
-
-  override DataFlowCallable getEnclosingCallable() {
-    result.getScope().getAStmt() = ret // TODO: check nested function definitions
-  }
 }
 
 /** A data flow node that represents the output of a call. */

--- a/python/ql/test/experimental/dataflow/coverage/argumentPassing.py
+++ b/python/ql/test/experimental/dataflow/coverage/argumentPassing.py
@@ -112,7 +112,7 @@ def with_multiple_kw_args(a, b, c):
     SINK3(c)
 
 
-@expects(9)
+@expects(12)
 def test_multiple_kw_args():
     with_multiple_kw_args(b=arg2, c=arg3, a=arg1)
     with_multiple_kw_args(arg1, *(arg2,), arg3)

--- a/python/ql/test/experimental/dataflow/coverage/dataflow.expected
+++ b/python/ql/test/experimental/dataflow/coverage/dataflow.expected
@@ -61,6 +61,7 @@ edges
 | test.py:0:0:0:0 | ModuleVariableNode for Global Variable SOURCE in Module test | test.py:492:33:492:38 | ControlFlowNode for SOURCE |
 | test.py:0:0:0:0 | ModuleVariableNode for Global Variable SOURCE in Module test | test.py:497:39:497:44 | ControlFlowNode for SOURCE |
 | test.py:0:0:0:0 | ModuleVariableNode for Global Variable SOURCE in Module test | test.py:509:9:509:14 | ControlFlowNode for SOURCE |
+| test.py:0:0:0:0 | ModuleVariableNode for Global Variable SOURCE in Module test | test.py:588:16:588:21 | ControlFlowNode for SOURCE |
 | test.py:20:1:20:6 | GSSA Variable SOURCE | test.py:0:0:0:0 | ModuleVariableNode for Global Variable SOURCE in Module test |
 | test.py:20:10:20:17 | ControlFlowNode for Str | test.py:20:1:20:6 | GSSA Variable SOURCE |
 | test.py:42:10:42:26 | ControlFlowNode for Tuple [Tuple element at index 1] | test.py:43:9:43:9 | ControlFlowNode for x [Tuple element at index 1] |
@@ -179,6 +180,7 @@ edges
 | test.py:497:39:497:44 | ControlFlowNode for SOURCE | test.py:497:10:497:45 | KwOverflowNode for f_extra_keyword() [Dictionary element at key b] |
 | test.py:509:9:509:14 | ControlFlowNode for SOURCE | test.py:511:10:511:10 | ControlFlowNode for a |
 | test.py:509:9:509:14 | ControlFlowNode for SOURCE | test.py:516:10:516:10 | ControlFlowNode for b |
+| test.py:588:16:588:21 | ControlFlowNode for SOURCE | test.py:591:10:591:36 | ControlFlowNode for return_from_inner_scope() |
 nodes
 | datamodel.py:0:0:0:0 | ModuleVariableNode for Global Variable SOURCE in Module datamodel | semmle.label | ModuleVariableNode for Global Variable SOURCE in Module datamodel |
 | datamodel.py:13:1:13:6 | GSSA Variable SOURCE | semmle.label | GSSA Variable SOURCE |
@@ -355,6 +357,8 @@ nodes
 | test.py:509:9:509:14 | ControlFlowNode for SOURCE | semmle.label | ControlFlowNode for SOURCE |
 | test.py:511:10:511:10 | ControlFlowNode for a | semmle.label | ControlFlowNode for a |
 | test.py:516:10:516:10 | ControlFlowNode for b | semmle.label | ControlFlowNode for b |
+| test.py:588:16:588:21 | ControlFlowNode for SOURCE | semmle.label | ControlFlowNode for SOURCE |
+| test.py:591:10:591:36 | ControlFlowNode for return_from_inner_scope() | semmle.label | ControlFlowNode for return_from_inner_scope() |
 #select
 | datamodel.py:38:6:38:17 | ControlFlowNode for f() | datamodel.py:13:10:13:17 | ControlFlowNode for Str | datamodel.py:38:6:38:17 | ControlFlowNode for f() | Flow found |
 | datamodel.py:38:6:38:17 | ControlFlowNode for f() | datamodel.py:38:8:38:13 | ControlFlowNode for SOURCE | datamodel.py:38:6:38:17 | ControlFlowNode for f() | Flow found |
@@ -452,3 +456,5 @@ nodes
 | test.py:511:10:511:10 | ControlFlowNode for a | test.py:509:9:509:14 | ControlFlowNode for SOURCE | test.py:511:10:511:10 | ControlFlowNode for a | Flow found |
 | test.py:516:10:516:10 | ControlFlowNode for b | test.py:20:10:20:17 | ControlFlowNode for Str | test.py:516:10:516:10 | ControlFlowNode for b | Flow found |
 | test.py:516:10:516:10 | ControlFlowNode for b | test.py:509:9:509:14 | ControlFlowNode for SOURCE | test.py:516:10:516:10 | ControlFlowNode for b | Flow found |
+| test.py:591:10:591:36 | ControlFlowNode for return_from_inner_scope() | test.py:20:10:20:17 | ControlFlowNode for Str | test.py:591:10:591:36 | ControlFlowNode for return_from_inner_scope() | Flow found |
+| test.py:591:10:591:36 | ControlFlowNode for return_from_inner_scope() | test.py:588:16:588:21 | ControlFlowNode for SOURCE | test.py:591:10:591:36 | ControlFlowNode for return_from_inner_scope() | Flow found |

--- a/python/ql/test/experimental/dataflow/coverage/test.py
+++ b/python/ql/test/experimental/dataflow/coverage/test.py
@@ -580,3 +580,12 @@ def test_dynamic_tuple_creation_4():
 
     SINK(tup[0])  # Flow missing
     SINK_F(tup[1])
+
+def return_from_inner_scope(x):
+    try:
+        return x[0]
+    except IndexError:
+        return SOURCE
+
+def test_return_from_inner_scope():
+    SINK(return_from_inner_scope([]))

--- a/python/ql/test/library-tests/PointsTo/new/ImpliesDataflow.expected
+++ b/python/ql/test/library-tests/PointsTo/new/ImpliesDataflow.expected
@@ -15,8 +15,6 @@
 | code/q_super.py:48:5:48:17 | ControlFlowNode for ClassExpr | code/q_super.py:51:25:51:29 | ControlFlowNode for Attribute |
 | code/q_super.py:63:5:63:17 | ControlFlowNode for ClassExpr | code/q_super.py:66:19:66:23 | ControlFlowNode for Attribute |
 | code/r_regressions.py:46:1:46:14 | ControlFlowNode for FunctionExpr | code/r_regressions.py:52:9:52:12 | ControlFlowNode for fail |
-| code/r_regressions.py:86:1:86:24 | ControlFlowNode for ClassExpr | code/r_regressions.py:85:2:85:33 | ControlFlowNode for method_decorator()() |
-| code/r_regressions.py:86:1:86:24 | ControlFlowNode for ClassExpr | code/r_regressions.py:90:1:90:9 | ControlFlowNode for TestFirst |
 | code/t_type.py:3:1:3:16 | ControlFlowNode for ClassExpr | code/t_type.py:6:1:6:9 | ControlFlowNode for type() |
 | code/t_type.py:3:1:3:16 | ControlFlowNode for ClassExpr | code/t_type.py:13:5:13:13 | ControlFlowNode for type() |
 | code/test_package/module2.py:5:5:5:6 | ControlFlowNode for Dict | code/j_convoluted_imports.py:25:1:25:1 | ControlFlowNode for r |


### PR DESCRIPTION
The override removed some flow, this reinstates it. Differences job suggesting that performance has not suffered: https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/294/