### PR TITLE
JS: better support for forms in js/xss-through-dom

### DIFF
--- a/javascript/ql/test/library-tests/DOM/Customizations.expected
+++ b/javascript/ql/test/library-tests/DOM/Customizations.expected
@@ -4,7 +4,9 @@ test_documentRef
 test_locationRef
 | customization.js:3:3:3:14 | doc.location |
 test_domValueRef
+| customization.js:4:3:4:20 | doc.getElementById |
 | customization.js:4:3:4:28 | doc.get ... 'test') |
+| nameditems.js:1:1:1:23 | documen ... entById |
 | nameditems.js:1:1:1:30 | documen ... ('foo') |
 | nameditems.js:1:1:2:19 | documen ... em('x') |
 | tst.js:49:3:49:8 | window |

--- a/javascript/ql/test/library-tests/DOM/externs/externs.js
+++ b/javascript/ql/test/library-tests/DOM/externs/externs.js
@@ -8,3 +8,13 @@ function EventTarget() {}
 
 /** @type {EventTarget} */
 var window;
+
+/**
+ * @see http://dev.w3.org/html5/workers/
+ * @interface
+ * @extends {EventTarget}
+ */
+function WorkerGlobalScope() {}
+
+/** @type {WorkerLocation} */
+WorkerGlobalScope.prototype.location;

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -44,8 +44,11 @@ nodes
 | xss-through-dom.js:73:9:73:41 | selector |
 | xss-through-dom.js:73:20:73:41 | $("inpu ... 0).name |
 | xss-through-dom.js:73:20:73:41 | $("inpu ... 0).name |
-| xss-through-dom.js:77:7:77:14 | selector |
-| xss-through-dom.js:77:7:77:14 | selector |
+| xss-through-dom.js:77:4:77:11 | selector |
+| xss-through-dom.js:77:4:77:11 | selector |
+| xss-through-dom.js:79:4:79:34 | documen ... t.value |
+| xss-through-dom.js:79:4:79:34 | documen ... t.value |
+| xss-through-dom.js:79:4:79:34 | documen ... t.value |
 edges
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() |
@@ -61,10 +64,11 @@ edges
 | xss-through-dom.js:61:30:61:69 | $(docum ... value") | xss-through-dom.js:61:30:61:69 | $(docum ... value") |
 | xss-through-dom.js:64:30:64:40 | valMethod() | xss-through-dom.js:64:30:64:40 | valMethod() |
 | xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name | xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name |
-| xss-through-dom.js:73:9:73:41 | selector | xss-through-dom.js:77:7:77:14 | selector |
-| xss-through-dom.js:73:9:73:41 | selector | xss-through-dom.js:77:7:77:14 | selector |
+| xss-through-dom.js:73:9:73:41 | selector | xss-through-dom.js:77:4:77:11 | selector |
+| xss-through-dom.js:73:9:73:41 | selector | xss-through-dom.js:77:4:77:11 | selector |
 | xss-through-dom.js:73:20:73:41 | $("inpu ... 0).name | xss-through-dom.js:73:9:73:41 | selector |
 | xss-through-dom.js:73:20:73:41 | $("inpu ... 0).name | xss-through-dom.js:73:9:73:41 | selector |
+| xss-through-dom.js:79:4:79:34 | documen ... t.value | xss-through-dom.js:79:4:79:34 | documen ... t.value |
 #select
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:2:16:2:34 | $("textarea").val() | DOM text |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | DOM text |
@@ -80,4 +84,5 @@ edges
 | xss-through-dom.js:61:30:61:69 | $(docum ... value") | xss-through-dom.js:61:30:61:69 | $(docum ... value") | xss-through-dom.js:61:30:61:69 | $(docum ... value") | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:61:30:61:69 | $(docum ... value") | DOM text |
 | xss-through-dom.js:64:30:64:40 | valMethod() | xss-through-dom.js:64:30:64:40 | valMethod() | xss-through-dom.js:64:30:64:40 | valMethod() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:64:30:64:40 | valMethod() | DOM text |
 | xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name | xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name | xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name | DOM text |
-| xss-through-dom.js:77:7:77:14 | selector | xss-through-dom.js:73:20:73:41 | $("inpu ... 0).name | xss-through-dom.js:77:7:77:14 | selector | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:73:20:73:41 | $("inpu ... 0).name | DOM text |
+| xss-through-dom.js:77:4:77:11 | selector | xss-through-dom.js:73:20:73:41 | $("inpu ... 0).name | xss-through-dom.js:77:4:77:11 | selector | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:73:20:73:41 | $("inpu ... 0).name | DOM text |
+| xss-through-dom.js:79:4:79:34 | documen ... t.value | xss-through-dom.js:79:4:79:34 | documen ... t.value | xss-through-dom.js:79:4:79:34 | documen ... t.value | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:79:4:79:34 | documen ... t.value | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
@@ -74,5 +74,7 @@
     if (something()) {
         selector = $("textarea").val || ''
     }
-    $(selector); // NOT OK
+	$(selector); // NOT OK
+	
+	$(document.my_form.my_input.value); // NOT OK
 })();


### PR DESCRIPTION
Gets a TP/TN for CVE-2018-8035  

We must have lost the TP with https://github.com/github/codeql/commit/f23c6030aab56ba62def832e5c03570e1c61b57c.  
And this is my attempt at recognizing the source again. 
