### PR TITLE
Java: Fix taint-step handling for untrusted-data-external-api

### DIFF
--- a/java/ql/src/semmle/code/java/security/ExternalAPIs.qll
+++ b/java/ql/src/semmle/code/java/security/ExternalAPIs.qll
@@ -76,7 +76,7 @@ class ExternalAPIDataNode extends DataFlow::Node {
       m.fromSource()
     ) and
     // Not already modeled as a taint step
-    not exists(DataFlow::Node next | TaintTracking::localTaintStep(this, next)) and
+    not exists(DataFlow::Node next | TaintTracking::defaultAdditionalTaintStep(this, next)) and
     // Not a call to a known safe external API
     not call.getCallee() instanceof SafeExternalAPIMethod
   }

--- a/java/ql/src/semmle/code/java/security/ExternalAPIs.qll
+++ b/java/ql/src/semmle/code/java/security/ExternalAPIs.qll
@@ -75,7 +75,8 @@ class ExternalAPIDataNode extends DataFlow::Node {
       m.getASourceOverriddenMethod() = call.getCallee().getSourceDeclaration() and
       m.fromSource()
     ) and
-    // Not already modeled as a taint step
+    // Not already modeled as a taint step (we need both of these to handle `AdditionalTaintStep` subclasses as well)
+    not exists(DataFlow::Node next | TaintTracking::localTaintStep(this, next)) and
     not exists(DataFlow::Node next | TaintTracking::defaultAdditionalTaintStep(this, next)) and
     // Not a call to a known safe external API
     not call.getCallee() instanceof SafeExternalAPIMethod


### PR DESCRIPTION
The previous implementation would not handle any `AdditionalTaintStep` subclasses.

/cc @lcartey (since I'm not able to put your as assigned or reviewer)