### PR TITLE
Fix links to CodeQL library pages

### DIFF
--- a/docs/codeql/codeql-language-guides/abstract-syntax-tree-classes-for-working-with-java-programs.rst
+++ b/docs/codeql/codeql-language-guides/abstract-syntax-tree-classes-for-working-with-java-programs.rst
@@ -19,7 +19,7 @@ This table lists all subclasses of `Stmt`_.
 +------------------------------------------------------------------------------------+---------------------------------+---------------------------------+--------------------------------------------+
 | `Expr`_ ``;``                                                                      | ExprStmt_                       |                                 |                                            |
 +------------------------------------------------------------------------------------+---------------------------------+---------------------------------+--------------------------------------------+
-| ``{`` `Stmt`_  ``... }``                                                           | Block_                          |                                 |                                            |
+| ``{`` `Stmt`_  ``... }``                                                           | BlockStmt_                      |                                 |                                            |
 +------------------------------------------------------------------------------------+---------------------------------+---------------------------------+--------------------------------------------+
 | ``if (`` `Expr`_ ``)`` `Stmt`_  ``else`` `Stmt`_                                   | IfStmt_                         | `ConditionalStmt`_              |                                            |
 +------------------------------------------------------------------------------------+                                 |                                 |                                            |
@@ -348,7 +348,7 @@ Further reading
 .. _ArrayCreationExpr: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Expr.qll/type.Expr$ArrayCreationExpr.html
 .. _EmptyStmt: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Statement.qll/type.Statement$EmptyStmt.html
 .. _ExprStmt: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Statement.qll/type.Statement$ExprStmt.html
-.. _Block: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Statement.qll/type.Statement$Block.html
+.. _BlockStmt: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Statement.qll/type.Statement$BlockStmt.html
 .. _IfStmt: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Statement.qll/type.Statement$IfStmt.html
 .. _WhileStmt: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Statement.qll/type.Statement$WhileStmt.html
 .. _DoStmt: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Statement.qll/type.Statement$DoStmt.html

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-and-tracking-tainted-data-in-python.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-and-tracking-tainted-data-in-python.rst
@@ -35,7 +35,7 @@ The explicit components are:
 
 A taint tracking or data flow query gives results when there is the flow of data from a source to a sink, which is not blocked by a sanitizer.
 
-These three components are bound together using a `TaintTracking::Configuration <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/Configuration.qll/type.Configuration$TaintTracking$Configuration.html>`__.
+These three components are bound together using a `TaintTracking::Configuration <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/old/Configuration.qll/type.Configuration$TaintTracking$Configuration.html>`__.
 The purpose of the configuration is to specify exactly which sources and sinks are relevant to the specific query.
 
 The final, implicit component is the "kind" of taint, represented by the `TaintKind <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/old/TaintTracking.qll/type.TaintTracking$TaintKind.html>`__ class.

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-and-tracking-tainted-data-in-python.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-and-tracking-tainted-data-in-python.rst
@@ -29,16 +29,16 @@ The taint tracking library is in the `TaintTracking <https://codeql.github.com/c
 Any taint tracking or data flow analysis query has three explicit components, one of which is optional, and an implicit component.
 The explicit components are:
 
-1. One or more ``sources`` of potentially insecure or unsafe data, represented by the `TaintTracking::Source <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/TaintTracking.qll/type.TaintTracking$TaintSource.html>`__ class.
-2. One or more ``sinks``, to where the data or taint may flow, represented by the `TaintTracking::Sink <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/TaintTracking.qll/type.TaintTracking$TaintSink.html>`__ class.
-3. Zero or more ``sanitizers``, represented by the `Sanitizer <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/TaintTracking.qll/type.TaintTracking$Sanitizer.html>`__ class.
+1. One or more ``sources`` of potentially insecure or unsafe data, represented by the `TaintTracking::Source <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/old/TaintTracking.qll/type.TaintTracking$TaintSource.html>`__ class.
+2. One or more ``sinks``, to where the data or taint may flow, represented by the `TaintTracking::Sink <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/old/TaintTracking.qll/type.TaintTracking$TaintSink.html>`__ class.
+3. Zero or more ``sanitizers``, represented by the `Sanitizer <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/old/TaintTracking.qll/type.TaintTracking$Sanitizer.html>`__ class.
 
 A taint tracking or data flow query gives results when there is the flow of data from a source to a sink, which is not blocked by a sanitizer.
 
 These three components are bound together using a `TaintTracking::Configuration <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/Configuration.qll/type.Configuration$TaintTracking$Configuration.html>`__.
 The purpose of the configuration is to specify exactly which sources and sinks are relevant to the specific query.
 
-The final, implicit component is the "kind" of taint, represented by the `TaintKind <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/TaintTracking.qll/type.TaintTracking$TaintKind.html>`__ class.
+The final, implicit component is the "kind" of taint, represented by the `TaintKind <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/old/TaintTracking.qll/type.TaintTracking$TaintKind.html>`__ class.
 The kind of taint determines which non-value-preserving steps are possible, in addition to value-preserving steps that are built into the analysis.
 In the above example ``dir = path + "/"``, taint flows from ``path`` to ``dir`` if the taint represents a string, but not if the taint is ``None``.
 

--- a/docs/codeql/codeql-language-guides/codeql-library-for-cpp.rst
+++ b/docs/codeql/codeql-language-guides/codeql-library-for-cpp.rst
@@ -160,11 +160,11 @@ This table lists subclasses of Stmt_ representing C/C++ statements.
 +==========================================================+================================+===================================================+
 | ``__asm__ ("`` *movb %bh, (%eax)* ``");``                | AsmStmt_                       | Specific to a given CPU instruction set           |
 +----------------------------------------------------------+--------------------------------+---------------------------------------------------+
-| ``{`` Stmt_... ``}``                                     | Block_                         |                                                   |
+| ``{`` Stmt_... ``}``                                     | BlockStmt_                     |                                                   |
 +----------------------------------------------------------+--------------------------------+---------------------------------------------------+
-| ``catch (`` Parameter_ ``)`` Block_                      | CatchBlock_                    |                                                   |
+| ``catch (`` Parameter_ ``)`` BlockStmt_                  | CatchBlock_                    |                                                   |
 +----------------------------------------------------------+--------------------------------+---------------------------------------------------+
-| ``catch ( ... )`` Block_                                 | CatchAnyBlock_                 |                                                   |
+| ``catch ( ... )`` BlockStmt_                             | CatchAnyBlock_                 |                                                   |
 +----------------------------------------------------------+--------------------------------+---------------------------------------------------+
 | ``goto *`` *labelptr* ``;``                              | ComputedGotoStmt_              | GNU extension; use with LabelLiteral_             |
 +----------------------------------------------------------+--------------------------------+---------------------------------------------------+
@@ -584,7 +584,7 @@ Further reading
 .. _TemplateVariable: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/Variable.qll/type.Variable$TemplateVariable.html
 .. _Stmt: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/stmts/Stmt.qll/type.Stmt$Stmt.html
 .. _AsmStmt: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/stmts/Stmt.qll/type.Stmt$AsmStmt.html
-.. _Block: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/stmts/Block.qll/type.Block$Block.html
+.. _BlockStmt: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/stmts/Block.qll/type.Block$BlockStmt.html
 .. _CatchBlock: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/stmts/Stmt.qll/type.Stmt$CatchBlock.html
 .. _CatchAnyBlock: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/stmts/Stmt.qll/type.Stmt$CatchAnyBlock.html
 .. _ComputedGotoStmt: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/stmts/Stmt.qll/type.Stmt$ComputedGotoStmt.html
@@ -751,6 +751,6 @@ Further reading
 .. _IncludeNext: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/Include.qll/type.Include$IncludeNext.html
 .. _Macro: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/Macro.qll/type.Macro$Macro.html
 .. _Char16Type: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/Type.qll/type.Type$Char16Type.html
-.. _Char32Type: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/Type.qll/type.Type$Char32Type.html>
+.. _Char32Type: https://codeql.github.com/codeql-standard-libraries/cpp/semmle/code/cpp/Type.qll/type.Type$Char32Type.html
 
 

--- a/docs/codeql/codeql-language-guides/codeql-library-for-python.rst
+++ b/docs/codeql/codeql-language-guides/codeql-library-for-python.rst
@@ -333,7 +333,7 @@ The CodeQL library for Python also supplies classes to specify taint-tracking an
 Summary
 ^^^^^^^
 
-- `TaintKind <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/TaintTracking.qll/type.TaintTracking$TaintKind.html>`__
+- `TaintKind <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/old/TaintTracking.qll/type.TaintTracking$TaintKind.html>`__
 - `Configuration <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/Configuration.qll/type.Configuration$TaintTracking$Configuration.html>`__
 
 For more information about these classes, see ":doc:`Analyzing data flow and tracking tainted data in Python <analyzing-data-flow-and-tracking-tainted-data-in-python>`."

--- a/docs/codeql/codeql-language-guides/codeql-library-for-python.rst
+++ b/docs/codeql/codeql-language-guides/codeql-library-for-python.rst
@@ -334,7 +334,7 @@ Summary
 ^^^^^^^
 
 - `TaintKind <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/old/TaintTracking.qll/type.TaintTracking$TaintKind.html>`__
-- `Configuration <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/Configuration.qll/type.Configuration$TaintTracking$Configuration.html>`__
+- `Configuration <https://codeql.github.com/codeql-standard-libraries/python/semmle/python/dataflow/old/Configuration.qll/type.Configuration$TaintTracking$Configuration.html>`__
 
 For more information about these classes, see ":doc:`Analyzing data flow and tracking tainted data in Python <analyzing-data-flow-and-tracking-tainted-data-in-python>`."
 


### PR DESCRIPTION
This PR fixes a few documentation links that were broken by recent library changes. I hope the changes speak for themselves, so please can I get reviews from @github/codeql-c, @github/codeql-java and @github/codeql-python.  