### PR TITLE
JS: Api graph tweaks

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -83,6 +83,12 @@ module API {
     DataFlow::Node getARhs() { Impl::rhs(this, result) }
 
     /**
+     * Gets a data-flow node that may interprocedurally flow to the right-hand side of a definition
+     * of the API component represented by this node.
+     */
+    DataFlow::Node getAValueReachingRhs() { result = Impl::trackDefNode(getARhs()) }
+
+    /**
      * Gets a node representing member `m` of this API component.
      *
      * For example, modules have an `exports` member representing their exports, and objects have
@@ -825,9 +831,10 @@ module API {
     }
 
     /** Gets the API node a parameter of this invocation. */
-    Node getAParameter() {
-      result = getParameter(_)
-    }
+    Node getAParameter() { result = getParameter(_) }
+
+    /** Gets the API node for the last parameter of this invocation. */
+    Node getLastParameter() { result = getParameter(getNumArgument() - 1) }
 
     /** Gets the API node for the return value of this call. */
     Node getReturn() { result.getAnImmediateUse() = this }

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -840,10 +840,16 @@ module API {
     Node getLastParameter() { result = getParameter(getNumArgument() - 1) }
 
     /** Gets the API node for the return value of this call. */
-    Node getReturn() { result.getAnImmediateUse() = this }
+    Node getReturn() {
+      result = callee.getReturn() and
+      result.getAnImmediateUse() = this
+    }
 
     /** Gets the API node for the object constructed by this invocation. */
-    Node getInstance() { result.getAnImmediateUse() = this }
+    Node getInstance() {
+      result = callee.getInstance() and
+      result.getAnImmediateUse() = this
+    }
   }
 
   /** A call connected to the API graph. */

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -822,7 +822,10 @@ module API {
   class InvokeNode extends DataFlow::InvokeNode {
     API::Node callee;
 
-    InvokeNode() { this = callee.getReturn().getAnImmediateUse() or this = callee.getInstance().getAnImmediateUse() }
+    InvokeNode() {
+      this = callee.getReturn().getAnImmediateUse() or
+      this = callee.getInstance().getAnImmediateUse()
+    }
 
     /** Gets the API node for the `i`th parameter of this invocation. */
     Node getParameter(int i) {
@@ -844,12 +847,10 @@ module API {
   }
 
   /** A call connected to the API graph. */
-  class CallNode extends InvokeNode, DataFlow::CallNode {
-  }
+  class CallNode extends InvokeNode, DataFlow::CallNode { }
 
   /** A `new` call connected to the API graph. */
-  class NewNode extends InvokeNode, DataFlow::NewNode {
-  }
+  class NewNode extends InvokeNode, DataFlow::NewNode { }
 }
 
 private module Label {

--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -62,22 +62,20 @@ private module MongoDB {
   }
 
   /** A call to a MongoDB query method. */
-  private class QueryCall extends DatabaseAccess, DataFlow::CallNode {
+  private class QueryCall extends DatabaseAccess, API::CallNode {
     int queryArgIdx;
-    API::Node callee;
 
     QueryCall() {
       exists(string method |
         CollectionMethodSignatures::interpretsArgumentAsQuery(method, queryArgIdx) and
-        callee = getACollection().getMember(method)
-      ) and
-      this = callee.getACall()
+        this = getACollection().getMember(method).getACall()
+      )
     }
 
     override DataFlow::Node getAQueryArgument() { result = getArgument(queryArgIdx) }
 
     DataFlow::Node getACodeOperator() {
-      result = getADollarWhereProperty(callee.getParameter(queryArgIdx))
+      result = getADollarWhereProperty(getParameter(queryArgIdx))
     }
   }
 
@@ -670,14 +668,12 @@ private module Minimongo {
   }
 
   /** A call to a Minimongo query method. */
-  private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
+  private class QueryCall extends DatabaseAccess, API::CallNode {
     int queryArgIdx;
-    API::Node callee;
 
     QueryCall() {
       exists(string m |
-        callee = API::moduleImport("minimongo").getAMember().getReturn().getAMember().getMember(m) and
-        this = callee.getACall() and
+        this = API::moduleImport("minimongo").getAMember().getReturn().getAMember().getMember(m).getACall() and
         CollectionMethodSignatures::interpretsArgumentAsQuery(m, queryArgIdx)
       )
     }
@@ -685,7 +681,7 @@ private module Minimongo {
     override DataFlow::Node getAQueryArgument() { result = getArgument(queryArgIdx) }
 
     DataFlow::Node getACodeOperator() {
-      result = getADollarWhereProperty(callee.getParameter(queryArgIdx))
+      result = getADollarWhereProperty(getParameter(queryArgIdx))
     }
   }
 
@@ -706,14 +702,12 @@ private module Minimongo {
  */
 private module MarsDB {
   /** A call to a MarsDB query method. */
-  private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
+  private class QueryCall extends DatabaseAccess, API::MethodCallNode {
     int queryArgIdx;
-    API::Node callee;
 
     QueryCall() {
       exists(string m |
-        callee = API::moduleImport("marsdb").getMember("Collection").getInstance().getMember(m) and
-        this = callee.getACall() and
+        this = API::moduleImport("marsdb").getMember("Collection").getInstance().getMember(m).getACall() and
         // implements parts of the Minimongo interface
         Minimongo::CollectionMethodSignatures::interpretsArgumentAsQuery(m, queryArgIdx)
       )
@@ -722,7 +716,7 @@ private module MarsDB {
     override DataFlow::Node getAQueryArgument() { result = getArgument(queryArgIdx) }
 
     DataFlow::Node getACodeOperator() {
-      result = getADollarWhereProperty(callee.getParameter(queryArgIdx))
+      result = getADollarWhereProperty(getParameter(queryArgIdx))
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -708,7 +708,7 @@ private module Minimongo {
  */
 private module MarsDB {
   /** A call to a MarsDB query method. */
-  private class QueryCall extends DatabaseAccess, API::MethodCallNode {
+  private class QueryCall extends DatabaseAccess, API::CallNode {
     int queryArgIdx;
 
     QueryCall() {

--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -673,7 +673,13 @@ private module Minimongo {
 
     QueryCall() {
       exists(string m |
-        this = API::moduleImport("minimongo").getAMember().getReturn().getAMember().getMember(m).getACall() and
+        this =
+          API::moduleImport("minimongo")
+              .getAMember()
+              .getReturn()
+              .getAMember()
+              .getMember(m)
+              .getACall() and
         CollectionMethodSignatures::interpretsArgumentAsQuery(m, queryArgIdx)
       )
     }
@@ -707,7 +713,8 @@ private module MarsDB {
 
     QueryCall() {
       exists(string m |
-        this = API::moduleImport("marsdb").getMember("Collection").getInstance().getMember(m).getACall() and
+        this =
+          API::moduleImport("marsdb").getMember("Collection").getInstance().getMember(m).getACall() and
         // implements parts of the Minimongo interface
         Minimongo::CollectionMethodSignatures::interpretsArgumentAsQuery(m, queryArgIdx)
       )

--- a/javascript/ql/test/ApiGraphs/call-nodes/index.js
+++ b/javascript/ql/test/ApiGraphs/call-nodes/index.js
@@ -1,0 +1,4 @@
+import { foo } from 'mylibrary';
+
+foo({ value: 1 }, { value: 1 });
+foo({ value: 2 }, { value: 2 });

--- a/javascript/ql/test/ApiGraphs/call-nodes/test.expected
+++ b/javascript/ql/test/ApiGraphs/call-nodes/test.expected
@@ -1,0 +1,3 @@
+ERROR: Could not resolve predicate getArgument/1 (/Users/asger/git/code/ql/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll:716,60-71)
+ERROR: Could not resolve predicate getParameter/1 (/Users/asger/git/code/ql/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll:719,40-52)
+ERROR: Could not resolve type API::MethodCallNode (/Users/asger/git/code/ql/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll:705,51-70)

--- a/javascript/ql/test/ApiGraphs/call-nodes/test.expected
+++ b/javascript/ql/test/ApiGraphs/call-nodes/test.expected
@@ -1,3 +1,4 @@
-ERROR: Could not resolve predicate getArgument/1 (/Users/asger/git/code/ql/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll:716,60-71)
-ERROR: Could not resolve predicate getParameter/1 (/Users/asger/git/code/ql/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll:719,40-52)
-ERROR: Could not resolve type API::MethodCallNode (/Users/asger/git/code/ql/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll:705,51-70)
+values
+| index.js:3:1:3:31 | foo({ v ... e: 1 }) | 1 | 1 |
+| index.js:4:1:4:31 | foo({ v ... e: 2 }) | 2 | 2 |
+mismatch

--- a/javascript/ql/test/ApiGraphs/call-nodes/test.ql
+++ b/javascript/ql/test/ApiGraphs/call-nodes/test.ql
@@ -1,17 +1,11 @@
 import javascript
 
 class FooCall extends API::CallNode {
-  FooCall() {
-    this = API::moduleImport("mylibrary").getMember("foo").getACall()
-  }
+  FooCall() { this = API::moduleImport("mylibrary").getMember("foo").getACall() }
 
-  DataFlow::Node getFirst() {
-    result = getParameter(0).getMember("value").getARhs()
-  }
+  DataFlow::Node getFirst() { result = getParameter(0).getMember("value").getARhs() }
 
-  DataFlow::Node getSecond() {
-    result = getParameter(1).getMember("value").getARhs()
-  }
+  DataFlow::Node getSecond() { result = getParameter(1).getMember("value").getARhs() }
 }
 
 query predicate values(FooCall call, int first, int second) {

--- a/javascript/ql/test/ApiGraphs/call-nodes/test.ql
+++ b/javascript/ql/test/ApiGraphs/call-nodes/test.ql
@@ -1,0 +1,25 @@
+import javascript
+
+class FooCall extends API::CallNode {
+  FooCall() {
+    this = API::moduleImport("mylibrary").getMember("foo").getACall()
+  }
+
+  DataFlow::Node getFirst() {
+    result = getParameter(0).getMember("value").getARhs()
+  }
+
+  DataFlow::Node getSecond() {
+    result = getParameter(1).getMember("value").getARhs()
+  }
+}
+
+query predicate values(FooCall call, int first, int second) {
+  first = call.getFirst().getIntValue() and
+  second = call.getSecond().getIntValue()
+}
+
+query predicate mismatch(FooCall call, string msg) {
+  call.getFirst().getIntValue() != call.getSecond().getIntValue() and
+  msg = "mismatching parameter indices found for call"
+}


### PR DESCRIPTION
Contains a few tweaks to the API graphs API. 

`getACall` and friends now return `API::CallNode` which is a subtype of the old return type `DataFlow::CallNode`. The new class represents a call whose callee has an API node. It exposes methods for getting the API nodes corresponding to its parameters and return value, without accidentally mixing it up with other calls.

The latter could happen in cases like:
```js
import { foo } from 'somewhere';

foo(x, y);
foo(z, w);
```
In the above case, both calls have the same API node as callee. This means if you use `callee.getParameter(0)` and `callee.getParameter(1)` there's no guarantee that you'll get parameters that corresponds to the same call site.

Second, adds `Node.getAValueReachingRhs` for getting a node that transitively flows to the RHS. It's analogous to `getAUse()` vs `getAnImmediateUse()`. We _could_ rename `getARhs` to `getAnImmediateRhs` for consistency but I think I like the current naming better.

There are very few uses of these new concepts (for the latter, there are none at all) as the brach that needed it got tangled up in an unrelated mess, so I'm trying to cherry-pick out some independent improvements from that line of work.

@max-schaefer can you review?

@tausbn @erik-krogh the change to `getACall` was the thing I mentioned in our meeting today