### PR TITLE
C++/C#/JS/Python/Java XML.qll: Remove abstract from class hierarchy.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/XML.qll
+++ b/cpp/ql/src/semmle/code/cpp/XML.qll
@@ -4,8 +4,10 @@
 
 import semmle.files.FileSystem
 
+private class TXMLLocatable = @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
+
 /** An XML element that has a location. */
-abstract class XMLLocatable extends @xmllocatable {
+class XMLLocatable extends @xmllocatable, TXMLLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
@@ -33,7 +35,7 @@ abstract class XMLLocatable extends @xmllocatable {
   }
 
   /** Gets a textual representation of this element. */
-  abstract string toString();
+  string toString() { none() } // overridden in subclasses
 }
 
 /**
@@ -51,7 +53,7 @@ class XMLParent extends @xmlparent {
    * Gets a printable representation of this XML parent.
    * (Intended to be overridden in subclasses.)
    */
-  abstract string getName();
+  string getName() { none() } // overridden in subclasses
 
   /** Gets the file to which this XML parent belongs. */
   XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }

--- a/cpp/ql/src/semmle/code/cpp/XML.qll
+++ b/cpp/ql/src/semmle/code/cpp/XML.qll
@@ -4,7 +4,8 @@
 
 import semmle.files.FileSystem
 
-private class TXMLLocatable = @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
+private class TXMLLocatable =
+  @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
 
 /** An XML element that has a location. */
 class XMLLocatable extends @xmllocatable, TXMLLocatable {

--- a/csharp/ql/src/semmle/code/csharp/XML.qll
+++ b/csharp/ql/src/semmle/code/csharp/XML.qll
@@ -4,8 +4,10 @@
 
 import semmle.files.FileSystem
 
+private class TXMLLocatable = @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
+
 /** An XML element that has a location. */
-abstract class XMLLocatable extends @xmllocatable {
+class XMLLocatable extends @xmllocatable, TXMLLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
@@ -33,7 +35,7 @@ abstract class XMLLocatable extends @xmllocatable {
   }
 
   /** Gets a textual representation of this element. */
-  abstract string toString();
+  string toString() { none() } // overridden in subclasses
 }
 
 /**
@@ -51,7 +53,7 @@ class XMLParent extends @xmlparent {
    * Gets a printable representation of this XML parent.
    * (Intended to be overridden in subclasses.)
    */
-  abstract string getName();
+  string getName() { none() } // overridden in subclasses
 
   /** Gets the file to which this XML parent belongs. */
   XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }

--- a/csharp/ql/src/semmle/code/csharp/XML.qll
+++ b/csharp/ql/src/semmle/code/csharp/XML.qll
@@ -4,7 +4,8 @@
 
 import semmle.files.FileSystem
 
-private class TXMLLocatable = @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
+private class TXMLLocatable =
+  @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
 
 /** An XML element that has a location. */
 class XMLLocatable extends @xmllocatable, TXMLLocatable {

--- a/java/ql/src/semmle/code/xml/XML.qll
+++ b/java/ql/src/semmle/code/xml/XML.qll
@@ -4,8 +4,10 @@
 
 import semmle.files.FileSystem
 
+private class TXMLLocatable = @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
+
 /** An XML element that has a location. */
-abstract class XMLLocatable extends @xmllocatable {
+class XMLLocatable extends @xmllocatable, TXMLLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
@@ -33,7 +35,7 @@ abstract class XMLLocatable extends @xmllocatable {
   }
 
   /** Gets a textual representation of this element. */
-  abstract string toString();
+  string toString() { none() } // overridden in subclasses
 }
 
 /**
@@ -51,7 +53,7 @@ class XMLParent extends @xmlparent {
    * Gets a printable representation of this XML parent.
    * (Intended to be overridden in subclasses.)
    */
-  abstract string getName();
+  string getName() { none() } // overridden in subclasses
 
   /** Gets the file to which this XML parent belongs. */
   XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }

--- a/java/ql/src/semmle/code/xml/XML.qll
+++ b/java/ql/src/semmle/code/xml/XML.qll
@@ -4,7 +4,8 @@
 
 import semmle.files.FileSystem
 
-private class TXMLLocatable = @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
+private class TXMLLocatable =
+  @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
 
 /** An XML element that has a location. */
 class XMLLocatable extends @xmllocatable, TXMLLocatable {

--- a/javascript/ql/src/semmle/javascript/XML.qll
+++ b/javascript/ql/src/semmle/javascript/XML.qll
@@ -4,8 +4,10 @@
 
 import semmle.files.FileSystem
 
+private class TXMLLocatable = @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
+
 /** An XML element that has a location. */
-abstract class XMLLocatable extends @xmllocatable {
+class XMLLocatable extends @xmllocatable, TXMLLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
@@ -33,7 +35,7 @@ abstract class XMLLocatable extends @xmllocatable {
   }
 
   /** Gets a textual representation of this element. */
-  abstract string toString();
+  string toString() { none() } // overridden in subclasses
 }
 
 /**
@@ -51,7 +53,7 @@ class XMLParent extends @xmlparent {
    * Gets a printable representation of this XML parent.
    * (Intended to be overridden in subclasses.)
    */
-  abstract string getName();
+  string getName() { none() } // overridden in subclasses
 
   /** Gets the file to which this XML parent belongs. */
   XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }

--- a/javascript/ql/src/semmle/javascript/XML.qll
+++ b/javascript/ql/src/semmle/javascript/XML.qll
@@ -4,7 +4,8 @@
 
 import semmle.files.FileSystem
 
-private class TXMLLocatable = @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
+private class TXMLLocatable =
+  @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
 
 /** An XML element that has a location. */
 class XMLLocatable extends @xmllocatable, TXMLLocatable {

--- a/python/ql/src/semmle/python/xml/XML.qll
+++ b/python/ql/src/semmle/python/xml/XML.qll
@@ -4,8 +4,10 @@
 
 import semmle.files.FileSystem
 
+private class TXMLLocatable = @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
+
 /** An XML element that has a location. */
-abstract class XMLLocatable extends @xmllocatable {
+class XMLLocatable extends @xmllocatable, TXMLLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
@@ -33,7 +35,7 @@ abstract class XMLLocatable extends @xmllocatable {
   }
 
   /** Gets a textual representation of this element. */
-  abstract string toString();
+  string toString() { none() } // overridden in subclasses
 }
 
 /**
@@ -51,7 +53,7 @@ class XMLParent extends @xmlparent {
    * Gets a printable representation of this XML parent.
    * (Intended to be overridden in subclasses.)
    */
-  abstract string getName();
+  string getName() { none() } // overridden in subclasses
 
   /** Gets the file to which this XML parent belongs. */
   XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }

--- a/python/ql/src/semmle/python/xml/XML.qll
+++ b/python/ql/src/semmle/python/xml/XML.qll
@@ -4,7 +4,8 @@
 
 import semmle.files.FileSystem
 
-private class TXMLLocatable = @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
+private class TXMLLocatable =
+  @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
 
 /** An XML element that has a location. */
 class XMLLocatable extends @xmllocatable, TXMLLocatable {


### PR DESCRIPTION
Addresses a part of https://github.com/github/codeql-c-analysis-team/issues/60