### PR TITLE
Add pre-commit hook to scripts folder and document it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@ If you have an idea for a query that you would like to share with other CodeQL u
 
     - The queries and libraries must be autoformatted, for example using the "Format Document" command in [CodeQL for Visual Studio Code](https://help.semmle.com/codeql/codeql-for-vscode/procedures/about-codeql-for-vscode.html).
 
+    If you prefer, you can use this [pre-commit hook](misc/scripts/pre-commit) that automatically checks whether your files are correctly formatted. See the [pre-commit hook installation guide](docs/install-pre-commit-hook.md) for instructions on how to install the hook.
+
 4. **Compilation**
 
     - Compilation of the query and any associated libraries and tests must be resilient to future development of the [supported](docs/supported-queries.md) libraries. This means that the functionality cannot use internal libraries, cannot depend on the output of `getAQlClass`, and cannot make use of regexp matching on `toString`.

--- a/docs/pre-commit-hook-setup.md
+++ b/docs/pre-commit-hook-setup.md
@@ -3,7 +3,7 @@
 As stated in [CONTRIBUTING](../CONTRIBUTING.md) all CodeQL files must be formatted according to our [CodeQL style guide](ql-style-guide.md). You can use our pre-commit hook to avoid committing incorrectly formatted code. To use it, simply copy the [pre-commit](../misc/scripts/pre-commit) script to `.git/modules/ql/hooks/pre-commit` and make sure that:
 
 - The script is executable. On Linux and macOS this can be done using `chmod +x`.
-- The CodeQL CLI has in added to your `PATH`.
+- The CodeQL CLI has been added to your `PATH`.
 
 The script will abort a commit that contains incorrectly formatted code in .ql or .qll files and print an error message like:
 

--- a/docs/pre-commit-hook-setup.md
+++ b/docs/pre-commit-hook-setup.md
@@ -1,0 +1,13 @@
+# CodeQL pre-commit-hook setup
+
+As stated in [CONTRIBUTING](../CONTRIBUTING.md) all CodeQL files must be formatted according to our [CodeQL style guide](ql-style-guide.md). You can use our pre-commit hook to avoid committing incorrectly formatted code. To use it, simply copy the [pre-commit](../misc/scripts/pre-commit) script to `.git/modules/ql/hooks/pre-commit` and make sure that it is executable.
+
+The script will abort a commit that contains incorrectly formatted code in .ql or .qll files and print an error message like:
+
+```
+> git commit -m "My commit."
+code/ql/cpp/ql/src/Options.qll would change by autoformatting.
+code/ql/cpp/ql/src/printAst.ql would change by autoformatting.
+```
+
+If you prefer to have the script automatically format the code (and not abort the commit), you can replace the line `codeql query format --check-only` with `codeql query format --in-place` (and `exit $exitVal` with `exit 0`).

--- a/docs/pre-commit-hook-setup.md
+++ b/docs/pre-commit-hook-setup.md
@@ -1,6 +1,6 @@
 # CodeQL pre-commit-hook setup
 
-As stated in [CONTRIBUTING](../CONTRIBUTING.md) all CodeQL files must be formatted according to our [CodeQL style guide](ql-style-guide.md). You can use our pre-commit hook to avoid committing incorrectly formatted code. To use it, simply copy the [pre-commit](../misc/scripts/pre-commit) script to `.git/modules/ql/hooks/pre-commit` and make sure that:
+As stated in [CONTRIBUTING](../CONTRIBUTING.md) all CodeQL files must be formatted according to our [CodeQL style guide](ql-style-guide.md). You can use our pre-commit hook to avoid committing incorrectly formatted code. To use it, simply copy the [pre-commit](../misc/scripts/pre-commit) script to `.git/hooks/pre-commit` and make sure that:
 
 - The script is executable. On Linux and macOS this can be done using `chmod +x`.
 - The CodeQL CLI has been added to your `PATH`.

--- a/docs/pre-commit-hook-setup.md
+++ b/docs/pre-commit-hook-setup.md
@@ -1,13 +1,16 @@
 # CodeQL pre-commit-hook setup
 
-As stated in [CONTRIBUTING](../CONTRIBUTING.md) all CodeQL files must be formatted according to our [CodeQL style guide](ql-style-guide.md). You can use our pre-commit hook to avoid committing incorrectly formatted code. To use it, simply copy the [pre-commit](../misc/scripts/pre-commit) script to `.git/modules/ql/hooks/pre-commit` and make sure that it is executable.
+As stated in [CONTRIBUTING](../CONTRIBUTING.md) all CodeQL files must be formatted according to our [CodeQL style guide](ql-style-guide.md). You can use our pre-commit hook to avoid committing incorrectly formatted code. To use it, simply copy the [pre-commit](../misc/scripts/pre-commit) script to `.git/modules/ql/hooks/pre-commit` and make sure that:
+
+- The script is executable. On Linux and macOS this can be done using `chmod +x`.
+- The CodeQL CLI has in added to your `PATH`.
 
 The script will abort a commit that contains incorrectly formatted code in .ql or .qll files and print an error message like:
 
 ```
 > git commit -m "My commit."
-code/ql/cpp/ql/src/Options.qll would change by autoformatting.
-code/ql/cpp/ql/src/printAst.ql would change by autoformatting.
+ql/cpp/ql/src/Options.qll would change by autoformatting.
+ql/cpp/ql/src/printAst.ql would change by autoformatting.
 ```
 
 If you prefer to have the script automatically format the code (and not abort the commit), you can replace the line `codeql query format --check-only` with `codeql query format --in-place` (and `exit $exitVal` with `exit 0`).

--- a/misc/scripts/pre-commit
+++ b/misc/scripts/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+exec 1>&2
+exitVal=0
+while read -r f
+do
+  filename="${f##*/}"
+  extension="${filename##*.}"
+  p="$PWD/$f";
+  if [[ -f "$p" ]] && { [ "$extension" == "ql" ] || [ "$extension" == "qll" ]; }
+  then
+    if ! codeql query format --check-only "$p"
+    then
+      exitVal=1
+    fi
+  fi
+done <<<"$(git diff --cached --relative --name-only)"
+exit $exitVal


### PR DESCRIPTION
Fixes https://github.com/github/codeql-c-analysis-team/issues/194.

@criemen suggested that the git pre-commit hook that checks whether ql files are correctly formatted should be available more widely. So this PR:
1. Adds the script to the `misc/scripts` folder
2. Documents its intended use in CONTRIBUTING.md
3. Adds a setup note in docs folder

I've run the script through shellcheck and fixed all the warnings, but if you spot any antipatterns in the script feel free to call them out!