### PR TITLE
C++: Improve EscapesTree.qll analysis in the presence of temporary objects

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/EscapesTree.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/EscapesTree.qll
@@ -226,7 +226,8 @@ private predicate addressMayEscapeMutablyAt(Expr e) {
     // If we go through a temporary object step, we can take a reference to a temporary const pointer
     // object, where the pointer doesn't point to a const value
     exists(TemporaryObjectExpr temp, PointerType pt |
-      temp.getConversion() = e and pt = temp.getType().stripTopLevelSpecifiers()
+      temp.getConversion() = e.(ReferenceToExpr) and
+      pt = temp.getType().stripTopLevelSpecifiers()
     |
       not pt.getBaseType().isConst()
     )

--- a/cpp/ql/test/library-tests/defuse/definition.expected
+++ b/cpp/ql/test/library-tests/defuse/definition.expected
@@ -77,6 +77,8 @@
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:46:11:46:11 | n |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:49:5:49:7 | ... ++ |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:53:22:53:22 | i |
+| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:60:10:60:11 | 2 |
+| pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 |
 | test.cpp:4:7:4:7 | a | test.cpp:5:3:5:8 | ... = ... |
 | test.cpp:4:7:4:7 | a | test.cpp:13:3:13:7 | ... = ... |
 | test.cpp:4:7:4:7 | a | test.cpp:19:5:19:9 | ... = ... |

--- a/cpp/ql/test/library-tests/defuse/definition.expected
+++ b/cpp/ql/test/library-tests/defuse/definition.expected
@@ -1,5 +1,6 @@
 | addressOf.cpp:23:9:23:9 | i | addressOf.cpp:24:22:24:30 | call to move |
 | addressOf.cpp:23:9:23:9 | i | addressOf.cpp:25:25:25:26 | & ... |
+| addressOf.cpp:23:9:23:9 | i | addressOf.cpp:26:31:26:32 | & ... |
 | addressOf.cpp:31:23:31:23 | i | addressOf.cpp:32:18:32:19 | & ... |
 | addressOf.cpp:31:23:31:23 | i | addressOf.cpp:34:18:34:33 | ... ? ... : ... |
 | addressOf.cpp:31:23:31:23 | i | addressOf.cpp:35:18:35:23 | & ... |
@@ -78,6 +79,7 @@
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:49:5:49:7 | ... ++ |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:53:22:53:22 | i |
 | pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:60:10:60:11 | 2 |
+| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:61:34:61:35 | & ... |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 |
 | test.cpp:4:7:4:7 | a | test.cpp:5:3:5:8 | ... = ... |
 | test.cpp:4:7:4:7 | a | test.cpp:13:3:13:7 | ... = ... |

--- a/cpp/ql/test/library-tests/defuse/definition.expected
+++ b/cpp/ql/test/library-tests/defuse/definition.expected
@@ -81,6 +81,8 @@
 | pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:60:10:60:11 | 2 |
 | pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:61:34:61:35 | & ... |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 |
+| pass_by_ref.cpp:74:7:74:7 | x | pass_by_ref.cpp:74:10:74:11 | 2 |
+| pass_by_ref.cpp:74:7:74:7 | x | pass_by_ref.cpp:75:35:75:36 | & ... |
 | test.cpp:4:7:4:7 | a | test.cpp:5:3:5:8 | ... = ... |
 | test.cpp:4:7:4:7 | a | test.cpp:13:3:13:7 | ... = ... |
 | test.cpp:4:7:4:7 | a | test.cpp:19:5:19:9 | ... = ... |

--- a/cpp/ql/test/library-tests/defuse/definitionUsePair.expected
+++ b/cpp/ql/test/library-tests/defuse/definitionUsePair.expected
@@ -79,6 +79,8 @@
 | pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:61:34:61:35 | & ... | pass_by_ref.cpp:62:10:62:10 | x |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 | pass_by_ref.cpp:67:34:67:34 | p |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 | pass_by_ref.cpp:68:10:68:10 | p |
+| pass_by_ref.cpp:74:7:74:7 | x | pass_by_ref.cpp:74:10:74:11 | 2 | pass_by_ref.cpp:75:36:75:36 | x |
+| pass_by_ref.cpp:74:7:74:7 | x | pass_by_ref.cpp:75:35:75:36 | & ... | pass_by_ref.cpp:76:10:76:10 | x |
 | test.cpp:4:7:4:7 | a | test.cpp:5:3:5:8 | ... = ... | test.cpp:9:7:9:7 | a |
 | test.cpp:4:7:4:7 | a | test.cpp:13:3:13:7 | ... = ... | test.cpp:14:7:14:7 | a |
 | test.cpp:4:7:4:7 | a | test.cpp:13:3:13:7 | ... = ... | test.cpp:18:7:18:7 | a |

--- a/cpp/ql/test/library-tests/defuse/definitionUsePair.expected
+++ b/cpp/ql/test/library-tests/defuse/definitionUsePair.expected
@@ -75,6 +75,10 @@
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:46:11:46:11 | n | pass_by_ref.cpp:53:22:53:22 | i |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:49:5:49:7 | ... ++ | pass_by_ref.cpp:53:22:53:22 | i |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:53:22:53:22 | i | pass_by_ref.cpp:54:10:54:10 | i |
+| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:60:10:60:11 | 2 | pass_by_ref.cpp:61:35:61:35 | x |
+| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:60:10:60:11 | 2 | pass_by_ref.cpp:62:10:62:10 | x |
+| pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 | pass_by_ref.cpp:67:34:67:34 | p |
+| pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 | pass_by_ref.cpp:68:10:68:10 | p |
 | test.cpp:4:7:4:7 | a | test.cpp:5:3:5:8 | ... = ... | test.cpp:9:7:9:7 | a |
 | test.cpp:4:7:4:7 | a | test.cpp:13:3:13:7 | ... = ... | test.cpp:14:7:14:7 | a |
 | test.cpp:4:7:4:7 | a | test.cpp:13:3:13:7 | ... = ... | test.cpp:18:7:18:7 | a |

--- a/cpp/ql/test/library-tests/defuse/definitionUsePair.expected
+++ b/cpp/ql/test/library-tests/defuse/definitionUsePair.expected
@@ -76,7 +76,7 @@
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:49:5:49:7 | ... ++ | pass_by_ref.cpp:53:22:53:22 | i |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:53:22:53:22 | i | pass_by_ref.cpp:54:10:54:10 | i |
 | pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:60:10:60:11 | 2 | pass_by_ref.cpp:61:35:61:35 | x |
-| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:60:10:60:11 | 2 | pass_by_ref.cpp:62:10:62:10 | x |
+| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:61:34:61:35 | & ... | pass_by_ref.cpp:62:10:62:10 | x |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 | pass_by_ref.cpp:67:34:67:34 | p |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 | pass_by_ref.cpp:68:10:68:10 | p |
 | test.cpp:4:7:4:7 | a | test.cpp:5:3:5:8 | ... = ... | test.cpp:9:7:9:7 | a |

--- a/cpp/ql/test/library-tests/defuse/exprDefinition.expected
+++ b/cpp/ql/test/library-tests/defuse/exprDefinition.expected
@@ -17,6 +17,8 @@
 | pass_by_ref.cpp:31:7:31:9 | arr | pass_by_ref.cpp:31:15:31:18 | {...} | pass_by_ref.cpp:31:15:31:18 | {...} |
 | pass_by_ref.cpp:37:7:37:9 | arr | pass_by_ref.cpp:37:15:37:18 | {...} | pass_by_ref.cpp:37:15:37:18 | {...} |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:46:11:46:11 | n | pass_by_ref.cpp:46:11:46:11 | n |
+| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:60:10:60:11 | 2 | pass_by_ref.cpp:60:10:60:11 | 2 |
+| pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 | pass_by_ref.cpp:66:12:66:18 | 0 |
 | test.cpp:4:7:4:7 | a | test.cpp:5:3:5:8 | ... = ... | test.cpp:5:7:5:8 | a0 |
 | test.cpp:4:7:4:7 | a | test.cpp:13:3:13:7 | ... = ... | test.cpp:13:7:13:7 | b |
 | test.cpp:4:7:4:7 | a | test.cpp:19:5:19:9 | ... = ... | test.cpp:19:9:19:9 | 1 |

--- a/cpp/ql/test/library-tests/defuse/exprDefinition.expected
+++ b/cpp/ql/test/library-tests/defuse/exprDefinition.expected
@@ -19,6 +19,7 @@
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:46:11:46:11 | n | pass_by_ref.cpp:46:11:46:11 | n |
 | pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:60:10:60:11 | 2 | pass_by_ref.cpp:60:10:60:11 | 2 |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:66:12:66:18 | 0 | pass_by_ref.cpp:66:12:66:18 | 0 |
+| pass_by_ref.cpp:74:7:74:7 | x | pass_by_ref.cpp:74:10:74:11 | 2 | pass_by_ref.cpp:74:10:74:11 | 2 |
 | test.cpp:4:7:4:7 | a | test.cpp:5:3:5:8 | ... = ... | test.cpp:5:7:5:8 | a0 |
 | test.cpp:4:7:4:7 | a | test.cpp:13:3:13:7 | ... = ... | test.cpp:13:7:13:7 | b |
 | test.cpp:4:7:4:7 | a | test.cpp:19:5:19:9 | ... = ... | test.cpp:19:9:19:9 | 1 |

--- a/cpp/ql/test/library-tests/defuse/isAddressOfAccess.expected
+++ b/cpp/ql/test/library-tests/defuse/isAddressOfAccess.expected
@@ -1,7 +1,7 @@
 | addressOf.cpp:14:28:14:29 | d_ | non-const address |
 | addressOf.cpp:24:32:24:32 | i | non-const address |
 | addressOf.cpp:25:26:25:26 | i | non-const address |
-| addressOf.cpp:26:32:26:32 | i | const address |
+| addressOf.cpp:26:32:26:32 | i | non-const address |
 | addressOf.cpp:32:19:32:19 | i | non-const address |
 | addressOf.cpp:34:18:34:18 | i |  |
 | addressOf.cpp:34:23:34:23 | i | non-const address |
@@ -151,7 +151,7 @@
 | pass_by_ref.cpp:49:5:49:5 | i |  |
 | pass_by_ref.cpp:53:22:53:22 | i | non-const address |
 | pass_by_ref.cpp:54:10:54:10 | i |  |
-| pass_by_ref.cpp:61:35:61:35 | x | const address |
+| pass_by_ref.cpp:61:35:61:35 | x | non-const address |
 | pass_by_ref.cpp:62:10:62:10 | x |  |
 | pass_by_ref.cpp:67:34:67:34 | p | const address |
 | pass_by_ref.cpp:68:10:68:10 | p |  |

--- a/cpp/ql/test/library-tests/defuse/isAddressOfAccess.expected
+++ b/cpp/ql/test/library-tests/defuse/isAddressOfAccess.expected
@@ -155,6 +155,8 @@
 | pass_by_ref.cpp:62:10:62:10 | x |  |
 | pass_by_ref.cpp:67:34:67:34 | p | const address |
 | pass_by_ref.cpp:68:10:68:10 | p |  |
+| pass_by_ref.cpp:75:36:75:36 | x | non-const address |
+| pass_by_ref.cpp:76:10:76:10 | x |  |
 | test.cpp:5:3:5:3 | a |  |
 | test.cpp:5:7:5:8 | a0 |  |
 | test.cpp:6:3:6:3 | b |  |

--- a/cpp/ql/test/library-tests/defuse/isAddressOfAccess.expected
+++ b/cpp/ql/test/library-tests/defuse/isAddressOfAccess.expected
@@ -151,6 +151,10 @@
 | pass_by_ref.cpp:49:5:49:5 | i |  |
 | pass_by_ref.cpp:53:22:53:22 | i | non-const address |
 | pass_by_ref.cpp:54:10:54:10 | i |  |
+| pass_by_ref.cpp:61:35:61:35 | x | const address |
+| pass_by_ref.cpp:62:10:62:10 | x |  |
+| pass_by_ref.cpp:67:34:67:34 | p | const address |
+| pass_by_ref.cpp:68:10:68:10 | p |  |
 | test.cpp:5:3:5:3 | a |  |
 | test.cpp:5:7:5:8 | a0 |  |
 | test.cpp:6:3:6:3 | b |  |

--- a/cpp/ql/test/library-tests/defuse/pass_by_ref.cpp
+++ b/cpp/ql/test/library-tests/defuse/pass_by_ref.cpp
@@ -67,3 +67,11 @@ int * noTemporaryObject() {
   constPointerReferenceParameter(p);
   return p;
 }
+
+void pointerRvalueReferenceParameter(int * && pRef);
+
+int temporaryObject2() {
+  int x = 2;
+  pointerRvalueReferenceParameter(&x);
+  return x;
+}

--- a/cpp/ql/test/library-tests/defuse/pass_by_ref.cpp
+++ b/cpp/ql/test/library-tests/defuse/pass_by_ref.cpp
@@ -53,3 +53,17 @@ int afterIf(int n) {
   referenceParameter(i);
   return i;
 }
+
+void constPointerReferenceParameter(int * const & pRef);
+
+int temporaryObject() {
+  int x = 2;
+  constPointerReferenceParameter(&x);
+  return x;
+}
+
+int * noTemporaryObject() {
+  int *p = nullptr;
+  constPointerReferenceParameter(p);
+  return p;
+}

--- a/cpp/ql/test/library-tests/defuse/useOfVar.expected
+++ b/cpp/ql/test/library-tests/defuse/useOfVar.expected
@@ -118,6 +118,10 @@
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:49:5:49:5 | i |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:53:22:53:22 | i |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:54:10:54:10 | i |
+| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:61:35:61:35 | x |
+| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:62:10:62:10 | x |
+| pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:67:34:67:34 | p |
+| pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:68:10:68:10 | p |
 | test.cpp:3:16:3:17 | a0 | test.cpp:5:7:5:8 | a0 |
 | test.cpp:3:24:3:25 | b0 | test.cpp:6:7:6:8 | b0 |
 | test.cpp:3:32:3:33 | c0 | test.cpp:7:7:7:8 | c0 |

--- a/cpp/ql/test/library-tests/defuse/useOfVar.expected
+++ b/cpp/ql/test/library-tests/defuse/useOfVar.expected
@@ -122,6 +122,8 @@
 | pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:62:10:62:10 | x |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:67:34:67:34 | p |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:68:10:68:10 | p |
+| pass_by_ref.cpp:74:7:74:7 | x | pass_by_ref.cpp:75:36:75:36 | x |
+| pass_by_ref.cpp:74:7:74:7 | x | pass_by_ref.cpp:76:10:76:10 | x |
 | test.cpp:3:16:3:17 | a0 | test.cpp:5:7:5:8 | a0 |
 | test.cpp:3:24:3:25 | b0 | test.cpp:6:7:6:8 | b0 |
 | test.cpp:3:32:3:33 | c0 | test.cpp:7:7:7:8 | c0 |

--- a/cpp/ql/test/library-tests/defuse/useOfVarActual.expected
+++ b/cpp/ql/test/library-tests/defuse/useOfVarActual.expected
@@ -58,6 +58,7 @@
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:54:10:54:10 | i |
 | pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:62:10:62:10 | x |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:68:10:68:10 | p |
+| pass_by_ref.cpp:74:7:74:7 | x | pass_by_ref.cpp:76:10:76:10 | x |
 | test.cpp:3:16:3:17 | a0 | test.cpp:5:7:5:8 | a0 |
 | test.cpp:3:24:3:25 | b0 | test.cpp:6:7:6:8 | b0 |
 | test.cpp:3:32:3:33 | c0 | test.cpp:7:7:7:8 | c0 |

--- a/cpp/ql/test/library-tests/defuse/useOfVarActual.expected
+++ b/cpp/ql/test/library-tests/defuse/useOfVarActual.expected
@@ -56,6 +56,8 @@
 | pass_by_ref.cpp:45:17:45:17 | n | pass_by_ref.cpp:48:7:48:7 | n |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:49:5:49:5 | i |
 | pass_by_ref.cpp:46:7:46:7 | i | pass_by_ref.cpp:54:10:54:10 | i |
+| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:62:10:62:10 | x |
+| pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:68:10:68:10 | p |
 | test.cpp:3:16:3:17 | a0 | test.cpp:5:7:5:8 | a0 |
 | test.cpp:3:24:3:25 | b0 | test.cpp:6:7:6:8 | b0 |
 | test.cpp:3:32:3:33 | c0 | test.cpp:7:7:7:8 | c0 |

--- a/cpp/ql/test/library-tests/defuse/useUsePair.expected
+++ b/cpp/ql/test/library-tests/defuse/useUsePair.expected
@@ -25,6 +25,8 @@
 | pass_by_ref.cpp:21:7:21:8 | i2 | pass_by_ref.cpp:24:26:24:27 | i2 | pass_by_ref.cpp:27:39:27:40 | i2 |
 | pass_by_ref.cpp:21:7:21:8 | i2 | pass_by_ref.cpp:25:27:25:28 | i2 | pass_by_ref.cpp:27:39:27:40 | i2 |
 | pass_by_ref.cpp:45:17:45:17 | n | pass_by_ref.cpp:46:11:46:11 | n | pass_by_ref.cpp:48:7:48:7 | n |
+| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:61:35:61:35 | x | pass_by_ref.cpp:62:10:62:10 | x |
+| pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:67:34:67:34 | p | pass_by_ref.cpp:68:10:68:10 | p |
 | test.cpp:4:7:4:7 | a | test.cpp:14:7:14:7 | a | test.cpp:18:7:18:7 | a |
 | test.cpp:4:7:4:7 | a | test.cpp:14:7:14:7 | a | test.cpp:24:7:24:7 | a |
 | test.cpp:4:7:4:7 | a | test.cpp:14:7:14:7 | a | test.cpp:28:11:28:11 | a |

--- a/cpp/ql/test/library-tests/defuse/useUsePair.expected
+++ b/cpp/ql/test/library-tests/defuse/useUsePair.expected
@@ -25,7 +25,6 @@
 | pass_by_ref.cpp:21:7:21:8 | i2 | pass_by_ref.cpp:24:26:24:27 | i2 | pass_by_ref.cpp:27:39:27:40 | i2 |
 | pass_by_ref.cpp:21:7:21:8 | i2 | pass_by_ref.cpp:25:27:25:28 | i2 | pass_by_ref.cpp:27:39:27:40 | i2 |
 | pass_by_ref.cpp:45:17:45:17 | n | pass_by_ref.cpp:46:11:46:11 | n | pass_by_ref.cpp:48:7:48:7 | n |
-| pass_by_ref.cpp:60:7:60:7 | x | pass_by_ref.cpp:61:35:61:35 | x | pass_by_ref.cpp:62:10:62:10 | x |
 | pass_by_ref.cpp:66:8:66:8 | p | pass_by_ref.cpp:67:34:67:34 | p | pass_by_ref.cpp:68:10:68:10 | p |
 | test.cpp:4:7:4:7 | a | test.cpp:14:7:14:7 | a | test.cpp:18:7:18:7 | a |
 | test.cpp:4:7:4:7 | a | test.cpp:14:7:14:7 | a | test.cpp:24:7:24:7 | a |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
@@ -50,5 +50,4 @@
 | PointlessComparison.cpp:43:6:43:29 | ... >= ... | Comparison is always true because ... >> ... >= 140737488355327.5. |
 | PointlessComparison.cpp:44:6:44:28 | ... >= ... | Comparison is always true because ... >> ... >= 140737488355327.5. |
 | RegressionTests.cpp:57:7:57:22 | ... <= ... | Comparison is always true because * ... <= 4294967295. |
-| RegressionTests.cpp:125:7:125:11 | ... > ... | Comparison is always false because x <= 0. |
 | Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
@@ -50,4 +50,5 @@
 | PointlessComparison.cpp:43:6:43:29 | ... >= ... | Comparison is always true because ... >> ... >= 140737488355327.5. |
 | PointlessComparison.cpp:44:6:44:28 | ... >= ... | Comparison is always true because ... >> ... >= 140737488355327.5. |
 | RegressionTests.cpp:57:7:57:22 | ... <= ... | Comparison is always true because * ... <= 4294967295. |
+| RegressionTests.cpp:125:7:125:11 | ... > ... | Comparison is always false because x <= 0. |
 | Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/RegressionTests.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/RegressionTests.cpp
@@ -122,5 +122,5 @@ void f(int *const &ref_to_ptr);
 void testTempObject() {
   int x = 0;
   f(&x);
-  if (x > 0) {} // BAD [FALSE POSITIVE]
+  if (x > 0) {} // GOOD [NO LONGER REPORTED]
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/RegressionTests.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/RegressionTests.cpp
@@ -116,3 +116,11 @@ void negativeZero4(int val) {
   if (val == 0) // GOOD [NO LONGER REPORTED]
     ;
 }
+
+void f(int *const &ref_to_ptr);
+
+void testTempObject() {
+  int x = 0;
+  f(&x);
+  if (x > 0) {} // BAD [FALSE POSITIVE]
+}


### PR DESCRIPTION
Merge after https://github.com/github/codeql/pull/4716

Draft, as I want a CI run, but also investigate the issue a bit more on LGTM before having this PR merged.

Fixes https://github.com/github/codeql-c-analysis-team/issues/171
