### PR TITLE
C#: Fix CIL trap file writing in debug mode

### DIFF
--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -77,7 +77,7 @@ namespace Semmle.Extraction
         {
             if (idLabelCache.ContainsKey(id))
             {
-                ExtractionError("Label collision for " + id, entity.Label.ToString(), Entities.Location.Create(this, entity.ReportingLocation), "", Severity.Warning);
+                this.Extractor.Message(new Message("Label collision for " + id, entity.Label.ToString(), Entities.Location.Create(this, entity.ReportingLocation), "", Severity.Warning));
             }
             else
             {


### PR DESCRIPTION
When the extractor was executed in debug mode, it produced invalid trap files. I didn't investigate this too much as it happens only during debug. The change seems to solve the issue.

Based on top of https://github.com/github/codeql/pull/4758. 