### PR TITLE
C#: Remove trap stack usage

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Field.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Field.cs
@@ -59,7 +59,5 @@ namespace Semmle.Extraction.CIL.Entities
         {
             cx2.Populate(this);
         }
-
-        TrapStackBehaviour IEntity.TrapStackBehaviour => TrapStackBehaviour.NoLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeContainer.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeContainer.cs
@@ -40,7 +40,5 @@ namespace Semmle.Extraction.CIL.Entities
             WriteQuotedId(writer);
             return writer.ToString();
         }
-
-        TrapStackBehaviour IEntity.TrapStackBehaviour => TrapStackBehaviour.NoLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CIL/ExtractionProduct.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/ExtractionProduct.cs
@@ -70,8 +70,6 @@ namespace Semmle.Extraction.CIL
             this.Cx = cx;
             cx.Cx.AddFreshLabel(this);
         }
-
-        TrapStackBehaviour IEntity.TrapStackBehaviour => TrapStackBehaviour.NoLabel;
     }
 
     /// <summary>
@@ -114,8 +112,6 @@ namespace Semmle.Extraction.CIL
             WriteQuotedId(writer);
             return writer.ToString();
         }
-
-        TrapStackBehaviour IEntity.TrapStackBehaviour => TrapStackBehaviour.NoLabel;
     }
 
     /// <summary>

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Attribute.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Attribute.cs
@@ -112,8 +112,6 @@ namespace Semmle.Extraction.CSharp.Entities
                 : Expression.Create(Context, syntax, parent, childIndex);
         }
 
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
-
         public override Microsoft.CodeAnalysis.Location ReportingLocation => attributeSyntax?.Name.GetLocation();
 
         private Semmle.Extraction.Entities.Location location;

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/CommentBlock.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/CommentBlock.cs
@@ -43,7 +43,5 @@ namespace Semmle.Extraction.CSharp.Entities
 
             public CommentBlock Create(Context cx, ICommentBlock init) => new CommentBlock(cx, init);
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/CommentLine.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/CommentLine.cs
@@ -144,7 +144,5 @@ namespace Semmle.Extraction.CSharp.Entities
             public CommentLine Create(Context cx, (Microsoft.CodeAnalysis.Location, CommentLineType, string, string) init) =>
                 new CommentLine(cx, init.Item1, init.Item2, init.Item3, init.Item4);
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Compilation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Compilation.cs
@@ -65,14 +65,10 @@ namespace Semmle.Extraction.CSharp.Entities
             }
             trapFile.compilation_finished(this, (float)p.Total.Cpu.TotalSeconds, (float)p.Total.Elapsed.TotalSeconds);
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
     }
 
     internal class Diagnostic : FreshEntity
     {
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
-
         private readonly Microsoft.CodeAnalysis.Diagnostic diagnostic;
 
         public Diagnostic(Context cx, Microsoft.CodeAnalysis.Diagnostic diag) : base(cx)

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Event.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Event.cs
@@ -71,7 +71,5 @@ namespace Semmle.Extraction.CSharp.Entities
 
             public Event Create(Context cx, IEventSymbol init) => new Event(cx, init);
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
@@ -305,8 +305,6 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         public override string ToString() => Label.ToString();
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
     }
 
     internal static class CallTypeExtensions

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Field.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Field.cs
@@ -136,6 +136,5 @@ namespace Semmle.Extraction.CSharp.Entities
 
             public Field Create(Context cx, IFieldSymbol init) => new Field(cx, init);
         }
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.PushesLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
@@ -41,7 +41,5 @@ namespace Semmle.Extraction.CSharp.Entities
             trapFile.local_functions(this, symbol.Name, returnType, originalDefinition);
             ExtractRefReturn(trapFile, symbol, this);
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NeedsLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalVariable.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalVariable.cs
@@ -59,7 +59,5 @@ namespace Semmle.Extraction.CSharp.Entities
 
             public LocalVariable Create(Context cx, ISymbol init) => new LocalVariable(cx, init);
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NeedsLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -345,7 +345,5 @@ namespace Semmle.Extraction.CSharp.Entities
             PopulateMetadataHandle(trapFile);
             PopulateNullability(trapFile, symbol.GetAnnotatedReturnType());
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.PushesLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifier.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifier.cs
@@ -146,6 +146,5 @@ namespace Semmle.Extraction.CSharp.Entities
 
             public Modifier Create(Context cx, string init) => new Modifier(cx, init);
         }
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Namespace.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Namespace.cs
@@ -43,8 +43,6 @@ namespace Semmle.Extraction.CSharp.Entities
             public Namespace Create(Context cx, INamespaceSymbol init) => new Namespace(cx, init);
         }
 
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
-
         public override int GetHashCode() => QualifiedName.GetHashCode();
 
         private string QualifiedName => symbol.ToDisplayString();

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/NamespaceDeclaration.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/NamespaceDeclaration.cs
@@ -60,8 +60,6 @@ namespace Semmle.Extraction.CSharp.Entities
                 new NamespaceDeclaration(cx, init.decl, init.parent);
         }
 
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
-
         public override Microsoft.CodeAnalysis.Location ReportingLocation => node.Name.GetLocation();
 
         public override bool NeedsPopulation => true;

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Parameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Parameter.cs
@@ -175,8 +175,6 @@ namespace Semmle.Extraction.CSharp.Entities
 
             public Parameter Create(Context cx, (IParameterSymbol, IEntity, Parameter) init) => new Parameter(cx, init.Item1, init.Item2, init.Item3);
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
     }
 
     internal class VarargsType : Type

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
@@ -130,7 +130,5 @@ namespace Semmle.Extraction.CSharp.Entities
 
             public Property Create(Context cx, IPropertySymbol init) => new Property(cx, init);
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.PushesLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statement.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statement.cs
@@ -34,8 +34,6 @@ namespace Semmle.Extraction.CSharp.Entities
         bool IStatementParentEntity.IsTopLevelParent => false;
 
         protected abstract CSharpSyntaxNode GetStatementSyntax();
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NeedsLabel;
     }
 
     internal abstract class Statement<TSyntax> : Statement where TSyntax : CSharpSyntaxNode

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
@@ -130,7 +130,5 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public static TypeMention Create(Context cx, TypeSyntax syntax, IEntity parent, AnnotatedTypeSymbol? type, Microsoft.CodeAnalysis.Location loc = null) =>
             Create(cx, syntax, parent, Type.Create(cx, type?.Symbol), loc);
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Nullability.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Nullability.cs
@@ -106,8 +106,6 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override bool NeedsPopulation => true;
 
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
-
         public override void Populate(TextWriter trapFile)
         {
             trapFile.nullability(this, symbol.Annotation);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
@@ -310,8 +310,6 @@ namespace Semmle.Extraction.CSharp.Entities
             }
         }
 
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
-
         public override bool Equals(object obj)
         {
             var other = obj as Type;

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameterConstraints.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameterConstraints.cs
@@ -7,8 +7,6 @@ namespace Semmle.Extraction.CSharp.Entities
         public TypeParameterConstraints(Context cx)
             : base(cx) { }
 
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
-
         protected override void Populate(TextWriter trapFile)
         {
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/UsingDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/UsingDirective.cs
@@ -54,7 +54,5 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         public sealed override Microsoft.CodeAnalysis.Location ReportingLocation => node.GetLocation();
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Populators/Comments.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Populators/Comments.cs
@@ -12,20 +12,10 @@ namespace Semmle.Extraction.CSharp.Populators
         {
             cx.Try(null, null, () =>
             {
-                gen.GenerateBindings((entity, duplicationGuardKey, block, binding) =>
+                gen.GenerateBindings((entity, block, binding) =>
                 {
                     var commentBlock = Entities.CommentBlock.Create(cx, block);
-                    Action a = () =>
-                    {
-                        commentBlock.BindTo(entity, binding);
-                    };
-                    // When the duplication guard key exists, it means that the entity is guarded against
-                    // trap duplication (<see cref = "Context.BindComments(IEntity, Location)" />).
-                    // We must therefore also guard comment construction.
-                    if (duplicationGuardKey != null)
-                        cx.WithDuplicationGuard(duplicationGuardKey, a);
-                    else
-                        a();
+                    commentBlock.BindTo(entity, binding);
                 });
             });
         }

--- a/csharp/extractor/Semmle.Extraction/CommentProcessing.cs
+++ b/csharp/extractor/Semmle.Extraction/CommentProcessing.cs
@@ -24,15 +24,6 @@ namespace Semmle.Extraction.CommentProcessing
         // Program elements sorted by location.
         private readonly SortedDictionary<Location, Label> elements = new SortedDictionary<Location, Label>(new LocationComparer());
 
-        private readonly Dictionary<Label, Key> duplicationGuardKeys = new Dictionary<Label, Key>();
-
-        private Key? GetDuplicationGuardKey(Label label)
-        {
-            if (duplicationGuardKeys.TryGetValue(label, out var duplicationGuardKey))
-                return duplicationGuardKey;
-            return null;
-        }
-
         private class LocationComparer : IComparer<Location>
         {
             public int Compare(Location? l1, Location? l2) => CommentProcessor.Compare(l1, l2);
@@ -66,14 +57,11 @@ namespace Semmle.Extraction.CommentProcessing
         /// Called by the populator when there is a program element which can have comments.
         /// </summary>
         /// <param name="elementLabel">The label of the element in the trap file.</param>
-        /// <param name="duplicationGuardKey">The duplication guard key of the element, if any.</param>
         /// <param name="loc">The location of the element.</param>
-        public void AddElement(Label elementLabel, Key? duplicationGuardKey, Location loc)
+        public void AddElement(Label elementLabel, Location loc)
         {
             if (loc != null && loc.IsInSource)
                 elements[loc] = elementLabel;
-            if (duplicationGuardKey != null)
-                duplicationGuardKeys[elementLabel] = duplicationGuardKey;
         }
 
         // Ensure that commentBlock and element refer to the same file
@@ -109,19 +97,19 @@ namespace Semmle.Extraction.CommentProcessing
             if (previousElement != null)
             {
                 var key = previousElement.Value.Value;
-                callback(key, GetDuplicationGuardKey(key), commentBlock, CommentBinding.Before);
+                callback(key, commentBlock, CommentBinding.Before);
             }
 
             if (nextElement != null)
             {
                 var key = nextElement.Value.Value;
-                callback(key, GetDuplicationGuardKey(key), commentBlock, CommentBinding.After);
+                callback(key, commentBlock, CommentBinding.After);
             }
 
             if (parentElement != null)
             {
                 var key = parentElement.Value.Value;
-                callback(key, GetDuplicationGuardKey(key), commentBlock, CommentBinding.Parent);
+                callback(key, commentBlock, CommentBinding.Parent);
             }
 
             // Heuristic to decide which is the "best" element associated with the comment.
@@ -171,7 +159,7 @@ namespace Semmle.Extraction.CommentProcessing
             if (bestElement != null)
             {
                 var label = bestElement.Value.Value;
-                callback(label, GetDuplicationGuardKey(label), commentBlock, CommentBinding.Best);
+                callback(label, commentBlock, CommentBinding.Best);
             }
         }
 

--- a/csharp/extractor/Semmle.Extraction/Comments.cs
+++ b/csharp/extractor/Semmle.Extraction/Comments.cs
@@ -71,10 +71,9 @@ namespace Semmle.Extraction.CommentProcessing
     /// Callback for generated comment associations.
     /// </summary>
     /// <param name="elementLabel">The label of the element</param>
-    /// <param name="duplicationGuardKey">The duplication guard key of the element, if any</param>
     /// <param name="commentBlock">The comment block associated with the element</param>
     /// <param name="binding">The relationship between the commentblock and the element</param>
-    public delegate void CommentBindingCallback(Label elementLabel, Key? duplicationGuardKey, ICommentBlock commentBlock, CommentBinding binding);
+    public delegate void CommentBindingCallback(Label elementLabel, ICommentBlock commentBlock, CommentBinding binding);
 
     /// <summary>
     /// Computes the binding information between comments and program elements.
@@ -86,9 +85,8 @@ namespace Semmle.Extraction.CommentProcessing
         /// This can be called in any order.
         /// </summary>
         /// <param name="elementLabel">Label of the element.</param>
-        /// <param name="duplicationGuardKey">The duplication guard key of the element, if any.</param>
         /// <param name="location">Location of the element.</param>
-        void AddElement(Label elementLabel, Key? duplicationGuardKey, Location location);
+        void AddElement(Label elementLabel, Location location);
 
         /// <summary>
         /// Registers a line of comment.

--- a/csharp/extractor/Semmle.Extraction/Entities/ExtractionError.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/ExtractionError.cs
@@ -16,7 +16,5 @@ namespace Semmle.Extraction.Entities
         {
             trapFile.extractor_messages(this, msg.Severity, "C# extractor", msg.Text, msg.EntityText, msg.Location ?? Location.Create(cx), msg.StackTrace);
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction/Entities/File.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/File.cs
@@ -92,7 +92,5 @@ namespace Semmle.Extraction.Entities
 
             public File Create(Context cx, string init) => new File(cx, init);
         }
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
     }
 }

--- a/csharp/extractor/Semmle.Extraction/Entities/Folder.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/Folder.cs
@@ -33,8 +33,6 @@ namespace Semmle.Extraction.Entities
             public Folder Create(Context cx, PathTransformer.ITransformedPath init) => new Folder(cx, init);
         }
 
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
-
         public override int GetHashCode() => symbol.GetHashCode();
 
         public override bool Equals(object? obj)

--- a/csharp/extractor/Semmle.Extraction/Entities/Location.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/Location.cs
@@ -23,8 +23,6 @@ namespace Semmle.Extraction.Entities
         }
 
         public override Microsoft.CodeAnalysis.Location? ReportingLocation => symbol;
-
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
     }
 
     public static class LocationExtensions

--- a/csharp/extractor/Semmle.Extraction/Entity.cs
+++ b/csharp/extractor/Semmle.Extraction/Entity.cs
@@ -43,37 +43,6 @@ namespace Semmle.Extraction
         /// The location for reporting purposes.
         /// </summary>
         Location? ReportingLocation { get; }
-
-        /// <summary>
-        /// How the entity handles .push and .pop.
-        /// </summary>
-        TrapStackBehaviour TrapStackBehaviour { get; }
-    }
-
-    /// <summary>
-    /// How an entity behaves with respect to .push and .pop
-    /// </summary>
-    public enum TrapStackBehaviour
-    {
-        /// <summary>
-        /// The entity must not be extracted inside a .push/.pop
-        /// </summary>
-        NoLabel,
-
-        /// <summary>
-        /// The entity defines its own label, creating a .push/.pop
-        /// </summary>
-        PushesLabel,
-
-        /// <summary>
-        /// The entity must be extracted inside a .push/.pop
-        /// </summary>
-        NeedsLabel,
-
-        /// <summary>
-        /// The entity can be extracted inside or outside of a .push/.pop
-        /// </summary>
-        OptionalLabel
     }
 
     /// <summary>

--- a/csharp/extractor/Semmle.Extraction/FreshEntity.cs
+++ b/csharp/extractor/Semmle.Extraction/FreshEntity.cs
@@ -53,7 +53,5 @@ namespace Semmle.Extraction
         public override string ToString() => Label.ToString();
 
         public virtual Microsoft.CodeAnalysis.Location? ReportingLocation => null;
-
-        public abstract TrapStackBehaviour TrapStackBehaviour { get; }
     }
 }

--- a/csharp/extractor/Semmle.Extraction/Symbol.cs
+++ b/csharp/extractor/Semmle.Extraction/Symbol.cs
@@ -71,8 +71,6 @@ namespace Semmle.Extraction
             var other = obj as CachedEntity<TSymbol>;
             return other?.GetType() == GetType() && Equals(other.symbol, symbol);
         }
-
-        public abstract TrapStackBehaviour TrapStackBehaviour { get; }
     }
 
     /// <summary>

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -189,7 +189,6 @@
 | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:25 | this access |
 | AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:22:58:25 | this access |
 | AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:37:58:40 | this access |
-| AccessorCalls.cs:58:34:58:34 | 1 | AccessorCalls.cs:58:34:58:34 | 1 |
 | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:37:58:40 | this access |
 | AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:37:58:40 | this access |
 | AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:42:58:42 | 0 |
@@ -1647,9 +1646,7 @@
 | Foreach.cs:25:5:28:5 | {...} | Foreach.cs:25:5:28:5 | {...} |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:36:26:39 | access to parameter args |
 | Foreach.cs:26:18:26:31 | (..., ...) | Foreach.cs:26:23:26:23 | String x |
-| Foreach.cs:26:19:26:23 | 1 | Foreach.cs:26:19:26:23 | 1 |
 | Foreach.cs:26:23:26:23 | String x | Foreach.cs:26:23:26:23 | String x |
-| Foreach.cs:26:26:26:30 | 1 | Foreach.cs:26:26:26:30 | 1 |
 | Foreach.cs:26:30:26:30 | Int32 y | Foreach.cs:26:30:26:30 | Int32 y |
 | Foreach.cs:26:36:26:39 | access to parameter args | Foreach.cs:26:36:26:39 | access to parameter args |
 | Foreach.cs:27:11:27:11 | ; | Foreach.cs:27:11:27:11 | ; |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -189,7 +189,6 @@
 | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:25 | this access | normal |
 | AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:22:58:25 | this access | normal |
 | AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:33:58:44 | (..., ...) | normal |
-| AccessorCalls.cs:58:34:58:34 | 1 | AccessorCalls.cs:58:34:58:34 | 1 | normal |
 | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:37:58:40 | this access | normal |
 | AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:42:58:42 | 0 | normal |
 | AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:42:58:42 | 0 | normal |
@@ -2281,9 +2280,7 @@
 | Foreach.cs:25:5:28:5 | {...} | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | empty |
 | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | empty |
 | Foreach.cs:26:18:26:31 | (..., ...) | Foreach.cs:26:18:26:31 | (..., ...) | normal |
-| Foreach.cs:26:19:26:23 | 1 | Foreach.cs:26:19:26:23 | 1 | normal |
 | Foreach.cs:26:23:26:23 | String x | Foreach.cs:26:23:26:23 | String x | normal |
-| Foreach.cs:26:26:26:30 | 1 | Foreach.cs:26:26:26:30 | 1 | normal |
 | Foreach.cs:26:30:26:30 | Int32 y | Foreach.cs:26:30:26:30 | Int32 y | normal |
 | Foreach.cs:26:36:26:39 | access to parameter args | Foreach.cs:26:36:26:39 | access to parameter args | normal |
 | Foreach.cs:27:11:27:11 | ; | Foreach.cs:27:11:27:11 | ; | normal |

--- a/csharp/ql/test/library-tests/csharp7/TupleTypes.expected
+++ b/csharp/ql/test/library-tests/csharp7/TupleTypes.expected
@@ -27,8 +27,10 @@
 | (Int32,Int32,Int32) | (int, int, int) | ValueTuple<Int32, Int32, Int32> | 3 | 0 | CSharp7.cs:75:10:75:10 | x |
 | (Int32,Int32,Int32) | (int, int, int) | ValueTuple<Int32, Int32, Int32> | 3 | 1 | CSharp7.cs:75:13:75:13 | y |
 | (Int32,Int32,Int32) | (int, int, int) | ValueTuple<Int32, Int32, Int32> | 3 | 2 | CSharp7.cs:75:16:75:22 | Item3 |
+| (Int32,String) | (int, string) | ValueTuple<Int32, String> | 2 | 0 | CSharp7.cs:97:19:97:19 | Item1 |
 | (Int32,String) | (int, string) | ValueTuple<Int32, String> | 2 | 0 | CSharp7.cs:285:41:285:48 | Key |
 | (Int32,String) | (int, string) | ValueTuple<Int32, String> | 2 | 0 | CSharp7.cs:287:19:287:23 | a |
+| (Int32,String) | (int, string) | ValueTuple<Int32, String> | 2 | 1 | CSharp7.cs:97:22:97:37 | Item2 |
 | (Int32,String) | (int, string) | ValueTuple<Int32, String> | 2 | 1 | CSharp7.cs:285:51:285:60 | Value |
 | (Int32,String) | (int, string) | ValueTuple<Int32, String> | 2 | 1 | CSharp7.cs:287:26:287:33 | b |
 | (String,(Int32,Int32)) | (string, (int, int)) | ValueTuple<String, (Int32,Int32)> | 2 | 0 | CSharp7.cs:109:10:109:15 | m1 |


### PR DESCRIPTION
This PR removes the trap stack behaviour completely from the extractor. This means that deduplication of elements inside methods will not happen. When we're extracting a method body multiple times, the trap importer keeps only one version of the body. This doesn't work correctly if the body has different content based on `#if`s.

~~https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/731/~~
~~https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/734/~~
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/792/

The first differences job failed with 
```
20:57:51  ERROR: an uncaught error occurred while executing command 'languageStats'. The error was:
20:57:51  java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters: external/corefx/src/System.Private.Xml/tests/Xslt/TestFiles/TestData/XsltApiV2/Stra?e.xml
```