### PR TITLE
C++: Simplify and generalize EscapesTree::addressMayEscapeMutablyAt

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/EscapesTree.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/EscapesTree.qll
@@ -212,14 +212,9 @@ private predicate addressMayEscapeAt(Expr e) {
 
 private predicate addressMayEscapeMutablyAt(Expr e) {
   addressMayEscapeAt(e) and
-  exists(Type t | t = e.getType().getUnderlyingType() |
-    exists(PointerType pt |
-      pt = t
-      or
-      pt = t.(SpecifiedType).getBaseType()
-    |
-      not pt.getBaseType().isConst()
-    )
+  exists(Type t | t = e.getType().getUnderlyingType().stripTopLevelSpecifiers() |
+    t instanceof PointerType and
+    not t.(PointerType).getBaseType().isConst()
     or
     t instanceof ReferenceType and
     not t.(ReferenceType).getBaseType().isConst()

--- a/cpp/ql/src/semmle/code/cpp/dataflow/EscapesTree.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/EscapesTree.qll
@@ -212,7 +212,7 @@ private predicate addressMayEscapeAt(Expr e) {
 
 private predicate addressMayEscapeMutablyAt(Expr e) {
   addressMayEscapeAt(e) and
-  exists(Type t | t = e.getType().getUnderlyingType().stripTopLevelSpecifiers() |
+  exists(Type t | t = e.getType().stripTopLevelSpecifiers() |
     t instanceof PointerType and
     not t.(PointerType).getBaseType().isConst()
     or


### PR DESCRIPTION
This is just a very small cleanup suggested by @jbj 

The semantics of the code changes slightly, as we now apply `stripTopLevelSpecifiers()` to all three cases.
However, for `ReferenceType` I was not able to come up with specifiers on the `ReferenceType` at all.
On `IntegralTypes`, per [expr.type]/2, `cv` qualifiers are not present anyways, so this  semantic change only affects other specifiers.
For these rare cases, I'd expect the code change to be a slight improvement.
