### PR TITLE
JS: add class-field flowstep to js/shell-command-constructed-from-input

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeShellCommandConstruction.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeShellCommandConstruction.qll
@@ -41,5 +41,15 @@ module UnsafeShellCommandConstruction {
         mid.getPathSummary().hasReturn() = false
       )
     }
+
+    override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+      // flow-step from a property written in the constructor to a use in an instance method.
+      // "simulates" client usage of a class, and regains some flow-steps lost by `hasFlowPath` above.
+      exists(DataFlow::ClassNode clz, string name |
+        pred =
+          DataFlow::thisNode(clz.getConstructor().getFunction()).getAPropertyWrite(name).getRhs() and
+        succ = DataFlow::thisNode(clz.getInstanceMethod(_).getFunction()).getAPropertyRead(name)
+      )
+    }
   }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
@@ -195,6 +195,12 @@ nodes
 | lib/lib.js:343:29:343:34 | unsafe |
 | lib/lib.js:345:22:345:27 | unsafe |
 | lib/lib.js:345:22:345:27 | unsafe |
+| lib/lib.js:354:20:354:23 | opts |
+| lib/lib.js:354:20:354:23 | opts |
+| lib/lib.js:355:20:355:23 | opts |
+| lib/lib.js:355:20:355:34 | opts.learn_args |
+| lib/lib.js:360:28:360:42 | this.learn_args |
+| lib/lib.js:360:28:360:42 | this.learn_args |
 edges
 | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name |
 | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name |
@@ -425,6 +431,11 @@ edges
 | lib/lib.js:343:29:343:34 | unsafe | lib/lib.js:345:22:345:27 | unsafe |
 | lib/lib.js:343:29:343:34 | unsafe | lib/lib.js:345:22:345:27 | unsafe |
 | lib/lib.js:343:29:343:34 | unsafe | lib/lib.js:345:22:345:27 | unsafe |
+| lib/lib.js:354:20:354:23 | opts | lib/lib.js:355:20:355:23 | opts |
+| lib/lib.js:354:20:354:23 | opts | lib/lib.js:355:20:355:23 | opts |
+| lib/lib.js:355:20:355:23 | opts | lib/lib.js:355:20:355:34 | opts.learn_args |
+| lib/lib.js:355:20:355:34 | opts.learn_args | lib/lib.js:360:28:360:42 | this.learn_args |
+| lib/lib.js:355:20:355:34 | opts.learn_args | lib/lib.js:360:28:360:42 | this.learn_args |
 #select
 | lib/lib2.js:4:10:4:25 | "rm -rf " + name | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name | $@ based on library input is later used in $@. | lib/lib2.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/lib2.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/lib2.js:8:10:8:25 | "rm -rf " + name | lib/lib2.js:7:32:7:35 | name | lib/lib2.js:8:22:8:25 | name | $@ based on library input is later used in $@. | lib/lib2.js:8:10:8:25 | "rm -rf " + name | String concatenation | lib/lib2.js:8:2:8:26 | cp.exec ... + name) | shell command |
@@ -481,3 +492,4 @@ edges
 | lib/lib.js:325:12:325:51 | "MyWind ... " + arg | lib/lib.js:324:40:324:42 | arg | lib/lib.js:325:49:325:51 | arg | $@ based on library input is later used in $@. | lib/lib.js:325:12:325:51 | "MyWind ... " + arg | String concatenation | lib/lib.js:326:2:326:13 | cp.exec(cmd) | shell command |
 | lib/lib.js:340:10:340:26 | "rm -rf " + id(n) | lib/lib.js:339:39:339:39 | n | lib/lib.js:340:22:340:26 | id(n) | $@ based on library input is later used in $@. | lib/lib.js:340:10:340:26 | "rm -rf " + id(n) | String concatenation | lib/lib.js:340:2:340:27 | cp.exec ...  id(n)) | shell command |
 | lib/lib.js:345:10:345:27 | "rm -rf " + unsafe | lib/lib.js:343:29:343:34 | unsafe | lib/lib.js:345:22:345:27 | unsafe | $@ based on library input is later used in $@. | lib/lib.js:345:10:345:27 | "rm -rf " + unsafe | String concatenation | lib/lib.js:345:2:345:28 | cp.exec ... unsafe) | shell command |
+| lib/lib.js:360:17:360:56 | "learn  ... + model | lib/lib.js:354:20:354:23 | opts | lib/lib.js:360:28:360:42 | this.learn_args | $@ based on library input is later used in $@. | lib/lib.js:360:17:360:56 | "learn  ... + model | String concatenation | lib/lib.js:361:3:361:18 | cp.exec(command) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
@@ -350,3 +350,15 @@ Object.defineProperty(module.exports, "boundProblem", {
 		return boundProblem.bind(this, "safe");
 	}
 });
+
+function MyTrainer(opts) {
+	this.learn_args = opts.learn_args
+}
+
+MyTrainer.prototype = {
+	train: function() {
+		var command = "learn " + this.learn_args + " " + model; // NOT OK
+		cp.exec(command); 
+	}
+};
+module.exports.MyTrainer = MyTrainer;


### PR DESCRIPTION
Regains TP/TN for CVE-2018-3746 and CVE-2020-4066. 

Those two CVEs were lost with https://github.com/github/codeql/pull/4460.  
A simple solution would have been to revert that PR.   
But with this solution we can keep the precision gain from https://github.com/github/codeql/pull/4460, while still getting TPs on the two CVEs. 

--- 

I wondering if we should promote this flow-step to all taint/data-flow queries?  
Because without it we miss the following: 
```JavaScript
class Foo {
  constructor() {
    this.bar = SOURCE;
  }
  baz() {
    var SINK = this.bar; 
  }
}
```

We only get the above flow if there is some call to `baz()` (which seems to connect the `this` nodes). 