### PR TITLE
C#: Improve array argument CIL extraction for attributes

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Attribute.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Attribute.cs
@@ -69,7 +69,7 @@ namespace Semmle.Extraction.CIL.Entities
         {
             if (value is System.Collections.Immutable.ImmutableArray<CustomAttributeTypedArgument<Type>> values)
             {
-                return "[" + string.Join(",", values.Select(v => v.Value?.ToString() ?? "null")) + "]";
+                return "[" + string.Join(",", values.Select(v => GetStringValue(v.Value))) + "]";
             }
 
             return value?.ToString() ?? "null";

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Attribute.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Attribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection.Metadata;
 
 namespace Semmle.Extraction.CIL.Entities
@@ -51,17 +52,27 @@ namespace Semmle.Extraction.CIL.Entities
                 for (var index = 0; index < decoded.FixedArguments.Length; ++index)
                 {
                     var value = decoded.FixedArguments[index].Value;
-                    var stringValue = value?.ToString();
-                    yield return Tuples.cil_attribute_positional_argument(this, index, stringValue ?? "null");
+                    var stringValue = GetStringValue(value);
+                    yield return Tuples.cil_attribute_positional_argument(this, index, stringValue);
                 }
 
                 foreach (var p in decoded.NamedArguments)
                 {
                     var value = p.Value;
-                    var stringValue = value?.ToString();
-                    yield return Tuples.cil_attribute_named_argument(this, p.Name, stringValue ?? "null");
+                    var stringValue = GetStringValue(value);
+                    yield return Tuples.cil_attribute_named_argument(this, p.Name, stringValue);
                 }
             }
+        }
+
+        private static string GetStringValue(object? value)
+        {
+            if (value is System.Collections.Immutable.ImmutableArray<CustomAttributeTypedArgument<Type>> values)
+            {
+                return "[" + string.Join(",", values.Select(v => v.Value?.ToString() ?? "null")) + "]";
+            }
+
+            return value?.ToString() ?? "null";
         }
 
         public static IEnumerable<IExtractionProduct> Populate(Context cx, IEntity @object, CustomAttributeHandleCollection attributes)

--- a/csharp/ql/test/library-tests/cil/attributes/Test.cs
+++ b/csharp/ql/test/library-tests/cil/attributes/Test.cs
@@ -1,0 +1,7 @@
+// semmle-extractor-options: --cil
+
+using System;
+
+class Test
+{
+}

--- a/csharp/ql/test/library-tests/cil/attributes/attribute.expected
+++ b/csharp/ql/test/library-tests/cil/attributes/attribute.expected
@@ -978,7 +978,7 @@ attrArgPositional
 | !0 System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1.Enumerator.Current | [NullableAttribute(...)] | 0 | 1 |
 | !0 System.Tuple`1.Item1 | [NullableAttribute(...)] | 0 | 1 |
 | !0 System.Tuple`2.Item1 | [NullableAttribute(...)] | 0 | 1 |
-| !0[] System.ArraySegment`1.Array | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| !0[] System.ArraySegment`1.Array | [NullableAttribute(...)] | 0 | [2,1] |
 | !1 System.Collections.Generic.Dictionary`2.ValueCollection.Enumerator.Current | [NullableAttribute(...)] | 0 | 1 |
 | !1 System.Tuple`2.Item2 | [NullableAttribute(...)] | 0 | 1 |
 | Internal.Runtime.CompilerServices.Unsafe | [CLSCompliantAttribute(...)] | 0 | False |
@@ -1024,11 +1024,11 @@ attrArgPositional
 | System.AggregateException System.Threading.Tasks.Task.Exception | [NullableAttribute(...)] | 0 | 2 |
 | System.AppContext | [NullableAttribute(...)] | 0 | 0 |
 | System.AppContext | [NullableContextAttribute(...)] | 0 | 2 |
-| System.AppContext.FirstChanceException | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.AppContext.FirstChanceException | [NullableAttribute(...)] | 0 | [2,1] |
 | System.AppDomain | [NullableAttribute(...)] | 0 | 0 |
 | System.AppDomain | [NullableContextAttribute(...)] | 0 | 2 |
 | System.AppDomain System.AppDomain.CurrentDomain | [NullableAttribute(...)] | 0 | 1 |
-| System.AppDomain.FirstChanceException | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.AppDomain.FirstChanceException | [NullableAttribute(...)] | 0 | [2,1] |
 | System.AppDomainSetup | [NullableAttribute(...)] | 0 | 0 |
 | System.AppDomainSetup | [NullableContextAttribute(...)] | 0 | 2 |
 | System.AppDomainSetup System.AppDomain.SetupInformation | [NullableAttribute(...)] | 0 | 1 |
@@ -1050,7 +1050,7 @@ attrArgPositional
 | System.Array | [NullableAttribute(...)] | 0 | 0 |
 | System.Array | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Array | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.ArraySegment<!0> System.ArraySegment`1.Empty | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.ArraySegment<!0> System.ArraySegment`1.Empty | [NullableAttribute(...)] | 0 | [0,1] |
 | System.ArraySegment`1 | [DefaultMemberAttribute(...)] | 0 | Item |
 | System.ArraySegment`1 | [NullableAttribute(...)] | 0 | 0 |
 | System.ArraySegment`1 | [NullableContextAttribute(...)] | 0 | 1 |
@@ -1069,7 +1069,7 @@ attrArgPositional
 | System.BadImageFormatException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
 | System.BitConverter | [NullableAttribute(...)] | 0 | 0 |
 | System.BitConverter | [NullableContextAttribute(...)] | 0 | 1 |
-| System.BitConverter.<>c.<>9__39_0 | [TupleElementNamesAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.BitConverter.<>c.<>9__39_0 | [TupleElementNamesAttribute(...)] | 0 | [value,startIndex,length] |
 | System.Buffer | [NullableAttribute(...)] | 0 | 0 |
 | System.Buffer | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Buffers.ArrayPool`1 | [NullableAttribute(...)] | 0 | 0 |
@@ -1113,8 +1113,8 @@ attrArgPositional
 | System.Collections.Generic.Comparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Collections.Generic.Comparer`1 | [TypeDependencyAttribute(...)] | 0 | System.Collections.Generic.ObjectComparer`1 |
 | System.Collections.Generic.Comparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Collections.Generic.Dictionary<!0,!1>.KeyCollection System.Collections.Generic.Dictionary`2.Keys | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Collections.Generic.Dictionary<!0,!1>.ValueCollection System.Collections.Generic.Dictionary`2.Values | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.Dictionary<!0,!1>.KeyCollection System.Collections.Generic.Dictionary`2.Keys | [NullableAttribute(...)] | 0 | [1,0,0] |
+| System.Collections.Generic.Dictionary<!0,!1>.ValueCollection System.Collections.Generic.Dictionary`2.Values | [NullableAttribute(...)] | 0 | [1,0,0] |
 | System.Collections.Generic.Dictionary`2 | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
 | System.Collections.Generic.Dictionary`2 | [DefaultMemberAttribute(...)] | 0 | Item |
 | System.Collections.Generic.Dictionary`2 | [NullableAttribute(...)] | 0 | 0 |
@@ -1130,20 +1130,20 @@ attrArgPositional
 | System.Collections.Generic.EqualityComparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Collections.Generic.EqualityComparer`1 | [TypeDependencyAttribute(...)] | 0 | System.Collections.Generic.ObjectEqualityComparer`1 |
 | System.Collections.Generic.EqualityComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Collections.Generic.GenericComparer`1 | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.GenericComparer`1 | [NullableAttribute(...)] | 0 | [0,1] |
 | System.Collections.Generic.GenericComparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Collections.Generic.GenericComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Collections.Generic.GenericEqualityComparer`1 | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.GenericEqualityComparer`1 | [NullableAttribute(...)] | 0 | [0,1] |
 | System.Collections.Generic.GenericEqualityComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
 | System.Collections.Generic.IAsyncEnumerable`1 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Collections.Generic.ICollection`1 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Collections.Generic.IComparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
-| System.Collections.Generic.IDictionary<System.String,System.String> System.Diagnostics.Tracing.EventCommandEventArgs.Arguments | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.IDictionary<System.String,System.String> System.Diagnostics.Tracing.EventCommandEventArgs.Arguments | [NullableAttribute(...)] | 0 | [2,1,2] |
 | System.Collections.Generic.IDictionary`2 | [DefaultMemberAttribute(...)] | 0 | Item |
 | System.Collections.Generic.IDictionary`2 | [NullableContextAttribute(...)] | 0 | 1 |
-| System.Collections.Generic.IEqualityComparer<System.String> System.Collections.Generic.NonRandomizedStringEqualityComparer.Default | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.IEqualityComparer<System.String> System.Collections.Generic.NonRandomizedStringEqualityComparer.Default | [NullableAttribute(...)] | 0 | [1,2] |
 | System.Collections.Generic.IEqualityComparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
-| System.Collections.Generic.IList<System.String> System.Runtime.CompilerServices.TupleElementNamesAttribute.TransformNames | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.IList<System.String> System.Runtime.CompilerServices.TupleElementNamesAttribute.TransformNames | [NullableAttribute(...)] | 0 | [1,2] |
 | System.Collections.Generic.IList`1 | [DefaultMemberAttribute(...)] | 0 | Item |
 | System.Collections.Generic.IList`1 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Collections.Generic.IReadOnlyDictionary`2 | [DefaultMemberAttribute(...)] | 0 | Item |
@@ -1154,25 +1154,25 @@ attrArgPositional
 | System.Collections.Generic.KeyNotFoundException | [NullableAttribute(...)] | 0 | 0 |
 | System.Collections.Generic.KeyNotFoundException | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Collections.Generic.KeyNotFoundException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Collections.Generic.KeyValuePair<!0,!1> System.Collections.Generic.Dictionary`2.Enumerator.Current | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.KeyValuePair<!0,!1> System.Collections.Generic.Dictionary`2.Enumerator.Current | [NullableAttribute(...)] | 0 | [0,1,1] |
 | System.Collections.Generic.KeyValuePair`2 | [NullableAttribute(...)] | 0 | 0 |
 | System.Collections.Generic.KeyValuePair`2 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Collections.Generic.KeyValuePair`2 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Collections.Generic.List<!0> System.Threading.ThreadLocal`1.ValuesForDebugDisplay | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.List<!0> System.Threading.ThreadLocal`1.ValuesForDebugDisplay | [NullableAttribute(...)] | 0 | [2,1] |
 | System.Collections.Generic.List`1 | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
 | System.Collections.Generic.List`1 | [DefaultMemberAttribute(...)] | 0 | Item |
 | System.Collections.Generic.List`1 | [NullableAttribute(...)] | 0 | 0 |
 | System.Collections.Generic.List`1 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Collections.Generic.List`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
 | System.Collections.Generic.List`1.Enumerator | [NullableContextAttribute(...)] | 0 | 0 |
-| System.Collections.Generic.NonRandomizedStringEqualityComparer | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.NonRandomizedStringEqualityComparer | [NullableAttribute(...)] | 0 | [0,2] |
 | System.Collections.Generic.NonRandomizedStringEqualityComparer | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Collections.Generic.NullableComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
 | System.Collections.Generic.NullableEqualityComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Collections.Generic.ObjectComparer`1 | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.ObjectComparer`1 | [NullableAttribute(...)] | 0 | [0,1] |
 | System.Collections.Generic.ObjectComparer`1 | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Collections.Generic.ObjectComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Collections.Generic.ObjectEqualityComparer`1 | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.ObjectEqualityComparer`1 | [NullableAttribute(...)] | 0 | [0,1] |
 | System.Collections.Generic.ObjectEqualityComparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Collections.Generic.ObjectEqualityComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
 | System.Collections.Generic.ValueListBuilder`1 | [DefaultMemberAttribute(...)] | 0 | Item |
@@ -1217,7 +1217,7 @@ attrArgPositional
 | System.Collections.ObjectModel.Collection`1 | [NullableAttribute(...)] | 0 | 0 |
 | System.Collections.ObjectModel.Collection`1 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Collections.ObjectModel.Collection`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Collections.ObjectModel.ReadOnlyCollection<System.String> System.Diagnostics.Tracing.EventWrittenEventArgs.PayloadNames | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.ObjectModel.ReadOnlyCollection<System.String> System.Diagnostics.Tracing.EventWrittenEventArgs.PayloadNames | [NullableAttribute(...)] | 0 | [2,1] |
 | System.Collections.ObjectModel.ReadOnlyCollection`1 | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
 | System.Collections.ObjectModel.ReadOnlyCollection`1 | [DefaultMemberAttribute(...)] | 0 | Item |
 | System.Collections.ObjectModel.ReadOnlyCollection`1 | [NullableAttribute(...)] | 0 | 0 |
@@ -1258,7 +1258,7 @@ attrArgPositional
 | System.Diagnostics.ConditionalAttribute | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Diagnostics.Contracts.Contract | [NullableAttribute(...)] | 0 | 0 |
 | System.Diagnostics.Contracts.Contract | [NullableContextAttribute(...)] | 0 | 1 |
-| System.Diagnostics.Contracts.Contract.ContractFailed | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Diagnostics.Contracts.Contract.ContractFailed | [NullableAttribute(...)] | 0 | [2,1] |
 | System.Diagnostics.Contracts.ContractAbbreviatorAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
 | System.Diagnostics.Contracts.ContractArgumentValidatorAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
 | System.Diagnostics.Contracts.ContractClassAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
@@ -1311,13 +1311,13 @@ attrArgPositional
 | System.Diagnostics.Tracing.EventDataAttribute | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Diagnostics.Tracing.EventListener | [NullableAttribute(...)] | 0 | 0 |
 | System.Diagnostics.Tracing.EventListener | [NullableContextAttribute(...)] | 0 | 1 |
-| System.Diagnostics.Tracing.EventListener.EventSourceCreated | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Diagnostics.Tracing.EventListener.EventWritten | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Diagnostics.Tracing.EventListener.EventSourceCreated | [NullableAttribute(...)] | 0 | [2,1] |
+| System.Diagnostics.Tracing.EventListener.EventWritten | [NullableAttribute(...)] | 0 | [2,1] |
 | System.Diagnostics.Tracing.EventPayload | [DefaultMemberAttribute(...)] | 0 | Item |
 | System.Diagnostics.Tracing.EventSource | [NullableAttribute(...)] | 0 | 0 |
 | System.Diagnostics.Tracing.EventSource | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Diagnostics.Tracing.EventSource System.Diagnostics.Tracing.EventWrittenEventArgs.EventSource | [NullableAttribute(...)] | 0 | 1 |
-| System.Diagnostics.Tracing.EventSource.EventCommandExecuted | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Diagnostics.Tracing.EventSource.EventCommandExecuted | [NullableAttribute(...)] | 0 | [2,1] |
 | System.Diagnostics.Tracing.EventSource.EventData | [NullableContextAttribute(...)] | 0 | 0 |
 | System.Diagnostics.Tracing.EventSourceAttribute | [NullableAttribute(...)] | 0 | 0 |
 | System.Diagnostics.Tracing.EventSourceAttribute | [NullableContextAttribute(...)] | 0 | 2 |
@@ -1359,7 +1359,7 @@ attrArgPositional
 | System.Exception | [NullableAttribute(...)] | 0 | 0 |
 | System.Exception | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Exception | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Exception.SerializeObjectState | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Exception.SerializeObjectState | [NullableAttribute(...)] | 0 | [2,1] |
 | System.Exception[] System.Reflection.ReflectionTypeLoadException.LoaderExceptions | [NullableAttribute(...)] | 0 | 2 |
 | System.ExecutionEngineException | [NullableAttribute(...)] | 0 | 0 |
 | System.ExecutionEngineException | [NullableContextAttribute(...)] | 0 | 2 |
@@ -1419,11 +1419,11 @@ attrArgPositional
 | System.Globalization.CultureTypes.WindowsOnlyCultures | [ObsoleteAttribute(...)] | 0 | This value has been deprecated.  Please use other values in CultureTypes. |
 | System.Globalization.DateTimeFormatInfo | [NullableAttribute(...)] | 0 | 0 |
 | System.Globalization.DateTimeFormatInfo | [NullableContextAttribute(...)] | 0 | 1 |
-| System.Globalization.EraInfo[] System.Globalization.ChineseLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Globalization.EraInfo[] System.Globalization.EastAsianLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Globalization.EraInfo[] System.Globalization.JapaneseLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Globalization.EraInfo[] System.Globalization.KoreanLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Globalization.EraInfo[] System.Globalization.TaiwanLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Globalization.EraInfo[] System.Globalization.ChineseLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | [2,1] |
+| System.Globalization.EraInfo[] System.Globalization.EastAsianLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | [2,1] |
+| System.Globalization.EraInfo[] System.Globalization.JapaneseLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | [2,1] |
+| System.Globalization.EraInfo[] System.Globalization.KoreanLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | [2,1] |
+| System.Globalization.EraInfo[] System.Globalization.TaiwanLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | [2,1] |
 | System.Globalization.GregorianCalendar | [NullableAttribute(...)] | 0 | 0 |
 | System.Globalization.GregorianCalendar | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Globalization.HebrewCalendar | [NullableAttribute(...)] | 0 | 0 |
@@ -1513,9 +1513,9 @@ attrArgPositional
 | System.IO.IOException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
 | System.IO.MemoryStream | [NullableAttribute(...)] | 0 | 0 |
 | System.IO.MemoryStream | [NullableContextAttribute(...)] | 0 | 1 |
-| System.IO.Path.<>c.<>9__37_0 | [TupleElementNamesAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.IO.Path.<>c.<>9__38_0 | [TupleElementNamesAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.IO.Path.<>c.<>9__39_0 | [TupleElementNamesAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.IO.Path.<>c.<>9__37_0 | [TupleElementNamesAttribute(...)] | 0 | [First,FirstLength,Second,SecondLength,HasSeparator] |
+| System.IO.Path.<>c.<>9__38_0 | [TupleElementNamesAttribute(...)] | 0 | [First,FirstLength,Second,SecondLength,Third,ThirdLength,FirstHasSeparator,ThirdHasSeparator,null] |
+| System.IO.Path.<>c.<>9__39_0 | [TupleElementNamesAttribute(...)] | 0 | [First,FirstLength,Second,SecondLength,Third,ThirdLength,Fourth,FourthLength,FirstHasSeparator,ThirdHasSeparator,FourthHasSeparator,null,null,null,null] |
 | System.IO.Path.InvalidPathChars | [NullableAttribute(...)] | 0 | 1 |
 | System.IO.Path.InvalidPathChars | [ObsoleteAttribute(...)] | 0 | Please use GetInvalidPathChars or GetInvalidFileNameChars instead. |
 | System.IO.PathTooLongException | [NullableAttribute(...)] | 0 | 0 |
@@ -1561,7 +1561,7 @@ attrArgPositional
 | System.Lazy`1 | [DebuggerDisplayAttribute(...)] | 0 | ThreadSafetyMode={Mode}, IsValueCreated={IsValueCreated}, IsValueFaulted={IsValueFaulted}, Value={ValueForDebugDisplay} |
 | System.Lazy`1 | [NullableAttribute(...)] | 0 | 0 |
 | System.Lazy`1 | [NullableContextAttribute(...)] | 0 | 1 |
-| System.Lazy`2 | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Lazy`2 | [NullableAttribute(...)] | 0 | [0,1] |
 | System.Lazy`2 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.MarshalByRefObject | [ComVisibleAttribute(...)] | 0 | True |
 | System.MarshalByRefObject | [NullableAttribute(...)] | 0 | 0 |
@@ -1569,9 +1569,9 @@ attrArgPositional
 | System.MemberAccessException | [NullableAttribute(...)] | 0 | 0 |
 | System.MemberAccessException | [NullableContextAttribute(...)] | 0 | 2 |
 | System.MemberAccessException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Memory<!0> System.Buffers.IMemoryOwner`1.Memory | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Memory<!0> System.Buffers.MemoryManager`1.Memory | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Memory<!0> System.Memory`1.Empty | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Memory<!0> System.Buffers.IMemoryOwner`1.Memory | [NullableAttribute(...)] | 0 | [0,1] |
+| System.Memory<!0> System.Buffers.MemoryManager`1.Memory | [NullableAttribute(...)] | 0 | [0,1] |
+| System.Memory<!0> System.Memory`1.Empty | [NullableAttribute(...)] | 0 | [0,1] |
 | System.Memory`1 | [DebuggerDisplayAttribute(...)] | 0 | {ToString(),raw} |
 | System.Memory`1 | [NullableAttribute(...)] | 0 | 0 |
 | System.Memory`1 | [NullableContextAttribute(...)] | 0 | 1 |
@@ -1640,16 +1640,16 @@ attrArgPositional
 | System.PlatformNotSupportedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
 | System.Progress`1 | [NullableAttribute(...)] | 0 | 0 |
 | System.Progress`1 | [NullableContextAttribute(...)] | 0 | 1 |
-| System.Progress`1.ProgressChanged | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Progress`1.ProgressChanged | [NullableAttribute(...)] | 0 | [2,1] |
 | System.RankException | [NullableAttribute(...)] | 0 | 0 |
 | System.RankException | [NullableContextAttribute(...)] | 0 | 2 |
 | System.RankException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.ReadOnlyMemory<!0> System.ReadOnlyMemory`1.Empty | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.ReadOnlyMemory<!0> System.ReadOnlyMemory`1.Empty | [NullableAttribute(...)] | 0 | [0,1] |
 | System.ReadOnlyMemory`1 | [DebuggerDisplayAttribute(...)] | 0 | {ToString(),raw} |
 | System.ReadOnlyMemory`1 | [NullableAttribute(...)] | 0 | 0 |
 | System.ReadOnlyMemory`1 | [NullableContextAttribute(...)] | 0 | 1 |
-| System.ReadOnlySpan<!0> System.ReadOnlyMemory`1.Span | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.ReadOnlySpan<!0> System.ReadOnlySpan`1.Empty | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.ReadOnlySpan<!0> System.ReadOnlyMemory`1.Span | [NullableAttribute(...)] | 0 | [0,1] |
+| System.ReadOnlySpan<!0> System.ReadOnlySpan`1.Empty | [NullableAttribute(...)] | 0 | [0,1] |
 | System.ReadOnlySpan<System.Byte> System.Text.Encoding.Preamble | [NullableAttribute(...)] | 0 | 0 |
 | System.ReadOnlySpan<System.Byte> System.Text.UTF32Encoding.Preamble | [NullableAttribute(...)] | 0 | 0 |
 | System.ReadOnlySpan<System.Byte> System.Text.UnicodeEncoding.Preamble | [NullableAttribute(...)] | 0 | 0 |
@@ -1878,7 +1878,7 @@ attrArgPositional
 | System.Runtime.CompilerServices.ConditionalWeakTable`2.CreateValueCallback | [NullableContextAttribute(...)] | 0 | 0 |
 | System.Runtime.CompilerServices.ContractHelper | [NullableAttribute(...)] | 0 | 0 |
 | System.Runtime.CompilerServices.ContractHelper | [NullableContextAttribute(...)] | 0 | 2 |
-| System.Runtime.CompilerServices.ContractHelper.InternalContractFailed | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Runtime.CompilerServices.ContractHelper.InternalContractFailed | [NullableAttribute(...)] | 0 | [2,1] |
 | System.Runtime.CompilerServices.CustomConstantAttribute | [NullableAttribute(...)] | 0 | 0 |
 | System.Runtime.CompilerServices.CustomConstantAttribute | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Runtime.CompilerServices.DateTimeConstantAttribute | [NullableAttribute(...)] | 0 | 0 |
@@ -2063,14 +2063,14 @@ attrArgPositional
 | System.Runtime.Loader.AssemblyLoadContext.AssemblyLoad | [NullableAttribute(...)] | 0 | 2 |
 | System.Runtime.Loader.AssemblyLoadContext.AssemblyResolve | [NullableAttribute(...)] | 0 | 2 |
 | System.Runtime.Loader.AssemblyLoadContext.ContextualReflectionScope | [NullableContextAttribute(...)] | 0 | 0 |
-| System.Runtime.Loader.AssemblyLoadContext.Resolving | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Runtime.Loader.AssemblyLoadContext.ResolvingUnmanagedDll | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Runtime.Loader.AssemblyLoadContext.Resolving | [NullableAttribute(...)] | 0 | [2,1,1,2] |
+| System.Runtime.Loader.AssemblyLoadContext.ResolvingUnmanagedDll | [NullableAttribute(...)] | 0 | [2,1,1] |
 | System.Runtime.Loader.AssemblyLoadContext.ResourceResolve | [NullableAttribute(...)] | 0 | 2 |
 | System.Runtime.Loader.AssemblyLoadContext.TypeResolve | [NullableAttribute(...)] | 0 | 2 |
-| System.Runtime.Loader.AssemblyLoadContext.Unloading | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Runtime.Loader.AssemblyLoadContext._resolving | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Runtime.Loader.AssemblyLoadContext._resolvingUnmanagedDll | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Runtime.Loader.AssemblyLoadContext._unloading | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Runtime.Loader.AssemblyLoadContext.Unloading | [NullableAttribute(...)] | 0 | [2,1] |
+| System.Runtime.Loader.AssemblyLoadContext._resolving | [NullableAttribute(...)] | 0 | [2,1,1,1] |
+| System.Runtime.Loader.AssemblyLoadContext._resolvingUnmanagedDll | [NullableAttribute(...)] | 0 | [2,1,1] |
+| System.Runtime.Loader.AssemblyLoadContext._unloading | [NullableAttribute(...)] | 0 | [2,1] |
 | System.Runtime.Remoting.ObjectHandle | [NullableAttribute(...)] | 0 | 0 |
 | System.Runtime.Remoting.ObjectHandle | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Runtime.Serialization.IDeserializationCallback | [NullableContextAttribute(...)] | 0 | 2 |
@@ -2119,8 +2119,8 @@ attrArgPositional
 | System.Security.VerificationException | [NullableAttribute(...)] | 0 | 0 |
 | System.Security.VerificationException | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Security.VerificationException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Span<!0> System.Memory`1.Span | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
-| System.Span<!0> System.Span`1.Empty | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Span<!0> System.Memory`1.Span | [NullableAttribute(...)] | 0 | [0,1] |
+| System.Span<!0> System.Span`1.Empty | [NullableAttribute(...)] | 0 | [0,1] |
 | System.Span<System.Char> System.Text.StringBuilder.RemainingCurrentChunk | [NullableAttribute(...)] | 0 | 0 |
 | System.Span`1 | [DebuggerDisplayAttribute(...)] | 0 | {ToString(),raw} |
 | System.Span`1 | [DefaultMemberAttribute(...)] | 0 | Item |
@@ -2232,7 +2232,7 @@ attrArgPositional
 | System.Threading.SynchronizationContext | [NullableAttribute(...)] | 0 | 0 |
 | System.Threading.SynchronizationContext | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Threading.SynchronizationContext System.Threading.SynchronizationContext.Current | [NullableAttribute(...)] | 0 | 2 |
-| System.Threading.SynchronizationContext.<>c.<>9__8_0 | [TupleElementNamesAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Threading.SynchronizationContext.<>c.<>9__8_0 | [TupleElementNamesAttribute(...)] | 0 | [d,state] |
 | System.Threading.SynchronizationLockException | [NullableAttribute(...)] | 0 | 0 |
 | System.Threading.SynchronizationLockException | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Threading.SynchronizationLockException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
@@ -2271,7 +2271,7 @@ attrArgPositional
 | System.Threading.Tasks.TaskScheduler System.Threading.Tasks.TaskFactory.Scheduler | [NullableAttribute(...)] | 0 | 2 |
 | System.Threading.Tasks.TaskScheduler System.Threading.Tasks.TaskFactory`1.Scheduler | [NullableAttribute(...)] | 0 | 2 |
 | System.Threading.Tasks.TaskScheduler System.Threading.Tasks.TaskScheduler.InternalCurrent | [NullableAttribute(...)] | 0 | 2 |
-| System.Threading.Tasks.TaskScheduler.UnobservedTaskException | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Threading.Tasks.TaskScheduler.UnobservedTaskException | [NullableAttribute(...)] | 0 | [2,1] |
 | System.Threading.Tasks.TaskSchedulerException | [NullableAttribute(...)] | 0 | 0 |
 | System.Threading.Tasks.TaskSchedulerException | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Threading.Tasks.TaskSchedulerException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
@@ -2282,7 +2282,7 @@ attrArgPositional
 | System.Threading.Tasks.UnobservedTaskExceptionEventArgs | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Threading.Tasks.ValueTask | [NullableAttribute(...)] | 0 | 0 |
 | System.Threading.Tasks.ValueTask | [NullableContextAttribute(...)] | 0 | 1 |
-| System.Threading.Tasks.ValueTask<!0> System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.Task | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Threading.Tasks.ValueTask<!0> System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.Task | [NullableAttribute(...)] | 0 | [0,1] |
 | System.Threading.Tasks.ValueTask`1 | [NullableAttribute(...)] | 0 | 0 |
 | System.Threading.Tasks.ValueTask`1 | [NullableContextAttribute(...)] | 0 | 1 |
 | System.Threading.Thread | [NullableAttribute(...)] | 0 | 0 |
@@ -2293,7 +2293,7 @@ attrArgPositional
 | System.Threading.ThreadInterruptedException | [NullableAttribute(...)] | 0 | 0 |
 | System.Threading.ThreadInterruptedException | [NullableContextAttribute(...)] | 0 | 2 |
 | System.Threading.ThreadInterruptedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Threading.ThreadLocal<System.Object> System.LocalDataStoreSlot.Data | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Threading.ThreadLocal<System.Object> System.LocalDataStoreSlot.Data | [NullableAttribute(...)] | 0 | [1,2] |
 | System.Threading.ThreadLocal`1 | [DebuggerDisplayAttribute(...)] | 0 | IsValueCreated={IsValueCreated}, Value={ValueForDebugDisplay}, Count={ValuesCountForDebugDisplay} |
 | System.Threading.ThreadLocal`1 | [NullableAttribute(...)] | 0 | 0 |
 | System.Threading.ThreadLocal`1 | [NullableContextAttribute(...)] | 0 | 1 |
@@ -2394,7 +2394,7 @@ attrArgPositional
 | System.TypeUnloadedException | [NullableAttribute(...)] | 0 | 0 |
 | System.TypeUnloadedException | [NullableContextAttribute(...)] | 0 | 2 |
 | System.TypeUnloadedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
-| System.Type[] System.Reflection.ReflectionTypeLoadException.Types | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Type[] System.Reflection.ReflectionTypeLoadException.Types | [NullableAttribute(...)] | 0 | [2,1] |
 | System.TypedReference | [CLSCompliantAttribute(...)] | 0 | False |
 | System.TypedReference | [NullableAttribute(...)] | 0 | 0 |
 | System.TypedReference | [NullableContextAttribute(...)] | 0 | 1 |

--- a/csharp/ql/test/library-tests/cil/attributes/attribute.expected
+++ b/csharp/ql/test/library-tests/cil/attributes/attribute.expected
@@ -1,0 +1,2614 @@
+attrNoArg
+| !0 System.Lazy`1.Value | [DebuggerBrowsableAttribute(...)] |
+| !0 System.ReadOnlySpan`1.Enumerator.Current | [IsReadOnlyAttribute(...)] |
+| !0 System.ReadOnlySpan`1.Item | [IsReadOnlyAttribute(...)] |
+| !0 System.Threading.Tasks.Task`1.Result | [DebuggerBrowsableAttribute(...)] |
+| !0 System.Threading.Tasks.ValueTask`1.Result | [DebuggerBrowsableAttribute(...)] |
+| !0 System.Threading.ThreadLocal`1.Value | [DebuggerBrowsableAttribute(...)] |
+| !0[] System.Collections.Concurrent.IProducerConsumerCollectionDebugView`1.Items | [DebuggerBrowsableAttribute(...)] |
+| !0[] System.Collections.Generic.DictionaryKeyCollectionDebugView`2.Items | [DebuggerBrowsableAttribute(...)] |
+| !0[] System.Collections.Generic.ICollectionDebugView`1.Items | [DebuggerBrowsableAttribute(...)] |
+| !0[] System.MemoryDebugView`1.Items | [DebuggerBrowsableAttribute(...)] |
+| !0[] System.SpanDebugView`1.Items | [DebuggerBrowsableAttribute(...)] |
+| !1[] System.Collections.Generic.DictionaryValueCollectionDebugView`2.Items | [DebuggerBrowsableAttribute(...)] |
+| <>f__AnonymousType0`1 | [CompilerGeneratedAttribute(...)] |
+| <>f__AnonymousType0`1.<message>i__Field | [DebuggerBrowsableAttribute(...)] |
+| <PrivateImplementationDetails> | [CompilerGeneratedAttribute(...)] |
+| Internal.Runtime.InteropServices.ComponentActivator.<>c__DisplayClass6_0 | [CompilerGeneratedAttribute(...)] |
+| Interop.Sys.<>c__DisplayClass39_0 | [CompilerGeneratedAttribute(...)] |
+| Interop.Sys.FileStatusFlags | [FlagsAttribute(...)] |
+| Interop.Sys.MountPointFound | [UnmanagedFunctionPointerAttribute(...)] |
+| Interop.Sys.OpenFlags | [FlagsAttribute(...)] |
+| Interop.Sys.PollEvents | [FlagsAttribute(...)] |
+| InteropErrorExtensions | [ExtensionAttribute(...)] |
+| Microsoft.CodeAnalysis.EmbeddedAttribute | [CompilerGeneratedAttribute(...)] |
+| Microsoft.CodeAnalysis.EmbeddedAttribute | [EmbeddedAttribute(...)] |
+| Microsoft.Reflection.ReflectionExtensions | [ExtensionAttribute(...)] |
+| Microsoft.Win32.SafeHandles.SafeFileHandle.<>c | [CompilerGeneratedAttribute(...)] |
+| Microsoft.Win32.SafeHandles.SafeFileHandle.<IsAsync>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.AppContext.FirstChanceException | [CompilerGeneratedAttribute(...)] |
+| System.AppContext.ProcessExit | [CompilerGeneratedAttribute(...)] |
+| System.AppContext.UnhandledException | [CompilerGeneratedAttribute(...)] |
+| System.AppDomain.DomainUnload | [CompilerGeneratedAttribute(...)] |
+| System.AppDomain.ReflectionOnlyAssemblyResolve | [CompilerGeneratedAttribute(...)] |
+| System.ArgIterator | [IsByRefLikeAttribute(...)] |
+| System.Array.SorterGenericArray | [IsReadOnlyAttribute(...)] |
+| System.Array.SorterObjectArray | [IsReadOnlyAttribute(...)] |
+| System.ArraySegment`1 | [IsReadOnlyAttribute(...)] |
+| System.ArraySegment`1.<Empty>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.AssemblyLoadEventArgs.<LoadedAssembly>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Attribute | [AttributeUsageAttribute(...)] |
+| System.AttributeTargets | [FlagsAttribute(...)] |
+| System.AttributeUsageAttribute | [AttributeUsageAttribute(...)] |
+| System.Base64FormattingOptions | [FlagsAttribute(...)] |
+| System.BitConverter.<>c | [CompilerGeneratedAttribute(...)] |
+| System.BitConverter.IsLittleEndian | [IntrinsicAttribute(...)] |
+| System.Buffers.StandardFormat | [IsReadOnlyAttribute(...)] |
+| System.Buffers.Text.Utf8Parser.ParseNumberOptions | [FlagsAttribute(...)] |
+| System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1.t_tlsBuckets | [ThreadStaticAttribute(...)] |
+| System.ByReference`1 | [IsByRefLikeAttribute(...)] |
+| System.ByReference`1 | [IsReadOnlyAttribute(...)] |
+| System.ByReference`1 | [NonVersionableAttribute(...)] |
+| System.CLSCompliantAttribute | [AttributeUsageAttribute(...)] |
+| System.Collections.ArrayList | [DebuggerTypeProxyAttribute(...)] |
+| System.Collections.Concurrent.ConcurrentQueueSegment`1.Slot.Item | [AllowNullAttribute(...)] |
+| System.Collections.Concurrent.ConcurrentQueueSegment`1.Slot.Item | [MaybeNullAttribute(...)] |
+| System.Collections.Concurrent.ConcurrentQueue`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Collections.Concurrent.ConcurrentQueue`1.<Enumerate>d__26 | [CompilerGeneratedAttribute(...)] |
+| System.Collections.Generic.Comparer`1.<Default>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Collections.Generic.Dictionary`2 | [DebuggerTypeProxyAttribute(...)] |
+| System.Collections.Generic.Dictionary`2.KeyCollection | [DebuggerTypeProxyAttribute(...)] |
+| System.Collections.Generic.Dictionary`2.KeyCollection.Enumerator._currentKey | [AllowNullAttribute(...)] |
+| System.Collections.Generic.Dictionary`2.KeyCollection.Enumerator._currentKey | [MaybeNullAttribute(...)] |
+| System.Collections.Generic.Dictionary`2.ValueCollection | [DebuggerTypeProxyAttribute(...)] |
+| System.Collections.Generic.Dictionary`2.ValueCollection.Enumerator._currentValue | [AllowNullAttribute(...)] |
+| System.Collections.Generic.Dictionary`2.ValueCollection.Enumerator._currentValue | [MaybeNullAttribute(...)] |
+| System.Collections.Generic.EqualityComparer`1.<Default>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Collections.Generic.KeyValuePair<!0,!1>[] System.Collections.Generic.IDictionaryDebugView`2.Items | [DebuggerBrowsableAttribute(...)] |
+| System.Collections.Generic.KeyValuePair`2 | [IsReadOnlyAttribute(...)] |
+| System.Collections.Generic.List`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Collections.Generic.List`1.Enumerator._current | [AllowNullAttribute(...)] |
+| System.Collections.Generic.List`1.Enumerator._current | [MaybeNullAttribute(...)] |
+| System.Collections.Generic.NonRandomizedStringEqualityComparer.<Default>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Collections.Generic.ValueListBuilder`1 | [IsByRefLikeAttribute(...)] |
+| System.Collections.Hashtable | [DebuggerTypeProxyAttribute(...)] |
+| System.Collections.KeyValuePairs._key | [DebuggerBrowsableAttribute(...)] |
+| System.Collections.KeyValuePairs._value | [DebuggerBrowsableAttribute(...)] |
+| System.Collections.KeyValuePairs[] System.Collections.Hashtable.HashtableDebugView.Items | [DebuggerBrowsableAttribute(...)] |
+| System.Collections.ObjectModel.Collection`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Collections.ObjectModel.ReadOnlyCollection`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.CommonlyUsedGenericInstantiations.<AsyncHelper2>d__4`1 | [CompilerGeneratedAttribute(...)] |
+| System.CommonlyUsedGenericInstantiations.<AsyncHelper3>d__5 | [CompilerGeneratedAttribute(...)] |
+| System.CommonlyUsedGenericInstantiations.<AsyncHelper>d__3`1 | [CompilerGeneratedAttribute(...)] |
+| System.ComponentModel.DefaultValueAttribute | [AttributeUsageAttribute(...)] |
+| System.ComponentModel.EditorBrowsableAttribute | [AttributeUsageAttribute(...)] |
+| System.ComponentModel.EditorBrowsableAttribute.<State>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Console.<>c | [CompilerGeneratedAttribute(...)] |
+| System.ConsoleCancelEventArgs.<Cancel>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.ConsoleKeyInfo | [IsReadOnlyAttribute(...)] |
+| System.ConsoleModifiers | [FlagsAttribute(...)] |
+| System.ConsolePal.<>c | [CompilerGeneratedAttribute(...)] |
+| System.ConsolePal.<>c__DisplayClass115_0 | [CompilerGeneratedAttribute(...)] |
+| System.ConsolePal.ControlCHandlerRegistrar.<>c | [CompilerGeneratedAttribute(...)] |
+| System.ConsolePal.TerminalFormatStrings.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Convert | [ExtensionAttribute(...)] |
+| System.DTSubString | [IsByRefLikeAttribute(...)] |
+| System.DateTime | [IsReadOnlyAttribute(...)] |
+| System.DateTimeOffset | [IsReadOnlyAttribute(...)] |
+| System.DateTimeResult | [IsByRefLikeAttribute(...)] |
+| System.DefaultBinder.Primitives | [FlagsAttribute(...)] |
+| System.Delegate | [ClassInterfaceAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.AllowNullAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.DisallowNullAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute.<ParameterValue>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.MaybeNullAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.<ReturnValue>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.NotNullAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.<ParameterName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.NotNullWhenAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.<ReturnValue>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.SuppressMessageAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.SuppressMessageAttribute.<Category>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.SuppressMessageAttribute.<CheckId>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.SuppressMessageAttribute.<Justification>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.SuppressMessageAttribute.<MessageId>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.SuppressMessageAttribute.<Scope>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.CodeAnalysis.SuppressMessageAttribute.<Target>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.ConditionalAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.ConditionalAttribute.<ConditionString>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Contracts.ContractAbbreviatorAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Contracts.ContractArgumentValidatorAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Contracts.ContractClassAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Contracts.ContractClassForAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Contracts.ContractInvariantMethodAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Contracts.ContractOptionAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Contracts.ContractPublicPropertyNameAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Contracts.ContractReferenceAssemblyAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Contracts.ContractRuntimeIgnoredAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Contracts.ContractVerificationAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Contracts.PureAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Debug.t_indentLevel | [ThreadStaticAttribute(...)] |
+| System.Diagnostics.DebuggableAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.DebuggableAttribute.<DebuggingFlags>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggableAttribute.DebuggingModes | [FlagsAttribute(...)] |
+| System.Diagnostics.DebuggerBrowsableAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.DebuggerBrowsableAttribute.<State>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggerDisplayAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.DebuggerDisplayAttribute.<Name>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggerDisplayAttribute.<TargetTypeName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggerDisplayAttribute.<Type>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggerDisplayAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggerHiddenAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.DebuggerNonUserCodeAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.DebuggerStepThroughAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.DebuggerStepperBoundaryAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.DebuggerTypeProxyAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.DebuggerTypeProxyAttribute.<ProxyTypeName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggerTypeProxyAttribute.<TargetTypeName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggerVisualizerAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.DebuggerVisualizerAttribute.<Description>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggerVisualizerAttribute.<TargetTypeName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggerVisualizerAttribute.<VisualizerObjectSourceTypeName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.DebuggerVisualizerAttribute.<VisualizerTypeName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.StackFrameHelper.t_reentrancy | [ThreadStaticAttribute(...)] |
+| System.Diagnostics.StackTraceHiddenAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload | [EventDataAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<Count>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<CounterType>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<DisplayName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<DisplayUnits>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<IntervalSec>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<Max>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<Mean>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<Metadata>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<Min>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<Name>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<Series>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<StandardDeviation>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayload.<get_ForEnumeration>d__51 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayloadType | [EventDataAttribute(...)] |
+| System.Diagnostics.Tracing.CounterPayloadType.<Payload>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.DataCollector.ThreadInstance | [ThreadStaticAttribute(...)] |
+| System.Diagnostics.Tracing.DiagnosticCounter.<EventSource>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.DiagnosticCounter.<Name>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventActivityOptions | [FlagsAttribute(...)] |
+| System.Diagnostics.Tracing.EventAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Tracing.EventAttribute.<ActivityOptions>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventAttribute.<Channel>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventAttribute.<EventId>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventAttribute.<Keywords>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventAttribute.<Level>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventAttribute.<Message>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventAttribute.<Tags>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventAttribute.<Task>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventAttribute.<Version>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventChannelAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Tracing.EventChannelAttribute.<Enabled>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventChannelAttribute.<EventChannelType>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventCommandEventArgs.<Arguments>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventCommandEventArgs.<Command>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventDataAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Tracing.EventDataAttribute.<Keywords>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventDataAttribute.<Name>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventDataAttribute.<Tags>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventFieldAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Tracing.EventFieldAttribute.<Format>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventFieldAttribute.<Name>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventFieldAttribute.<Tags>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventFieldTags | [FlagsAttribute(...)] |
+| System.Diagnostics.Tracing.EventIgnoreAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Tracing.EventKeywords | [FlagsAttribute(...)] |
+| System.Diagnostics.Tracing.EventListener.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventListener.EventWritten | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventListener._EventSourceCreated | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventManifestOptions | [FlagsAttribute(...)] |
+| System.Diagnostics.Tracing.EventPayload.<GetEnumerator>d__17 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventPipeController.<IsControllerInitialized>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventPipeEventDispatcher.EventListenerSubscription.<Level>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventPipeEventDispatcher.EventListenerSubscription.<MatchAnyKeywords>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventProvider.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventProvider.s_returnCode | [ThreadStaticAttribute(...)] |
+| System.Diagnostics.Tracing.EventSource.m_EventSourceExceptionRecurenceCount | [ThreadStaticAttribute(...)] |
+| System.Diagnostics.Tracing.EventSource.m_EventSourceInDecodeObject | [ThreadStaticAttribute(...)] |
+| System.Diagnostics.Tracing.EventSourceAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Tracing.EventSourceAttribute.<Guid>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventSourceAttribute.<LocalizationResources>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventSourceAttribute.<Name>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventSourceCreatedEventArgs.<EventSource>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventSourceSettings | [FlagsAttribute(...)] |
+| System.Diagnostics.Tracing.EventTags | [FlagsAttribute(...)] |
+| System.Diagnostics.Tracing.EventWrittenEventArgs.<EventId>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventWrittenEventArgs.<Payload>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventWrittenEventArgs.<RelatedActivityId>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.EventWrittenEventArgs.<TimeStamp>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload | [EventDataAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload.<CounterType>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload.<DisplayName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload.<DisplayRateTimeScale>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload.<DisplayUnits>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload.<Increment>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload.<IntervalSec>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload.<Metadata>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload.<Name>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload.<Series>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingCounterPayload.<get_ForEnumeration>d__39 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingEventCounter.<DisplayRateTimeScale>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingEventCounterPayloadType | [EventDataAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingEventCounterPayloadType.<Payload>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingPollingCounter.<DisplayRateTimeScale>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingPollingCounterPayloadType | [EventDataAttribute(...)] |
+| System.Diagnostics.Tracing.IncrementingPollingCounterPayloadType.<Payload>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.ManifestBuilder.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.NonEventAttribute | [AttributeUsageAttribute(...)] |
+| System.Diagnostics.Tracing.PollingPayloadType | [EventDataAttribute(...)] |
+| System.Diagnostics.Tracing.PollingPayloadType.<Payload>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue | [IsReadOnlyAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.<>c__DisplayClass33_0 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_0 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_1 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_2 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_3 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_4 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_5 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_6 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_7 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_8 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_9 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_10 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_11 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_12 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_13 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_14 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_15 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_16 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_17 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_18 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_19 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.PropertyValue.ReferenceTypeHelper`1.<>c__DisplayClass0_20 | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.RuntimeEventSource.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.ScalarArrayTypeInfo.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.ScalarTypeInfo.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.TraceLoggingMetadataCollector.<Tags>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Diagnostics.Tracing.TraceLoggingTypeInfo.threadCache | [ThreadStaticAttribute(...)] |
+| System.Diagnostics.Tracing.XplatEventLogger.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Environment.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Exception.DispatchState | [IsReadOnlyAttribute(...)] |
+| System.FlagsAttribute | [AttributeUsageAttribute(...)] |
+| System.GC.MemoryLoadChangeNotification | [IsReadOnlyAttribute(...)] |
+| System.GC.MemoryLoadChangeNotification.<HighMemoryPercent>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.GC.MemoryLoadChangeNotification.<LowMemoryPercent>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.GC.MemoryLoadChangeNotification.<Notification>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.GCMemoryInfo | [IsReadOnlyAttribute(...)] |
+| System.GCMemoryInfo.<FragmentedBytes>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.GCMemoryInfo.<HeapSizeBytes>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.GCMemoryInfo.<HighMemoryLoadThresholdBytes>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.GCMemoryInfo.<MemoryLoadBytes>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.GCMemoryInfo.<TotalAvailableMemoryBytes>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Globalization.CalendarData.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Globalization.CompareOptions | [FlagsAttribute(...)] |
+| System.Globalization.CultureInfo.s_currentThreadCulture | [ThreadStaticAttribute(...)] |
+| System.Globalization.CultureInfo.s_currentThreadUICulture | [ThreadStaticAttribute(...)] |
+| System.Globalization.CultureTypes | [FlagsAttribute(...)] |
+| System.Globalization.DateTimeFormatFlags | [FlagsAttribute(...)] |
+| System.Globalization.DateTimeStyles | [FlagsAttribute(...)] |
+| System.Globalization.DaylightTimeStruct | [IsReadOnlyAttribute(...)] |
+| System.Globalization.GlobalizationExtensions | [ExtensionAttribute(...)] |
+| System.Globalization.GlobalizationMode.<Invariant>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Globalization.MonthNameStyles | [FlagsAttribute(...)] |
+| System.Globalization.NumberStyles | [FlagsAttribute(...)] |
+| System.Globalization.TextInfo.ToLowerConversion | [IsReadOnlyAttribute(...)] |
+| System.Globalization.TextInfo.ToUpperConversion | [IsReadOnlyAttribute(...)] |
+| System.Globalization.TimeSpanParse.StringParser | [IsByRefLikeAttribute(...)] |
+| System.Globalization.TimeSpanParse.TimeSpanRawInfo | [IsByRefLikeAttribute(...)] |
+| System.Globalization.TimeSpanParse.TimeSpanResult | [IsByRefLikeAttribute(...)] |
+| System.Globalization.TimeSpanParse.TimeSpanStandardStyles | [FlagsAttribute(...)] |
+| System.Globalization.TimeSpanParse.TimeSpanToken | [IsByRefLikeAttribute(...)] |
+| System.Globalization.TimeSpanParse.TimeSpanTokenizer | [IsByRefLikeAttribute(...)] |
+| System.Globalization.TimeSpanStyles | [FlagsAttribute(...)] |
+| System.Guid | [NonVersionableAttribute(...)] |
+| System.IO.FileAccess | [FlagsAttribute(...)] |
+| System.IO.FileAttributes | [FlagsAttribute(...)] |
+| System.IO.FileLoadException.<FileName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.IO.FileLoadException.<FusionLog>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.IO.FileNotFoundException.<FileName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.IO.FileNotFoundException.<FusionLog>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.IO.FileOptions | [FlagsAttribute(...)] |
+| System.IO.FileShare | [FlagsAttribute(...)] |
+| System.IO.FileStream.<>c | [CompilerGeneratedAttribute(...)] |
+| System.IO.Path.<>c | [CompilerGeneratedAttribute(...)] |
+| System.IO.Stream.<<ReadAsync>g__FinishReadAsync\|47_0>d | [CompilerGeneratedAttribute(...)] |
+| System.IO.Stream.<>c | [CompilerGeneratedAttribute(...)] |
+| System.IO.Stream.<CopyToAsyncInternal>d__30 | [CompilerGeneratedAttribute(...)] |
+| System.IO.Stream.<FinishWriteAsync>d__60 | [CompilerGeneratedAttribute(...)] |
+| System.IO.Stream.SynchronousAsyncResult.<>c | [CompilerGeneratedAttribute(...)] |
+| System.IO.StreamReader.<ReadAsyncInternal>d__64 | [CompilerGeneratedAttribute(...)] |
+| System.IO.StreamReader.<ReadBufferAsync>d__67 | [CompilerGeneratedAttribute(...)] |
+| System.IO.StreamReader.<ReadLineAsyncInternal>d__59 | [CompilerGeneratedAttribute(...)] |
+| System.IO.StreamReader.<ReadToEndAsyncInternal>d__61 | [CompilerGeneratedAttribute(...)] |
+| System.IO.StreamWriter.<DisposeAsyncCore>d__33 | [CompilerGeneratedAttribute(...)] |
+| System.IO.StreamWriter.<FlushAsyncInternal>d__74 | [CompilerGeneratedAttribute(...)] |
+| System.IO.StreamWriter.<WriteAsyncInternal>d__61 | [CompilerGeneratedAttribute(...)] |
+| System.IO.StreamWriter.<WriteAsyncInternal>d__63 | [CompilerGeneratedAttribute(...)] |
+| System.IO.StreamWriter.<WriteAsyncInternal>d__66 | [CompilerGeneratedAttribute(...)] |
+| System.IO.TextReader.<>c | [CompilerGeneratedAttribute(...)] |
+| System.IO.TextReader.<ReadBlockAsyncInternal>d__20 | [CompilerGeneratedAttribute(...)] |
+| System.IO.TextReader.<ReadToEndAsync>d__14 | [CompilerGeneratedAttribute(...)] |
+| System.IO.TextWriter.<<WriteAsync>g__WriteAsyncCore\|60_0>d | [CompilerGeneratedAttribute(...)] |
+| System.IO.TextWriter.<<WriteLineAsync>g__WriteLineAsyncCore\|66_0>d | [CompilerGeneratedAttribute(...)] |
+| System.IO.TextWriter.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Index | [IsReadOnlyAttribute(...)] |
+| System.IntPtr | [IsReadOnlyAttribute(...)] |
+| System.IntPtr.Zero | [IntrinsicAttribute(...)] |
+| System.LazyHelper.<State>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Lazy`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.LocalDataStoreSlot.<Data>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.MTAThreadAttribute | [AttributeUsageAttribute(...)] |
+| System.MarshalByRefObject | [ClassInterfaceAttribute(...)] |
+| System.Marvin.<DefaultSeed>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.MdUtf8String | [IsReadOnlyAttribute(...)] |
+| System.MemoryExtensions | [ExtensionAttribute(...)] |
+| System.Memory`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Memory`1 | [IsReadOnlyAttribute(...)] |
+| System.MulticastDelegate | [ClassInterfaceAttribute(...)] |
+| System.NonSerializedAttribute | [AttributeUsageAttribute(...)] |
+| System.Nullable`1 | [NonVersionableAttribute(...)] |
+| System.Number.BigInteger | [IsByRefLikeAttribute(...)] |
+| System.Number.BigInteger.<_blocks>e__FixedBuffer | [CompilerGeneratedAttribute(...)] |
+| System.Number.BigInteger.<_blocks>e__FixedBuffer | [UnsafeValueTypeAttribute(...)] |
+| System.Number.BigInteger._blocks | [FixedBufferAttribute(...)] |
+| System.Number.DiyFp | [IsByRefLikeAttribute(...)] |
+| System.Number.DiyFp | [IsReadOnlyAttribute(...)] |
+| System.Number.FloatingPointInfo | [IsReadOnlyAttribute(...)] |
+| System.Number.FloatingPointInfo.<DenormalMantissaBits>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.FloatingPointInfo.<DenormalMantissaMask>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.FloatingPointInfo.<ExponentBias>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.FloatingPointInfo.<ExponentBits>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.FloatingPointInfo.<InfinityBits>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.FloatingPointInfo.<MaxBinaryExponent>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.FloatingPointInfo.<MinBinaryExponent>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.FloatingPointInfo.<NormalMantissaBits>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.FloatingPointInfo.<NormalMantissaMask>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.FloatingPointInfo.<OverflowDecimalExponent>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.FloatingPointInfo.<ZeroBits>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Number.NumberBuffer | [IsByRefLikeAttribute(...)] |
+| System.Numerics.Vector | [IntrinsicAttribute(...)] |
+| System.Numerics.Vector`1 | [IntrinsicAttribute(...)] |
+| System.ObsoleteAttribute | [AttributeUsageAttribute(...)] |
+| System.ParamArrayAttribute | [AttributeUsageAttribute(...)] |
+| System.ParamsArray | [IsReadOnlyAttribute(...)] |
+| System.ParseFlags | [FlagsAttribute(...)] |
+| System.PlatformID.MacOSX | [EditorBrowsableAttribute(...)] |
+| System.PlatformID.Win32S | [EditorBrowsableAttribute(...)] |
+| System.PlatformID.Win32Windows | [EditorBrowsableAttribute(...)] |
+| System.PlatformID.WinCE | [EditorBrowsableAttribute(...)] |
+| System.PlatformID.Xbox | [EditorBrowsableAttribute(...)] |
+| System.Progress`1.ProgressChanged | [CompilerGeneratedAttribute(...)] |
+| System.Random.t_threadRandom | [ThreadStaticAttribute(...)] |
+| System.Range | [IsReadOnlyAttribute(...)] |
+| System.Range.<End>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Range.<Start>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.ReadOnlyMemory`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.ReadOnlyMemory`1 | [IsReadOnlyAttribute(...)] |
+| System.ReadOnlySpan`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.ReadOnlySpan`1 | [IsByRefLikeAttribute(...)] |
+| System.ReadOnlySpan`1 | [IsReadOnlyAttribute(...)] |
+| System.ReadOnlySpan`1 | [NonVersionableAttribute(...)] |
+| System.ReadOnlySpan`1.Enumerator | [IsByRefLikeAttribute(...)] |
+| System.Reflection.AssemblyAlgorithmIdAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyAlgorithmIdAttribute.<AlgorithmId>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyCompanyAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyCompanyAttribute.<Company>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyConfigurationAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyConfigurationAttribute.<Configuration>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyCopyrightAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyCopyrightAttribute.<Copyright>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyCultureAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyCultureAttribute.<Culture>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyDefaultAliasAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyDefaultAliasAttribute.<DefaultAlias>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyDelaySignAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyDelaySignAttribute.<DelaySign>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyDescriptionAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyDescriptionAttribute.<Description>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyFileVersionAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyFileVersionAttribute.<Version>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyFlagsAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyInformationalVersionAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyInformationalVersionAttribute.<InformationalVersion>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyKeyFileAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyKeyFileAttribute.<KeyFile>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyKeyNameAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyKeyNameAttribute.<KeyName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyMetadataAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyMetadataAttribute.<Key>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyMetadataAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyNameFlags | [FlagsAttribute(...)] |
+| System.Reflection.AssemblyNameFormatter | [ExtensionAttribute(...)] |
+| System.Reflection.AssemblyProductAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyProductAttribute.<Product>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblySignatureKeyAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblySignatureKeyAttribute.<Countersignature>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblySignatureKeyAttribute.<PublicKey>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyTitleAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyTitleAttribute.<Title>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyTrademarkAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyTrademarkAttribute.<Trademark>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.AssemblyVersionAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.AssemblyVersionAttribute.<Version>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.Associates.Attributes | [FlagsAttribute(...)] |
+| System.Reflection.BindingFlags | [FlagsAttribute(...)] |
+| System.Reflection.CallingConventions | [FlagsAttribute(...)] |
+| System.Reflection.ConstArray | [IsReadOnlyAttribute(...)] |
+| System.Reflection.CustomAttributeCtorParameter | [IsReadOnlyAttribute(...)] |
+| System.Reflection.CustomAttributeEncodedArgument | [IsReadOnlyAttribute(...)] |
+| System.Reflection.CustomAttributeExtensions | [ExtensionAttribute(...)] |
+| System.Reflection.CustomAttributeNamedArgument | [IsReadOnlyAttribute(...)] |
+| System.Reflection.CustomAttributeNamedParameter | [IsReadOnlyAttribute(...)] |
+| System.Reflection.CustomAttributeType | [IsReadOnlyAttribute(...)] |
+| System.Reflection.CustomAttributeTypedArgument | [IsReadOnlyAttribute(...)] |
+| System.Reflection.DefaultMemberAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.DefaultMemberAttribute.<MemberName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.Emit.AssemblyBuilderAccess | [FlagsAttribute(...)] |
+| System.Reflection.Emit.DynamicResolver.SecurityControlFlags | [FlagsAttribute(...)] |
+| System.Reflection.Emit.EventToken.<Token>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.Emit.ExceptionHandler | [IsReadOnlyAttribute(...)] |
+| System.Reflection.Emit.FieldToken.<Token>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.Emit.Label | [IsReadOnlyAttribute(...)] |
+| System.Reflection.Emit.MethodToken.<Token>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.Emit.OpCode | [IsReadOnlyAttribute(...)] |
+| System.Reflection.Emit.ParameterToken.<Token>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.Emit.PropertyToken.<Token>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.Emit.SignatureToken.<Token>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.Emit.StringToken.<Token>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.Emit.TypeToken.<Token>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.EventAttributes | [FlagsAttribute(...)] |
+| System.Reflection.ExceptionHandlingClauseOptions | [FlagsAttribute(...)] |
+| System.Reflection.FieldAttributes | [FlagsAttribute(...)] |
+| System.Reflection.GenericParameterAttributes | [FlagsAttribute(...)] |
+| System.Reflection.INVOCATION_FLAGS | [FlagsAttribute(...)] |
+| System.Reflection.IntrospectionExtensions | [ExtensionAttribute(...)] |
+| System.Reflection.ManifestResourceInfo.<FileName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.ManifestResourceInfo.<ReferencedAssembly>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.ManifestResourceInfo.<ResourceLocation>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.MdSigCallingConvention | [FlagsAttribute(...)] |
+| System.Reflection.MemberTypes | [FlagsAttribute(...)] |
+| System.Reflection.Metadata.AssemblyExtensions | [ExtensionAttribute(...)] |
+| System.Reflection.MetadataEnumResult.<smallResult>e__FixedBuffer | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.MetadataEnumResult.<smallResult>e__FixedBuffer | [UnsafeValueTypeAttribute(...)] |
+| System.Reflection.MetadataEnumResult.smallResult | [FixedBufferAttribute(...)] |
+| System.Reflection.MetadataImport | [IsReadOnlyAttribute(...)] |
+| System.Reflection.MethodAttributes | [FlagsAttribute(...)] |
+| System.Reflection.MethodSemanticsAttributes | [FlagsAttribute(...)] |
+| System.Reflection.Module.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.ObfuscateAssemblyAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.ObfuscateAssemblyAttribute.<AssemblyIsPrivate>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.ObfuscateAssemblyAttribute.<StripAfterObfuscation>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.ObfuscationAttribute | [AttributeUsageAttribute(...)] |
+| System.Reflection.ObfuscationAttribute.<ApplyToMembers>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.ObfuscationAttribute.<Exclude>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.ObfuscationAttribute.<Feature>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.ObfuscationAttribute.<StripAfterObfuscation>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.PInvokeAttributes | [FlagsAttribute(...)] |
+| System.Reflection.ParameterAttributes | [FlagsAttribute(...)] |
+| System.Reflection.ParameterModifier | [IsReadOnlyAttribute(...)] |
+| System.Reflection.PortableExecutableKinds | [FlagsAttribute(...)] |
+| System.Reflection.PropertyAttributes | [FlagsAttribute(...)] |
+| System.Reflection.ReflectionTypeLoadException.<LoaderExceptions>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.ReflectionTypeLoadException.<Types>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.ResourceAttributes | [FlagsAttribute(...)] |
+| System.Reflection.ResourceLocation | [FlagsAttribute(...)] |
+| System.Reflection.RuntimeAssembly._ModuleResolve | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.RuntimeReflectionExtensions | [ExtensionAttribute(...)] |
+| System.Reflection.SignatureTypeExtensions | [ExtensionAttribute(...)] |
+| System.Reflection.TypeAttributes | [FlagsAttribute(...)] |
+| System.Reflection.TypeInfo.<GetDeclaredMethods>d__10 | [CompilerGeneratedAttribute(...)] |
+| System.Reflection.TypeInfo.<get_DeclaredNestedTypes>d__22 | [CompilerGeneratedAttribute(...)] |
+| System.ResolveEventArgs.<Name>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.ResolveEventArgs.<RequestingAssembly>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Resources.NeutralResourcesLanguageAttribute | [AttributeUsageAttribute(...)] |
+| System.Resources.NeutralResourcesLanguageAttribute.<CultureName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Resources.NeutralResourcesLanguageAttribute.<Location>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Resources.ResourceFallbackManager.<GetEnumerator>d__5 | [CompilerGeneratedAttribute(...)] |
+| System.Resources.ResourceReader.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Resources.ResourceReader.<>c__DisplayClass49_0`1 | [CompilerGeneratedAttribute(...)] |
+| System.Resources.SatelliteContractVersionAttribute | [AttributeUsageAttribute(...)] |
+| System.Resources.SatelliteContractVersionAttribute.<Version>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.AssemblyTargetedPatchBandAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.AssemblyTargetedPatchBandAttribute.<TargetedPatchBand>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.AccessedThroughPropertyAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.AccessedThroughPropertyAttribute.<PropertyName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.AsyncMethodBuilderAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.AsyncMethodBuilderAttribute.<BuilderType>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.AsyncStateMachineAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.StateMachine | [AllowNullAttribute(...)] |
+| System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.StateMachine | [MaybeNullAttribute(...)] |
+| System.Runtime.CompilerServices.CallerArgumentExpressionAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.CallerArgumentExpressionAttribute.<ParameterName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.CallerFilePathAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.CallerLineNumberAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.CallerMemberNameAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.CompilationRelaxations | [FlagsAttribute(...)] |
+| System.Runtime.CompilerServices.CompilationRelaxationsAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.CompilationRelaxationsAttribute.<CompilationRelaxations>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.CompilerGeneratedAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.CompilerGlobalScopeAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.ConditionalWeakTable`2.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredAsyncDisposable | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1.Enumerator | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredTaskAwaitable | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ContractHelper.InternalContractFailed | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.CustomConstantAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.DateTimeConstantAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.DecimalConstantAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.DefaultDependencyAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.DefaultDependencyAttribute.<LoadHint>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.DependencyAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.DependencyAttribute.<DependentAssembly>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.DependencyAttribute.<LoadHint>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.DisablePrivateReflectionAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.EnumeratorCancellationAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.ExtensionAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.FixedAddressValueTypeAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.FixedBufferAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.FixedBufferAttribute.<ElementType>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.FixedBufferAttribute.<Length>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.IndexerNameAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.InternalsVisibleToAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.InternalsVisibleToAttribute.<AllInternalsVisible>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.InternalsVisibleToAttribute.<AssemblyName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.IntrinsicAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.IsByRefLikeAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.IsByRefLikeAttribute | [EditorBrowsableAttribute(...)] |
+| System.Runtime.CompilerServices.IsReadOnlyAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.IsReadOnlyAttribute | [EditorBrowsableAttribute(...)] |
+| System.Runtime.CompilerServices.IteratorStateMachineAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.JitHelpers | [ExtensionAttribute(...)] |
+| System.Runtime.CompilerServices.MethodImplAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.MethodImplAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.MethodImplOptions | [FlagsAttribute(...)] |
+| System.Runtime.CompilerServices.NullableAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.NullableAttribute | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.NullableAttribute | [EmbeddedAttribute(...)] |
+| System.Runtime.CompilerServices.NullableContextAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.NullableContextAttribute | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.NullableContextAttribute | [EmbeddedAttribute(...)] |
+| System.Runtime.CompilerServices.NullablePublicOnlyAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.NullablePublicOnlyAttribute | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.NullablePublicOnlyAttribute | [EmbeddedAttribute(...)] |
+| System.Runtime.CompilerServices.ReferenceAssemblyAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.ReferenceAssemblyAttribute.<Description>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.RuntimeCompatibilityAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.RuntimeCompatibilityAttribute.<WrapNonExceptionThrows>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.SpecialNameAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.StateMachineAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.StateMachineAttribute.<StateMachineType>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.StringFreezingAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.StrongBox`1.Value | [MaybeNullAttribute(...)] |
+| System.Runtime.CompilerServices.SuppressIldasmAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.TaskAwaiter | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.TaskAwaiter.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.TaskAwaiter`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.TupleElementNamesAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.TypeDependencyAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.TypeForwardedFromAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.TypeForwardedFromAttribute.<AssemblyFullName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.TypeForwardedToAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.TypeForwardedToAttribute.<Destination>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.UnsafeValueTypeAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.CompilerServices.ValueTaskAwaiter | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.ValueTaskAwaiter.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.CompilerServices.ValueTaskAwaiter`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.YieldAwaitable | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter | [IsReadOnlyAttribute(...)] |
+| System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.ConstrainedExecution.ReliabilityContractAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.ConstrainedExecution.ReliabilityContractAttribute.<Cer>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.ConstrainedExecution.ReliabilityContractAttribute.<ConsistencyGuarantee>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs.<Exception>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.AllowReversePInvokeCallsAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.BStrWrapper.<WrappedObject>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.BestFitMappingAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.BestFitMappingAttribute.<BestFitMapping>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.ClassInterfaceAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.ClassInterfaceAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.CoClassAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.CoClassAttribute.<CoClass>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.ComDefaultInterfaceAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.ComDefaultInterfaceAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.ComEventInterfaceAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.ComEventInterfaceAttribute.<EventProvider>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.ComEventInterfaceAttribute.<SourceInterface>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.ComImportAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.ComSourceInterfacesAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.ComSourceInterfacesAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.FUNCFLAGS | [FlagsAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IBindCtx | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IConnectionPoint | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IConnectionPointContainer | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IDLFLAG | [FlagsAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IEnumConnectionPoints | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IEnumConnections | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IEnumMoniker | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IEnumString | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IEnumVARIANT | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IMPLTYPEFLAGS | [FlagsAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IMoniker | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.INVOKEKIND | [FlagsAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IPersistFile | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IRunningObjectTable | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.IStream | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.ITypeComp | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.ITypeInfo | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.ITypeInfo2 | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.ITypeLib | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.ITypeLib2 | [InterfaceTypeAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.LIBFLAGS | [FlagsAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.PARAMFLAG | [FlagsAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.TYPEFLAGS | [FlagsAttribute(...)] |
+| System.Runtime.InteropServices.ComTypes.VARFLAGS | [FlagsAttribute(...)] |
+| System.Runtime.InteropServices.ComVisibleAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.ComVisibleAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.CurrencyWrapper.<WrappedObject>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.DefaultCharSetAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.DefaultCharSetAttribute.<CharSet>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute.<Paths>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.DefaultParameterValueAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.DefaultParameterValueAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.DispIdAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.DispIdAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.DispatchWrapper.<WrappedObject>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.DllImportAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.DllImportAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.DllImportSearchPath | [FlagsAttribute(...)] |
+| System.Runtime.InteropServices.ErrorWrapper.<ErrorCode>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.FieldOffsetAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.FieldOffsetAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.GuidAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.GuidAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.HandleRef | [IsReadOnlyAttribute(...)] |
+| System.Runtime.InteropServices.InAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.InterfaceTypeAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.InterfaceTypeAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.LCIDConversionAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.LCIDConversionAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.Marshal.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.MarshalAsAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.MarshalAsAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.MemoryMarshal.<ToEnumerable>d__3`1 | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.NativeCallableAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.OptionalAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.OutAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.PreserveSigAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.ProgIdAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.ProgIdAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.StructLayoutAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.StructLayoutAttribute.<Value>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.TypeIdentifierAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.TypeIdentifierAttribute.<Identifier>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.TypeIdentifierAttribute.<Scope>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.UnknownWrapper.<WrappedObject>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute.<CallingConvention>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.InteropServices.VariantWrapper.<WrappedObject>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Intrinsics.Vector64 | [ExtensionAttribute(...)] |
+| System.Runtime.Intrinsics.Vector64DebugView`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.Intrinsics.Vector64`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Runtime.Intrinsics.Vector64`1 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.Vector64`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.Intrinsics.Vector128 | [ExtensionAttribute(...)] |
+| System.Runtime.Intrinsics.Vector128DebugView`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.Intrinsics.Vector128`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Runtime.Intrinsics.Vector128`1 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.Vector128`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.Intrinsics.Vector256 | [ExtensionAttribute(...)] |
+| System.Runtime.Intrinsics.Vector256DebugView`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.Intrinsics.Vector256`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Runtime.Intrinsics.Vector256`1 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.Vector256`1 | [IsReadOnlyAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Aes | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Avx | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Avx2 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Bmi1 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Bmi1.X64 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Bmi2 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Bmi2.X64 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Fma | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Lzcnt | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Lzcnt.X64 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Pclmulqdq | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Popcnt | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Popcnt.X64 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Sse | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Sse2 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Sse2.X64 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Sse3 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Sse41 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Sse41.X64 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Sse42 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Sse42.X64 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Sse.X64 | [IntrinsicAttribute(...)] |
+| System.Runtime.Intrinsics.X86.Ssse3 | [IntrinsicAttribute(...)] |
+| System.Runtime.Loader.AssemblyDependencyResolver.<>c__DisplayClass6_0 | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Loader.AssemblyDependencyResolver.corehost_error_writer_fn | [UnmanagedFunctionPointerAttribute(...)] |
+| System.Runtime.Loader.AssemblyDependencyResolver.corehost_resolve_component_dependencies_result_fn | [UnmanagedFunctionPointerAttribute(...)] |
+| System.Runtime.Loader.AssemblyLoadContext.<get_All>d__88 | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Loader.AssemblyLoadContext.<get_Assemblies>d__58 | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Loader.AssemblyLoadContext.AssemblyLoad | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Loader.AssemblyLoadContext.AssemblyResolve | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Loader.AssemblyLoadContext.ContextualReflectionScope | [EditorBrowsableAttribute(...)] |
+| System.Runtime.Loader.AssemblyLoadContext.ResourceResolve | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Loader.AssemblyLoadContext.TypeResolve | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Loader.AssemblyLoadContext._resolving | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Loader.AssemblyLoadContext._resolvingUnmanagedDll | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Loader.AssemblyLoadContext._unloading | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Loader.LibraryNameVariation.<DetermineLibraryNameVariations>d__5 | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Serialization.DeserializationToken | [IsReadOnlyAttribute(...)] |
+| System.Runtime.Serialization.DeserializationTracker.<DeserializationInProgress>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Serialization.OnDeserializedAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.Serialization.OnDeserializingAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.Serialization.OnSerializedAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.Serialization.OnSerializingAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.Serialization.OptionalFieldAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.Serialization.SafeSerializationEventArgs.<StreamingContext>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Serialization.SerializationEntry | [IsReadOnlyAttribute(...)] |
+| System.Runtime.Serialization.SerializationInfo.<AsyncDeserializationInProgress>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Serialization.SerializationInfo.<IsAssemblyNameSetExplicit>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Serialization.SerializationInfo.<IsFullTypeNameSetExplicit>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Serialization.StreamingContext | [IsReadOnlyAttribute(...)] |
+| System.Runtime.Serialization.StreamingContextStates | [FlagsAttribute(...)] |
+| System.Runtime.TargetedPatchingOptOutAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.TargetedPatchingOptOutAttribute.<Reason>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Runtime.Versioning.NonVersionableAttribute | [AttributeUsageAttribute(...)] |
+| System.Runtime.Versioning.TargetFrameworkAttribute | [AttributeUsageAttribute(...)] |
+| System.RuntimeArgumentHandle | [IsByRefLikeAttribute(...)] |
+| System.RuntimeType.RuntimeTypeCache.Filter | [IsReadOnlyAttribute(...)] |
+| System.STAThreadAttribute | [AttributeUsageAttribute(...)] |
+| System.Security.AllowPartiallyTrustedCallersAttribute | [AttributeUsageAttribute(...)] |
+| System.Security.AllowPartiallyTrustedCallersAttribute.<PartialTrustVisibilityLevel>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityCriticalAttribute | [AttributeUsageAttribute(...)] |
+| System.Security.SecurityCriticalAttribute.<Scope>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityElement.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityException.<Demanded>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityException.<DenySetInstance>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityException.<FailedAssemblyInfo>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityException.<GrantedSet>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityException.<Method>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityException.<PermissionState>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityException.<PermissionType>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityException.<PermitOnlySetInstance>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityException.<RefusedSet>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityException.<Url>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityRulesAttribute | [AttributeUsageAttribute(...)] |
+| System.Security.SecurityRulesAttribute.<RuleSet>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecurityRulesAttribute.<SkipVerificationInFullTrust>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Security.SecuritySafeCriticalAttribute | [AttributeUsageAttribute(...)] |
+| System.Security.SecurityTransparentAttribute | [AttributeUsageAttribute(...)] |
+| System.Security.SecurityTreatAsSafeAttribute | [AttributeUsageAttribute(...)] |
+| System.Security.SuppressUnmanagedCodeSecurityAttribute | [AttributeUsageAttribute(...)] |
+| System.Security.UnverifiableCodeAttribute | [AttributeUsageAttribute(...)] |
+| System.SerializableAttribute | [AttributeUsageAttribute(...)] |
+| System.SpanHelpers | [ExtensionAttribute(...)] |
+| System.SpanHelpers.ComparerComparable`2 | [IsReadOnlyAttribute(...)] |
+| System.Span`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Span`1 | [IsByRefLikeAttribute(...)] |
+| System.Span`1 | [IsReadOnlyAttribute(...)] |
+| System.Span`1 | [NonVersionableAttribute(...)] |
+| System.Span`1.Enumerator | [IsByRefLikeAttribute(...)] |
+| System.StringSplitOptions | [FlagsAttribute(...)] |
+| System.TermInfo.ParameterizedStrings.FormatParam | [IsReadOnlyAttribute(...)] |
+| System.TermInfo.ParameterizedStrings.t_cachedOneElementArgsArray | [ThreadStaticAttribute(...)] |
+| System.TermInfo.ParameterizedStrings.t_cachedStack | [ThreadStaticAttribute(...)] |
+| System.TermInfo.ParameterizedStrings.t_cachedTwoElementArgsArray | [ThreadStaticAttribute(...)] |
+| System.Text.CodePageDataItem.<BodyName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Text.CodePageDataItem.<CodePage>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Text.CodePageDataItem.<DisplayName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Text.CodePageDataItem.<Flags>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Text.CodePageDataItem.<HeaderName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Text.CodePageDataItem.<UIFamilyCodePage>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Text.CodePageDataItem.<WebName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Text.EncodingExtensions | [ExtensionAttribute(...)] |
+| System.Text.EncodingInfo.<CodePage>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Text.EncodingInfo.<DisplayName>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Text.EncodingInfo.<Name>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Text.Rune | [IsReadOnlyAttribute(...)] |
+| System.Text.SpanRuneEnumerator | [IsByRefLikeAttribute(...)] |
+| System.Text.StringBuilderCache.t_cachedInstance | [ThreadStaticAttribute(...)] |
+| System.Text.StringOrCharArray | [IsReadOnlyAttribute(...)] |
+| System.Text.ValueStringBuilder | [IsByRefLikeAttribute(...)] |
+| System.ThreadStaticAttribute | [AttributeUsageAttribute(...)] |
+| System.Threading.AsyncLocalValueChangedArgs`1 | [IsReadOnlyAttribute(...)] |
+| System.Threading.AsyncLocalValueChangedArgs`1.<CurrentValue>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Threading.AsyncLocalValueChangedArgs`1.<PreviousValue>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Threading.AsyncLocalValueChangedArgs`1.<ThreadContextChanged>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Threading.AsyncLocalValueMap.<Empty>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Threading.CancellationToken | [IsReadOnlyAttribute(...)] |
+| System.Threading.CancellationToken.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.CancellationTokenRegistration | [IsReadOnlyAttribute(...)] |
+| System.Threading.CancellationTokenSource.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.CancellationTokenSource.CallbackNode.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.CancellationTokenSource.LinkedNCancellationTokenSource.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.QueueUserWorkItemCallback.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.ReaderWriterLockSlim.WaiterStates | [FlagsAttribute(...)] |
+| System.Threading.ReaderWriterLockSlim.t_rwc | [ThreadStaticAttribute(...)] |
+| System.Threading.SemaphoreSlim.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.SemaphoreSlim.<WaitUntilCountOrTimeoutAsync>d__33 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.SpinLock | [DebuggerTypeProxyAttribute(...)] |
+| System.Threading.SynchronizationContext.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.AwaitTaskContinuation.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.ConcurrentExclusiveSchedulerPair | [DebuggerTypeProxyAttribute(...)] |
+| System.Threading.Tasks.ConcurrentExclusiveSchedulerPair.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.ConcurrentExclusiveSchedulerPair.ConcurrentExclusiveTaskScheduler | [DebuggerTypeProxyAttribute(...)] |
+| System.Threading.Tasks.ConcurrentExclusiveSchedulerPair.ProcessingMode | [FlagsAttribute(...)] |
+| System.Threading.Tasks.GenericDelegateCache`2.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.InternalTaskOptions | [FlagsAttribute(...)] |
+| System.Threading.Tasks.SingleProducerSingleConsumerQueue`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Threading.Tasks.SingleProducerSingleConsumerQueue`1.<GetEnumerator>d__11 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1.<RunContinuationsAsynchronously>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1._result | [AllowNullAttribute(...)] |
+| System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1._result | [MaybeNullAttribute(...)] |
+| System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags | [FlagsAttribute(...)] |
+| System.Threading.Tasks.SynchronizationContextAwaitTaskContinuation.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.SynchronizationContextAwaitTaskContinuation.<>c__DisplayClass6_0 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.SynchronizationContextTaskScheduler.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Task | [DebuggerTypeProxyAttribute(...)] |
+| System.Threading.Tasks.Task.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Task.<CompletedTask>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Task.<Factory>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Task.DelayPromise.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Task.DelayPromiseWithCancellation.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Task.t_currentTask | [ThreadStaticAttribute(...)] |
+| System.Threading.Tasks.TaskAsyncEnumerableExtensions | [ExtensionAttribute(...)] |
+| System.Threading.Tasks.TaskContinuationOptions | [FlagsAttribute(...)] |
+| System.Threading.Tasks.TaskCreationOptions | [FlagsAttribute(...)] |
+| System.Threading.Tasks.TaskExtensions | [ExtensionAttribute(...)] |
+| System.Threading.Tasks.TaskFactory`1.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.TaskFactory`1.<>c__DisplayClass32_0 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.TaskFactory`1.<>c__DisplayClass35_0 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.TaskFactory`1.<>c__DisplayClass38_0`1 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.TaskFactory`1.<>c__DisplayClass41_0`2 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.TaskFactory`1.<>c__DisplayClass44_0`3 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.TaskFactory`1.FromAsyncTrimPromise`1.m_thisRef | [AllowNullAttribute(...)] |
+| System.Threading.Tasks.TaskFactory`1.FromAsyncTrimPromise`1.m_thisRef | [MaybeNullAttribute(...)] |
+| System.Threading.Tasks.TaskScheduler | [DebuggerTypeProxyAttribute(...)] |
+| System.Threading.Tasks.TaskScheduler.UnobservedTaskException | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.TaskSchedulerAwaitTaskContinuation.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.TaskToApm.<>c__DisplayClass3_0 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Task`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Threading.Tasks.Task`1.TaskWhenAnyCast.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.Task`1.m_result | [MaybeNullAttribute(...)] |
+| System.Threading.Tasks.ThreadPoolTaskScheduler.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.ThreadPoolTaskScheduler.<FilterTasksFromWorkItems>d__6 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.UnwrapPromise`1.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.ValueTask | [AsyncMethodBuilderAttribute(...)] |
+| System.Threading.Tasks.ValueTask | [IsReadOnlyAttribute(...)] |
+| System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.ValueTask`1 | [AsyncMethodBuilderAttribute(...)] |
+| System.Threading.Tasks.ValueTask`1 | [IsReadOnlyAttribute(...)] |
+| System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.Tasks.ValueTask`1._result | [AllowNullAttribute(...)] |
+| System.Threading.Thread.t_currentProcessorIdCache | [ThreadStaticAttribute(...)] |
+| System.Threading.Thread.t_currentThread | [ThreadStaticAttribute(...)] |
+| System.Threading.ThreadHandle | [IsReadOnlyAttribute(...)] |
+| System.Threading.ThreadLocal`1 | [DebuggerTypeProxyAttribute(...)] |
+| System.Threading.ThreadLocal`1.LinkedSlot._value | [AllowNullAttribute(...)] |
+| System.Threading.ThreadLocal`1.LinkedSlot._value | [MaybeNullAttribute(...)] |
+| System.Threading.ThreadLocal`1.ts_finalizationHelper | [ThreadStaticAttribute(...)] |
+| System.Threading.ThreadLocal`1.ts_slotArray | [ThreadStaticAttribute(...)] |
+| System.Threading.ThreadPool.<GetLocallyQueuedWorkItems>d__51 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.ThreadPool.<GetQueuedWorkItems>d__50 | [CompilerGeneratedAttribute(...)] |
+| System.Threading.ThreadPoolGlobals.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.ThreadPoolWorkQueueThreadLocals.threadLocals | [ThreadStaticAttribute(...)] |
+| System.Threading.ThreadState | [FlagsAttribute(...)] |
+| System.Threading.TimerQueue.<ActiveCount>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Threading.TimerQueue.<Instances>k__BackingField | [CompilerGeneratedAttribute(...)] |
+| System.Threading.TimerQueueTimer.<>c | [CompilerGeneratedAttribute(...)] |
+| System.Threading.WaitHandle.t_safeWaitHandlesForRent | [ThreadStaticAttribute(...)] |
+| System.Threading.WaitHandleExtensions | [ExtensionAttribute(...)] |
+| System.ThrowHelper | [StackTraceHiddenAttribute(...)] |
+| System.TimeSpan | [IsReadOnlyAttribute(...)] |
+| System.TimeZoneInfo.<>c | [CompilerGeneratedAttribute(...)] |
+| System.TimeZoneInfo.<>c__DisplayClass125_0 | [CompilerGeneratedAttribute(...)] |
+| System.TimeZoneInfo.TransitionTime | [IsReadOnlyAttribute(...)] |
+| System.TimeZoneInfoOptions | [FlagsAttribute(...)] |
+| System.TupleExtensions | [ExtensionAttribute(...)] |
+| System.Type.<>c | [CompilerGeneratedAttribute(...)] |
+| System.TypedReference | [IsByRefLikeAttribute(...)] |
+| System.TypedReference | [NonVersionableAttribute(...)] |
+| System.UIntPtr | [IsReadOnlyAttribute(...)] |
+| System.UIntPtr.Zero | [IntrinsicAttribute(...)] |
+| System.__Canon | [ClassInterfaceAttribute(...)] |
+| System.__DTString | [IsByRefLikeAttribute(...)] |
+| bool | [IsReadOnlyAttribute(...)] |
+| byte | [IsReadOnlyAttribute(...)] |
+| char | [IsReadOnlyAttribute(...)] |
+| decimal | [IsReadOnlyAttribute(...)] |
+| decimal | [NonVersionableAttribute(...)] |
+| double | [IsReadOnlyAttribute(...)] |
+| float | [IsReadOnlyAttribute(...)] |
+| int | [IsReadOnlyAttribute(...)] |
+| long | [IsReadOnlyAttribute(...)] |
+| object | [ClassInterfaceAttribute(...)] |
+| object[] System.Collections.ArrayList.ArrayListDebugView.Items | [DebuggerBrowsableAttribute(...)] |
+| sbyte | [IsReadOnlyAttribute(...)] |
+| short | [IsReadOnlyAttribute(...)] |
+| string.Empty | [IntrinsicAttribute(...)] |
+| uint | [IsReadOnlyAttribute(...)] |
+| ulong | [IsReadOnlyAttribute(...)] |
+| ushort | [IsReadOnlyAttribute(...)] |
+attrArgNamed
+| System.Buffers.ArrayPoolEventSource | [EventSourceAttribute(...)] | Guid | 0866B2B8-5CEF-5DB9-2612-0C0FFD814A44 |
+| System.Buffers.ArrayPoolEventSource | [EventSourceAttribute(...)] | Name | System.Buffers.ArrayPoolEventSource |
+| System.Collections.KeyValuePairs | [DebuggerDisplayAttribute(...)] | Name | [{_key}] |
+| System.Diagnostics.Tracing.FrameworkEventSource | [EventSourceAttribute(...)] | Guid | 8E9F5090-2D75-4d03-8A81-E5AFBF85DAF1 |
+| System.Diagnostics.Tracing.FrameworkEventSource | [EventSourceAttribute(...)] | Name | System.Diagnostics.Eventing.FrameworkEventSource |
+| System.Diagnostics.Tracing.NativeRuntimeEventSource | [EventSourceAttribute(...)] | Guid | 5E5BB766-BBFC-5662-0548-1D44FAD9BB56 |
+| System.Diagnostics.Tracing.NativeRuntimeEventSource | [EventSourceAttribute(...)] | Name | Microsoft-Windows-DotNETRuntime |
+| System.Diagnostics.Tracing.RuntimeEventSource | [EventSourceAttribute(...)] | Guid | 49592C0F-5A05-516D-AA4B-A64E02026C89 |
+| System.Diagnostics.Tracing.RuntimeEventSource | [EventSourceAttribute(...)] | Name | System.Runtime |
+| System.Globalization.CompareInfo.m_SortVersion | [OptionalFieldAttribute(...)] | VersionAdded | 3 |
+| System.Globalization.CompareInfo.m_name | [OptionalFieldAttribute(...)] | VersionAdded | 2 |
+| System.Text.Encoding._isReadOnly | [OptionalFieldAttribute(...)] | VersionAdded | 2 |
+| System.Threading.Tasks.TplEventSource | [EventSourceAttribute(...)] | Guid | 2e5dba47-a3d2-4d16-8ee0-6671ffdcd7b5 |
+| System.Threading.Tasks.TplEventSource | [EventSourceAttribute(...)] | LocalizationResources | System.Private.CoreLib.Resources.Strings |
+| System.Threading.Tasks.TplEventSource | [EventSourceAttribute(...)] | Name | System.Threading.Tasks.TplEventSource |
+attrArgPositional
+| !0 System.ArraySegment`1.Enumerator.Current | [NullableAttribute(...)] | 0 | 1 |
+| !0 System.Collections.Generic.Dictionary`2.KeyCollection.Enumerator.Current | [NullableAttribute(...)] | 0 | 1 |
+| !0 System.Collections.Generic.IAsyncEnumerator`1.Current | [NullableAttribute(...)] | 0 | 1 |
+| !0 System.Collections.Generic.IEnumerator`1.Current | [NullableAttribute(...)] | 0 | 1 |
+| !0 System.Collections.Generic.List`1.Enumerator.Current | [NullableAttribute(...)] | 0 | 1 |
+| !0 System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1.Enumerator.Current | [NullableAttribute(...)] | 0 | 1 |
+| !0 System.Tuple`1.Item1 | [NullableAttribute(...)] | 0 | 1 |
+| !0 System.Tuple`2.Item1 | [NullableAttribute(...)] | 0 | 1 |
+| !0[] System.ArraySegment`1.Array | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| !1 System.Collections.Generic.Dictionary`2.ValueCollection.Enumerator.Current | [NullableAttribute(...)] | 0 | 1 |
+| !1 System.Tuple`2.Item2 | [NullableAttribute(...)] | 0 | 1 |
+| Internal.Runtime.CompilerServices.Unsafe | [CLSCompliantAttribute(...)] | 0 | False |
+| Internal.Runtime.CompilerServices.Unsafe | [NullableAttribute(...)] | 0 | 0 |
+| Internal.Runtime.CompilerServices.Unsafe | [NullableContextAttribute(...)] | 0 | 1 |
+| Internal.Threading.Tasks.AsyncCausalitySupport | [NullableAttribute(...)] | 0 | 0 |
+| Internal.Threading.Tasks.AsyncCausalitySupport | [NullableContextAttribute(...)] | 0 | 1 |
+| System.AccessViolationException | [NullableAttribute(...)] | 0 | 0 |
+| System.AccessViolationException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.AccessViolationException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Action`4 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`4 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`5 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`5 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`6 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`6 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`7 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`7 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`8 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`8 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`9 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`9 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`10 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`10 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`11 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`11 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`12 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`12 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`13 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`13 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`14 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`14 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`15 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`15 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Action`16 | [NullableAttribute(...)] | 0 | 0 |
+| System.Action`16 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Activator | [NullableAttribute(...)] | 0 | 0 |
+| System.Activator | [NullableContextAttribute(...)] | 0 | 1 |
+| System.AggregateException | [DebuggerDisplayAttribute(...)] | 0 | Count = {InnerExceptionCount} |
+| System.AggregateException | [NullableAttribute(...)] | 0 | 0 |
+| System.AggregateException | [NullableContextAttribute(...)] | 0 | 1 |
+| System.AggregateException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.AggregateException System.Threading.Tasks.Task.Exception | [NullableAttribute(...)] | 0 | 2 |
+| System.AppContext | [NullableAttribute(...)] | 0 | 0 |
+| System.AppContext | [NullableContextAttribute(...)] | 0 | 2 |
+| System.AppContext.FirstChanceException | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.AppDomain | [NullableAttribute(...)] | 0 | 0 |
+| System.AppDomain | [NullableContextAttribute(...)] | 0 | 2 |
+| System.AppDomain System.AppDomain.CurrentDomain | [NullableAttribute(...)] | 0 | 1 |
+| System.AppDomain.FirstChanceException | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.AppDomainSetup | [NullableAttribute(...)] | 0 | 0 |
+| System.AppDomainSetup | [NullableContextAttribute(...)] | 0 | 2 |
+| System.AppDomainSetup System.AppDomain.SetupInformation | [NullableAttribute(...)] | 0 | 1 |
+| System.ApplicationException | [NullableAttribute(...)] | 0 | 0 |
+| System.ApplicationException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.ApplicationException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ArgumentException | [NullableAttribute(...)] | 0 | 0 |
+| System.ArgumentException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.ArgumentException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ArgumentNullException | [NullableAttribute(...)] | 0 | 0 |
+| System.ArgumentNullException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.ArgumentNullException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ArgumentOutOfRangeException | [NullableAttribute(...)] | 0 | 0 |
+| System.ArgumentOutOfRangeException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.ArgumentOutOfRangeException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ArithmeticException | [NullableAttribute(...)] | 0 | 0 |
+| System.ArithmeticException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.ArithmeticException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Array | [NullableAttribute(...)] | 0 | 0 |
+| System.Array | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Array | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ArraySegment<!0> System.ArraySegment`1.Empty | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.ArraySegment`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.ArraySegment`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.ArraySegment`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ArraySegment`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ArraySegment`1.Enumerator | [NullableContextAttribute(...)] | 0 | 0 |
+| System.ArrayTypeMismatchException | [NullableAttribute(...)] | 0 | 0 |
+| System.ArrayTypeMismatchException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.ArrayTypeMismatchException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.AssemblyLoadEventArgs | [NullableAttribute(...)] | 0 | 0 |
+| System.AssemblyLoadEventArgs | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Attribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Attribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Attribute | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.BadImageFormatException | [NullableAttribute(...)] | 0 | 0 |
+| System.BadImageFormatException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.BadImageFormatException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.BitConverter | [NullableAttribute(...)] | 0 | 0 |
+| System.BitConverter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.BitConverter.<>c.<>9__39_0 | [TupleElementNamesAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Buffer | [NullableAttribute(...)] | 0 | 0 |
+| System.Buffer | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Buffers.ArrayPool`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Buffers.ArrayPool`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ByReference`1 | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.ByReference`1 | [ObsoleteAttribute(...)] | 1 | True |
+| System.CannotUnloadAppDomainException | [NullableAttribute(...)] | 0 | 0 |
+| System.CannotUnloadAppDomainException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.CannotUnloadAppDomainException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.ArrayList | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Collections.ArrayList | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ArrayList | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.ArrayList | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.ArrayList | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.ArrayList.FixedSizeArrayList | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ArrayList.FixedSizeList | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ArrayList.IListWrapper | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ArrayList.Range | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ArrayList.ReadOnlyArrayList | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ArrayList.ReadOnlyList | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ArrayList.SyncArrayList | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ArrayList.SyncIList | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.Comparer | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.Comparer | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Comparer | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Concurrent.ConcurrentQueueSegment`1 | [DebuggerDisplayAttribute(...)] | 0 | Capacity = {Capacity} |
+| System.Collections.Concurrent.ConcurrentQueueSegment`1.Slot | [DebuggerDisplayAttribute(...)] | 0 | Item = {Item}, SequenceNumber = {SequenceNumber} |
+| System.Collections.Concurrent.ConcurrentQueue`1 | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Collections.Concurrent.ConcurrentQueue`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.Concurrent.ConcurrentQueue`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Concurrent.IProducerConsumerCollection`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Concurrent.PaddedHeadAndTail | [DebuggerDisplayAttribute(...)] | 0 | Head = {Head}, Tail = {Tail} |
+| System.Collections.DictionaryEntry | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.DictionaryEntry | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.DictionaryEntry | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.EmptyReadOnlyDictionaryInternal | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.Generic.ArraySortHelper`1 | [TypeDependencyAttribute(...)] | 0 | System.Collections.Generic.GenericArraySortHelper`1 |
+| System.Collections.Generic.ArraySortHelper`2 | [TypeDependencyAttribute(...)] | 0 | System.Collections.Generic.GenericArraySortHelper`2 |
+| System.Collections.Generic.ByteEqualityComparer | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.Comparer`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.Generic.Comparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.Comparer`1 | [TypeDependencyAttribute(...)] | 0 | System.Collections.Generic.ObjectComparer`1 |
+| System.Collections.Generic.Comparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.Dictionary<!0,!1>.KeyCollection System.Collections.Generic.Dictionary`2.Keys | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.Dictionary<!0,!1>.ValueCollection System.Collections.Generic.Dictionary`2.Values | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.Dictionary`2 | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Collections.Generic.Dictionary`2 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.Generic.Dictionary`2 | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.Generic.Dictionary`2 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.Dictionary`2 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.Dictionary`2.Enumerator | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Collections.Generic.Dictionary`2.KeyCollection | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Collections.Generic.Dictionary`2.KeyCollection | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Collections.Generic.Dictionary`2.ValueCollection | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Collections.Generic.Dictionary`2.ValueCollection | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Collections.Generic.EnumEqualityComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.EqualityComparer`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.Generic.EqualityComparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.EqualityComparer`1 | [TypeDependencyAttribute(...)] | 0 | System.Collections.Generic.ObjectEqualityComparer`1 |
+| System.Collections.Generic.EqualityComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.GenericComparer`1 | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.GenericComparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.GenericComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.GenericEqualityComparer`1 | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.GenericEqualityComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.IAsyncEnumerable`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.ICollection`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.IComparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.IDictionary<System.String,System.String> System.Diagnostics.Tracing.EventCommandEventArgs.Arguments | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.IDictionary`2 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.Generic.IDictionary`2 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.IEqualityComparer<System.String> System.Collections.Generic.NonRandomizedStringEqualityComparer.Default | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.IEqualityComparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.IList<System.String> System.Runtime.CompilerServices.TupleElementNamesAttribute.TransformNames | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.IList`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.Generic.IList`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.IReadOnlyDictionary`2 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.Generic.IReadOnlyDictionary`2 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.IReadOnlyList`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.Generic.IReadOnlyList`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.ISet`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.KeyNotFoundException | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.Generic.KeyNotFoundException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Collections.Generic.KeyNotFoundException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.KeyValuePair<!0,!1> System.Collections.Generic.Dictionary`2.Enumerator.Current | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.KeyValuePair`2 | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.Generic.KeyValuePair`2 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.KeyValuePair`2 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.List<!0> System.Threading.ThreadLocal`1.ValuesForDebugDisplay | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.List`1 | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Collections.Generic.List`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.Generic.List`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.Generic.List`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.List`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.List`1.Enumerator | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Collections.Generic.NonRandomizedStringEqualityComparer | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.NonRandomizedStringEqualityComparer | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Collections.Generic.NullableComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.NullableEqualityComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.ObjectComparer`1 | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.ObjectComparer`1 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Collections.Generic.ObjectComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.ObjectEqualityComparer`1 | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.Generic.ObjectEqualityComparer`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Generic.ObjectEqualityComparer`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Generic.ValueListBuilder`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.Generic.ValueListBuilder`1 | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Collections.Generic.ValueListBuilder`1 | [ObsoleteAttribute(...)] | 1 | True |
+| System.Collections.Hashtable | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Collections.Hashtable | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.Hashtable | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.Hashtable | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.Hashtable | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.Hashtable.SyncHashtable | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ICollection | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.IComparer | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Collections.IComparer System.Collections.Hashtable.comparer | [NullableAttribute(...)] | 0 | 2 |
+| System.Collections.IComparer System.Collections.Hashtable.comparer | [ObsoleteAttribute(...)] | 0 | Please use KeyComparer properties. |
+| System.Collections.IDictionary | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.IDictionary | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.IDictionary System.Exception.Data | [NullableAttribute(...)] | 0 | 1 |
+| System.Collections.IDictionaryEnumerator | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.IEnumerable | [ComVisibleAttribute(...)] | 0 | True |
+| System.Collections.IEnumerable | [GuidAttribute(...)] | 0 | 496B0ABE-CDEE-11d3-88E8-00902754C43A |
+| System.Collections.IEnumerable | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.IEnumerator | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Collections.IEqualityComparer | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.IEqualityComparer System.Collections.Hashtable.EqualityComparer | [NullableAttribute(...)] | 0 | 2 |
+| System.Collections.IHashCodeProvider | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.IHashCodeProvider | [ObsoleteAttribute(...)] | 0 | Please use IEqualityComparer instead. |
+| System.Collections.IHashCodeProvider | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.IHashCodeProvider System.Collections.Hashtable.hcp | [NullableAttribute(...)] | 0 | 2 |
+| System.Collections.IHashCodeProvider System.Collections.Hashtable.hcp | [ObsoleteAttribute(...)] | 0 | Please use EqualityComparer property. |
+| System.Collections.IList | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.IList | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Collections.IStructuralComparable | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.IStructuralEquatable | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.KeyValuePairs | [DebuggerDisplayAttribute(...)] | 0 | {_value} |
+| System.Collections.ListDictionaryInternal | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ListDictionaryInternal | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.ListDictionaryInternal | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.ListDictionaryInternal | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.ObjectModel.Collection`1 | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Collections.ObjectModel.Collection`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ObjectModel.Collection`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.ObjectModel.Collection`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.ObjectModel.Collection`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Collections.ObjectModel.ReadOnlyCollection<System.String> System.Diagnostics.Tracing.EventWrittenEventArgs.PayloadNames | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Collections.ObjectModel.ReadOnlyCollection`1 | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Collections.ObjectModel.ReadOnlyCollection`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Collections.ObjectModel.ReadOnlyCollection`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Collections.ObjectModel.ReadOnlyCollection`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Collections.ObjectModel.ReadOnlyCollection`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ComponentModel.DefaultValueAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.ComponentModel.DefaultValueAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Convert | [NullableAttribute(...)] | 0 | 0 |
+| System.Convert | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Convert.DBNull | [NullableAttribute(...)] | 0 | 1 |
+| System.CultureAwareComparer | [NullableAttribute(...)] | 0 | 0 |
+| System.CultureAwareComparer | [NullableContextAttribute(...)] | 0 | 2 |
+| System.CultureAwareComparer | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.CurrentSystemTimeZone | [ObsoleteAttribute(...)] | 0 | System.CurrentSystemTimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo.Local instead. |
+| System.DBNull | [NullableAttribute(...)] | 0 | 0 |
+| System.DBNull | [NullableContextAttribute(...)] | 0 | 1 |
+| System.DTSubString | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.DTSubString | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.DTSubString | [ObsoleteAttribute(...)] | 1 | True |
+| System.DataMisalignedException | [NullableAttribute(...)] | 0 | 0 |
+| System.DataMisalignedException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.DataMisalignedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.DateTime | [NullableAttribute(...)] | 0 | 0 |
+| System.DateTime | [NullableContextAttribute(...)] | 0 | 1 |
+| System.DateTime | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.DateTimeOffset | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.DateTimeResult | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.DateTimeResult | [ObsoleteAttribute(...)] | 1 | True |
+| System.Delegate | [ComVisibleAttribute(...)] | 0 | True |
+| System.Delegate | [NullableAttribute(...)] | 0 | 0 |
+| System.Delegate | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.CodeAnalysis.SuppressMessageAttribute | [ConditionalAttribute(...)] | 0 | CODE_ANALYSIS |
+| System.Diagnostics.CodeAnalysis.SuppressMessageAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.CodeAnalysis.SuppressMessageAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.ConditionalAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.ConditionalAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Contracts.Contract | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Contracts.Contract | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Contracts.Contract.ContractFailed | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Diagnostics.Contracts.ContractAbbreviatorAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
+| System.Diagnostics.Contracts.ContractArgumentValidatorAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
+| System.Diagnostics.Contracts.ContractClassAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
+| System.Diagnostics.Contracts.ContractClassAttribute | [ConditionalAttribute(...)] | 0 | DEBUG |
+| System.Diagnostics.Contracts.ContractClassAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Contracts.ContractClassAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Contracts.ContractClassForAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
+| System.Diagnostics.Contracts.ContractClassForAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Contracts.ContractClassForAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Contracts.ContractException | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Contracts.ContractException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.Contracts.ContractException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Diagnostics.Contracts.ContractFailedEventArgs | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Contracts.ContractFailedEventArgs | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.Contracts.ContractFailureKind | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Diagnostics.Contracts.ContractInvariantMethodAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
+| System.Diagnostics.Contracts.ContractOptionAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
+| System.Diagnostics.Contracts.ContractOptionAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Contracts.ContractOptionAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Contracts.ContractPublicPropertyNameAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
+| System.Diagnostics.Contracts.ContractPublicPropertyNameAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Contracts.ContractPublicPropertyNameAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Contracts.ContractRuntimeIgnoredAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
+| System.Diagnostics.Contracts.ContractVerificationAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
+| System.Diagnostics.Contracts.PureAttribute | [ConditionalAttribute(...)] | 0 | CONTRACTS_FULL |
+| System.Diagnostics.Debug | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Debug | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.DebugProvider | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.DebugProvider | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.Debugger | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Debugger | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.DebuggerDisplayAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.DebuggerDisplayAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.DebuggerTypeProxyAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.DebuggerTypeProxyAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.DebuggerVisualizerAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.DebuggerVisualizerAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.StackFrame | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.StackFrame | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.StackTrace | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.StackTrace | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.SymbolStore.ISymbolDocumentWriter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Tracing.DiagnosticCounter | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.DiagnosticCounter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Tracing.EventAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.EventAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.Tracing.EventCounter | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.EventCounter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Tracing.EventDataAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.EventDataAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.Tracing.EventListener | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.EventListener | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Tracing.EventListener.EventSourceCreated | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Diagnostics.Tracing.EventListener.EventWritten | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Diagnostics.Tracing.EventPayload | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Diagnostics.Tracing.EventSource | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.EventSource | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.Tracing.EventSource System.Diagnostics.Tracing.EventWrittenEventArgs.EventSource | [NullableAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Tracing.EventSource.EventCommandExecuted | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Diagnostics.Tracing.EventSource.EventData | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.EventSourceAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.EventSourceAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.Tracing.EventSourceCreatedEventArgs | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.EventSourceCreatedEventArgs | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.Tracing.EventSourceException | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.EventSourceException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.Tracing.EventWrittenEventArgs | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.EventWrittenEventArgs | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Diagnostics.Tracing.IncrementingEventCounter | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.IncrementingEventCounter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Tracing.IncrementingPollingCounter | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.IncrementingPollingCounter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Tracing.PollingCounter | [NullableAttribute(...)] | 0 | 0 |
+| System.Diagnostics.Tracing.PollingCounter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Diagnostics.Tracing.SessionMask | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Diagnostics.Tracing.TraceLoggingEventHandleTable | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.DivideByZeroException | [NullableAttribute(...)] | 0 | 0 |
+| System.DivideByZeroException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.DivideByZeroException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.DllNotFoundException | [NullableAttribute(...)] | 0 | 0 |
+| System.DllNotFoundException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.DllNotFoundException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.DuplicateWaitObjectException | [NullableAttribute(...)] | 0 | 0 |
+| System.DuplicateWaitObjectException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.DuplicateWaitObjectException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.EntryPointNotFoundException | [NullableAttribute(...)] | 0 | 0 |
+| System.EntryPointNotFoundException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.EntryPointNotFoundException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Enum | [NullableAttribute(...)] | 0 | 0 |
+| System.Enum | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Enum | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Environment | [NullableAttribute(...)] | 0 | 0 |
+| System.Environment | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Environment.SpecialFolder | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Environment.SpecialFolderOption | [NullableContextAttribute(...)] | 0 | 0 |
+| System.EventArgs | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.EventArgs.Empty | [NullableAttribute(...)] | 0 | 1 |
+| System.Exception | [NullableAttribute(...)] | 0 | 0 |
+| System.Exception | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Exception | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Exception.SerializeObjectState | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Exception[] System.Reflection.ReflectionTypeLoadException.LoaderExceptions | [NullableAttribute(...)] | 0 | 2 |
+| System.ExecutionEngineException | [NullableAttribute(...)] | 0 | 0 |
+| System.ExecutionEngineException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.ExecutionEngineException | [ObsoleteAttribute(...)] | 0 | This type previously indicated an unspecified fatal error in the runtime. The runtime no longer raises this exception so this type is obsolete. |
+| System.ExecutionEngineException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.FieldAccessException | [NullableAttribute(...)] | 0 | 0 |
+| System.FieldAccessException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.FieldAccessException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.FormatException | [NullableAttribute(...)] | 0 | 0 |
+| System.FormatException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.FormatException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.FormattableString | [NullableAttribute(...)] | 0 | 0 |
+| System.FormattableString | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Func`5 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`5 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`6 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`6 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`7 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`7 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`8 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`8 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`9 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`9 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`10 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`10 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`11 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`11 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`12 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`12 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`13 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`13 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`14 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`14 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`15 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`15 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`16 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`16 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Func`17 | [NullableAttribute(...)] | 0 | 0 |
+| System.Func`17 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.GC | [NullableAttribute(...)] | 0 | 0 |
+| System.GC | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.Calendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.Calendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.ChineseLunisolarCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.ChineseLunisolarCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.CompareInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.CompareInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.CompareInfo | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Globalization.CultureInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.CultureInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.CultureInfo System.Globalization.CultureInfo.DefaultThreadCurrentCulture | [NullableAttribute(...)] | 0 | 2 |
+| System.Globalization.CultureInfo System.Globalization.CultureInfo.DefaultThreadCurrentUICulture | [NullableAttribute(...)] | 0 | 2 |
+| System.Globalization.CultureNotFoundException | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.CultureNotFoundException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Globalization.CultureNotFoundException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Globalization.CultureTypes.FrameworkCultures | [ObsoleteAttribute(...)] | 0 | This value has been deprecated.  Please use other values in CultureTypes. |
+| System.Globalization.CultureTypes.WindowsOnlyCultures | [ObsoleteAttribute(...)] | 0 | This value has been deprecated.  Please use other values in CultureTypes. |
+| System.Globalization.DateTimeFormatInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.DateTimeFormatInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.EraInfo[] System.Globalization.ChineseLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Globalization.EraInfo[] System.Globalization.EastAsianLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Globalization.EraInfo[] System.Globalization.JapaneseLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Globalization.EraInfo[] System.Globalization.KoreanLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Globalization.EraInfo[] System.Globalization.TaiwanLunisolarCalendar.CalEraInfo | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Globalization.GregorianCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.GregorianCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.HebrewCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.HebrewCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.HijriCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.HijriCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.IdnMapping | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.IdnMapping | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.JapaneseCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.JapaneseCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.JapaneseLunisolarCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.JapaneseLunisolarCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.JulianCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.JulianCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.KoreanCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.KoreanCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.KoreanLunisolarCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.KoreanLunisolarCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.NumberFormatInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.NumberFormatInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.PersianCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.PersianCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.RegionInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.RegionInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.SortKey | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.SortKey | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.SortVersion | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.SortVersion | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Globalization.SortVersion | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Globalization.StringInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.StringInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.TaiwanCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.TaiwanCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.TaiwanLunisolarCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.TaiwanLunisolarCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.TextElementEnumerator | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.TextElementEnumerator | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.TextInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.TextInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.ThaiBuddhistCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.ThaiBuddhistCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Globalization.TimeSpanParse.StringParser | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Globalization.TimeSpanParse.StringParser | [ObsoleteAttribute(...)] | 1 | True |
+| System.Globalization.TimeSpanParse.TimeSpanRawInfo | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Globalization.TimeSpanParse.TimeSpanRawInfo | [ObsoleteAttribute(...)] | 1 | True |
+| System.Globalization.TimeSpanParse.TimeSpanResult | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Globalization.TimeSpanParse.TimeSpanResult | [ObsoleteAttribute(...)] | 1 | True |
+| System.Globalization.TimeSpanParse.TimeSpanToken | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Globalization.TimeSpanParse.TimeSpanToken | [ObsoleteAttribute(...)] | 1 | True |
+| System.Globalization.TimeSpanParse.TimeSpanTokenizer | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Globalization.TimeSpanParse.TimeSpanTokenizer | [ObsoleteAttribute(...)] | 1 | True |
+| System.Globalization.UmAlQuraCalendar | [NullableAttribute(...)] | 0 | 0 |
+| System.Globalization.UmAlQuraCalendar | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Guid | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.HashCode | [NullableAttribute(...)] | 0 | 0 |
+| System.HashCode | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IAsyncResult | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ICloneable | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IComparable | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IComparable`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IConvertible | [CLSCompliantAttribute(...)] | 0 | False |
+| System.IConvertible | [NullableContextAttribute(...)] | 0 | 2 |
+| System.ICustomFormatter | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IEquatable`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IFormatProvider | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IFormattable | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IO.BinaryReader | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.BinaryReader | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IO.BinaryWriter | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.BinaryWriter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IO.DirectoryNotFoundException | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.DirectoryNotFoundException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IO.DirectoryNotFoundException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.IO.EndOfStreamException | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.EndOfStreamException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IO.EndOfStreamException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.IO.FileLoadException | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.FileLoadException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IO.FileLoadException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.IO.FileNotFoundException | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.FileNotFoundException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IO.FileNotFoundException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.IO.FileStream | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.FileStream | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IO.IOException | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.IOException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IO.IOException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.IO.MemoryStream | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.MemoryStream | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IO.Path.<>c.<>9__37_0 | [TupleElementNamesAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.IO.Path.<>c.<>9__38_0 | [TupleElementNamesAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.IO.Path.<>c.<>9__39_0 | [TupleElementNamesAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.IO.Path.InvalidPathChars | [NullableAttribute(...)] | 0 | 1 |
+| System.IO.Path.InvalidPathChars | [ObsoleteAttribute(...)] | 0 | Please use GetInvalidPathChars or GetInvalidFileNameChars instead. |
+| System.IO.PathTooLongException | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.PathTooLongException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IO.PathTooLongException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.IO.Stream | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.Stream | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IO.StreamReader | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.StreamReader | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IO.StreamWriter | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.StreamWriter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IO.TextReader | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.TextReader | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IO.TextWriter | [NullableAttribute(...)] | 0 | 0 |
+| System.IO.TextWriter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IObservable`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IObserver`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IProgress`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.IndexOutOfRangeException | [NullableAttribute(...)] | 0 | 0 |
+| System.IndexOutOfRangeException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.IndexOutOfRangeException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.InsufficientExecutionStackException | [NullableAttribute(...)] | 0 | 0 |
+| System.InsufficientExecutionStackException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.InsufficientExecutionStackException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.InsufficientMemoryException | [NullableAttribute(...)] | 0 | 0 |
+| System.InsufficientMemoryException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.InsufficientMemoryException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.IntPtr | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.IntPtr System.IO.FileStream.Handle | [ObsoleteAttribute(...)] | 0 | This property has been deprecated.  Please use FileStream's SafeFileHandle property instead.  https://go.microsoft.com/fwlink/?linkid=14202 |
+| System.IntPtr System.Threading.WaitHandle.Handle | [ObsoleteAttribute(...)] | 0 | Use the SafeWaitHandle property instead. |
+| System.InvalidCastException | [NullableAttribute(...)] | 0 | 0 |
+| System.InvalidCastException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.InvalidCastException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.InvalidOperationException | [NullableAttribute(...)] | 0 | 0 |
+| System.InvalidOperationException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.InvalidOperationException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.InvalidProgramException | [NullableAttribute(...)] | 0 | 0 |
+| System.InvalidProgramException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.InvalidProgramException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.InvalidTimeZoneException | [NullableAttribute(...)] | 0 | 0 |
+| System.InvalidTimeZoneException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.InvalidTimeZoneException | [TypeForwardedFromAttribute(...)] | 0 | System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Lazy`1 | [DebuggerDisplayAttribute(...)] | 0 | ThreadSafetyMode={Mode}, IsValueCreated={IsValueCreated}, IsValueFaulted={IsValueFaulted}, Value={ValueForDebugDisplay} |
+| System.Lazy`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Lazy`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Lazy`2 | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Lazy`2 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.MarshalByRefObject | [ComVisibleAttribute(...)] | 0 | True |
+| System.MarshalByRefObject | [NullableAttribute(...)] | 0 | 0 |
+| System.MarshalByRefObject | [NullableContextAttribute(...)] | 0 | 1 |
+| System.MemberAccessException | [NullableAttribute(...)] | 0 | 0 |
+| System.MemberAccessException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.MemberAccessException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Memory<!0> System.Buffers.IMemoryOwner`1.Memory | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Memory<!0> System.Buffers.MemoryManager`1.Memory | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Memory<!0> System.Memory`1.Empty | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Memory`1 | [DebuggerDisplayAttribute(...)] | 0 | {ToString(),raw} |
+| System.Memory`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Memory`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.MethodAccessException | [NullableAttribute(...)] | 0 | 0 |
+| System.MethodAccessException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.MethodAccessException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.MissingFieldException | [NullableAttribute(...)] | 0 | 0 |
+| System.MissingFieldException | [NullableContextAttribute(...)] | 0 | 1 |
+| System.MissingFieldException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.MissingMemberException | [NullableAttribute(...)] | 0 | 0 |
+| System.MissingMemberException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.MissingMemberException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.MissingMethodException | [NullableAttribute(...)] | 0 | 0 |
+| System.MissingMethodException | [NullableContextAttribute(...)] | 0 | 1 |
+| System.MissingMethodException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ModuleHandle | [NullableAttribute(...)] | 0 | 0 |
+| System.ModuleHandle | [NullableContextAttribute(...)] | 0 | 2 |
+| System.MulticastDelegate | [ComVisibleAttribute(...)] | 0 | True |
+| System.MulticastDelegate | [NullableAttribute(...)] | 0 | 0 |
+| System.MulticastDelegate | [NullableContextAttribute(...)] | 0 | 1 |
+| System.MulticastNotSupportedException | [NullableAttribute(...)] | 0 | 0 |
+| System.MulticastNotSupportedException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.MulticastNotSupportedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.NotFiniteNumberException | [NullableAttribute(...)] | 0 | 0 |
+| System.NotFiniteNumberException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.NotFiniteNumberException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.NotImplementedException | [NullableAttribute(...)] | 0 | 0 |
+| System.NotImplementedException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.NotImplementedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.NotSupportedException | [NullableAttribute(...)] | 0 | 0 |
+| System.NotSupportedException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.NotSupportedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.NullReferenceException | [NullableAttribute(...)] | 0 | 0 |
+| System.NullReferenceException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.NullReferenceException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Nullable`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Number.BigInteger | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Number.BigInteger | [ObsoleteAttribute(...)] | 1 | True |
+| System.Number.DiyFp | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Number.DiyFp | [ObsoleteAttribute(...)] | 1 | True |
+| System.Number.NumberBuffer | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Number.NumberBuffer | [ObsoleteAttribute(...)] | 1 | True |
+| System.Numerics.Vector`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.ObjectDisposedException | [NullableAttribute(...)] | 0 | 0 |
+| System.ObjectDisposedException | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ObjectDisposedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ObsoleteAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.ObsoleteAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.OperatingSystem | [NullableAttribute(...)] | 0 | 0 |
+| System.OperatingSystem | [NullableContextAttribute(...)] | 0 | 1 |
+| System.OperationCanceledException | [NullableAttribute(...)] | 0 | 0 |
+| System.OperationCanceledException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.OperationCanceledException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.OrdinalComparer | [NullableAttribute(...)] | 0 | 0 |
+| System.OrdinalComparer | [NullableContextAttribute(...)] | 0 | 2 |
+| System.OrdinalComparer | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.OutOfMemoryException | [NullableAttribute(...)] | 0 | 0 |
+| System.OutOfMemoryException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.OutOfMemoryException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.OverflowException | [NullableAttribute(...)] | 0 | 0 |
+| System.OverflowException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.OverflowException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ParamsArray | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.PlatformNotSupportedException | [NullableAttribute(...)] | 0 | 0 |
+| System.PlatformNotSupportedException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.PlatformNotSupportedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Progress`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Progress`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Progress`1.ProgressChanged | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.RankException | [NullableAttribute(...)] | 0 | 0 |
+| System.RankException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.RankException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ReadOnlyMemory<!0> System.ReadOnlyMemory`1.Empty | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.ReadOnlyMemory`1 | [DebuggerDisplayAttribute(...)] | 0 | {ToString(),raw} |
+| System.ReadOnlyMemory`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.ReadOnlyMemory`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ReadOnlySpan<!0> System.ReadOnlyMemory`1.Span | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.ReadOnlySpan<!0> System.ReadOnlySpan`1.Empty | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.ReadOnlySpan<System.Byte> System.Text.Encoding.Preamble | [NullableAttribute(...)] | 0 | 0 |
+| System.ReadOnlySpan<System.Byte> System.Text.UTF32Encoding.Preamble | [NullableAttribute(...)] | 0 | 0 |
+| System.ReadOnlySpan<System.Byte> System.Text.UnicodeEncoding.Preamble | [NullableAttribute(...)] | 0 | 0 |
+| System.ReadOnlySpan<System.Byte> char.CategoryForLatin1 | [NullableAttribute(...)] | 0 | 0 |
+| System.ReadOnlySpan`1 | [DebuggerDisplayAttribute(...)] | 0 | {ToString(),raw} |
+| System.ReadOnlySpan`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.ReadOnlySpan`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.ReadOnlySpan`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ReadOnlySpan`1 | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.ReadOnlySpan`1 | [ObsoleteAttribute(...)] | 1 | True |
+| System.ReadOnlySpan`1.Enumerator | [NullableAttribute(...)] | 0 | 0 |
+| System.ReadOnlySpan`1.Enumerator | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.ReadOnlySpan`1.Enumerator | [ObsoleteAttribute(...)] | 1 | True |
+| System.Reflection.AmbiguousMatchException | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AmbiguousMatchException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.AmbiguousMatchException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Reflection.Assembly | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Assembly | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Assembly.ModuleResolve | [NullableAttribute(...)] | 0 | 2 |
+| System.Reflection.AssemblyCompanyAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyCompanyAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyConfigurationAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyConfigurationAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyCopyrightAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyCopyrightAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyCultureAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyCultureAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyDefaultAliasAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyDefaultAliasAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyDescriptionAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyDescriptionAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyFileVersionAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyFileVersionAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyInformationalVersionAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyInformationalVersionAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyKeyFileAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyKeyFileAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyKeyNameAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyKeyNameAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyMetadataAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyMetadataAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyName | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyName | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.AssemblyProductAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyProductAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblySignatureKeyAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblySignatureKeyAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyTitleAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyTitleAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyTrademarkAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyTrademarkAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.AssemblyVersionAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.AssemblyVersionAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Binder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Binder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.CerHashtable`2 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Reflection.ConstArray | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Reflection.ConstructorInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.ConstructorInfo | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.ConstructorInfo System.Type.TypeInitializer | [NullableAttribute(...)] | 0 | 2 |
+| System.Reflection.ConstructorInfo.ConstructorName | [NullableAttribute(...)] | 0 | 1 |
+| System.Reflection.ConstructorInfo.TypeConstructorName | [NullableAttribute(...)] | 0 | 1 |
+| System.Reflection.CustomAttributeData | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.CustomAttributeData | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.CustomAttributeExtensions | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.CustomAttributeExtensions | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.CustomAttributeFormatException | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.CustomAttributeFormatException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.CustomAttributeFormatException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Reflection.CustomAttributeNamedArgument | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.CustomAttributeNamedArgument | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.CustomAttributeTypedArgument | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.CustomAttributeTypedArgument | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.DefaultMemberAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.DefaultMemberAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.AssemblyBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.AssemblyBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.ConstructorBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.ConstructorBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.CustomAttributeBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.CustomAttributeBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.DynamicILInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.DynamicILInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.DynamicMethod | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.DynamicMethod | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.DynamicScope | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Reflection.Emit.EnumBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.EnumBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.EventBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.EventBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.FieldBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.FieldBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.FlowControl.Phi | [ObsoleteAttribute(...)] | 0 | This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202 |
+| System.Reflection.Emit.GenericTypeParameterBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.GenericTypeParameterBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.ILGenerator | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.ILGenerator | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.LocalBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.LocalBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.MethodBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.MethodBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.ModuleBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.ModuleBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.OpCode | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.OpCode | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.Emit.OpCodeType.Annotation | [ObsoleteAttribute(...)] | 0 | This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202 |
+| System.Reflection.Emit.OperandType.InlinePhi | [ObsoleteAttribute(...)] | 0 | This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202 |
+| System.Reflection.Emit.ParameterBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.ParameterBuilder | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.Emit.PropertyBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.PropertyBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.SignatureHelper | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.SignatureHelper | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.Emit.TypeBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Emit.TypeBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.EventInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.EventInfo | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.ExceptionHandlingClause | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.ExceptionHandlingClause | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.FieldInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.FieldInfo | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.ICustomAttributeProvider | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.IReflect | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.IReflectableType | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.InterfaceMapping | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.InterfaceMapping | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.InvalidFilterCriteriaException | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.InvalidFilterCriteriaException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.InvalidFilterCriteriaException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Reflection.LocalVariableInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.LocalVariableInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.ManifestResourceInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.ManifestResourceInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.MemberInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.MemberInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.MetadataEnumResult | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Reflection.MethodBase | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.MethodBase | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.MethodBase System.Reflection.Emit.GenericTypeParameterBuilder.DeclaringMethod | [NullableAttribute(...)] | 0 | 2 |
+| System.Reflection.MethodBase System.Reflection.Emit.TypeBuilder.DeclaringMethod | [NullableAttribute(...)] | 0 | 2 |
+| System.Reflection.MethodBase System.Type.DeclaringMethod | [NullableAttribute(...)] | 0 | 2 |
+| System.Reflection.MethodBody | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.MethodBody | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.MethodInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.MethodInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.MethodInfo System.Reflection.Assembly.EntryPoint | [NullableAttribute(...)] | 0 | 2 |
+| System.Reflection.MethodInfo System.Reflection.Emit.AssemblyBuilder.EntryPoint | [NullableAttribute(...)] | 0 | 2 |
+| System.Reflection.Missing.Value | [NullableAttribute(...)] | 0 | 1 |
+| System.Reflection.Module | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.Module | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.ObfuscationAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.ObfuscationAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.ParameterInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.ParameterInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.ParameterInfo.ClassImpl | [NullableAttribute(...)] | 0 | 2 |
+| System.Reflection.ParameterInfo.DefaultValueImpl | [NullableAttribute(...)] | 0 | 2 |
+| System.Reflection.ParameterInfo.NameImpl | [NullableAttribute(...)] | 0 | 2 |
+| System.Reflection.ParameterModifier | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Reflection.Pointer | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Reflection.PropertyInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.PropertyInfo | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.ReflectionContext | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.ReflectionContext | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.ReflectionTypeLoadException | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.ReflectionTypeLoadException | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.ReflectionTypeLoadException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Reflection.RuntimeReflectionExtensions | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.RuntimeReflectionExtensions | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.StrongNameKeyPair | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.StrongNameKeyPair | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.TargetException | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.TargetException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.TargetException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Reflection.TargetInvocationException | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.TargetInvocationException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.TargetInvocationException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Reflection.TargetParameterCountException | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.TargetParameterCountException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Reflection.TargetParameterCountException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Reflection.TypeDelegator | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.TypeDelegator | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Reflection.TypeInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Reflection.TypeInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ResolveEventArgs | [NullableAttribute(...)] | 0 | 0 |
+| System.ResolveEventArgs | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Resources.MissingManifestResourceException | [NullableAttribute(...)] | 0 | 0 |
+| System.Resources.MissingManifestResourceException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Resources.MissingManifestResourceException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Resources.MissingSatelliteAssemblyException | [NullableAttribute(...)] | 0 | 0 |
+| System.Resources.MissingSatelliteAssemblyException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Resources.MissingSatelliteAssemblyException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Resources.NeutralResourcesLanguageAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Resources.NeutralResourcesLanguageAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Resources.ResourceManager | [NullableAttribute(...)] | 0 | 0 |
+| System.Resources.ResourceManager | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Resources.ResourceManager.MainAssembly | [NullableAttribute(...)] | 0 | 2 |
+| System.Resources.ResourceSet | [NullableAttribute(...)] | 0 | 0 |
+| System.Resources.ResourceSet | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Resources.SatelliteContractVersionAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Resources.SatelliteContractVersionAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.AmbiguousImplementationException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.AmbiguousImplementationException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.AmbiguousImplementationException | [TypeForwardedFromAttribute(...)] | 0 | System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a |
+| System.Runtime.AssemblyTargetedPatchBandAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.AssemblyTargetedPatchBandAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.AccessedThroughPropertyAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.AccessedThroughPropertyAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.AsyncIteratorMethodBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.AsyncIteratorMethodBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.AsyncMethodBuilderAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.AsyncMethodBuilderAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.AsyncTaskMethodBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.AsyncTaskMethodBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.AsyncVoidMethodBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.AsyncVoidMethodBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.CallerArgumentExpressionAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.CallerArgumentExpressionAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.ConditionalWeakTable`2 | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.ConditionalWeakTable`2 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.ConditionalWeakTable`2.CreateValueCallback | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.ContractHelper | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.ContractHelper | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.CompilerServices.ContractHelper.InternalContractFailed | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Runtime.CompilerServices.CustomConstantAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.CustomConstantAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.CompilerServices.DateTimeConstantAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.DateTimeConstantAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.DependencyAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.DependencyAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.FixedBufferAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.FixedBufferAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.IAsyncStateMachine | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.ICastable | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.CompilerServices.INotifyCompletion | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.IStrongBox | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.CompilerServices.ITuple | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Runtime.CompilerServices.ITuple | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.CompilerServices.InternalsVisibleToAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.InternalsVisibleToAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.ReferenceAssemblyAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.ReferenceAssemblyAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.CompilerServices.RuntimeFeature | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.RuntimeFeature | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.RuntimeHelpers | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.RuntimeHelpers | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.RuntimeHelpers.CleanupCode | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.RuntimeHelpers.TryCode | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.RuntimeWrappedException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.RuntimeWrappedException | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.RuntimeWrappedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Runtime.CompilerServices.StateMachineAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.StateMachineAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.StrongBox`1.Value | [NullableAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.TupleElementNamesAttribute | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.CompilerServices.TypeForwardedFromAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.TypeForwardedFromAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.CompilerServices.TypeForwardedToAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.CompilerServices.TypeForwardedToAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.ExceptionServices.ExceptionDispatchInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.ExceptionServices.ExceptionDispatchInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ArrayWithOffset | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.ArrayWithOffset | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.BStrWrapper | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.BStrWrapper | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.COMException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.COMException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.COMException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Runtime.InteropServices.CoClassAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.CoClassAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComDefaultInterfaceAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.ComDefaultInterfaceAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComEventInterfaceAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.ComEventInterfaceAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComEventsHelper | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.ComEventsHelper | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComSourceInterfacesAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.ComSourceInterfacesAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.CONNECTDATA.pUnk | [NullableAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.EXCEPINFO | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.ComTypes.EXCEPINFO | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IBindCtx | [GuidAttribute(...)] | 0 | 0000000e-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.IBindCtx | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IConnectionPoint | [GuidAttribute(...)] | 0 | B196B286-BAB4-101A-B69C-00AA00341D07 |
+| System.Runtime.InteropServices.ComTypes.IConnectionPoint | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IConnectionPointContainer | [GuidAttribute(...)] | 0 | B196B284-BAB4-101A-B69C-00AA00341D07 |
+| System.Runtime.InteropServices.ComTypes.IConnectionPointContainer | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IEnumConnectionPoints | [GuidAttribute(...)] | 0 | B196B285-BAB4-101A-B69C-00AA00341D07 |
+| System.Runtime.InteropServices.ComTypes.IEnumConnectionPoints | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IEnumConnections | [GuidAttribute(...)] | 0 | B196B287-BAB4-101A-B69C-00AA00341D07 |
+| System.Runtime.InteropServices.ComTypes.IEnumConnections | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IEnumMoniker | [GuidAttribute(...)] | 0 | 00000102-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.IEnumMoniker | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IEnumString | [GuidAttribute(...)] | 0 | 00000101-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.IEnumString | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IEnumVARIANT | [GuidAttribute(...)] | 0 | 00020404-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.IEnumVARIANT | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IEnumerable | [GuidAttribute(...)] | 0 | 496B0ABE-CDEE-11d3-88E8-00902754C43A |
+| System.Runtime.InteropServices.ComTypes.IMoniker | [GuidAttribute(...)] | 0 | 0000000f-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.IMoniker | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IPersistFile | [GuidAttribute(...)] | 0 | 0000010b-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.IPersistFile | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IRunningObjectTable | [GuidAttribute(...)] | 0 | 00000010-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.IRunningObjectTable | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.IStream | [GuidAttribute(...)] | 0 | 0000000c-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.IStream | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.ITypeComp | [GuidAttribute(...)] | 0 | 00020403-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.ITypeComp | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.ITypeInfo | [GuidAttribute(...)] | 0 | 00020401-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.ITypeInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.ITypeInfo2 | [GuidAttribute(...)] | 0 | 00020412-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.ITypeInfo2 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.ITypeLib | [GuidAttribute(...)] | 0 | 00020402-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.ITypeLib | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.ITypeLib2 | [GuidAttribute(...)] | 0 | 00020411-0000-0000-C000-000000000046 |
+| System.Runtime.InteropServices.ComTypes.ITypeLib2 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.STATSTG.pwcsName | [NullableAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ComTypes.VARDESC.lpstrSchema | [NullableAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.DefaultParameterValueAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.DefaultParameterValueAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.DispatchWrapper | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.DispatchWrapper | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.DllImportAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.DllImportAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.DllImportAttribute.EntryPoint | [NullableAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.ErrorWrapper | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.ErrorWrapper | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.Expando.IExpando | [GuidAttribute(...)] | 0 | AFBF15E6-C37C-11d2-B88E-00A0C9B471B8 |
+| System.Runtime.InteropServices.ExternalException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.ExternalException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.ExternalException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Runtime.InteropServices.GCHandle | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.GCHandle | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.GuidAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.GuidAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.HandleRef | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.HandleRef | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.ICustomAdapter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ICustomFactory | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ICustomMarshaler | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.InvalidComObjectException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.InvalidComObjectException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.InvalidComObjectException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Runtime.InteropServices.InvalidOleVariantTypeException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.InvalidOleVariantTypeException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.InvalidOleVariantTypeException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Runtime.InteropServices.Marshal | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.Marshal | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.MarshalAsAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.MarshalAsAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.MarshalDirectiveException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.MarshalDirectiveException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.MarshalDirectiveException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Runtime.InteropServices.NativeCallableAttribute.EntryPoint | [NullableAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.NativeLibrary | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.NativeLibrary | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.ProgIdAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.ProgIdAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.SEHException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.SEHException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.SEHException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Runtime.InteropServices.SafeArrayRankMismatchException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.SafeArrayRankMismatchException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.SafeArrayRankMismatchException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Runtime.InteropServices.SafeArrayTypeMismatchException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.SafeArrayTypeMismatchException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.SafeArrayTypeMismatchException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Runtime.InteropServices.SafeHandle System.Threading.ThreadPoolBoundHandle.Handle | [NullableAttribute(...)] | 0 | 1 |
+| System.Runtime.InteropServices.StructLayoutAttribute System.Type.StructLayoutAttribute | [NullableAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.TypeIdentifierAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.TypeIdentifierAttribute | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.UnknownWrapper | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.UnknownWrapper | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.InteropServices.VariantWrapper | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.InteropServices.VariantWrapper | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.Intrinsics.Arm.Arm64.Aes | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.Arm.Arm64.Base | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.Arm.Arm64.Sha1 | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.Arm.Arm64.Sha256 | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.Arm.Arm64.Simd | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.Vector64`1 | [DebuggerDisplayAttribute(...)] | 0 | {DisplayString,nq} |
+| System.Runtime.Intrinsics.Vector128`1 | [DebuggerDisplayAttribute(...)] | 0 | {DisplayString,nq} |
+| System.Runtime.Intrinsics.Vector256`1 | [DebuggerDisplayAttribute(...)] | 0 | {DisplayString,nq} |
+| System.Runtime.Intrinsics.X86.Aes | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Avx | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Avx2 | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Bmi1 | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Bmi2 | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Fma | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Lzcnt | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Pclmulqdq | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Popcnt | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Sse | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Sse2 | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Sse3 | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Sse41 | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Sse42 | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Intrinsics.X86.Ssse3 | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Loader.AssemblyDependencyResolver | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.Loader.AssemblyDependencyResolver | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.Loader.AssemblyLoadContext | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.Loader.AssemblyLoadContext | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.Loader.AssemblyLoadContext System.Runtime.Loader.AssemblyLoadContext.CurrentContextualReflectionContext | [NullableAttribute(...)] | 0 | 2 |
+| System.Runtime.Loader.AssemblyLoadContext.AssemblyLoad | [NullableAttribute(...)] | 0 | 2 |
+| System.Runtime.Loader.AssemblyLoadContext.AssemblyResolve | [NullableAttribute(...)] | 0 | 2 |
+| System.Runtime.Loader.AssemblyLoadContext.ContextualReflectionScope | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Runtime.Loader.AssemblyLoadContext.Resolving | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Runtime.Loader.AssemblyLoadContext.ResolvingUnmanagedDll | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Runtime.Loader.AssemblyLoadContext.ResourceResolve | [NullableAttribute(...)] | 0 | 2 |
+| System.Runtime.Loader.AssemblyLoadContext.TypeResolve | [NullableAttribute(...)] | 0 | 2 |
+| System.Runtime.Loader.AssemblyLoadContext.Unloading | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Runtime.Loader.AssemblyLoadContext._resolving | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Runtime.Loader.AssemblyLoadContext._resolvingUnmanagedDll | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Runtime.Loader.AssemblyLoadContext._unloading | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Runtime.Remoting.ObjectHandle | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.Remoting.ObjectHandle | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.Serialization.IDeserializationCallback | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.Serialization.IFormatterConverter | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Runtime.Serialization.IFormatterConverter | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.Serialization.IObjectReference | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.Serialization.ISafeSerializationData | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.Serialization.ISerializable | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.Serialization.SerializationEntry | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.Serialization.SerializationEntry | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.Serialization.SerializationException | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.Serialization.SerializationException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.Serialization.SerializationException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Runtime.Serialization.SerializationInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.Serialization.SerializationInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.Serialization.SerializationInfoEnumerator | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.Serialization.SerializationInfoEnumerator | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.Serialization.StreamingContext | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.Serialization.StreamingContext | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Runtime.TargetedPatchingOptOutAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.TargetedPatchingOptOutAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Runtime.Versioning.TargetFrameworkAttribute | [NullableAttribute(...)] | 0 | 0 |
+| System.Runtime.Versioning.TargetFrameworkAttribute | [NullableContextAttribute(...)] | 0 | 1 |
+| System.RuntimeType.ListBuilder`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.RuntimeTypeHandle | [NullableAttribute(...)] | 0 | 0 |
+| System.RuntimeTypeHandle | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Security.Cryptography.CryptographicException | [NullableAttribute(...)] | 0 | 0 |
+| System.Security.Cryptography.CryptographicException | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Security.Cryptography.CryptographicException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Security.IPermission | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Security.ISecurityEncodable | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Security.PermissionSet | [NullableAttribute(...)] | 0 | 0 |
+| System.Security.PermissionSet | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Security.PermissionSet System.AppDomain.PermissionSet | [NullableAttribute(...)] | 0 | 1 |
+| System.Security.Principal.IIdentity | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Security.Principal.IPrincipal | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Security.Principal.IPrincipal System.Threading.Thread.CurrentPrincipal | [NullableAttribute(...)] | 0 | 2 |
+| System.Security.SecurityCriticalScope | [ObsoleteAttribute(...)] | 0 | SecurityCriticalScope is only used for .NET 2.0 transparency compatibility. |
+| System.Security.SecurityCriticalScope System.Security.SecurityCriticalAttribute.Scope | [ObsoleteAttribute(...)] | 0 | SecurityCriticalScope is only used for .NET 2.0 transparency compatibility. |
+| System.Security.SecurityElement | [NullableAttribute(...)] | 0 | 0 |
+| System.Security.SecurityElement | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Security.SecurityException | [NullableAttribute(...)] | 0 | 0 |
+| System.Security.SecurityException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Security.SecurityException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Security.SecurityTreatAsSafeAttribute | [ObsoleteAttribute(...)] | 0 | SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility.  Please use the SecuritySafeCriticalAttribute instead. |
+| System.Security.VerificationException | [NullableAttribute(...)] | 0 | 0 |
+| System.Security.VerificationException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Security.VerificationException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Span<!0> System.Memory`1.Span | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Span<!0> System.Span`1.Empty | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Span<System.Char> System.Text.StringBuilder.RemainingCurrentChunk | [NullableAttribute(...)] | 0 | 0 |
+| System.Span`1 | [DebuggerDisplayAttribute(...)] | 0 | {ToString(),raw} |
+| System.Span`1 | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Span`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Span`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Span`1 | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Span`1 | [ObsoleteAttribute(...)] | 1 | True |
+| System.Span`1.Enumerator | [NullableAttribute(...)] | 0 | 0 |
+| System.Span`1.Enumerator | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Span`1.Enumerator | [ObsoleteAttribute(...)] | 1 | True |
+| System.StackOverflowException | [NullableAttribute(...)] | 0 | 0 |
+| System.StackOverflowException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.StackOverflowException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.StringComparer | [NullableAttribute(...)] | 0 | 0 |
+| System.StringComparer | [NullableContextAttribute(...)] | 0 | 1 |
+| System.StringComparer | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.SystemException | [NullableAttribute(...)] | 0 | 0 |
+| System.SystemException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.SystemException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Text.DecoderFallback | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.DecoderFallback | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.DecoderFallback System.Text.Decoder.Fallback | [NullableAttribute(...)] | 0 | 2 |
+| System.Text.DecoderFallbackBuffer System.Text.Decoder.FallbackBuffer | [NullableAttribute(...)] | 0 | 1 |
+| System.Text.DecoderFallbackException | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.DecoderFallbackException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Text.DecoderFallbackException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Text.DecoderReplacementFallback | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.DecoderReplacementFallback | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.DecoderReplacementFallbackBuffer | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.DecoderReplacementFallbackBuffer | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.EncoderFallback | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.EncoderFallback | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.EncoderFallback System.Text.Encoder.Fallback | [NullableAttribute(...)] | 0 | 2 |
+| System.Text.EncoderFallbackBuffer System.Text.Encoder.FallbackBuffer | [NullableAttribute(...)] | 0 | 1 |
+| System.Text.EncoderFallbackException | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.EncoderFallbackException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Text.EncoderFallbackException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Text.EncoderReplacementFallback | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.EncoderReplacementFallback | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.Encoding | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.Encoding | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.EncodingInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.EncodingInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.EncodingProvider | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.EncodingProvider | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.Rune | [DebuggerDisplayAttribute(...)] | 0 | {DebuggerDisplay,nq} |
+| System.Text.SpanRuneEnumerator | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Text.SpanRuneEnumerator | [ObsoleteAttribute(...)] | 1 | True |
+| System.Text.StringBuilder | [DefaultMemberAttribute(...)] | 0 | Chars |
+| System.Text.StringBuilder | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.StringBuilder | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.StringBuilder | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Text.StringBuilder.ChunkEnumerator | [NullableContextAttribute(...)] | 0 | 0 |
+| System.Text.UTF7Encoding | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.UTF7Encoding | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.UTF32Encoding | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.UTF32Encoding | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.UnicodeEncoding | [NullableAttribute(...)] | 0 | 0 |
+| System.Text.UnicodeEncoding | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Text.ValueStringBuilder | [DefaultMemberAttribute(...)] | 0 | Item |
+| System.Text.ValueStringBuilder | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.Text.ValueStringBuilder | [ObsoleteAttribute(...)] | 1 | True |
+| System.Threading.AbandonedMutexException | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.AbandonedMutexException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.AbandonedMutexException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.ApartmentState System.Threading.Thread.ApartmentState | [ObsoleteAttribute(...)] | 0 | The ApartmentState property has been deprecated.  Use GetApartmentState, SetApartmentState or TrySetApartmentState instead. |
+| System.Threading.ApartmentState System.Threading.Thread.ApartmentState | [ObsoleteAttribute(...)] | 1 | False |
+| System.Threading.AsyncLocalValueChangedArgs`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.AsyncLocalValueChangedArgs`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.AsyncLocal`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.AsyncLocal`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.CancellationToken | [DebuggerDisplayAttribute(...)] | 0 | IsCancellationRequested = {IsCancellationRequested} |
+| System.Threading.CancellationToken | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.CancellationToken | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.CancellationTokenSource | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.CancellationTokenSource | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.CompressedStack | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.CompressedStack | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.EventWaitHandle | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.EventWaitHandle | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.ExecutionContext System.Threading.Tasks.Task.CapturedContext | [NullableAttribute(...)] | 0 | 2 |
+| System.Threading.ExecutionContext System.Threading.Thread.ExecutionContext | [NullableAttribute(...)] | 0 | 2 |
+| System.Threading.IOCompletionCallback | [CLSCompliantAttribute(...)] | 0 | False |
+| System.Threading.Interlocked | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Interlocked | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.LazyInitializer | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.LazyInitializer | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.LockRecursionException | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.LockRecursionException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.LockRecursionException | [TypeForwardedFromAttribute(...)] | 0 | System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.ManualResetEventSlim | [DebuggerDisplayAttribute(...)] | 0 | Set = {IsSet} |
+| System.Threading.Monitor | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Monitor | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Mutex | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Mutex | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Overlapped | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Overlapped | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.Semaphore | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Semaphore | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.SemaphoreFullException | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.SemaphoreFullException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.SemaphoreFullException | [TypeForwardedFromAttribute(...)] | 0 | System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.SemaphoreSlim | [DebuggerDisplayAttribute(...)] | 0 | Current Count = {m_currentCount} |
+| System.Threading.SemaphoreSlim | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.SemaphoreSlim | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.SpinLock | [DebuggerDisplayAttribute(...)] | 0 | IsHeld = {IsHeld} |
+| System.Threading.SpinWait | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.SpinWait | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.SynchronizationContext | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.SynchronizationContext | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.SynchronizationContext System.Threading.SynchronizationContext.Current | [NullableAttribute(...)] | 0 | 2 |
+| System.Threading.SynchronizationContext.<>c.<>9__8_0 | [TupleElementNamesAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Threading.SynchronizationLockException | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.SynchronizationLockException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.SynchronizationLockException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.Tasks.ConcurrentExclusiveSchedulerPair | [DebuggerDisplayAttribute(...)] | 0 | Concurrent={ConcurrentTaskCountForDebugger}, Exclusive={ExclusiveTaskCountForDebugger}, Mode={ModeForDebugger} |
+| System.Threading.Tasks.ConcurrentExclusiveSchedulerPair | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.ConcurrentExclusiveSchedulerPair | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.ConcurrentExclusiveSchedulerPair.ConcurrentExclusiveTaskScheduler | [DebuggerDisplayAttribute(...)] | 0 | Count={CountForDebugger}, MaxConcurrencyLevel={m_maxConcurrencyLevel}, Id={Id} |
+| System.Threading.Tasks.MultiProducerMultiConsumerQueue`1 | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Threading.Tasks.SingleProducerSingleConsumerQueue`1 | [DebuggerDisplayAttribute(...)] | 0 | Count = {Count} |
+| System.Threading.Tasks.Sources.IValueTaskSource | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.Sources.IValueTaskSource`1 | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.Task | [DebuggerDisplayAttribute(...)] | 0 | Id = {Id}, Status = {Status}, Method = {DebuggerDisplayMethodDescription} |
+| System.Threading.Tasks.Task | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.Task | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.Task System.Threading.Tasks.Task.InternalCurrent | [NullableAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.Task System.Threading.Tasks.Task.ParentForDebugger | [NullableAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.TaskAsyncEnumerableExtensions | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.TaskAsyncEnumerableExtensions | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.TaskCanceledException | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.TaskCanceledException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.TaskCanceledException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.Tasks.TaskCompletionSource`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.TaskCompletionSource`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.TaskExtensions | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.TaskExtensions | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.TaskFactory | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.TaskFactory | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.TaskFactory`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.TaskFactory`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.TaskScheduler | [DebuggerDisplayAttribute(...)] | 0 | Id={Id} |
+| System.Threading.Tasks.TaskScheduler | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.TaskScheduler | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.TaskScheduler System.Threading.Tasks.Task.ExecutingTaskScheduler | [NullableAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.TaskScheduler System.Threading.Tasks.TaskFactory.Scheduler | [NullableAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.TaskScheduler System.Threading.Tasks.TaskFactory`1.Scheduler | [NullableAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.TaskScheduler System.Threading.Tasks.TaskScheduler.InternalCurrent | [NullableAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.TaskScheduler.UnobservedTaskException | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Threading.Tasks.TaskSchedulerException | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.TaskSchedulerException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.TaskSchedulerException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.Tasks.Task`1 | [DebuggerDisplayAttribute(...)] | 0 | Id = {Id}, Status = {Status}, Method = {DebuggerDisplayMethodDescription}, Result = {DebuggerDisplayResultDescription} |
+| System.Threading.Tasks.Task`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.Task`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.UnobservedTaskExceptionEventArgs | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.UnobservedTaskExceptionEventArgs | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.Tasks.ValueTask | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.ValueTask | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Tasks.ValueTask<!0> System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.Task | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Threading.Tasks.ValueTask`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Tasks.ValueTask`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Thread | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Thread | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.ThreadAbortException | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.ThreadAbortException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.ThreadAbortException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.ThreadInterruptedException | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.ThreadInterruptedException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.ThreadInterruptedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.ThreadLocal<System.Object> System.LocalDataStoreSlot.Data | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.Threading.ThreadLocal`1 | [DebuggerDisplayAttribute(...)] | 0 | IsValueCreated={IsValueCreated}, Value={ValueForDebugDisplay}, Count={ValuesCountForDebugDisplay} |
+| System.Threading.ThreadLocal`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.ThreadLocal`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.ThreadPool | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.ThreadPool | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.ThreadStartException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.ThreadStateException | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.ThreadStateException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.ThreadStateException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.Timer | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Timer | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.Volatile | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.Volatile | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.WaitHandle | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.WaitHandle | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Threading.WaitHandle System.Threading.ManualResetEventSlim.WaitHandle | [NullableAttribute(...)] | 0 | 1 |
+| System.Threading.WaitHandleCannotBeOpenedException | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.WaitHandleCannotBeOpenedException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Threading.WaitHandleCannotBeOpenedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Threading.WaitHandleExtensions | [NullableAttribute(...)] | 0 | 0 |
+| System.Threading.WaitHandleExtensions | [NullableContextAttribute(...)] | 0 | 1 |
+| System.TimeZone | [NullableAttribute(...)] | 0 | 0 |
+| System.TimeZone | [NullableContextAttribute(...)] | 0 | 1 |
+| System.TimeZone | [ObsoleteAttribute(...)] | 0 | System.TimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo instead. |
+| System.TimeZoneInfo | [NullableAttribute(...)] | 0 | 0 |
+| System.TimeZoneInfo | [NullableContextAttribute(...)] | 0 | 1 |
+| System.TimeZoneInfo | [TypeForwardedFromAttribute(...)] | 0 | System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.TimeZoneInfo.AdjustmentRule | [NullableContextAttribute(...)] | 0 | 0 |
+| System.TimeZoneInfo.TransitionTime | [NullableContextAttribute(...)] | 0 | 0 |
+| System.TimeZoneNotFoundException | [NullableAttribute(...)] | 0 | 0 |
+| System.TimeZoneNotFoundException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.TimeZoneNotFoundException | [TypeForwardedFromAttribute(...)] | 0 | System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.TimeoutException | [NullableAttribute(...)] | 0 | 0 |
+| System.TimeoutException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.TimeoutException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Tuple | [NullableAttribute(...)] | 0 | 0 |
+| System.Tuple | [NullableContextAttribute(...)] | 0 | 1 |
+| System.TupleExtensions | [NullableAttribute(...)] | 0 | 0 |
+| System.TupleExtensions | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Tuple`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Tuple`2 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Tuple`3 | [NullableAttribute(...)] | 0 | 0 |
+| System.Tuple`3 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Tuple`3 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Tuple`4 | [NullableAttribute(...)] | 0 | 0 |
+| System.Tuple`4 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Tuple`4 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Tuple`5 | [NullableAttribute(...)] | 0 | 0 |
+| System.Tuple`5 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Tuple`5 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Tuple`6 | [NullableAttribute(...)] | 0 | 0 |
+| System.Tuple`6 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Tuple`6 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Tuple`7 | [NullableAttribute(...)] | 0 | 0 |
+| System.Tuple`7 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Tuple`7 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Tuple`8 | [NullableAttribute(...)] | 0 | 0 |
+| System.Tuple`8 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Tuple`8 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Type | [NullableAttribute(...)] | 0 | 0 |
+| System.Type | [NullableContextAttribute(...)] | 0 | 1 |
+| System.Type System.Reflection.Emit.ConstructorBuilder.DeclaringType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.ConstructorBuilder.ReflectedType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.DynamicMethod.DeclaringType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.DynamicMethod.ReflectedType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.EnumBuilder.BaseType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.EnumBuilder.DeclaringType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.EnumBuilder.ReflectedType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.FieldBuilder.DeclaringType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.FieldBuilder.ReflectedType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.GenericTypeParameterBuilder.BaseType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.GenericTypeParameterBuilder.DeclaringType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.GenericTypeParameterBuilder.ReflectedType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.MethodBuilder.DeclaringType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.MethodBuilder.ReflectedType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.PropertyBuilder.DeclaringType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.PropertyBuilder.ReflectedType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.TypeBuilder.BaseType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.TypeBuilder.DeclaringType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.Emit.TypeBuilder.ReflectedType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.FieldInfo.FieldType | [NullableAttribute(...)] | 0 | 1 |
+| System.Type System.Reflection.MemberInfo.DeclaringType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.MemberInfo.ReflectedType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Reflection.PropertyInfo.PropertyType | [NullableAttribute(...)] | 0 | 1 |
+| System.Type System.Reflection.TypeDelegator.BaseType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Type.BaseType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Type.DeclaringType | [NullableAttribute(...)] | 0 | 2 |
+| System.Type System.Type.ReflectedType | [NullableAttribute(...)] | 0 | 2 |
+| System.TypeAccessException | [NullableAttribute(...)] | 0 | 0 |
+| System.TypeAccessException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.TypeAccessException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.TypeInitializationException | [NullableAttribute(...)] | 0 | 0 |
+| System.TypeInitializationException | [NullableContextAttribute(...)] | 0 | 1 |
+| System.TypeInitializationException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.TypeLoadException | [NullableAttribute(...)] | 0 | 0 |
+| System.TypeLoadException | [NullableContextAttribute(...)] | 0 | 1 |
+| System.TypeLoadException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.TypeUnloadedException | [NullableAttribute(...)] | 0 | 0 |
+| System.TypeUnloadedException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.TypeUnloadedException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Type[] System.Reflection.ReflectionTypeLoadException.Types | [NullableAttribute(...)] | 0 | System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[Semmle.Extraction.CIL.Entities.Type]] |
+| System.TypedReference | [CLSCompliantAttribute(...)] | 0 | False |
+| System.TypedReference | [NullableAttribute(...)] | 0 | 0 |
+| System.TypedReference | [NullableContextAttribute(...)] | 0 | 1 |
+| System.UIntPtr | [CLSCompliantAttribute(...)] | 0 | False |
+| System.UIntPtr | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.UnauthorizedAccessException | [NullableAttribute(...)] | 0 | 0 |
+| System.UnauthorizedAccessException | [NullableContextAttribute(...)] | 0 | 2 |
+| System.UnauthorizedAccessException | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.UnhandledExceptionEventArgs | [NullableAttribute(...)] | 0 | 0 |
+| System.UnhandledExceptionEventArgs | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ValueTuple | [NullableAttribute(...)] | 0 | 0 |
+| System.ValueTuple | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ValueTuple | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ValueTuple`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ValueTuple`1.Item1 | [NullableAttribute(...)] | 0 | 1 |
+| System.ValueTuple`2 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ValueTuple`2.Item1 | [NullableAttribute(...)] | 0 | 1 |
+| System.ValueTuple`2.Item2 | [NullableAttribute(...)] | 0 | 1 |
+| System.ValueTuple`3 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ValueTuple`3.Item1 | [NullableAttribute(...)] | 0 | 1 |
+| System.ValueTuple`3.Item2 | [NullableAttribute(...)] | 0 | 1 |
+| System.ValueTuple`3.Item3 | [NullableAttribute(...)] | 0 | 1 |
+| System.ValueTuple`4 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ValueTuple`4.Item1 | [NullableAttribute(...)] | 0 | 1 |
+| System.ValueTuple`4.Item2 | [NullableAttribute(...)] | 0 | 1 |
+| System.ValueTuple`4.Item3 | [NullableAttribute(...)] | 0 | 1 |
+| System.ValueTuple`4.Item4 | [NullableAttribute(...)] | 0 | 1 |
+| System.ValueTuple`5 | [NullableAttribute(...)] | 0 | 0 |
+| System.ValueTuple`5 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ValueTuple`5 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ValueTuple`6 | [NullableAttribute(...)] | 0 | 0 |
+| System.ValueTuple`6 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ValueTuple`6 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ValueTuple`7 | [NullableAttribute(...)] | 0 | 0 |
+| System.ValueTuple`7 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ValueTuple`7 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ValueTuple`8 | [NullableAttribute(...)] | 0 | 0 |
+| System.ValueTuple`8 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.ValueTuple`8 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.ValueTuple`8.Rest | [NullableAttribute(...)] | 0 | 0 |
+| System.ValueType | [NullableAttribute(...)] | 0 | 0 |
+| System.ValueType | [NullableContextAttribute(...)] | 0 | 2 |
+| System.ValueType | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.Version | [NullableAttribute(...)] | 0 | 0 |
+| System.Version | [NullableContextAttribute(...)] | 0 | 2 |
+| System.Version | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.WeakReference | [NullableAttribute(...)] | 0 | 0 |
+| System.WeakReference | [NullableContextAttribute(...)] | 0 | 2 |
+| System.WeakReference | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.WeakReference`1 | [NullableAttribute(...)] | 0 | 0 |
+| System.WeakReference`1 | [NullableContextAttribute(...)] | 0 | 1 |
+| System.WeakReference`1 | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| System.__Canon | [ComVisibleAttribute(...)] | 0 | True |
+| System.__DTString | [ObsoleteAttribute(...)] | 0 | Types with embedded references are not supported in this version of your compiler. |
+| System.__DTString | [ObsoleteAttribute(...)] | 1 | True |
+| bool | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| bool.FalseString | [NullableAttribute(...)] | 0 | 1 |
+| bool.TrueString | [NullableAttribute(...)] | 0 | 1 |
+| byte | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| byte* System.IO.UnmanagedMemoryStream.PositionPointer | [CLSCompliantAttribute(...)] | 0 | False |
+| char | [NullableAttribute(...)] | 0 | 0 |
+| char | [NullableContextAttribute(...)] | 0 | 1 |
+| char | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| decimal | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| decimal.MaxValue | [DecimalConstantAttribute(...)] | 0 | 0 |
+| decimal.MaxValue | [DecimalConstantAttribute(...)] | 1 | 0 |
+| decimal.MaxValue | [DecimalConstantAttribute(...)] | 2 | 4294967295 |
+| decimal.MaxValue | [DecimalConstantAttribute(...)] | 3 | 4294967295 |
+| decimal.MaxValue | [DecimalConstantAttribute(...)] | 4 | 4294967295 |
+| decimal.MinValue | [DecimalConstantAttribute(...)] | 0 | 0 |
+| decimal.MinValue | [DecimalConstantAttribute(...)] | 1 | 128 |
+| decimal.MinValue | [DecimalConstantAttribute(...)] | 2 | 4294967295 |
+| decimal.MinValue | [DecimalConstantAttribute(...)] | 3 | 4294967295 |
+| decimal.MinValue | [DecimalConstantAttribute(...)] | 4 | 4294967295 |
+| decimal.MinusOne | [DecimalConstantAttribute(...)] | 0 | 0 |
+| decimal.MinusOne | [DecimalConstantAttribute(...)] | 1 | 128 |
+| decimal.MinusOne | [DecimalConstantAttribute(...)] | 2 | 0 |
+| decimal.MinusOne | [DecimalConstantAttribute(...)] | 3 | 0 |
+| decimal.MinusOne | [DecimalConstantAttribute(...)] | 4 | 1 |
+| decimal.One | [DecimalConstantAttribute(...)] | 0 | 0 |
+| decimal.One | [DecimalConstantAttribute(...)] | 1 | 0 |
+| decimal.One | [DecimalConstantAttribute(...)] | 2 | 0 |
+| decimal.One | [DecimalConstantAttribute(...)] | 3 | 0 |
+| decimal.One | [DecimalConstantAttribute(...)] | 4 | 1 |
+| decimal.Zero | [DecimalConstantAttribute(...)] | 0 | 0 |
+| decimal.Zero | [DecimalConstantAttribute(...)] | 1 | 0 |
+| decimal.Zero | [DecimalConstantAttribute(...)] | 2 | 0 |
+| decimal.Zero | [DecimalConstantAttribute(...)] | 3 | 0 |
+| decimal.Zero | [DecimalConstantAttribute(...)] | 4 | 0 |
+| double | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| float | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| int | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| int System.Threading.Overlapped.EventHandle | [ObsoleteAttribute(...)] | 0 | This property is not 64-bit compatible.  Use EventHandleIntPtr instead.  http://go.microsoft.com/fwlink/?linkid=14202 |
+| int[] System.Globalization.StringInfo.Indexes | [NullableAttribute(...)] | 0 | 2 |
+| long | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| object | [ComVisibleAttribute(...)] | 0 | True |
+| object | [NullableContextAttribute(...)] | 0 | 2 |
+| object | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| object System.Array.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.ArraySegment`1.Enumerator.Current | [NullableAttribute(...)] | 0 | 2 |
+| object System.CharEnumerator.Current | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.ArrayList.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.DictionaryEntry.Value | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.Generic.Dictionary`2.Enumerator.Current | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.Generic.Dictionary`2.Enumerator.Key | [NullableAttribute(...)] | 0 | 1 |
+| object System.Collections.Generic.Dictionary`2.Enumerator.Value | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.Generic.Dictionary`2.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.Generic.Dictionary`2.KeyCollection.Enumerator.Current | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.Generic.Dictionary`2.KeyCollection.SyncRoot | [NullableAttribute(...)] | 0 | 1 |
+| object System.Collections.Generic.Dictionary`2.ValueCollection.Enumerator.Current | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.Generic.Dictionary`2.ValueCollection.SyncRoot | [NullableAttribute(...)] | 0 | 1 |
+| object System.Collections.Generic.List`1.Enumerator.Current | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.Generic.List`1.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.Hashtable.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.IDictionary.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.IDictionaryEnumerator.Value | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.ListDictionaryInternal.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.ObjectModel.Collection`1.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Collections.ObjectModel.ReadOnlyCollection`1.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Delegate.Target | [NullableAttribute(...)] | 0 | 2 |
+| object System.IAsyncResult.AsyncState | [NullableAttribute(...)] | 0 | 2 |
+| object System.Reflection.CustomAttributeTypedArgument.Value | [NullableAttribute(...)] | 0 | 2 |
+| object System.Reflection.ParameterInfo.DefaultValue | [NullableAttribute(...)] | 0 | 2 |
+| object System.Reflection.ParameterInfo.RawDefaultValue | [NullableAttribute(...)] | 0 | 2 |
+| object System.Runtime.CompilerServices.StrongBox`1.Value | [NullableAttribute(...)] | 0 | 2 |
+| object System.Runtime.Serialization.SerializationEntry.Value | [NullableAttribute(...)] | 0 | 2 |
+| object System.Runtime.Serialization.SerializationInfoEnumerator.Current | [NullableAttribute(...)] | 0 | 2 |
+| object System.Runtime.Serialization.SerializationInfoEnumerator.Value | [NullableAttribute(...)] | 0 | 2 |
+| object System.Security.PermissionSet.SyncRoot | [NullableAttribute(...)] | 0 | 1 |
+| object System.Text.StringRuneEnumerator.Current | [NullableAttribute(...)] | 0 | 2 |
+| object System.Threading.Tasks.Task.AsyncState | [NullableAttribute(...)] | 0 | 2 |
+| object System.Tuple`1.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Tuple`2.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Tuple`3.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Tuple`4.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Tuple`5.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Tuple`6.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Tuple`7.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.Tuple`8.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.ValueTuple.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.ValueTuple`1.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.ValueTuple`2.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.ValueTuple`3.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.ValueTuple`4.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.ValueTuple`5.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.ValueTuple`6.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.ValueTuple`7.Item | [NullableAttribute(...)] | 0 | 2 |
+| object System.ValueTuple`8.Item | [NullableAttribute(...)] | 0 | 2 |
+| sbyte | [CLSCompliantAttribute(...)] | 0 | False |
+| sbyte | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| short | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| string | [DefaultMemberAttribute(...)] | 0 | Chars |
+| string | [NullableAttribute(...)] | 0 | 0 |
+| string | [NullableContextAttribute(...)] | 0 | 1 |
+| string | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| string System.AppContext.BaseDirectory | [NullableAttribute(...)] | 0 | 1 |
+| string System.AppDomain.FriendlyName | [NullableAttribute(...)] | 0 | 1 |
+| string System.ArgumentException.Message | [NullableAttribute(...)] | 0 | 1 |
+| string System.ArgumentOutOfRangeException.Message | [NullableAttribute(...)] | 0 | 1 |
+| string System.BadImageFormatException.Message | [NullableAttribute(...)] | 0 | 1 |
+| string System.Diagnostics.CodeAnalysis.SuppressMessageAttribute.Category | [NullableAttribute(...)] | 0 | 1 |
+| string System.Diagnostics.CodeAnalysis.SuppressMessageAttribute.CheckId | [NullableAttribute(...)] | 0 | 1 |
+| string System.Diagnostics.Contracts.ContractException.Failure | [NullableAttribute(...)] | 0 | 1 |
+| string System.Diagnostics.Contracts.ContractOptionAttribute.Value | [NullableAttribute(...)] | 0 | 2 |
+| string System.Diagnostics.DebuggerDisplayAttribute.Value | [NullableAttribute(...)] | 0 | 1 |
+| string System.Diagnostics.DebuggerTypeProxyAttribute.ProxyTypeName | [NullableAttribute(...)] | 0 | 1 |
+| string System.Diagnostics.DebuggerVisualizerAttribute.VisualizerTypeName | [NullableAttribute(...)] | 0 | 1 |
+| string System.Diagnostics.Tracing.EventFieldAttribute.Name | [NullableAttribute(...)] | 0 | 2 |
+| string System.Diagnostics.Tracing.EventSource.Name | [NullableAttribute(...)] | 0 | 1 |
+| string System.Diagnostics.Tracing.TraceLoggingEventTypes.Name | [NullableAttribute(...)] | 0 | 1 |
+| string System.Exception.Message | [NullableAttribute(...)] | 0 | 1 |
+| string System.Globalization.CultureNotFoundException.DefaultMessage | [NullableAttribute(...)] | 0 | 1 |
+| string System.Globalization.CultureNotFoundException.Message | [NullableAttribute(...)] | 0 | 1 |
+| string System.IO.FileLoadException.Message | [NullableAttribute(...)] | 0 | 1 |
+| string System.IO.FileNotFoundException.Message | [NullableAttribute(...)] | 0 | 1 |
+| string System.MissingMemberException.Message | [NullableAttribute(...)] | 0 | 1 |
+| string System.Reflection.Assembly.CodeBase | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Assembly.FullName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.AssemblyMetadataAttribute.Value | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.AssemblyName.FullName | [NullableAttribute(...)] | 0 | 1 |
+| string System.Reflection.Emit.AssemblyBuilder.CodeBase | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Emit.AssemblyBuilder.FullName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Emit.EnumBuilder.AssemblyQualifiedName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Emit.EnumBuilder.FullName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Emit.EnumBuilder.Namespace | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Emit.GenericTypeParameterBuilder.AssemblyQualifiedName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Emit.GenericTypeParameterBuilder.FullName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Emit.GenericTypeParameterBuilder.Namespace | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Emit.TypeBuilder.AssemblyQualifiedName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Emit.TypeBuilder.FullName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.Emit.TypeBuilder.Namespace | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.ParameterInfo.Name | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.TypeDelegator.AssemblyQualifiedName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.TypeDelegator.FullName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Reflection.TypeDelegator.Namespace | [NullableAttribute(...)] | 0 | 2 |
+| string System.Runtime.Intrinsics.Vector64`1.DisplayString | [NullableAttribute(...)] | 0 | 1 |
+| string System.Runtime.Intrinsics.Vector128`1.DisplayString | [NullableAttribute(...)] | 0 | 1 |
+| string System.Runtime.Intrinsics.Vector256`1.DisplayString | [NullableAttribute(...)] | 0 | 1 |
+| string System.Runtime.Loader.AssemblyLoadContext.Name | [NullableAttribute(...)] | 0 | 2 |
+| string System.Runtime.Versioning.TargetFrameworkAttribute.FrameworkDisplayName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Security.SecurityElement.Tag | [NullableAttribute(...)] | 0 | 1 |
+| string System.Text.Rune.DebuggerDisplay | [NullableAttribute(...)] | 0 | 1 |
+| string System.Threading.Thread.Name | [NullableAttribute(...)] | 0 | 2 |
+| string System.Type.AssemblyQualifiedName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Type.FullName | [NullableAttribute(...)] | 0 | 2 |
+| string System.Type.Namespace | [NullableAttribute(...)] | 0 | 2 |
+| uint | [CLSCompliantAttribute(...)] | 0 | False |
+| uint | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| uint System.Reflection.AssemblyAlgorithmIdAttribute.AlgorithmId | [CLSCompliantAttribute(...)] | 0 | False |
+| uint System.Reflection.AssemblyFlagsAttribute.Flags | [CLSCompliantAttribute(...)] | 0 | False |
+| uint System.Reflection.AssemblyFlagsAttribute.Flags | [ObsoleteAttribute(...)] | 0 | This property has been deprecated. Please use AssemblyFlags instead. https://go.microsoft.com/fwlink/?linkid=14202 |
+| ulong | [CLSCompliantAttribute(...)] | 0 | False |
+| ulong | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| ulong System.Runtime.InteropServices.SafeBuffer.ByteLength | [CLSCompliantAttribute(...)] | 0 | False |
+| ushort | [CLSCompliantAttribute(...)] | 0 | False |
+| ushort | [TypeForwardedFromAttribute(...)] | 0 | mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 |
+| void* System.Buffers.MemoryHandle.Pointer | [CLSCompliantAttribute(...)] | 0 | False |

--- a/csharp/ql/test/library-tests/cil/attributes/attribute.ql
+++ b/csharp/ql/test/library-tests/cil/attributes/attribute.ql
@@ -1,0 +1,32 @@
+import semmle.code.cil.Attribute
+import semmle.code.cil.Declaration
+
+query predicate attrNoArg(string dec, string attr) {
+  exists(Declaration d, Attribute a |
+    a.getDeclaration() = d and
+    not exists(a.getAnArgument())
+  |
+    dec = d.toStringWithTypes() and
+    attr = a.toStringWithTypes()
+  )
+}
+
+query predicate attrArgNamed(string dec, string attr, string name, string value) {
+  exists(Declaration d, Attribute a |
+    a.getDeclaration() = d and
+    a.getNamedArgument(name) = value
+  |
+    dec = d.toStringWithTypes() and
+    attr = a.toStringWithTypes()
+  )
+}
+
+query predicate attrArgPositional(string dec, string attr, int index, string value) {
+  exists(Declaration d, Attribute a |
+    a.getDeclaration() = d and
+    a.getArgument(index) = value
+  |
+    dec = d.toStringWithTypes() and
+    attr = a.toStringWithTypes()
+  )
+}


### PR DESCRIPTION
We were calling `.ToString()` on attribute arguments to store them in the DB. This works for strings, and numeric types. `System.Type` instances are not yet extracted. For arrays we were simply storing the `.ToString()`'d type name in the DB. This has been change to the string `"[1,2,3]"`. This is still not great, because the string `"[]"` can't be told apart from an empty array. But we already had this problem with `"null"` and `null`. I'll adjust these in a follow up PR.

~~This PR adds commits on top of https://github.com/github/codeql/pull/4758.~~