### PR TITLE
Actions: Pin to fixed version of Sphinx Action

### DIFF
--- a/.github/workflows/generate-query-help-docs.yml
+++ b/.github/workflows/generate-query-help-docs.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         PATH="$PATH:codeql-cli/codeql" python codeql/docs/codeql/query-help-markdown.py
     - name: Run Sphinx for query help
-      uses: ammaraskar/sphinx-action@master
+      uses: ammaraskar/sphinx-action@8b4f60114d7fd1faeba1a712269168508d4750d2 # v0.4
       with:
         docs-folder: "query-help/"
         pre-build-command: "python -m pip install --upgrade recommonmark"


### PR DESCRIPTION
Better for security to fix the commit SHA of the external Action, rather than specifying a branch or tag.