### PR TITLE
C++: Create tests readme.

### DIFF
--- a/cpp/ql/test/README.md
+++ b/cpp/ql/test/README.md
@@ -1,0 +1,33 @@
+# C/C++ CodeQL tests
+
+This document provides additional information about the C/C++ CodeQL Tests located in `cpp/ql/test`.  See [Contributing to CodeQL](CONTRIBUTING.md) for general information about contributing to this repository.
+
+The tests can be run through Visual Studio Code.  Advanced users may also use the `odasa qltest` command.
+
+## Contributing to the tests
+
+We are keen to have unit tests for all of our QL code.
+
+Every query in `cpp/ql/src` (outside of `cpp/ql/src/experimental`) should have a test in the corresponding subdirectory of `cpp/ql/test/query-tests`. At a minimum, each query test shall contain one case that should be detected by the query, and one related case that should not.
+
+TODO: example?
+
+Library features should also have test coverage, in `cpp/ql/test/library-tests`.
+
+## Copying code
+
+The contents of `cpp/ql/test` should be original - nothing should be copied from other sources. In particular do not copy-paste C/C++ code from third party projects, your own projects, or the standard C/C++ library implementation of your compiler (regardless of the associated license). As an exception, required declarations may be taken from the following sources where necessary:
+ - ISO/IEC Programming languages - C (all versions)
+ - ISO/IEC Programming languages - C++ (all versions)
+
+TODO: example
+
+In addition, C/C++ and QL code may be copied from other queries and tests in this repository.
+
+## Including files
+
+Standard and third party library header files should not be included in tests by means of `#include` or similar mechanisms. This is because the tests should be independent of platform and library versions installed on the running machine. Standard library declarations may be inserted directly where necessary (see the rules in the section above), but it is generally better to avoid using the standard library at all when possible.
+
+`#include` may be used to include files from the same directory within `cpp/ql/test`.
+
+TODO: example

--- a/cpp/ql/test/README.md
+++ b/cpp/ql/test/README.md
@@ -10,7 +10,15 @@ We are keen to have unit tests for all of our QL code.
 
 Every query in `cpp/ql/src` (outside of `cpp/ql/src/experimental`) should have a test in the corresponding subdirectory of `cpp/ql/test/query-tests`. At a minimum, each query test shall contain one case that should be detected by the query, and one related case that should not.
 
-TODO: example?
+For example a simple test for the "Memory is never freed" (`cpp/memory-never-freed`) query might contain the following cases:
+```
+int *array1, *array2;
+
+array1 = (int *)malloc(sizeof(int) * 100); // BAD: never freed
+
+array2 = (int *)malloc(sizeof(int) * 100); // GOOD
+free(array2);
+```
 
 Features of the QL libraries in `cpp/ql/src` should also have test coverage, in `cpp/ql/test/library-tests`.
 
@@ -20,14 +28,25 @@ The contents of `cpp/ql/test` should be original - nothing should be copied from
  - ISO/IEC Programming languages - C (all versions)
  - ISO/IEC Programming languages - C++ (all versions)
 
-TODO: example
-
 In addition, C/C++ and QL code may be copied from other queries and tests in this repository.
+
+For example the test above for the "Memory is never freed" (`cpp/memory-never-freed`) query requires the following declarations, taken from Programming languages — C (November 2018):
+```
+void *malloc(size_t size);
+void free(void *ptr);
+```
+We also need to write our own definition of `size_t`.  Any unsigned integral type will do for our purposes:
+```
+typedef unsigned int size_t;
+```
 
 ## Including files
 
 Standard and third party library header files should not be included in tests by means of `#include` or similar mechanisms. This is because the tests should be independent of platform and library versions installed on the running machine. Standard library declarations may be inserted directly where necessary (see the rules in the section above), but it is generally better to avoid using the standard library at all when possible.
 
-`#include` may be used to include files from the same directory within `cpp/ql/test`.
-
-TODO: example
+`#include` may be used to include files from the same directory within `cpp/ql/test`.  For example the test for "Include header files only" (`cpp/include-non-header`) includes other files in the test directory:
+```
+#include "test.H"
+#include "test.xpm"
+#include "test2.c"
+```

--- a/cpp/ql/test/README.md
+++ b/cpp/ql/test/README.md
@@ -27,8 +27,9 @@ Features of the QL libraries in `cpp/ql/src` should also have test coverage, in 
 The contents of `cpp/ql/test` should be original - nothing should be copied from other sources. In particular do not copy-paste C/C++ code from third party projects, your own projects, or the standard C/C++ library implementation of your compiler (regardless of the associated license). As an exception, required declarations may be taken from the following sources where necessary:
  - ISO/IEC Programming languages - C (all versions)
  - ISO/IEC Programming languages - C++ (all versions)
-
-In addition, C/C++ and QL code may be copied from other queries and tests in this repository.
+ - code from existing queries and tests in this repository
+	- this includes 'translating QL to C++', that is, writing C/C++ declarations from the information such as parameter names and positions specified in QL classes (when there is enough information to do so).
+ - code in the public domain
 
 For example the test above for the "Memory is never freed" (`cpp/memory-never-freed`) query requires the following declarations, taken from Programming languages — C (November 2018):
 ```

--- a/cpp/ql/test/README.md
+++ b/cpp/ql/test/README.md
@@ -25,8 +25,8 @@ Features of the QL libraries in `cpp/ql/src` should also have test coverage, in 
 ## Copying code
 
 The contents of `cpp/ql/test` should be original - nothing should be copied from other sources. In particular do not copy-paste C/C++ code from third-party projects, your own projects, or the standard C/C++ library implementation of your compiler (regardless of the associated license). As an exception, required declarations may be taken from the following sources where necessary:
- - ISO/IEC Programming languages - C (all versions)
- - ISO/IEC Programming languages - C++ (all versions)
+ - [ISO/IEC Programming languages - C](https://www.iso.org/standard/74528.html) (all versions)
+ - [ISO/IEC Programming languages - C++](https://www.iso.org/standard/68564.html) (all versions)
  - Code from existing queries and tests in this repository
    This includes 'translating QL to C++', that is, writing C/C++ declarations from the information such as parameter names and positions specified in QL classes (when there is enough information to do so).
  - Code in the public domain

--- a/cpp/ql/test/README.md
+++ b/cpp/ql/test/README.md
@@ -2,7 +2,7 @@
 
 This document provides additional information about the C/C++ CodeQL Tests located in `cpp/ql/test`.  See [Contributing to CodeQL](CONTRIBUTING.md) for general information about contributing to this repository.
 
-The tests can be run through Visual Studio Code.  Advanced users may also use the `odasa qltest` command.
+The tests can be run through Visual Studio Code.  Advanced users may also use the `codeql test run` command.
 
 ## Contributing to the tests
 

--- a/cpp/ql/test/README.md
+++ b/cpp/ql/test/README.md
@@ -8,7 +8,7 @@ The tests can be run through Visual Studio Code.  Advanced users may also use th
 
 We are keen to have unit tests for all of our QL code.
 
-Every query in `cpp/ql/src` (outside of `cpp/ql/src/experimental`) should have a test in the corresponding subdirectory of `cpp/ql/test/query-tests`. At a minimum, each query test shall contain one case that should be detected by the query, and one related case that should not.
+Every query in `cpp/ql/src` (outside of `cpp/ql/src/experimental`) should have a test in the corresponding subdirectory of `cpp/ql/test/query-tests`. At a minimum, each query test should contain one case that should be detected by the query, and one related case that should not.
 
 For example a simple test for the "Memory is never freed" (`cpp/memory-never-freed`) query might contain the following cases:
 ```
@@ -24,14 +24,14 @@ Features of the QL libraries in `cpp/ql/src` should also have test coverage, in 
 
 ## Copying code
 
-The contents of `cpp/ql/test` should be original - nothing should be copied from other sources. In particular do not copy-paste C/C++ code from third party projects, your own projects, or the standard C/C++ library implementation of your compiler (regardless of the associated license). As an exception, required declarations may be taken from the following sources where necessary:
+The contents of `cpp/ql/test` should be original - nothing should be copied from other sources. In particular do not copy-paste C/C++ code from third-party projects, your own projects, or the standard C/C++ library implementation of your compiler (regardless of the associated license). As an exception, required declarations may be taken from the following sources where necessary:
  - ISO/IEC Programming languages - C (all versions)
  - ISO/IEC Programming languages - C++ (all versions)
- - code from existing queries and tests in this repository
-	- this includes 'translating QL to C++', that is, writing C/C++ declarations from the information such as parameter names and positions specified in QL classes (when there is enough information to do so).
- - code in the public domain
+ - Code from existing queries and tests in this repository
+   This includes 'translating QL to C++', that is, writing C/C++ declarations from the information such as parameter names and positions specified in QL classes (when there is enough information to do so).
+ - Code in the public domain
 
-For example the test above for the "Memory is never freed" (`cpp/memory-never-freed`) query requires the following declarations, taken from Programming languages — C (November 2018):
+For example the test above for the "Memory is never freed" (`cpp/memory-never-freed`) query requires the following declarations, taken from [ISO/IEC 9899:2018 - Programming languages - C](https://www.iso.org/standard/74528.html):
 ```
 void *malloc(size_t size);
 void free(void *ptr);
@@ -43,7 +43,7 @@ typedef unsigned int size_t;
 
 ## Including files
 
-Standard and third party library header files should not be included in tests by means of `#include` or similar mechanisms. This is because the tests should be independent of platform and library versions installed on the running machine. Standard library declarations may be inserted directly where necessary (see the rules in the section above), but it is generally better to avoid using the standard library at all when possible.
+Standard and third-party library header files should not be included in tests by means of `#include` or similar mechanisms. This is because the tests should be independent of platform and library versions installed on the running machine. Standard library declarations may be inserted directly where necessary (see the rules in the section above), but it is generally better to avoid using the standard library at all when possible.
 
 `#include` may be used to include files from the same directory within `cpp/ql/test`.  For example the test for "Include header files only" (`cpp/include-non-header`) includes other files in the test directory:
 ```

--- a/cpp/ql/test/README.md
+++ b/cpp/ql/test/README.md
@@ -12,7 +12,7 @@ Every query in `cpp/ql/src` (outside of `cpp/ql/src/experimental`) should have a
 
 TODO: example?
 
-Library features should also have test coverage, in `cpp/ql/test/library-tests`.
+Features of the QL libraries in `cpp/ql/src` should also have test coverage, in `cpp/ql/test/library-tests`.
 
 ## Copying code
 


### PR DESCRIPTION
Add a `README.md` for the C/C++ CodeQL tests.  See https://github.com/github/codeql-c-analysis-team/issues/84.

A specific goal is to document how we include declarations of standard library functions and types in the tests, without creating any dependencies (that might vary from machine to machine) or potential IP concerns.  This policy was decided before Semmle was acquired by GitHub, and is a little strict IMO, but is still assumed to be current.

It's very much open to discussion what else should be in this document, and how it should be presented.

TODO:
 - [x] get some early feedback
 - [x] add examples
 - [x] review from the doc team
 - [ ] review from legal? (even though this doc represents current practices, not new ones)
