### PR TITLE
JS: fixup for execa.shell and execa.shellSync models

### DIFF
--- a/javascript/change-notes/202020-12-22-execa.md
+++ b/javascript/change-notes/202020-12-22-execa.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* The command injection security queries now recognize additional sinks.
+  Affected packages are
+    [execa](https://npmjs.com/package/execa)

--- a/javascript/ql/src/semmle/javascript/frameworks/SystemCommandExecutors.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SystemCommandExecutors.qll
@@ -18,15 +18,18 @@ private predicate execApi(string mod, string fn, int cmdArg, int optionsArg, boo
     shell = false and
     (
       fn = "node" or
-      fn = "shell" or
-      fn = "shellSync" or
       fn = "stdout" or
       fn = "stderr" or
       fn = "sync"
     )
     or
     shell = true and
-    (fn = "command" or fn = "commandSync")
+    (
+      fn = "command" or
+      fn = "commandSync" or
+      fn = "shell" or
+      fn = "shellSync"
+    )
   ) and
   cmdArg = 0
 }

--- a/javascript/ql/test/query-tests/Security/CWE-078/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/Consistency.expected
@@ -1,0 +1,2 @@
+| query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js:8 | expected an alert, but found none | NOT OK | ComandInjection |
+| query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js:9 | expected an alert, but found none | NOT OK | ComandInjection |

--- a/javascript/ql/test/query-tests/Security/CWE-078/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/Consistency.expected
@@ -1,2 +1,0 @@
-| query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js:8 | expected an alert, but found none | NOT OK | ComandInjection |
-| query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js:9 | expected an alert, but found none | NOT OK | ComandInjection |

--- a/javascript/ql/test/query-tests/Security/CWE-078/ShellCommandInjectionFromEnvironment.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/ShellCommandInjectionFromEnvironment.expected
@@ -4,10 +4,30 @@ nodes
 | tst_shell-command-injection-from-environment.js:6:26:6:53 | path.jo ... "temp") |
 | tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname |
 | tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname |
+| tst_shell-command-injection-from-environment.js:8:14:8:53 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:8:14:8:53 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:8:26:8:53 | path.jo ... "temp") |
+| tst_shell-command-injection-from-environment.js:8:36:8:44 | __dirname |
+| tst_shell-command-injection-from-environment.js:8:36:8:44 | __dirname |
+| tst_shell-command-injection-from-environment.js:9:18:9:57 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:9:18:9:57 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:9:30:9:57 | path.jo ... "temp") |
+| tst_shell-command-injection-from-environment.js:9:40:9:48 | __dirname |
+| tst_shell-command-injection-from-environment.js:9:40:9:48 | __dirname |
 edges
 | tst_shell-command-injection-from-environment.js:6:26:6:53 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:6:14:6:53 | 'rm -rf ... "temp") |
 | tst_shell-command-injection-from-environment.js:6:26:6:53 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:6:14:6:53 | 'rm -rf ... "temp") |
 | tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname | tst_shell-command-injection-from-environment.js:6:26:6:53 | path.jo ... "temp") |
 | tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname | tst_shell-command-injection-from-environment.js:6:26:6:53 | path.jo ... "temp") |
+| tst_shell-command-injection-from-environment.js:8:26:8:53 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:8:14:8:53 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:8:26:8:53 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:8:14:8:53 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:8:36:8:44 | __dirname | tst_shell-command-injection-from-environment.js:8:26:8:53 | path.jo ... "temp") |
+| tst_shell-command-injection-from-environment.js:8:36:8:44 | __dirname | tst_shell-command-injection-from-environment.js:8:26:8:53 | path.jo ... "temp") |
+| tst_shell-command-injection-from-environment.js:9:30:9:57 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:9:18:9:57 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:9:30:9:57 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:9:18:9:57 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:9:40:9:48 | __dirname | tst_shell-command-injection-from-environment.js:9:30:9:57 | path.jo ... "temp") |
+| tst_shell-command-injection-from-environment.js:9:40:9:48 | __dirname | tst_shell-command-injection-from-environment.js:9:30:9:57 | path.jo ... "temp") |
 #select
 | tst_shell-command-injection-from-environment.js:6:14:6:53 | 'rm -rf ... "temp") | tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname | tst_shell-command-injection-from-environment.js:6:14:6:53 | 'rm -rf ... "temp") | This shell command depends on an uncontrolled $@. | tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname | absolute path |
+| tst_shell-command-injection-from-environment.js:8:14:8:53 | 'rm -rf ... "temp") | tst_shell-command-injection-from-environment.js:8:36:8:44 | __dirname | tst_shell-command-injection-from-environment.js:8:14:8:53 | 'rm -rf ... "temp") | This shell command depends on an uncontrolled $@. | tst_shell-command-injection-from-environment.js:8:36:8:44 | __dirname | absolute path |
+| tst_shell-command-injection-from-environment.js:9:18:9:57 | 'rm -rf ... "temp") | tst_shell-command-injection-from-environment.js:9:40:9:48 | __dirname | tst_shell-command-injection-from-environment.js:9:18:9:57 | 'rm -rf ... "temp") | This shell command depends on an uncontrolled $@. | tst_shell-command-injection-from-environment.js:9:40:9:48 | __dirname | absolute path |

--- a/javascript/ql/test/query-tests/Security/CWE-078/ShellCommandInjectionFromEnvironment.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/ShellCommandInjectionFromEnvironment.expected
@@ -1,13 +1,13 @@
 nodes
-| tst_shell-command-injection-from-environment.js:5:14:5:53 | 'rm -rf ... "temp") |
-| tst_shell-command-injection-from-environment.js:5:14:5:53 | 'rm -rf ... "temp") |
-| tst_shell-command-injection-from-environment.js:5:26:5:53 | path.jo ... "temp") |
-| tst_shell-command-injection-from-environment.js:5:36:5:44 | __dirname |
-| tst_shell-command-injection-from-environment.js:5:36:5:44 | __dirname |
+| tst_shell-command-injection-from-environment.js:6:14:6:53 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:6:14:6:53 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:6:26:6:53 | path.jo ... "temp") |
+| tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname |
+| tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname |
 edges
-| tst_shell-command-injection-from-environment.js:5:26:5:53 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:5:14:5:53 | 'rm -rf ... "temp") |
-| tst_shell-command-injection-from-environment.js:5:26:5:53 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:5:14:5:53 | 'rm -rf ... "temp") |
-| tst_shell-command-injection-from-environment.js:5:36:5:44 | __dirname | tst_shell-command-injection-from-environment.js:5:26:5:53 | path.jo ... "temp") |
-| tst_shell-command-injection-from-environment.js:5:36:5:44 | __dirname | tst_shell-command-injection-from-environment.js:5:26:5:53 | path.jo ... "temp") |
+| tst_shell-command-injection-from-environment.js:6:26:6:53 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:6:14:6:53 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:6:26:6:53 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:6:14:6:53 | 'rm -rf ... "temp") |
+| tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname | tst_shell-command-injection-from-environment.js:6:26:6:53 | path.jo ... "temp") |
+| tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname | tst_shell-command-injection-from-environment.js:6:26:6:53 | path.jo ... "temp") |
 #select
-| tst_shell-command-injection-from-environment.js:5:14:5:53 | 'rm -rf ... "temp") | tst_shell-command-injection-from-environment.js:5:36:5:44 | __dirname | tst_shell-command-injection-from-environment.js:5:14:5:53 | 'rm -rf ... "temp") | This shell command depends on an uncontrolled $@. | tst_shell-command-injection-from-environment.js:5:36:5:44 | __dirname | absolute path |
+| tst_shell-command-injection-from-environment.js:6:14:6:53 | 'rm -rf ... "temp") | tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname | tst_shell-command-injection-from-environment.js:6:14:6:53 | 'rm -rf ... "temp") | This shell command depends on an uncontrolled $@. | tst_shell-command-injection-from-environment.js:6:36:6:44 | __dirname | absolute path |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UselessUseOfCat.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UselessUseOfCat.expected
@@ -58,8 +58,9 @@ syncCommand
 | other.js:12:5:12:30 | require ... nc(cmd) |
 | other.js:30:5:30:36 | require ... ")(cmd) |
 | third-party-command-injection.js:6:9:6:28 | cp.execSync(command) |
-| tst_shell-command-injection-from-environment.js:4:2:4:62 | cp.exec ... emp")]) |
-| tst_shell-command-injection-from-environment.js:5:2:5:54 | cp.exec ... temp")) |
+| tst_shell-command-injection-from-environment.js:5:2:5:62 | cp.exec ... emp")]) |
+| tst_shell-command-injection-from-environment.js:6:2:6:54 | cp.exec ... temp")) |
+| tst_shell-command-injection-from-environment.js:9:2:9:58 | execa.s ... temp")) |
 | uselesscat.js:16:1:16:29 | execSyn ... uinfo') |
 | uselesscat.js:18:1:18:26 | execSyn ... path}`) |
 | uselesscat.js:20:1:20:36 | execSyn ... wc -l') |

--- a/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js
@@ -1,6 +1,10 @@
 var cp = require('child_process'),
-    path = require('path');
+    path = require('path'),
+    execa = require("execa");
 (function() {
 	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
 	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
+
+	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
 });


### PR DESCRIPTION
A long overdue fix for <https://github.com/github/codeql-javascript-team/issues/220>.