### PR TITLE
C++: Fix join order in definitionHasPhiNode

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -404,15 +404,26 @@ private import PhiInsertion
  */
 private module PhiInsertion {
   /**
+   * Holds if `phiBlock` is a block in the dominance frontier of a block that has a definition of the
+   * memory location `defLocation`.
+   */
+  pragma[noinline]
+  private predicate dominanceFrontierOfDefinition(
+    Alias::MemoryLocation defLocation, OldBlock phiBlock
+  ) {
+    exists(OldBlock defBlock |
+      phiBlock = Dominance::getDominanceFrontier(defBlock) and
+      definitionHasDefinitionInBlock(defLocation, defBlock)
+    )
+  }
+
+  /**
    * Holds if a `Phi` instruction needs to be inserted for location `defLocation` at the beginning of block `phiBlock`.
    */
   predicate definitionHasPhiNode(Alias::MemoryLocation defLocation, OldBlock phiBlock) {
-    exists(OldBlock defBlock |
-      phiBlock = Dominance::getDominanceFrontier(defBlock) and
-      definitionHasDefinitionInBlock(defLocation, defBlock) and
-      /* We can also eliminate those nodes where the definition is not live on any incoming edge */
-      definitionLiveOnEntryToBlock(defLocation, phiBlock)
-    )
+    dominanceFrontierOfDefinition(defLocation, phiBlock) and
+    /* We can also eliminate those nodes where the definition is not live on any incoming edge */
+    definitionLiveOnEntryToBlock(defLocation, phiBlock)
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -404,15 +404,26 @@ private import PhiInsertion
  */
 private module PhiInsertion {
   /**
+   * Holds if `phiBlock` is a block in the dominance frontier of a block that has a definition of the
+   * memory location `defLocation`.
+   */
+  pragma[noinline]
+  private predicate dominanceFrontierOfDefinition(
+    Alias::MemoryLocation defLocation, OldBlock phiBlock
+  ) {
+    exists(OldBlock defBlock |
+      phiBlock = Dominance::getDominanceFrontier(defBlock) and
+      definitionHasDefinitionInBlock(defLocation, defBlock)
+    )
+  }
+
+  /**
    * Holds if a `Phi` instruction needs to be inserted for location `defLocation` at the beginning of block `phiBlock`.
    */
   predicate definitionHasPhiNode(Alias::MemoryLocation defLocation, OldBlock phiBlock) {
-    exists(OldBlock defBlock |
-      phiBlock = Dominance::getDominanceFrontier(defBlock) and
-      definitionHasDefinitionInBlock(defLocation, defBlock) and
-      /* We can also eliminate those nodes where the definition is not live on any incoming edge */
-      definitionLiveOnEntryToBlock(defLocation, phiBlock)
-    )
+    dominanceFrontierOfDefinition(defLocation, phiBlock) and
+    /* We can also eliminate those nodes where the definition is not live on any incoming edge */
+    definitionLiveOnEntryToBlock(defLocation, phiBlock)
   }
 
   /**

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -404,15 +404,26 @@ private import PhiInsertion
  */
 private module PhiInsertion {
   /**
+   * Holds if `phiBlock` is a block in the dominance frontier of a block that has a definition of the
+   * memory location `defLocation`.
+   */
+  pragma[noinline]
+  private predicate dominanceFrontierOfDefinition(
+    Alias::MemoryLocation defLocation, OldBlock phiBlock
+  ) {
+    exists(OldBlock defBlock |
+      phiBlock = Dominance::getDominanceFrontier(defBlock) and
+      definitionHasDefinitionInBlock(defLocation, defBlock)
+    )
+  }
+
+  /**
    * Holds if a `Phi` instruction needs to be inserted for location `defLocation` at the beginning of block `phiBlock`.
    */
   predicate definitionHasPhiNode(Alias::MemoryLocation defLocation, OldBlock phiBlock) {
-    exists(OldBlock defBlock |
-      phiBlock = Dominance::getDominanceFrontier(defBlock) and
-      definitionHasDefinitionInBlock(defLocation, defBlock) and
-      /* We can also eliminate those nodes where the definition is not live on any incoming edge */
-      definitionLiveOnEntryToBlock(defLocation, phiBlock)
-    )
+    dominanceFrontierOfDefinition(defLocation, phiBlock) and
+    /* We can also eliminate those nodes where the definition is not live on any incoming edge */
+    definitionLiveOnEntryToBlock(defLocation, phiBlock)
   }
 
   /**


### PR DESCRIPTION
When trying to make sense of https://github.com/github/codeql-c-analysis-team/issues/190 yesterday, I noticed a bad join order (which sadly didn't fix that issue, but nonetheless seems worth fixing) on `kamailio/kamailio`.

Before:
```
[2020-11-26 09:49:25] (682s) Starting to evaluate predicate SSAConstruction::PhiInsertion::definitionHasPhiNode#2#ff/2@i6#72c4bw (iteration 6)
[2020-11-26 09:49:27] (683s) Tuple counts for SSAConstruction::PhiInsertion::definitionHasPhiNode#2#ff/2@i6#72c4bw:
    23942751 ~1%      {3} r1 = JOIN SSAConstruction::PhiInsertion::definitionHasDefinitionInBlock#2#ff#prev_delta AS L WITH SSAConstruction::PhiInsertion::definitionLiveOnEntryToBlock#2#ff AS R ON FIRST 1 OUTPUT L.<1>, R.<1>, L.<0>
    11753    ~24%     {2} r2 = JOIN r1 WITH Dominance::getDominanceFrontier#2#ff AS R ON FIRST 2 OUTPUT r1.<2>, r1.<1>
    3224     ~36%     {2} r3 = r2 AND NOT SSAConstruction::PhiInsertion::definitionHasPhiNode#2#ff#prev AS R(r2.<0>, r2.<1>)
    return r3
```
After:
```
[2020-11-26 09:22:05] (652s) Starting to evaluate predicate SSAConstruction::PhiInsertion::definitionHasPhiNode#2#ff/2@i6#64968w (iteration 6)
[2020-11-26 09:22:05] (652s) Tuple counts for SSAConstruction::PhiInsertion::dominanceFrontierOfDefinition#2#ff/2@i5#64968x:
    320824  ~0%      {2} r1 = SCAN SSAConstruction::PhiInsertion::definitionHasDefinitionInBlock#2#ff#prev_delta AS I OUTPUT I.<1>, I.<0>
    314862  ~17%     {2} r2 = JOIN r1 WITH Dominance::getDominanceFrontier#2#ff AS R ON FIRST 1 OUTPUT r1.<1>, R.<1>
    242301  ~7%      {2} r3 = r2 AND NOT SSAConstruction::PhiInsertion::dominanceFrontierOfDefinition#2#ff#prev AS R(r2.<0>, r2.<1>)
    return r3
...
[2020-11-26 09:22:05] (652s) Tuple counts for SSAConstruction::PhiInsertion::definitionHasPhiNode#2#ff/2@i6#64968w:
    13051    ~0%     {2} r1 = JOIN SSAConstruction::PhiInsertion::dominanceFrontierOfDefinition#2#ff#prev_delta AS L WITH SSAConstruction::PhiInsertion::definitionLiveOnEntryToBlock#2#ff AS R ON FIRST 2 OUTPUT L.<0>, L.<1>
    return r1
```

I can't quite work out why the intermediary tuple counts have changed, but the size of the final predicate is unchanged:

Before:
```
[2020-11-26 09:49:27] (684s)  >>> Created relation SSAConstruction::PhiInsertion::definitionHasPhiNode#2#ff/2@72c4bw with 404674 rows.
```
After:
```
[2020-11-26 09:22:05] (652s)  >>> Created relation SSAConstruction::PhiInsertion::definitionHasPhiNode#2#ff/2@64968w with 404674 rows.
```

CPP-differences: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1572/