### PR TITLE
C++: Overridable isSource on DefaultTaintTracking

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-079/CgiXss.ql
+++ b/cpp/ql/src/Security/CWE/CWE-079/CgiXss.ql
@@ -29,6 +29,8 @@ class QueryString extends EnvironmentRead {
 }
 
 class Configuration extends TaintTrackingConfiguration {
+  override predicate isSource(Expr source) { source instanceof QueryString }
+
   override predicate isSink(Element tainted) {
     exists(PrintStdoutCall call | call.getAnArgument() = tainted)
   }

--- a/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
+++ b/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
@@ -34,6 +34,10 @@ predicate sqlite_encryption_used() {
 }
 
 class Configuration extends TaintTrackingConfiguration {
+  override predicate isSource(Expr source) {
+    super.isSource(source) and source instanceof SensitiveExpr
+  }
+
   override predicate isSink(Element taintedArg) {
     exists(SqliteFunctionCall sqliteCall |
       taintedArg = sqliteCall.getASource() and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
@@ -734,8 +734,8 @@ module TaintedWithPath {
    * through a global variable.
    */
   predicate taintedWithoutGlobals(Element tainted) {
-    exists(PathNode sourceNode, FinalPathNode sinkNode |
-      sourceNode.(WrapPathNode).inner().getNode() = getNodeForSource(_) and
+    exists(AdjustedConfiguration cfg, PathNode sourceNode, FinalPathNode sinkNode |
+      cfg.isSource(sourceNode.(WrapPathNode).inner().getNode()) and
       edgesWithoutGlobals+(sourceNode, sinkNode) and
       tainted = sinkNode.inner()
     )


### PR DESCRIPTION
When using `DefaultTaintTracking` we create a configuration that extends `TaintTrackingConfiguration` and define appropriate sinks. However, there is no way to restrict the sources to be anything other than anything that is considered user input.

This seems to be the source of the slowdown in https://github.com/github/codeql/pull/4784: when running `cpp/cgi-xss` on
`openjdk` (which has the largest performance slowdown of about 16%), there are many sources that are user inputs and flow to a sink, but the source isn’t restricted by anything other than “it’s user input” until the where clause of the query, at which point we filter them all away.

This PR adds support for an overridable `isSource` predicate when extending `TaintTrackingConfiguration`. To avoid breaking the API, the default implementation of `isSource` is consistent with what we have on `main` currently.

CPP-differences: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1629/