### PR TITLE
C++: Downgrade two queries to recommendation

### DIFF
--- a/cpp/change-notes/2020-11-27-downgrade-to-recommendation.md
+++ b/cpp/change-notes/2020-11-27-downgrade-to-recommendation.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The queries `cpp/local-variable-hides-global-variable` and `cpp/missing-header-guard` now have severity `recommendation` instead of `warning`.

--- a/cpp/ql/src/Best Practices/Hiding/LocalVariableHidesGlobalVariable.ql
+++ b/cpp/ql/src/Best Practices/Hiding/LocalVariableHidesGlobalVariable.ql
@@ -2,7 +2,7 @@
  * @name Local variable hides global variable
  * @description A local variable or parameter that hides a global variable of the same name. This may be confusing. Consider renaming one of the variables.
  * @kind problem
- * @problem.severity warning
+ * @problem.severity recommendation
  * @precision very-high
  * @id cpp/local-variable-hides-global-variable
  * @tags maintainability

--- a/cpp/ql/src/jsf/4.07 Header Files/AV Rule 35.ql
+++ b/cpp/ql/src/jsf/4.07 Header Files/AV Rule 35.ql
@@ -4,7 +4,7 @@
  *              the file from being included twice). This prevents errors and
  *              inefficiencies caused by repeated inclusion.
  * @kind problem
- * @problem.severity warning
+ * @problem.severity recommendation
  * @precision high
  * @id cpp/missing-header-guard
  * @tags efficiency


### PR DESCRIPTION
Fixes the concrete parts of https://github.com/github/codeql-c-analysis-team/issues/162.

The `cpp/local-variable-hides-global-variable` doesn't seem right as a warning without some additional context. For example, is the local variable and the global variable used in the same function body, and do they have similar enough types that it would be possible to confuse them.

The `cpp/missing-header-guard` query enforces good style and helps with compilation speed, but AFAIK it has never flagged a correctness issue. Therefore I think it should be a recommendation.