### PR TITLE
Update JavaScript dataflow guide filename to match article title

### DIFF
--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-and-tracking-tainted-data-in-python.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-and-tracking-tainted-data-in-python.rst
@@ -17,7 +17,7 @@ Taint tracking differs from basic data flow in that it considers non-value-prese
 For example, in the assignment ``dir = path + "/"``, if ``path`` is tainted then ``dir`` is also tainted,
 even though there is no data flow from ``path`` to ``path + "/"``.
 
-Separate CodeQL libraries have been written to handle 'normal' data flow and taint tracking in :doc:`C/C++ <analyzing-data-flow-in-cpp>`, :doc:`C# <analyzing-data-flow-in-csharp>`, :doc:`Java <analyzing-data-flow-in-java>`, and :doc:`JavaScript <analyzing-data-flow-in-javascript>`. You can access the appropriate classes and predicates that reason about these different modes of data flow by importing the appropriate library in your query.
+Separate CodeQL libraries have been written to handle 'normal' data flow and taint tracking in :doc:`C/C++ <analyzing-data-flow-in-cpp>`, :doc:`C# <analyzing-data-flow-in-csharp>`, :doc:`Java <analyzing-data-flow-in-java>`, and :doc:`JavaScript <analyzing-data-flow-in-javascript-and-typescript>`. You can access the appropriate classes and predicates that reason about these different modes of data flow by importing the appropriate library in your query.
 In Python analysis, we can use the same taint tracking library to model both 'normal' data flow and taint flow, but we are still able make the distinction between steps that preserve values and those that don't by defining additional data flow properties.
 
 For further information on data flow and taint tracking with CodeQL, see ":ref:`Introduction to data flow <about-data-flow-analysis>`."

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-javascript-and-typescript.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-javascript-and-typescript.rst
@@ -1,4 +1,4 @@
-.. _analyzing-data-flow-in-javascript:
+.. _analyzing-data-flow-in-javascript-and-typescript:
 
 Analyzing data flow in JavaScript and TypeScript
 ================================================

--- a/docs/codeql/codeql-language-guides/codeql-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/codeql-for-javascript.rst
@@ -11,7 +11,7 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
    basic-query-for-javascript-code
    codeql-library-for-javascript
    codeql-library-for-typescript
-   analyzing-data-flow-in-javascript
+   analyzing-data-flow-in-javascript-and-typescript
    using-flow-labels-for-precise-data-flow-analysis
    using-type-tracking-for-api-modeling
    abstract-syntax-tree-classes-for-working-with-javascript-and-typescript-programs
@@ -23,7 +23,7 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 
 -  :doc:`CodeQL library for TypeScript <codeql-library-for-typescript>`: When you're analyzing a TypeScript program, you can make use of the large collection of classes in the CodeQL library for TypeScript.
 
--  :doc:`Analyzing data flow in JavaScript and TypeScript <analyzing-data-flow-in-javascript>`: This topic describes how data flow analysis is implemented in the CodeQL libraries for JavaScript/TypeScript and includes examples to help you write your own data flow queries.
+-  :doc:`Analyzing data flow in JavaScript and TypeScript <analyzing-data-flow-in-javascript-and-typescript>`: This topic describes how data flow analysis is implemented in the CodeQL libraries for JavaScript/TypeScript and includes examples to help you write your own data flow queries.
 
 -  :doc:`Using flow labels for precise data flow analysis <using-flow-labels-for-precise-data-flow-analysis>`: You can associate flow labels with each value tracked by the flow analysis to determine whether the flow contains potential vulnerabilities.
 

--- a/docs/codeql/codeql-language-guides/data-flow-cheat-sheet-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/data-flow-cheat-sheet-for-javascript.rst
@@ -36,12 +36,12 @@ This query reports flow paths which:
 - Step through variables, function calls, properties, strings, arrays, promises, exceptions, and steps added by `isAdditionalTaintStep <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/dataflow/TaintTracking.qll/predicate.TaintTracking$TaintTracking$Configuration$isAdditionalTaintStep.2.html>`__.
 - End at a node matched by `isSink <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/dataflow/Configuration.qll/predicate.Configuration$Configuration$isSink.1.html>`__.
 
-See also: "`Global data flow <analyzing-data-flow-in-javascript.html#global-data-flow>`__" and ":ref:`Creating path queries <creating-path-queries>`."
+See also: "`Global data flow <analyzing-data-flow-in-javascript-and-typescript.html#global-data-flow>`__" and ":ref:`Creating path queries <creating-path-queries>`."
 
 DataFlow module
 ---------------
 
-Use data flow nodes to match program elements independently of syntax. See also: ":doc:`Analyzing data flow in JavaScript and TypeScript <analyzing-data-flow-in-javascript>`."
+Use data flow nodes to match program elements independently of syntax. See also: ":doc:`Analyzing data flow in JavaScript and TypeScript <analyzing-data-flow-in-javascript-and-typescript>`."
 
 Predicates in the ``DataFlow::`` module:
 

--- a/docs/codeql/codeql-language-guides/using-flow-labels-for-precise-data-flow-analysis.rst
+++ b/docs/codeql/codeql-language-guides/using-flow-labels-for-precise-data-flow-analysis.rst
@@ -9,7 +9,7 @@ Overview
 --------
 
 You can use basic inter-procedural data-flow analysis and taint tracking as described in
-":doc:`Analyzing data flow in JavaScript and TypeScript <analyzing-data-flow-in-javascript>`" to check whether there is a path in
+":doc:`Analyzing data flow in JavaScript and TypeScript <analyzing-data-flow-in-javascript-and-typescript>`" to check whether there is a path in
 the data-flow graph from some source node to a sink node that does not pass through any sanitizer
 nodes. Another way of thinking about this is that it statically models the flow of data through the
 program, and associates a flag with every data value telling us whether it might have come from a

--- a/docs/codeql/codeql-language-guides/using-type-tracking-for-api-modeling.rst
+++ b/docs/codeql/codeql-language-guides/using-type-tracking-for-api-modeling.rst
@@ -11,8 +11,8 @@ The type-tracking library makes it possible to track values through properties a
 usually to recognize method calls and properties accessed on a specific type of object.
 
 This is an advanced topic and is intended for readers already familiar with the
-`SourceNode <analyzing-data-flow-in-javascript.html#source-nodes>`__ class as well as
-`taint tracking <analyzing-data-flow-in-javascript.html#using-global-analyzing-data-flow-and-tracking-tainted-data-in-python>`__.
+`SourceNode <analyzing-data-flow-in-javascript-and-typescript.html#source-nodes>`__ class as well as
+`taint tracking <analyzing-data-flow-in-javascript-and-typescript.html#using-global-analyzing-data-flow-and-tracking-tainted-data-in-python>`__.
 For TypeScript analysis also consider reading about `static type information <codeql-library-for-typescript.html.html#static-type-information>`__ first.
 
 
@@ -458,7 +458,7 @@ Here's an example that the model from this tutorial won't find:
   let wrapper = wrapDB(firebase.database())
   wrapper.db.ref("forecast"); // <-- not found
 
-This is an example of where `data-flow configurations <analyzing-data-flow-in-javascript.html#global-data-flow>`__ are more powerful.
+This is an example of where `data-flow configurations <analyzing-data-flow-in-javascript-and-typescript.html#global-data-flow>`__ are more powerful.
 
 When to use type tracking
 -------------------------
@@ -491,7 +491,7 @@ Prefer type tracking when:
 
 Prefer data-flow configurations when:
 
-- Tracking user-controlled data -- use `taint tracking <analyzing-data-flow-in-javascript.html#using-global-analyzing-data-flow-and-tracking-tainted-data-in-python>`__.
+- Tracking user-controlled data -- use `taint tracking <analyzing-data-flow-in-javascript-and-typescript.html#using-global-analyzing-data-flow-and-tracking-tainted-data-in-python>`__.
 - Differentiating between different kinds of user-controlled data -- see ":doc:`Using flow labels for precise data flow analysis <using-flow-labels-for-precise-data-flow-analysis>`."
 - Tracking transformations of a value through generic utility functions.
 - Tracking values through string manipulation.

--- a/docs/codeql/writing-codeql-queries/about-data-flow-analysis.rst
+++ b/docs/codeql/writing-codeql-queries/about-data-flow-analysis.rst
@@ -19,7 +19,7 @@ See the following tutorials for more information about analyzing data flow in sp
 - ":ref:`Analyzing data flow in C/C++ <analyzing-data-flow-in-cpp>`"
 - ":ref:`Analyzing data flow in C# <analyzing-data-flow-in-csharp>`"
 - ":ref:`Analyzing data flow in Java <analyzing-data-flow-in-java>`"
-- ":ref:`Analyzing data flow in JavaScript/TypeScript <analyzing-data-flow-in-javascript>`"
+- ":ref:`Analyzing data flow in JavaScript/TypeScript <analyzing-data-flow-in-javascript-and-typescript>`"
 - ":ref:`Analyzing data flow and tracking tainted data in Python <analyzing-data-flow-and-tracking-tainted-data-in-python>`"
 
 .. pull-quote::

--- a/docs/codeql/writing-codeql-queries/creating-path-queries.rst
+++ b/docs/codeql/writing-codeql-queries/creating-path-queries.rst
@@ -27,7 +27,7 @@ For more language-specific information on analyzing data flow, see:
 - ":ref:`Analyzing data flow in C/C++ <analyzing-data-flow-in-cpp>`"
 - ":ref:`Analyzing data flow in C# <analyzing-data-flow-in-csharp>`"
 - ":ref:`Analyzing data flow in Java <analyzing-data-flow-in-java>`" 
-- ":ref:`Analyzing data flow in JavaScript/TypeScript <analyzing-data-flow-in-javascript>`"
+- ":ref:`Analyzing data flow in JavaScript/TypeScript <analyzing-data-flow-in-javascript-and-typescript>`"
 - ":ref:`Analyzing data flow and tracking tainted data in Python <analyzing-data-flow-and-tracking-tainted-data-in-python>`"
 
 


### PR DESCRIPTION
In the CodeQL docs, the source `rst` file names were recently updated to match the article titles. "Analyzing data flow in JavaScript and TypeScript" was missed somehow, so this PR updates the name of that source file to `analyzing-data-flow-in-javascript-and-typescript.rst` and updates links to this article throughout the docs.