### PR TITLE
C#: Add missing CFG edges for nested `finally` blocks

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
@@ -693,7 +693,7 @@ module FinallySplitting {
       then result = ""
       else
         if nestLevel > 0
-        then result = "finally(" + (nestLevel + 1) + "): " + type.toString()
+        then result = "finally(" + nestLevel + "): " + type.toString()
         else result = "finally: " + type.toString()
     }
   }

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
@@ -29,7 +29,7 @@ private module Cached {
     TInitializerSplitKind() or
     TConditionalCompletionSplitKind() or
     TAssertionSplitKind() or
-    TFinallySplitKind(int nestLevel) { nestLevel = FinallySplitting::nestLevel(_) } or
+    TFinallySplitKind(int nestLevel) { nestLevel = any(Statements::TryStmtTree t).nestLevel() } or
     TExceptionHandlerSplitKind() or
     TBooleanSplitKind(BooleanSplitting::BooleanSplitSubKind kind) { kind.startsSplit(_) } or
     TLoopSplitKind(LoopSplitting::AnalyzableLoopStmt loop)
@@ -43,7 +43,7 @@ private module Cached {
       success in [false, true]
     } or
     TFinallySplit(FinallySplitting::FinallySplitType type, int nestLevel) {
-      nestLevel = FinallySplitting::nestLevel(_)
+      nestLevel = any(Statements::TryStmtTree t).nestLevel()
     } or
     TExceptionHandlerSplit(ExceptionClass ec) or
     TBooleanSplit(BooleanSplitting::BooleanSplitSubKind kind, boolean branch) {
@@ -610,12 +610,6 @@ module AssertionSplitting {
   }
 }
 
-pragma[noinline]
-private ControlFlowElement getAChild(ControlFlowElement cfe, Callable c) {
-  result = cfe.getAChild() and
-  c = result.getEnclosingCallable()
-}
-
 module FinallySplitting {
   /**
    * The type of a split `finally` node.
@@ -639,45 +633,14 @@ module FinallySplitting {
     }
   }
 
-  /**
-   * Gets a descendant that belongs to the `finally` block of try statement
-   * `try`.
-   */
-  ControlFlowElement getAFinallyDescendant(TryStmt try) {
-    result = try.getFinally()
-    or
-    exists(ControlFlowElement mid |
-      mid = getAFinallyDescendant(try) and
-      result = getAChild(mid, mid.getEnclosingCallable()) and
-      not exists(TryStmt nestedTry |
-        result = nestedTry.getFinally() and
-        nestedTry != try
-      )
-    )
-  }
-
-  /**
-   * Holds if `innerTry` has a `finally` block and is immediately nested inside the
-   * `finally` block of `outerTry`.
-   */
-  private predicate nestedFinally(TryStmt outerTry, TryStmt innerTry) {
-    exists(ControlFlowElement innerFinally |
-      innerFinally = getAChild(getAFinallyDescendant(outerTry), outerTry.getEnclosingCallable()) and
-      innerFinally = innerTry.getFinally()
-    )
-  }
-
-  /** Gets the nesting level of the `finally` block for `try`. */
-  int nestLevel(TryStmt try) { result = strictcount(TryStmt outer | nestedFinally*(outer, try)) }
-
   /** A control flow element that belongs to a `finally` block. */
   private class FinallyControlFlowElement extends ControlFlowElement {
-    private TryStmt try;
+    private Statements::TryStmtTree try;
 
-    FinallyControlFlowElement() { this = getAFinallyDescendant(try) }
+    FinallyControlFlowElement() { this = try.getAFinallyDescendant() }
 
     /** Gets the immediate `try` block that this node belongs to. */
-    TryStmt getTryStmt() { result = try }
+    Statements::TryStmtTree getTryStmt() { result = try }
 
     /** Holds if this node is the entry node in the `finally` block it belongs to. */
     predicate isEntryNode() { first(try.getFinally(), this) }
@@ -685,7 +648,9 @@ module FinallySplitting {
 
   /** A control flow element that does not belong to a `finally` block. */
   private class NonFinallyControlFlowElement extends ControlFlowElement {
-    NonFinallyControlFlowElement() { not this = getAFinallyDescendant(_) }
+    NonFinallyControlFlowElement() {
+      not this = any(Statements::TryStmtTree t).getAFinallyDescendant()
+    }
   }
 
   /**
@@ -727,8 +692,8 @@ module FinallySplitting {
       if type instanceof NormalSuccessor
       then result = ""
       else
-        if nestLevel > 1
-        then result = "finally(" + nestLevel + "): " + type.toString()
+        if nestLevel > 0
+        then result = "finally(" + (nestLevel + 1) + "): " + type.toString()
         else result = "finally: " + type.toString()
     }
   }
@@ -759,7 +724,7 @@ module FinallySplitting {
     ControlFlowElement pred, FinallyControlFlowElement succ, int nestLevel, Completion c
   ) {
     succ.isEntryNode() and
-    nestLevel = nestLevel(succ.getTryStmt()) and
+    nestLevel = succ.getTryStmt().nestLevel() and
     succ(pred, succ, c)
   }
 
@@ -783,9 +748,11 @@ module FinallySplitting {
     }
 
     pragma[noinline]
-    private predicate exit0(ControlFlowElement pred, TryStmt try, int nestLevel, Completion c) {
+    private predicate exit0(
+      ControlFlowElement pred, Statements::TryStmtTree try, int nestLevel, Completion c
+    ) {
       this.appliesToPredecessor(pred) and
-      nestLevel = nestLevel(try) and
+      nestLevel = try.nestLevel() and
       last(try, pred, c)
     }
 
@@ -821,7 +788,7 @@ module FinallySplitting {
         )
       )
       or
-      // If this split is normal, and an outer split can exit based on a inherited
+      // If this split is normal, and an outer split can exit based on an inherited
       // completion, we need to exit this split as well. For example, in
       //
       // ```csharp
@@ -881,10 +848,10 @@ module FinallySplitting {
           if fcfe.isEntryNode()
           then
             // entering a nested `finally` block
-            nestLevel(fcfe.getTryStmt()) > this.getNestLevel()
+            fcfe.getTryStmt().nestLevel() > this.getNestLevel()
           else
             // staying in the same (possibly nested) `finally` block as `pred`
-            nestLevel(fcfe.getTryStmt()) >= this.getNestLevel()
+            fcfe.getTryStmt().nestLevel() >= this.getNestLevel()
         )
     }
   }

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -641,6 +641,30 @@
 | Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:13:220:36 | call to method WriteLine | 1 |
 | Finally.cs:222:9:225:9 | catch {...} | Finally.cs:224:13:224:38 | call to method WriteLine | 5 |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:216:10:216:12 | exit M11 | 9 |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:239:21:239:22 | access to parameter b1 | 8 |
+| Finally.cs:233:10:233:12 | exit M12 | Finally.cs:233:10:233:12 | exit M12 | 1 |
+| Finally.cs:233:10:233:12 | exit M12 (abnormal) | Finally.cs:233:10:233:12 | exit M12 (abnormal) | 1 |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | 6 |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:27:240:42 | object creation of type ExceptionA | 1 |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | 5 |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:246:25:246:26 | access to parameter b2 | 5 |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | 5 |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | 5 |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | 5 |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | 1 |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | 1 |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | object creation of type ExceptionA | 1 |
+| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | 4 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | 4 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | 4 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | 4 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | 4 |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:254:31:254:43 | "Mid finally" | 6 |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:254:13:254:44 | call to method WriteLine | 1 |
+| Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine | 4 |
+| Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine | 4 |
+| Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:258:13:258:46 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 4 |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:233:10:233:12 | exit M12 (normal) | 8 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:8:29:8:32 | access to parameter args | 3 |
 | Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 | 2 |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -479,12 +479,12 @@
 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | 1 |
 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | 1 |
 | Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:93:31:93:45 | object creation of type Exception | 1 |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:23 | [finally(2): exception(Exception)] ...-- | 4 |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:23 | [finally: break, finally(2): exception(Exception)] ...-- | 4 |
+| Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- | 4 |
+| Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- | 4 |
 | Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:97:21:97:23 | [finally: break] ...-- | 4 |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:23 | [finally: continue, finally(2): exception(Exception)] ...-- | 4 |
+| Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- | 4 |
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:97:21:97:23 | [finally: continue] ...-- | 4 |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:23 | [finally: return, finally(2): exception(Exception)] ...-- | 4 |
+| Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- | 4 |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:97:21:97:23 | [finally: return] ...-- | 4 |
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:97:21:97:23 | ...-- | 4 |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:107:17:107:21 | access to field Field | 7 |
@@ -613,25 +613,25 @@
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:199:27:199:42 | object creation of type ExceptionA | 1 |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:205:21:205:22 | [finally: exception(Exception)] access to parameter b2 | 5 |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:205:21:205:22 | access to parameter b2 | 5 |
-| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | 4 |
-| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | 4 |
-| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | 4 |
+| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | 4 |
+| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | 4 |
+| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | 4 |
 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | 1 |
 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | 1 |
 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:205:31:205:46 | object creation of type ExceptionB | 1 |
-| Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | 3 |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | 3 |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | 3 |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | 3 |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | 3 |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | 3 |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | 3 |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | 3 |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | 3 |
-| Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; | 2 |
-| Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; | 2 |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; | 2 |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] throw ...; | 2 |
+| Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; | 2 |
+| Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; | 2 |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; | 2 |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; | 2 |
 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | 2 |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] throw ...; | 2 |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; | 2 |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; | 2 |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; | 2 |
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | 2 |
 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:209:25:209:47 | throw ...; | 2 |
 | Finally.cs:211:13:211:29 | ...; | Finally.cs:195:10:195:12 | exit M10 (normal) | 9 |
@@ -648,16 +648,16 @@
 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:27:240:42 | object creation of type ExceptionA | 1 |
 | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | 5 |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:246:25:246:26 | access to parameter b2 | 5 |
-| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | 5 |
-| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | 5 |
-| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | 5 |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine | 5 |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine | 5 |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine | 5 |
 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | 1 |
 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | 1 |
 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | object creation of type ExceptionA | 1 |
-| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | 4 |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | 4 |
+| Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine | 4 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine | 4 |
 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | 4 |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | 4 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine | 4 |
 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | 4 |
 | Finally.cs:250:17:252:17 | {...} | Finally.cs:254:31:254:43 | "Mid finally" | 6 |
 | Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:254:13:254:44 | call to method WriteLine | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -1363,12 +1363,12 @@ conditionBlock
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | true |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | true |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:93:31:93:45 | object creation of type Exception | true |
-| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | true |
-| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | true |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | true |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | true |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: break] {...} | true |
-| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | true |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | true |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: continue] {...} | true |
-| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | true |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | true |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: return] {...} | true |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | {...} | true |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:82:21:82:27 | return ...; | true |
@@ -1385,17 +1385,17 @@ conditionBlock
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | false |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | true |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:93:31:93:45 | object creation of type Exception | false |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | false |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | false |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | false |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | false |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: break] {...} | false |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | false |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | false |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: continue] {...} | false |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | true |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | true |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: return] {...} | true |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | {...} | false |
 | Finally.cs:82:21:82:27 | return ...; | Finally.cs:93:25:93:46 | [finally: return] throw ...; | true |
 | Finally.cs:82:21:82:27 | return ...; | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | true |
-| Finally.cs:82:21:82:27 | return ...; | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | true |
+| Finally.cs:82:21:82:27 | return ...; | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | true |
 | Finally.cs:82:21:82:27 | return ...; | Finally.cs:96:17:98:17 | [finally: return] {...} | false |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:84:21:84:29 | continue; | true |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:85:17:86:26 | if (...) ... | false |
@@ -1407,15 +1407,15 @@ conditionBlock
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | false |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | true |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:93:31:93:45 | object creation of type Exception | false |
-| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | false |
-| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | false |
+| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | false |
+| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | false |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break] {...} | false |
-| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | true |
+| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | true |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: continue] {...} | true |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | {...} | false |
 | Finally.cs:84:21:84:29 | continue; | Finally.cs:93:25:93:46 | [finally: continue] throw ...; | true |
 | Finally.cs:84:21:84:29 | continue; | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | true |
-| Finally.cs:84:21:84:29 | continue; | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | true |
+| Finally.cs:84:21:84:29 | continue; | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | true |
 | Finally.cs:84:21:84:29 | continue; | Finally.cs:96:17:98:17 | [finally: continue] {...} | false |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:86:21:86:26 | break; | true |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:89:13:99:13 | {...} | false |
@@ -1423,17 +1423,17 @@ conditionBlock
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:93:25:93:46 | throw ...; | false |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | true |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:93:31:93:45 | object creation of type Exception | false |
-| Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | false |
-| Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | true |
+| Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | false |
+| Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | true |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break] {...} | true |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | {...} | false |
 | Finally.cs:86:21:86:26 | break; | Finally.cs:93:25:93:46 | [finally: break] throw ...; | true |
 | Finally.cs:86:21:86:26 | break; | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | true |
-| Finally.cs:86:21:86:26 | break; | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | true |
+| Finally.cs:86:21:86:26 | break; | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | true |
 | Finally.cs:86:21:86:26 | break; | Finally.cs:96:17:98:17 | [finally: break] {...} | false |
 | Finally.cs:89:13:99:13 | {...} | Finally.cs:93:25:93:46 | throw ...; | true |
 | Finally.cs:89:13:99:13 | {...} | Finally.cs:93:31:93:45 | object creation of type Exception | true |
-| Finally.cs:89:13:99:13 | {...} | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | true |
+| Finally.cs:89:13:99:13 | {...} | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | true |
 | Finally.cs:89:13:99:13 | {...} | Finally.cs:96:17:98:17 | {...} | false |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:108:17:108:23 | return ...; | true |
 | Finally.cs:107:33:107:33 | 0 | Finally.cs:109:13:110:49 | if (...) ... | false |
@@ -1624,19 +1624,19 @@ conditionBlock
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | true |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | true |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | false |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | false |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | false |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | true |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | true |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | true |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | true |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | {...} | false |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | false |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | false |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | true |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | false |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | false |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | true |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | true |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | true |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | false |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:211:13:211:29 | ...; | false |
@@ -1644,36 +1644,36 @@ conditionBlock
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | true |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | true |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | true |
-| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | true |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | false |
-| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | true |
-| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | false |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | false |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | true |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | true |
-| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | true |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | false |
-| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | true |
-| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | false |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | false |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:205:25:205:47 | throw ...; | true |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:205:31:205:46 | object creation of type ExceptionB | true |
-| Finally.cs:202:9:212:9 | {...} | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | true |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | true |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:208:13:210:13 | {...} | false |
-| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | true |
-| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:209:31:209:46 | object creation of type ExceptionC | false |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:211:13:211:29 | ...; | false |
-| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
-| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
-| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
-| Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | true |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | true |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | true |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | false |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | true |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | true |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | false |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:209:31:209:46 | object creation of type ExceptionC | true |
@@ -1688,10 +1688,10 @@ conditionBlock
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | true |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | true |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | false |
-| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | false |
-| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | false |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | true |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | true |
-| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | true |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | true |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | {...} | false |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:254:13:254:44 | call to method WriteLine | false |
@@ -1699,15 +1699,15 @@ conditionBlock
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:257:9:259:9 | {...} | false |
 | Finally.cs:240:21:240:43 | throw ...; | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | true |
 | Finally.cs:240:21:240:43 | throw ...; | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | true |
-| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | true |
 | Finally.cs:240:21:240:43 | throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | false |
 | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | true |
 | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | true |
-| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | true |
 | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | false |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:247:25:247:47 | throw ...; | true |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:247:31:247:46 | object creation of type ExceptionA | true |
-| Finally.cs:243:13:253:13 | {...} | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | true |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | true |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:250:17:252:17 | {...} | false |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine | false |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | false |
@@ -2688,14 +2688,14 @@ conditionFlow
 | Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | false |
 | Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | true |
 | Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:208:13:210:13 | {...} | false |
-| Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | true |
-| Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | true |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | true |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | false |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | true |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | true |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | false |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -1678,6 +1678,40 @@ conditionBlock
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | false |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:209:31:209:46 | object creation of type ExceptionC | true |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:211:13:211:29 | ...; | false |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:240:21:240:43 | throw ...; | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:243:13:253:13 | {...} | false |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:25:247:47 | throw ...; | false |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | false |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | false |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | true |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | {...} | false |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:254:13:254:44 | call to method WriteLine | false |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | false |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:257:9:259:9 | {...} | false |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | true |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | true |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | false |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | true |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | true |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | true |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | false |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:247:25:247:47 | throw ...; | true |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:247:31:247:46 | object creation of type ExceptionA | true |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | true |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:250:17:252:17 | {...} | false |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine | false |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | false |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:257:9:259:9 | {...} | false |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 (normal) | true |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:22:8:24 | String arg | false |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 (normal) | true |
@@ -2666,6 +2700,14 @@ conditionFlow
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | false |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | true |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:211:13:211:29 | ...; | false |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | true |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:243:13:253:13 | {...} | false |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | true |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | false |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | true |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | false |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | true |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:250:17:252:17 | {...} | false |
 | LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:10:13:10:19 | return ...; | true |
 | LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:11:29:11:32 | access to parameter args | false |
 | LoopUnrolling.cs:60:17:60:17 | [b (line 55): false] access to parameter b | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | false |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -1852,36 +1852,36 @@ dominance
 | Finally.cs:92:30:92:30 | [finally: continue] 3 | Finally.cs:92:25:92:30 | [finally: continue] ... == ... |
 | Finally.cs:92:30:92:30 | [finally: return] 3 | Finally.cs:92:25:92:30 | [finally: return] ... == ... |
 | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: break] throw ...; |
-| Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: continue] throw ...; |
-| Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} |
 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: return] throw ...; |
-| Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
+| Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} |
 | Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:93:25:93:46 | throw ...; |
-| Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally(2): exception(Exception)] ...; |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: break, finally(2): exception(Exception)] ...; |
+| Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; |
+| Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; |
 | Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:97:21:97:24 | [finally: break] ...; |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: continue, finally(2): exception(Exception)] ...; |
+| Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; |
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:97:21:97:24 | [finally: continue] ...; |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: return, finally(2): exception(Exception)] ...; |
+| Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:97:21:97:24 | [finally: return] ...; |
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:97:21:97:24 | ...; |
-| Finally.cs:97:21:97:21 | [finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally(2): exception(Exception)] ...-- |
-| Finally.cs:97:21:97:21 | [finally: break, finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: break, finally(2): exception(Exception)] ...-- |
+| Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- |
+| Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- |
 | Finally.cs:97:21:97:21 | [finally: break] access to local variable i | Finally.cs:97:21:97:23 | [finally: break] ...-- |
-| Finally.cs:97:21:97:21 | [finally: continue, finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: continue, finally(2): exception(Exception)] ...-- |
+| Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- |
 | Finally.cs:97:21:97:21 | [finally: continue] access to local variable i | Finally.cs:97:21:97:23 | [finally: continue] ...-- |
-| Finally.cs:97:21:97:21 | [finally: return, finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: return, finally(2): exception(Exception)] ...-- |
+| Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- |
 | Finally.cs:97:21:97:21 | [finally: return] access to local variable i | Finally.cs:97:21:97:23 | [finally: return] ...-- |
 | Finally.cs:97:21:97:21 | access to local variable i | Finally.cs:97:21:97:23 | ...-- |
 | Finally.cs:97:21:97:24 | ...; | Finally.cs:97:21:97:21 | access to local variable i |
-| Finally.cs:97:21:97:24 | [finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally(2): exception(Exception)] access to local variable i |
-| Finally.cs:97:21:97:24 | [finally: break, finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: break, finally(2): exception(Exception)] access to local variable i |
+| Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i |
+| Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i |
 | Finally.cs:97:21:97:24 | [finally: break] ...; | Finally.cs:97:21:97:21 | [finally: break] access to local variable i |
-| Finally.cs:97:21:97:24 | [finally: continue, finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: continue, finally(2): exception(Exception)] access to local variable i |
+| Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i |
 | Finally.cs:97:21:97:24 | [finally: continue] ...; | Finally.cs:97:21:97:21 | [finally: continue] access to local variable i |
-| Finally.cs:97:21:97:24 | [finally: return, finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: return, finally(2): exception(Exception)] access to local variable i |
+| Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i |
 | Finally.cs:97:21:97:24 | [finally: return] ...; | Finally.cs:97:21:97:21 | [finally: return] access to local variable i |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:104:5:119:5 | {...} |
 | Finally.cs:104:5:119:5 | {...} | Finally.cs:105:9:118:9 | try {...} ... |
@@ -2238,52 +2238,52 @@ dominance
 | Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:205:31:205:46 | object creation of type ExceptionB |
 | Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:208:13:210:13 | {...} |
-| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(ExceptionB)] {...} |
-| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] {...} |
-| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:208:13:210:13 | [finally(2): exception(ExceptionB)] {...} |
+| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} |
+| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} |
+| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} |
 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
-| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:205:25:205:47 | throw ...; |
-| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally(2): exception(Exception)] if (...) ... |
-| Finally.cs:208:13:210:13 | [finally(2): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally(2): exception(ExceptionB)] if (...) ... |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] if (...) ... |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] if (...) ... |
+| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... |
+| Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] if (...) ... |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] if (...) ... |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:209:17:209:47 | if (...) ... |
-| Finally.cs:209:17:209:47 | [finally(2): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 |
-| Finally.cs:209:17:209:47 | [finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 |
+| Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 |
+| Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 |
 | Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 |
 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 |
 | Finally.cs:209:17:209:47 | if (...) ... | Finally.cs:209:21:209:22 | access to parameter b3 |
-| Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:209:31:209:46 | object creation of type ExceptionC |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:211:13:211:29 | ...; |
-| Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; |
-| Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] throw ...; |
+| Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; |
+| Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; |
 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] throw ...; |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; |
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; |
 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:209:25:209:47 | throw ...; |
 | Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access | Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" |
@@ -2349,42 +2349,42 @@ dominance
 | Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
 | Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:250:17:252:17 | {...} |
-| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} |
-| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} |
-| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} |
 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
-| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | throw ...; |
-| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; |
-| Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; |
+| Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; |
 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; |
 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; |
 | Finally.cs:250:17:252:17 | {...} | Finally.cs:251:21:251:55 | ...; |
 | Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:254:13:254:45 | ...; |
 | Finally.cs:251:21:251:55 | ...; | Finally.cs:251:39:251:53 | "Inner finally" |
-| Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" |
-| Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" |
 | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" |
 | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" |
 | Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:251:21:251:54 | call to method WriteLine |
-| Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine |
-| Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine |
 | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine |
 | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine |
 | Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | {...} |
 | Finally.cs:254:13:254:45 | ...; | Finally.cs:254:31:254:43 | "Mid finally" |
@@ -5927,29 +5927,29 @@ postDominance
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:92:25:92:30 | [finally: continue] ... == ... |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:92:25:92:30 | [finally: return] ... == ... |
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:92:25:92:30 | ... == ... |
-| Finally.cs:97:21:97:21 | [finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:24 | [finally(2): exception(Exception)] ...; |
-| Finally.cs:97:21:97:21 | [finally: break, finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:24 | [finally: break, finally(2): exception(Exception)] ...; |
+| Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; |
+| Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; |
 | Finally.cs:97:21:97:21 | [finally: break] access to local variable i | Finally.cs:97:21:97:24 | [finally: break] ...; |
-| Finally.cs:97:21:97:21 | [finally: continue, finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:24 | [finally: continue, finally(2): exception(Exception)] ...; |
+| Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; |
 | Finally.cs:97:21:97:21 | [finally: continue] access to local variable i | Finally.cs:97:21:97:24 | [finally: continue] ...; |
-| Finally.cs:97:21:97:21 | [finally: return, finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:24 | [finally: return, finally(2): exception(Exception)] ...; |
+| Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; |
 | Finally.cs:97:21:97:21 | [finally: return] access to local variable i | Finally.cs:97:21:97:24 | [finally: return] ...; |
 | Finally.cs:97:21:97:21 | access to local variable i | Finally.cs:97:21:97:24 | ...; |
 | Finally.cs:97:21:97:23 | ...-- | Finally.cs:97:21:97:21 | access to local variable i |
-| Finally.cs:97:21:97:23 | [finally(2): exception(Exception)] ...-- | Finally.cs:97:21:97:21 | [finally(2): exception(Exception)] access to local variable i |
-| Finally.cs:97:21:97:23 | [finally: break, finally(2): exception(Exception)] ...-- | Finally.cs:97:21:97:21 | [finally: break, finally(2): exception(Exception)] access to local variable i |
+| Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- | Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i |
+| Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- | Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i |
 | Finally.cs:97:21:97:23 | [finally: break] ...-- | Finally.cs:97:21:97:21 | [finally: break] access to local variable i |
-| Finally.cs:97:21:97:23 | [finally: continue, finally(2): exception(Exception)] ...-- | Finally.cs:97:21:97:21 | [finally: continue, finally(2): exception(Exception)] access to local variable i |
+| Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- | Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i |
 | Finally.cs:97:21:97:23 | [finally: continue] ...-- | Finally.cs:97:21:97:21 | [finally: continue] access to local variable i |
-| Finally.cs:97:21:97:23 | [finally: return, finally(2): exception(Exception)] ...-- | Finally.cs:97:21:97:21 | [finally: return, finally(2): exception(Exception)] access to local variable i |
+| Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- | Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i |
 | Finally.cs:97:21:97:23 | [finally: return] ...-- | Finally.cs:97:21:97:21 | [finally: return] access to local variable i |
 | Finally.cs:97:21:97:24 | ...; | Finally.cs:96:17:98:17 | {...} |
-| Finally.cs:97:21:97:24 | [finally(2): exception(Exception)] ...; | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:97:21:97:24 | [finally: break, finally(2): exception(Exception)] ...; | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:97:21:97:24 | [finally: break] ...; | Finally.cs:96:17:98:17 | [finally: break] {...} |
-| Finally.cs:97:21:97:24 | [finally: continue, finally(2): exception(Exception)] ...; | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} |
 | Finally.cs:97:21:97:24 | [finally: continue] ...; | Finally.cs:96:17:98:17 | [finally: continue] {...} |
-| Finally.cs:97:21:97:24 | [finally: return, finally(2): exception(Exception)] ...; | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
+| Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} |
 | Finally.cs:97:21:97:24 | [finally: return] ...; | Finally.cs:96:17:98:17 | [finally: return] {...} |
 | Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:116:17:116:32 | ... > ... |
 | Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:116:17:116:32 | [finally: return] ... > ... |
@@ -6238,35 +6238,35 @@ postDominance
 | Finally.cs:205:21:205:22 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:205:17:205:47 | [finally: exception(Exception)] if (...) ... |
 | Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:205:17:205:47 | [finally: exception(ExceptionA)] if (...) ... |
 | Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:205:17:205:47 | if (...) ... |
-| Finally.cs:208:13:210:13 | [finally(2): exception(ExceptionB)] {...} | Finally.cs:205:25:205:47 | throw ...; |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(ExceptionB)] {...} | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] {...} | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} | Finally.cs:205:25:205:47 | throw ...; |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:205:21:205:22 | access to parameter b2 |
-| Finally.cs:209:17:209:47 | [finally(2): exception(Exception)] if (...) ... | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:209:17:209:47 | [finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:208:13:210:13 | [finally(2): exception(ExceptionB)] {...} |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(ExceptionB)] {...} |
+| Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} |
 | Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] {...} |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} |
 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:209:17:209:47 | if (...) ... | Finally.cs:208:13:210:13 | {...} |
-| Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally(2): exception(Exception)] if (...) ... |
-| Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally(2): exception(ExceptionB)] if (...) ... |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] if (...) ... |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] if (...) ... |
+| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... |
+| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] if (...) ... |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] if (...) ... |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:209:17:209:47 | if (...) ... |
-| Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
 | Finally.cs:209:25:209:47 | throw ...; | Finally.cs:209:31:209:46 | object creation of type ExceptionC |
 | Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
@@ -6324,36 +6324,36 @@ postDominance
 | Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... |
 | Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... |
 | Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:246:21:247:47 | if (...) ... |
-| Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | Finally.cs:247:25:247:47 | throw ...; |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} | Finally.cs:247:25:247:47 | throw ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
 | Finally.cs:250:17:252:17 | {...} | Finally.cs:246:25:246:26 | access to parameter b2 |
-| Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" |
-| Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" |
 | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" |
 | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" |
 | Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:251:39:251:53 | "Inner finally" |
 | Finally.cs:251:21:251:55 | ...; | Finally.cs:250:17:252:17 | {...} |
-| Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} |
+| Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} |
 | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} |
 | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:251:21:251:55 | ...; |
-| Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; |
-| Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; |
+| Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; |
+| Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; |
 | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; |
 | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; |
 | Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:254:31:254:43 | "Mid finally" |
 | Finally.cs:254:13:254:45 | ...; | Finally.cs:251:21:251:54 | call to method WriteLine |
@@ -10128,12 +10128,12 @@ blockDominance
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally: break] {...} |
-| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally: continue] {...} |
-| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
+| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | [finally: return] {...} |
 | Finally.cs:74:10:74:11 | enter M4 | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:74:10:74:11 | exit M4 | Finally.cs:74:10:74:11 | exit M4 |
@@ -10158,12 +10158,12 @@ blockDominance
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: break] {...} |
-| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: continue] {...} |
-| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | [finally: return] {...} |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:74:10:74:11 | exit M4 (abnormal) |
@@ -10182,18 +10182,18 @@ blockDominance
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: break] {...} |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: continue] {...} |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | [finally: return] {...} |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:82:21:82:27 | return ...; | Finally.cs:82:21:82:27 | return ...; |
 | Finally.cs:82:21:82:27 | return ...; | Finally.cs:93:25:93:46 | [finally: return] throw ...; |
 | Finally.cs:82:21:82:27 | return ...; | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception |
-| Finally.cs:82:21:82:27 | return ...; | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
+| Finally.cs:82:21:82:27 | return ...; | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} |
 | Finally.cs:82:21:82:27 | return ...; | Finally.cs:96:17:98:17 | [finally: return] {...} |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:83:17:84:29 | if (...) ... |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:84:21:84:29 | continue; |
@@ -10206,16 +10206,16 @@ blockDominance
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break] {...} |
-| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | [finally: continue] {...} |
 | Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:84:21:84:29 | continue; | Finally.cs:84:21:84:29 | continue; |
 | Finally.cs:84:21:84:29 | continue; | Finally.cs:93:25:93:46 | [finally: continue] throw ...; |
 | Finally.cs:84:21:84:29 | continue; | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
-| Finally.cs:84:21:84:29 | continue; | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:84:21:84:29 | continue; | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} |
 | Finally.cs:84:21:84:29 | continue; | Finally.cs:96:17:98:17 | [finally: continue] {...} |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:85:17:86:26 | if (...) ... |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:86:21:86:26 | break; |
@@ -10224,19 +10224,19 @@ blockDominance
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:93:25:93:46 | throw ...; |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | [finally: break] {...} |
 | Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:86:21:86:26 | break; | Finally.cs:86:21:86:26 | break; |
 | Finally.cs:86:21:86:26 | break; | Finally.cs:93:25:93:46 | [finally: break] throw ...; |
 | Finally.cs:86:21:86:26 | break; | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception |
-| Finally.cs:86:21:86:26 | break; | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:86:21:86:26 | break; | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:86:21:86:26 | break; | Finally.cs:96:17:98:17 | [finally: break] {...} |
 | Finally.cs:89:13:99:13 | {...} | Finally.cs:89:13:99:13 | {...} |
 | Finally.cs:89:13:99:13 | {...} | Finally.cs:93:25:93:46 | throw ...; |
 | Finally.cs:89:13:99:13 | {...} | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:89:13:99:13 | {...} | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
+| Finally.cs:89:13:99:13 | {...} | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
 | Finally.cs:89:13:99:13 | {...} | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:93:25:93:46 | [finally: break] throw ...; | Finally.cs:93:25:93:46 | [finally: break] throw ...; |
 | Finally.cs:93:25:93:46 | [finally: continue] throw ...; | Finally.cs:93:25:93:46 | [finally: continue] throw ...; |
@@ -10244,22 +10244,22 @@ blockDominance
 | Finally.cs:93:25:93:46 | throw ...; | Finally.cs:93:25:93:46 | throw ...; |
 | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: break] throw ...; |
 | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception |
-| Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: continue] throw ...; |
 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
-| Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} |
 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: return] throw ...; |
 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception |
-| Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
+| Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} |
 | Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:93:25:93:46 | throw ...; |
 | Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:96:17:98:17 | [finally: break] {...} |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} |
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:96:17:98:17 | [finally: continue] {...} |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:96:17:98:17 | [finally: return] {...} |
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:96:17:98:17 | {...} |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:103:10:103:11 | enter M5 |
@@ -10811,19 +10811,19 @@ blockDominance
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:205:31:205:46 | object creation of type ExceptionB |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:208:13:210:13 | {...} |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:209:31:209:46 | object creation of type ExceptionC |
 | Finally.cs:195:10:195:12 | enter M10 | Finally.cs:211:13:211:29 | ...; |
@@ -10834,10 +10834,10 @@ blockDominance
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:199:21:199:43 | throw ...; |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB |
-| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} |
-| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:199:21:199:43 | throw ...; |
@@ -10847,79 +10847,79 @@ blockDominance
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB |
-| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} |
-| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} |
-| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB |
-| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} |
-| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC |
 | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:202:9:212:9 | {...} |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:205:25:205:47 | throw ...; |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:205:31:205:46 | object creation of type ExceptionB |
-| Finally.cs:202:9:212:9 | {...} | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:208:13:210:13 | {...} |
-| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:209:31:209:46 | object creation of type ExceptionC |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:211:13:211:29 | ...; |
 | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; |
-| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
-| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:205:25:205:47 | throw ...; | Finally.cs:205:25:205:47 | throw ...; |
-| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; |
 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB |
-| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
-| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
+| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |
 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB |
-| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
-| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
+| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:205:25:205:47 | throw ...; |
 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:205:31:205:46 | object creation of type ExceptionB |
-| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC |
-| Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:208:13:210:13 | {...} |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:209:31:209:46 | object creation of type ExceptionC |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:211:13:211:29 | ...; |
-| Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:209:31:209:46 | object creation of type ExceptionC |
 | Finally.cs:211:13:211:29 | ...; | Finally.cs:211:13:211:29 | ...; |
@@ -10945,10 +10945,10 @@ blockDominance
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
-| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
-| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | {...} |
 | Finally.cs:233:10:233:12 | enter M12 | Finally.cs:254:13:254:44 | call to method WriteLine |
@@ -10961,7 +10961,7 @@ blockDominance
 | Finally.cs:240:21:240:43 | throw ...; | Finally.cs:240:21:240:43 | throw ...; |
 | Finally.cs:240:21:240:43 | throw ...; | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
 | Finally.cs:240:21:240:43 | throw ...; | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
-| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:240:21:240:43 | throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:21:240:43 | throw ...; |
 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:27:240:42 | object creation of type ExceptionA |
@@ -10970,19 +10970,19 @@ blockDominance
 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
-| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
-| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} |
 | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
 | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
-| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:243:13:253:13 | {...} |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:247:25:247:47 | throw ...; |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
-| Finally.cs:243:13:253:13 | {...} | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:250:17:252:17 | {...} |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} |
@@ -10992,17 +10992,17 @@ blockDominance
 | Finally.cs:247:25:247:47 | throw ...; | Finally.cs:247:25:247:47 | throw ...; |
 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
-| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
-| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | throw ...; |
 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
-| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:250:17:252:17 | {...} | Finally.cs:250:17:252:17 | {...} |
 | Finally.cs:250:17:252:17 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine |
@@ -14131,14 +14131,14 @@ postBlockDominance
 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception |
 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception |
 | Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:93:31:93:45 | object creation of type Exception |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} |
 | Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:86:21:86:26 | break; |
 | Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:96:17:98:17 | [finally: break] {...} |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} |
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:84:21:84:29 | continue; |
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:96:17:98:17 | [finally: continue] {...} |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} |
+| Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:82:21:82:27 | return ...; |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:96:17:98:17 | [finally: return] {...} |
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:89:13:99:13 | {...} |
@@ -14354,21 +14354,21 @@ postBlockDominance
 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB |
 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB |
 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:205:31:205:46 | object creation of type ExceptionB |
-| Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:195:10:195:12 | enter M10 |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:202:9:212:9 | {...} |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:208:13:210:13 | {...} |
-| Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC |
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC |
 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:209:31:209:46 | object creation of type ExceptionC |
 | Finally.cs:211:13:211:29 | ...; | Finally.cs:195:10:195:12 | enter M10 |
@@ -14398,10 +14398,10 @@ postBlockDominance
 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
-| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} |
 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} |
 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
 | Finally.cs:250:17:252:17 | {...} | Finally.cs:233:10:233:12 | enter M12 |
 | Finally.cs:250:17:252:17 | {...} | Finally.cs:243:13:253:13 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -2319,6 +2319,93 @@ dominance
 | Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | exit M11 (normal) |
 | Finally.cs:230:9:230:34 | ...; | Finally.cs:230:27:230:32 | "Done" |
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:33 | call to method WriteLine |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:234:5:261:5 | {...} |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:236:9:255:9 | {...} |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:238:13:241:13 | {...} |
+| Finally.cs:238:13:241:13 | {...} | Finally.cs:239:17:240:43 | if (...) ... |
+| Finally.cs:239:17:240:43 | if (...) ... | Finally.cs:239:21:239:22 | access to parameter b1 |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:240:27:240:42 | object creation of type ExceptionA |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:243:13:253:13 | {...} |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:21:240:43 | throw ...; |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... |
+| Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... | Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} |
+| Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... | Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:245:17:248:17 | {...} |
+| Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} | Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... |
+| Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... |
+| Finally.cs:245:17:248:17 | {...} | Finally.cs:246:21:247:47 | if (...) ... |
+| Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 |
+| Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 |
+| Finally.cs:246:21:247:47 | if (...) ... | Finally.cs:246:25:246:26 | access to parameter b2 |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:250:17:252:17 | {...} |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | throw ...; |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; |
+| Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:251:21:251:55 | ...; |
+| Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:254:13:254:45 | ...; |
+| Finally.cs:251:21:251:55 | ...; | Finally.cs:251:39:251:53 | "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:251:21:251:54 | call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | {...} |
+| Finally.cs:254:13:254:45 | ...; | Finally.cs:254:31:254:43 | "Mid finally" |
+| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:254:13:254:44 | call to method WriteLine |
+| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} |
+| Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; |
+| Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; |
+| Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:258:13:258:47 | [finally: exception(OutOfMemoryException)] ...; |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:258:13:258:47 | ...; |
+| Finally.cs:258:13:258:46 | call to method WriteLine | Finally.cs:260:9:260:34 | ...; |
+| Finally.cs:258:13:258:47 | ...; | Finally.cs:258:31:258:45 | "Outer finally" |
+| Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; | Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" |
+| Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; | Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" |
+| Finally.cs:258:13:258:47 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:258:31:258:45 | [finally: exception(OutOfMemoryException)] "Outer finally" |
+| Finally.cs:258:31:258:45 | "Outer finally" | Finally.cs:258:13:258:46 | call to method WriteLine |
+| Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" | Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine |
+| Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" | Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine |
+| Finally.cs:258:31:258:45 | [finally: exception(OutOfMemoryException)] "Outer finally" | Finally.cs:258:13:258:46 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| Finally.cs:260:9:260:33 | call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (normal) |
+| Finally.cs:260:9:260:34 | ...; | Finally.cs:260:27:260:32 | "Done" |
+| Finally.cs:260:27:260:32 | "Done" | Finally.cs:260:9:260:33 | call to method WriteLine |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:7:5:10:5 | {...} |
 | Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:8:29:8:32 | access to parameter args |
@@ -6215,6 +6302,78 @@ postDominance
 | Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:230:27:230:32 | "Done" |
 | Finally.cs:230:9:230:34 | ...; | Finally.cs:228:13:228:40 | call to method WriteLine |
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:34 | ...; |
+| Finally.cs:233:10:233:12 | exit M12 (normal) | Finally.cs:260:9:260:33 | call to method WriteLine |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:233:10:233:12 | enter M12 |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:234:5:261:5 | {...} |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:236:9:255:9 | {...} |
+| Finally.cs:238:13:241:13 | {...} | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:239:17:240:43 | if (...) ... | Finally.cs:238:13:241:13 | {...} |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:239:17:240:43 | if (...) ... |
+| Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:240:21:240:43 | throw ...; |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:239:21:239:22 | access to parameter b1 |
+| Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} |
+| Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... | Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:243:13:253:13 | {...} |
+| Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} | Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... |
+| Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... |
+| Finally.cs:245:17:248:17 | {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} |
+| Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:246:21:247:47 | if (...) ... | Finally.cs:245:17:248:17 | {...} |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:246:21:247:47 | if (...) ... |
+| Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | Finally.cs:247:25:247:47 | throw ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:246:25:246:26 | access to parameter b2 |
+| Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" |
+| Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:251:39:251:53 | "Inner finally" |
+| Finally.cs:251:21:251:55 | ...; | Finally.cs:250:17:252:17 | {...} |
+| Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
+| Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:251:21:251:55 | ...; |
+| Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; |
+| Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:254:31:254:43 | "Mid finally" |
+| Finally.cs:254:13:254:45 | ...; | Finally.cs:251:21:251:54 | call to method WriteLine |
+| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:254:13:254:45 | ...; |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine |
+| Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" |
+| Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" |
+| Finally.cs:258:13:258:46 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:258:31:258:45 | [finally: exception(OutOfMemoryException)] "Outer finally" |
+| Finally.cs:258:13:258:46 | call to method WriteLine | Finally.cs:258:31:258:45 | "Outer finally" |
+| Finally.cs:258:13:258:47 | ...; | Finally.cs:257:9:259:9 | {...} |
+| Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} |
+| Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:258:13:258:47 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} |
+| Finally.cs:258:31:258:45 | "Outer finally" | Finally.cs:258:13:258:47 | ...; |
+| Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" | Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; |
+| Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" | Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; |
+| Finally.cs:258:31:258:45 | [finally: exception(OutOfMemoryException)] "Outer finally" | Finally.cs:258:13:258:47 | [finally: exception(OutOfMemoryException)] ...; |
+| Finally.cs:260:9:260:33 | call to method WriteLine | Finally.cs:260:27:260:32 | "Done" |
+| Finally.cs:260:9:260:34 | ...; | Finally.cs:258:13:258:46 | call to method WriteLine |
+| Finally.cs:260:27:260:32 | "Done" | Finally.cs:260:9:260:34 | ...; |
 | Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | exit M1 (normal) |
 | Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:6:10:6:11 | enter M1 |
@@ -10773,6 +10932,88 @@ blockDominance
 | Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:13:220:36 | call to method WriteLine |
 | Finally.cs:222:9:225:9 | catch {...} | Finally.cs:222:9:225:9 | catch {...} |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:227:9:229:9 | {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:233:10:233:12 | enter M12 |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:233:10:233:12 | exit M12 |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:233:10:233:12 | exit M12 (abnormal) |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:240:21:240:43 | throw ...; |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:240:27:240:42 | object creation of type ExceptionA |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:243:13:253:13 | {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:25:247:47 | throw ...; |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:250:17:252:17 | {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:254:13:254:44 | call to method WriteLine |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:257:9:259:9 | {...} |
+| Finally.cs:233:10:233:12 | exit M12 | Finally.cs:233:10:233:12 | exit M12 |
+| Finally.cs:233:10:233:12 | exit M12 (abnormal) | Finally.cs:233:10:233:12 | exit M12 (abnormal) |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:240:21:240:43 | throw ...; |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:21:240:43 | throw ...; |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:27:240:42 | object creation of type ExceptionA |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:243:13:253:13 | {...} |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:247:25:247:47 | throw ...; |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:250:17:252:17 | {...} |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:257:9:259:9 | {...} |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:247:25:247:47 | throw ...; |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | throw ...; |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:250:17:252:17 | {...} |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:257:9:259:9 | {...} |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:254:13:254:44 | call to method WriteLine |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | {...} |
+| Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} |
+| Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:257:9:259:9 | {...} |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | enter M1 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | exit M1 (normal) |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
@@ -14143,6 +14384,40 @@ postBlockDominance
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:220:13:220:36 | call to method WriteLine |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:222:9:225:9 | catch {...} |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:227:9:229:9 | {...} |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:233:10:233:12 | enter M12 |
+| Finally.cs:233:10:233:12 | exit M12 | Finally.cs:233:10:233:12 | exit M12 |
+| Finally.cs:233:10:233:12 | exit M12 (abnormal) | Finally.cs:233:10:233:12 | exit M12 (abnormal) |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:240:21:240:43 | throw ...; |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:27:240:42 | object creation of type ExceptionA |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:233:10:233:12 | enter M12 |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:243:13:253:13 | {...} |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:247:25:247:47 | throw ...; |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
+| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:233:10:233:12 | enter M12 |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:243:13:253:13 | {...} |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:250:17:252:17 | {...} |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:233:10:233:12 | enter M12 |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:243:13:253:13 | {...} |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:250:17:252:17 | {...} |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:254:13:254:44 | call to method WriteLine |
+| Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} |
+| Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} |
+| Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:233:10:233:12 | enter M12 |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:243:13:253:13 | {...} |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:250:17:252:17 | {...} |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:257:9:259:9 | {...} |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | enter M1 |
 | Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | enter M1 |
 | Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 (normal) |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -2507,6 +2507,98 @@ nodeEnclosing
 | Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | M11 |
 | Finally.cs:230:9:230:34 | ...; | Finally.cs:216:10:216:12 | M11 |
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:233:10:233:12 | exit M12 | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:233:10:233:12 | exit M12 (abnormal) | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:233:10:233:12 | exit M12 (normal) | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:238:13:241:13 | {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:239:17:240:43 | if (...) ... | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:245:17:248:17 | {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:246:21:247:47 | if (...) ... | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:254:13:254:45 | ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:13:258:46 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:13:258:46 | call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:13:258:47 | ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:13:258:47 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:31:258:45 | "Outer finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:258:31:258:45 | [finally: exception(OutOfMemoryException)] "Outer finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:260:9:260:33 | call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:260:9:260:34 | ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:260:27:260:32 | "Done" | Finally.cs:233:10:233:12 | M12 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | M1 |
@@ -5264,6 +5356,30 @@ blockEnclosing
 | Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:216:10:216:12 | M11 |
 | Finally.cs:222:9:225:9 | catch {...} | Finally.cs:216:10:216:12 | M11 |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:233:10:233:12 | exit M12 | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:233:10:233:12 | exit M12 (abnormal) | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:233:10:233:12 | M12 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | M1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -2006,37 +2006,37 @@ nodeEnclosing
 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:21 | [finally(2): exception(Exception)] access to local variable i | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:21 | [finally: break, finally(2): exception(Exception)] access to local variable i | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:21 | [finally: break] access to local variable i | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:21 | [finally: continue, finally(2): exception(Exception)] access to local variable i | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:21 | [finally: continue] access to local variable i | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:21 | [finally: return, finally(2): exception(Exception)] access to local variable i | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:21 | [finally: return] access to local variable i | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:21 | access to local variable i | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:23 | ...-- | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:23 | [finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:23 | [finally: break, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:23 | [finally: break] ...-- | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:23 | [finally: continue, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:23 | [finally: continue] ...-- | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:23 | [finally: return, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:23 | [finally: return] ...-- | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:24 | ...; | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:24 | [finally(2): exception(Exception)] ...; | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:24 | [finally: break, finally(2): exception(Exception)] ...; | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:24 | [finally: break] ...; | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:24 | [finally: continue, finally(2): exception(Exception)] ...; | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:24 | [finally: continue] ...; | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:97:21:97:24 | [finally: return, finally(2): exception(Exception)] ...; | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:97:21:97:24 | [finally: return] ...; | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:103:10:103:11 | M5 |
 | Finally.cs:103:10:103:11 | exit M5 | Finally.cs:103:10:103:11 | M5 |
@@ -2425,49 +2425,49 @@ nodeEnclosing
 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:208:13:210:13 | [finally(2): exception(ExceptionB)] {...} | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(ExceptionB)] {...} | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] {...} | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:17:209:47 | [finally(2): exception(Exception)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:17:209:47 | [finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:17:209:47 | if (...) ... | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:25:209:47 | throw ...; | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access | Finally.cs:195:10:195:12 | M10 |
@@ -2541,41 +2541,41 @@ nodeEnclosing
 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:250:17:252:17 | {...} | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:251:21:251:55 | ...; | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:254:13:254:45 | ...; | Finally.cs:233:10:233:12 | M12 |
@@ -5194,12 +5194,12 @@ blockEnclosing
 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:74:10:74:11 | M4 |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
+| Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:74:10:74:11 | M4 |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:103:10:103:11 | M5 |
@@ -5334,19 +5334,19 @@ blockEnclosing
 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:211:13:211:29 | ...; | Finally.cs:195:10:195:12 | M10 |
@@ -5369,10 +5369,10 @@ blockEnclosing
 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:250:17:252:17 | {...} | Finally.cs:233:10:233:12 | M12 |
 | Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:233:10:233:12 | M12 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -1580,6 +1580,36 @@
 | Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:230:27:230:32 | "Done" |
 | Finally.cs:230:9:230:34 | ...; | Finally.cs:230:9:230:34 | ...; |
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:27:230:32 | "Done" |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:234:5:261:5 | {...} |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:236:9:255:9 | {...} |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:238:13:241:13 | {...} | Finally.cs:238:13:241:13 | {...} |
+| Finally.cs:239:17:240:43 | if (...) ... | Finally.cs:239:17:240:43 | if (...) ... |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:239:21:239:22 | access to parameter b1 |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:240:27:240:42 | object creation of type ExceptionA |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:27:240:42 | object creation of type ExceptionA |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:243:13:253:13 | {...} |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:245:17:248:17 | {...} | Finally.cs:245:17:248:17 | {...} |
+| Finally.cs:246:21:247:47 | if (...) ... | Finally.cs:246:21:247:47 | if (...) ... |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:246:25:246:26 | access to parameter b2 |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | object creation of type ExceptionA |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:250:17:252:17 | {...} |
+| Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:251:39:251:53 | "Inner finally" |
+| Finally.cs:251:21:251:55 | ...; | Finally.cs:251:21:251:55 | ...; |
+| Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:251:39:251:53 | "Inner finally" |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:254:31:254:43 | "Mid finally" |
+| Finally.cs:254:13:254:45 | ...; | Finally.cs:254:13:254:45 | ...; |
+| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:254:31:254:43 | "Mid finally" |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:257:9:259:9 | {...} |
+| Finally.cs:258:13:258:46 | call to method WriteLine | Finally.cs:258:31:258:45 | "Outer finally" |
+| Finally.cs:258:13:258:47 | ...; | Finally.cs:258:13:258:47 | ...; |
+| Finally.cs:258:31:258:45 | "Outer finally" | Finally.cs:258:31:258:45 | "Outer finally" |
+| Finally.cs:260:9:260:33 | call to method WriteLine | Finally.cs:260:27:260:32 | "Done" |
+| Finally.cs:260:9:260:34 | ...; | Finally.cs:260:9:260:34 | ...; |
+| Finally.cs:260:27:260:32 | "Done" | Finally.cs:260:27:260:32 | "Done" |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:7:5:10:5 | {...} |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:29:8:32 | access to parameter args |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:8:22:8:24 | String arg |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -2214,6 +2214,71 @@
 | Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:230:9:230:33 | call to method WriteLine | normal |
 | Finally.cs:230:9:230:34 | ...; | Finally.cs:230:9:230:33 | call to method WriteLine | normal |
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:27:230:32 | "Done" | normal |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:258:13:258:46 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:258:13:258:46 | call to method WriteLine | throw(ExceptionA) [normal] |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:258:13:258:46 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:260:9:260:33 | call to method WriteLine | normal |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | normal |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | throw(ExceptionA) [normal] |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine | normal |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine | throw(Exception) |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:254:31:254:43 | "Mid finally" | throw(OutOfMemoryException) |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | normal |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] |
+| Finally.cs:238:13:241:13 | {...} | Finally.cs:239:21:239:22 | access to parameter b1 | false |
+| Finally.cs:238:13:241:13 | {...} | Finally.cs:240:21:240:43 | throw ...; | throw(ExceptionA) |
+| Finally.cs:238:13:241:13 | {...} | Finally.cs:240:27:240:42 | object creation of type ExceptionA | throw(Exception) |
+| Finally.cs:239:17:240:43 | if (...) ... | Finally.cs:239:21:239:22 | access to parameter b1 | false |
+| Finally.cs:239:17:240:43 | if (...) ... | Finally.cs:240:21:240:43 | throw ...; | throw(ExceptionA) |
+| Finally.cs:239:17:240:43 | if (...) ... | Finally.cs:240:27:240:42 | object creation of type ExceptionA | throw(Exception) |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:239:21:239:22 | access to parameter b1 | false |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:239:21:239:22 | access to parameter b1 | true |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:240:21:240:43 | throw ...; | throw(ExceptionA) |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:240:27:240:42 | object creation of type ExceptionA | throw(Exception) |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:27:240:42 | object creation of type ExceptionA | normal |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:27:240:42 | object creation of type ExceptionA | throw(Exception) |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | normal |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | normal |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] |
+| Finally.cs:245:17:248:17 | {...} | Finally.cs:246:25:246:26 | access to parameter b2 | false |
+| Finally.cs:245:17:248:17 | {...} | Finally.cs:247:25:247:47 | throw ...; | throw(ExceptionA) |
+| Finally.cs:245:17:248:17 | {...} | Finally.cs:247:31:247:46 | object creation of type ExceptionA | throw(Exception) |
+| Finally.cs:246:21:247:47 | if (...) ... | Finally.cs:246:25:246:26 | access to parameter b2 | false |
+| Finally.cs:246:21:247:47 | if (...) ... | Finally.cs:247:25:247:47 | throw ...; | throw(ExceptionA) |
+| Finally.cs:246:21:247:47 | if (...) ... | Finally.cs:247:31:247:46 | object creation of type ExceptionA | throw(Exception) |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:246:25:246:26 | access to parameter b2 | false |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:246:25:246:26 | access to parameter b2 | true |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:247:25:247:47 | throw ...; | throw(ExceptionA) |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:247:31:247:46 | object creation of type ExceptionA | throw(Exception) |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | object creation of type ExceptionA | normal |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:31:247:46 | object creation of type ExceptionA | throw(Exception) |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | normal |
+| Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:251:21:251:54 | call to method WriteLine | normal |
+| Finally.cs:251:21:251:55 | ...; | Finally.cs:251:21:251:54 | call to method WriteLine | normal |
+| Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:251:39:251:53 | "Inner finally" | normal |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:254:13:254:44 | call to method WriteLine | normal |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:254:13:254:44 | call to method WriteLine | throw(Exception) |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:254:31:254:43 | "Mid finally" | throw(OutOfMemoryException) |
+| Finally.cs:254:13:254:45 | ...; | Finally.cs:254:13:254:44 | call to method WriteLine | normal |
+| Finally.cs:254:13:254:45 | ...; | Finally.cs:254:13:254:44 | call to method WriteLine | throw(Exception) |
+| Finally.cs:254:13:254:45 | ...; | Finally.cs:254:31:254:43 | "Mid finally" | throw(OutOfMemoryException) |
+| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:254:31:254:43 | "Mid finally" | normal |
+| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:254:31:254:43 | "Mid finally" | throw(OutOfMemoryException) |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:258:13:258:46 | call to method WriteLine | normal |
+| Finally.cs:258:13:258:46 | call to method WriteLine | Finally.cs:258:13:258:46 | call to method WriteLine | normal |
+| Finally.cs:258:13:258:47 | ...; | Finally.cs:258:13:258:46 | call to method WriteLine | normal |
+| Finally.cs:258:31:258:45 | "Outer finally" | Finally.cs:258:31:258:45 | "Outer finally" | normal |
+| Finally.cs:260:9:260:33 | call to method WriteLine | Finally.cs:260:9:260:33 | call to method WriteLine | normal |
+| Finally.cs:260:9:260:34 | ...; | Finally.cs:260:9:260:33 | call to method WriteLine | normal |
+| Finally.cs:260:27:260:32 | "Done" | Finally.cs:260:27:260:32 | "Done" | normal |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | empty |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | empty |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:8:22:8:24 | String arg | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -847,9 +847,9 @@
 | BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:15:17:15:28 | ... == ... | false |
 | BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:16:17:16:17 | ; | normal |
 | BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | empty |
-| BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:10:21:10:26 | break; | normal [break] |
+| BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:10:21:10:26 | break; | normal [break] (0) |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | empty |
-| BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:10:21:10:26 | break; | normal [break] |
+| BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:10:21:10:26 | break; | normal [break] (0) |
 | BreakInTry.cs:7:26:7:28 | String arg | BreakInTry.cs:7:26:7:28 | String arg | normal |
 | BreakInTry.cs:7:33:7:36 | access to parameter args | BreakInTry.cs:7:33:7:36 | access to parameter args | normal |
 | BreakInTry.cs:8:13:11:13 | {...} | BreakInTry.cs:9:21:9:31 | ... == ... | false |
@@ -872,17 +872,17 @@
 | BreakInTry.cs:16:17:16:17 | ; | BreakInTry.cs:16:17:16:17 | ; | normal |
 | BreakInTry.cs:21:5:36:5 | {...} | BreakInTry.cs:35:7:35:7 | ; | normal |
 | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | empty |
-| BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:31:21:31:32 | ... == ... | false [break] |
-| BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:32:21:32:21 | ; | normal [break] |
+| BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:31:21:31:32 | ... == ... | false [break] (0) |
+| BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:32:21:32:21 | ; | normal [break] (0) |
 | BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:22:22:22:24 | String arg | normal |
 | BreakInTry.cs:22:29:22:32 | access to parameter args | BreakInTry.cs:22:29:22:32 | access to parameter args | normal |
-| BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:31:21:31:32 | ... == ... | break [false] |
+| BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:31:21:31:32 | ... == ... | break [false] (0) |
 | BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:31:21:31:32 | ... == ... | false |
-| BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:32:21:32:21 | ; | break [normal] |
+| BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:32:21:32:21 | ; | break [normal] (0) |
 | BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:32:21:32:21 | ; | normal |
-| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:21:31:32 | ... == ... | break [false] |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:21:31:32 | ... == ... | break [false] (0) |
 | BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:21:31:32 | ... == ... | false |
-| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:32:21:32:21 | ; | break [normal] |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:32:21:32:21 | ; | break [normal] (0) |
 | BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:32:21:32:21 | ; | normal |
 | BreakInTry.cs:25:13:28:13 | {...} | BreakInTry.cs:26:21:26:31 | ... == ... | false |
 | BreakInTry.cs:25:13:28:13 | {...} | BreakInTry.cs:27:21:27:26 | break; | break |
@@ -903,13 +903,13 @@
 | BreakInTry.cs:31:29:31:32 | null | BreakInTry.cs:31:29:31:32 | null | normal |
 | BreakInTry.cs:32:21:32:21 | ; | BreakInTry.cs:32:21:32:21 | ; | normal |
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:35:7:35:7 | ; | normal |
-| BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | return [empty] |
-| BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:50:21:50:26 | break; | return [normal] |
+| BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | return [empty] (0) |
+| BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:50:21:50:26 | break; | return [normal] (0) |
 | BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:53:7:53:7 | ; | normal |
 | BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | empty |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | return [empty] |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:50:21:50:26 | break; | normal [break] |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:50:21:50:26 | break; | return [normal] |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | return [empty] (0) |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:50:21:50:26 | break; | normal [break] (0) |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:50:21:50:26 | break; | return [normal] (0) |
 | BreakInTry.cs:41:9:44:9 | {...} | BreakInTry.cs:42:17:42:28 | ... == ... | false |
 | BreakInTry.cs:41:9:44:9 | {...} | BreakInTry.cs:43:17:43:23 | return ...; | return |
 | BreakInTry.cs:42:13:43:23 | if (...) ... | BreakInTry.cs:42:17:42:28 | ... == ... | false |
@@ -920,9 +920,9 @@
 | BreakInTry.cs:42:25:42:28 | null | BreakInTry.cs:42:25:42:28 | null | normal |
 | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:43:17:43:23 | return ...; | return |
 | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | empty |
-| BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:50:21:50:26 | break; | normal [break] |
+| BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:50:21:50:26 | break; | normal [break] (0) |
 | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | empty |
-| BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:50:21:50:26 | break; | normal [break] |
+| BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:50:21:50:26 | break; | normal [break] (0) |
 | BreakInTry.cs:47:26:47:28 | String arg | BreakInTry.cs:47:26:47:28 | String arg | normal |
 | BreakInTry.cs:47:33:47:36 | access to parameter args | BreakInTry.cs:47:33:47:36 | access to parameter args | normal |
 | BreakInTry.cs:48:13:51:13 | {...} | BreakInTry.cs:49:21:49:31 | ... == ... | false |
@@ -936,13 +936,13 @@
 | BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:50:21:50:26 | break; | break |
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:53:7:53:7 | ; | normal |
 | BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | empty |
-| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | return [empty] |
-| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:68:21:68:26 | break; | normal [break] |
-| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:68:21:68:26 | break; | return [normal] |
+| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | return [empty] (0) |
+| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:68:21:68:26 | break; | normal [break] (0) |
+| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:68:21:68:26 | break; | return [normal] (0) |
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | empty |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | return [empty] |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | break; | normal [break] |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | break; | return [normal] |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | return [empty] (0) |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | break; | normal [break] (0) |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | break; | return [normal] (0) |
 | BreakInTry.cs:59:9:62:9 | {...} | BreakInTry.cs:60:17:60:28 | ... == ... | false |
 | BreakInTry.cs:59:9:62:9 | {...} | BreakInTry.cs:61:17:61:23 | return ...; | return |
 | BreakInTry.cs:60:13:61:23 | if (...) ... | BreakInTry.cs:60:17:60:28 | ... == ... | false |
@@ -953,9 +953,9 @@
 | BreakInTry.cs:60:25:60:28 | null | BreakInTry.cs:60:25:60:28 | null | normal |
 | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:61:17:61:23 | return ...; | return |
 | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | empty |
-| BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:68:21:68:26 | break; | normal [break] |
+| BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:68:21:68:26 | break; | normal [break] (0) |
 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | empty |
-| BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:68:21:68:26 | break; | normal [break] |
+| BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:68:21:68:26 | break; | normal [break] (0) |
 | BreakInTry.cs:65:26:65:28 | String arg | BreakInTry.cs:65:26:65:28 | String arg | normal |
 | BreakInTry.cs:65:33:65:36 | access to parameter args | BreakInTry.cs:65:33:65:36 | access to parameter args | normal |
 | BreakInTry.cs:66:13:69:13 | {...} | BreakInTry.cs:67:21:67:31 | ... == ... | false |
@@ -980,14 +980,14 @@
 | CompileTimeOperators.cs:22:9:22:25 | return ...; | CompileTimeOperators.cs:22:9:22:25 | return ...; | return |
 | CompileTimeOperators.cs:22:16:22:24 | nameof(...) | CompileTimeOperators.cs:22:16:22:24 | nameof(...) | normal |
 | CompileTimeOperators.cs:22:23:22:23 | access to parameter i | CompileTimeOperators.cs:22:23:22:23 | access to parameter i | normal |
-| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | goto(End) [normal] |
-| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(Exception) [normal] |
-| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | goto(End) [normal] (0) |
+| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(Exception) [normal] (0) |
+| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | normal |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | goto(End) [normal] |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | goto(End) [normal] (0) |
 | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | normal |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(Exception) [normal] |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(Exception) [normal] (0) |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:32:13:32:21 | goto ...; | goto(End) |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:33:13:33:37 | call to method WriteLine | normal |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:33:13:33:37 | call to method WriteLine | throw(Exception) |
@@ -1537,9 +1537,9 @@
 | ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:88:9:88:27 | call to method Exit | exit |
 | ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:26:88:26 | 0 | normal |
 | ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
-| ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:100:13:100:40 | call to method WriteLine | exit [normal] |
+| ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:100:13:100:40 | call to method WriteLine | exit [normal] (0) |
 | ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
-| ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:100:13:100:40 | call to method WriteLine | exit [normal] |
+| ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:100:13:100:40 | call to method WriteLine | exit [normal] (0) |
 | ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
 | ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
 | ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:18 | this access | normal |
@@ -1636,11 +1636,11 @@
 | Extensions.cs:25:23:25:32 | access to method Parse | Extensions.cs:25:23:25:32 | access to method Parse | normal |
 | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | normal |
 | Finally.cs:8:5:17:5 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | normal |
-| Finally.cs:8:5:17:5 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:8:5:17:5 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:8:5:17:5 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:8:5:17:5 | {...} | Finally.cs:15:13:15:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:15:13:15:40 | call to method WriteLine | normal |
-| Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:15:13:15:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:15:13:15:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:15:13:15:40 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:15:13:15:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | Finally.cs:10:9:12:9 | {...} | Finally.cs:11:13:11:37 | call to method WriteLine | normal |
 | Finally.cs:10:9:12:9 | {...} | Finally.cs:11:13:11:37 | call to method WriteLine | throw(Exception) |
 | Finally.cs:10:9:12:9 | {...} | Finally.cs:11:31:11:36 | "Try1" | throw(OutOfMemoryException) |
@@ -1657,13 +1657,13 @@
 | Finally.cs:15:13:15:41 | ...; | Finally.cs:15:13:15:40 | call to method WriteLine | normal |
 | Finally.cs:15:31:15:39 | "Finally" | Finally.cs:15:31:15:39 | "Finally" | normal |
 | Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | normal |
-| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | return [normal] |
-| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | throw(IOException) [normal] |
+| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | return [normal] (0) |
+| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:20:5:52:5 | {...} | Finally.cs:50:13:50:40 | call to method WriteLine | throw(IOException) [normal] (0) |
 | Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | normal |
-| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | return [normal] |
-| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | throw(IOException) [normal] |
+| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | return [normal] (0) |
+| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:50:13:50:40 | call to method WriteLine | throw(IOException) [normal] (0) |
 | Finally.cs:22:9:25:9 | {...} | Finally.cs:23:13:23:37 | call to method WriteLine | throw(Exception) |
 | Finally.cs:22:9:25:9 | {...} | Finally.cs:23:31:23:36 | "Try2" | throw(OutOfMemoryException) |
 | Finally.cs:22:9:25:9 | {...} | Finally.cs:24:13:24:19 | return ...; | return |
@@ -1706,15 +1706,15 @@
 | Finally.cs:50:13:50:41 | ...; | Finally.cs:50:13:50:40 | call to method WriteLine | normal |
 | Finally.cs:50:31:50:39 | "Finally" | Finally.cs:50:31:50:39 | "Finally" | normal |
 | Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | normal |
-| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | return [normal] |
-| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(IOException) [normal] |
-| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | return [normal] (0) |
+| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(IOException) [normal] (0) |
+| Finally.cs:55:5:72:5 | {...} | Finally.cs:70:13:70:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | normal |
-| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | return [normal] |
-| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(IOException) [normal] |
-| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | return [normal] (0) |
+| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(IOException) [normal] (0) |
+| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:70:13:70:40 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | Finally.cs:57:9:60:9 | {...} | Finally.cs:58:13:58:37 | call to method WriteLine | throw(Exception) |
 | Finally.cs:57:9:60:9 | {...} | Finally.cs:58:31:58:36 | "Try3" | throw(OutOfMemoryException) |
 | Finally.cs:57:9:60:9 | {...} | Finally.cs:59:13:59:19 | return ...; | return |
@@ -1733,10 +1733,10 @@
 | Finally.cs:61:48:61:51 | true | Finally.cs:61:48:61:51 | true | true |
 | Finally.cs:62:9:64:9 | {...} | Finally.cs:63:13:63:18 | throw ...; | throw(IOException) |
 | Finally.cs:63:13:63:18 | throw ...; | Finally.cs:63:13:63:18 | throw ...; | throw(IOException) |
-| Finally.cs:65:9:67:9 | catch (...) {...} | Finally.cs:65:9:67:9 | catch (...) {...} | throw(Exception) [no-match] |
-| Finally.cs:65:9:67:9 | catch (...) {...} | Finally.cs:65:9:67:9 | catch (...) {...} | throw(OutOfMemoryException) [no-match] |
-| Finally.cs:65:9:67:9 | catch (...) {...} | Finally.cs:65:35:65:51 | ... != ... | throw(Exception) [false] |
-| Finally.cs:65:9:67:9 | catch (...) {...} | Finally.cs:65:35:65:51 | ... != ... | throw(OutOfMemoryException) [false] |
+| Finally.cs:65:9:67:9 | catch (...) {...} | Finally.cs:65:9:67:9 | catch (...) {...} | throw(Exception) [no-match] (0) |
+| Finally.cs:65:9:67:9 | catch (...) {...} | Finally.cs:65:9:67:9 | catch (...) {...} | throw(OutOfMemoryException) [no-match] (0) |
+| Finally.cs:65:9:67:9 | catch (...) {...} | Finally.cs:65:35:65:51 | ... != ... | throw(Exception) [false] (0) |
+| Finally.cs:65:9:67:9 | catch (...) {...} | Finally.cs:65:35:65:51 | ... != ... | throw(OutOfMemoryException) [false] (0) |
 | Finally.cs:65:9:67:9 | catch (...) {...} | Finally.cs:66:9:67:9 | {...} | normal |
 | Finally.cs:65:26:65:26 | Exception e | Finally.cs:65:26:65:26 | Exception e | normal |
 | Finally.cs:65:35:65:35 | access to local variable e | Finally.cs:65:35:65:35 | access to local variable e | normal |
@@ -1750,30 +1750,30 @@
 | Finally.cs:70:13:70:41 | ...; | Finally.cs:70:13:70:40 | call to method WriteLine | normal |
 | Finally.cs:70:31:70:39 | "Finally" | Finally.cs:70:31:70:39 | "Finally" | normal |
 | Finally.cs:75:5:101:5 | {...} | Finally.cs:77:16:77:20 | ... > ... | false |
-| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | normal [break] |
-| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | return [normal] |
-| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
+| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | normal [break] (0) |
+| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | return [normal] (0) |
+| Finally.cs:75:5:101:5 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] (1) |
 | Finally.cs:76:9:76:19 | ... ...; | Finally.cs:76:13:76:18 | Int32 i = ... | normal |
 | Finally.cs:76:13:76:18 | Int32 i = ... | Finally.cs:76:13:76:18 | Int32 i = ... | normal |
 | Finally.cs:76:17:76:18 | 10 | Finally.cs:76:17:76:18 | 10 | normal |
 | Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:77:16:77:20 | ... > ... | false |
-| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | normal [break] |
-| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | return [normal] |
-| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
+| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | normal [break] (0) |
+| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | return [normal] (0) |
+| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] (1) |
 | Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:77:16:77:16 | access to local variable i | normal |
 | Finally.cs:77:16:77:20 | ... > ... | Finally.cs:77:16:77:20 | ... > ... | false |
 | Finally.cs:77:16:77:20 | ... > ... | Finally.cs:77:16:77:20 | ... > ... | true |
 | Finally.cs:77:20:77:20 | 0 | Finally.cs:77:20:77:20 | 0 | normal |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | break [normal] |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | continue [normal] |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | break [normal] (0) |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | continue [normal] (0) |
 | Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | normal |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | return [normal] |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
-| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | break [normal] |
-| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | continue [normal] |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | return [normal] (0) |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] (1) |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | break [normal] (0) |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | continue [normal] (0) |
 | Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | normal |
-| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | return [normal] |
-| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | return [normal] (0) |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] (1) |
 | Finally.cs:80:13:87:13 | {...} | Finally.cs:82:21:82:27 | return ...; | return |
 | Finally.cs:80:13:87:13 | {...} | Finally.cs:84:21:84:29 | continue; | continue |
 | Finally.cs:80:13:87:13 | {...} | Finally.cs:85:21:85:26 | ... == ... | false |
@@ -1800,9 +1800,9 @@
 | Finally.cs:85:26:85:26 | 2 | Finally.cs:85:26:85:26 | 2 | normal |
 | Finally.cs:86:21:86:26 | break; | Finally.cs:86:21:86:26 | break; | break |
 | Finally.cs:89:13:99:13 | {...} | Finally.cs:97:21:97:23 | ...-- | normal |
-| Finally.cs:89:13:99:13 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
+| Finally.cs:89:13:99:13 | {...} | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] (1) |
 | Finally.cs:90:17:98:17 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | normal |
-| Finally.cs:90:17:98:17 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] |
+| Finally.cs:90:17:98:17 | try {...} ... | Finally.cs:97:21:97:23 | ...-- | throw(Exception) [normal] (1) |
 | Finally.cs:91:17:94:17 | {...} | Finally.cs:92:25:92:30 | ... == ... | false |
 | Finally.cs:91:17:94:17 | {...} | Finally.cs:93:25:93:46 | throw ...; | throw(Exception) |
 | Finally.cs:91:17:94:17 | {...} | Finally.cs:93:31:93:45 | object creation of type Exception | throw(Exception) |
@@ -1822,25 +1822,25 @@
 | Finally.cs:97:21:97:23 | ...-- | Finally.cs:97:21:97:23 | ...-- | normal |
 | Finally.cs:97:21:97:24 | ...; | Finally.cs:97:21:97:23 | ...-- | normal |
 | Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | false |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | return [false] |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | throw(Exception) [false] |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | throw(NullReferenceException) [false] |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | throw(OutOfMemoryException) [false] |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | return [false] (0) |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | throw(Exception) [false] (0) |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | throw(NullReferenceException) [false] (0) |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:116:17:116:32 | ... > ... | throw(OutOfMemoryException) [false] (0) |
 | Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | normal |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | return [normal] |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(NullReferenceException) [normal] |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | return [normal] (0) |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(NullReferenceException) [normal] (0) |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:117:17:117:36 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | false |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | return [false] |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | throw(Exception) [false] |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | throw(NullReferenceException) [false] |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | throw(OutOfMemoryException) [false] |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | return [false] (0) |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | throw(Exception) [false] (0) |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | throw(NullReferenceException) [false] (0) |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:116:17:116:32 | ... > ... | throw(OutOfMemoryException) [false] (0) |
 | Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | normal |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | return [normal] |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(NullReferenceException) [normal] |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | return [normal] (0) |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(NullReferenceException) [normal] (0) |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:117:17:117:36 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | Finally.cs:106:9:111:9 | {...} | Finally.cs:107:17:107:21 | access to field Field | throw(NullReferenceException) |
 | Finally.cs:106:9:111:9 | {...} | Finally.cs:107:17:107:28 | access to property Length | throw(Exception) |
 | Finally.cs:106:9:111:9 | {...} | Finally.cs:107:17:107:28 | access to property Length | throw(NullReferenceException) |
@@ -1935,13 +1935,13 @@
 | Finally.cs:128:9:130:9 | {...} | Finally.cs:129:13:129:13 | ; | normal |
 | Finally.cs:129:13:129:13 | ; | Finally.cs:129:13:129:13 | ; | normal |
 | Finally.cs:134:5:145:5 | {...} | Finally.cs:141:13:141:44 | throw ...; | throw(ArgumentException) |
-| Finally.cs:134:5:145:5 | {...} | Finally.cs:142:13:142:37 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:134:5:145:5 | {...} | Finally.cs:142:13:142:37 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:134:5:145:5 | {...} | Finally.cs:142:13:142:37 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:134:5:145:5 | {...} | Finally.cs:142:13:142:37 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | Finally.cs:134:5:145:5 | {...} | Finally.cs:144:9:144:33 | call to method WriteLine | normal |
 | Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:141:13:141:44 | throw ...; | throw(ArgumentException) |
 | Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:142:13:142:37 | call to method WriteLine | normal |
-| Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:142:13:142:37 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:142:13:142:37 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:142:13:142:37 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:142:13:142:37 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | Finally.cs:136:9:138:9 | {...} | Finally.cs:137:13:137:36 | call to method WriteLine | normal |
 | Finally.cs:136:9:138:9 | {...} | Finally.cs:137:13:137:36 | call to method WriteLine | throw(Exception) |
 | Finally.cs:136:9:138:9 | {...} | Finally.cs:137:31:137:35 | "Try" | throw(OutOfMemoryException) |
@@ -1965,23 +1965,23 @@
 | Finally.cs:144:9:144:34 | ...; | Finally.cs:144:9:144:33 | call to method WriteLine | normal |
 | Finally.cs:144:27:144:32 | "Dead" | Finally.cs:144:27:144:32 | "Dead" | normal |
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:158:21:158:36 | ... == ... | false |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:158:21:158:36 | ... == ... | throw(ArgumentNullException) [false] |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:158:21:158:36 | ... == ... | throw(Exception) [false] |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:158:21:158:36 | ... == ... | throw(ArgumentNullException) [false] (0) |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:158:21:158:36 | ... == ... | throw(Exception) [false] (0) |
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | normal |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | throw(ArgumentNullException) [normal] |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | throw(ArgumentNullException) [normal] (0) |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:163:17:163:42 | call to method WriteLine | throw(Exception) [normal] (0) |
 | Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | normal |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | throw(ArgumentNullException) [normal] |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | throw(ArgumentNullException) [normal] (0) |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:167:17:167:37 | call to method WriteLine | throw(Exception) [normal] (0) |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:158:21:158:36 | ... == ... | false |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:158:21:158:36 | ... == ... | throw(ArgumentNullException) [false] |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:158:21:158:36 | ... == ... | throw(Exception) [false] |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:158:21:158:36 | ... == ... | throw(ArgumentNullException) [false] (0) |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:158:21:158:36 | ... == ... | throw(Exception) [false] (0) |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | normal |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | throw(ArgumentNullException) [normal] |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | throw(ArgumentNullException) [normal] (0) |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:163:17:163:42 | call to method WriteLine | throw(Exception) [normal] (0) |
 | Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | normal |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | throw(ArgumentNullException) [normal] |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | throw(Exception) [normal] |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | throw(ArgumentNullException) [normal] (0) |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:167:17:167:37 | call to method WriteLine | throw(Exception) [normal] (0) |
 | Finally.cs:150:9:153:9 | {...} | Finally.cs:151:17:151:28 | ... == ... | false |
 | Finally.cs:150:9:153:9 | {...} | Finally.cs:152:17:152:50 | throw ...; | throw(ArgumentNullException) |
 | Finally.cs:150:9:153:9 | {...} | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | throw(Exception) |
@@ -2052,26 +2052,26 @@
 | Finally.cs:167:17:167:38 | ...; | Finally.cs:167:17:167:37 | call to method WriteLine | normal |
 | Finally.cs:167:35:167:36 | "" | Finally.cs:167:35:167:36 | "" | normal |
 | Finally.cs:177:5:193:5 | {...} | Finally.cs:186:21:186:22 | access to parameter b2 | false |
-| Finally.cs:177:5:193:5 | {...} | Finally.cs:186:21:186:22 | access to parameter b2 | throw(Exception) [false] |
-| Finally.cs:177:5:193:5 | {...} | Finally.cs:186:21:186:22 | access to parameter b2 | throw(ExceptionA) [false] |
-| Finally.cs:177:5:193:5 | {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(Exception) [no-match] |
-| Finally.cs:177:5:193:5 | {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(ExceptionB) [no-match] |
-| Finally.cs:177:5:193:5 | {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(Exception) [false] |
-| Finally.cs:177:5:193:5 | {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(ExceptionB) [false] |
+| Finally.cs:177:5:193:5 | {...} | Finally.cs:186:21:186:22 | access to parameter b2 | throw(Exception) [false] (0) |
+| Finally.cs:177:5:193:5 | {...} | Finally.cs:186:21:186:22 | access to parameter b2 | throw(ExceptionA) [false] (0) |
+| Finally.cs:177:5:193:5 | {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(Exception) [no-match] (0) |
+| Finally.cs:177:5:193:5 | {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(ExceptionB) [no-match] (0) |
+| Finally.cs:177:5:193:5 | {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(Exception) [false] (0) |
+| Finally.cs:177:5:193:5 | {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(ExceptionB) [false] (0) |
 | Finally.cs:177:5:193:5 | {...} | Finally.cs:190:21:190:22 | access to parameter b1 | false |
-| Finally.cs:177:5:193:5 | {...} | Finally.cs:190:21:190:22 | access to parameter b1 | throw(Exception) [false] |
-| Finally.cs:177:5:193:5 | {...} | Finally.cs:190:21:190:22 | access to parameter b1 | throw(ExceptionA) [false] |
+| Finally.cs:177:5:193:5 | {...} | Finally.cs:190:21:190:22 | access to parameter b1 | throw(Exception) [false] (0) |
+| Finally.cs:177:5:193:5 | {...} | Finally.cs:190:21:190:22 | access to parameter b1 | throw(ExceptionA) [false] (0) |
 | Finally.cs:177:5:193:5 | {...} | Finally.cs:190:25:190:47 | throw ...; | throw(ExceptionC) |
 | Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:186:21:186:22 | access to parameter b2 | false |
-| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:186:21:186:22 | access to parameter b2 | throw(Exception) [false] |
-| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:186:21:186:22 | access to parameter b2 | throw(ExceptionA) [false] |
-| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:188:13:191:13 | catch (...) {...} | throw(Exception) [no-match] |
-| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:188:13:191:13 | catch (...) {...} | throw(ExceptionB) [no-match] |
-| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:188:38:188:39 | access to parameter b2 | throw(Exception) [false] |
-| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:188:38:188:39 | access to parameter b2 | throw(ExceptionB) [false] |
+| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:186:21:186:22 | access to parameter b2 | throw(Exception) [false] (0) |
+| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:186:21:186:22 | access to parameter b2 | throw(ExceptionA) [false] (0) |
+| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:188:13:191:13 | catch (...) {...} | throw(Exception) [no-match] (0) |
+| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:188:13:191:13 | catch (...) {...} | throw(ExceptionB) [no-match] (0) |
+| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:188:38:188:39 | access to parameter b2 | throw(Exception) [false] (0) |
+| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:188:38:188:39 | access to parameter b2 | throw(ExceptionB) [false] (0) |
 | Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:190:21:190:22 | access to parameter b1 | false |
-| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:190:21:190:22 | access to parameter b1 | throw(Exception) [false] |
-| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:190:21:190:22 | access to parameter b1 | throw(ExceptionA) [false] |
+| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:190:21:190:22 | access to parameter b1 | throw(Exception) [false] (0) |
+| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:190:21:190:22 | access to parameter b1 | throw(ExceptionA) [false] (0) |
 | Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:190:25:190:47 | throw ...; | throw(ExceptionC) |
 | Finally.cs:179:9:181:9 | {...} | Finally.cs:180:17:180:18 | access to parameter b1 | false |
 | Finally.cs:179:9:181:9 | {...} | Finally.cs:180:21:180:43 | throw ...; | throw(ExceptionA) |
@@ -2086,17 +2086,17 @@
 | Finally.cs:180:27:180:42 | object creation of type ExceptionA | Finally.cs:180:27:180:42 | object creation of type ExceptionA | normal |
 | Finally.cs:180:27:180:42 | object creation of type ExceptionA | Finally.cs:180:27:180:42 | object creation of type ExceptionA | throw(Exception) |
 | Finally.cs:183:9:192:9 | {...} | Finally.cs:186:21:186:22 | access to parameter b2 | false |
-| Finally.cs:183:9:192:9 | {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(Exception) [no-match] |
-| Finally.cs:183:9:192:9 | {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(ExceptionB) [no-match] |
-| Finally.cs:183:9:192:9 | {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(Exception) [false] |
-| Finally.cs:183:9:192:9 | {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(ExceptionB) [false] |
+| Finally.cs:183:9:192:9 | {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(Exception) [no-match] (0) |
+| Finally.cs:183:9:192:9 | {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(ExceptionB) [no-match] (0) |
+| Finally.cs:183:9:192:9 | {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(Exception) [false] (0) |
+| Finally.cs:183:9:192:9 | {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(ExceptionB) [false] (0) |
 | Finally.cs:183:9:192:9 | {...} | Finally.cs:190:21:190:22 | access to parameter b1 | false |
 | Finally.cs:183:9:192:9 | {...} | Finally.cs:190:25:190:47 | throw ...; | throw(ExceptionC) |
 | Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:186:21:186:22 | access to parameter b2 | false |
-| Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:188:13:191:13 | catch (...) {...} | throw(Exception) [no-match] |
-| Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:188:13:191:13 | catch (...) {...} | throw(ExceptionB) [no-match] |
-| Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:188:38:188:39 | access to parameter b2 | throw(Exception) [false] |
-| Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:188:38:188:39 | access to parameter b2 | throw(ExceptionB) [false] |
+| Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:188:13:191:13 | catch (...) {...} | throw(Exception) [no-match] (0) |
+| Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:188:13:191:13 | catch (...) {...} | throw(ExceptionB) [no-match] (0) |
+| Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:188:38:188:39 | access to parameter b2 | throw(Exception) [false] (0) |
+| Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:188:38:188:39 | access to parameter b2 | throw(ExceptionB) [false] (0) |
 | Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:190:21:190:22 | access to parameter b1 | false |
 | Finally.cs:184:13:191:13 | try {...} ... | Finally.cs:190:25:190:47 | throw ...; | throw(ExceptionC) |
 | Finally.cs:185:13:187:13 | {...} | Finally.cs:186:21:186:22 | access to parameter b2 | false |
@@ -2111,10 +2111,10 @@
 | Finally.cs:186:25:186:47 | throw ...; | Finally.cs:186:31:186:46 | object creation of type ExceptionB | throw(Exception) |
 | Finally.cs:186:31:186:46 | object creation of type ExceptionB | Finally.cs:186:31:186:46 | object creation of type ExceptionB | normal |
 | Finally.cs:186:31:186:46 | object creation of type ExceptionB | Finally.cs:186:31:186:46 | object creation of type ExceptionB | throw(Exception) |
-| Finally.cs:188:13:191:13 | catch (...) {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(Exception) [no-match] |
-| Finally.cs:188:13:191:13 | catch (...) {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(ExceptionB) [no-match] |
-| Finally.cs:188:13:191:13 | catch (...) {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(Exception) [false] |
-| Finally.cs:188:13:191:13 | catch (...) {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(ExceptionB) [false] |
+| Finally.cs:188:13:191:13 | catch (...) {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(Exception) [no-match] (0) |
+| Finally.cs:188:13:191:13 | catch (...) {...} | Finally.cs:188:13:191:13 | catch (...) {...} | throw(ExceptionB) [no-match] (0) |
+| Finally.cs:188:13:191:13 | catch (...) {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(Exception) [false] (0) |
+| Finally.cs:188:13:191:13 | catch (...) {...} | Finally.cs:188:38:188:39 | access to parameter b2 | throw(ExceptionB) [false] (0) |
 | Finally.cs:188:13:191:13 | catch (...) {...} | Finally.cs:190:21:190:22 | access to parameter b1 | false |
 | Finally.cs:188:13:191:13 | catch (...) {...} | Finally.cs:190:25:190:47 | throw ...; | throw(ExceptionC) |
 | Finally.cs:188:38:188:39 | access to parameter b2 | Finally.cs:188:38:188:39 | access to parameter b2 | false |
@@ -2127,18 +2127,18 @@
 | Finally.cs:190:21:190:22 | access to parameter b1 | Finally.cs:190:21:190:22 | access to parameter b1 | true |
 | Finally.cs:190:25:190:47 | throw ...; | Finally.cs:190:25:190:47 | throw ...; | throw(ExceptionC) |
 | Finally.cs:190:31:190:46 | object creation of type ExceptionC | Finally.cs:190:31:190:46 | object creation of type ExceptionC | normal |
-| Finally.cs:196:5:214:5 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | throw(Exception) [false] |
-| Finally.cs:196:5:214:5 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | throw(ExceptionB) [false] |
+| Finally.cs:196:5:214:5 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | throw(Exception) [false] (1) |
+| Finally.cs:196:5:214:5 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | throw(ExceptionB) [false] (1) |
 | Finally.cs:196:5:214:5 | {...} | Finally.cs:209:25:209:47 | throw ...; | throw(ExceptionC) |
-| Finally.cs:196:5:214:5 | {...} | Finally.cs:211:13:211:28 | ... = ... | throw(Exception) [normal] |
-| Finally.cs:196:5:214:5 | {...} | Finally.cs:211:13:211:28 | ... = ... | throw(ExceptionA) [normal] |
+| Finally.cs:196:5:214:5 | {...} | Finally.cs:211:13:211:28 | ... = ... | throw(Exception) [normal] (0) |
+| Finally.cs:196:5:214:5 | {...} | Finally.cs:211:13:211:28 | ... = ... | throw(ExceptionA) [normal] (0) |
 | Finally.cs:196:5:214:5 | {...} | Finally.cs:213:9:213:24 | ... = ... | normal |
-| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | throw(Exception) [false] |
-| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | throw(ExceptionB) [false] |
+| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | throw(Exception) [false] (1) |
+| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | throw(ExceptionB) [false] (1) |
 | Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:209:25:209:47 | throw ...; | throw(ExceptionC) |
 | Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | normal |
-| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | throw(Exception) [normal] |
-| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | throw(ExceptionA) [normal] |
+| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | throw(Exception) [normal] (0) |
+| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:211:13:211:28 | ... = ... | throw(ExceptionA) [normal] (0) |
 | Finally.cs:198:9:200:9 | {...} | Finally.cs:199:17:199:18 | access to parameter b1 | false |
 | Finally.cs:198:9:200:9 | {...} | Finally.cs:199:21:199:43 | throw ...; | throw(ExceptionA) |
 | Finally.cs:198:9:200:9 | {...} | Finally.cs:199:27:199:42 | object creation of type ExceptionA | throw(Exception) |
@@ -2151,13 +2151,13 @@
 | Finally.cs:199:21:199:43 | throw ...; | Finally.cs:199:27:199:42 | object creation of type ExceptionA | throw(Exception) |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:199:27:199:42 | object creation of type ExceptionA | normal |
 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:199:27:199:42 | object creation of type ExceptionA | throw(Exception) |
-| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | throw(Exception) [false] |
-| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | throw(ExceptionB) [false] |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | throw(Exception) [false] (1) |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:209:21:209:22 | access to parameter b3 | throw(ExceptionB) [false] (1) |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:209:25:209:47 | throw ...; | throw(ExceptionC) |
 | Finally.cs:202:9:212:9 | {...} | Finally.cs:211:13:211:28 | ... = ... | normal |
 | Finally.cs:203:13:210:13 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | false |
-| Finally.cs:203:13:210:13 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | throw(Exception) [false] |
-| Finally.cs:203:13:210:13 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | throw(ExceptionB) [false] |
+| Finally.cs:203:13:210:13 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | throw(Exception) [false] (1) |
+| Finally.cs:203:13:210:13 | try {...} ... | Finally.cs:209:21:209:22 | access to parameter b3 | throw(ExceptionB) [false] (1) |
 | Finally.cs:203:13:210:13 | try {...} ... | Finally.cs:209:25:209:47 | throw ...; | throw(ExceptionC) |
 | Finally.cs:204:13:206:13 | {...} | Finally.cs:205:21:205:22 | access to parameter b2 | false |
 | Finally.cs:204:13:206:13 | {...} | Finally.cs:205:25:205:47 | throw ...; | throw(ExceptionB) |
@@ -2214,22 +2214,26 @@
 | Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:230:9:230:33 | call to method WriteLine | normal |
 | Finally.cs:230:9:230:34 | ...; | Finally.cs:230:9:230:33 | call to method WriteLine | normal |
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:27:230:32 | "Done" | normal |
-| Finally.cs:234:5:261:5 | {...} | Finally.cs:258:13:258:46 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:234:5:261:5 | {...} | Finally.cs:258:13:258:46 | call to method WriteLine | throw(ExceptionA) [normal] |
-| Finally.cs:234:5:261:5 | {...} | Finally.cs:258:13:258:46 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:258:13:258:46 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:258:13:258:46 | call to method WriteLine | throw(ExceptionA) [normal] (0) |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:258:13:258:46 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | Finally.cs:234:5:261:5 | {...} | Finally.cs:260:9:260:33 | call to method WriteLine | normal |
 | Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | normal |
-| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | throw(ExceptionA) [normal] |
-| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
-| Finally.cs:236:9:255:9 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:236:9:255:9 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | throw(ExceptionA) [normal] (0) |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:258:13:258:46 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] (1) |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] (0) |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] (1) |
 | Finally.cs:236:9:255:9 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine | normal |
 | Finally.cs:236:9:255:9 | {...} | Finally.cs:254:13:254:44 | call to method WriteLine | throw(Exception) |
 | Finally.cs:236:9:255:9 | {...} | Finally.cs:254:31:254:43 | "Mid finally" | throw(OutOfMemoryException) |
 | Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | normal |
-| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] (0) |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] (1) |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] (0) |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] (1) |
 | Finally.cs:238:13:241:13 | {...} | Finally.cs:239:21:239:22 | access to parameter b1 | false |
 | Finally.cs:238:13:241:13 | {...} | Finally.cs:240:21:240:43 | throw ...; | throw(ExceptionA) |
 | Finally.cs:238:13:241:13 | {...} | Finally.cs:240:27:240:42 | object creation of type ExceptionA | throw(Exception) |
@@ -2243,11 +2247,11 @@
 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:27:240:42 | object creation of type ExceptionA | normal |
 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:27:240:42 | object creation of type ExceptionA | throw(Exception) |
 | Finally.cs:243:13:253:13 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | normal |
-| Finally.cs:243:13:253:13 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:243:13:253:13 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] (1) |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] (1) |
 | Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | normal |
-| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] |
-| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(Exception) [normal] (1) |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:251:21:251:54 | call to method WriteLine | throw(ExceptionA) [normal] (1) |
 | Finally.cs:245:17:248:17 | {...} | Finally.cs:246:25:246:26 | access to parameter b2 | false |
 | Finally.cs:245:17:248:17 | {...} | Finally.cs:247:25:247:47 | throw ...; | throw(ExceptionA) |
 | Finally.cs:245:17:248:17 | {...} | Finally.cs:247:31:247:46 | object creation of type ExceptionA | throw(Exception) |
@@ -2869,12 +2873,12 @@
 | Patterns.cs:16:18:16:28 | ... is ... | Patterns.cs:16:18:16:28 | ... is ... | true |
 | Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:23:16:28 | Object v1 | normal |
 | Patterns.cs:17:9:18:9 | {...} | Patterns.cs:17:9:18:9 | {...} | normal |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:23:17:23:22 | break; | normal [break] |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:26:17:26:22 | break; | normal [break] |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:29:17:29:22 | break; | normal [break] |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:32:17:32:22 | break; | normal [break] |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:34:17:34:22 | break; | normal [break] |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:37:17:37:22 | break; | normal [break] |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:23:17:23:22 | break; | normal [break] (0) |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:26:17:26:22 | break; | normal [break] (0) |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:29:17:29:22 | break; | normal [break] (0) |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:32:17:32:22 | break; | normal [break] (0) |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:34:17:34:22 | break; | normal [break] (0) |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:37:17:37:22 | break; | normal [break] (0) |
 | Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:20:17:20:17 | access to local variable o | normal |
 | Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:22:18:22:22 | "xyz" | no-match |
 | Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:23:17:23:22 | break; | break |
@@ -3101,14 +3105,14 @@
 | Switch.cs:37:17:37:23 | call to method Throw | Switch.cs:37:17:37:23 | call to method Throw | throw(Exception) |
 | Switch.cs:39:13:39:20 | default: | Switch.cs:40:17:40:23 | return ...; | return |
 | Switch.cs:40:17:40:23 | return ...; | Switch.cs:40:17:40:23 | return ...; | return |
-| Switch.cs:45:5:53:5 | {...} | Switch.cs:49:17:49:22 | break; | normal [break] |
+| Switch.cs:45:5:53:5 | {...} | Switch.cs:49:17:49:22 | break; | normal [break] (0) |
 | Switch.cs:45:5:53:5 | {...} | Switch.cs:50:18:50:21 | access to type Boolean | no-match |
 | Switch.cs:45:5:53:5 | {...} | Switch.cs:50:30:50:38 | ... != ... | false |
-| Switch.cs:45:5:53:5 | {...} | Switch.cs:51:17:51:22 | break; | normal [break] |
-| Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:49:17:49:22 | break; | normal [break] |
+| Switch.cs:45:5:53:5 | {...} | Switch.cs:51:17:51:22 | break; | normal [break] (0) |
+| Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:49:17:49:22 | break; | normal [break] (0) |
 | Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:50:18:50:21 | access to type Boolean | no-match |
 | Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:50:30:50:38 | ... != ... | false |
-| Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:51:17:51:22 | break; | normal [break] |
+| Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:51:17:51:22 | break; | normal [break] (0) |
 | Switch.cs:46:17:46:17 | access to parameter o | Switch.cs:46:17:46:17 | access to parameter o | normal |
 | Switch.cs:48:13:48:23 | case ...: | Switch.cs:48:18:48:20 | access to type Int32 | no-match |
 | Switch.cs:48:13:48:23 | case ...: | Switch.cs:49:17:49:22 | break; | break |
@@ -3125,10 +3129,10 @@
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:50:30:50:38 | ... != ... | true |
 | Switch.cs:50:35:50:38 | null | Switch.cs:50:35:50:38 | null | normal |
 | Switch.cs:51:17:51:22 | break; | Switch.cs:51:17:51:22 | break; | break |
-| Switch.cs:56:5:64:5 | {...} | Switch.cs:60:17:60:22 | break; | normal [break] |
-| Switch.cs:56:5:64:5 | {...} | Switch.cs:62:17:62:22 | break; | normal [break] |
-| Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:60:17:60:22 | break; | normal [break] |
-| Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:62:17:62:22 | break; | normal [break] |
+| Switch.cs:56:5:64:5 | {...} | Switch.cs:60:17:60:22 | break; | normal [break] (0) |
+| Switch.cs:56:5:64:5 | {...} | Switch.cs:62:17:62:22 | break; | normal [break] (0) |
+| Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:60:17:60:22 | break; | normal [break] (0) |
+| Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:62:17:62:22 | break; | normal [break] (0) |
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:57:17:57:17 | 1 | normal |
 | Switch.cs:57:17:57:21 | ... + ... | Switch.cs:57:17:57:21 | ... + ... | normal |
 | Switch.cs:57:21:57:21 | 2 | Switch.cs:57:21:57:21 | 2 | normal |
@@ -3139,12 +3143,12 @@
 | Switch.cs:61:13:61:19 | case ...: | Switch.cs:62:17:62:22 | break; | break |
 | Switch.cs:61:18:61:18 | 3 | Switch.cs:61:18:61:18 | 3 | match |
 | Switch.cs:62:17:62:22 | break; | Switch.cs:62:17:62:22 | break; | break |
-| Switch.cs:67:5:75:5 | {...} | Switch.cs:71:17:71:22 | break; | normal [break] |
+| Switch.cs:67:5:75:5 | {...} | Switch.cs:71:17:71:22 | break; | normal [break] (0) |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:72:18:72:19 | "" | no-match |
-| Switch.cs:67:5:75:5 | {...} | Switch.cs:73:17:73:22 | break; | normal [break] |
-| Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:71:17:71:22 | break; | normal [break] |
+| Switch.cs:67:5:75:5 | {...} | Switch.cs:73:17:73:22 | break; | normal [break] (0) |
+| Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:71:17:71:22 | break; | normal [break] (0) |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:72:18:72:19 | "" | no-match |
-| Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:73:17:73:22 | break; | normal [break] |
+| Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:73:17:73:22 | break; | normal [break] (0) |
 | Switch.cs:68:17:68:25 | (...) ... | Switch.cs:68:17:68:25 | (...) ... | normal |
 | Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:25:68:25 | access to parameter s | normal |
 | Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 | no-match |
@@ -3161,7 +3165,7 @@
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:88:9:88:21 | return ...; | return |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:82:17:82:28 | return ...; | return |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:83:18:83:18 | 2 | no-match |
-| Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:85:21:85:26 | break; | normal [break] |
+| Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:85:21:85:26 | break; | normal [break] (0) |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:86:17:86:28 | return ...; | return |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:79:17:79:17 | access to parameter i | normal |
 | Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:18:81:18 | 1 | no-match |
@@ -3341,23 +3345,23 @@
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:150:18:150:18 | 2 | no-match |
 | Switch.cs:150:21:150:29 | return ...; | Switch.cs:150:21:150:29 | return ...; | return |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:28:150:28 | 2 | normal |
-| Switch.cs:155:5:161:5 | {...} | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
+| Switch.cs:155:5:161:5 | {...} | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] (0) |
 | Switch.cs:155:5:161:5 | {...} | Switch.cs:158:13:158:48 | call to method WriteLine | normal |
 | Switch.cs:155:5:161:5 | {...} | Switch.cs:160:13:160:48 | call to method WriteLine | normal |
 | Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:13:156:54 | String s = ... | normal |
-| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] (0) |
 | Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:13:156:54 | String s = ... | normal |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] (0) |
 | Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:17:156:17 | access to parameter b | normal |
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:54 | ... switch { ... } | normal |
-| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] (0) |
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | true | match |
 | Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | true | no-match |
 | Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:38 | ... => ... | normal |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" | normal |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false | match |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false | no-match |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] (0) |
 | Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | ... => ... | normal |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" | normal |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:158:13:158:48 | call to method WriteLine | normal |
@@ -3540,7 +3544,7 @@
 | cflow.cs:38:5:68:5 | {...} | cflow.cs:64:21:64:55 | throw ...; | throw(NullReferenceException) |
 | cflow.cs:38:5:68:5 | {...} | cflow.cs:67:9:67:17 | return ...; | return |
 | cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:47:18:47:18 | 3 | no-match |
-| cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:49:17:49:22 | break; | normal [break] |
+| cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:49:17:49:22 | break; | normal [break] (0) |
 | cflow.cs:39:17:39:17 | access to parameter a | cflow.cs:39:17:39:17 | access to parameter a | normal |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:41:18:41:18 | 1 | no-match |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:42:17:42:38 | call to method WriteLine | normal |
@@ -3568,8 +3572,8 @@
 | cflow.cs:48:17:48:39 | ...; | cflow.cs:48:17:48:38 | call to method WriteLine | normal |
 | cflow.cs:48:35:48:37 | "3" | cflow.cs:48:35:48:37 | "3" | normal |
 | cflow.cs:49:17:49:22 | break; | cflow.cs:49:17:49:22 | break; | break |
-| cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:55:17:55:22 | break; | normal [break] |
-| cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:58:17:58:22 | break; | normal [break] |
+| cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:55:17:55:22 | break; | normal [break] (0) |
+| cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:58:17:58:22 | break; | normal [break] (0) |
 | cflow.cs:51:17:51:17 | access to parameter a | cflow.cs:51:17:51:17 | access to parameter a | normal |
 | cflow.cs:53:13:53:20 | case ...: | cflow.cs:53:18:53:19 | 42 | no-match |
 | cflow.cs:53:13:53:20 | case ...: | cflow.cs:54:17:54:47 | call to method WriteLine | normal |
@@ -3586,7 +3590,7 @@
 | cflow.cs:58:17:58:22 | break; | cflow.cs:58:17:58:22 | break; | break |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:62:18:62:18 | 0 | no-match |
 | cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:64:21:64:55 | throw ...; | throw(NullReferenceException) |
-| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:65:17:65:22 | break; | normal [break] |
+| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:65:17:65:22 | break; | normal [break] (0) |
 | cflow.cs:60:17:60:32 | call to method Parse | cflow.cs:60:17:60:32 | call to method Parse | normal |
 | cflow.cs:60:27:60:31 | access to field Field | cflow.cs:60:27:60:31 | access to field Field | normal |
 | cflow.cs:60:27:60:31 | this access | cflow.cs:60:27:60:31 | this access | normal |
@@ -3791,7 +3795,7 @@
 | cflow.cs:150:13:150:32 | call to method WriteLine | cflow.cs:150:13:150:32 | call to method WriteLine | normal |
 | cflow.cs:150:13:150:33 | ...; | cflow.cs:150:13:150:32 | call to method WriteLine | normal |
 | cflow.cs:150:31:150:31 | access to local variable x | cflow.cs:150:31:150:31 | access to local variable x | normal |
-| cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:156:17:156:22 | break; | normal [break] |
+| cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:156:17:156:22 | break; | normal [break] (0) |
 | cflow.cs:152:18:152:18 | access to local variable x | cflow.cs:152:18:152:18 | access to local variable x | normal |
 | cflow.cs:152:18:152:20 | ...++ | cflow.cs:152:18:152:20 | ...++ | normal |
 | cflow.cs:153:9:157:9 | {...} | cflow.cs:155:17:155:22 | ... > ... | false |
@@ -3806,7 +3810,7 @@
 | cflow.cs:155:17:155:22 | ... > ... | cflow.cs:155:17:155:22 | ... > ... | true |
 | cflow.cs:155:21:155:22 | 20 | cflow.cs:155:21:155:22 | 20 | normal |
 | cflow.cs:156:17:156:22 | break; | cflow.cs:156:17:156:22 | break; | break |
-| cflow.cs:159:9:165:9 | for (...;...;...) ... | cflow.cs:164:17:164:22 | break; | normal [break] |
+| cflow.cs:159:9:165:9 | for (...;...;...) ... | cflow.cs:164:17:164:22 | break; | normal [break] (0) |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:163:17:163:22 | ... > ... | false |
 | cflow.cs:160:9:165:9 | {...} | cflow.cs:164:17:164:22 | break; | break |
 | cflow.cs:161:13:161:32 | call to method WriteLine | cflow.cs:161:13:161:32 | call to method WriteLine | normal |
@@ -3967,9 +3971,9 @@
 | cflow.cs:202:13:204:13 | {...} | cflow.cs:203:17:203:38 | throw ...; | throw(Exception) |
 | cflow.cs:203:17:203:38 | throw ...; | cflow.cs:203:17:203:38 | throw ...; | throw(Exception) |
 | cflow.cs:203:23:203:37 | object creation of type Exception | cflow.cs:203:23:203:37 | object creation of type Exception | normal |
-| cflow.cs:209:5:222:5 | {...} | cflow.cs:219:17:219:22 | break; | normal [break] |
+| cflow.cs:209:5:222:5 | {...} | cflow.cs:219:17:219:22 | break; | normal [break] (0) |
 | cflow.cs:209:5:222:5 | {...} | cflow.cs:221:18:221:34 | ... < ... | false |
-| cflow.cs:210:9:221:36 | do ... while (...); | cflow.cs:219:17:219:22 | break; | normal [break] |
+| cflow.cs:210:9:221:36 | do ... while (...); | cflow.cs:219:17:219:22 | break; | normal [break] (0) |
 | cflow.cs:210:9:221:36 | do ... while (...); | cflow.cs:221:18:221:34 | ... < ... | false |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:215:17:215:25 | continue; | continue |
 | cflow.cs:211:9:221:9 | {...} | cflow.cs:217:17:217:32 | ... < ... | false |
@@ -4010,9 +4014,9 @@
 | cflow.cs:221:18:221:34 | ... < ... | cflow.cs:221:18:221:34 | ... < ... | true |
 | cflow.cs:221:33:221:34 | 10 | cflow.cs:221:33:221:34 | 10 | normal |
 | cflow.cs:225:5:238:5 | {...} | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | empty |
-| cflow.cs:225:5:238:5 | {...} | cflow.cs:235:17:235:22 | break; | normal [break] |
+| cflow.cs:225:5:238:5 | {...} | cflow.cs:235:17:235:22 | break; | normal [break] (0) |
 | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | empty |
-| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:235:17:235:22 | break; | normal [break] |
+| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:235:17:235:22 | break; | normal [break] (0) |
 | cflow.cs:226:22:226:22 | String x | cflow.cs:226:22:226:22 | String x | normal |
 | cflow.cs:226:27:226:64 | call to method Repeat | cflow.cs:226:27:226:64 | call to method Repeat | normal |
 | cflow.cs:226:57:226:59 | "a" | cflow.cs:226:57:226:59 | "a" | normal |
@@ -4050,9 +4054,9 @@
 | cflow.cs:234:13:236:13 | {...} | cflow.cs:235:17:235:22 | break; | break |
 | cflow.cs:235:17:235:22 | break; | cflow.cs:235:17:235:22 | break; | break |
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:244:31:244:41 | goto ...; | goto(Label) |
-| cflow.cs:241:5:259:5 | {...} | cflow.cs:252:17:252:22 | break; | normal [break] |
+| cflow.cs:241:5:259:5 | {...} | cflow.cs:252:17:252:22 | break; | normal [break] (0) |
 | cflow.cs:241:5:259:5 | {...} | cflow.cs:254:17:254:27 | goto ...; | goto(Label) |
-| cflow.cs:241:5:259:5 | {...} | cflow.cs:257:17:257:22 | break; | normal [break] |
+| cflow.cs:241:5:259:5 | {...} | cflow.cs:257:17:257:22 | break; | normal [break] (0) |
 | cflow.cs:242:9:242:13 | Label: | cflow.cs:242:9:242:13 | Label: | normal |
 | cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:20:242:40 | !... | false |
 | cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:43:242:45 | {...} | normal |
@@ -4076,9 +4080,9 @@
 | cflow.cs:244:13:244:28 | ... > ... | cflow.cs:244:13:244:28 | ... > ... | true |
 | cflow.cs:244:28:244:28 | 0 | cflow.cs:244:28:244:28 | 0 | normal |
 | cflow.cs:244:31:244:41 | goto ...; | cflow.cs:244:31:244:41 | goto ...; | goto(Label) |
-| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:252:17:252:22 | break; | normal [break] |
+| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:252:17:252:22 | break; | normal [break] (0) |
 | cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:254:17:254:27 | goto ...; | goto(Label) |
-| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:257:17:257:22 | break; | normal [break] |
+| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:257:17:257:22 | break; | normal [break] (0) |
 | cflow.cs:246:17:246:21 | access to field Field | cflow.cs:246:17:246:21 | access to field Field | normal |
 | cflow.cs:246:17:246:21 | this access | cflow.cs:246:17:246:21 | this access | normal |
 | cflow.cs:246:17:246:28 | access to property Length | cflow.cs:246:17:246:28 | access to property Length | normal |
@@ -4108,9 +4112,9 @@
 | cflow.cs:256:35:256:35 | 0 | cflow.cs:256:35:256:35 | 0 | normal |
 | cflow.cs:257:17:257:22 | break; | cflow.cs:257:17:257:22 | break; | break |
 | cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | normal |
-| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | return [normal] |
-| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | throw(Exception) [normal] |
-| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | return [normal] (0) |
+| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | throw(Exception) [normal] (0) |
+| cflow.cs:262:5:277:5 | {...} | cflow.cs:275:13:275:41 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | cflow.cs:263:9:263:23 | yield return ...; | cflow.cs:263:9:263:23 | yield return ...; | normal |
 | cflow.cs:263:22:263:22 | 0 | cflow.cs:263:22:263:22 | 0 | normal |
 | cflow.cs:264:9:267:9 | for (...;...;...) ... | cflow.cs:264:25:264:30 | ... < ... | false |
@@ -4126,9 +4130,9 @@
 | cflow.cs:266:13:266:27 | yield return ...; | cflow.cs:266:13:266:27 | yield return ...; | normal |
 | cflow.cs:266:26:266:26 | access to local variable i | cflow.cs:266:26:266:26 | access to local variable i | normal |
 | cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | normal |
-| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | return [normal] |
-| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | throw(Exception) [normal] |
-| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | throw(OutOfMemoryException) [normal] |
+| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | return [normal] (0) |
+| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | throw(Exception) [normal] (0) |
+| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:275:13:275:41 | call to method WriteLine | throw(OutOfMemoryException) [normal] (0) |
 | cflow.cs:269:9:272:9 | {...} | cflow.cs:270:13:270:24 | yield break; | return |
 | cflow.cs:269:9:272:9 | {...} | cflow.cs:271:13:271:42 | call to method WriteLine | normal |
 | cflow.cs:269:9:272:9 | {...} | cflow.cs:271:13:271:42 | call to method WriteLine | throw(Exception) |

--- a/csharp/ql/test/library-tests/controlflow/graph/Finally.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/Finally.cs
@@ -229,4 +229,34 @@ public class Finally
         }
         Console.WriteLine("Done");
     }
+
+    void M12(bool b1, bool b2)
+    {
+        try
+        {
+            try
+            {
+                if (b1)
+                    throw new ExceptionA();
+            }
+            finally
+            {
+                try
+                {
+                    if (b2)
+                        throw new ExceptionA();
+                }
+                finally
+                {
+                    Console.WriteLine("Inner finally");
+                }
+            }
+            Console.WriteLine("Mid finally");
+        }
+        finally
+        {
+            Console.WriteLine("Outer finally");
+        }
+        Console.WriteLine("Done");
+    }
 }

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -2626,6 +2626,105 @@
 | Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | exit M11 (normal) | semmle.label | successor |
 | Finally.cs:230:9:230:34 | ...; | Finally.cs:230:27:230:32 | "Done" | semmle.label | successor |
 | Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:33 | call to method WriteLine | semmle.label | successor |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:234:5:261:5 | {...} | semmle.label | successor |
+| Finally.cs:233:10:233:12 | exit M12 (abnormal) | Finally.cs:233:10:233:12 | exit M12 | semmle.label | successor |
+| Finally.cs:233:10:233:12 | exit M12 (normal) | Finally.cs:233:10:233:12 | exit M12 | semmle.label | successor |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:235:9:259:9 | try {...} ... | semmle.label | successor |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:236:9:255:9 | {...} | semmle.label | successor |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:237:13:253:13 | try {...} ... | semmle.label | successor |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:238:13:241:13 | {...} | semmle.label | successor |
+| Finally.cs:238:13:241:13 | {...} | Finally.cs:239:17:240:43 | if (...) ... | semmle.label | successor |
+| Finally.cs:239:17:240:43 | if (...) ... | Finally.cs:239:21:239:22 | access to parameter b1 | semmle.label | successor |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | semmle.label | true |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:243:13:253:13 | {...} | semmle.label | false |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:21:240:43 | throw ...; | semmle.label | successor |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... | semmle.label | successor |
+| Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... | semmle.label | successor |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:244:17:252:17 | try {...} ... | semmle.label | successor |
+| Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... | Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} | semmle.label | successor |
+| Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... | Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} | semmle.label | successor |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:245:17:248:17 | {...} | semmle.label | successor |
+| Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} | Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
+| Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... | semmle.label | successor |
+| Finally.cs:245:17:248:17 | {...} | Finally.cs:246:21:247:47 | if (...) ... | semmle.label | successor |
+| Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | semmle.label | successor |
+| Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | semmle.label | successor |
+| Finally.cs:246:21:247:47 | if (...) ... | Finally.cs:246:25:246:26 | access to parameter b2 | semmle.label | successor |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | semmle.label | true |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | semmle.label | false |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | semmle.label | true |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | semmle.label | false |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | semmle.label | true |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:250:17:252:17 | {...} | semmle.label | false |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | semmle.label | successor |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | throw ...; | semmle.label | successor |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:251:21:251:55 | ...; | semmle.label | successor |
+| Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:254:13:254:45 | ...; | semmle.label | successor |
+| Finally.cs:251:21:251:55 | ...; | Finally.cs:251:39:251:53 | "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:251:21:251:54 | call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | {...} | semmle.label | successor |
+| Finally.cs:254:13:254:45 | ...; | Finally.cs:254:31:254:43 | "Mid finally" | semmle.label | successor |
+| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:254:13:254:44 | call to method WriteLine | semmle.label | successor |
+| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
+| Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; | semmle.label | successor |
+| Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:258:13:258:47 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | successor |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:258:13:258:47 | ...; | semmle.label | successor |
+| Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (abnormal) | semmle.label | exception(ExceptionA) |
+| Finally.cs:258:13:258:46 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (abnormal) | semmle.label | exception(OutOfMemoryException) |
+| Finally.cs:258:13:258:46 | call to method WriteLine | Finally.cs:260:9:260:34 | ...; | semmle.label | successor |
+| Finally.cs:258:13:258:47 | ...; | Finally.cs:258:31:258:45 | "Outer finally" | semmle.label | successor |
+| Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; | Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" | semmle.label | successor |
+| Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; | Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" | semmle.label | successor |
+| Finally.cs:258:13:258:47 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:258:31:258:45 | [finally: exception(OutOfMemoryException)] "Outer finally" | semmle.label | successor |
+| Finally.cs:258:31:258:45 | "Outer finally" | Finally.cs:258:13:258:46 | call to method WriteLine | semmle.label | successor |
+| Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" | Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" | Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:258:31:258:45 | [finally: exception(OutOfMemoryException)] "Outer finally" | Finally.cs:258:13:258:46 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:260:9:260:33 | call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (normal) | semmle.label | successor |
+| Finally.cs:260:9:260:34 | ...; | Finally.cs:260:27:260:32 | "Done" | semmle.label | successor |
+| Finally.cs:260:27:260:32 | "Done" | Finally.cs:260:9:260:33 | call to method WriteLine | semmle.label | successor |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:7:5:10:5 | {...} | semmle.label | successor |
 | Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 | semmle.label | successor |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:8:29:8:32 | access to parameter args | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -2680,8 +2680,10 @@
 | Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
 | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
 | Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:254:13:254:45 | ...; | semmle.label | successor |
 | Finally.cs:251:21:251:55 | ...; | Finally.cs:251:39:251:53 | "Inner finally" | semmle.label | successor |
 | Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -2043,49 +2043,49 @@
 | Finally.cs:92:30:92:30 | [finally: break] 3 | Finally.cs:92:25:92:30 | [finally: break] ... == ... | semmle.label | successor |
 | Finally.cs:92:30:92:30 | [finally: continue] 3 | Finally.cs:92:25:92:30 | [finally: continue] ... == ... | semmle.label | successor |
 | Finally.cs:92:30:92:30 | [finally: return] 3 | Finally.cs:92:25:92:30 | [finally: return] ... == ... | semmle.label | successor |
-| Finally.cs:93:25:93:46 | [finally: break] throw ...; | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:93:25:93:46 | [finally: continue] throw ...; | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:93:25:93:46 | [finally: return] throw ...; | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:93:25:93:46 | throw ...; | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:93:25:93:46 | [finally: break] throw ...; | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:93:25:93:46 | [finally: continue] throw ...; | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:93:25:93:46 | [finally: return] throw ...; | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:93:25:93:46 | throw ...; | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: break] throw ...; | semmle.label | successor |
-| Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: continue] throw ...; | semmle.label | successor |
-| Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: return] throw ...; | semmle.label | successor |
-| Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:93:25:93:46 | throw ...; | semmle.label | successor |
-| Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally(2): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: break, finally(2): exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; | semmle.label | successor |
 | Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:97:21:97:24 | [finally: break] ...; | semmle.label | successor |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: continue, finally(2): exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; | semmle.label | successor |
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:97:21:97:24 | [finally: continue] ...; | semmle.label | successor |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: return, finally(2): exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; | semmle.label | successor |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:97:21:97:24 | [finally: return] ...; | semmle.label | successor |
 | Finally.cs:96:17:98:17 | {...} | Finally.cs:97:21:97:24 | ...; | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally(2): exception(Exception)] ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally: break, finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: break, finally(2): exception(Exception)] ...-- | semmle.label | successor |
+| Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- | semmle.label | successor |
+| Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- | semmle.label | successor |
 | Finally.cs:97:21:97:21 | [finally: break] access to local variable i | Finally.cs:97:21:97:23 | [finally: break] ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally: continue, finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: continue, finally(2): exception(Exception)] ...-- | semmle.label | successor |
+| Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- | semmle.label | successor |
 | Finally.cs:97:21:97:21 | [finally: continue] access to local variable i | Finally.cs:97:21:97:23 | [finally: continue] ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally: return, finally(2): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: return, finally(2): exception(Exception)] ...-- | semmle.label | successor |
+| Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- | semmle.label | successor |
 | Finally.cs:97:21:97:21 | [finally: return] access to local variable i | Finally.cs:97:21:97:23 | [finally: return] ...-- | semmle.label | successor |
 | Finally.cs:97:21:97:21 | access to local variable i | Finally.cs:97:21:97:23 | ...-- | semmle.label | successor |
 | Finally.cs:97:21:97:23 | ...-- | Finally.cs:77:16:77:16 | access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:23 | [finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:97:21:97:23 | [finally: break, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:97:21:97:23 | [finally: break] ...-- | Finally.cs:74:10:74:11 | exit M4 (normal) | semmle.label | break |
-| Finally.cs:97:21:97:23 | [finally: continue, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:97:21:97:23 | [finally: continue] ...-- | Finally.cs:77:16:77:16 | access to local variable i | semmle.label | continue |
-| Finally.cs:97:21:97:23 | [finally: return, finally(2): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
 | Finally.cs:97:21:97:23 | [finally: return] ...-- | Finally.cs:74:10:74:11 | exit M4 (normal) | semmle.label | return |
 | Finally.cs:97:21:97:24 | ...; | Finally.cs:97:21:97:21 | access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally(2): exception(Exception)] access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally: break, finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: break, finally(2): exception(Exception)] access to local variable i | semmle.label | successor |
+| Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i | semmle.label | successor |
+| Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i | semmle.label | successor |
 | Finally.cs:97:21:97:24 | [finally: break] ...; | Finally.cs:97:21:97:21 | [finally: break] access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally: continue, finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: continue, finally(2): exception(Exception)] access to local variable i | semmle.label | successor |
+| Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i | semmle.label | successor |
 | Finally.cs:97:21:97:24 | [finally: continue] ...; | Finally.cs:97:21:97:21 | [finally: continue] access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally: return, finally(2): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: return, finally(2): exception(Exception)] access to local variable i | semmle.label | successor |
+| Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i | semmle.label | successor |
 | Finally.cs:97:21:97:24 | [finally: return] ...; | Finally.cs:97:21:97:21 | [finally: return] access to local variable i | semmle.label | successor |
 | Finally.cs:103:10:103:11 | enter M5 | Finally.cs:104:5:119:5 | {...} | semmle.label | successor |
 | Finally.cs:103:10:103:11 | exit M5 (abnormal) | Finally.cs:103:10:103:11 | exit M5 | semmle.label | successor |
@@ -2525,67 +2525,67 @@
 | Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | semmle.label | false |
 | Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | semmle.label | true |
 | Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:208:13:210:13 | {...} | semmle.label | false |
-| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(ExceptionB)] {...} | semmle.label | exception(ExceptionB) |
-| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] {...} | semmle.label | exception(ExceptionB) |
-| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:208:13:210:13 | [finally(2): exception(ExceptionB)] {...} | semmle.label | exception(ExceptionB) |
+| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} | semmle.label | exception(ExceptionB) |
+| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} | semmle.label | exception(ExceptionB) |
+| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} | semmle.label | exception(ExceptionB) |
 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | semmle.label | successor |
-| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:205:25:205:47 | throw ...; | semmle.label | successor |
-| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally(2): exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally(2): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally(2): exception(ExceptionB)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] if (...) ... | semmle.label | successor |
+| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... | semmle.label | successor |
+| Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... | semmle.label | successor |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... | semmle.label | successor |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... | semmle.label | successor |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] if (...) ... | semmle.label | successor |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... | semmle.label | successor |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... | semmle.label | successor |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... | semmle.label | successor |
 | Finally.cs:208:13:210:13 | {...} | Finally.cs:209:17:209:47 | if (...) ... | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally(2): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | semmle.label | successor |
+| Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | semmle.label | successor |
+| Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | semmle.label | successor |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | semmle.label | successor |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | semmle.label | successor |
 | Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | semmle.label | successor |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | semmle.label | successor |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | semmle.label | successor |
 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | semmle.label | successor |
 | Finally.cs:209:17:209:47 | if (...) ... | Finally.cs:209:21:209:22 | access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
-| Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
+| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
+| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
+| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | semmle.label | false |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | semmle.label | false |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | semmle.label | true |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:211:13:211:29 | ...; | semmle.label | false |
-| Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
 | Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
 | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
 | Finally.cs:209:25:209:47 | throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] throw ...; | semmle.label | successor |
+| Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; | semmle.label | successor |
+| Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; | semmle.label | successor |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; | semmle.label | successor |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; | semmle.label | successor |
 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; | semmle.label | successor |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; | semmle.label | successor |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; | semmle.label | successor |
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | semmle.label | successor |
 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:209:25:209:47 | throw ...; | semmle.label | successor |
 | Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access | Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" | semmle.label | successor |
@@ -2658,50 +2658,50 @@
 | Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | semmle.label | false |
 | Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | semmle.label | true |
 | Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:250:17:252:17 | {...} | semmle.label | false |
-| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | semmle.label | successor |
-| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | throw ...; | semmle.label | successor |
-| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | semmle.label | successor |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; | semmle.label | successor |
 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; | semmle.label | successor |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; | semmle.label | successor |
 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | semmle.label | successor |
 | Finally.cs:250:17:252:17 | {...} | Finally.cs:251:21:251:55 | ...; | semmle.label | successor |
-| Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
 | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
 | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
 | Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:254:13:254:45 | ...; | semmle.label | successor |
 | Finally.cs:251:21:251:55 | ...; | Finally.cs:251:39:251:53 | "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
 | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" | semmle.label | successor |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
 | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | semmle.label | successor |
 | Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:251:21:251:54 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
 | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine | semmle.label | successor |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
 | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
 | Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
 | Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | {...} | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -685,33 +685,33 @@ finallyNode
 | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:79:13:99:13 | try {...} ... |
 | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:79:13:99:13 | try {...} ... |
 | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:79:13:99:13 | try {...} ... |
-| Finally.cs:96:17:98:17 | [finally(2): exception(Exception)] {...} | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:96:17:98:17 | [finally: break, finally(2): exception(Exception)] {...} | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(2): exception(Exception)] {...} | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:96:17:98:17 | [finally: return, finally(2): exception(Exception)] {...} | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:21 | [finally(2): exception(Exception)] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:21 | [finally: break, finally(2): exception(Exception)] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:97:21:97:21 | [finally: break] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:21 | [finally: continue, finally(2): exception(Exception)] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:97:21:97:21 | [finally: continue] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:21 | [finally: return, finally(2): exception(Exception)] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:97:21:97:21 | [finally: return] access to local variable i | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:23 | [finally(2): exception(Exception)] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:23 | [finally: break, finally(2): exception(Exception)] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:97:21:97:23 | [finally: break] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:23 | [finally: continue, finally(2): exception(Exception)] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:97:21:97:23 | [finally: continue] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:23 | [finally: return, finally(2): exception(Exception)] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:97:21:97:23 | [finally: return] ...-- | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:24 | [finally(2): exception(Exception)] ...; | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:24 | [finally: break, finally(2): exception(Exception)] ...; | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:97:21:97:24 | [finally: break] ...; | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:24 | [finally: continue, finally(2): exception(Exception)] ...; | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:97:21:97:24 | [finally: continue] ...; | Finally.cs:90:17:98:17 | try {...} ... |
-| Finally.cs:97:21:97:24 | [finally: return, finally(2): exception(Exception)] ...; | Finally.cs:90:17:98:17 | try {...} ... |
+| Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:97:21:97:24 | [finally: return] ...; | Finally.cs:90:17:98:17 | try {...} ... |
 | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:105:9:118:9 | try {...} ... |
 | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:105:9:118:9 | try {...} ... |
@@ -935,45 +935,45 @@ finallyNode
 | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:197:9:212:9 | try {...} ... |
 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:197:9:212:9 | try {...} ... |
 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:197:9:212:9 | try {...} ... |
-| Finally.cs:208:13:210:13 | [finally(2): exception(Exception)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:208:13:210:13 | [finally(2): exception(ExceptionB)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(2): exception(ExceptionB)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:17:209:47 | [finally(2): exception(Exception)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:17:209:47 | [finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:21:209:22 | [finally(2): exception(Exception)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:21:209:22 | [finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(Exception)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:25:209:47 | [finally(2): exception(Exception)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:25:209:47 | [finally(2): exception(ExceptionB)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(Exception)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(Exception)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:31:209:46 | [finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:31:209:46 | [finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(Exception)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(2): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:203:13:210:13 | try {...} ... |
 | Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access | Finally.cs:197:9:212:9 | try {...} ... |
 | Finally.cs:211:13:211:16 | [finally: exception(ExceptionA)] this access | Finally.cs:197:9:212:9 | try {...} ... |
@@ -997,37 +997,37 @@ finallyNode
 | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:237:13:253:13 | try {...} ... |
 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:237:13:253:13 | try {...} ... |
 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:237:13:253:13 | try {...} ... |
-| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
 | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
 | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
 | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
 | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
 | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
 | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
 | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:235:9:259:9 | try {...} ... |
 | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:235:9:259:9 | try {...} ... |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -983,6 +983,64 @@ finallyNode
 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:197:9:212:9 | try {...} ... |
 | Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" | Finally.cs:197:9:212:9 | try {...} ... |
 | Finally.cs:211:26:211:28 | [finally: exception(ExceptionA)] "0" | Finally.cs:197:9:212:9 | try {...} ... |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:237:13:253:13 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally(2): exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally(2): exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(2): exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(Exception)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally(2): exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(Exception)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally(2): exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally(2): exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(2): exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(Exception)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally(2): exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(Exception)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(2): exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:244:17:252:17 | try {...} ... |
+| Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:257:9:259:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:258:13:258:46 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:258:13:258:47 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" | Finally.cs:235:9:259:9 | try {...} ... |
+| Finally.cs:258:31:258:45 | [finally: exception(OutOfMemoryException)] "Outer finally" | Finally.cs:235:9:259:9 | try {...} ... |
 | cflow.cs:274:9:276:9 | [finally: return] {...} | cflow.cs:268:9:276:9 | try {...} ... |
 | cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine | cflow.cs:268:9:276:9 | try {...} ... |
 | cflow.cs:275:13:275:42 | [finally: return] ...; | cflow.cs:268:9:276:9 | try {...} ... |
@@ -1089,6 +1147,7 @@ entryPoint
 | Finally.cs:176:10:176:11 | M9 | Finally.cs:177:5:193:5 | {...} |
 | Finally.cs:195:10:195:12 | M10 | Finally.cs:196:5:214:5 | {...} |
 | Finally.cs:216:10:216:12 | M11 | Finally.cs:217:5:231:5 | {...} |
+| Finally.cs:233:10:233:12 | M12 | Finally.cs:234:5:261:5 | {...} |
 | Foreach.cs:6:10:6:11 | M1 | Foreach.cs:7:5:10:5 | {...} |
 | Foreach.cs:12:10:12:11 | M2 | Foreach.cs:13:5:16:5 | {...} |
 | Foreach.cs:18:10:18:11 | M3 | Foreach.cs:19:5:22:5 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.ql
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.ql
@@ -16,9 +16,7 @@ class MyFinallySplitControlFlowNode extends ElementNode {
     )
   }
 
-  TryStmt getTryStmt() {
-    this.getElement() = Splitting::FinallySplitting::getAFinallyDescendant(result)
-  }
+  Statements::TryStmtTree getTryStmt() { this.getElement() = result.getAFinallyDescendant() }
 }
 
 query predicate finallyNode(MyFinallySplitControlFlowNode f, TryStmt try) { try = f.getTryStmt() }


### PR DESCRIPTION
In nested `finally` blocks such as
```csharp
void M12(bool b1, bool b2)
{
    try
    {
        try
        {
            if (b1)
                throw new ExceptionA();
        }
        finally
        {
            try
            {
                if (b2)
                    throw new ExceptionA();
            }
            finally
            {
                Console.WriteLine("Inner finally");
            }
        }
        Console.WriteLine("Mid finally");
    }
    finally
    {
        Console.WriteLine("Outer finally");
    }
    Console.WriteLine("Done");
}
```
we were unable to distinguish whether the inner `finally` block inherited an `ExceptionA` completion from the outer `throw` or the inner `throw`. The (somewhat surprising) effect was that we were missing a CFG edge (highlighted):

![cfg](https://user-images.githubusercontent.com/3667920/101328040-c99d8100-386f-11eb-8cc7-e53fcc2f25ca.png)

The solution is to record information about the nesting level of inherited completions, which enables us to distinguish the two cases. Commit-by-commit review is encouraged.

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/670/