### PR TITLE
C#: Implement CFG for `not` patterns

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Completion.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Completion.qll
@@ -269,18 +269,15 @@ private predicate typePatternCommonSubType(Type t, Type strippedType) {
  * constantly non-matches (`value = false`).
  */
 private predicate isMatchingConstant(PatternExpr pe, boolean value) {
-  exists(Expr e | mustHaveMatchingCompletion(e, pe) |
-    exists(Expr stripped | stripped = e.stripCasts() |
-      exists(string strippedValue, string patternValue |
-        strippedValue = stripped.getValue() and
-        patternValue = pe.getValue() and
-        if strippedValue = patternValue then value = true else value = false
-      )
-    )
-    or
-    pe instanceof DiscardPatternExpr and
-    value = true
+  exists(Expr e, string exprValue, string patternValue |
+    mustHaveMatchingCompletion(e, pe) and
+    exprValue = e.stripCasts().getValue() and
+    patternValue = pe.getValue() and
+    if exprValue = patternValue then value = true else value = false
   )
+  or
+  pe instanceof DiscardPatternExpr and
+  value = true
   or
   exists(Type t, Type strippedType |
     typePatternMustHaveMatchingCompletion(pe, t, strippedType) and

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
@@ -225,15 +225,11 @@ abstract private class PostOrderTree extends ControlFlowTree {
 }
 
 abstract private class SwitchTree extends ControlFlowTree, Switch {
-  Expr expr;
-
-  SwitchTree() { expr = this.getExpr() }
-
-  override predicate propagatesAbnormal(ControlFlowElement child) { child = expr }
+  override predicate propagatesAbnormal(ControlFlowElement child) { child = this.getExpr() }
 
   override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
     // Flow from last element of switch expression to first element of first case
-    last(expr, pred, c) and
+    last(this.getExpr(), pred, c) and
     c instanceof NormalCompletion and
     first(this.getCase(0), succ)
     or
@@ -254,17 +250,12 @@ abstract private class SwitchTree extends ControlFlowTree, Switch {
 }
 
 abstract private class CaseTree extends ControlFlowTree, Case {
-  PatternExpr pattern;
-  ControlFlowElement body;
-
-  CaseTree() { pattern = this.getPattern() and body = this.getBody() }
-
   final override predicate propagatesAbnormal(ControlFlowElement child) {
-    child in [pattern, this.getCondition().(ControlFlowElement), body]
+    child in [this.getPattern(), this.getCondition().(ControlFlowElement), this.getBody()]
   }
 
   override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
-    last(pattern, pred, c) and
+    last(this.getPattern(), pred, c) and
     c.(MatchingCompletion).isMatch() and
     (
       if exists(this.getCondition())
@@ -273,13 +264,13 @@ abstract private class CaseTree extends ControlFlowTree, Case {
         first(this.getCondition(), succ)
       else
         // Flow from last element of pattern to first element of body
-        first(body, succ)
+        first(this.getBody(), succ)
     )
     or
     // Flow from last element of condition to first element of body
     last(this.getCondition(), pred, c) and
     c instanceof TrueCompletion and
-    first(body, succ)
+    first(this.getBody(), succ)
   }
 }
 
@@ -427,13 +418,11 @@ module Expressions {
     }
   }
 
+  private class StatOrDynAccessorCall_ =
+    @dynamic_member_access_expr or @dynamic_element_access_expr or @call_access_expr;
+
   /** A normal or a (potential) dynamic call to an accessor. */
-  private class StatOrDynAccessorCall extends Expr {
-    StatOrDynAccessorCall() {
-      this instanceof AccessorCall or
-      this instanceof DynamicAccess
-    }
-  }
+  private class StatOrDynAccessorCall extends Expr, StatOrDynAccessorCall_ { }
 
   /**
    * An expression that writes via an accessor call, for example `x.Prop = 0`,
@@ -528,120 +517,101 @@ module Expressions {
   }
 
   private class LogicalAndExprTree extends PostOrderTree, LogicalAndExpr {
-    private Expr left;
-    private Expr right;
+    final override predicate propagatesAbnormal(ControlFlowElement child) {
+      child in [this.getLeftOperand(), this.getRightOperand()]
+    }
 
-    LogicalAndExprTree() { left = this.getLeftOperand() and right = this.getRightOperand() }
-
-    final override predicate propagatesAbnormal(ControlFlowElement child) { child in [left, right] }
-
-    final override predicate first(ControlFlowElement first) { first(left, first) }
+    final override predicate first(ControlFlowElement first) { first(this.getLeftOperand(), first) }
 
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
       // Flow from last element of left operand to first element of right operand
-      last(left, pred, c) and
+      last(this.getLeftOperand(), pred, c) and
       c instanceof TrueCompletion and
-      first(right, succ)
+      first(this.getRightOperand(), succ)
       or
       // Post-order: flow from last element of left operand to element itself
-      last(left, pred, c) and
+      last(this.getLeftOperand(), pred, c) and
       c instanceof FalseCompletion and
       succ = this
       or
       // Post-order: flow from last element of right operand to element itself
-      last(right, pred, c) and
+      last(this.getRightOperand(), pred, c) and
       c instanceof NormalCompletion and
       succ = this
     }
   }
 
   private class LogicalOrExprTree extends PostOrderTree, LogicalOrExpr {
-    private Expr left;
-    private Expr right;
+    final override predicate propagatesAbnormal(ControlFlowElement child) {
+      child in [this.getLeftOperand(), this.getRightOperand()]
+    }
 
-    LogicalOrExprTree() { left = this.getLeftOperand() and right = this.getRightOperand() }
-
-    final override predicate propagatesAbnormal(ControlFlowElement child) { child in [left, right] }
-
-    final override predicate first(ControlFlowElement first) { first(left, first) }
+    final override predicate first(ControlFlowElement first) { first(this.getLeftOperand(), first) }
 
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
       // Flow from last element of left operand to first element of right operand
-      last(left, pred, c) and
+      last(this.getLeftOperand(), pred, c) and
       c instanceof FalseCompletion and
-      first(right, succ)
+      first(this.getRightOperand(), succ)
       or
       // Post-order: flow from last element of left operand to element itself
-      last(left, pred, c) and
+      last(this.getLeftOperand(), pred, c) and
       c instanceof TrueCompletion and
       succ = this
       or
       // Post-order: flow from last element of right operand to element itself
-      last(right, pred, c) and
+      last(this.getRightOperand(), pred, c) and
       c instanceof NormalCompletion and
       succ = this
     }
   }
 
   private class NullCoalescingExprTree extends PostOrderTree, NullCoalescingExpr {
-    private Expr left;
-    private Expr right;
+    final override predicate propagatesAbnormal(ControlFlowElement child) {
+      child in [this.getLeftOperand(), this.getRightOperand()]
+    }
 
-    NullCoalescingExprTree() { left = this.getLeftOperand() and right = this.getRightOperand() }
-
-    final override predicate propagatesAbnormal(ControlFlowElement child) { child in [left, right] }
-
-    final override predicate first(ControlFlowElement first) { first(left, first) }
+    final override predicate first(ControlFlowElement first) { first(this.getLeftOperand(), first) }
 
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
       // Flow from last element of left operand to first element of right operand
-      last(left, pred, c) and
+      last(this.getLeftOperand(), pred, c) and
       c.(NullnessCompletion).isNull() and
-      first(right, succ)
+      first(getRightOperand(), succ)
       or
       // Post-order: flow from last element of left operand to element itself
-      last(left, pred, c) and
+      last(this.getLeftOperand(), pred, c) and
       succ = this and
       c instanceof NormalCompletion and
       not c.(NullnessCompletion).isNull()
       or
       // Post-order: flow from last element of right operand to element itself
-      last(right, pred, c) and
+      last(getRightOperand(), pred, c) and
       c instanceof NormalCompletion and
       succ = this
     }
   }
 
   private class ConditionalExprTree extends PostOrderTree, ConditionalExpr {
-    private Expr condition;
-    private Expr thenBranch;
-    private Expr elseBranch;
-
-    ConditionalExprTree() {
-      condition = this.getCondition() and
-      thenBranch = this.getThen() and
-      elseBranch = this.getElse()
-    }
-
     final override predicate propagatesAbnormal(ControlFlowElement child) {
-      child in [condition, thenBranch, elseBranch]
+      child in [this.getCondition(), this.getThen(), this.getElse()]
     }
 
-    final override predicate first(ControlFlowElement first) { first(condition, first) }
+    final override predicate first(ControlFlowElement first) { first(this.getCondition(), first) }
 
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
       // Flow from last element of condition to first element of then branch
-      last(condition, pred, c) and
+      last(this.getCondition(), pred, c) and
       c instanceof TrueCompletion and
-      first(thenBranch, succ)
+      first(this.getThen(), succ)
       or
       // Flow from last element of condition to first element of else branch
-      last(condition, pred, c) and
+      last(this.getCondition(), pred, c) and
       c instanceof FalseCompletion and
-      first(elseBranch, succ)
+      first(this.getElse(), succ)
       or
       // Post-order: flow from last element of a branch to element itself
-      last([thenBranch, elseBranch], pred, c) and
+      last([this.getThen(), this.getElse()], pred, c) and
       c instanceof NormalCompletion and
       succ = this
     }
@@ -653,15 +623,13 @@ module Expressions {
    * tracking.
    */
   private class AssignOperationWithExpandedAssignment extends AssignOperation, ControlFlowTree {
-    private Expr expanded;
-
-    AssignOperationWithExpandedAssignment() { expanded = this.getExpandedAssignment() }
-
-    final override predicate first(ControlFlowElement first) { first(expanded, first) }
+    final override predicate first(ControlFlowElement first) {
+      first(this.getExpandedAssignment(), first)
+    }
 
     final override predicate last(ControlFlowElement last, Completion c) {
-      last = expanded and
-      last(expanded, last, c)
+      last = this.getExpandedAssignment() and
+      last(this.getExpandedAssignment(), last, c)
     }
 
     final override predicate propagatesAbnormal(ControlFlowElement child) { none() }
@@ -711,16 +679,12 @@ module Expressions {
   }
 
   private class ThrowExprTree extends PostOrderTree, ThrowExpr {
-    private Expr expr;
+    final override predicate propagatesAbnormal(ControlFlowElement child) { child = this.getExpr() }
 
-    ThrowExprTree() { expr = this.getExpr() }
-
-    final override predicate propagatesAbnormal(ControlFlowElement child) { child = expr }
-
-    final override predicate first(ControlFlowElement first) { first(expr, first) }
+    final override predicate first(ControlFlowElement first) { first(this.getExpr(), first) }
 
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
-      last(expr, pred, c) and
+      last(this.getExpr(), pred, c) and
       c instanceof NormalCompletion and
       succ = this
     }
@@ -827,7 +791,7 @@ module Expressions {
       child = this.getACase()
     }
 
-    final override predicate first(ControlFlowElement first) { first(expr, first) }
+    final override predicate first(ControlFlowElement first) { first(this.getExpr(), first) }
 
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
       SwitchTree.super.succ(pred, succ, c)
@@ -839,7 +803,7 @@ module Expressions {
   }
 
   private class SwitchCaseExprTree extends PostOrderTree, CaseTree, SwitchCaseExpr {
-    final override predicate first(ControlFlowElement first) { first(pattern, first) }
+    final override predicate first(ControlFlowElement first) { first(this.getPattern(), first) }
 
     final override predicate last(ControlFlowElement last, Completion c) {
       PostOrderTree.super.last(last, c)
@@ -849,7 +813,7 @@ module Expressions {
         this = se.getCase(i) and
         not this.matchesAll() and
         not exists(se.getCase(i + 1)) and
-        last([pattern, this.getCondition()], last, cc) and
+        last([this.getPattern(), this.getCondition()], last, cc) and
         (cc.(MatchingCompletion).isNonMatch() or cc instanceof FalseCompletion) and
         c =
           any(NestedCompletion nc |
@@ -866,7 +830,7 @@ module Expressions {
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
       CaseTree.super.succ(pred, succ, c)
       or
-      last(body, pred, c) and
+      last(this.getBody(), pred, c) and
       succ = this and
       c instanceof NormalCompletion
     }
@@ -922,17 +886,15 @@ module Expressions {
   }
 
   private class NotPatternExprTree extends PostOrderTree, NotPatternExpr {
-    private PatternExpr operand;
+    final override predicate propagatesAbnormal(ControlFlowElement child) {
+      child = this.getPattern()
+    }
 
-    NotPatternExprTree() { operand = this.getPattern() }
-
-    final override predicate propagatesAbnormal(ControlFlowElement child) { child = operand }
-
-    final override predicate first(ControlFlowElement first) { first(operand, first) }
+    final override predicate first(ControlFlowElement first) { first(this.getPattern(), first) }
 
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
       succ = this and
-      last(operand, pred, c) and
+      last(this.getPattern(), pred, c) and
       c instanceof NormalCompletion
     }
   }
@@ -1003,15 +965,13 @@ module Statements {
   }
 
   private class IfStmtTree extends PreOrderTree, IfStmt {
-    private Expr condition;
-
-    IfStmtTree() { condition = this.getCondition() }
-
-    final override predicate propagatesAbnormal(ControlFlowElement child) { child = condition }
+    final override predicate propagatesAbnormal(ControlFlowElement child) {
+      child = this.getCondition()
+    }
 
     final override predicate last(ControlFlowElement last, Completion c) {
       // Condition exits with a false completion and there is no `else` branch
-      last(condition, last, c) and
+      last(this.getCondition(), last, c) and
       c instanceof FalseCompletion and
       not exists(this.getElse())
       or
@@ -1025,10 +985,10 @@ module Statements {
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
       // Pre-order: flow from statement itself to first element of condition
       pred = this and
-      first(condition, succ) and
+      first(this.getCondition(), succ) and
       c instanceof SimpleCompletion
       or
-      last(condition, pred, c) and
+      last(this.getCondition(), pred, c) and
       (
         // Flow from last element of condition to first element of then branch
         c instanceof TrueCompletion and first(this.getThen(), succ)
@@ -1043,7 +1003,7 @@ module Statements {
     final override predicate last(ControlFlowElement last, Completion c) {
       // Switch expression exits normally and there are no cases
       not exists(this.getACase()) and
-      last(expr, last, c) and
+      last(this.getExpr(), last, c) and
       c instanceof NormalCompletion
       or
       // A statement exits with a `break` completion
@@ -1075,7 +1035,7 @@ module Statements {
       or
       // Pre-order: flow from statement itself to first switch expression
       pred = this and
-      first(expr, succ) and
+      first(this.getExpr(), succ) and
       c instanceof SimpleCompletion
       or
       // Flow from last element of non-`case` statement `i` to first element of statement `i+1`
@@ -1100,27 +1060,23 @@ module Statements {
       c instanceof FalseCompletion
       or
       // Case pattern exits with a non-match
-      last(pattern, last, c) and
+      last(this.getPattern(), last, c) and
       not c.(MatchingCompletion).isMatch()
       or
       // Case body exits with any completion
-      last(body, last, c)
+      last(this.getBody(), last, c)
     }
 
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
       CaseTree.super.succ(pred, succ, c)
       or
       pred = this and
-      first(pattern, succ) and
+      first(this.getPattern(), succ) and
       c instanceof SimpleCompletion
     }
   }
 
   abstract private class LoopStmtTree extends PreOrderTree, LoopStmt {
-    Stmt body;
-
-    LoopStmtTree() { body = this.getBody() }
-
     final override predicate propagatesAbnormal(ControlFlowElement child) {
       child = this.getCondition()
     }
@@ -1131,10 +1087,10 @@ module Statements {
       c instanceof FalseCompletion
       or
       // Body exits with a break completion
-      last(body, last, c.(NestedBreakCompletion).getAnInnerCompatibleCompletion())
+      last(this.getBody(), last, c.(NestedBreakCompletion).getAnInnerCompatibleCompletion())
       or
       // Body exits with a completion that does not continue the loop
-      last(body, last, c) and
+      last(this.getBody(), last, c) and
       not c instanceof BreakCompletion and
       not c.continuesLoop()
     }
@@ -1143,11 +1099,11 @@ module Statements {
       // Flow from last element of condition to first element of loop body
       last(this.getCondition(), pred, c) and
       c instanceof TrueCompletion and
-      first(body, succ)
+      first(this.getBody(), succ)
       or
       // Flow from last element of loop body back to first element of condition
       not this instanceof ForStmt and
-      last(body, pred, c) and
+      last(this.getBody(), pred, c) and
       c.continuesLoop() and
       first(this.getCondition(), succ)
     }
@@ -1168,7 +1124,7 @@ module Statements {
       LoopStmtTree.super.succ(pred, succ, c)
       or
       pred = this and
-      first(body, succ) and
+      first(this.getBody(), succ) and
       c instanceof SimpleCompletion
     }
   }
@@ -1179,7 +1135,7 @@ module Statements {
       result = this.getCondition()
       or
       not exists(this.getCondition()) and
-      result = body
+      result = this.getBody()
     }
 
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
@@ -1214,11 +1170,11 @@ module Statements {
       // Flow from last element of condition into first element of loop body
       last(this.getCondition(), pred, c) and
       c instanceof TrueCompletion and
-      first(body, succ)
+      first(this.getBody(), succ)
       or
       // Flow from last element of loop body to first element of update/condition/self
       exists(ControlFlowElement next |
-        last(body, pred, c) and
+        last(this.getBody(), pred, c) and
         c.continuesLoop() and
         first(next, succ) and
         if exists(this.getUpdate(0))
@@ -1318,8 +1274,6 @@ module Statements {
   }
 
   class TryStmtTree extends PreOrderTree, TryStmt {
-    ControlFlowTree body;
-
     final override predicate propagatesAbnormal(ControlFlowElement child) {
       child = this.getFinally()
     }

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
@@ -368,7 +368,8 @@ module Expressions {
       not this instanceof NoNodeExpr and
       not this instanceof SwitchExpr and
       not this instanceof SwitchCaseExpr and
-      not this instanceof ConstructorInitializer
+      not this instanceof ConstructorInitializer and
+      not this instanceof NotPatternExpr
     }
 
     final override ControlFlowElement getChildElement(int i) { result = getExprChild(this, i) }
@@ -515,20 +516,14 @@ module Expressions {
 
     LogicalNotExprTree() { operand = this.getOperand() }
 
-    final override predicate propagatesAbnormal(ControlFlowElement child) {
-      child = this.getOperand()
-    }
+    final override predicate propagatesAbnormal(ControlFlowElement child) { child = operand }
 
     final override predicate first(ControlFlowElement first) { first(operand, first) }
 
     final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
       succ = this and
-      (
-        last(operand, pred, c.(BooleanCompletion).getDual())
-        or
-        last(operand, pred, c) and
-        c instanceof SimpleCompletion
-      )
+      last(operand, pred, c) and
+      c instanceof NormalCompletion
     }
   }
 
@@ -923,6 +918,22 @@ module Expressions {
         not InitializerSplitting::constructorInitializeOrder(con, _, _) and
         first(con.getBody(), succ)
       )
+    }
+  }
+
+  private class NotPatternExprTree extends PostOrderTree, NotPatternExpr {
+    private PatternExpr operand;
+
+    NotPatternExprTree() { operand = this.getPattern() }
+
+    final override predicate propagatesAbnormal(ControlFlowElement child) { child = operand }
+
+    final override predicate first(ControlFlowElement first) { first(operand, first) }
+
+    final override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
+      succ = this and
+      last(operand, pred, c) and
+      c instanceof NormalCompletion
     }
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
@@ -623,14 +623,13 @@ module Expressions {
    * tracking.
    */
   private class AssignOperationWithExpandedAssignment extends AssignOperation, ControlFlowTree {
-    final override predicate first(ControlFlowElement first) {
-      first(this.getExpandedAssignment(), first)
-    }
+    private Expr expanded;
 
-    final override predicate last(ControlFlowElement last, Completion c) {
-      last = this.getExpandedAssignment() and
-      last(this.getExpandedAssignment(), last, c)
-    }
+    AssignOperationWithExpandedAssignment() { expanded = this.getExpandedAssignment() }
+
+    final override predicate first(ControlFlowElement first) { first(expanded, first) }
+
+    final override predicate last(ControlFlowElement last, Completion c) { last(expanded, last, c) }
 
     final override predicate propagatesAbnormal(ControlFlowElement child) { none() }
 

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
@@ -465,6 +465,12 @@ module ConditionalCompletionSplitting {
         or
         last(succ.(SwitchCaseExpr).getBody(), pred, c) and
         completion = c
+        or
+        last(succ.(NotPatternExpr).getPattern(), pred, c) and
+        completion.(MatchingCompletion).getDual() = c
+        or
+        last(succ.(IsExpr).getPattern(), pred, c) and
+        completion.(BooleanCompletion).getValue() = c.(MatchingCompletion).getValue()
       )
     }
 

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -970,6 +970,15 @@
 | Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:69:13:69:17 | [no-match] not ... | 1 |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 | 1 |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:65:26:65:27 | exit M6 | 6 |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:78:13:78:15 | > ... | 5 |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:74:26:74:27 | exit M7 | 4 |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:13:78:24 | ... => ... | 2 |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:13:79:15 | < ... | 2 |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:13:79:24 | ... => ... | 2 |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:13 | 1 | 1 |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:13:80:20 | ... => ... | 2 |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:13:81:13 | _ | 1 |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:13:81:20 | ... => ... | 2 |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | exit M1 | 7 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:18:12:21 | null | 5 |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 | 2 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -924,7 +924,7 @@
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:16:17:16:18 | "" | 5 |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:17:13:17:19 | (...) ... | 5 |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:13:10:13:11 | exit M6 | 4 |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:8:13:8:23 | ... is ... | 9 |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:8:13:8:23 | ... is ... | 9 |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:10:13:10:42 | call to method WriteLine | 6 |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:31 | ... is ... | 4 |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:14:13:14:45 | call to method WriteLine | 6 |
@@ -942,7 +942,21 @@
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:18:33:23 | Object v2 | 2 |
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:34:17:34:22 | break; | 1 |
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:37:17:37:22 | break; | 5 |
-| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | exit Test | 4 |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | exit M1 | 4 |
+| Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:47:24:47:25 | exit M2 | 7 |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:21 | ... is ... | 5 |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | exit M3 | 3 |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:30 | ... is ... | 3 |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:39 | ... is ... | 3 |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | exit M4 | 10 |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:13:60:17 | not ... | 5 |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | exit M5 | 4 |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:28 | ... => ... | 2 |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | _ | 1 |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:24 | ... => ... | 2 |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:69:13:69:17 | not ... | 5 |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 | 1 |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:65:26:65:27 | exit M6 | 6 |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | exit M1 | 7 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | ... is ... | 6 |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 | 2 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -924,11 +924,17 @@
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:16:17:16:18 | "" | 5 |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:17:13:17:19 | (...) ... | 5 |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:13:10:13:11 | exit M6 | 4 |
-| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:8:13:8:23 | ... is ... | 9 |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:8:18:8:23 | Int32 i1 | 8 |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:8:13:8:23 | [false] ... is ... | 1 |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:8:13:8:23 | [true] ... is ... | 1 |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:10:13:10:42 | call to method WriteLine | 6 |
-| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:31 | ... is ... | 4 |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:23:12:31 | String s1 | 3 |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:12:18:12:31 | [false] ... is ... | 1 |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:12:18:12:31 | [true] ... is ... | 1 |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:14:13:14:45 | call to method WriteLine | 6 |
-| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:18:16:28 | ... is ... | 4 |
+| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:23:16:28 | Object v1 | 3 |
+| Patterns.cs:16:18:16:28 | [false] ... is ... | Patterns.cs:16:18:16:28 | [false] ... is ... | 1 |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:16:18:16:28 | [true] ... is ... | 1 |
 | Patterns.cs:17:9:18:9 | {...} | Patterns.cs:17:9:18:9 | {...} | 1 |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:22:18:22:22 | "xyz" | 4 |
 | Patterns.cs:23:17:23:22 | break; | Patterns.cs:23:17:23:22 | break; | 1 |
@@ -944,26 +950,37 @@
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:37:17:37:22 | break; | 5 |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | exit M1 | 4 |
 | Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:47:24:47:25 | exit M2 | 7 |
-| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:21 | ... is ... | 5 |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:18:51:21 | null | 3 |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:9:51:21 | [false] ... is ... | 1 |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:9:51:21 | [true] ... is ... | 1 |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | exit M3 | 3 |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:14:51:21 | [match] not ... | 1 |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:14:51:21 | [no-match] not ... | 1 |
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:30 | ... is ... | 3 |
 | Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:39 | ... is ... | 3 |
 | Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | exit M4 | 10 |
-| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:13:60:17 | not ... | 5 |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:17:60:17 | 1 | 4 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | exit M5 | 4 |
+| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:60:13:60:17 | [match] not ... | 1 |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:60:13:60:17 | [no-match] not ... | 1 |
 | Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:28 | ... => ... | 2 |
 | Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | _ | 1 |
 | Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:24 | ... => ... | 2 |
-| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:69:13:69:17 | not ... | 5 |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:69:17:69:17 | 2 | 4 |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:69:13:69:17 | [no-match] not ... | 1 |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 | 1 |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:65:26:65:27 | exit M6 | 6 |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | exit M1 | 7 |
-| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | ... is ... | 6 |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:18:12:21 | null | 5 |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 | 2 |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:12:13:12:21 | [false] ... is ... | 1 |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:12:13:12:21 | [true] ... is ... | 1 |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; | 1 |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:28 | call to method WriteLine | 3 |
-| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:19:13:19:21 | ... is ... | 6 |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:19:18:19:21 | null | 5 |
 | PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | exit M3 | 1 |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:19:13:19:21 | [false] ... is ... | 1 |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:19:13:19:21 | [true] ... is ... | 1 |
 | PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | 4 |
 | PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:17:10:17:11 | exit M3 (normal) | 4 |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | exit Method | 4 |
@@ -1079,7 +1096,9 @@
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:52 | ... => ... | 2 |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:48 | call to method WriteLine | 5 |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:48 | call to method WriteLine | 5 |
-| TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | ... is ... | 14 |
+| TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:18:7:22 | Int32 j | 13 |
+| TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:7:13:7:22 | [false] ... is ... | 1 |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:7:13:7:22 | [true] ... is ... | 1 |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:25:7:25 | ; | 1 |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | exit M | 5 |
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | exit M1 | 19 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -1872,6 +1872,22 @@ conditionBlock
 | Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:70:13:70:13 | 2 | false |
 | Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:70:18:70:27 | "possible" | false |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" | true |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:78:20:78:24 | "> 1" | true |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:79:15:79:15 | 0 | false |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:79:20:79:24 | "< 0" | false |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:80:13:80:13 | 1 | false |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:80:18:80:20 | "1" | false |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:81:13:81:13 | _ | false |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:81:18:81:20 | "0" | false |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:20:79:24 | "< 0" | true |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:80:13:80:13 | 1 | false |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:80:18:80:20 | "1" | false |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:81:13:81:13 | _ | false |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:81:18:81:20 | "0" | false |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:18:80:20 | "1" | true |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:81:13:81:13 | _ | false |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:81:18:81:20 | "0" | false |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:18:81:20 | "0" | true |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | [false] ... is ... | false |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | [true] ... is ... | true |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:13:13:13:19 | return ...; | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -1783,15 +1783,42 @@ conditionBlock
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | false |
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | false |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... | false |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:8:13:8:23 | [false] ... is ... | false |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:8:13:8:23 | [true] ... is ... | true |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:9:9:11:9 | {...} | true |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:12:14:18:9 | if (...) ... | false |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:12:18:12:31 | [false] ... is ... | false |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:12:18:12:31 | [true] ... is ... | false |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:13:9:15:9 | {...} | false |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:16:14:18:9 | if (...) ... | false |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:16:18:16:28 | [false] ... is ... | false |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:16:18:16:28 | [true] ... is ... | false |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:17:9:18:9 | {...} | false |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:14:18:9 | if (...) ... | false |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:18:12:31 | [false] ... is ... | false |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:18:12:31 | [true] ... is ... | false |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:13:9:15:9 | {...} | false |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:16:14:18:9 | if (...) ... | false |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:16:18:16:28 | [false] ... is ... | false |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:16:18:16:28 | [true] ... is ... | false |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:17:9:18:9 | {...} | false |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:9:9:11:9 | {...} | true |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:31 | [false] ... is ... | false |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:31 | [true] ... is ... | true |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:13:9:15:9 | {...} | true |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:16:14:18:9 | if (...) ... | false |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:16:18:16:28 | [false] ... is ... | false |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:16:18:16:28 | [true] ... is ... | false |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:17:9:18:9 | {...} | false |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:14:18:9 | if (...) ... | false |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:18:16:28 | [false] ... is ... | false |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:18:16:28 | [true] ... is ... | false |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:17:9:18:9 | {...} | false |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:13:9:15:9 | {...} | true |
+| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:18:16:28 | [false] ... is ... | false |
+| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:18:16:28 | [true] ... is ... | true |
 | Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:17:9:18:9 | {...} | true |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:17:9:18:9 | {...} | true |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:23:17:23:22 | break; | true |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:24:13:24:36 | case ...: | false |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:24:30:24:31 | access to local variable i2 | false |
@@ -1818,19 +1845,45 @@ conditionBlock
 | Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:35:13:35:20 | default: | false |
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:34:17:34:22 | break; | true |
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:35:13:35:20 | default: | false |
-| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:25:51:25 | access to parameter c | true |
-| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:34:51:34 | access to parameter c | false |
-| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:22:60:28 | "not 1" | true |
-| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:61:13:61:13 | _ | false |
-| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:61:18:61:24 | "other" | false |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:21 | [false] ... is ... | true |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:21 | [true] ... is ... | false |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:14:51:21 | [match] not ... | false |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:14:51:21 | [no-match] not ... | true |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:25:51:25 | access to parameter c | false |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:34:51:34 | access to parameter c | true |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:34:51:34 | access to parameter c | false |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:25:51:25 | access to parameter c | true |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:9:51:21 | [true] ... is ... | true |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:25:51:25 | access to parameter c | true |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:9:51:21 | [false] ... is ... | false |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:34:51:34 | access to parameter c | false |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:13:60:17 | [match] not ... | false |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:13:60:17 | [no-match] not ... | true |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:22:60:28 | "not 1" | false |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:61:13:61:13 | _ | true |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:61:18:61:24 | "other" | true |
+| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:60:22:60:28 | "not 1" | true |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:61:13:61:13 | _ | false |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:61:18:61:24 | "other" | false |
 | Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" | true |
-| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:70:13:70:13 | 2 | false |
-| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:70:18:70:27 | "possible" | false |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:69:13:69:17 | [no-match] not ... | true |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:70:13:70:13 | 2 | true |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:70:18:70:27 | "possible" | true |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:70:13:70:13 | 2 | false |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:70:18:70:27 | "possible" | false |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" | true |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | [false] ... is ... | false |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | [true] ... is ... | true |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:13:13:13:19 | return ...; | true |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:14:9:14:29 | ...; | false |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:14:9:14:29 | ...; | false |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:13:13:13:19 | return ...; | true |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:19:13:19:21 | [false] ... is ... | false |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:19:13:19:21 | [true] ... is ... | true |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:20:45:20:53 | nameof(...) | true |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:21:9:21:29 | ...; | false |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:21:9:21:29 | ...; | false |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | true |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:10:10:10:11 | exit M2 (abnormal) | false |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:15:17:15:23 | return ...; | true |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:16:13:16:19 | case ...: | false |
@@ -1999,7 +2052,10 @@ conditionBlock
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:158:13:158:49 | ...; | true |
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:160:13:160:49 | ...; | false |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" | true |
+| TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | [false] ... is ... | false |
+| TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | [true] ... is ... | true |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:25:7:25 | ; | true |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:7:25:7:25 | ; | true |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:24:25:24 | access to local variable x | true |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:28:25:28 | access to local variable y | false |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:12:13:12:49 | ...; | true |
@@ -2712,20 +2768,20 @@ conditionFlow
 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | true |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | false |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... | true |
-| Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:9:9:11:9 | {...} | true |
-| Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:12:14:18:9 | if (...) ... | false |
-| Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:13:9:15:9 | {...} | true |
-| Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:16:14:18:9 | if (...) ... | false |
-| Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:17:9:18:9 | {...} | true |
-| Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:20:9:38:9 | switch (...) {...} | false |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:14:18:9 | if (...) ... | false |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:9:9:11:9 | {...} | true |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:14:18:9 | if (...) ... | false |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:13:9:15:9 | {...} | true |
+| Patterns.cs:16:18:16:28 | [false] ... is ... | Patterns.cs:20:9:38:9 | switch (...) {...} | false |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:17:9:18:9 | {...} | true |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:25:17:25:52 | ...; | true |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:27:13:27:24 | case ...: | false |
-| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:25:51:25 | access to parameter c | true |
-| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:34:51:34 | access to parameter c | false |
-| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:13:13:13:19 | return ...; | true |
-| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:14:9:14:29 | ...; | false |
-| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | true |
-| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:21:9:21:29 | ...; | false |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:34:51:34 | access to parameter c | false |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:25:51:25 | access to parameter c | true |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:14:9:14:29 | ...; | false |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:13:13:13:19 | return ...; | true |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:21:9:21:29 | ...; | false |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | true |
 | Switch.cs:21:21:21:29 | ... == ... | Switch.cs:22:21:22:27 | return ...; | true |
 | Switch.cs:21:21:21:29 | ... == ... | Switch.cs:23:27:23:27 | 0 | false |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:32:24:55 | [false] ... && ... | false |
@@ -2752,8 +2808,8 @@ conditionFlow
 | Switch.cs:125:42:125:46 | false | Switch.cs:125:37:125:46 | [false] ... => ... | false |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; | true |
 | Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; | false |
-| TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:7:25:7:25 | ; | true |
-| TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; | false |
+| TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; | false |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:7:25:7:25 | ; | true |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:24:25:24 | access to local variable x | true |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:28:25:28 | access to local variable y | false |
 | cflow.cs:11:13:11:17 | ... > ... | cflow.cs:12:13:12:49 | ...; | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -1783,11 +1783,11 @@ conditionBlock
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | false |
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | false |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... | false |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:9:9:11:9 | {...} | true |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:12:14:18:9 | if (...) ... | false |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:13:9:15:9 | {...} | false |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:16:14:18:9 | if (...) ... | false |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:17:9:18:9 | {...} | false |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:9:9:11:9 | {...} | true |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:12:14:18:9 | if (...) ... | false |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:13:9:15:9 | {...} | false |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:16:14:18:9 | if (...) ... | false |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:17:9:18:9 | {...} | false |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:13:9:15:9 | {...} | true |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:16:14:18:9 | if (...) ... | false |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:17:9:18:9 | {...} | false |
@@ -1818,6 +1818,15 @@ conditionBlock
 | Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:35:13:35:20 | default: | false |
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:34:17:34:22 | break; | true |
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:35:13:35:20 | default: | false |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:25:51:25 | access to parameter c | true |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:34:51:34 | access to parameter c | false |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:22:60:28 | "not 1" | true |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:61:13:61:13 | _ | false |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:61:18:61:24 | "other" | false |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" | true |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:70:13:70:13 | 2 | false |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:70:18:70:27 | "possible" | false |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" | true |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:13:13:13:19 | return ...; | true |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:14:9:14:29 | ...; | false |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:20:45:20:53 | nameof(...) | true |
@@ -2711,6 +2720,8 @@ conditionFlow
 | Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:20:9:38:9 | switch (...) {...} | false |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:25:17:25:52 | ...; | true |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:27:13:27:24 | case ...: | false |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:25:51:25 | access to parameter c | true |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:34:51:34 | access to parameter c | false |
 | PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:13:13:13:19 | return ...; | true |
 | PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:14:9:14:29 | ...; | false |
 | PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -3177,6 +3177,25 @@ dominance
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:67:16:71:9 | ... switch { ... } |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:27 | ... => ... |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:75:5:83:5 | {...} |
+| Patterns.cs:74:26:74:27 | exit M7 (normal) | Patterns.cs:74:26:74:27 | exit M7 |
+| Patterns.cs:75:5:83:5 | {...} | Patterns.cs:76:16:76:16 | access to parameter i |
+| Patterns.cs:76:9:82:10 | return ...; | Patterns.cs:74:26:74:27 | exit M7 (normal) |
+| Patterns.cs:76:16:76:16 | access to parameter i | Patterns.cs:78:15:78:15 | 1 |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:76:9:82:10 | return ...; |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:20:78:24 | "> 1" |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:79:15:79:15 | 0 |
+| Patterns.cs:78:15:78:15 | 1 | Patterns.cs:78:13:78:15 | > ... |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:13:78:24 | ... => ... |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:20:79:24 | "< 0" |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:80:13:80:13 | 1 |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:13:79:15 | < ... |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:13:79:24 | ... => ... |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:18:80:20 | "1" |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:13:80:20 | ... => ... |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:18:81:20 | "0" |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:13:81:20 | ... => ... |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:6:5:8:5 | {...} |
 | PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | exit M1 |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:29 | ...; |
@@ -7170,6 +7189,23 @@ postDominance
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:69:13:69:17 | [no-match] not ... |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:18:70:27 | "possible" |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:74:26:74:27 | exit M7 | Patterns.cs:74:26:74:27 | exit M7 (normal) |
+| Patterns.cs:74:26:74:27 | exit M7 (normal) | Patterns.cs:76:9:82:10 | return ...; |
+| Patterns.cs:75:5:83:5 | {...} | Patterns.cs:74:26:74:27 | enter M7 |
+| Patterns.cs:76:9:82:10 | return ...; | Patterns.cs:76:16:82:9 | ... switch { ... } |
+| Patterns.cs:76:16:76:16 | access to parameter i | Patterns.cs:75:5:83:5 | {...} |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:78:13:78:24 | ... => ... |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:79:13:79:24 | ... => ... |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:80:13:80:20 | ... => ... |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:81:13:81:20 | ... => ... |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:15:78:15 | 1 |
+| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:78:20:78:24 | "> 1" |
+| Patterns.cs:78:15:78:15 | 1 | Patterns.cs:76:16:76:16 | access to parameter i |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:15:79:15 | 0 |
+| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:79:20:79:24 | "< 0" |
+| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:80:18:80:20 | "1" |
+| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:81:18:81:20 | "0" |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:13:81:13 | _ |
 | PostDominance.cs:5:10:5:11 | exit M1 | PostDominance.cs:5:10:5:11 | exit M1 (normal) |
 | PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:7:9:7:28 | call to method WriteLine |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:5:10:5:11 | enter M1 |
@@ -11682,6 +11718,32 @@ blockDominance
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:18:70:27 | "possible" |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:74:26:74:27 | enter M7 |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:76:16:82:9 | ... switch { ... } |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:78:20:78:24 | "> 1" |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:79:15:79:15 | 0 |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:79:20:79:24 | "< 0" |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:80:13:80:13 | 1 |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:80:18:80:20 | "1" |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:81:18:81:20 | "0" |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:76:16:82:9 | ... switch { ... } |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:20:78:24 | "> 1" |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:15:79:15 | 0 |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:20:79:24 | "< 0" |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:80:13:80:13 | 1 |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:80:18:80:20 | "1" |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:81:18:81:20 | "0" |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:20:79:24 | "< 0" |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:13 | 1 |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:18:80:20 | "1" |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:81:18:81:20 | "0" |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:18:80:20 | "1" |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:18:81:20 | "0" |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:18:81:20 | "0" |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | exit M2 (normal) |
@@ -15024,6 +15086,24 @@ postBlockDominance
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:69:13:69:17 | [no-match] not ... |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:13 | 2 |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:18:70:27 | "possible" |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:74:26:74:27 | enter M7 |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:74:26:74:27 | enter M7 |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:76:16:82:9 | ... switch { ... } |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:78:20:78:24 | "> 1" |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:79:15:79:15 | 0 |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:79:20:79:24 | "< 0" |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:80:13:80:13 | 1 |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:80:18:80:20 | "1" |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:81:18:81:20 | "0" |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:20:78:24 | "> 1" |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:15:79:15 | 0 |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:20:79:24 | "< 0" |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:13 | 1 |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:18:80:20 | "1" |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:18:81:20 | "0" |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | enter M2 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -3058,9 +3058,10 @@ dominance
 | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:16:7:23 | Object o = ... |
 | Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:8:13:8:13 | access to local variable o |
 | Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:8:18:8:23 | Int32 i1 |
-| Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:9:9:11:9 | {...} |
-| Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:12:14:18:9 | if (...) ... |
-| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:23 | ... is ... |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:14:18:9 | if (...) ... |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:9:9:11:9 | {...} |
+| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:23 | [false] ... is ... |
+| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:23 | [true] ... is ... |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:10:13:10:43 | ...; |
 | Patterns.cs:10:13:10:43 | ...; | Patterns.cs:10:33:10:36 | "int " |
 | Patterns.cs:10:31:10:41 | $"..." | Patterns.cs:10:13:10:42 | call to method WriteLine |
@@ -3068,9 +3069,10 @@ dominance
 | Patterns.cs:10:38:10:39 | access to local variable i1 | Patterns.cs:10:31:10:41 | $"..." |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:18 | access to local variable o |
 | Patterns.cs:12:18:12:18 | access to local variable o | Patterns.cs:12:23:12:31 | String s1 |
-| Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:13:9:15:9 | {...} |
-| Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:16:14:18:9 | if (...) ... |
-| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:31 | ... is ... |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:14:18:9 | if (...) ... |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:13:9:15:9 | {...} |
+| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:31 | [false] ... is ... |
+| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:31 | [true] ... is ... |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:14:13:14:46 | ...; |
 | Patterns.cs:14:13:14:46 | ...; | Patterns.cs:14:33:14:39 | "string " |
 | Patterns.cs:14:31:14:44 | $"..." | Patterns.cs:14:13:14:45 | call to method WriteLine |
@@ -3078,8 +3080,9 @@ dominance
 | Patterns.cs:14:41:14:42 | access to local variable s1 | Patterns.cs:14:31:14:44 | $"..." |
 | Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:18:16:18 | access to local variable o |
 | Patterns.cs:16:18:16:18 | access to local variable o | Patterns.cs:16:23:16:28 | Object v1 |
-| Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:17:9:18:9 | {...} |
-| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:28 | ... is ... |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:17:9:18:9 | {...} |
+| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:28 | [false] ... is ... |
+| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:28 | [true] ... is ... |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:20:17:20:17 | access to local variable o |
 | Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:22:13:22:23 | case ...: |
 | Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:22:18:22:22 | "xyz" |
@@ -3130,11 +3133,13 @@ dominance
 | Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:9 | access to parameter c |
 | Patterns.cs:50:24:50:25 | exit M3 (normal) | Patterns.cs:50:24:50:25 | exit M3 |
 | Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:51:18:51:21 | null |
-| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:25:51:25 | access to parameter c |
-| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:25:51:25 | access to parameter c |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | exit M3 (normal) |
-| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:9:51:21 | ... is ... |
-| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | not ... |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:9:51:21 | [true] ... is ... |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:9:51:21 | [false] ... is ... |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | [match] not ... |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | [no-match] not ... |
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:30:51:30 | 1 |
 | Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:25:51:30 | ... is ... |
 | Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:39:51:39 | 2 |
@@ -3154,9 +3159,10 @@ dominance
 | Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:56:26:56:27 | exit M5 (normal) |
 | Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:60:17:60:17 | 1 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:9:62:10 | return ...; |
-| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:22:60:28 | "not 1" |
-| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:61:13:61:13 | _ |
-| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | not ... |
+| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | [match] not ... |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | [no-match] not ... |
 | Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:28 | ... => ... |
 | Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" |
 | Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:24 | ... => ... |
@@ -3166,8 +3172,8 @@ dominance
 | Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:65:26:65:27 | exit M6 (normal) |
 | Patterns.cs:67:16:67:16 | 2 | Patterns.cs:69:17:69:17 | 2 |
 | Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:9:71:10 | return ...; |
-| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:70:13:70:13 | 2 |
-| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | not ... |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | [no-match] not ... |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:67:16:71:9 | ... switch { ... } |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:27 | ... => ... |
@@ -3182,18 +3188,20 @@ dominance
 | PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:12:9:13:19 | if (...) ... |
 | PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:12:13:12:13 | access to parameter s |
 | PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:18:12:21 | null |
-| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:13:13:13:19 | return ...; |
-| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:14:9:14:29 | ...; |
-| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | ... is ... |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | [false] ... is ... |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | [true] ... is ... |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:27:14:27 | access to parameter s |
 | PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:9:14:28 | call to method WriteLine |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:18:5:22:5 | {...} |
 | PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:19:9:20:55 | if (...) ... |
 | PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:19:13:19:13 | access to parameter s |
 | PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:18:19:21 | null |
-| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) |
-| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:21:9:21:29 | ...; |
-| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | ... is ... |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:21:9:21:29 | ...; |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | [false] ... is ... |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | [true] ... is ... |
 | PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:17:10:17:11 | exit M3 (abnormal) |
 | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:13:20:55 | throw ...; |
 | PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException |
@@ -3517,9 +3525,9 @@ dominance
 | TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:6:9:6:23 | ... = ... |
 | TypeAccesses.cs:7:9:7:25 | if (...) ... | TypeAccesses.cs:7:13:7:13 | access to parameter o |
 | TypeAccesses.cs:7:13:7:13 | access to parameter o | TypeAccesses.cs:7:18:7:22 | Int32 j |
-| TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:7:25:7:25 | ; |
-| TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; |
-| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | ... is ... |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:7:25:7:25 | ; |
+| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | [false] ... is ... |
+| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | [true] ... is ... |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:17:8:27 | typeof(...) |
 | TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:3:10:3:10 | exit M (normal) |
 | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:13:8:27 | Type t = ... |
@@ -7050,27 +7058,29 @@ postDominance
 | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:9:7:24 | ... ...; |
 | Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:7:16:7:23 | Object o = ... |
 | Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:8:9:18:9 | if (...) ... |
-| Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:8:18:8:23 | Int32 i1 |
 | Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:13 | access to local variable o |
+| Patterns.cs:9:9:11:9 | {...} | Patterns.cs:8:13:8:23 | [true] ... is ... |
 | Patterns.cs:10:13:10:42 | call to method WriteLine | Patterns.cs:10:31:10:41 | $"..." |
 | Patterns.cs:10:13:10:43 | ...; | Patterns.cs:9:9:11:9 | {...} |
 | Patterns.cs:10:31:10:41 | $"..." | Patterns.cs:10:38:10:39 | access to local variable i1 |
 | Patterns.cs:10:33:10:36 | "int " | Patterns.cs:10:13:10:43 | ...; |
 | Patterns.cs:10:38:10:39 | access to local variable i1 | Patterns.cs:10:33:10:36 | "int " |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:8:13:8:23 | [false] ... is ... |
 | Patterns.cs:12:18:12:18 | access to local variable o | Patterns.cs:12:14:18:9 | if (...) ... |
-| Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:12:23:12:31 | String s1 |
 | Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:18 | access to local variable o |
+| Patterns.cs:13:9:15:9 | {...} | Patterns.cs:12:18:12:31 | [true] ... is ... |
 | Patterns.cs:14:13:14:45 | call to method WriteLine | Patterns.cs:14:31:14:44 | $"..." |
 | Patterns.cs:14:13:14:46 | ...; | Patterns.cs:13:9:15:9 | {...} |
 | Patterns.cs:14:31:14:44 | $"..." | Patterns.cs:14:41:14:42 | access to local variable s1 |
 | Patterns.cs:14:33:14:39 | "string " | Patterns.cs:14:13:14:46 | ...; |
 | Patterns.cs:14:41:14:42 | access to local variable s1 | Patterns.cs:14:33:14:39 | "string " |
+| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:12:18:12:31 | [false] ... is ... |
 | Patterns.cs:16:18:16:18 | access to local variable o | Patterns.cs:16:14:18:9 | if (...) ... |
-| Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:16:23:16:28 | Object v1 |
 | Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:18 | access to local variable o |
+| Patterns.cs:17:9:18:9 | {...} | Patterns.cs:16:18:16:28 | [true] ... is ... |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:10:13:10:42 | call to method WriteLine |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:14:13:14:45 | call to method WriteLine |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:16:18:16:28 | ... is ... |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:16:18:16:28 | [false] ... is ... |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:17:9:18:9 | {...} |
 | Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:20:9:38:9 | switch (...) {...} |
 | Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:20:17:20:17 | access to local variable o |
@@ -7116,13 +7126,15 @@ postDominance
 | Patterns.cs:50:24:50:25 | exit M3 | Patterns.cs:50:24:50:25 | exit M3 (normal) |
 | Patterns.cs:50:24:50:25 | exit M3 (normal) | Patterns.cs:51:9:51:39 | ... ? ... : ... |
 | Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:50:24:50:25 | enter M3 |
-| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:14:51:21 | not ... |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:14:51:21 | [no-match] not ... |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:14:51:21 | [match] not ... |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:25:51:30 | ... is ... |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:34:51:39 | ... is ... |
-| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:18:51:21 | null |
 | Patterns.cs:51:18:51:21 | null | Patterns.cs:51:9:51:9 | access to parameter c |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:9:51:21 | [true] ... is ... |
 | Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:51:30:51:30 | 1 |
 | Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:9:51:21 | [false] ... is ... |
 | Patterns.cs:51:34:51:39 | ... is ... | Patterns.cs:51:39:51:39 | 2 |
 | Patterns.cs:51:39:51:39 | 2 | Patterns.cs:51:34:51:34 | access to parameter c |
 | Patterns.cs:53:24:53:25 | exit M4 | Patterns.cs:53:24:53:25 | exit M4 (normal) |
@@ -7141,9 +7153,10 @@ postDominance
 | Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:57:5:63:5 | {...} |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:60:13:60:28 | ... => ... |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:61:13:61:24 | ... => ... |
-| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:17:60:17 | 1 |
 | Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:22:60:28 | "not 1" |
 | Patterns.cs:60:17:60:17 | 1 | Patterns.cs:58:16:58:16 | access to parameter i |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:17 | [match] not ... |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:60:13:60:17 | [no-match] not ... |
 | Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:61:18:61:24 | "other" |
 | Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:13 | _ |
 | Patterns.cs:65:26:65:27 | exit M6 | Patterns.cs:65:26:65:27 | exit M6 (normal) |
@@ -7152,9 +7165,9 @@ postDominance
 | Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:67:16:71:9 | ... switch { ... } |
 | Patterns.cs:67:16:67:16 | 2 | Patterns.cs:66:5:72:5 | {...} |
 | Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:70:13:70:27 | ... => ... |
-| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:17:69:17 | 2 |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:69:17:69:17 | 2 |
 | Patterns.cs:69:17:69:17 | 2 | Patterns.cs:67:16:67:16 | 2 |
-| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:69:13:69:17 | not ... |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:69:13:69:17 | [no-match] not ... |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:18:70:27 | "possible" |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:13 | 2 |
 | PostDominance.cs:5:10:5:11 | exit M1 | PostDominance.cs:5:10:5:11 | exit M1 (normal) |
@@ -7169,21 +7182,22 @@ postDominance
 | PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:10:10:10:11 | enter M2 |
 | PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:11:5:15:5 | {...} |
 | PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:9:13:19 | if (...) ... |
-| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:12:18:12:21 | null |
 | PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:13 | access to parameter s |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:12:13:12:21 | [true] ... is ... |
 | PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:14:27:14:27 | access to parameter s |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:12:13:12:21 | [false] ... is ... |
 | PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:9:14:29 | ...; |
 | PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | PostDominance.cs:20:13:20:55 | throw ...; |
 | PostDominance.cs:17:10:17:11 | exit M3 (normal) | PostDominance.cs:21:9:21:28 | call to method WriteLine |
 | PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:17:10:17:11 | enter M3 |
 | PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:18:5:22:5 | {...} |
 | PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:9:20:55 | if (...) ... |
-| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:19:18:19:21 | null |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:19:18:19:21 | null |
 | PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:13 | access to parameter s |
 | PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException |
 | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:45:20:53 | nameof(...) |
 | PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:21:27:21:27 | access to parameter s |
-| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:19:13:19:21 | ... is ... |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:19:13:19:21 | [false] ... is ... |
 | PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:9:21:29 | ...; |
 | Qualifiers.cs:7:16:7:21 | exit Method | Qualifiers.cs:7:16:7:21 | exit Method (normal) |
 | Qualifiers.cs:7:16:7:21 | exit Method (normal) | Qualifiers.cs:7:28:7:31 | null |
@@ -7486,9 +7500,9 @@ postDominance
 | TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:6:13:6:13 | access to parameter o |
 | TypeAccesses.cs:7:9:7:25 | if (...) ... | TypeAccesses.cs:6:9:6:23 | ... = ... |
 | TypeAccesses.cs:7:13:7:13 | access to parameter o | TypeAccesses.cs:7:9:7:25 | if (...) ... |
-| TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:7:18:7:22 | Int32 j |
 | TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:13 | access to parameter o |
-| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:7:13:7:22 | ... is ... |
+| TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:13:7:22 | [true] ... is ... |
+| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:7:13:7:22 | [false] ... is ... |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:7:25:7:25 | ; |
 | TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:8:17:8:27 | typeof(...) |
 | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:9:8:28 | ... ...; |
@@ -11511,10 +11525,16 @@ blockDominance
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:5:10:5:11 | enter M1 |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:8:13:8:23 | [false] ... is ... |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:8:13:8:23 | [true] ... is ... |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:9:9:11:9 | {...} |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:12:14:18:9 | if (...) ... |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:12:18:12:31 | [false] ... is ... |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:12:18:12:31 | [true] ... is ... |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:13:9:15:9 | {...} |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:16:14:18:9 | if (...) ... |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:16:18:16:28 | [false] ... is ... |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:16:18:16:28 | [true] ... is ... |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:17:9:18:9 | {...} |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:20:9:38:9 | switch (...) {...} |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:23:17:23:22 | break; |
@@ -11529,14 +11549,41 @@ blockDominance
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:35:13:35:20 | default: |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:40:9:42:9 | switch (...) {...} |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:8:13:8:23 | [false] ... is ... |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:14:18:9 | if (...) ... |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:18:12:31 | [false] ... is ... |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:18:12:31 | [true] ... is ... |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:13:9:15:9 | {...} |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:16:14:18:9 | if (...) ... |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:16:18:16:28 | [false] ... is ... |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:16:18:16:28 | [true] ... is ... |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:17:9:18:9 | {...} |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:8:13:8:23 | [true] ... is ... |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:9:9:11:9 | {...} |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:9:9:11:9 | {...} |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:14:18:9 | if (...) ... |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:31 | [false] ... is ... |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:31 | [true] ... is ... |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:13:9:15:9 | {...} |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:16:14:18:9 | if (...) ... |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:16:18:16:28 | [false] ... is ... |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:16:18:16:28 | [true] ... is ... |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:17:9:18:9 | {...} |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:12:18:12:31 | [false] ... is ... |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:14:18:9 | if (...) ... |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:18:16:28 | [false] ... is ... |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:18:16:28 | [true] ... is ... |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:17:9:18:9 | {...} |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:12:18:12:31 | [true] ... is ... |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:13:9:15:9 | {...} |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:13:9:15:9 | {...} |
 | Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:14:18:9 | if (...) ... |
+| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:18:16:28 | [false] ... is ... |
+| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:18:16:28 | [true] ... is ... |
 | Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:17:9:18:9 | {...} |
+| Patterns.cs:16:18:16:28 | [false] ... is ... | Patterns.cs:16:18:16:28 | [false] ... is ... |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:16:18:16:28 | [true] ... is ... |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:17:9:18:9 | {...} |
 | Patterns.cs:17:9:18:9 | {...} | Patterns.cs:17:9:18:9 | {...} |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:20:9:38:9 | switch (...) {...} |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:23:17:23:22 | break; |
@@ -11587,42 +11634,79 @@ blockDominance
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
 | Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:47:24:47:25 | enter M2 |
 | Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:50:24:50:25 | enter M3 |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:21 | [false] ... is ... |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:21 | [true] ... is ... |
 | Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:39 | ... ? ... : ... |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:14:51:21 | [match] not ... |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:14:51:21 | [no-match] not ... |
 | Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:25:51:25 | access to parameter c |
 | Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:9:51:21 | [false] ... is ... |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:9:51:21 | [true] ... is ... |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:25:51:25 | access to parameter c |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:9:51:39 | ... ? ... : ... |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:9:51:21 | [true] ... is ... |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:14:51:21 | [match] not ... |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:9:51:21 | [false] ... is ... |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:14:51:21 | [no-match] not ... |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:34:51:34 | access to parameter c |
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:25 | access to parameter c |
 | Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:34 | access to parameter c |
 | Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | enter M4 |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | enter M5 |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:58:16:62:9 | ... switch { ... } |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:13:60:17 | [match] not ... |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:13:60:17 | [no-match] not ... |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:22:60:28 | "not 1" |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:61:13:61:13 | _ |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:61:18:61:24 | "other" |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:16:62:9 | ... switch { ... } |
+| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:60:13:60:17 | [match] not ... |
+| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:60:13:60:17 | [no-match] not ... |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:61:18:61:24 | "other" |
 | Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:22:60:28 | "not 1" |
 | Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | _ |
 | Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" |
 | Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:18:61:24 | "other" |
 | Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:65:26:65:27 | enter M6 |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:69:13:69:17 | [no-match] not ... |
 | Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:70:13:70:13 | 2 |
 | Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:70:18:70:27 | "possible" |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:69:13:69:17 | [no-match] not ... |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:70:18:70:27 | "possible" |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:18:70:27 | "possible" |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | exit M2 (normal) |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | [false] ... is ... |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | [true] ... is ... |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:13:13:13:19 | return ...; |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:14:9:14:29 | ...; |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 (normal) |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:12:13:12:21 | [false] ... is ... |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:12:13:12:21 | [true] ... is ... |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:13:13:13:19 | return ...; |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:29 | ...; |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | enter M3 |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | exit M3 |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:19:13:19:21 | [false] ... is ... |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:19:13:19:21 | [true] ... is ... |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:20:45:20:53 | nameof(...) |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:21:9:21:29 | ...; |
 | PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | exit M3 |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:19:13:19:21 | [false] ... is ... |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:21:9:21:29 | ...; |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:19:13:19:21 | [true] ... is ... |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) |
 | PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:45:20:53 | nameof(...) |
 | PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:9:21:29 | ...; |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | enter Method |
@@ -11945,8 +12029,13 @@ blockDominance
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:49 | ...; |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | enter M |
+| TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | [false] ... is ... |
+| TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | [true] ... is ... |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:25:7:25 | ; |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:8:9:8:28 | ... ...; |
+| TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:7:13:7:22 | [false] ... is ... |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:7:13:7:22 | [true] ... is ... |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:7:25:7:25 | ; |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:25:7:25 | ; |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:9:8:28 | ... ...; |
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | enter M1 |
@@ -14820,16 +14909,33 @@ postBlockDominance
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:5:10:5:11 | enter M1 |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:8:13:8:23 | [false] ... is ... |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:8:13:8:23 | [true] ... is ... |
+| Patterns.cs:9:9:11:9 | {...} | Patterns.cs:8:13:8:23 | [true] ... is ... |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:9:9:11:9 | {...} |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:8:13:8:23 | [false] ... is ... |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:14:18:9 | if (...) ... |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:12:18:12:31 | [false] ... is ... |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:12:18:12:31 | [true] ... is ... |
+| Patterns.cs:13:9:15:9 | {...} | Patterns.cs:12:18:12:31 | [true] ... is ... |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:13:9:15:9 | {...} |
+| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:12:18:12:31 | [false] ... is ... |
 | Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:14:18:9 | if (...) ... |
+| Patterns.cs:16:18:16:28 | [false] ... is ... | Patterns.cs:16:18:16:28 | [false] ... is ... |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:16:18:16:28 | [true] ... is ... |
+| Patterns.cs:17:9:18:9 | {...} | Patterns.cs:16:18:16:28 | [true] ... is ... |
 | Patterns.cs:17:9:18:9 | {...} | Patterns.cs:17:9:18:9 | {...} |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | enter M1 |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:8:13:8:23 | [false] ... is ... |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:8:13:8:23 | [true] ... is ... |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:9:9:11:9 | {...} |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:12:14:18:9 | if (...) ... |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:12:18:12:31 | [false] ... is ... |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:12:18:12:31 | [true] ... is ... |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:13:9:15:9 | {...} |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:16:14:18:9 | if (...) ... |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:16:18:16:28 | [false] ... is ... |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:16:18:16:28 | [true] ... is ... |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:17:9:18:9 | {...} |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:20:9:38:9 | switch (...) {...} |
 | Patterns.cs:23:17:23:22 | break; | Patterns.cs:23:17:23:22 | break; |
@@ -14844,10 +14950,16 @@ postBlockDominance
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:35:13:35:20 | default: |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | enter M1 |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:8:13:8:23 | [false] ... is ... |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:8:13:8:23 | [true] ... is ... |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:9:9:11:9 | {...} |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:12:14:18:9 | if (...) ... |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:12:18:12:31 | [false] ... is ... |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:12:18:12:31 | [true] ... is ... |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:13:9:15:9 | {...} |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:16:14:18:9 | if (...) ... |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:16:18:16:28 | [false] ... is ... |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:16:18:16:28 | [true] ... is ... |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:17:9:18:9 | {...} |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:20:9:38:9 | switch (...) {...} |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:23:17:23:22 | break; |
@@ -14864,41 +14976,76 @@ postBlockDominance
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
 | Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:47:24:47:25 | enter M2 |
 | Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:50:24:50:25 | enter M3 |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:9:51:21 | [false] ... is ... |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:14:51:21 | [no-match] not ... |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:9:51:21 | [true] ... is ... |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:14:51:21 | [match] not ... |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | enter M3 |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:9:51:21 | [false] ... is ... |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:9:51:21 | [true] ... is ... |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:9:51:39 | ... ? ... : ... |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:14:51:21 | [match] not ... |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:14:51:21 | [no-match] not ... |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:25:51:25 | access to parameter c |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:14:51:21 | [match] not ... |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:14:51:21 | [no-match] not ... |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:9:51:21 | [true] ... is ... |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:14:51:21 | [match] not ... |
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:9:51:21 | [false] ... is ... |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:14:51:21 | [no-match] not ... |
 | Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:34 | access to parameter c |
 | Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | enter M4 |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | enter M5 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | enter M5 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:16:62:9 | ... switch { ... } |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:60:13:60:17 | [match] not ... |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:60:13:60:17 | [no-match] not ... |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:60:22:60:28 | "not 1" |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:61:13:61:13 | _ |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:61:18:61:24 | "other" |
+| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:60:13:60:17 | [match] not ... |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:60:13:60:17 | [no-match] not ... |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:17 | [match] not ... |
 | Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:60:13:60:17 | [no-match] not ... |
 | Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:60:13:60:17 | [no-match] not ... |
 | Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:13 | _ |
 | Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:18:61:24 | "other" |
 | Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:65:26:65:27 | enter M6 |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:65:26:65:27 | enter M6 |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:69:13:69:17 | [no-match] not ... |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:65:26:65:27 | enter M6 |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:69:13:69:17 | [no-match] not ... |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:65:26:65:27 | enter M6 |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:69:13:69:17 | [no-match] not ... |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:13 | 2 |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:18:70:27 | "possible" |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | enter M2 |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 (normal) |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:12:13:12:21 | [false] ... is ... |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:12:13:12:21 | [true] ... is ... |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:13:13:13:19 | return ...; |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:14:9:14:29 | ...; |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:12:13:12:21 | [false] ... is ... |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:12:13:12:21 | [true] ... is ... |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:12:13:12:21 | [true] ... is ... |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:12:13:12:21 | [false] ... is ... |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:29 | ...; |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | enter M3 |
 | PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | exit M3 |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:17:10:17:11 | enter M3 |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:19:13:19:21 | [false] ... is ... |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:19:13:19:21 | [true] ... is ... |
 | PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:45:20:53 | nameof(...) |
 | PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:17:10:17:11 | enter M3 |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:19:13:19:21 | [false] ... is ... |
 | PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:9:21:29 | ...; |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | enter Method |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:23:8:34 | enter StaticMethod |
@@ -15140,8 +15287,13 @@ postBlockDominance
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:49 | ...; |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | enter M |
+| TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:7:13:7:22 | [false] ... is ... |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:7:13:7:22 | [true] ... is ... |
+| TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:13:7:22 | [true] ... is ... |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:25:7:25 | ; |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | enter M |
+| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:7:13:7:22 | [false] ... is ... |
+| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:7:13:7:22 | [true] ... is ... |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:7:25:7:25 | ; |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:9:8:28 | ... ...; |
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | enter M1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -3050,8 +3050,8 @@ dominance
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:9:17:24 | ... = ... |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:6:5:43:5 | {...} |
-| Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:5:10:5:13 | exit Test |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:6:5:43:5 | {...} |
+| Patterns.cs:5:10:5:11 | exit M1 (normal) | Patterns.cs:5:10:5:11 | exit M1 |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:7:9:7:24 | ... ...; |
 | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:20:7:23 | null |
 | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:8:9:18:9 | if (...) ... |
@@ -3120,7 +3120,57 @@ dominance
 | Patterns.cs:36:17:36:52 | ...; | Patterns.cs:36:35:36:50 | "Something else" |
 | Patterns.cs:36:35:36:50 | "Something else" | Patterns.cs:36:17:36:51 | call to method WriteLine |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o |
-| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | exit Test (normal) |
+| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:11 | exit M1 (normal) |
+| Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:48:9:48:9 | access to parameter c |
+| Patterns.cs:47:24:47:25 | exit M2 (normal) | Patterns.cs:47:24:47:25 | exit M2 |
+| Patterns.cs:48:9:48:9 | access to parameter c | Patterns.cs:48:18:48:20 | a |
+| Patterns.cs:48:9:48:20 | ... is ... | Patterns.cs:47:24:47:25 | exit M2 (normal) |
+| Patterns.cs:48:14:48:20 | not ... | Patterns.cs:48:9:48:20 | ... is ... |
+| Patterns.cs:48:18:48:20 | a | Patterns.cs:48:14:48:20 | not ... |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:9 | access to parameter c |
+| Patterns.cs:50:24:50:25 | exit M3 (normal) | Patterns.cs:50:24:50:25 | exit M3 |
+| Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:51:18:51:21 | null |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | exit M3 (normal) |
+| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:9:51:21 | ... is ... |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | not ... |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:30:51:30 | 1 |
+| Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:25:51:30 | ... is ... |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:39:51:39 | 2 |
+| Patterns.cs:51:39:51:39 | 2 | Patterns.cs:51:34:51:39 | ... is ... |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:9:54:9 | access to parameter c |
+| Patterns.cs:53:24:53:25 | exit M4 (normal) | Patterns.cs:53:24:53:25 | exit M4 |
+| Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:54:18:54:37 | Patterns u |
+| Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:53:24:53:25 | exit M4 (normal) |
+| Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:9:54:37 | ... is ... |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:33:54:33 | 1 |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:14:54:37 | not ... |
+| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:18:54:37 | { ... } |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | { ... } |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:57:5:63:5 | {...} |
+| Patterns.cs:56:26:56:27 | exit M5 (normal) | Patterns.cs:56:26:56:27 | exit M5 |
+| Patterns.cs:57:5:63:5 | {...} | Patterns.cs:58:16:58:16 | access to parameter i |
+| Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:56:26:56:27 | exit M5 (normal) |
+| Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:60:17:60:17 | 1 |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:9:62:10 | return ...; |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | not ... |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:28 | ... => ... |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:24 | ... => ... |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:66:5:72:5 | {...} |
+| Patterns.cs:65:26:65:27 | exit M6 (normal) | Patterns.cs:65:26:65:27 | exit M6 |
+| Patterns.cs:66:5:72:5 | {...} | Patterns.cs:67:16:67:16 | 2 |
+| Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:65:26:65:27 | exit M6 (normal) |
+| Patterns.cs:67:16:67:16 | 2 | Patterns.cs:69:17:69:17 | 2 |
+| Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:9:71:10 | return ...; |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | not ... |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" |
+| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:67:16:71:9 | ... switch { ... } |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:27 | ... => ... |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:6:5:8:5 | {...} |
 | PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | exit M1 |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:29 | ...; |
@@ -6992,9 +7042,9 @@ postDominance
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:13:17:19 | (...) ... |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:9:17:25 | ...; |
-| Patterns.cs:5:10:5:13 | exit Test | Patterns.cs:5:10:5:13 | exit Test (normal) |
-| Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:40:17:40:17 | access to local variable o |
-| Patterns.cs:6:5:43:5 | {...} | Patterns.cs:5:10:5:13 | enter Test |
+| Patterns.cs:5:10:5:11 | exit M1 | Patterns.cs:5:10:5:11 | exit M1 (normal) |
+| Patterns.cs:5:10:5:11 | exit M1 (normal) | Patterns.cs:40:17:40:17 | access to local variable o |
+| Patterns.cs:6:5:43:5 | {...} | Patterns.cs:5:10:5:11 | enter M1 |
 | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:6:5:43:5 | {...} |
 | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:7:20:7:23 | null |
 | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:9:7:24 | ... ...; |
@@ -7057,6 +7107,56 @@ postDominance
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:37:17:37:22 | break; |
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:40:9:42:9 | switch (...) {...} |
+| Patterns.cs:47:24:47:25 | exit M2 | Patterns.cs:47:24:47:25 | exit M2 (normal) |
+| Patterns.cs:47:24:47:25 | exit M2 (normal) | Patterns.cs:48:9:48:20 | ... is ... |
+| Patterns.cs:48:9:48:9 | access to parameter c | Patterns.cs:47:24:47:25 | enter M2 |
+| Patterns.cs:48:9:48:20 | ... is ... | Patterns.cs:48:14:48:20 | not ... |
+| Patterns.cs:48:14:48:20 | not ... | Patterns.cs:48:18:48:20 | a |
+| Patterns.cs:48:18:48:20 | a | Patterns.cs:48:9:48:9 | access to parameter c |
+| Patterns.cs:50:24:50:25 | exit M3 | Patterns.cs:50:24:50:25 | exit M3 (normal) |
+| Patterns.cs:50:24:50:25 | exit M3 (normal) | Patterns.cs:51:9:51:39 | ... ? ... : ... |
+| Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:50:24:50:25 | enter M3 |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:14:51:21 | not ... |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:25:51:30 | ... is ... |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:34:51:39 | ... is ... |
+| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:18:51:21 | null |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:9:51:9 | access to parameter c |
+| Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:51:30:51:30 | 1 |
+| Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:51:34:51:39 | ... is ... | Patterns.cs:51:39:51:39 | 2 |
+| Patterns.cs:51:39:51:39 | 2 | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:53:24:53:25 | exit M4 | Patterns.cs:53:24:53:25 | exit M4 (normal) |
+| Patterns.cs:53:24:53:25 | exit M4 (normal) | Patterns.cs:54:9:54:37 | ... is ... |
+| Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:53:24:53:25 | enter M4 |
+| Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:54:14:54:37 | not ... |
+| Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:18:54:37 | { ... } |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:9:54:9 | access to parameter c |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:27:54:35 | { ... } |
+| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:33:54:33 | 1 |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:18:54:37 | Patterns u |
+| Patterns.cs:56:26:56:27 | exit M5 | Patterns.cs:56:26:56:27 | exit M5 (normal) |
+| Patterns.cs:56:26:56:27 | exit M5 (normal) | Patterns.cs:58:9:62:10 | return ...; |
+| Patterns.cs:57:5:63:5 | {...} | Patterns.cs:56:26:56:27 | enter M5 |
+| Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:58:16:62:9 | ... switch { ... } |
+| Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:57:5:63:5 | {...} |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:60:13:60:28 | ... => ... |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:61:13:61:24 | ... => ... |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:17:60:17 | 1 |
+| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:58:16:58:16 | access to parameter i |
+| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:61:18:61:24 | "other" |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:65:26:65:27 | exit M6 | Patterns.cs:65:26:65:27 | exit M6 (normal) |
+| Patterns.cs:65:26:65:27 | exit M6 (normal) | Patterns.cs:67:9:71:10 | return ...; |
+| Patterns.cs:66:5:72:5 | {...} | Patterns.cs:65:26:65:27 | enter M6 |
+| Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:67:16:71:9 | ... switch { ... } |
+| Patterns.cs:67:16:67:16 | 2 | Patterns.cs:66:5:72:5 | {...} |
+| Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:70:13:70:27 | ... => ... |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:17:69:17 | 2 |
+| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:67:16:67:16 | 2 |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:69:13:69:17 | not ... |
+| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:18:70:27 | "possible" |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:13 | 2 |
 | PostDominance.cs:5:10:5:11 | exit M1 | PostDominance.cs:5:10:5:11 | exit M1 (normal) |
 | PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:7:9:7:28 | call to method WriteLine |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:5:10:5:11 | enter M1 |
@@ -11410,25 +11510,25 @@ blockDominance
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:5:10:5:13 | enter Test |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:9:9:11:9 | {...} |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:12:14:18:9 | if (...) ... |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:13:9:15:9 | {...} |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:16:14:18:9 | if (...) ... |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:17:9:18:9 | {...} |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:20:9:38:9 | switch (...) {...} |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:23:17:23:22 | break; |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:24:13:24:36 | case ...: |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:24:30:24:31 | access to local variable i2 |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:25:17:25:52 | ...; |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:27:13:27:24 | case ...: |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:28:17:28:47 | ...; |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:30:13:30:27 | case ...: |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:31:17:31:50 | ...; |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:33:13:33:24 | case ...: |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:34:17:34:22 | break; |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:35:13:35:20 | default: |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:40:9:42:9 | switch (...) {...} |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:5:10:5:11 | enter M1 |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:9:9:11:9 | {...} |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:12:14:18:9 | if (...) ... |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:13:9:15:9 | {...} |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:16:14:18:9 | if (...) ... |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:17:9:18:9 | {...} |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:20:9:38:9 | switch (...) {...} |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:23:17:23:22 | break; |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:24:13:24:36 | case ...: |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:24:30:24:31 | access to local variable i2 |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:25:17:25:52 | ...; |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:27:13:27:24 | case ...: |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:28:17:28:47 | ...; |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:30:13:30:27 | case ...: |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:31:17:31:50 | ...; |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:33:13:33:24 | case ...: |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:34:17:34:22 | break; |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:35:13:35:20 | default: |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:40:9:42:9 | switch (...) {...} |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:9:9:11:9 | {...} |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:14:18:9 | if (...) ... |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:13:9:15:9 | {...} |
@@ -11485,6 +11585,31 @@ blockDominance
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:35:13:35:20 | default: |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
+| Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:47:24:47:25 | enter M2 |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:50:24:50:25 | enter M3 |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:39 | ... ? ... : ... |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:9:51:39 | ... ? ... : ... |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | enter M4 |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | enter M5 |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:58:16:62:9 | ... switch { ... } |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:61:18:61:24 | "other" |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:16:62:9 | ... switch { ... } |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:18:61:24 | "other" |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:65:26:65:27 | enter M6 |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:70:18:70:27 | "possible" |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:18:70:27 | "possible" |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | exit M2 (normal) |
@@ -14694,13 +14819,13 @@ postBlockDominance
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:15:31:15:31 | 0 |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:5:10:5:13 | enter Test |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:5:10:5:11 | enter M1 |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:9:9:11:9 | {...} |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:14:18:9 | if (...) ... |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:13:9:15:9 | {...} |
 | Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:14:18:9 | if (...) ... |
 | Patterns.cs:17:9:18:9 | {...} | Patterns.cs:17:9:18:9 | {...} |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | enter Test |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | enter M1 |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:9:9:11:9 | {...} |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:12:14:18:9 | if (...) ... |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:13:9:15:9 | {...} |
@@ -14718,7 +14843,7 @@ postBlockDominance
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:13:33:24 | case ...: |
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:35:13:35:20 | default: |
-| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | enter Test |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | enter M1 |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:9:9:11:9 | {...} |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:12:14:18:9 | if (...) ... |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:13:9:15:9 | {...} |
@@ -14737,6 +14862,31 @@ postBlockDominance
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:35:13:35:20 | default: |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
+| Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:47:24:47:25 | enter M2 |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:50:24:50:25 | enter M3 |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | enter M3 |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:9:51:39 | ... ? ... : ... |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | enter M4 |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | enter M5 |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | enter M5 |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:16:62:9 | ... switch { ... } |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:61:18:61:24 | "other" |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:18:61:24 | "other" |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:65:26:65:27 | enter M6 |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:65:26:65:27 | enter M6 |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:65:26:65:27 | enter M6 |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:18:70:27 | "possible" |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | enter M2 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -3484,80 +3484,137 @@ nodeEnclosing
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:13:10:13:11 | M6 |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:13:10:13:11 | M6 |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:13:10:13:11 | M6 |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:5:10:5:13 | exit Test | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:6:5:43:5 | {...} | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:7:20:7:23 | null | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:9:9:11:9 | {...} | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:10:13:10:42 | call to method WriteLine | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:10:13:10:43 | ...; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:10:31:10:41 | $"..." | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:10:33:10:36 | "int " | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:10:38:10:39 | access to local variable i1 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:12:18:12:18 | access to local variable o | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:13:9:15:9 | {...} | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:14:13:14:45 | call to method WriteLine | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:14:13:14:46 | ...; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:14:31:14:44 | $"..." | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:14:33:14:39 | "string " | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:14:41:14:42 | access to local variable s1 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:16:18:16:18 | access to local variable o | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:17:9:18:9 | {...} | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:23:17:23:22 | break; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:24:30:24:31 | access to local variable i2 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:24:35:24:35 | 0 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:25:17:25:51 | call to method WriteLine | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:25:17:25:52 | ...; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:25:35:25:50 | $"..." | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:25:37:25:45 | "positive " | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:25:47:25:48 | access to local variable i2 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:26:17:26:22 | break; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:28:17:28:46 | call to method WriteLine | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:28:17:28:47 | ...; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:28:35:28:45 | $"..." | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:28:37:28:40 | "int " | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:28:42:28:43 | access to local variable i3 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:29:17:29:22 | break; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:31:17:31:49 | call to method WriteLine | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:31:17:31:50 | ...; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:31:35:31:48 | $"..." | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:31:37:31:43 | "string " | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:31:45:31:46 | access to local variable s2 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:32:17:32:22 | break; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:34:17:34:22 | break; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:35:13:35:20 | default: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:36:17:36:51 | call to method WriteLine | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:36:17:36:52 | ...; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:36:35:36:50 | "Something else" | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:37:17:37:22 | break; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | Test |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:5:10:5:11 | exit M1 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:5:10:5:11 | exit M1 (normal) | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:6:5:43:5 | {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:7:20:7:23 | null | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:9:9:11:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:10:13:10:42 | call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:10:13:10:43 | ...; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:10:31:10:41 | $"..." | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:10:33:10:36 | "int " | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:10:38:10:39 | access to local variable i1 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:12:18:12:18 | access to local variable o | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:13:9:15:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:14:13:14:45 | call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:14:13:14:46 | ...; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:14:31:14:44 | $"..." | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:14:33:14:39 | "string " | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:14:41:14:42 | access to local variable s1 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:16:18:16:18 | access to local variable o | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:17:9:18:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:23:17:23:22 | break; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:30:24:31 | access to local variable i2 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:35:24:35 | 0 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:25:17:25:51 | call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:25:17:25:52 | ...; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:25:35:25:50 | $"..." | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:25:37:25:45 | "positive " | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:25:47:25:48 | access to local variable i2 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:26:17:26:22 | break; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:28:17:28:46 | call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:28:17:28:47 | ...; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:28:35:28:45 | $"..." | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:28:37:28:40 | "int " | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:28:42:28:43 | access to local variable i3 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:29:17:29:22 | break; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:31:17:31:49 | call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:31:17:31:50 | ...; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:31:35:31:48 | $"..." | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:31:37:31:43 | "string " | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:31:45:31:46 | access to local variable s2 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:32:17:32:22 | break; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:34:17:34:22 | break; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:35:13:35:20 | default: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:36:17:36:51 | call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:36:17:36:52 | ...; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:36:35:36:50 | "Something else" | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:37:17:37:22 | break; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:47:24:47:25 | M2 |
+| Patterns.cs:47:24:47:25 | exit M2 | Patterns.cs:47:24:47:25 | M2 |
+| Patterns.cs:47:24:47:25 | exit M2 (normal) | Patterns.cs:47:24:47:25 | M2 |
+| Patterns.cs:48:9:48:9 | access to parameter c | Patterns.cs:47:24:47:25 | M2 |
+| Patterns.cs:48:9:48:20 | ... is ... | Patterns.cs:47:24:47:25 | M2 |
+| Patterns.cs:48:14:48:20 | not ... | Patterns.cs:47:24:47:25 | M2 |
+| Patterns.cs:48:18:48:20 | a | Patterns.cs:47:24:47:25 | M2 |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:50:24:50:25 | exit M3 | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:50:24:50:25 | exit M3 (normal) | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:30:51:30 | 1 | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:34:51:39 | ... is ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:39:51:39 | 2 | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:53:24:53:25 | exit M4 | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:53:24:53:25 | exit M4 (normal) | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:14:54:37 | not ... | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:56:26:56:27 | exit M5 | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:56:26:56:27 | exit M5 (normal) | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:57:5:63:5 | {...} | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:65:26:65:27 | exit M6 | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:65:26:65:27 | exit M6 (normal) | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:66:5:72:5 | {...} | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:67:16:67:16 | 2 | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:65:26:65:27 | M6 |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:5:10:5:11 | exit M1 | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | M1 |
@@ -5634,25 +5691,39 @@ blockEnclosing
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:13:10:13:11 | M6 |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:13:10:13:11 | M6 |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:13:10:13:11 | M6 |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:9:9:11:9 | {...} | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:13:9:15:9 | {...} | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:17:9:18:9 | {...} | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:23:17:23:22 | break; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:24:30:24:31 | access to local variable i2 | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:25:17:25:52 | ...; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:28:17:28:47 | ...; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:31:17:31:50 | ...; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:34:17:34:22 | break; | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:35:13:35:20 | default: | Patterns.cs:5:10:5:13 | Test |
-| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | Test |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:9:9:11:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:13:9:15:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:17:9:18:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:23:17:23:22 | break; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:30:24:31 | access to local variable i2 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:25:17:25:52 | ...; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:28:17:28:47 | ...; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:31:17:31:50 | ...; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:34:17:34:22 | break; | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:35:13:35:20 | default: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:47:24:47:25 | M2 |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:65:26:65:27 | M6 |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | M2 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -3621,6 +3621,27 @@ nodeEnclosing
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:74:26:74:27 | exit M7 | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:74:26:74:27 | exit M7 (normal) | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:75:5:83:5 | {...} | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:76:9:82:10 | return ...; | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:76:16:76:16 | access to parameter i | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:78:15:78:15 | 1 | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:74:26:74:27 | M7 |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:5:10:5:11 | exit M1 | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | M1 |
@@ -5746,6 +5767,15 @@ blockEnclosing
 | Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:74:26:74:27 | M7 |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | M2 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -3493,7 +3493,8 @@ nodeEnclosing
 | Patterns.cs:7:20:7:23 | null | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:10:13:10:42 | call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
@@ -3503,7 +3504,8 @@ nodeEnclosing
 | Patterns.cs:10:38:10:39 | access to local variable i1 | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:12:18:12:18 | access to local variable o | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:14:13:14:45 | call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
@@ -3513,7 +3515,8 @@ nodeEnclosing
 | Patterns.cs:14:41:14:42 | access to local variable s1 | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:16:18:16:18 | access to local variable o | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:16:18:16:28 | [false] ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:17:9:18:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | M1 |
@@ -3569,9 +3572,11 @@ nodeEnclosing
 | Patterns.cs:50:24:50:25 | exit M3 | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:50:24:50:25 | exit M3 (normal) | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
-| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | M3 |
-| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:51:18:51:21 | null | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:50:24:50:25 | M3 |
@@ -3596,7 +3601,8 @@ nodeEnclosing
 | Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | M5 |
-| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:60:17:60:17 | 1 | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:56:26:56:27 | M5 |
@@ -3610,7 +3616,7 @@ nodeEnclosing
 | Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:67:16:67:16 | 2 | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:65:26:65:27 | M6 |
-| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:69:17:69:17 | 2 | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:65:26:65:27 | M6 |
@@ -3628,7 +3634,8 @@ nodeEnclosing
 | PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:10:10:10:11 | M2 |
-| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:12:18:12:21 | null | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:10:10:10:11 | M2 |
@@ -3641,7 +3648,8 @@ nodeEnclosing
 | PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:17:10:17:11 | M3 |
-| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:19:18:19:21 | null | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:17:10:17:11 | M3 |
@@ -4004,7 +4012,8 @@ nodeEnclosing
 | TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:7:9:7:25 | if (...) ... | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:7:13:7:13 | access to parameter o | TypeAccesses.cs:3:10:3:10 | M |
-| TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:3:10:3:10 | M |
+| TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:3:10:3:10 | M |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | M |
@@ -5692,10 +5701,16 @@ blockEnclosing
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:13:10:13:11 | M6 |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:13:10:13:11 | M6 |
 | Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:16:18:16:28 | [false] ... is ... | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:17:9:18:9 | {...} | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:23:17:23:22 | break; | Patterns.cs:5:10:5:11 | M1 |
@@ -5712,25 +5727,36 @@ blockEnclosing
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:47:24:47:25 | M2 |
 | Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:50:24:50:25 | M3 |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | M4 |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:61:13:61:13 | _ | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:61:18:61:24 | "other" | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:65:26:65:27 | M6 |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:10:10:10:11 | M2 |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:10:10:10:11 | M2 |
 | PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:17:10:17:11 | exit M3 | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:17:10:17:11 | M3 |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:17:10:17:11 | M3 |
 | PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:17:10:17:11 | M3 |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | Method |
@@ -5847,6 +5873,8 @@ blockEnclosing
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:154:10:154:12 | M15 |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | M |
+| TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:3:10:3:10 | M |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | M |
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | M1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -2260,6 +2260,24 @@
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:13 | 2 |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:18:70:27 | "possible" |
+| Patterns.cs:75:5:83:5 | {...} | Patterns.cs:75:5:83:5 | {...} |
+| Patterns.cs:76:9:82:10 | return ...; | Patterns.cs:76:16:76:16 | access to parameter i |
+| Patterns.cs:76:16:76:16 | access to parameter i | Patterns.cs:76:16:76:16 | access to parameter i |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:76:16:76:16 | access to parameter i |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:15:78:15 | 1 |
+| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:78:15:78:15 | 1 |
+| Patterns.cs:78:15:78:15 | 1 | Patterns.cs:78:15:78:15 | 1 |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:20:78:24 | "> 1" |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:15:79:15 | 0 |
+| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:79:15:79:15 | 0 |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:15:79:15 | 0 |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:20:79:24 | "< 0" |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:13 | 1 |
+| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:80:13:80:13 | 1 |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:18:80:20 | "1" |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:18:81:20 | "0" |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:6:5:8:5 | {...} |
 | PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:7:27:7:27 | access to parameter s |
 | PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:9:7:29 | ...; |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -2216,6 +2216,50 @@
 | Patterns.cs:37:17:37:22 | break; | Patterns.cs:37:17:37:22 | break; |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:40:17:40:17 | access to local variable o |
+| Patterns.cs:48:9:48:9 | access to parameter c | Patterns.cs:48:9:48:9 | access to parameter c |
+| Patterns.cs:48:9:48:20 | ... is ... | Patterns.cs:48:9:48:9 | access to parameter c |
+| Patterns.cs:48:14:48:20 | not ... | Patterns.cs:48:18:48:20 | a |
+| Patterns.cs:48:18:48:20 | a | Patterns.cs:48:18:48:20 | a |
+| Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:51:9:51:9 | access to parameter c |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:9:51:9 | access to parameter c |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:9:51:9 | access to parameter c |
+| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:18:51:21 | null |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:18:51:21 | null |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:51:25:51:25 | access to parameter c |
+| Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:30:51:30 | 1 |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:51:34:51:39 | ... is ... | Patterns.cs:51:34:51:34 | access to parameter c |
+| Patterns.cs:51:39:51:39 | 2 | Patterns.cs:51:39:51:39 | 2 |
+| Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:54:9:54:9 | access to parameter c |
+| Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:54:9:54:9 | access to parameter c |
+| Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:18:54:37 | Patterns u |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:18:54:37 | Patterns u |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:18:54:37 | Patterns u |
+| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:33:54:33 | 1 |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:33:54:33 | 1 |
+| Patterns.cs:57:5:63:5 | {...} | Patterns.cs:57:5:63:5 | {...} |
+| Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:58:16:58:16 | access to parameter i |
+| Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:58:16:58:16 | access to parameter i |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:16:58:16 | access to parameter i |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:17:60:17 | 1 |
+| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:17:60:17 | 1 |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:17:60:17 | 1 |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:18:61:24 | "other" |
+| Patterns.cs:66:5:72:5 | {...} | Patterns.cs:66:5:72:5 | {...} |
+| Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:67:16:67:16 | 2 |
+| Patterns.cs:67:16:67:16 | 2 | Patterns.cs:67:16:67:16 | 2 |
+| Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:16:67:16 | 2 |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:17:69:17 | 2 |
+| Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:69:17:69:17 | 2 |
+| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:17:69:17 | 2 |
+| Patterns.cs:69:22:69:33 | "impossible" | Patterns.cs:69:22:69:33 | "impossible" |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:18:70:27 | "possible" |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:6:5:8:5 | {...} |
 | PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:7:27:7:27 | access to parameter s |
 | PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:9:7:29 | ...; |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -2959,6 +2959,27 @@
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 | match |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:27 | ... => ... | normal |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:18:70:27 | "possible" | normal |
+| Patterns.cs:75:5:83:5 | {...} | Patterns.cs:76:9:82:10 | return ...; | return |
+| Patterns.cs:76:9:82:10 | return ...; | Patterns.cs:76:9:82:10 | return ...; | return |
+| Patterns.cs:76:16:76:16 | access to parameter i | Patterns.cs:76:16:76:16 | access to parameter i | normal |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:76:16:82:9 | ... switch { ... } | normal |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:13:78:15 | > ... | match |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:13:78:15 | > ... | no-match |
+| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:78:13:78:24 | ... => ... | normal |
+| Patterns.cs:78:15:78:15 | 1 | Patterns.cs:78:15:78:15 | 1 | normal |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:20:78:24 | "> 1" | normal |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:13:79:15 | < ... | match |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:13:79:15 | < ... | no-match |
+| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:79:13:79:24 | ... => ... | normal |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:15:79:15 | 0 | normal |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:20:79:24 | "< 0" | normal |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:13 | 1 | match |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:13 | 1 | no-match |
+| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:80:13:80:20 | ... => ... | normal |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:18:80:20 | "1" | normal |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:13:81:13 | _ | match |
+| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:81:13:81:20 | ... => ... | normal |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:18:81:20 | "0" | normal |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:28 | call to method WriteLine | normal |
 | PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:7:9:7:28 | call to method WriteLine | normal |
 | PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:9:7:28 | call to method WriteLine | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -2906,6 +2906,52 @@
 | Patterns.cs:37:17:37:22 | break; | Patterns.cs:37:17:37:22 | break; | break |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o | normal |
 | Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:40:17:40:17 | access to local variable o | normal |
+| Patterns.cs:48:9:48:9 | access to parameter c | Patterns.cs:48:9:48:9 | access to parameter c | normal |
+| Patterns.cs:48:9:48:20 | ... is ... | Patterns.cs:48:9:48:20 | ... is ... | normal |
+| Patterns.cs:48:14:48:20 | not ... | Patterns.cs:48:14:48:20 | not ... | normal |
+| Patterns.cs:48:18:48:20 | a | Patterns.cs:48:18:48:20 | a | normal |
+| Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:51:9:51:9 | access to parameter c | normal |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:9:51:21 | ... is ... | false |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:9:51:21 | ... is ... | true |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:9:51:39 | ... ? ... : ... | normal |
+| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:14:51:21 | not ... | normal |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:18:51:21 | null | normal |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:25 | access to parameter c | normal |
+| Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:51:25:51:30 | ... is ... | normal |
+| Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:30:51:30 | 1 | normal |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:34 | access to parameter c | normal |
+| Patterns.cs:51:34:51:39 | ... is ... | Patterns.cs:51:34:51:39 | ... is ... | normal |
+| Patterns.cs:51:39:51:39 | 2 | Patterns.cs:51:39:51:39 | 2 | normal |
+| Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:54:9:54:9 | access to parameter c | normal |
+| Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:54:9:54:37 | ... is ... | normal |
+| Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:14:54:37 | not ... | normal |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:18:54:37 | Patterns u | normal |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:18:54:37 | { ... } | normal |
+| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:27:54:35 | { ... } | normal |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:33:54:33 | 1 | normal |
+| Patterns.cs:57:5:63:5 | {...} | Patterns.cs:58:9:62:10 | return ...; | return |
+| Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:58:9:62:10 | return ...; | return |
+| Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:58:16:58:16 | access to parameter i | normal |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:16:62:9 | ... switch { ... } | normal |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:13:60:17 | not ... | match |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:13:60:17 | not ... | no-match |
+| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:13:60:28 | ... => ... | normal |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:17:60:17 | 1 | normal |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:22:60:28 | "not 1" | normal |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | _ | match |
+| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:61:13:61:24 | ... => ... | normal |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:18:61:24 | "other" | normal |
+| Patterns.cs:66:5:72:5 | {...} | Patterns.cs:67:9:71:10 | return ...; | return |
+| Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:67:9:71:10 | return ...; | return |
+| Patterns.cs:67:16:67:16 | 2 | Patterns.cs:67:16:67:16 | 2 | normal |
+| Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:16:71:9 | ... switch { ... } | normal |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:13:69:17 | not ... | no-match |
+| Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:69:13:69:33 | ... => ... | normal |
+| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:17:69:17 | 2 | normal |
+| Patterns.cs:69:22:69:33 | "impossible" | Patterns.cs:69:22:69:33 | "impossible" | normal |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 | match |
+| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:27 | ... => ... | normal |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:18:70:27 | "possible" | normal |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:28 | call to method WriteLine | normal |
 | PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:7:9:7:28 | call to method WriteLine | normal |
 | PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:9:7:28 | call to method WriteLine | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -2820,7 +2820,8 @@
 | Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:8:13:8:13 | access to local variable o | normal |
 | Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:8:13:8:23 | ... is ... | false |
 | Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:8:13:8:23 | ... is ... | true |
-| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:18:8:23 | Int32 i1 | normal |
+| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:18:8:23 | Int32 i1 | match |
+| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:18:8:23 | Int32 i1 | no-match |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:10:13:10:42 | call to method WriteLine | normal |
 | Patterns.cs:10:13:10:42 | call to method WriteLine | Patterns.cs:10:13:10:42 | call to method WriteLine | normal |
 | Patterns.cs:10:13:10:43 | ...; | Patterns.cs:10:13:10:42 | call to method WriteLine | normal |
@@ -2833,7 +2834,8 @@
 | Patterns.cs:12:18:12:18 | access to local variable o | Patterns.cs:12:18:12:18 | access to local variable o | normal |
 | Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:12:18:12:31 | ... is ... | false |
 | Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:12:18:12:31 | ... is ... | true |
-| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:23:12:31 | String s1 | normal |
+| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:23:12:31 | String s1 | match |
+| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:23:12:31 | String s1 | no-match |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:14:13:14:45 | call to method WriteLine | normal |
 | Patterns.cs:14:13:14:45 | call to method WriteLine | Patterns.cs:14:13:14:45 | call to method WriteLine | normal |
 | Patterns.cs:14:13:14:46 | ...; | Patterns.cs:14:13:14:45 | call to method WriteLine | normal |
@@ -2845,7 +2847,8 @@
 | Patterns.cs:16:18:16:18 | access to local variable o | Patterns.cs:16:18:16:18 | access to local variable o | normal |
 | Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:16:18:16:28 | ... is ... | false |
 | Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:16:18:16:28 | ... is ... | true |
-| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:23:16:28 | Object v1 | normal |
+| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:23:16:28 | Object v1 | match |
+| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:23:16:28 | Object v1 | no-match |
 | Patterns.cs:17:9:18:9 | {...} | Patterns.cs:17:9:18:9 | {...} | normal |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:23:17:23:22 | break; | normal [break] (0) |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:26:17:26:22 | break; | normal [break] (0) |
@@ -2914,8 +2917,10 @@
 | Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:9:51:21 | ... is ... | false |
 | Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:9:51:21 | ... is ... | true |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:51:9:51:39 | ... ? ... : ... | normal |
-| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:14:51:21 | not ... | normal |
-| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:18:51:21 | null | normal |
+| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:14:51:21 | not ... | match |
+| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:14:51:21 | not ... | no-match |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:18:51:21 | null | match |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:18:51:21 | null | no-match |
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:25 | access to parameter c | normal |
 | Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:51:25:51:30 | ... is ... | normal |
 | Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:30:51:30 | 1 | normal |
@@ -2936,7 +2941,8 @@
 | Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:13:60:17 | not ... | match |
 | Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:13:60:17 | not ... | no-match |
 | Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:13:60:28 | ... => ... | normal |
-| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:17:60:17 | 1 | normal |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:17:60:17 | 1 | match |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:17:60:17 | 1 | no-match |
 | Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:22:60:28 | "not 1" | normal |
 | Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | _ | match |
 | Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:61:13:61:24 | ... => ... | normal |
@@ -2945,9 +2951,10 @@
 | Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:67:9:71:10 | return ...; | return |
 | Patterns.cs:67:16:67:16 | 2 | Patterns.cs:67:16:67:16 | 2 | normal |
 | Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:16:71:9 | ... switch { ... } | normal |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:13:69:17 | not ... | match |
 | Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:13:69:17 | not ... | no-match |
 | Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:69:13:69:33 | ... => ... | normal |
-| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:17:69:17 | 2 | normal |
+| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:17:69:17 | 2 | match |
 | Patterns.cs:69:22:69:33 | "impossible" | Patterns.cs:69:22:69:33 | "impossible" | normal |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | 2 | match |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:27 | ... => ... | normal |
@@ -2963,7 +2970,8 @@
 | PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:13:12:13 | access to parameter s | normal |
 | PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:12:13:12:21 | ... is ... | false |
 | PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:12:13:12:21 | ... is ... | true |
-| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:18:12:21 | null | normal |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:18:12:21 | null | match |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:18:12:21 | null | no-match |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:13:13:13:19 | return ...; | return |
 | PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:14:9:14:28 | call to method WriteLine | normal |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:9:14:28 | call to method WriteLine | normal |
@@ -2975,7 +2983,8 @@
 | PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:13:19:13 | access to parameter s | normal |
 | PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:19:13:19:21 | ... is ... | false |
 | PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:19:13:19:21 | ... is ... | true |
-| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:18:19:21 | null | normal |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:18:19:21 | null | match |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:18:19:21 | null | no-match |
 | PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:20:13:20:55 | throw ...; | throw(ArgumentNullException) |
 | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | normal |
 | PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:45:20:53 | nameof(...) | normal |
@@ -3412,7 +3421,8 @@
 | TypeAccesses.cs:7:13:7:13 | access to parameter o | TypeAccesses.cs:7:13:7:13 | access to parameter o | normal |
 | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:7:13:7:22 | ... is ... | false |
 | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:7:13:7:22 | ... is ... | true |
-| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:18:7:22 | Int32 j | normal |
+| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:18:7:22 | Int32 j | match |
+| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:18:7:22 | Int32 j | no-match |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:25:7:25 | ; | normal |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:13:8:27 | Type t = ... | normal |
 | TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:8:13:8:27 | Type t = ... | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExtractorOptions.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExtractorOptions.cs
@@ -1,1 +1,0 @@
-// semmle-extractor-options: /langversion:8.0

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -3518,9 +3518,10 @@
 | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:16:7:23 | Object o = ... | semmle.label | successor |
 | Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:8:13:8:13 | access to local variable o | semmle.label | successor |
 | Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:8:18:8:23 | Int32 i1 | semmle.label | successor |
-| Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:9:9:11:9 | {...} | semmle.label | true |
-| Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:12:14:18:9 | if (...) ... | semmle.label | false |
-| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:23 | ... is ... | semmle.label | successor |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:14:18:9 | if (...) ... | semmle.label | false |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:9:9:11:9 | {...} | semmle.label | true |
+| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:23 | [false] ... is ... | semmle.label | no-match |
+| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:23 | [true] ... is ... | semmle.label | match |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:10:13:10:43 | ...; | semmle.label | successor |
 | Patterns.cs:10:13:10:42 | call to method WriteLine | Patterns.cs:20:9:38:9 | switch (...) {...} | semmle.label | successor |
 | Patterns.cs:10:13:10:43 | ...; | Patterns.cs:10:33:10:36 | "int " | semmle.label | successor |
@@ -3529,9 +3530,10 @@
 | Patterns.cs:10:38:10:39 | access to local variable i1 | Patterns.cs:10:31:10:41 | $"..." | semmle.label | successor |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:18 | access to local variable o | semmle.label | successor |
 | Patterns.cs:12:18:12:18 | access to local variable o | Patterns.cs:12:23:12:31 | String s1 | semmle.label | successor |
-| Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:13:9:15:9 | {...} | semmle.label | true |
-| Patterns.cs:12:18:12:31 | ... is ... | Patterns.cs:16:14:18:9 | if (...) ... | semmle.label | false |
-| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:31 | ... is ... | semmle.label | successor |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:14:18:9 | if (...) ... | semmle.label | false |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:13:9:15:9 | {...} | semmle.label | true |
+| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:31 | [false] ... is ... | semmle.label | no-match |
+| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:31 | [true] ... is ... | semmle.label | match |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:14:13:14:46 | ...; | semmle.label | successor |
 | Patterns.cs:14:13:14:45 | call to method WriteLine | Patterns.cs:20:9:38:9 | switch (...) {...} | semmle.label | successor |
 | Patterns.cs:14:13:14:46 | ...; | Patterns.cs:14:33:14:39 | "string " | semmle.label | successor |
@@ -3540,9 +3542,10 @@
 | Patterns.cs:14:41:14:42 | access to local variable s1 | Patterns.cs:14:31:14:44 | $"..." | semmle.label | successor |
 | Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:18:16:18 | access to local variable o | semmle.label | successor |
 | Patterns.cs:16:18:16:18 | access to local variable o | Patterns.cs:16:23:16:28 | Object v1 | semmle.label | successor |
-| Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:17:9:18:9 | {...} | semmle.label | true |
-| Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:20:9:38:9 | switch (...) {...} | semmle.label | false |
-| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:28 | ... is ... | semmle.label | successor |
+| Patterns.cs:16:18:16:28 | [false] ... is ... | Patterns.cs:20:9:38:9 | switch (...) {...} | semmle.label | false |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:17:9:18:9 | {...} | semmle.label | true |
+| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:28 | [false] ... is ... | semmle.label | no-match |
+| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:28 | [true] ... is ... | semmle.label | match |
 | Patterns.cs:17:9:18:9 | {...} | Patterns.cs:20:9:38:9 | switch (...) {...} | semmle.label | successor |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:20:17:20:17 | access to local variable o | semmle.label | successor |
 | Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:22:13:22:23 | case ...: | semmle.label | successor |
@@ -3601,11 +3604,13 @@
 | Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:9 | access to parameter c | semmle.label | successor |
 | Patterns.cs:50:24:50:25 | exit M3 (normal) | Patterns.cs:50:24:50:25 | exit M3 | semmle.label | successor |
 | Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:51:18:51:21 | null | semmle.label | successor |
-| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:25:51:25 | access to parameter c | semmle.label | true |
-| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:34:51:34 | access to parameter c | semmle.label | false |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:34:51:34 | access to parameter c | semmle.label | false |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:25:51:25 | access to parameter c | semmle.label | true |
 | Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | exit M3 (normal) | semmle.label | successor |
-| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:9:51:21 | ... is ... | semmle.label | successor |
-| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | not ... | semmle.label | successor |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:9:51:21 | [true] ... is ... | semmle.label | match |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:9:51:21 | [false] ... is ... | semmle.label | no-match |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | [match] not ... | semmle.label | no-match |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | [no-match] not ... | semmle.label | match |
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:30:51:30 | 1 | semmle.label | successor |
 | Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:51:9:51:39 | ... ? ... : ... | semmle.label | successor |
 | Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:25:51:30 | ... is ... | semmle.label | successor |
@@ -3627,10 +3632,11 @@
 | Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:56:26:56:27 | exit M5 (normal) | semmle.label | return |
 | Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:60:17:60:17 | 1 | semmle.label | successor |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:9:62:10 | return ...; | semmle.label | successor |
-| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:22:60:28 | "not 1" | semmle.label | match |
-| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:61:13:61:13 | _ | semmle.label | no-match |
+| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:60:22:60:28 | "not 1" | semmle.label | match |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:61:13:61:13 | _ | semmle.label | no-match |
 | Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:58:16:62:9 | ... switch { ... } | semmle.label | successor |
-| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | not ... | semmle.label | successor |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | [match] not ... | semmle.label | no-match |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | [no-match] not ... | semmle.label | match |
 | Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:28 | ... => ... | semmle.label | successor |
 | Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" | semmle.label | match |
 | Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:58:16:62:9 | ... switch { ... } | semmle.label | successor |
@@ -3641,8 +3647,8 @@
 | Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:65:26:65:27 | exit M6 (normal) | semmle.label | return |
 | Patterns.cs:67:16:67:16 | 2 | Patterns.cs:69:17:69:17 | 2 | semmle.label | successor |
 | Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:9:71:10 | return ...; | semmle.label | successor |
-| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:70:13:70:13 | 2 | semmle.label | no-match |
-| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | not ... | semmle.label | successor |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:70:13:70:13 | 2 | semmle.label | no-match |
+| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | [no-match] not ... | semmle.label | match |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" | semmle.label | match |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:67:16:71:9 | ... switch { ... } | semmle.label | successor |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:27 | ... => ... | semmle.label | successor |
@@ -3657,9 +3663,10 @@
 | PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:12:9:13:19 | if (...) ... | semmle.label | successor |
 | PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:12:13:12:13 | access to parameter s | semmle.label | successor |
 | PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:18:12:21 | null | semmle.label | successor |
-| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:13:13:13:19 | return ...; | semmle.label | true |
-| PostDominance.cs:12:13:12:21 | ... is ... | PostDominance.cs:14:9:14:29 | ...; | semmle.label | false |
-| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | ... is ... | semmle.label | successor |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:14:9:14:29 | ...; | semmle.label | false |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:13:13:13:19 | return ...; | semmle.label | true |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | [false] ... is ... | semmle.label | no-match |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | [true] ... is ... | semmle.label | match |
 | PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
 | PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:10:10:10:11 | exit M2 (normal) | semmle.label | successor |
 | PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:27:14:27 | access to parameter s | semmle.label | successor |
@@ -3670,9 +3677,10 @@
 | PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:19:9:20:55 | if (...) ... | semmle.label | successor |
 | PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:19:13:19:13 | access to parameter s | semmle.label | successor |
 | PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:18:19:21 | null | semmle.label | successor |
-| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | semmle.label | true |
-| PostDominance.cs:19:13:19:21 | ... is ... | PostDominance.cs:21:9:21:29 | ...; | semmle.label | false |
-| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | ... is ... | semmle.label | successor |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:21:9:21:29 | ...; | semmle.label | false |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | semmle.label | true |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | [false] ... is ... | semmle.label | no-match |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | [true] ... is ... | semmle.label | match |
 | PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | semmle.label | exception(ArgumentNullException) |
 | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:13:20:55 | throw ...; | semmle.label | successor |
 | PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | semmle.label | successor |
@@ -4049,9 +4057,10 @@
 | TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:6:9:6:23 | ... = ... | semmle.label | successor |
 | TypeAccesses.cs:7:9:7:25 | if (...) ... | TypeAccesses.cs:7:13:7:13 | access to parameter o | semmle.label | successor |
 | TypeAccesses.cs:7:13:7:13 | access to parameter o | TypeAccesses.cs:7:18:7:22 | Int32 j | semmle.label | successor |
-| TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:7:25:7:25 | ; | semmle.label | true |
-| TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; | semmle.label | false |
-| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | ... is ... | semmle.label | successor |
+| TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; | semmle.label | false |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:7:25:7:25 | ; | semmle.label | true |
+| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | [false] ... is ... | semmle.label | no-match |
+| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | [true] ... is ... | semmle.label | match |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:8:9:8:28 | ... ...; | semmle.label | successor |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:17:8:27 | typeof(...) | semmle.label | successor |
 | TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:3:10:3:10 | exit M (normal) | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -3652,6 +3652,29 @@
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" | semmle.label | match |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:67:16:71:9 | ... switch { ... } | semmle.label | successor |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:27 | ... => ... | semmle.label | successor |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:75:5:83:5 | {...} | semmle.label | successor |
+| Patterns.cs:74:26:74:27 | exit M7 (normal) | Patterns.cs:74:26:74:27 | exit M7 | semmle.label | successor |
+| Patterns.cs:75:5:83:5 | {...} | Patterns.cs:76:16:76:16 | access to parameter i | semmle.label | successor |
+| Patterns.cs:76:9:82:10 | return ...; | Patterns.cs:74:26:74:27 | exit M7 (normal) | semmle.label | return |
+| Patterns.cs:76:16:76:16 | access to parameter i | Patterns.cs:78:15:78:15 | 1 | semmle.label | successor |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:76:9:82:10 | return ...; | semmle.label | successor |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:20:78:24 | "> 1" | semmle.label | match |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:79:15:79:15 | 0 | semmle.label | no-match |
+| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } | semmle.label | successor |
+| Patterns.cs:78:15:78:15 | 1 | Patterns.cs:78:13:78:15 | > ... | semmle.label | successor |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:13:78:24 | ... => ... | semmle.label | successor |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:20:79:24 | "< 0" | semmle.label | match |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:80:13:80:13 | 1 | semmle.label | no-match |
+| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } | semmle.label | successor |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:13:79:15 | < ... | semmle.label | successor |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:13:79:24 | ... => ... | semmle.label | successor |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:18:80:20 | "1" | semmle.label | match |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:81:13:81:13 | _ | semmle.label | no-match |
+| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } | semmle.label | successor |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:13:80:20 | ... => ... | semmle.label | successor |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:18:81:20 | "0" | semmle.label | match |
+| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } | semmle.label | successor |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:13:81:20 | ... => ... | semmle.label | successor |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:6:5:8:5 | {...} | semmle.label | successor |
 | PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | exit M1 | semmle.label | successor |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:29 | ...; | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -3510,8 +3510,8 @@
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... | semmle.label | non-null |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:9:17:24 | ... = ... | semmle.label | successor |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... | semmle.label | successor |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:6:5:43:5 | {...} | semmle.label | successor |
-| Patterns.cs:5:10:5:13 | exit Test (normal) | Patterns.cs:5:10:5:13 | exit Test | semmle.label | successor |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:6:5:43:5 | {...} | semmle.label | successor |
+| Patterns.cs:5:10:5:11 | exit M1 (normal) | Patterns.cs:5:10:5:11 | exit M1 | semmle.label | successor |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:7:9:7:24 | ... ...; | semmle.label | successor |
 | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:20:7:23 | null | semmle.label | successor |
 | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:8:9:18:9 | if (...) ... | semmle.label | successor |
@@ -3591,7 +3591,61 @@
 | Patterns.cs:36:35:36:50 | "Something else" | Patterns.cs:36:17:36:51 | call to method WriteLine | semmle.label | successor |
 | Patterns.cs:37:17:37:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | semmle.label | break |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o | semmle.label | successor |
-| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:13 | exit Test (normal) | semmle.label | successor |
+| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:11 | exit M1 (normal) | semmle.label | successor |
+| Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:48:9:48:9 | access to parameter c | semmle.label | successor |
+| Patterns.cs:47:24:47:25 | exit M2 (normal) | Patterns.cs:47:24:47:25 | exit M2 | semmle.label | successor |
+| Patterns.cs:48:9:48:9 | access to parameter c | Patterns.cs:48:18:48:20 | a | semmle.label | successor |
+| Patterns.cs:48:9:48:20 | ... is ... | Patterns.cs:47:24:47:25 | exit M2 (normal) | semmle.label | successor |
+| Patterns.cs:48:14:48:20 | not ... | Patterns.cs:48:9:48:20 | ... is ... | semmle.label | successor |
+| Patterns.cs:48:18:48:20 | a | Patterns.cs:48:14:48:20 | not ... | semmle.label | successor |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:9 | access to parameter c | semmle.label | successor |
+| Patterns.cs:50:24:50:25 | exit M3 (normal) | Patterns.cs:50:24:50:25 | exit M3 | semmle.label | successor |
+| Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:51:18:51:21 | null | semmle.label | successor |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:25:51:25 | access to parameter c | semmle.label | true |
+| Patterns.cs:51:9:51:21 | ... is ... | Patterns.cs:51:34:51:34 | access to parameter c | semmle.label | false |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | exit M3 (normal) | semmle.label | successor |
+| Patterns.cs:51:14:51:21 | not ... | Patterns.cs:51:9:51:21 | ... is ... | semmle.label | successor |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | not ... | semmle.label | successor |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:30:51:30 | 1 | semmle.label | successor |
+| Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:51:9:51:39 | ... ? ... : ... | semmle.label | successor |
+| Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:25:51:30 | ... is ... | semmle.label | successor |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:39:51:39 | 2 | semmle.label | successor |
+| Patterns.cs:51:34:51:39 | ... is ... | Patterns.cs:51:9:51:39 | ... ? ... : ... | semmle.label | successor |
+| Patterns.cs:51:39:51:39 | 2 | Patterns.cs:51:34:51:39 | ... is ... | semmle.label | successor |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:9:54:9 | access to parameter c | semmle.label | successor |
+| Patterns.cs:53:24:53:25 | exit M4 (normal) | Patterns.cs:53:24:53:25 | exit M4 | semmle.label | successor |
+| Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:54:18:54:37 | Patterns u | semmle.label | successor |
+| Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:53:24:53:25 | exit M4 (normal) | semmle.label | successor |
+| Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:9:54:37 | ... is ... | semmle.label | successor |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:33:54:33 | 1 | semmle.label | successor |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:14:54:37 | not ... | semmle.label | successor |
+| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:18:54:37 | { ... } | semmle.label | successor |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | { ... } | semmle.label | successor |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:57:5:63:5 | {...} | semmle.label | successor |
+| Patterns.cs:56:26:56:27 | exit M5 (normal) | Patterns.cs:56:26:56:27 | exit M5 | semmle.label | successor |
+| Patterns.cs:57:5:63:5 | {...} | Patterns.cs:58:16:58:16 | access to parameter i | semmle.label | successor |
+| Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:56:26:56:27 | exit M5 (normal) | semmle.label | return |
+| Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:60:17:60:17 | 1 | semmle.label | successor |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:9:62:10 | return ...; | semmle.label | successor |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:22:60:28 | "not 1" | semmle.label | match |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:61:13:61:13 | _ | semmle.label | no-match |
+| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:58:16:62:9 | ... switch { ... } | semmle.label | successor |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | not ... | semmle.label | successor |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:28 | ... => ... | semmle.label | successor |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" | semmle.label | match |
+| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:58:16:62:9 | ... switch { ... } | semmle.label | successor |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:24 | ... => ... | semmle.label | successor |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:66:5:72:5 | {...} | semmle.label | successor |
+| Patterns.cs:65:26:65:27 | exit M6 (normal) | Patterns.cs:65:26:65:27 | exit M6 | semmle.label | successor |
+| Patterns.cs:66:5:72:5 | {...} | Patterns.cs:67:16:67:16 | 2 | semmle.label | successor |
+| Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:65:26:65:27 | exit M6 (normal) | semmle.label | return |
+| Patterns.cs:67:16:67:16 | 2 | Patterns.cs:69:17:69:17 | 2 | semmle.label | successor |
+| Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:9:71:10 | return ...; | semmle.label | successor |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:70:13:70:13 | 2 | semmle.label | no-match |
+| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | not ... | semmle.label | successor |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" | semmle.label | match |
+| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:67:16:71:9 | ... switch { ... } | semmle.label | successor |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:27 | ... => ... | semmle.label | successor |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:6:5:8:5 | {...} | semmle.label | successor |
 | PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | exit M1 | semmle.label | successor |
 | PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:29 | ...; | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -1224,6 +1224,7 @@ entryPoint
 | Patterns.cs:53:24:53:25 | M4 | Patterns.cs:54:9:54:9 | access to parameter c |
 | Patterns.cs:56:26:56:27 | M5 | Patterns.cs:57:5:63:5 | {...} |
 | Patterns.cs:65:26:65:27 | M6 | Patterns.cs:66:5:72:5 | {...} |
+| Patterns.cs:74:26:74:27 | M7 | Patterns.cs:75:5:83:5 | {...} |
 | PostDominance.cs:5:10:5:11 | M1 | PostDominance.cs:6:5:8:5 | {...} |
 | PostDominance.cs:10:10:10:11 | M2 | PostDominance.cs:11:5:15:5 | {...} |
 | PostDominance.cs:17:10:17:11 | M3 | PostDominance.cs:18:5:22:5 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -1218,7 +1218,12 @@ entryPoint
 | NullCoalescing.cs:9:12:9:13 | M4 | NullCoalescing.cs:9:37:9:37 | access to parameter b |
 | NullCoalescing.cs:11:9:11:10 | M5 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 |
 | NullCoalescing.cs:13:10:13:11 | M6 | NullCoalescing.cs:14:5:18:5 | {...} |
-| Patterns.cs:5:10:5:13 | Test | Patterns.cs:6:5:43:5 | {...} |
+| Patterns.cs:5:10:5:11 | M1 | Patterns.cs:6:5:43:5 | {...} |
+| Patterns.cs:47:24:47:25 | M2 | Patterns.cs:48:9:48:9 | access to parameter c |
+| Patterns.cs:50:24:50:25 | M3 | Patterns.cs:51:9:51:9 | access to parameter c |
+| Patterns.cs:53:24:53:25 | M4 | Patterns.cs:54:9:54:9 | access to parameter c |
+| Patterns.cs:56:26:56:27 | M5 | Patterns.cs:57:5:63:5 | {...} |
+| Patterns.cs:65:26:65:27 | M6 | Patterns.cs:66:5:72:5 | {...} |
 | PostDominance.cs:5:10:5:11 | M1 | PostDominance.cs:6:5:8:5 | {...} |
 | PostDominance.cs:10:10:10:11 | M2 | PostDominance.cs:11:5:15:5 | {...} |
 | PostDominance.cs:17:10:17:11 | M3 | PostDominance.cs:18:5:22:5 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/Patterns.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/Patterns.cs
@@ -2,7 +2,7 @@ using System;
 
 class Patterns
 {
-    void Test()
+    void M1()
     {
         object o = null;
         if (o is int i1)
@@ -40,5 +40,34 @@ class Patterns
         switch (o)
         {
         }
+    }
+
+    public int P1 { get; set; }
+
+    public static bool M2(char c) =>
+        c is not 'a';
+
+    public static bool M3(object c) =>
+        c is not null ? c is 1 : c is 2;
+
+    public static bool M4(object c) =>
+        c is not Patterns { P1: 1 } u;
+
+    public static string M5(int i)
+    {
+        return i switch
+        {
+            not 1 => "not 1",
+            _ => "other"
+        };
+    }
+
+    public static string M6()
+    {
+        return 2 switch
+        {
+            not 2 => "impossible",
+            2 => "possible"
+        };
     }
 }

--- a/csharp/ql/test/library-tests/controlflow/graph/Patterns.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/Patterns.cs
@@ -70,4 +70,15 @@ class Patterns
             2 => "possible"
         };
     }
+
+    public static string M7(int i)
+    {
+        return i switch
+        {
+            > 1 => "> 1",
+            < 0 => "< 0",
+            1 => "1",
+            _ => "0"
+        };
+    }
 }

--- a/csharp/ql/test/library-tests/controlflow/guards/AbstractValue.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/AbstractValue.expected
@@ -370,6 +370,7 @@ abstractValue
 | non-null | Guards.cs:341:31:341:32 | "" |
 | non-null | Guards.cs:343:13:343:19 | access to type Console |
 | non-null | Guards.cs:343:31:343:31 | access to local variable s |
+| non-null | Guards.cs:349:13:349:13 | access to parameter o |
 | non-null | Splitting.cs:13:17:13:17 | access to parameter o |
 | non-null | Splitting.cs:23:24:23:24 | access to parameter o |
 | non-null | Splitting.cs:33:24:33:25 | "" |

--- a/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
@@ -103,6 +103,7 @@
 | Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:21 | ... != ... | Guards.cs:342:13:342:13 | access to local variable s | true |
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:27 | ... && ... | Guards.cs:342:13:342:13 | access to local variable s | true |
+| Guards.cs:349:13:349:13 | access to parameter o | Guards.cs:348:13:348:25 | ... is ... | Guards.cs:348:13:348:13 | access to parameter o | true |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
 | Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | true |
 | Splitting.cs:25:13:25:13 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | false |

--- a/csharp/ql/test/library-tests/controlflow/guards/ExtractorOptions.cs
+++ b/csharp/ql/test/library-tests/controlflow/guards/ExtractorOptions.cs
@@ -1,2 +1,2 @@
-// semmle-extractor-options: --cil /langversion:8.0
+// semmle-extractor-options: --cil
 #nullable enable

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedControlFlowNode.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedControlFlowNode.expected
@@ -242,6 +242,8 @@
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | non-null |
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:21 | ... != ... | Guards.cs:342:13:342:13 | access to local variable s | true |
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:27 | ... && ... | Guards.cs:342:13:342:13 | access to local variable s | true |
+| Guards.cs:349:13:349:13 | access to parameter o | Guards.cs:348:13:348:13 | access to parameter o | Guards.cs:348:13:348:13 | access to parameter o | non-null |
+| Guards.cs:349:13:349:13 | access to parameter o | Guards.cs:348:13:348:25 | ... is ... | Guards.cs:348:13:348:13 | access to parameter o | true |
 | Splitting.cs:13:17:13:17 | [b (line 9): true] access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
 | Splitting.cs:13:17:13:17 | [b (line 9): true] access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
 | Splitting.cs:14:13:14:13 | [b (line 9): false] access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | false |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
@@ -223,6 +223,8 @@
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | non-null |
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:21 | ... != ... | Guards.cs:342:13:342:13 | access to local variable s | true |
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:27 | ... && ... | Guards.cs:342:13:342:13 | access to local variable s | true |
+| Guards.cs:349:13:349:13 | access to parameter o | Guards.cs:348:13:348:13 | access to parameter o | Guards.cs:348:13:348:13 | access to parameter o | non-null |
+| Guards.cs:349:13:349:13 | access to parameter o | Guards.cs:348:13:348:25 | ... is ... | Guards.cs:348:13:348:13 | access to parameter o | true |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
 | Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | non-null |

--- a/csharp/ql/test/library-tests/controlflow/guards/Guards.cs
+++ b/csharp/ql/test/library-tests/controlflow/guards/Guards.cs
@@ -342,5 +342,11 @@ public class Guards
         if (s != null && !b)
             Console.WriteLine(s.Length); // null guarded
     }
+
+    void M29(object? o)
+    {
+        if (o is not null)
+            o.ToString(); // null guarded
+    }
 }
 

--- a/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
@@ -442,6 +442,7 @@
 | Guards.cs:342:26:342:27 | !... | true | Guards.cs:342:27:342:27 | access to parameter b | false |
 | Guards.cs:343:31:343:31 | access to local variable s | non-null | Guards.cs:341:20:341:32 | ... ? ... : ... | non-null |
 | Guards.cs:343:31:343:31 | access to local variable s | null | Guards.cs:341:20:341:32 | ... ? ... : ... | null |
+| Guards.cs:348:13:348:25 | ... is ... | true | Guards.cs:348:13:348:13 | access to parameter o | non-null |
 | Splitting.cs:12:17:12:25 | ... != ... | false | Splitting.cs:12:17:12:17 | access to parameter o | null |
 | Splitting.cs:12:17:12:25 | ... != ... | true | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
 | Splitting.cs:22:17:22:25 | ... != ... | false | Splitting.cs:22:17:22:17 | access to parameter o | null |

--- a/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
@@ -46,6 +46,7 @@
 | Guards.cs:283:17:283:17 | access to parameter o |
 | Guards.cs:287:17:287:17 | access to parameter o |
 | Guards.cs:343:31:343:31 | access to local variable s |
+| Guards.cs:349:13:349:13 | access to parameter o |
 | Splitting.cs:13:17:13:17 | access to parameter o |
 | Splitting.cs:23:24:23:24 | access to parameter o |
 | Splitting.cs:35:13:35:13 | access to parameter o |

--- a/csharp/ql/test/library-tests/csharp7/IsFlow.expected
+++ b/csharp/ql/test/library-tests/csharp7/IsFlow.expected
@@ -16,9 +16,10 @@
 | CSharp7.cs:256:18:256:20 | "x" | CSharp7.cs:256:27:256:27 | access to local variable o | semmle.label | match |
 | CSharp7.cs:256:18:256:20 | "x" | CSharp7.cs:259:13:259:36 | case ...: | semmle.label | no-match |
 | CSharp7.cs:256:27:256:27 | access to local variable o | CSharp7.cs:256:32:256:40 | String s4 | semmle.label | successor |
-| CSharp7.cs:256:27:256:40 | ... is ... | CSharp7.cs:257:17:257:45 | ...; | semmle.label | true |
-| CSharp7.cs:256:27:256:40 | ... is ... | CSharp7.cs:259:13:259:36 | case ...: | semmle.label | false |
-| CSharp7.cs:256:32:256:40 | String s4 | CSharp7.cs:256:27:256:40 | ... is ... | semmle.label | successor |
+| CSharp7.cs:256:27:256:40 | [false] ... is ... | CSharp7.cs:259:13:259:36 | case ...: | semmle.label | false |
+| CSharp7.cs:256:27:256:40 | [true] ... is ... | CSharp7.cs:257:17:257:45 | ...; | semmle.label | true |
+| CSharp7.cs:256:32:256:40 | String s4 | CSharp7.cs:256:27:256:40 | [false] ... is ... | semmle.label | no-match |
+| CSharp7.cs:256:32:256:40 | String s4 | CSharp7.cs:256:27:256:40 | [true] ... is ... | semmle.label | match |
 | CSharp7.cs:257:17:257:44 | call to method WriteLine | CSharp7.cs:258:17:258:22 | break; | semmle.label | successor |
 | CSharp7.cs:257:17:257:45 | ...; | CSharp7.cs:257:37:257:38 | "x " | semmle.label | successor |
 | CSharp7.cs:257:35:257:43 | $"..." | CSharp7.cs:257:17:257:44 | call to method WriteLine | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
+++ b/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
@@ -193,8 +193,9 @@
 | CSharp7.cs:235:13:235:13 | access to local variable o | CSharp7.cs:235:18:235:23 | SSA def(i1) |
 | CSharp7.cs:235:13:235:13 | access to local variable o | CSharp7.cs:239:18:239:18 | access to local variable o |
 | CSharp7.cs:235:13:235:13 | access to local variable o | CSharp7.cs:250:17:250:17 | access to local variable o |
-| CSharp7.cs:235:13:235:23 | ... is ... | CSharp7.cs:235:13:235:33 | [false] ... && ... |
-| CSharp7.cs:235:13:235:23 | ... is ... | CSharp7.cs:235:13:235:33 | [true] ... && ... |
+| CSharp7.cs:235:13:235:23 | [false] ... is ... | CSharp7.cs:235:13:235:33 | [false] ... && ... |
+| CSharp7.cs:235:13:235:23 | [true] ... is ... | CSharp7.cs:235:13:235:33 | [false] ... && ... |
+| CSharp7.cs:235:13:235:23 | [true] ... is ... | CSharp7.cs:235:13:235:33 | [true] ... && ... |
 | CSharp7.cs:235:18:235:23 | SSA def(i1) | CSharp7.cs:235:28:235:29 | access to local variable i1 |
 | CSharp7.cs:235:28:235:29 | access to local variable i1 | CSharp7.cs:235:28:235:33 | ... > ... |
 | CSharp7.cs:235:28:235:29 | access to local variable i1 | CSharp7.cs:237:38:237:39 | access to local variable i1 |
@@ -251,7 +252,7 @@
 | CSharp7.cs:299:25:299:30 | ... < ... | CSharp7.cs:299:25:299:44 | [true] ... && ... |
 | CSharp7.cs:299:35:299:35 | access to local variable x | CSharp7.cs:299:40:299:44 | SSA def(y) |
 | CSharp7.cs:299:35:299:35 | access to local variable x | CSharp7.cs:299:49:299:49 | access to local variable x |
-| CSharp7.cs:299:35:299:44 | ... is ... | CSharp7.cs:299:25:299:44 | [false] ... && ... |
-| CSharp7.cs:299:35:299:44 | ... is ... | CSharp7.cs:299:25:299:44 | [true] ... && ... |
+| CSharp7.cs:299:35:299:44 | [false] ... is ... | CSharp7.cs:299:25:299:44 | [false] ... && ... |
+| CSharp7.cs:299:35:299:44 | [true] ... is ... | CSharp7.cs:299:25:299:44 | [true] ... && ... |
 | CSharp7.cs:299:40:299:44 | SSA def(y) | CSharp7.cs:301:31:301:31 | access to local variable y |
 | CSharp7.cs:299:47:299:49 | SSA def(x) | CSharp7.cs:299:25:299:25 | SSA phi(x) |

--- a/csharp/ql/test/library-tests/csharp8/ispatternflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/ispatternflow.expected
@@ -10,20 +10,22 @@
 | patterns.cs:7:39:7:39 | 2 | patterns.cs:7:35:7:39 | ... = ... | semmle.label | successor |
 | patterns.cs:9:9:11:9 | if (...) ... | patterns.cs:9:13:9:13 | access to local variable o | semmle.label | successor |
 | patterns.cs:9:13:9:13 | access to local variable o | patterns.cs:9:18:9:29 | MyStruct ms1 | semmle.label | successor |
-| patterns.cs:9:13:9:29 | ... is ... | patterns.cs:10:9:11:9 | {...} | semmle.label | true |
-| patterns.cs:9:13:9:29 | ... is ... | patterns.cs:13:9:15:9 | if (...) ... | semmle.label | false |
-| patterns.cs:9:18:9:29 | MyStruct ms1 | patterns.cs:9:13:9:29 | ... is ... | semmle.label | successor |
+| patterns.cs:9:13:9:29 | [false] ... is ... | patterns.cs:13:9:15:9 | if (...) ... | semmle.label | false |
+| patterns.cs:9:13:9:29 | [true] ... is ... | patterns.cs:10:9:11:9 | {...} | semmle.label | true |
+| patterns.cs:9:18:9:29 | MyStruct ms1 | patterns.cs:9:13:9:29 | [false] ... is ... | semmle.label | no-match |
+| patterns.cs:9:18:9:29 | MyStruct ms1 | patterns.cs:9:13:9:29 | [true] ... is ... | semmle.label | match |
 | patterns.cs:10:9:11:9 | {...} | patterns.cs:13:9:15:9 | if (...) ... | semmle.label | successor |
 | patterns.cs:13:9:15:9 | if (...) ... | patterns.cs:13:13:13:13 | access to local variable o | semmle.label | successor |
 | patterns.cs:13:13:13:13 | access to local variable o | patterns.cs:13:18:13:40 | MyStruct s | semmle.label | successor |
-| patterns.cs:13:13:13:40 | ... is ... | patterns.cs:13:13:13:47 | [false] ... && ... | semmle.label | false |
-| patterns.cs:13:13:13:40 | ... is ... | patterns.cs:13:45:13:45 | access to local variable x | semmle.label | true |
+| patterns.cs:13:13:13:40 | [false] ... is ... | patterns.cs:13:13:13:47 | [false] ... && ... | semmle.label | false |
+| patterns.cs:13:13:13:40 | [true] ... is ... | patterns.cs:13:45:13:45 | access to local variable x | semmle.label | true |
 | patterns.cs:13:13:13:47 | [false] ... && ... | patterns.cs:13:13:13:56 | [false] ... && ... | semmle.label | false |
 | patterns.cs:13:13:13:47 | [true] ... && ... | patterns.cs:13:52:13:52 | access to local variable s | semmle.label | true |
 | patterns.cs:13:13:13:56 | [false] ... && ... | patterns.cs:17:9:19:9 | if (...) ... | semmle.label | false |
 | patterns.cs:13:13:13:56 | [true] ... && ... | patterns.cs:14:9:15:9 | {...} | semmle.label | true |
 | patterns.cs:13:18:13:40 | MyStruct s | patterns.cs:13:32:13:36 | Int32 x | semmle.label | successor |
-| patterns.cs:13:18:13:40 | { ... } | patterns.cs:13:13:13:40 | ... is ... | semmle.label | successor |
+| patterns.cs:13:18:13:40 | { ... } | patterns.cs:13:13:13:40 | [false] ... is ... | semmle.label | no-match |
+| patterns.cs:13:18:13:40 | { ... } | patterns.cs:13:13:13:40 | [true] ... is ... | semmle.label | match |
 | patterns.cs:13:27:13:38 | { ... } | patterns.cs:13:18:13:40 | { ... } | semmle.label | successor |
 | patterns.cs:13:32:13:36 | Int32 x | patterns.cs:13:27:13:38 | { ... } | semmle.label | successor |
 | patterns.cs:13:45:13:45 | access to local variable x | patterns.cs:13:47:13:47 | 4 | semmle.label | successor |
@@ -38,17 +40,19 @@
 | patterns.cs:14:9:15:9 | {...} | patterns.cs:17:9:19:9 | if (...) ... | semmle.label | successor |
 | patterns.cs:17:9:19:9 | if (...) ... | patterns.cs:17:13:17:13 | access to local variable o | semmle.label | successor |
 | patterns.cs:17:13:17:13 | access to local variable o | patterns.cs:17:18:17:21 | Object p | semmle.label | successor |
-| patterns.cs:17:13:17:21 | ... is ... | patterns.cs:18:9:19:9 | {...} | semmle.label | true |
-| patterns.cs:17:13:17:21 | ... is ... | patterns.cs:22:9:24:9 | if (...) ... | semmle.label | false |
+| patterns.cs:17:13:17:21 | [false] ... is ... | patterns.cs:22:9:24:9 | if (...) ... | semmle.label | false |
+| patterns.cs:17:13:17:21 | [true] ... is ... | patterns.cs:18:9:19:9 | {...} | semmle.label | true |
 | patterns.cs:17:18:17:19 | { ... } | patterns.cs:17:18:17:21 | { ... } | semmle.label | successor |
 | patterns.cs:17:18:17:21 | Object p | patterns.cs:17:18:17:19 | { ... } | semmle.label | successor |
-| patterns.cs:17:18:17:21 | { ... } | patterns.cs:17:13:17:21 | ... is ... | semmle.label | successor |
+| patterns.cs:17:18:17:21 | { ... } | patterns.cs:17:13:17:21 | [false] ... is ... | semmle.label | no-match |
+| patterns.cs:17:18:17:21 | { ... } | patterns.cs:17:13:17:21 | [true] ... is ... | semmle.label | match |
 | patterns.cs:18:9:19:9 | {...} | patterns.cs:22:9:24:9 | if (...) ... | semmle.label | successor |
 | patterns.cs:22:9:24:9 | if (...) ... | patterns.cs:22:13:22:13 | access to local variable o | semmle.label | successor |
 | patterns.cs:22:13:22:13 | access to local variable o | patterns.cs:22:31:22:32 | 12 | semmle.label | successor |
-| patterns.cs:22:13:22:53 | ... is ... | patterns.cs:23:9:24:9 | {...} | semmle.label | true |
-| patterns.cs:22:13:22:53 | ... is ... | patterns.cs:27:9:29:9 | if (...) ... | semmle.label | false |
-| patterns.cs:22:18:22:53 | { ... } | patterns.cs:22:13:22:53 | ... is ... | semmle.label | successor |
+| patterns.cs:22:13:22:53 | [false] ... is ... | patterns.cs:27:9:29:9 | if (...) ... | semmle.label | false |
+| patterns.cs:22:13:22:53 | [true] ... is ... | patterns.cs:23:9:24:9 | {...} | semmle.label | true |
+| patterns.cs:22:18:22:53 | { ... } | patterns.cs:22:13:22:53 | [false] ... is ... | semmle.label | no-match |
+| patterns.cs:22:18:22:53 | { ... } | patterns.cs:22:13:22:53 | [true] ... is ... | semmle.label | match |
 | patterns.cs:22:27:22:53 | { ... } | patterns.cs:22:18:22:53 | { ... } | semmle.label | successor |
 | patterns.cs:22:31:22:32 | 12 | patterns.cs:22:42:22:49 | Int32 subX | semmle.label | successor |
 | patterns.cs:22:38:22:51 | { ... } | patterns.cs:22:27:22:53 | { ... } | semmle.label | successor |
@@ -57,9 +61,10 @@
 | patterns.cs:23:9:24:9 | {...} | patterns.cs:27:9:29:9 | if (...) ... | semmle.label | successor |
 | patterns.cs:27:9:29:9 | if (...) ... | patterns.cs:27:13:27:13 | access to local variable o | semmle.label | successor |
 | patterns.cs:27:13:27:13 | access to local variable o | patterns.cs:27:31:27:32 | 12 | semmle.label | successor |
-| patterns.cs:27:13:27:58 | ... is ... | patterns.cs:5:10:5:19 | exit IsPatterns (normal) | semmle.label | false |
-| patterns.cs:27:13:27:58 | ... is ... | patterns.cs:28:9:29:9 | {...} | semmle.label | true |
-| patterns.cs:27:18:27:58 | { ... } | patterns.cs:27:13:27:58 | ... is ... | semmle.label | successor |
+| patterns.cs:27:13:27:58 | [false] ... is ... | patterns.cs:5:10:5:19 | exit IsPatterns (normal) | semmle.label | false |
+| patterns.cs:27:13:27:58 | [true] ... is ... | patterns.cs:28:9:29:9 | {...} | semmle.label | true |
+| patterns.cs:27:18:27:58 | { ... } | patterns.cs:27:13:27:58 | [false] ... is ... | semmle.label | no-match |
+| patterns.cs:27:18:27:58 | { ... } | patterns.cs:27:13:27:58 | [true] ... is ... | semmle.label | match |
 | patterns.cs:27:27:27:58 | { ... } | patterns.cs:27:18:27:58 | { ... } | semmle.label | successor |
 | patterns.cs:27:31:27:32 | 12 | patterns.cs:27:38:27:56 | MyStruct ms | semmle.label | successor |
 | patterns.cs:27:38:27:56 | MyStruct ms | patterns.cs:27:51:27:51 | _ | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/switchexprcontrolflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/switchexprcontrolflow.expected
@@ -146,9 +146,10 @@
 | patterns.cs:140:17:140:24 | Object y | patterns.cs:141:17:141:22 | access to type String | semmle.label | no-match |
 | patterns.cs:140:17:140:42 | ... => ... | patterns.cs:136:17:143:13 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:140:31:140:31 | access to local variable y | patterns.cs:140:36:140:37 | { ... } | semmle.label | successor |
-| patterns.cs:140:31:140:37 | ... is ... | patterns.cs:140:42:140:42 | 4 | semmle.label | true |
-| patterns.cs:140:31:140:37 | ... is ... | patterns.cs:141:17:141:22 | access to type String | semmle.label | false |
-| patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:31:140:37 | ... is ... | semmle.label | successor |
+| patterns.cs:140:31:140:37 | [false] ... is ... | patterns.cs:141:17:141:22 | access to type String | semmle.label | false |
+| patterns.cs:140:31:140:37 | [true] ... is ... | patterns.cs:140:42:140:42 | 4 | semmle.label | true |
+| patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:31:140:37 | [false] ... is ... | semmle.label | no-match |
+| patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:31:140:37 | [true] ... is ... | semmle.label | match |
 | patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:36:140:37 | { ... } | semmle.label | successor |
 | patterns.cs:140:42:140:42 | 4 | patterns.cs:140:17:140:42 | ... => ... | semmle.label | successor |
 | patterns.cs:141:17:141:22 | access to type String | patterns.cs:141:29:141:29 | 5 | semmle.label | match |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -191,6 +191,7 @@ nodes
 | D.cs:253:13:253:14 | access to local variable o2 |
 | D.cs:258:16:258:23 | SSA def(o) |
 | D.cs:266:9:267:25 | if (...) ... |
+| D.cs:266:13:266:27 | [true] ... is ... |
 | D.cs:267:13:267:13 | access to local variable o |
 | D.cs:269:9:269:16 | SSA def(o) |
 | D.cs:272:25:272:25 | access to local variable i |
@@ -345,6 +346,7 @@ nodes
 | E.cs:201:13:201:13 | access to local variable o |
 | E.cs:203:13:203:13 | access to local variable o |
 | E.cs:206:28:206:28 | SSA param(s) |
+| E.cs:208:13:208:23 | [false] ... is ... |
 | E.cs:210:16:210:16 | access to parameter s |
 | E.cs:217:13:217:20 | [b (line 213): true] SSA def(x) |
 | E.cs:218:9:218:9 | access to local variable x |
@@ -364,6 +366,7 @@ nodes
 | E.cs:301:13:301:27 | SSA def(s) |
 | E.cs:302:9:302:9 | access to local variable s |
 | E.cs:319:29:319:30 | SSA param(s1) |
+| E.cs:321:13:321:30 | [true] ... is ... |
 | E.cs:321:14:321:21 | ... ?? ... |
 | E.cs:321:20:321:21 | access to parameter s2 |
 | E.cs:323:13:323:14 | access to parameter s1 |
@@ -597,7 +600,8 @@ edges
 | D.cs:244:9:247:25 | if (...) ... | D.cs:247:13:247:13 | access to local variable o |
 | D.cs:249:13:249:38 | SSA def(o2) | D.cs:253:13:253:14 | access to local variable o2 |
 | D.cs:258:16:258:23 | SSA def(o) | D.cs:266:9:267:25 | if (...) ... |
-| D.cs:266:9:267:25 | if (...) ... | D.cs:267:13:267:13 | access to local variable o |
+| D.cs:266:9:267:25 | if (...) ... | D.cs:266:13:266:27 | [true] ... is ... |
+| D.cs:266:13:266:27 | [true] ... is ... | D.cs:267:13:267:13 | access to local variable o |
 | D.cs:269:9:269:16 | SSA def(o) | D.cs:272:25:272:25 | access to local variable i |
 | D.cs:272:25:272:25 | access to local variable i | D.cs:273:9:288:9 | {...} |
 | D.cs:272:25:272:25 | access to local variable i | D.cs:290:9:291:25 | if (...) ... |
@@ -744,7 +748,8 @@ edges
 | E.cs:190:29:190:29 | SSA param(o) | E.cs:192:17:192:17 | access to parameter o |
 | E.cs:198:13:198:29 | [b (line 196): false] SSA def(o) | E.cs:203:13:203:13 | access to local variable o |
 | E.cs:198:13:198:29 | [b (line 196): true] SSA def(o) | E.cs:201:13:201:13 | access to local variable o |
-| E.cs:206:28:206:28 | SSA param(s) | E.cs:210:16:210:16 | access to parameter s |
+| E.cs:206:28:206:28 | SSA param(s) | E.cs:208:13:208:23 | [false] ... is ... |
+| E.cs:208:13:208:23 | [false] ... is ... | E.cs:210:16:210:16 | access to parameter s |
 | E.cs:217:13:217:20 | [b (line 213): true] SSA def(x) | E.cs:218:9:218:9 | access to local variable x |
 | E.cs:217:13:217:20 | [b (line 213): true] SSA def(x) | E.cs:220:13:220:13 | access to local variable x |
 | E.cs:227:13:227:20 | [b (line 223): true] SSA def(x) | E.cs:229:13:229:13 | access to local variable x |
@@ -756,7 +761,8 @@ edges
 | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s |
 | E.cs:319:29:319:30 | SSA param(s1) | E.cs:321:20:321:21 | access to parameter s2 |
-| E.cs:321:14:321:21 | ... ?? ... | E.cs:323:13:323:14 | access to parameter s1 |
+| E.cs:321:13:321:30 | [true] ... is ... | E.cs:323:13:323:14 | access to parameter s1 |
+| E.cs:321:14:321:21 | ... ?? ... | E.cs:321:13:321:30 | [true] ... is ... |
 | E.cs:321:20:321:21 | access to parameter s2 | E.cs:321:14:321:21 | ... ?? ... |
 | E.cs:330:13:330:36 | SSA def(x) | E.cs:331:9:331:9 | access to local variable x |
 | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x |


### PR DESCRIPTION
This PR changes the CFG for pattern expressions (including `not` expressions). Example:

```csharp
public static bool M3(object c) =>
    c is not null ? c is 1 : c is 2;
```

<details>
  <summary>CFG before:</summary>
  
  <img width="433" alt="before" src="https://user-images.githubusercontent.com/3667920/104914487-81ee3700-598f-11eb-82ef-058f083d63a0.png">
</details>

<details>
  <summary>CFG after:</summary>
  
  <img width="398" alt="after" src="https://user-images.githubusercontent.com/3667920/104914527-929ead00-598f-11eb-8056-2d1f573416c2.png">
</details>

~https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/782/~
~https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/799/~
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/804/