### PR TITLE
C++: Fix join order in getAnOverload

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Function.qll
+++ b/cpp/ql/src/semmle/code/cpp/Function.qll
@@ -391,14 +391,19 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
   /** Holds if this function has a `noexcept` exception specification. */
   predicate isNoExcept() { getADeclarationEntry().isNoExcept() }
 
-  /** Gets a function that overloads this one. */
+  /**
+   * Gets a function that overloads this one.
+   *
+   * Note: if _overrides_ are wanted rather than _overloads_ then
+   * `MemberFunction::getAnOverridingFunction` should be used instead.
+   */
   Function getAnOverload() {
     (
       // If this function is declared in a class, only consider other
       // functions from the same class.
-      exists(string name, Namespace namespace, Class declaringType |
-        candGetAnOverloadMember(name, namespace, declaringType, this) and
-        candGetAnOverloadMember(name, namespace, declaringType, result)
+      exists(string name, Class declaringType |
+        candGetAnOverloadMember(name, declaringType, this) and
+        candGetAnOverloadMember(name, declaringType, result)
       )
       or
       // Conversely, if this function is not
@@ -468,11 +473,8 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
 }
 
 pragma[noinline]
-private predicate candGetAnOverloadMember(
-  string name, Namespace namespace, Class declaringType, Function f
-) {
+private predicate candGetAnOverloadMember(string name, Class declaringType, Function f) {
   f.getName() = name and
-  f.getNamespace() = namespace and
   f.getDeclaringType() = declaringType
 }
 


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/4889.

There was a bad join-order that caused a blowup in `getAnOverload`. I don't know if this is the smallest possible diff, but I think it'll reduce the likelihood of a bad join-order in the future.

Here are the tuple counts before and after this PR on the query:

```codeql
from Function f
select f, f.getAnOverload()
```

Notice that the final `#shared` predicate has the same number of tuples (and similarly for `#select`).

Before:
```
Tuple counts for #select#ff#shared/2@7a7fae:
182043    ~0%     {2} r1 = SCAN functions AS I OUTPUT I.<0> 'arg0', I.<1>
181606    ~0%     {3} r2 = JOIN r1 WITH QualifiedName::Declaration::getNamespace#bf AS R ON FIRST 1 OUTPUT r1.<1>, r1.<0> 'arg0', R.<1>
232974719 ~3%     {5} r3 = JOIN r2 WITH functions_102#join_rhs AS R ON FIRST 1 OUTPUT r2.<1> 'arg0', r2.<0>, r2.<2>, R.<1> 'arg1', R.<2>
232793095 ~3%     {5} r4 = SELECT r3 ON r3.<3> 'arg1' != r3.<0> 'arg0'
232793095 ~0%     {3} r5 = SCAN r4 OUTPUT r4.<3> 'arg1', r4.<2>, r4.<0> 'arg0'
162024142 ~9%     {2} r6 = JOIN r5 WITH QualifiedName::Declaration::getNamespace#bf AS R ON FIRST 2 OUTPUT r5.<2> 'arg0', r5.<0> 'arg1'
                  return r6

Tuple counts for #select#ff#shared#2/2@b13d56:
186868    ~0%     {2} r1 = #select#ff#shared AS L AND NOT project#Declaration::Declaration::getDeclaringType_dispred#ff AS R(L.<1> 'arg1')
                  return r1

Tuple counts for #select#ff#antijoin_rhs/2@dee9e1:
186868 ~0%     {2} r1 = JOIN functions AS L WITH #select#ff#shared#2 AS R ON FIRST 1 OUTPUT R.<0>, R.<1> 'arg1'
186868 ~0%     {2} r2 = STREAM DEDUP r1
37010  ~2%     {2} r3 = JOIN r2 WITH project#Declaration::Declaration::getDeclaringType_dispred#ff AS R ON FIRST 1 OUTPUT r2.<0> 'arg0', r2.<1> 'arg1'
37010  ~2%     {2} r4 = STREAM DEDUP r3
                return r4

Tuple counts for #select#ff#shared#3/2@c4884a:
149858 ~0%     {2} r1 = #select#ff#shared#2 AS L AND NOT #select#ff#antijoin_rhs AS R(L.<0> 'arg0', L.<1> 'arg1')
                return r1

...

Tuple counts for #select#query#ffffffffffffff/14@1bc37a:
104426  ~0%     {14} r1 = JOIN #select#query#ffffffffffffff#shared#3 AS L WITH Location::Location::hasLocationInfo_dispred#ffffff AS R ON FIRST 1 OUTPUT L.<1> 'f', L.<3> 'f#toString', L.<5> 'f#location#file_name', L.<6> 'f#location#start_line', L.<7> 'f#location#start_col', L.<8> 'f#location#end_line', L.<9> 'f#location#end_col', L.<2> '#col', L.<4> '#col#toString', R.<1> '#col#location#file_name', R.<2> '#col#location#start_line', R.<3> '#col#location#start_col', R.<4> '#col#location#end_line', R.<5> '#col#location#end_col'
3046    ~0%     {9} r2 = SCAN #select#query#ffffffffffffff#shared#2 AS I OUTPUT I.<0> 'f', I.<1> '#col', I.<2> 'f#toString', I.<3> '#col#toString', "", 0, 0, 0, 0
103604  ~4%     {9} r3 = JOIN #select#query#ffffffffffffff#shared#1 AS L WITH Location::Location::hasLocationInfo_dispred#ffffff AS R ON FIRST 1 OUTPUT L.<1> 'f', L.<2> '#col', L.<3> 'f#toString', L.<4> '#col#toString', R.<1> '#col#location#file_name', R.<2> '#col#location#start_line', R.<3> '#col#location#start_col', R.<4> '#col#location#end_line', R.<5> '#col#location#end_col'
106650  ~4%     {9} r4 = r2 \/ r3
3046    ~0%     {9} r5 = r4 AND NOT #select#query#ffffffffffffff#antijoin_rhs#1 AS R(r4.<0> 'f', r4.<1> '#col', r4.<2> 'f#toString', r4.<3> '#col#toString', r4.<4> 'f#location#file_name', r4.<5> 'f#location#start_line', r4.<6> 'f#location#start_col', r4.<7> 'f#location#end_line', r4.<8> 'f#location#end_col')
3046    ~0%     {14} r6 = SCAN r5 OUTPUT r5.<0> 'f', r5.<2> 'f#toString', r5.<4> 'f#location#file_name', r5.<5> 'f#location#start_line', r5.<6> 'f#location#start_col', r5.<7> 'f#location#end_line', r5.<8> 'f#location#end_col', r5.<1> '#col', r5.<3> '#col#toString', "", 0, 0, 0, 0
107472  ~0%     {14} r7 = r1 \/ r6
                return r7
```

After:
```
Tuple counts for Function::candGetAnOverloadNonMember#fff#antijoin_rhs/2@3fba50:
182043 ~0%       {2} r1 = SCAN functions AS I OUTPUT I.<0> 'arg0', I.<1> 'arg1'
182061 ~0%       {2} r2 = JOIN r1 WITH functions AS R ON FIRST 1 OUTPUT r1.<0> 'arg0', r1.<1> 'arg1'
158774 ~0%       {2} r3 = JOIN r2 WITH Declaration::Declaration::getDeclaringType_dispred#ff AS R ON FIRST 1 OUTPUT r2.<0> 'arg0', r2.<1> 'arg1'
158774 ~0%       {2} r4 = STREAM DEDUP r3
                  return r4

Tuple counts for Function::candGetAnOverloadNonMember#fff/3@9c8a2d:
182043 ~0%     {2} r1 = SCAN functions AS I OUTPUT I.<0> 'f', I.<1> 'name'
23269  ~2%     {2} r2 = r1 AND NOT Function::candGetAnOverloadNonMember#fff#antijoin_rhs AS R(r1.<0> 'f', r1.<1> 'name')
23269  ~0%     {3} r3 = JOIN r2 WITH QualifiedName::Declaration::getNamespace#bf AS R ON FIRST 1 OUTPUT r2.<1> 'name', R.<1> 'namespace', r2.<0> 'f'
                return r3

Tuple counts for #select#ff#shared#1/4@f3e497:
173118 ~0%      {4} r1 = JOIN Function::candGetAnOverloadNonMember#fff AS L WITH Function::candGetAnOverloadNonMember#fff AS R ON FIRST 2 OUTPUT L.<0> 'arg0', L.<1> 'arg1', L.<2> 'arg2', R.<2> 'arg2'
149858 ~0%      {4} r2 = SELECT r1 ON r1.<3> 'arg3' != r1.<2> 'arg2'
                return r2

...

Tuple counts for #select#query#ffffffffffffff/14@98d982:
104426  ~0%     {14} r1 = JOIN #select#query#ffffffffffffff#shared#3 AS L WITH Location::Location::hasLocationInfo_dispred#ffffff AS R ON FIRST 1 OUTPUT L.<1> 'f', L.<3> 'f#toString', L.<5> 'f#location#file_name', L.<6> 'f#location#start_line', L.<7> 'f#location#start_col', L.<8> 'f#location#end_line', L.<9> 'f#location#end_col', L.<2> '#col', L.<4> '#col#toString', R.<1> '#col#location#file_name', R.<2> '#col#location#start_line', R.<3> '#col#location#start_col', R.<4> '#col#location#end_line', R.<5> '#col#location#end_col'
3046    ~0%     {9} r2 = SCAN #select#query#ffffffffffffff#shared#2 AS I OUTPUT I.<0> 'f', I.<1> '#col', I.<2> 'f#toString', I.<3> '#col#toString', "", 0, 0, 0, 0
103604  ~4%     {9} r3 = JOIN #select#query#ffffffffffffff#shared#1 AS L WITH Location::Location::hasLocationInfo_dispred#ffffff AS R ON FIRST 1 OUTPUT L.<1> 'f', L.<2> '#col', L.<3> 'f#toString', L.<4> '#col#toString', R.<1> '#col#location#file_name', R.<2> '#col#location#start_line', R.<3> '#col#location#start_col', R.<4> '#col#location#end_line', R.<5> '#col#location#end_col'
106650  ~4%     {9} r4 = r2 \/ r3
3046    ~0%     {9} r5 = r4 AND NOT #select#query#ffffffffffffff#antijoin_rhs#1 AS R(r4.<0> 'f', r4.<1> '#col', r4.<2> 'f#toString', r4.<3> '#col#toString', r4.<4> 'f#location#file_name', r4.<5> 'f#location#start_line', r4.<6> 'f#location#start_col', r4.<7> 'f#location#end_line', r4.<8> 'f#location#end_col')
3046    ~0%     {14} r6 = SCAN r5 OUTPUT r5.<0> 'f', r5.<2> 'f#toString', r5.<4> 'f#location#file_name', r5.<5> 'f#location#start_line', r5.<6> 'f#location#start_col', r5.<7> 'f#location#end_line', r5.<8> 'f#location#end_col', r5.<1> '#col', r5.<3> '#col#toString', "", 0, 0, 0, 0
107472  ~0%     {14} r7 = r1 \/ r6
                return r7
```

CPP-difference: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1646/