### PR TITLE
C++: Use model interfaces in DefaultSafeExternalAPIFunction

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-020/SafeExternalAPIFunction.qll
+++ b/cpp/ql/src/Security/CWE/CWE-020/SafeExternalAPIFunction.qll
@@ -13,9 +13,7 @@ abstract class SafeExternalAPIFunction extends Function { }
 /** The default set of "safe" external APIs. */
 private class DefaultSafeExternalAPIFunction extends SafeExternalAPIFunction {
   DefaultSafeExternalAPIFunction() {
-    // implementation note: this should be based on the properties of public interfaces, rather than accessing implementation classes directly.  When we've done that, the three classes referenced here should be made fully private.
-    this instanceof PureStrFunction or
-    this instanceof StrLenFunction or
-    this instanceof PureMemFunction
+    this instanceof ArrayFunction and
+    not this.(ArrayFunction).hasArrayOutput(_)
   }
 }

--- a/cpp/ql/src/Security/CWE/CWE-020/SafeExternalAPIFunction.qll
+++ b/cpp/ql/src/Security/CWE/CWE-020/SafeExternalAPIFunction.qll
@@ -3,7 +3,7 @@
  */
 
 private import cpp
-private import semmle.code.cpp.models.implementations.Pure
+private import semmle.code.cpp.models.interfaces.SideEffect
 
 /**
  * A `Function` that is considered a "safe" external API from a security perspective.
@@ -13,7 +13,12 @@ abstract class SafeExternalAPIFunction extends Function { }
 /** The default set of "safe" external APIs. */
 private class DefaultSafeExternalAPIFunction extends SafeExternalAPIFunction {
   DefaultSafeExternalAPIFunction() {
-    this instanceof ArrayFunction and
-    not this.(ArrayFunction).hasArrayOutput(_)
+    // If a function does not write to any of its arguments, we consider it safe to
+    // pass untrusted data to it. This means that string functions such as `strcmp`
+    // and `strlen`, as well as memory functions such as `memcmp`, are considered safe.
+    exists(SideEffectFunction model | model = this |
+      model.hasOnlySpecificWriteSideEffects() and
+      not model.hasSpecificWriteSideEffect(_, _, _)
+    )
   }
 }

--- a/cpp/ql/src/Security/CWE/CWE-020/ir/SafeExternalAPIFunction.qll
+++ b/cpp/ql/src/Security/CWE/CWE-020/ir/SafeExternalAPIFunction.qll
@@ -13,9 +13,7 @@ abstract class SafeExternalAPIFunction extends Function { }
 /** The default set of "safe" external APIs. */
 private class DefaultSafeExternalAPIFunction extends SafeExternalAPIFunction {
   DefaultSafeExternalAPIFunction() {
-    // implementation note: this should be based on the properties of public interfaces, rather than accessing implementation classes directly.  When we've done that, the three classes referenced here should be made fully private.
-    this instanceof PureStrFunction or
-    this instanceof StrLenFunction or
-    this instanceof PureMemFunction
+    this instanceof ArrayFunction and
+    not this.(ArrayFunction).hasArrayOutput(_)
   }
 }

--- a/cpp/ql/src/Security/CWE/CWE-020/ir/SafeExternalAPIFunction.qll
+++ b/cpp/ql/src/Security/CWE/CWE-020/ir/SafeExternalAPIFunction.qll
@@ -3,7 +3,7 @@
  */
 
 private import cpp
-private import semmle.code.cpp.models.implementations.Pure
+private import semmle.code.cpp.models.interfaces.SideEffect
 
 /**
  * A `Function` that is considered a "safe" external API from a security perspective.
@@ -13,7 +13,12 @@ abstract class SafeExternalAPIFunction extends Function { }
 /** The default set of "safe" external APIs. */
 private class DefaultSafeExternalAPIFunction extends SafeExternalAPIFunction {
   DefaultSafeExternalAPIFunction() {
-    this instanceof ArrayFunction and
-    not this.(ArrayFunction).hasArrayOutput(_)
+    // If a function does not write to any of its arguments, we consider it safe to
+    // pass untrusted data to it. This means that string functions such as `strcmp`
+    // and `strlen`, as well as memory functions such as `memcmp`, are considered safe.
+    exists(SideEffectFunction model | model = this |
+      model.hasOnlySpecificWriteSideEffects() and
+      not model.hasSpecificWriteSideEffect(_, _, _)
+    )
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Pure.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Pure.qll
@@ -8,7 +8,8 @@ import semmle.code.cpp.models.interfaces.SideEffect
  *
  * INTERNAL: do not use.
  */
-class PureStrFunction extends AliasFunction, ArrayFunction, TaintFunction, SideEffectFunction {
+private class PureStrFunction extends AliasFunction, ArrayFunction, TaintFunction,
+  SideEffectFunction {
   PureStrFunction() {
     hasGlobalOrStdName([
         "atof", "atoi", "atol", "atoll", "strcasestr", "strchnul", "strchr", "strchrnul", "strstr",
@@ -68,7 +69,7 @@ class PureStrFunction extends AliasFunction, ArrayFunction, TaintFunction, SideE
  *
  * INTERNAL: do not use.
  */
-class StrLenFunction extends AliasFunction, ArrayFunction, SideEffectFunction {
+private class StrLenFunction extends AliasFunction, ArrayFunction, SideEffectFunction {
   StrLenFunction() {
     hasGlobalOrStdName(["strlen", "strnlen", "wcslen"])
     or
@@ -123,7 +124,8 @@ private class PureFunction extends TaintFunction, SideEffectFunction {
  *
  * INTERNAL: do not use.
  */
-class PureMemFunction extends AliasFunction, ArrayFunction, TaintFunction, SideEffectFunction {
+private class PureMemFunction extends AliasFunction, ArrayFunction, TaintFunction,
+  SideEffectFunction {
   PureMemFunction() { hasGlobalOrStdName(["memchr", "memrchr", "rawmemchr", "memcmp", "memmem"]) }
 
   override predicate hasArrayInput(int bufParam) {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Pure.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Pure.qll
@@ -3,11 +3,7 @@ import semmle.code.cpp.models.interfaces.Taint
 import semmle.code.cpp.models.interfaces.Alias
 import semmle.code.cpp.models.interfaces.SideEffect
 
-/**
- * Pure string functions.
- *
- * INTERNAL: do not use.
- */
+/** Pure string functions. */
 private class PureStrFunction extends AliasFunction, ArrayFunction, TaintFunction,
   SideEffectFunction {
   PureStrFunction() {
@@ -64,11 +60,7 @@ private class PureStrFunction extends AliasFunction, ArrayFunction, TaintFunctio
   }
 }
 
-/**
- * String standard `strlen` function, and related functions for computing string lengths.
- *
- * INTERNAL: do not use.
- */
+/** String standard `strlen` function, and related functions for computing string lengths. */
 private class StrLenFunction extends AliasFunction, ArrayFunction, SideEffectFunction {
   StrLenFunction() {
     hasGlobalOrStdName(["strlen", "strnlen", "wcslen"])
@@ -119,11 +111,7 @@ private class PureFunction extends TaintFunction, SideEffectFunction {
   override predicate hasOnlySpecificWriteSideEffects() { any() }
 }
 
-/**
- * Pure raw-memory functions.
- *
- * INTERNAL: do not use.
- */
+/** Pure raw-memory functions. */
 private class PureMemFunction extends AliasFunction, ArrayFunction, TaintFunction,
   SideEffectFunction {
   PureMemFunction() { hasGlobalOrStdName(["memchr", "memrchr", "rawmemchr", "memcmp", "memmem"]) }


### PR DESCRIPTION
Fixes https://github.com/github/codeql-c-analysis-team/issues/189.

It turns out that the set of functions which are `ArrayFunction`s with no output parameters is a strict superset of functions satisfying either `PureStrFunction`, `StrLenFunction` or `PureMemFunction`. And when you factor out the functions that satisfy either `TaintFunction` or `DataFlowFunction` (like we do in `ExternalAPIDataNode`), I think these two sets are equivalent.