### PR TITLE
JS: recognize more exported functions in js/shell-command-constructed-from-input

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
@@ -53,7 +53,7 @@ module UnsafeShellCommandConstruction {
     ExternalInputSource() {
       this =
         Exports::getAValueExportedBy(Exports::getTopmostPackageJSON())
-            .(DataFlow::FunctionNode)
+            .getAFunctionValue()
             .getAParameter() and
       not this.getName() = ["cmd", "command"] // looks to be on purpose.
     }


### PR DESCRIPTION
Gets a TP for https://github.com/github/codeql-javascript-CVE-coverage/issues/933 

We now follow [this reference](https://github.com/sebhildebrandt/systeminformation/blob/4f98f2ff208f355b7e242661cf9c4594a702dbec/lib/index.js#L446) to [this function](https://github.com/sebhildebrandt/systeminformation/blob/4f98f2ff208f355b7e242661cf9c4594a702dbec/lib/internet.js#L119), and therefore recognize the source. 