### PR TITLE
JS: Make SourceNode::Range non-recursive and make strings SourceNodes

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -618,11 +618,11 @@ module API {
     cached
     predicate use(TApiNode nd, DataFlow::Node ref) {
       exists(string m, Module mod | nd = MkModuleDef(m) and mod = importableModule(m) |
-        ref.(ModuleAsSourceNode).getModule() = mod
+        ref.(ModuleVarNode).getModule() = mod
       )
       or
       exists(string m, Module mod | nd = MkModuleExport(m) and mod = importableModule(m) |
-        ref.(ExportsAsSourceNode).getModule() = mod
+        ref.(ExportsVarNode).getModule() = mod
         or
         exists(DataFlow::Node base | use(MkModuleDef(m), base) |
           ref = trackUseNode(base).getAPropertyRead("exports")
@@ -695,9 +695,9 @@ module API {
       or
       // additional backwards step from `require('m')` to `exports` or `module.exports` in m
       exists(Import imp | imp.getImportedModuleNode() = trackDefNode(nd, t.continue()) |
-        result.(ExportsAsSourceNode).getModule() = imp.getImportedModule()
+        result.(ExportsVarNode).getModule() = imp.getImportedModule()
         or
-        exists(ModuleAsSourceNode mod |
+        exists(ModuleVarNode mod |
           mod.getModule() = imp.getImportedModule() and
           result = mod.(DataFlow::SourceNode).getAPropertyRead("exports")
         )
@@ -849,13 +849,21 @@ private module Label {
   string promised() { result = "promised" }
 }
 
+private class NodeModuleSourcesNodes extends DataFlow::SourceNode::Range {
+  NodeModuleSourcesNodes() {
+    exists(NodeModule m |
+      this = DataFlow::ssaDefinitionNode(SSA::implicitInit([m.getModuleVariable(), m.getExportsVariable()]))
+    )
+  }
+}
+
 /**
- * A CommonJS/AMD `module` variable, considered as a source node.
+ * A CommonJS/AMD `module` variable.
  */
-private class ModuleAsSourceNode extends DataFlow::SourceNode::Range {
+private class ModuleVarNode extends DataFlow::Node {
   Module m;
 
-  ModuleAsSourceNode() {
+  ModuleVarNode() {
     this = DataFlow::ssaDefinitionNode(SSA::implicitInit(m.(NodeModule).getModuleVariable()))
     or
     DataFlow::parameterNode(this, m.(AmdModule).getDefine().getModuleParameter())
@@ -865,12 +873,12 @@ private class ModuleAsSourceNode extends DataFlow::SourceNode::Range {
 }
 
 /**
- * A CommonJS/AMD `exports` variable, considered as a source node.
+ * A CommonJS/AMD `exports` variable.
  */
-private class ExportsAsSourceNode extends DataFlow::SourceNode::Range {
+private class ExportsVarNode extends DataFlow::Node {
   Module m;
 
-  ExportsAsSourceNode() {
+  ExportsVarNode() {
     this = DataFlow::ssaDefinitionNode(SSA::implicitInit(m.(NodeModule).getExportsVariable()))
     or
     DataFlow::parameterNode(this, m.(AmdModule).getDefine().getExportsParameter())

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -858,7 +858,7 @@ private class ModuleAsSourceNode extends DataFlow::SourceNode::Range {
   ModuleAsSourceNode() {
     this = DataFlow::ssaDefinitionNode(SSA::implicitInit(m.(NodeModule).getModuleVariable()))
     or
-    this = DataFlow::parameterNode(m.(AmdModule).getDefine().getModuleParameter())
+    DataFlow::parameterNode(this, m.(AmdModule).getDefine().getModuleParameter())
   }
 
   Module getModule() { result = m }
@@ -873,7 +873,7 @@ private class ExportsAsSourceNode extends DataFlow::SourceNode::Range {
   ExportsAsSourceNode() {
     this = DataFlow::ssaDefinitionNode(SSA::implicitInit(m.(NodeModule).getExportsVariable()))
     or
-    this = DataFlow::parameterNode(m.(AmdModule).getDefine().getExportsParameter())
+    DataFlow::parameterNode(this, m.(AmdModule).getDefine().getExportsParameter())
   }
 
   Module getModule() { result = m }

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -859,9 +859,7 @@ private class NodeModuleSourcesNodes extends DataFlow::SourceNode::Range {
     )
   }
 
-  Variable getVariable() {
-    result = v
-  }
+  Variable getVariable() { result = v }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -850,10 +850,17 @@ private module Label {
 }
 
 private class NodeModuleSourcesNodes extends DataFlow::SourceNode::Range {
+  Variable v;
+
   NodeModuleSourcesNodes() {
     exists(NodeModule m |
-      this = DataFlow::ssaDefinitionNode(SSA::implicitInit([m.getModuleVariable(), m.getExportsVariable()]))
+      this = DataFlow::ssaDefinitionNode(SSA::implicitInit(v)) and
+      v = [m.getModuleVariable(), m.getExportsVariable()]
     )
+  }
+
+  Variable getVariable() {
+    result = v
   }
 }
 
@@ -864,7 +871,7 @@ private class ModuleVarNode extends DataFlow::Node {
   Module m;
 
   ModuleVarNode() {
-    this = DataFlow::ssaDefinitionNode(SSA::implicitInit(m.(NodeModule).getModuleVariable()))
+    this.(NodeModuleSourcesNodes).getVariable() = m.(NodeModule).getModuleVariable()
     or
     DataFlow::parameterNode(this, m.(AmdModule).getDefine().getModuleParameter())
   }
@@ -879,7 +886,7 @@ private class ExportsVarNode extends DataFlow::Node {
   Module m;
 
   ExportsVarNode() {
-    this = DataFlow::ssaDefinitionNode(SSA::implicitInit(m.(NodeModule).getExportsVariable()))
+    this.(NodeModuleSourcesNodes).getVariable() = m.(NodeModule).getExportsVariable()
     or
     DataFlow::parameterNode(this, m.(AmdModule).getDefine().getExportsParameter())
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -96,9 +96,7 @@ module DataFlow {
 
     /** Holds if this node may evaluate to the string `s`, possibly through local data flow. */
     predicate mayHaveStringValue(string s) {
-      getAPredecessor().mayHaveStringValue(s)
-      or
-      s = getStringValue()
+      s = getALocalSource().getStringValue()
     }
 
     /** Gets the string value of this node, if it is a string literal or constant string concatenation. */

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -95,9 +95,7 @@ module DataFlow {
     predicate accessesGlobal(string g) { globalVarRef(g).flowsTo(this) }
 
     /** Holds if this node may evaluate to the string `s`, possibly through local data flow. */
-    predicate mayHaveStringValue(string s) {
-      s = getALocalSource().getStringValue()
-    }
+    predicate mayHaveStringValue(string s) { s = getALocalSource().getStringValue() }
 
     /** Gets the string value of this node, if it is a string literal or constant string concatenation. */
     string getStringValue() { result = asExpr().getStringValue() }

--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -308,7 +308,8 @@ module SourceNode {
         astNode instanceof DynamicImportExpr or
         astNode instanceof ImportSpecifier or
         astNode instanceof ImportMetaExpr or
-        astNode instanceof TaggedTemplateExpr
+        astNode instanceof TaggedTemplateExpr or
+        astNode instanceof ConstantString
       )
       or
       DataFlow::parameterNode(this, _)

--- a/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
@@ -24,46 +24,6 @@ DataFlow::SourceNode angular() {
 }
 
 /**
- * Holds if `tl` appears to be a top-level using the AngularJS library.
- *
- * Should not depend on the `SourceNode` class.
- */
-pragma[nomagic]
-private predicate isAngularTopLevel(TopLevel tl) {
-  exists(Import imprt |
-    imprt.getTopLevel() = tl and
-    imprt.getImportedPath().getValue() = "angular"
-  )
-  or
-  exists(GlobalVarAccess global |
-    global.getName() = "angular" and
-    global.getTopLevel() = tl
-  )
-}
-
-/**
- * Holds if `s` is a string in a top-level using the AngularJS library.
- *
- * Should not depend on the `SourceNode` class.
- */
-pragma[nomagic]
-private predicate isAngularString(Expr s) {
-  isAngularTopLevel(s.getTopLevel()) and
-  (
-    s instanceof StringLiteral or
-    s instanceof TemplateLiteral
-  )
-}
-
-/**
- * String literals in Angular code are often used as identifiers or references, so we
- * want to track them.
- */
-private class TrackStringsInAngularCode extends DataFlow::SourceNode::Range, DataFlow::ValueNode {
-  TrackStringsInAngularCode() { isAngularString(astNode) }
-}
-
-/**
  * Holds if `m` is of the form `angular.module("name", ...)`.
  */
 private DataFlow::CallNode angularModuleCall(string name) {

--- a/javascript/ql/test/library-tests/DataFlow/tests.expected
+++ b/javascript/ql/test/library-tests/DataFlow/tests.expected
@@ -1439,6 +1439,7 @@ sources
 | eval.js:1:1:5:1 | return of function k |
 | eval.js:3:3:3:6 | eval |
 | eval.js:3:3:3:16 | eval("x = 23") |
+| eval.js:3:8:3:15 | "x = 23" |
 | file://:0:0:0:0 | global access path |
 | sources.js:1:1:1:0 | this |
 | sources.js:1:1:1:12 | new (x => x) |
@@ -1475,6 +1476,8 @@ sources
 | tst.js:1:1:1:0 | this |
 | tst.js:1:1:1:24 | import  ... m 'fs'; |
 | tst.js:1:10:1:11 | fs |
+| tst.js:1:20:1:23 | 'fs' |
+| tst.js:4:9:4:12 | "hi" |
 | tst.js:16:1:20:9 | (functi ... ("arg") |
 | tst.js:16:2:16:1 | this |
 | tst.js:16:2:20:1 | functio ... n "";\\n} |
@@ -1483,6 +1486,8 @@ sources
 | tst.js:17:7:17:10 | Math |
 | tst.js:17:7:17:17 | Math.random |
 | tst.js:17:7:17:19 | Math.random() |
+| tst.js:19:10:19:11 | "" |
+| tst.js:20:4:20:8 | "arg" |
 | tst.js:22:7:22:18 | readFileSync |
 | tst.js:28:1:30:3 | (() =>\\n ... les\\n)() |
 | tst.js:28:2:29:3 | () =>\\n  x |
@@ -1500,6 +1505,8 @@ sources
 | tst.js:44:1:44:3 | o.m |
 | tst.js:44:1:44:5 | o.m() |
 | tst.js:46:1:46:6 | global |
+| tst.js:46:1:46:11 | global = "" |
+| tst.js:46:10:46:11 | "" |
 | tst.js:47:1:47:6 | global |
 | tst.js:49:1:54:1 | class A ... `\\n  }\\n} |
 | tst.js:49:17:49:17 | B |
@@ -1507,8 +1514,10 @@ sources
 | tst.js:50:14:53:3 | () {\\n   ... et`\\n  } |
 | tst.js:50:14:53:3 | return of constructor of class A |
 | tst.js:51:5:51:13 | super(42) |
+| tst.js:57:2:57:4 | x:  |
 | tst.js:58:1:58:3 | tag |
 | tst.js:58:1:58:13 | tag `x: ${x}` |
+| tst.js:58:6:58:8 | x:  |
 | tst.js:61:1:61:5 | ::o.m |
 | tst.js:61:3:61:5 | o.m |
 | tst.js:62:1:62:4 | o::g |
@@ -1527,6 +1536,7 @@ sources
 | tst.js:72:9:72:9 | p |
 | tst.js:72:9:72:11 | p() |
 | tst.js:75:9:75:21 | import('foo') |
+| tst.js:75:16:75:20 | 'foo' |
 | tst.js:80:10:80:10 | v |
 | tst.js:83:11:83:28 | [ for (v of o) v ] |
 | tst.js:85:11:85:28 | ( for (v of o) v ) |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -264,9 +264,13 @@ typetrack
 | flow2.js:18:33:18:79 | Promise ... urce)]) | flow2.js:18:45:18:78 | ["clean ... ource)] | copy $PromiseResolveField$ |
 | flow2.js:18:33:18:79 | Promise ... urce)]) | flow2.js:18:45:18:78 | ["clean ... ource)] | store $PromiseResolveField$ |
 | flow2.js:22:17:22:70 | await P ... urce)]) | flow2.js:22:23:22:70 | Promise ... urce)]) | load $PromiseResolveField$ |
+| flow2.js:22:23:22:70 | Promise ... urce)]) | flow2.js:22:37:22:43 | "clean" | copy $PromiseResolveField$ |
+| flow2.js:22:23:22:70 | Promise ... urce)]) | flow2.js:22:37:22:43 | "clean" | store $PromiseResolveField$ |
 | flow2.js:22:23:22:70 | Promise ... urce)]) | flow2.js:22:46:22:68 | Promise ... source) | copy $PromiseResolveField$ |
 | flow2.js:22:23:22:70 | Promise ... urce)]) | flow2.js:22:46:22:68 | Promise ... source) | store $PromiseResolveField$ |
 | flow2.js:25:17:25:69 | await P ... urce)]) | flow2.js:25:23:25:69 | Promise ... urce)]) | load $PromiseResolveField$ |
+| flow2.js:25:23:25:69 | Promise ... urce)]) | flow2.js:25:36:25:42 | "clean" | copy $PromiseResolveField$ |
+| flow2.js:25:23:25:69 | Promise ... urce)]) | flow2.js:25:36:25:42 | "clean" | store $PromiseResolveField$ |
 | flow2.js:25:23:25:69 | Promise ... urce)]) | flow2.js:25:45:25:67 | Promise ... source) | copy $PromiseResolveField$ |
 | flow2.js:25:23:25:69 | Promise ... urce)]) | flow2.js:25:45:25:67 | Promise ... source) | store $PromiseResolveField$ |
 | flow.js:20:2:20:43 | Promise ... ink(x)) | flow.js:20:36:20:42 | sink(x) | copy $PromiseResolveField$ |
@@ -285,10 +289,14 @@ typetrack
 | flow.js:26:2:26:81 | new Pro ... ink(y)) | flow.js:26:74:26:80 | sink(y) | copy $PromiseResolveField$ |
 | flow.js:26:2:26:81 | new Pro ... ink(y)) | flow.js:26:74:26:80 | sink(y) | store $PromiseResolveField$ |
 | flow.js:26:56:26:56 | x | flow.js:26:2:26:49 | new Pro ... ource)) | load $PromiseResolveField$ |
+| flow.js:28:2:28:23 | Promise ... ("foo") | flow.js:28:18:28:22 | "foo" | copy $PromiseResolveField$ |
+| flow.js:28:2:28:23 | Promise ... ("foo") | flow.js:28:18:28:22 | "foo" | store $PromiseResolveField$ |
 | flow.js:28:2:28:60 | Promise ... ink(z)) | flow.js:28:53:28:59 | sink(z) | copy $PromiseResolveField$ |
 | flow.js:28:2:28:60 | Promise ... ink(z)) | flow.js:28:53:28:59 | sink(z) | store $PromiseResolveField$ |
 | flow.js:28:30:28:30 | x | flow.js:28:2:28:23 | Promise ... ("foo") | load $PromiseResolveField$ |
 | flow.js:28:48:28:48 | z | flow.js:28:2:28:41 | Promise ... source) | load $PromiseResolveField$ |
+| flow.js:30:2:30:41 | Promise ...  "foo") | flow.js:30:36:30:40 | "foo" | copy $PromiseResolveField$ |
+| flow.js:30:2:30:41 | Promise ...  "foo") | flow.js:30:36:30:40 | "foo" | store $PromiseResolveField$ |
 | flow.js:30:2:30:60 | Promise ... ink(z)) | flow.js:30:53:30:59 | sink(z) | copy $PromiseResolveField$ |
 | flow.js:30:2:30:60 | Promise ... ink(z)) | flow.js:30:53:30:59 | sink(z) | store $PromiseResolveField$ |
 | flow.js:30:31:30:31 | x | flow.js:30:2:30:24 | Promise ... source) | load $PromiseResolveField$ |

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.expected
@@ -1900,6 +1900,7 @@ test_RouteSetup_getARouteHandler
 | src/advanced-routehandler-registration.js:135:2:135:53 | app.get ... andler) | src/advanced-routehandler-registration.js:135:31:135:52 | dynamic ... handler |
 | src/advanced-routehandler-registration.js:139:1:139:58 | app.get ... andler) | src/advanced-routehandler-registration.js:139:9:139:30 | bulkReq ... ky.path |
 | src/advanced-routehandler-registration.js:139:1:139:58 | app.get ... andler) | src/advanced-routehandler-registration.js:139:33:139:57 | bulkReq ... handler |
+| src/advanced-routehandler-registration.js:139:1:139:58 | app.get ... andler) | src/controllers/handler-in-bulk-require.js:1:26:1:32 | "bulky" |
 | src/advanced-routehandler-registration.js:139:1:139:58 | app.get ... andler) | src/controllers/handler-in-bulk-require.js:1:44:1:66 | (req, r ... defined |
 | src/advanced-routehandler-registration.js:147:1:147:37 | app.use ... (data)) | src/advanced-routehandler-registration.js:146:28:146:50 | (req, r ... defined |
 | src/advanced-routehandler-registration.js:147:1:147:37 | app.use ... (data)) | src/advanced-routehandler-registration.js:147:9:147:25 | handlers.handlerA |


### PR DESCRIPTION
[Evaluation](https://github.com/github/asgerf-dist-compare-reports/tree/js/source-node-tweaks_1605971495621) (internal link) shows a minor slow down due to optimizer wobbles, but it has been observed to help with the BDD node limit in some cases.