### PR TITLE
[CodeQL docs] Fix two CSS bugs

### DIFF
--- a/docs/codeql/_static/custom.css_t
+++ b/docs/codeql/_static/custom.css_t
@@ -34,6 +34,10 @@ article {
     min-height: calc(100vh - 145px); /* Makes sure GitHub footer stays at bottom of viewport */
 }
 
+article ul, article ol {
+    margin-left: 18px; /* Aligns list items with other text */
+}
+
 /* -- SIDEBAR ------------------------------------------------------------------------------- */
 
 .SideNav {

--- a/docs/codeql/_static/custom.css_t
+++ b/docs/codeql/_static/custom.css_t
@@ -181,6 +181,11 @@ table.docutils.footnote {
     margin-left: 10px;
 }
 
+table.footnote td.label {
+    padding-right: 10px;
+    display: table-cell;
+}
+
 /* -- STYLE PULL-QUOTE AS ADMONITION WHILE DOCS STILL PARSED FOR LGTM EMBEDDED HELP------------------------- */
 
 blockquote.pull-quote {


### PR DESCRIPTION
This PR fixes a couple of minor CSS bugs in the CodeQL docs (I've already pushed the fixes to the live site, so you'll have to believe me that they are improvements 😸 ):

- Improves the spacing for the footnotes beneath the "Languages and compilers" table, which were weirdly squashed before: [preview](http://docteam.internal.semmle.com/james/css-fixes/codeql-docs/codeql-overview/supported-languages-and-frameworks/).
- Improves the alignment of list items on different screen sizes. The bullet points previously sat to the left of the text above on small and medium sized screens: [preview](http://docteam.internal.semmle.com/james/css-fixes/codeql-docs/codeql-overview/supported-languages-and-frameworks/).