### PR TITLE
Data flow: Add `LocalCallContext` to `localFlowEntry`

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -1280,7 +1280,7 @@ private module LocalFlowBigStep {
    * Holds if `node` can be the first node in a maximal subsequence of local
    * flow steps in a dataflow path.
    */
-  predicate localFlowEntry(Node node, Configuration config) {
+  predicate localFlowEntry(Node node, LocalCallContext cc, Configuration config) {
     Stage2::revFlow(node, config) and
     (
       config.isSource(node) or
@@ -1291,7 +1291,8 @@ private module LocalFlowBigStep {
       store(_, _, node, _) or
       read(_, _, node) or
       node instanceof FlowCheckNode
-    )
+    ) and
+    cc.relevantFor(node.getEnclosingCallable())
   }
 
   /**
@@ -1334,7 +1335,7 @@ private module LocalFlowBigStep {
   ) {
     not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
     (
-      localFlowEntry(node1, config) and
+      localFlowEntry(node1, cc, config) and
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
@@ -1345,7 +1346,6 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -2131,7 +2131,7 @@ private module Stage4 {
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
+    localFlowEntry(node, _, config) and
     result = getLocalCallContext(cc, node.getEnclosingCallable())
   }
 


### PR DESCRIPTION
This forces the negation part of `localFlowStepPlus` to be restricted to nodes in `localFlowEntry`, as the negation can otherwise be slow to compute:

```
[2020-12-21 11:17:22] (83s) Tuple counts for DataFlowImpl::LocalFlowBigStep::localFlowStepPlus#ffffff#shared/2@93020e:
  14483346 ~0%     {2} r1 = JOIN DataFlowImplCommon::LocalCallContext::relevantFor_dispred#ff_10#join_rhs AS L WITH DataFlowPublic::Node::getEnclosingCallable_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1> 'arg0', L.<1> 'arg1'
  14201809 ~0%     {2} r2 = r1 AND NOT DataFlowImpl::LocalFlowBigStep::localFlowStepPlus#ffffff#antijoin_rhs AS R(r1.<0> 'arg0', r1.<1> 'arg1')
```

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/711/
https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1626/
https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/1089/
https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/332/