### PR TITLE
Python: Enclosing callable for synthetic arguments

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -287,6 +287,13 @@ class PosOverflowNode extends Node, TPosOverflowNode {
 
   override string toString() { result = "PosOverflowNode for " + call.getNode().toString() }
 
+  override DataFlowCallable getEnclosingCallable() {
+    exists(Node node |
+      node = TCfgNode(call) and
+      result = node.getEnclosingCallable()
+    )
+  }
+
   override Location getLocation() { result = call.getLocation() }
 }
 
@@ -300,6 +307,13 @@ class KwOverflowNode extends Node, TKwOverflowNode {
   KwOverflowNode() { this = TKwOverflowNode(call, _) }
 
   override string toString() { result = "KwOverflowNode for " + call.getNode().toString() }
+
+  override DataFlowCallable getEnclosingCallable() {
+    exists(Node node |
+      node = TCfgNode(call) and
+      result = node.getEnclosingCallable()
+    )
+  }
 
   override Location getLocation() { result = call.getLocation() }
 }
@@ -315,6 +329,13 @@ class KwUnpacked extends Node, TKwUnpacked {
   KwUnpacked() { this = TKwUnpacked(call, _, name) }
 
   override string toString() { result = "KwUnpacked " + name }
+
+  override DataFlowCallable getEnclosingCallable() {
+    exists(Node node |
+      node = TCfgNode(call) and
+      result = node.getEnclosingCallable()
+    )
+  }
 
   override Location getLocation() { result = call.getLocation() }
 }

--- a/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
@@ -1,8 +1,5 @@
 uniqueEnclosingCallable
 | test.py:239:27:239:27 | ControlFlowNode for p | Node should have one enclosing callable but has 0. |
-| test.py:245:5:245:22 | PosOverflowNode for overflowCallee() | Node should have one enclosing callable but has 0. |
-| test.py:248:5:248:26 | KwOverflowNode for overflowCallee() | Node should have one enclosing callable but has 0. |
-| test.py:251:5:251:33 | KwOverflowNode for overflowCallee() | Node should have one enclosing callable but has 0. |
 uniqueType
 uniqueNodeLocation
 missingLocation

--- a/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
@@ -1,4 +1,8 @@
 uniqueEnclosingCallable
+| test.py:239:27:239:27 | ControlFlowNode for p | Node should have one enclosing callable but has 0. |
+| test.py:245:5:245:22 | PosOverflowNode for overflowCallee() | Node should have one enclosing callable but has 0. |
+| test.py:248:5:248:26 | KwOverflowNode for overflowCallee() | Node should have one enclosing callable but has 0. |
+| test.py:251:5:251:33 | KwOverflowNode for overflowCallee() | Node should have one enclosing callable but has 0. |
 uniqueType
 uniqueNodeLocation
 missingLocation

--- a/python/ql/test/experimental/dataflow/consistency/test.py
+++ b/python/ql/test/experimental/dataflow/consistency/test.py
@@ -235,3 +235,17 @@ def non_const_eq_preserves_taint(x):
         SINK(tainted) # unsafe
     if tainted == x:
         SINK(tainted) # unsafe
+
+def overflowCallee(*args, p="", **kwargs):
+    print("args", args)
+    print("p", p)
+    print("kwargs", kwargs)
+
+def synth_arg_posOverflow():
+    overflowCallee(42)
+
+def synth_arg_kwOverflow():
+    overflowCallee(foo=42)
+
+def synth_arg_kwUnpacked():
+    overflowCallee(**{"p": "42"})


### PR DESCRIPTION
We had consistency failures because synthetic arguments do not have enclosing callables.