### PR TITLE
Java: Add missing broken crypto algorithms

### DIFF
--- a/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -12,7 +12,7 @@ data.</p>
 </overview>
 <recommendation>
 
-<p>Ensure that you use a strong, modern cryptographic algorithm. Use at least AES-128 or RSA-2048. Do not use the ECB encryption mode since it is vulnerable to reply attacks.</p>
+<p>Ensure that you use a strong, modern cryptographic algorithm. Use at least AES-128 or RSA-2048. Do not use the ECB encryption mode since it is vulnerable to replay and other attacks.</p>
 
 </recommendation>
 <example>

--- a/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -12,7 +12,7 @@ data.</p>
 </overview>
 <recommendation>
 
-<p>Ensure that you use a strong, modern cryptographic algorithm. Use at least AES-128 or RSA-2048.</p>
+<p>Ensure that you use a strong, modern cryptographic algorithm. Use at least AES-128 or RSA-2048. Do not use the ECB encryption mode since it is vulnerable to reply attacks.</p>
 
 </recommendation>
 <example>

--- a/java/ql/src/semmle/code/java/security/Encryption.qll
+++ b/java/ql/src/semmle/code/java/security/Encryption.qll
@@ -97,7 +97,9 @@ string getAnInsecureAlgorithmName() {
   result = "RC2" or
   result = "RC4" or
   result = "RC5" or
-  result = "ARCFOUR" // a variant of RC4
+  result = "ARCFOUR" or // a variant of RC4
+  result = "ECB" or // encryption mode ECB like AES/ECB/NoPadding is vulnerable to replay attacks
+  result = "AES/CBC/PKCS5Padding" // CBC mode of operation with PKCS#5 (or PKCS#7) padding is vulnerable to padding oracle attacks
 }
 
 /**

--- a/java/ql/src/semmle/code/java/security/Encryption.qll
+++ b/java/ql/src/semmle/code/java/security/Encryption.qll
@@ -99,7 +99,7 @@ string getAnInsecureAlgorithmName() {
   result = "RC5" or
   result = "ARCFOUR" or // a variant of RC4
   result = "ECB" or // encryption mode ECB like AES/ECB/NoPadding is vulnerable to replay and other attacks
-  result = "AES/CBC/PKCS5Padding" // CBC mode of operation with PKCS#5 (or PKCS#7) padding is vulnerable to padding oracle attacks
+  result = "AES/CBC/PKCS[5|7]Padding" // CBC mode of operation with PKCS#5 (or PKCS#7) padding is vulnerable to padding oracle attacks
 }
 
 /**
@@ -141,7 +141,7 @@ string getASecureAlgorithmName() {
   result = "SHA512" or
   result = "CCM" or
   result = "GCM" or
-  result = "AES" or
+  result = "AES([^a-zA-Z](?!ECB|CBC/PKCS[5|7]Padding)).*" or
   result = "Blowfish" or
   result = "ECIES"
 }

--- a/java/ql/src/semmle/code/java/security/Encryption.qll
+++ b/java/ql/src/semmle/code/java/security/Encryption.qll
@@ -98,7 +98,7 @@ string getAnInsecureAlgorithmName() {
   result = "RC4" or
   result = "RC5" or
   result = "ARCFOUR" or // a variant of RC4
-  result = "ECB" or // encryption mode ECB like AES/ECB/NoPadding is vulnerable to replay attacks
+  result = "ECB" or // encryption mode ECB like AES/ECB/NoPadding is vulnerable to replay and other attacks
   result = "AES/CBC/PKCS5Padding" // CBC mode of operation with PKCS#5 (or PKCS#7) padding is vulnerable to padding oracle attacks
 }
 

--- a/java/ql/test/library-tests/Encryption/Test.java
+++ b/java/ql/test/library-tests/Encryption/Test.java
@@ -14,7 +14,6 @@ class Test {
 			"AES/ECB/NoPadding",
 			"AES/CBC/PKCS5Padding");
 
-
 	List<String> goodStrings = Arrays.asList(
 			"AES",
 			"AES_function",

--- a/java/ql/test/library-tests/Encryption/Test.java
+++ b/java/ql/test/library-tests/Encryption/Test.java
@@ -10,7 +10,10 @@ class Test {
 			"des",
 			"des_function",
 			"function_using_des",
-			"EncryptWithDES");
+			"EncryptWithDES",
+			"AES/ECB/NoPadding",
+			"AES/CBC/PKCS5Padding");
+
 
 	List<String> goodStrings = Arrays.asList(
 			"AES",

--- a/java/ql/test/library-tests/Encryption/cryptoalgospec.expected
+++ b/java/ql/test/library-tests/Encryption/cryptoalgospec.expected
@@ -1,2 +1,2 @@
-| Test.java:35:4:35:17 | super(...) | Test.java:35:10:35:15 | "some" |
-| Test.java:39:3:39:38 | getInstance(...) | Test.java:39:29:39:37 | "another" |
+| Test.java:37:4:37:17 | super(...) | Test.java:37:10:37:15 | "some" |
+| Test.java:41:3:41:38 | getInstance(...) | Test.java:41:29:41:37 | "another" |

--- a/java/ql/test/library-tests/Encryption/insecure.expected
+++ b/java/ql/test/library-tests/Encryption/insecure.expected
@@ -3,3 +3,5 @@
 | Test.java:11:4:11:17 | "des_function" |
 | Test.java:12:4:12:23 | "function_using_des" |
 | Test.java:13:4:13:19 | "EncryptWithDES" |
+| Test.java:14:4:14:22 | "AES/ECB/NoPadding" |
+| Test.java:15:4:15:25 | "AES/CBC/PKCS5Padding" |

--- a/java/ql/test/library-tests/Encryption/secure.expected
+++ b/java/ql/test/library-tests/Encryption/secure.expected
@@ -1,2 +1,2 @@
-| Test.java:16:4:16:8 | "AES" |
-| Test.java:17:4:17:17 | "AES_function" |
+| Test.java:18:4:18:8 | "AES" |
+| Test.java:19:4:19:17 | "AES_function" |


### PR DESCRIPTION
Using broken or weak cryptographic algorithms can leave data vulnerable to being decrypted.

The ECB encryption mode is vulnerable to replay attacks and the CBC mode of operation with PKCS#5 (or PKCS#7) padding is vulnerable to padding oracle attacks. These two types of algorithms are widely treated as insecure/broken cryptographic algorithms in modern standards.

Some references are:
1. [Test cases for risky or broken cryptographic algorithm erroneously labeled as not vulnerable #92](https://github.com/OWASP/Benchmark/issues/92) - OWASP Test Cases
2. [codeql/csharp/ql/src/Security Features/Encryption using ECB.ql](https://github.com/github/codeql/blob/8d4f7e2db7ec3b7559a3e358fd1b8a7203ce7474/csharp/ql/src/Security%20Features/Encryption%20using%20ECB.ql) - C# Query for Encryption using ECB
3. [AES encryption algorithm should be used with secured mode](https://rules.sonarsource.com/java/type/Vulnerability/RSPEC-4432) - SonarSource Rule RSPEC-4432
4. [CWE-327](https://cwe.mitre.org/data/definitions/327.html) - Use of a Broken or Risky Cryptographic Algorithm

This query adds these two categories to the list of insecure ciphers.

Please consider to merge this PR. Thanks.