### PR TITLE
C++: Add cases in the Allocation model.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -83,7 +83,7 @@ private class AllocaAllocationFunction extends AllocationFunction {
         // --- stack allocation
         "alloca", // // alloca(size)
         "__builtin_alloca", // __builtin_alloca(size)
-        "_alloca", // __alloca(size)
+        "_alloca", // _alloca(size)
         "_malloca" // _malloca(size)
       ]) and
     sizeArg = 0

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -82,7 +82,9 @@ private class AllocaAllocationFunction extends AllocationFunction {
     hasGlobalName([
         // --- stack allocation
         "alloca", // // alloca(size)
-        "__builtin_alloca" // __builtin_alloca(size)
+        "__builtin_alloca", // __builtin_alloca(size)
+        "_alloca", // __alloca(size)
+        "_malloca" // _malloca(size)
       ]) and
     sizeArg = 0
   }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strdup.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strdup.qll
@@ -14,11 +14,14 @@ import semmle.code.cpp.models.interfaces.Taint
 private class StrdupFunction extends AllocationFunction, ArrayFunction, DataFlowFunction {
   StrdupFunction() {
     hasGlobalName([
+        // --- C library allocation
         "strdup", // strdup(str)
         "wcsdup", // wcsdup(str)
         "_strdup", // _strdup(str)
         "_wcsdup", // _wcsdup(str)
-        "_mbsdup" // _mbsdup(str)
+        "_mbsdup", // _mbsdup(str)
+        // --- Windows Automation
+        "SysAllocString" // SysAllocString(string)
       ])
   }
 
@@ -39,8 +42,8 @@ private class StrndupFunction extends AllocationFunction, ArrayFunction, DataFlo
   StrndupFunction() {
     exists(string name |
       hasGlobalName(name) and
-      // strndup(str, maxlen)
-      name = "strndup"
+      // --- C library allocation
+      name = "strndup" // strndup(str, maxlen)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strdup.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strdup.qll
@@ -19,9 +19,7 @@ private class StrdupFunction extends AllocationFunction, ArrayFunction, DataFlow
         "wcsdup", // wcsdup(str)
         "_strdup", // _strdup(str)
         "_wcsdup", // _wcsdup(str)
-        "_mbsdup", // _mbsdup(str)
-        // --- Windows Automation
-        "SysAllocString" // SysAllocString(string)
+        "_mbsdup" // _mbsdup(str)
       ])
   }
 

--- a/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
+++ b/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
@@ -18,3 +18,6 @@
 | test.cpp:235:2:235:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:227:7:227:13 | new | new |
 | test.cpp:239:2:239:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:228:7:228:17 | new[] | new[] |
 | test.cpp:272:3:272:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:265:7:265:13 | new | new |
+| test.cpp:441:2:441:10 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:434:13:434:18 | call to strdup | malloc |
+| test.cpp:443:2:443:10 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:436:13:436:19 | call to strndup | malloc |
+| test.cpp:445:2:445:10 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:438:16:438:21 | call to wcsdup | malloc |

--- a/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
@@ -424,3 +424,24 @@ void test13()
 
 	delete myPointer3.getPointer(); // GOOD
 }
+
+char *strdup(const char *s1);
+char *strndup(const char *s1, size_t n);
+wchar_t* wcsdup(const wchar_t* s1);
+
+void test14()
+{
+	char *s1 = strdup("string");
+	char *s2 = strdup("string");
+	char *s3 = strndup("string", 3);
+	char *s4 = strndup("string", 3);
+	wchar_t *s5 = wcsdup(L"string");
+	wchar_t *s6 = wcsdup(L"string");
+
+	delete s1; // BAD: strdup -> delete
+	free(s2); // GOOD
+	delete s3; // BAD: strndup -> delete
+	free(s4); // GOOD
+	delete s5; // BAD: wcsdup -> delete
+	free(s6); // GOOD
+}


### PR DESCRIPTION
While working on the https://github.com/github/codeql/pull/4783 I noticed a few holes in our allocation models.  I've also added test cases for `strdup`, a standard library function which it turns out we already support.