### PR TITLE
Remove unit tests for duplicate-code detection, take II

### DIFF
--- a/csharp/ql/test/query-tests/Metrics/Dependencies/ExternalDependencies/ExternalDependencies.expected
+++ b/csharp/ql/test/query-tests/Metrics/Dependencies/ExternalDependencies/ExternalDependencies.expected
@@ -1,5 +1,0 @@
-| /query-tests/Metrics/Dependencies/ExternalDependencies/File1.cs<\|>System.Net.Http<\|>4.2.2.0 | 11 |
-| /query-tests/Metrics/Dependencies/ExternalDependencies/File1.cs<\|>System.Private.DataContractSerialization<\|>4.1.5.0 | 2 |
-| /query-tests/Metrics/Dependencies/ExternalDependencies/File1.cs<\|>System.Private.Xml<\|>4.0.2.0 | 2 |
-| /query-tests/Metrics/Dependencies/ExternalDependencies/File1.cs<\|>System.Data.Common<\|>4.2.2.0 | 1 |
-| /query-tests/Metrics/Dependencies/ExternalDependencies/File2.cs<\|>System.Net.Http<\|>4.2.2.0 | 1 |

--- a/csharp/ql/test/query-tests/Metrics/Dependencies/ExternalDependencies/ExternalDependenciesSourceLinks.expected
+++ b/csharp/ql/test/query-tests/Metrics/Dependencies/ExternalDependencies/ExternalDependenciesSourceLinks.expected
@@ -1,5 +1,0 @@
-| /query-tests/Metrics/Dependencies/ExternalDependencies/File1.cs<\|>System.Data.Common<\|>4.2.2.0 | File1.cs:0:0:0:0 | File1.cs |
-| /query-tests/Metrics/Dependencies/ExternalDependencies/File1.cs<\|>System.Net.Http<\|>4.2.2.0 | File1.cs:0:0:0:0 | File1.cs |
-| /query-tests/Metrics/Dependencies/ExternalDependencies/File1.cs<\|>System.Private.DataContractSerialization<\|>4.1.5.0 | File1.cs:0:0:0:0 | File1.cs |
-| /query-tests/Metrics/Dependencies/ExternalDependencies/File1.cs<\|>System.Private.Xml<\|>4.0.2.0 | File1.cs:0:0:0:0 | File1.cs |
-| /query-tests/Metrics/Dependencies/ExternalDependencies/File2.cs<\|>System.Net.Http<\|>4.2.2.0 | File2.cs:0:0:0:0 | File2.cs |

--- a/csharp/ql/test/query-tests/Metrics/Files/FLinesOfDuplicatedCode/flinesofduplicatedcode.expected
+++ b/csharp/ql/test/query-tests/Metrics/Files/FLinesOfDuplicatedCode/flinesofduplicatedcode.expected
@@ -1,2 +1,0 @@
-| file1.cs:0:0:0:0 | file1.cs | 34 |
-| file2.cs:0:0:0:0 | file2.cs | 18 |

--- a/python/ql/test/query-tests/Metrics/duplicate/FLinesOfDuplicatedCode.expected
+++ b/python/ql/test/query-tests/Metrics/duplicate/FLinesOfDuplicatedCode.expected
@@ -1,4 +1,0 @@
-| duplicate_test.py:0:0:0:0 | duplicate_test.py | 228 |
-| similar.py:0:0:0:0 | similar.py | 59 |
-| with_import1.py:0:0:0:0 | with_import1.py | 30 |
-| with_import2.py:0:0:0:0 | with_import2.py | 30 |

--- a/python/ql/test/query-tests/Metrics/duplicate/FLinesOfSimilarCode.expected
+++ b/python/ql/test/query-tests/Metrics/duplicate/FLinesOfSimilarCode.expected
@@ -1,4 +1,0 @@
-| duplicate_test.py:0:0:0:0 | duplicate_test.py | 310 |
-| similar.py:0:0:0:0 | similar.py | 61 |
-| with_import1.py:0:0:0:0 | with_import1.py | 30 |
-| with_import2.py:0:0:0:0 | with_import2.py | 30 |


### PR DESCRIPTION
In #4689 I forgot to remove the `.expected` files too, but they are now of course useless.