### PR TITLE
Add `workflow_dispatch` to `generate-query-help-docs.yml`

### DIFF
--- a/.github/workflows/generate-query-help-docs.yml
+++ b/.github/workflows/generate-query-help-docs.yml
@@ -6,10 +6,6 @@ on:
         description:
           description: A description of the purpose of this job. For human consumption.
           required: false
-        ref: 
-          description: The branch in github/codeql to checkout when generating query help.
-          required: false
-          default: 'lgtm.com'
   push:
     branches:
      - 'lgtm.com'
@@ -17,19 +13,12 @@ on:
     paths:
       - '.github/workflows/generate-query-help-docs.yml'
       - 'docs/codeql/query-help/**'
-
+      
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - if: github.event.inputs.ref
-      name: Clone github/codeql (user defined ref)
-      uses: actions/checkout@v2
-      with:
-        path: codeql
-        ref: ${{ github.event.inputs.ref }}
-    - if: github.event.inputs.ref == ''
-      name: Clone github/codeql (default ref)
+    - name: Clone github/codeql
       uses: actions/checkout@v2
       with:
         path: codeql

--- a/.github/workflows/generate-query-help-docs.yml
+++ b/.github/workflows/generate-query-help-docs.yml
@@ -22,11 +22,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Clone github/codeql
+    - if: github.event.inputs.ref
+      name: Clone github/codeql (user defined ref)
       uses: actions/checkout@v2
       with:
         path: codeql
-        ref: '{{ github.event.inputs.ref }}' 
+        ref: ${{ github.event.inputs.ref }}
+    - if: github.event.inputs.ref == ''
+      name: Clone github/codeql (default ref)
+      uses: actions/checkout@v2
+      with:
+        path: codeql
     - name: Clone github/codeql-go
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/generate-query-help-docs.yml
+++ b/.github/workflows/generate-query-help-docs.yml
@@ -1,10 +1,13 @@
 name: Generate CodeQL query help documentation using Sphinx
 
 on:
+  workflow_dispatch:
+      inputs:
+      description:
+        description: A description of the purpose of this job. For human consumption.
+        required: false
   push:
     branches:
-     - main
-     - 'rc/**'
      - 'lgtm.com'
   pull_request:
     paths:

--- a/.github/workflows/generate-query-help-docs.yml
+++ b/.github/workflows/generate-query-help-docs.yml
@@ -3,9 +3,13 @@ name: Generate CodeQL query help documentation using Sphinx
 on:
   workflow_dispatch:
       inputs:
-      description:
-        description: A description of the purpose of this job. For human consumption.
-        required: false
+        description:
+          description: A description of the purpose of this job. For human consumption.
+          required: false
+        ref: 
+          description: The branch in github/codeql to checkout when generating query help.
+          required: false
+          default: 'lgtm.com'
   push:
     branches:
      - 'lgtm.com'
@@ -21,7 +25,8 @@ jobs:
     - name: Clone github/codeql
       uses: actions/checkout@v2
       with:
-        path: codeql 
+        path: codeql
+        ref: '{{ github.event.inputs.ref }}' 
     - name: Clone github/codeql-go
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
This PR adds a `workflow_dispatch` event to the workflow for generating the query help documentation, so that we can trigger query help generation manually. I've also removed `main` and `rc/**` from the `push` events because we only really want to run this workflow when upgrading the distribution on lgtm.com.