### PR TITLE
Fix typo in docs title

### DIFF
--- a/docs/codeql/query-help/java.rst
+++ b/docs/codeql/query-help/java.rst
@@ -1,5 +1,5 @@
-CodeQL query help for Java query
-================================
+CodeQL query help for Java
+==========================
 
 .. include:: ../reusables/query-help-overview.rst
 


### PR DESCRIPTION
Small typo: I'd somehow missed this when reviewing previously 🙃 