### PR TITLE
C#: Move `Expr::hasValue()` to `DotNet::Expr`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/exprs/Expr.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Expr.qll
@@ -51,9 +51,6 @@ class Expr extends DotNet::Expr, ControlFlowElement, @expr {
   /** Gets the value of this expression, if any */
   override string getValue() { expr_value(this, result) }
 
-  /** Holds if this expression has a value. */
-  predicate hasValue() { exists(getValue()) }
-
   /** Gets the enclosing statement of this expression, if any. */
   final Stmt getEnclosingStmt() { enclosingStmt(this, result) }
 

--- a/csharp/ql/src/semmle/code/dotnet/Expr.qll
+++ b/csharp/ql/src/semmle/code/dotnet/Expr.qll
@@ -17,6 +17,9 @@ class Expr extends Element, @dotnet_expr {
   /** Gets the constant value of this expression, if any. */
   string getValue() { none() }
 
+  /** Holds if this expression has a value. */
+  final predicate hasValue() { exists(this.getValue()) }
+
   /**
    * Gets the parent of this expression. This is for example the element
    * that uses the result of this expression.


### PR DESCRIPTION
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/709/

Fixes https://github.com/github/codeql/issues/4848.