### PR TITLE
Docs: Fix CSS for "pull-quotes" and expandable sections

### DIFF
--- a/docs/codeql/_static/custom.css_t
+++ b/docs/codeql/_static/custom.css_t
@@ -222,10 +222,12 @@ blockquote.pull-quote > :last-child {
 
 .toggle .name:after {
     content: " ▶";
+    font-family: "monospace";
 }
 
 .toggle .name.open:after {
     content: " ▼";
+    font-family: "monospace";
 }
 
 /* -- PRINT VIEW ----------------------------------------------------------------------------*/

--- a/docs/codeql/_static/custom.css_t
+++ b/docs/codeql/_static/custom.css_t
@@ -200,7 +200,7 @@ blockquote.pull-quote {
     border-radius: 5px;
 } 
 
-blockquote.pull-quote p:first-of-type {
+blockquote.pull-quote:first-line {
     font-weight: bold;
     margin-top: 0px;
 }


### PR DESCRIPTION
Two small CSS fixes that I've already pushed to the live site:
 
https://github.com/github/codeql/pull/4873/commits/c2fdb47abe066cec3d494c9e99cb885aa5551902: Only the first line (i.e. the title) of the "pull-quote" should be bold, rather than some of the list items being randomly bold.

  <details><summary>More details</summary>

  For example:

  Before: 

  ![image](https://user-images.githubusercontent.com/42641846/102971417-4461cf80-44f1-11eb-8591-30328274d53b.png)

  After: 

  ![image](https://user-images.githubusercontent.com/42641846/102971463-58a5cc80-44f1-11eb-8ea1-88ad189e9a2e.png)

  I double-checked that all pull-quotes do indeed have a title, so we don't accidentally highlight the first line of a paragraph. (For ref: `$ grep -r -A 2 '.. pull-quote::' --include="*.rst"`)

  </details>

https://github.com/github/codeql/pull/4873/commits/dc528767f67722877847170d315a87243c4daaf0: One of the arrow symbols (`▶`) got converted to the ▶️ emoji, while the other one (`▼`) remained a symbol (as intended). I've added some styling to stop Sphinx from converting either of them to emoji. 

  <details><summary>More details</summary>

  For example:

  Before: 

  ![image](https://user-images.githubusercontent.com/42641846/103020298-0f309e00-4540-11eb-8067-10eebdbe900c.png)

  After: 

  ![image](https://user-images.githubusercontent.com/42641846/103020318-18ba0600-4540-11eb-9467-3fca261f6217.png)

  </details>
