### PR TITLE
Python: Add regex FP with + for flags

### DIFF
--- a/python/ql/test/library-tests/regex/Mode.expected
+++ b/python/ql/test/library-tests/regex/Mode.expected
@@ -7,4 +7,5 @@
 | 50 | VERBOSE |
 | 51 | UNICODE |
 | 52 | UNICODE |
-| 64 | MULTILINE |
+| 56 | VERBOSE |
+| 68 | MULTILINE |

--- a/python/ql/test/library-tests/regex/test.py
+++ b/python/ql/test/library-tests/regex/test.py
@@ -1,5 +1,5 @@
 import re
-#            0123456789ABCDEF  
+#            0123456789ABCDEF
 re.compile(r'012345678')
 re.compile(r'(\033|~{)')
 re.compile(r'\A[+-]?\d+')
@@ -50,6 +50,10 @@ re.compile("", re.VERBOSE|re.DOTALL)
 re.compile("", flags=re.VERBOSE|re.IGNORECASE)
 re.search("", None, re.UNICODE)
 x = re.search("", flags=re.UNICODE)
+# using addition for flags was reported as FP in https://github.com/github/codeql/issues/4707
+re.compile("", re.VERBOSE+re.DOTALL) # TODO: Currently not recognized with Mode.ql
+# re.X is an alias for re.VERBOSE
+re.compile("", re.X)
 
 #empty choice
 re.compile(r'|x')


### PR DESCRIPTION
Notice that there is no new results for line 54

I also added a test for the short-named version of a flag, just since I didn't see any of those already. That just works out of the box (due to points-to).