### PR TITLE
C++: Add dataflow testcases that need flow through conflated memory

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/fields/conflated.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/conflated.cpp
@@ -1,0 +1,62 @@
+int user_input();
+void sink(int);
+
+struct A {
+  int* p;
+  int x;
+};
+
+void pointer_without_allocation(const A& ra) {
+  *ra.p = user_input();
+  sink(*ra.p); // $ MISSING: ast,ir
+}
+
+void argument_source(void*);
+void sink(void*);
+
+void pointer_without_allocation_2() {
+  char *raw;
+  argument_source(raw);
+  sink(raw); // $ ast MISSING: ir
+}
+
+A* makeA() {
+  return new A;
+}
+
+void no_InitializeDynamicAllocation_instruction() {
+  A* pa = makeA();
+  pa->x = user_input();
+  sink(pa->x); // $ ast MISSING: ir
+}
+
+void fresh_or_arg(A* arg, bool unknown) {
+  A* pa;
+  pa = unknown ? arg : new A;
+  pa->x = user_input();
+  sink(pa->x); // $ ast MISSING: ir
+}
+
+struct LinkedList {
+  LinkedList* next;
+  int y;
+
+  LinkedList() = default;
+  LinkedList(LinkedList* next) : next(next) {}
+};
+
+// Note: This example also suffers from #113: there is no ChiInstruction that merges the result of the
+// InitializeDynamicAllocation instruction into {AllAliasedMemory}. But even when that's fixed there's
+// still no dataflow because `ll->next->y = user_input()` writes to {AllAliasedMemory}. 
+void too_many_indirections() {
+  LinkedList* ll = new LinkedList;
+  ll->next = new LinkedList;
+  ll->next->y = user_input();
+  sink(ll->next->y); // $ ast MISSING: ir
+}
+
+void too_many_indirections_2(LinkedList* next) {
+  LinkedList* ll = new LinkedList(next);
+  ll->next->y = user_input();
+  sink(ll->next->y); // $ ast MISSING: ir
+}

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
@@ -121,6 +121,13 @@ postWithInFlow
 | by_reference.cpp:127:30:127:38 | inner_ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
 | complex.cpp:11:22:11:23 | a_ [post update] | PostUpdateNode should not be the target of local flow. |
 | complex.cpp:12:22:12:23 | b_ [post update] | PostUpdateNode should not be the target of local flow. |
+| conflated.cpp:10:3:10:7 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| conflated.cpp:10:7:10:7 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
+| conflated.cpp:29:7:29:7 | x [post update] | PostUpdateNode should not be the target of local flow. |
+| conflated.cpp:36:7:36:7 | x [post update] | PostUpdateNode should not be the target of local flow. |
+| conflated.cpp:53:7:53:10 | next [post update] | PostUpdateNode should not be the target of local flow. |
+| conflated.cpp:54:13:54:13 | y [post update] | PostUpdateNode should not be the target of local flow. |
+| conflated.cpp:60:13:60:13 | y [post update] | PostUpdateNode should not be the target of local flow. |
 | constructors.cpp:20:24:20:25 | a_ [post update] | PostUpdateNode should not be the target of local flow. |
 | constructors.cpp:21:24:21:25 | b_ [post update] | PostUpdateNode should not be the target of local flow. |
 | qualifiers.cpp:9:36:9:36 | a [post update] | PostUpdateNode should not be the target of local flow. |

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.expected
@@ -1,6 +1,10 @@
 uniqueEnclosingCallable
 uniqueType
 uniqueNodeLocation
+| E.cpp:15:31:15:33 | buf | Node should have one location but has 2. |
+| aliasing.cpp:2:11:2:13 | (unnamed parameter 0) | Node should have one location but has 2. |
+| conflated.cpp:2:11:2:13 | (unnamed parameter 0) | Node should have one location but has 2. |
+| conflated.cpp:14:22:14:25 | buf | Node should have one location but has 2. |
 | file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
@@ -129,6 +133,8 @@ postWithInFlow
 | complex.cpp:54:12:54:12 | Chi | PostUpdateNode should not be the target of local flow. |
 | complex.cpp:55:12:55:12 | Chi | PostUpdateNode should not be the target of local flow. |
 | complex.cpp:56:12:56:12 | Chi | PostUpdateNode should not be the target of local flow. |
+| conflated.cpp:45:39:45:42 | Chi | PostUpdateNode should not be the target of local flow. |
+| conflated.cpp:53:3:53:27 | Chi | PostUpdateNode should not be the target of local flow. |
 | constructors.cpp:20:24:20:29 | Chi | PostUpdateNode should not be the target of local flow. |
 | constructors.cpp:21:24:21:29 | Chi | PostUpdateNode should not be the target of local flow. |
 | constructors.cpp:23:28:23:28 | Chi | PostUpdateNode should not be the target of local flow. |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
@@ -309,6 +309,22 @@
 | complex.cpp:62:7:62:8 | b2 | AST only |
 | complex.cpp:65:7:65:8 | b3 | AST only |
 | complex.cpp:68:7:68:8 | b4 | AST only |
+| conflated.cpp:10:3:10:7 | * ... | AST only |
+| conflated.cpp:10:4:10:5 | ra | AST only |
+| conflated.cpp:19:19:19:21 | raw | AST only |
+| conflated.cpp:20:8:20:10 | raw | AST only |
+| conflated.cpp:29:3:29:4 | pa | AST only |
+| conflated.cpp:29:7:29:7 | x | AST only |
+| conflated.cpp:36:3:36:4 | pa | AST only |
+| conflated.cpp:36:7:36:7 | x | AST only |
+| conflated.cpp:53:7:53:10 | next | AST only |
+| conflated.cpp:54:3:54:4 | ll | AST only |
+| conflated.cpp:54:7:54:10 | next | AST only |
+| conflated.cpp:54:13:54:13 | y | AST only |
+| conflated.cpp:59:35:59:38 | next | AST only |
+| conflated.cpp:60:3:60:4 | ll | AST only |
+| conflated.cpp:60:7:60:10 | next | AST only |
+| conflated.cpp:60:13:60:13 | y | AST only |
 | constructors.cpp:20:24:20:25 | a_ | AST only |
 | constructors.cpp:21:24:21:25 | b_ | AST only |
 | constructors.cpp:28:10:28:10 | f | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
@@ -57,6 +57,7 @@
 | complex.cpp:54:6:54:10 | inner |
 | complex.cpp:55:6:55:10 | inner |
 | complex.cpp:56:6:56:10 | inner |
+| conflated.cpp:53:3:53:4 | ll |
 | constructors.cpp:20:24:20:25 | this |
 | constructors.cpp:21:24:21:25 | this |
 | qualifiers.cpp:9:30:9:33 | this |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
@@ -366,6 +366,23 @@
 | complex.cpp:62:7:62:8 | b2 |
 | complex.cpp:65:7:65:8 | b3 |
 | complex.cpp:68:7:68:8 | b4 |
+| conflated.cpp:10:3:10:7 | * ... |
+| conflated.cpp:10:4:10:5 | ra |
+| conflated.cpp:19:19:19:21 | raw |
+| conflated.cpp:20:8:20:10 | raw |
+| conflated.cpp:29:3:29:4 | pa |
+| conflated.cpp:29:7:29:7 | x |
+| conflated.cpp:36:3:36:4 | pa |
+| conflated.cpp:36:7:36:7 | x |
+| conflated.cpp:53:3:53:4 | ll |
+| conflated.cpp:53:7:53:10 | next |
+| conflated.cpp:54:3:54:4 | ll |
+| conflated.cpp:54:7:54:10 | next |
+| conflated.cpp:54:13:54:13 | y |
+| conflated.cpp:59:35:59:38 | next |
+| conflated.cpp:60:3:60:4 | ll |
+| conflated.cpp:60:7:60:10 | next |
+| conflated.cpp:60:13:60:13 | y |
 | constructors.cpp:20:24:20:25 | a_ |
 | constructors.cpp:20:24:20:25 | this |
 | constructors.cpp:21:24:21:25 | b_ |

--- a/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
@@ -336,6 +336,27 @@ edges
 | complex.cpp:62:7:62:8 | b2 [inner, f, b_] | complex.cpp:40:17:40:17 | b [inner, f, b_] |
 | complex.cpp:65:7:65:8 | b3 [inner, f, a_] | complex.cpp:40:17:40:17 | b [inner, f, a_] |
 | complex.cpp:65:7:65:8 | b3 [inner, f, b_] | complex.cpp:40:17:40:17 | b [inner, f, b_] |
+| conflated.cpp:19:19:19:21 | ref arg raw | conflated.cpp:20:8:20:10 | raw |
+| conflated.cpp:29:3:29:4 | pa [post update] [x] | conflated.cpp:30:8:30:9 | pa [x] |
+| conflated.cpp:29:3:29:22 | ... = ... | conflated.cpp:29:3:29:4 | pa [post update] [x] |
+| conflated.cpp:29:11:29:20 | call to user_input | conflated.cpp:29:3:29:22 | ... = ... |
+| conflated.cpp:30:8:30:9 | pa [x] | conflated.cpp:30:12:30:12 | x |
+| conflated.cpp:36:3:36:4 | pa [post update] [x] | conflated.cpp:37:8:37:9 | pa [x] |
+| conflated.cpp:36:3:36:22 | ... = ... | conflated.cpp:36:3:36:4 | pa [post update] [x] |
+| conflated.cpp:36:11:36:20 | call to user_input | conflated.cpp:36:3:36:22 | ... = ... |
+| conflated.cpp:37:8:37:9 | pa [x] | conflated.cpp:37:12:37:12 | x |
+| conflated.cpp:54:3:54:4 | ll [post update] [next, y] | conflated.cpp:55:8:55:9 | ll [next, y] |
+| conflated.cpp:54:3:54:28 | ... = ... | conflated.cpp:54:7:54:10 | next [post update] [y] |
+| conflated.cpp:54:7:54:10 | next [post update] [y] | conflated.cpp:54:3:54:4 | ll [post update] [next, y] |
+| conflated.cpp:54:17:54:26 | call to user_input | conflated.cpp:54:3:54:28 | ... = ... |
+| conflated.cpp:55:8:55:9 | ll [next, y] | conflated.cpp:55:12:55:15 | next [y] |
+| conflated.cpp:55:12:55:15 | next [y] | conflated.cpp:55:18:55:18 | y |
+| conflated.cpp:60:3:60:4 | ll [post update] [next, y] | conflated.cpp:61:8:61:9 | ll [next, y] |
+| conflated.cpp:60:3:60:28 | ... = ... | conflated.cpp:60:7:60:10 | next [post update] [y] |
+| conflated.cpp:60:7:60:10 | next [post update] [y] | conflated.cpp:60:3:60:4 | ll [post update] [next, y] |
+| conflated.cpp:60:17:60:26 | call to user_input | conflated.cpp:60:3:60:28 | ... = ... |
+| conflated.cpp:61:8:61:9 | ll [next, y] | conflated.cpp:61:12:61:15 | next [y] |
+| conflated.cpp:61:12:61:15 | next [y] | conflated.cpp:61:18:61:18 | y |
 | constructors.cpp:26:15:26:15 | f [a_] | constructors.cpp:28:10:28:10 | f [a_] |
 | constructors.cpp:26:15:26:15 | f [b_] | constructors.cpp:29:10:29:10 | f [b_] |
 | constructors.cpp:28:10:28:10 | f [a_] | constructors.cpp:28:12:28:12 | call to a |
@@ -827,6 +848,32 @@ nodes
 | complex.cpp:62:7:62:8 | b2 [inner, f, b_] | semmle.label | b2 [inner, f, b_] |
 | complex.cpp:65:7:65:8 | b3 [inner, f, a_] | semmle.label | b3 [inner, f, a_] |
 | complex.cpp:65:7:65:8 | b3 [inner, f, b_] | semmle.label | b3 [inner, f, b_] |
+| conflated.cpp:19:19:19:21 | ref arg raw | semmle.label | ref arg raw |
+| conflated.cpp:20:8:20:10 | raw | semmle.label | raw |
+| conflated.cpp:29:3:29:4 | pa [post update] [x] | semmle.label | pa [post update] [x] |
+| conflated.cpp:29:3:29:22 | ... = ... | semmle.label | ... = ... |
+| conflated.cpp:29:11:29:20 | call to user_input | semmle.label | call to user_input |
+| conflated.cpp:30:8:30:9 | pa [x] | semmle.label | pa [x] |
+| conflated.cpp:30:12:30:12 | x | semmle.label | x |
+| conflated.cpp:36:3:36:4 | pa [post update] [x] | semmle.label | pa [post update] [x] |
+| conflated.cpp:36:3:36:22 | ... = ... | semmle.label | ... = ... |
+| conflated.cpp:36:11:36:20 | call to user_input | semmle.label | call to user_input |
+| conflated.cpp:37:8:37:9 | pa [x] | semmle.label | pa [x] |
+| conflated.cpp:37:12:37:12 | x | semmle.label | x |
+| conflated.cpp:54:3:54:4 | ll [post update] [next, y] | semmle.label | ll [post update] [next, y] |
+| conflated.cpp:54:3:54:28 | ... = ... | semmle.label | ... = ... |
+| conflated.cpp:54:7:54:10 | next [post update] [y] | semmle.label | next [post update] [y] |
+| conflated.cpp:54:17:54:26 | call to user_input | semmle.label | call to user_input |
+| conflated.cpp:55:8:55:9 | ll [next, y] | semmle.label | ll [next, y] |
+| conflated.cpp:55:12:55:15 | next [y] | semmle.label | next [y] |
+| conflated.cpp:55:18:55:18 | y | semmle.label | y |
+| conflated.cpp:60:3:60:4 | ll [post update] [next, y] | semmle.label | ll [post update] [next, y] |
+| conflated.cpp:60:3:60:28 | ... = ... | semmle.label | ... = ... |
+| conflated.cpp:60:7:60:10 | next [post update] [y] | semmle.label | next [post update] [y] |
+| conflated.cpp:60:17:60:26 | call to user_input | semmle.label | call to user_input |
+| conflated.cpp:61:8:61:9 | ll [next, y] | semmle.label | ll [next, y] |
+| conflated.cpp:61:12:61:15 | next [y] | semmle.label | next [y] |
+| conflated.cpp:61:18:61:18 | y | semmle.label | y |
 | constructors.cpp:26:15:26:15 | f [a_] | semmle.label | f [a_] |
 | constructors.cpp:26:15:26:15 | f [b_] | semmle.label | f [b_] |
 | constructors.cpp:28:10:28:10 | f [a_] | semmle.label | f [a_] |
@@ -1028,6 +1075,11 @@ nodes
 | complex.cpp:42:18:42:18 | call to a | complex.cpp:55:19:55:28 | call to user_input | complex.cpp:42:18:42:18 | call to a | call to a flows from $@ | complex.cpp:55:19:55:28 | call to user_input | call to user_input |
 | complex.cpp:43:18:43:18 | call to b | complex.cpp:54:19:54:28 | call to user_input | complex.cpp:43:18:43:18 | call to b | call to b flows from $@ | complex.cpp:54:19:54:28 | call to user_input | call to user_input |
 | complex.cpp:43:18:43:18 | call to b | complex.cpp:56:19:56:28 | call to user_input | complex.cpp:43:18:43:18 | call to b | call to b flows from $@ | complex.cpp:56:19:56:28 | call to user_input | call to user_input |
+| conflated.cpp:20:8:20:10 | raw | conflated.cpp:19:19:19:21 | ref arg raw | conflated.cpp:20:8:20:10 | raw | raw flows from $@ | conflated.cpp:19:19:19:21 | ref arg raw | ref arg raw |
+| conflated.cpp:30:12:30:12 | x | conflated.cpp:29:11:29:20 | call to user_input | conflated.cpp:30:12:30:12 | x | x flows from $@ | conflated.cpp:29:11:29:20 | call to user_input | call to user_input |
+| conflated.cpp:37:12:37:12 | x | conflated.cpp:36:11:36:20 | call to user_input | conflated.cpp:37:12:37:12 | x | x flows from $@ | conflated.cpp:36:11:36:20 | call to user_input | call to user_input |
+| conflated.cpp:55:18:55:18 | y | conflated.cpp:54:17:54:26 | call to user_input | conflated.cpp:55:18:55:18 | y | y flows from $@ | conflated.cpp:54:17:54:26 | call to user_input | call to user_input |
+| conflated.cpp:61:18:61:18 | y | conflated.cpp:60:17:60:26 | call to user_input | conflated.cpp:61:18:61:18 | y | y flows from $@ | conflated.cpp:60:17:60:26 | call to user_input | call to user_input |
 | constructors.cpp:28:12:28:12 | call to a | constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:28:12:28:12 | call to a | call to a flows from $@ | constructors.cpp:34:11:34:20 | call to user_input | call to user_input |
 | constructors.cpp:28:12:28:12 | call to a | constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:28:12:28:12 | call to a | call to a flows from $@ | constructors.cpp:36:11:36:20 | call to user_input | call to user_input |
 | constructors.cpp:29:12:29:12 | call to b | constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:29:12:29:12 | call to b | call to b flows from $@ | constructors.cpp:35:14:35:23 | call to user_input | call to user_input |


### PR DESCRIPTION
Adds a couple of testcases to assist brainstorming the heuristics we need to determine when we should allow dataflow through conflated memory.

The tests are mostly scaled-down versions of tests we triaged in https://github.com/github/codeql-c-analysis-team/issues/143. Hopefully, this should make it easier to stare at the IR and get some ideas flowing.