### PR TITLE
C++: Fix Printf.qll specsAreKnown

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -921,7 +921,7 @@ class FormatLiteral extends Literal {
    * format specifiers are present in the format string).
    */
   predicate specsAreKnown() {
-    this.getNumConvSpec() = count(int n | exists(this.getNumArgNeeded(n)))
+    any()
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -921,7 +921,7 @@ class FormatLiteral extends Literal {
    * format specifiers are present in the format string).
    */
   predicate specsAreKnown() {
-    any()
+    this.getNumConvSpec() = count(int n | exists(this.getNumArgNeeded(n)))
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -900,6 +900,7 @@ class FormatLiteral extends Literal {
    */
   int getNumArgNeeded(int n) {
     exists(this.getConvSpecOffset(n)) and
+    exists(this.getConversionChar(n)) and
     result = count(int mode | hasFormatArgumentIndexFor(n, mode))
   }
 

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/TooManyFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/TooManyFormatArguments.expected
@@ -12,3 +12,6 @@
 | test.c:39:3:39:8 | call to printf | Format expects 2 arguments but given 5 |
 | test.c:40:3:40:8 | call to printf | Format expects 2 arguments but given 4 |
 | test.c:41:3:41:8 | call to printf | Format expects 2 arguments but given 3 |
+| test.c:46:2:46:7 | call to printf | Format expects 1 arguments but given 2 |
+| test.c:47:2:47:7 | call to printf | Format expects 1 arguments but given 2 |
+| test.c:48:2:48:7 | call to printf | Format expects 1 arguments but given 2 |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/TooManyFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/TooManyFormatArguments.expected
@@ -12,6 +12,3 @@
 | test.c:39:3:39:8 | call to printf | Format expects 2 arguments but given 5 |
 | test.c:40:3:40:8 | call to printf | Format expects 2 arguments but given 4 |
 | test.c:41:3:41:8 | call to printf | Format expects 2 arguments but given 3 |
-| test.c:46:2:46:7 | call to printf | Format expects 1 arguments but given 2 |
-| test.c:47:2:47:7 | call to printf | Format expects 1 arguments but given 2 |
-| test.c:48:2:48:7 | call to printf | Format expects 1 arguments but given 2 |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/test.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/test.c
@@ -43,7 +43,7 @@ void test(int i, const char *str)
 
 	printf("%@ %i %i", 1, 2); // GOOD
 
-	printf("%Y", 1, 2); // GOOD (unknown format character, this might be correct) [FALSE POSITIVE]
-	printf("%1.1Y", 1, 2); // GOOD (unknown format character, this might be correct) [FALSE POSITIVE]
-	printf("%*.*Y", 1, 2); // GOOD (unknown format character, this might be correct) [FALSE POSITIVE]
+	printf("%Y", 1, 2); // GOOD (unknown format character, this might be correct)
+	printf("%1.1Y", 1, 2); // GOOD (unknown format character, this might be correct)
+	printf("%*.*Y", 1, 2); // GOOD (unknown format character, this might be correct)
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/test.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/test.c
@@ -42,4 +42,8 @@ void test(int i, const char *str)
 	}
 
 	printf("%@ %i %i", 1, 2); // GOOD
+
+	printf("%Y", 1, 2); // GOOD (unknown format character, this might be correct) [FALSE POSITIVE]
+	printf("%1.1Y", 1, 2); // GOOD (unknown format character, this might be correct) [FALSE POSITIVE]
+	printf("%*.*Y", 1, 2); // GOOD (unknown format character, this might be correct) [FALSE POSITIVE]
 }


### PR DESCRIPTION
Quick fix for a false positive that's been around for a while.  It turns out `printf.qll`s `specsAreKnown` was broken, and probably has been since the introduction of `hasFormatArgumentIndexFor`.  This can cause incorrect query results, as demonstrated in the test.

The fix is to have `getNumArgNeeded` not return a result (that would be meaningless) when no conversion char is matched by `getConversionChar`, i.e. when we have an unknown conversion character.