### PR TITLE
JS: Add `security` tag to js/angular/double-compilation

### DIFF
--- a/javascript/ql/src/AngularJS/DoubleCompilation.ql
+++ b/javascript/ql/src/AngularJS/DoubleCompilation.ql
@@ -7,6 +7,7 @@
  * @id js/angular/double-compilation
  * @tags reliability
  *       frameworks/angularjs
+ *       security
  * @precision very-high
  */
 


### PR DESCRIPTION
As discussed.

I couldn't find any online references to the potential XSS issues that this can lead to, so I have not updated the documentation. 