### PR TITLE
Java: Remove some deprecated classes.

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSources.qll
@@ -204,6 +204,13 @@ private class BeanValidationSource extends RemoteFlowSource {
 /** Class for `tainted` user input. */
 abstract class UserInput extends DataFlow::Node { }
 
+/**
+ * Input that may be controlled by a remote user.
+ */
+private class RemoteUserInput extends UserInput {
+  RemoteUserInput() { this instanceof RemoteFlowSource }
+}
+
 /** A node with input that may be controlled by a local user. */
 abstract class LocalUserInput extends UserInput { }
 

--- a/java/ql/src/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSources.qll
@@ -204,15 +204,6 @@ private class BeanValidationSource extends RemoteFlowSource {
 /** Class for `tainted` user input. */
 abstract class UserInput extends DataFlow::Node { }
 
-/**
- * DEPRECATED: Use `RemoteFlowSource` instead.
- *
- * Input that may be controlled by a remote user.
- */
-deprecated class RemoteUserInput extends UserInput {
-  RemoteUserInput() { this instanceof RemoteFlowSource }
-}
-
 /** A node with input that may be controlled by a local user. */
 abstract class LocalUserInput extends UserInput { }
 

--- a/java/ql/src/semmle/code/java/dataflow/TaintTracking.qll
+++ b/java/ql/src/semmle/code/java/dataflow/TaintTracking.qll
@@ -9,10 +9,4 @@ import semmle.code.java.dataflow.internal.TaintTrackingUtil::StringBuilderVarMod
 
 module TaintTracking {
   import semmle.code.java.dataflow.internal.tainttracking1.TaintTrackingImpl
-  private import semmle.code.java.dataflow.TaintTracking2
-
-  /**
-   * DEPRECATED: Use TaintTracking2::Configuration instead.
-   */
-  deprecated class Configuration2 = TaintTracking2::Configuration;
 }

--- a/java/ql/src/semmle/code/java/security/Validation.qll
+++ b/java/ql/src/semmle/code/java/security/Validation.qll
@@ -63,18 +63,3 @@ private predicate validatedAccess(VarAccess va) {
 class ValidatedVariableAccess extends VarAccess {
   ValidatedVariableAccess() { validatedAccess(this) }
 }
-
-/**
- * DEPRECATED: Use ValidatedVariableAccess instead.
- *
- * A variable that is ever passed to a string verification method.
- */
-deprecated class ValidatedVariable extends Variable {
-  ValidatedVariable() {
-    exists(MethodAccess call, int arg, VarAccess access |
-      validationMethod(call.getMethod(), arg) and
-      call.getArgument(arg) = access and
-      access.getVariable() = this
-    )
-  }
-}


### PR DESCRIPTION
`RemoteUserInput` and `ValidatedVariable` were deprecated in 1.21 and `TaintTracking::Configuration2` was deprecated in 1.22.