### PR TITLE
C#: SSA refactorings

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/commons/ConsistencyChecks.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/ConsistencyChecks.qll
@@ -49,7 +49,7 @@ module SsaChecks {
     exists(Definition def, BasicBlock bb, ControlFlow::Node rnode, ControlFlow::Node dnode, int i |
       def.getAReadAtNode(rnode) = read
     |
-      def.definesAt(bb, i) and
+      def.definesAt(_, bb, i) and
       dnode = bb.getNode(max(int j | j = i or j = 0)) and
       not dnode.dominates(rnode)
     ) and

--- a/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
@@ -377,7 +377,17 @@ private predicate entryBB(BasicBlock bb) {
  * an annotated exit node.
  */
 class AnnotatedExitBasicBlock extends BasicBlock {
-  AnnotatedExitBasicBlock() { this.getANode() instanceof ControlFlow::Nodes::AnnotatedExitNode }
+  private boolean isNormal;
+
+  AnnotatedExitBasicBlock() {
+    this.getANode() =
+      any(ControlFlow::Nodes::AnnotatedExitNode n |
+        if n.isNormal() then isNormal = true else isNormal = false
+      )
+  }
+
+  /** Holds if this block represents a normal exit. */
+  predicate isNormal() { isNormal = true }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -270,7 +270,7 @@ module ControlFlow {
       /** Gets the callable that this exit applies to. */
       Callable getCallable() { result = c }
 
-      /** Holds if this node represent a normal exit. */
+      /** Holds if this node represents a normal exit. */
       predicate isNormal() { normal = true }
 
       override BasicBlocks::AnnotatedExitBlock getBasicBlock() {

--- a/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
@@ -621,8 +621,7 @@ private Ssa::Definition getAnSsaQualifier(Expr e, ControlFlow::Node cfn) {
 }
 
 private AssignableAccess getATrackedAccess(Ssa::Definition def, ControlFlow::Node cfn) {
-  result = def.getAReadAtNode(cfn) and
-  not def instanceof Ssa::ImplicitUntrackedDefinition
+  result = def.getAReadAtNode(cfn)
   or
   result = def.(Ssa::ExplicitDefinition).getADefinition().getTargetAccess() and
   cfn = def.getControlFlowNode()

--- a/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
@@ -19,7 +19,7 @@ module Ssa {
       }
 
       /**
-       * Holds if the this field or any of the fields part of the qualifier
+       * Holds if this field or any of the fields part of the qualifier
        * are volatile.
        */
       predicate isVolatile() { this.(Field).isVolatile() }
@@ -605,7 +605,7 @@ module Ssa {
 
     /**
      * Holds if the `i`th node of basic block `bb` is a reference to `v`,
-     * either a read (when `k` is `Read()`) or an SSA definition (when `k`
+     * either a read (when `k` is `SsaRead()`) or an SSA definition (when `k`
      * is `SsaDef()`).
      */
     private predicate ssaRef(BasicBlock bb, int i, SourceVariable v, SsaRefKind k) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
@@ -18,10 +18,7 @@ module Ssa {
         this instanceof Property
       }
 
-      /**
-       * Holds if this field or any of the fields part of the qualifier
-       * are volatile.
-       */
+      /** Holds if this is a volatile field. */
       predicate isVolatile() { this.(Field).isVolatile() }
     }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1691,8 +1691,6 @@ private class FieldOrPropertyRead extends FieldOrPropertyAccess, AssignableRead 
    * SSA updates.
    */
   predicate hasNonlocalValue() {
-    this = any(Ssa::ImplicitUntrackedDefinition udef).getARead()
-    or
     exists(Ssa::Definition def, Ssa::ImplicitDefinition idef |
       def.getARead() = this and
       idef = def.getAnUltimateDefinition()

--- a/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
+++ b/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
@@ -4,6 +4,7 @@
 | CSharp7.cs:10:9:10:9 | this access | CSharp7.cs:11:9:11:9 | this access |
 | CSharp7.cs:16:9:16:13 | [post] this access | CSharp7.cs:25:39:25:43 | this access |
 | CSharp7.cs:16:9:16:13 | this access | CSharp7.cs:25:39:25:43 | this access |
+| CSharp7.cs:17:9:17:11 | SSA entry def(this.field) | CSharp7.cs:17:18:17:22 | access to field field |
 | CSharp7.cs:17:9:17:11 | this | CSharp7.cs:17:18:17:22 | this access |
 | CSharp7.cs:21:9:21:11 | this | CSharp7.cs:21:16:21:20 | this access |
 | CSharp7.cs:22:9:22:11 | this | CSharp7.cs:22:16:22:20 | this access |
@@ -67,6 +68,7 @@
 | CSharp7.cs:84:23:84:23 | 2 | CSharp7.cs:84:16:84:24 | (..., ...) |
 | CSharp7.cs:87:10:87:18 | this | CSharp7.cs:92:18:92:28 | this access |
 | CSharp7.cs:89:13:89:34 | SSA def(t1) | CSharp7.cs:90:28:90:29 | access to local variable t1 |
+| CSharp7.cs:89:13:89:34 | SSA qualifier def(t1.Item1) | CSharp7.cs:92:20:92:27 | access to field Item1 |
 | CSharp7.cs:89:18:89:34 | (..., ...) | CSharp7.cs:89:13:89:34 | SSA def(t1) |
 | CSharp7.cs:89:19:89:27 | "tainted" | CSharp7.cs:89:18:89:34 | (..., ...) |
 | CSharp7.cs:89:30:89:33 | "X2" | CSharp7.cs:89:18:89:34 | (..., ...) |
@@ -100,6 +102,7 @@
 | CSharp7.cs:112:31:112:32 | access to local variable m2 | CSharp7.cs:112:26:112:33 | (..., ...) |
 | CSharp7.cs:114:9:114:67 | SSA def(m9) | CSharp7.cs:115:19:115:20 | access to local variable m9 |
 | CSharp7.cs:114:38:114:67 | SSA def(m2) | CSharp7.cs:118:9:118:10 | access to local variable m2 |
+| CSharp7.cs:114:38:114:67 | SSA qualifier def(m2.Item1) | CSharp7.cs:119:19:119:26 | access to field Item1 |
 | CSharp7.cs:114:49:114:67 | (..., ...) | CSharp7.cs:114:38:114:67 | ... = ... |
 | CSharp7.cs:114:50:114:58 | "DefUse2" | CSharp7.cs:114:49:114:67 | (..., ...) |
 | CSharp7.cs:114:61:114:66 | (..., ...) | CSharp7.cs:114:38:114:67 | SSA def(m2) |

--- a/csharp/ql/test/library-tests/dataflow/defuse/useUseEquivalence.ql
+++ b/csharp/ql/test/library-tests/dataflow/defuse/useUseEquivalence.ql
@@ -34,7 +34,7 @@ private TLocalScopeVariableReadOrSsaDef getANextReadOrDef(TLocalScopeVariableRea
       ssaDef.getARead() = read
     |
       pseudoDef.getAnInput() = ssaDef and
-      pseudoDef.definesAt(bb, i) and
+      pseudoDef.definesAt(_, bb, i) and
       cfn = read.getAReachableElement().getAControlFlowNode() and
       (
         cfn = bb.getNode(i)

--- a/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -325,6 +325,8 @@
 | LocalDataFlow.cs:243:9:243:17 | access to local variable nonSink10 | LocalDataFlow.cs:244:15:244:23 | access to local variable nonSink10 |
 | LocalDataFlow.cs:247:13:247:52 | SSA def(taintedDataContract) | LocalDataFlow.cs:248:22:248:40 | access to local variable taintedDataContract |
 | LocalDataFlow.cs:247:13:247:52 | SSA qualifier def(taintedDataContract.AList) | LocalDataFlow.cs:250:22:250:46 | access to property AList |
+| LocalDataFlow.cs:247:13:247:52 | SSA qualifier def(taintedDataContract.AString) | LocalDataFlow.cs:248:22:248:48 | access to property AString |
+| LocalDataFlow.cs:247:13:247:52 | SSA qualifier def(taintedDataContract.AnInt) | LocalDataFlow.cs:257:20:257:44 | access to property AnInt |
 | LocalDataFlow.cs:247:35:247:52 | object creation of type DataContract | LocalDataFlow.cs:247:13:247:52 | SSA def(taintedDataContract) |
 | LocalDataFlow.cs:248:13:248:48 | SSA def(sink53) | LocalDataFlow.cs:249:15:249:20 | access to local variable sink53 |
 | LocalDataFlow.cs:248:22:248:40 | [post] access to local variable taintedDataContract | LocalDataFlow.cs:250:22:250:40 | access to local variable taintedDataContract |
@@ -337,6 +339,7 @@
 | LocalDataFlow.cs:250:22:250:46 | access to property AList | LocalDataFlow.cs:259:20:259:44 | access to property AList |
 | LocalDataFlow.cs:250:22:250:57 | access to property AString | LocalDataFlow.cs:250:13:250:57 | SSA def(sink54) |
 | LocalDataFlow.cs:254:13:254:55 | SSA def(nonTaintedDataContract) | LocalDataFlow.cs:255:20:255:41 | access to local variable nonTaintedDataContract |
+| LocalDataFlow.cs:254:13:254:55 | SSA qualifier def(nonTaintedDataContract.AString) | LocalDataFlow.cs:255:20:255:49 | access to property AString |
 | LocalDataFlow.cs:254:38:254:55 | object creation of type DataContract | LocalDataFlow.cs:254:13:254:55 | SSA def(nonTaintedDataContract) |
 | LocalDataFlow.cs:255:9:255:49 | SSA def(nonSink0) | LocalDataFlow.cs:256:15:256:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:255:20:255:49 | access to property AString | LocalDataFlow.cs:255:9:255:49 | SSA def(nonSink0) |
@@ -347,10 +350,12 @@
 | LocalDataFlow.cs:259:9:259:53 | SSA def(nonSink2) | LocalDataFlow.cs:260:15:260:22 | access to local variable nonSink2 |
 | LocalDataFlow.cs:259:20:259:53 | access to property AnInt | LocalDataFlow.cs:259:9:259:53 | SSA def(nonSink2) |
 | LocalDataFlow.cs:263:17:263:37 | SSA def(taintedTextBox) | LocalDataFlow.cs:264:22:264:35 | access to local variable taintedTextBox |
+| LocalDataFlow.cs:263:17:263:37 | SSA qualifier def(taintedTextBox.Text) | LocalDataFlow.cs:264:22:264:40 | access to property Text |
 | LocalDataFlow.cs:263:34:263:37 | null | LocalDataFlow.cs:263:17:263:37 | SSA def(taintedTextBox) |
 | LocalDataFlow.cs:264:13:264:40 | SSA def(sink60) | LocalDataFlow.cs:265:15:265:20 | access to local variable sink60 |
 | LocalDataFlow.cs:264:22:264:40 | access to property Text | LocalDataFlow.cs:264:13:264:40 | SSA def(sink60) |
 | LocalDataFlow.cs:268:17:268:40 | SSA def(nonTaintedTextBox) | LocalDataFlow.cs:269:20:269:36 | access to local variable nonTaintedTextBox |
+| LocalDataFlow.cs:268:17:268:40 | SSA qualifier def(nonTaintedTextBox.Text) | LocalDataFlow.cs:269:20:269:41 | access to property Text |
 | LocalDataFlow.cs:268:37:268:40 | null | LocalDataFlow.cs:268:17:268:40 | SSA def(nonTaintedTextBox) |
 | LocalDataFlow.cs:269:9:269:41 | SSA def(nonSink0) | LocalDataFlow.cs:270:15:270:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:269:20:269:41 | access to property Text | LocalDataFlow.cs:269:9:269:41 | SSA def(nonSink0) |
@@ -396,6 +401,7 @@
 | LocalDataFlow.cs:314:22:314:26 | access to local variable sink0 | LocalDataFlow.cs:314:22:314:38 | ... ?? ... |
 | LocalDataFlow.cs:314:22:314:38 | ... ?? ... | LocalDataFlow.cs:314:13:314:38 | SSA def(sink74) |
 | LocalDataFlow.cs:314:31:314:38 | access to local variable nonSink0 | LocalDataFlow.cs:314:22:314:38 | ... ?? ... |
+| LocalDataFlow.cs:334:28:334:30 | SSA entry def(this.anInt) | LocalDataFlow.cs:334:41:334:45 | access to field anInt |
 | LocalDataFlow.cs:334:28:334:30 | this | LocalDataFlow.cs:334:41:334:45 | this access |
 | LocalDataFlow.cs:334:50:334:52 | this | LocalDataFlow.cs:334:56:334:60 | this access |
 | LocalDataFlow.cs:334:50:334:52 | value | LocalDataFlow.cs:334:64:334:68 | access to parameter value |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
@@ -421,6 +421,8 @@
 | LocalDataFlow.cs:243:30:243:37 | access to local variable nonSink0 | LocalDataFlow.cs:243:9:243:38 | call to method AppendLine |
 | LocalDataFlow.cs:247:13:247:52 | SSA def(taintedDataContract) | LocalDataFlow.cs:248:22:248:40 | access to local variable taintedDataContract |
 | LocalDataFlow.cs:247:13:247:52 | SSA qualifier def(taintedDataContract.AList) | LocalDataFlow.cs:250:22:250:46 | access to property AList |
+| LocalDataFlow.cs:247:13:247:52 | SSA qualifier def(taintedDataContract.AString) | LocalDataFlow.cs:248:22:248:48 | access to property AString |
+| LocalDataFlow.cs:247:13:247:52 | SSA qualifier def(taintedDataContract.AnInt) | LocalDataFlow.cs:257:20:257:44 | access to property AnInt |
 | LocalDataFlow.cs:247:35:247:52 | object creation of type DataContract | LocalDataFlow.cs:247:13:247:52 | SSA def(taintedDataContract) |
 | LocalDataFlow.cs:248:13:248:48 | SSA def(sink53) | LocalDataFlow.cs:249:15:249:20 | access to local variable sink53 |
 | LocalDataFlow.cs:248:22:248:40 | [post] access to local variable taintedDataContract | LocalDataFlow.cs:250:22:250:40 | access to local variable taintedDataContract |
@@ -437,6 +439,7 @@
 | LocalDataFlow.cs:250:22:250:49 | access to indexer | LocalDataFlow.cs:250:22:250:57 | access to property AString |
 | LocalDataFlow.cs:250:22:250:57 | access to property AString | LocalDataFlow.cs:250:13:250:57 | SSA def(sink54) |
 | LocalDataFlow.cs:254:13:254:55 | SSA def(nonTaintedDataContract) | LocalDataFlow.cs:255:20:255:41 | access to local variable nonTaintedDataContract |
+| LocalDataFlow.cs:254:13:254:55 | SSA qualifier def(nonTaintedDataContract.AString) | LocalDataFlow.cs:255:20:255:49 | access to property AString |
 | LocalDataFlow.cs:254:38:254:55 | object creation of type DataContract | LocalDataFlow.cs:254:13:254:55 | SSA def(nonTaintedDataContract) |
 | LocalDataFlow.cs:255:9:255:49 | SSA def(nonSink0) | LocalDataFlow.cs:256:15:256:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:255:20:255:41 | access to local variable nonTaintedDataContract | LocalDataFlow.cs:255:20:255:49 | access to property AString |
@@ -450,11 +453,13 @@
 | LocalDataFlow.cs:259:20:259:44 | access to property AList | LocalDataFlow.cs:259:20:259:47 | access to indexer |
 | LocalDataFlow.cs:259:20:259:53 | access to property AnInt | LocalDataFlow.cs:259:9:259:53 | SSA def(nonSink2) |
 | LocalDataFlow.cs:263:17:263:37 | SSA def(taintedTextBox) | LocalDataFlow.cs:264:22:264:35 | access to local variable taintedTextBox |
+| LocalDataFlow.cs:263:17:263:37 | SSA qualifier def(taintedTextBox.Text) | LocalDataFlow.cs:264:22:264:40 | access to property Text |
 | LocalDataFlow.cs:263:34:263:37 | null | LocalDataFlow.cs:263:17:263:37 | SSA def(taintedTextBox) |
 | LocalDataFlow.cs:264:13:264:40 | SSA def(sink60) | LocalDataFlow.cs:265:15:265:20 | access to local variable sink60 |
 | LocalDataFlow.cs:264:22:264:35 | access to local variable taintedTextBox | LocalDataFlow.cs:264:22:264:40 | access to property Text |
 | LocalDataFlow.cs:264:22:264:40 | access to property Text | LocalDataFlow.cs:264:13:264:40 | SSA def(sink60) |
 | LocalDataFlow.cs:268:17:268:40 | SSA def(nonTaintedTextBox) | LocalDataFlow.cs:269:20:269:36 | access to local variable nonTaintedTextBox |
+| LocalDataFlow.cs:268:17:268:40 | SSA qualifier def(nonTaintedTextBox.Text) | LocalDataFlow.cs:269:20:269:41 | access to property Text |
 | LocalDataFlow.cs:268:37:268:40 | null | LocalDataFlow.cs:268:17:268:40 | SSA def(nonTaintedTextBox) |
 | LocalDataFlow.cs:269:9:269:41 | SSA def(nonSink0) | LocalDataFlow.cs:270:15:270:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:269:20:269:36 | access to local variable nonTaintedTextBox | LocalDataFlow.cs:269:20:269:41 | access to property Text |
@@ -505,6 +510,7 @@
 | LocalDataFlow.cs:314:22:314:26 | access to local variable sink0 | LocalDataFlow.cs:314:22:314:38 | ... ?? ... |
 | LocalDataFlow.cs:314:22:314:38 | ... ?? ... | LocalDataFlow.cs:314:13:314:38 | SSA def(sink74) |
 | LocalDataFlow.cs:314:31:314:38 | access to local variable nonSink0 | LocalDataFlow.cs:314:22:314:38 | ... ?? ... |
+| LocalDataFlow.cs:334:28:334:30 | SSA entry def(this.anInt) | LocalDataFlow.cs:334:41:334:45 | access to field anInt |
 | LocalDataFlow.cs:334:28:334:30 | this | LocalDataFlow.cs:334:41:334:45 | this access |
 | LocalDataFlow.cs:334:50:334:52 | this | LocalDataFlow.cs:334:56:334:60 | this access |
 | LocalDataFlow.cs:334:50:334:52 | value | LocalDataFlow.cs:334:64:334:68 | access to parameter value |

--- a/csharp/ql/test/library-tests/dataflow/ssa/Capture.cs
+++ b/csharp/ql/test/library-tests/dataflow/ssa/Capture.cs
@@ -99,7 +99,7 @@ class Capture
             return x;
         });
 
-        var z = 12; // Should *not* get an SSA definition
+        var z = 12; // Should *not* get an SSA definition, but currently does because it is considered live via the lambda
         fn(() =>
         {
             z = 0;
@@ -119,7 +119,7 @@ class Capture
         };
         M1();
 
-        var b = 12; // Should *not* get an SSA definition
+        var b = 12; // Should *not* get an SSA definition, but currently does because it is considered live via the lambda
         void M2()
         {
             b = 0;
@@ -155,7 +155,7 @@ class Capture
         Use(f);
         void M6()
         {
-            f = 0; // Should *not* get an SSA definition (`f` is not read after `M6` is called)
+            f = 0; // Should *not* get an SSA definition (`f` is not read after `M6` is called), but currently does because it is considered live via the call to `M6`
         }
         M6();
 

--- a/csharp/ql/test/library-tests/dataflow/ssa/PreSsaConsistency.ql
+++ b/csharp/ql/test/library-tests/dataflow/ssa/PreSsaConsistency.ql
@@ -77,7 +77,7 @@ query predicate phiInconsistency(
         edef = phi.getAnUltimateDefinition()
       |
         edef.getADefinition() = adef and
-        phi.definesAt(bb, _) and
+        phi.definesAt(_, bb, _) and
         cfe = bb.getFirstNode().getElement()
       )
     )
@@ -88,7 +88,7 @@ query predicate phiInconsistency(
     |
       edef = phi.getAnUltimateDefinition() and
       edef.getADefinition() = adef and
-      phi.definesAt(bb, _) and
+      phi.definesAt(_, bb, _) and
       cfe = bb.getFirstNode().getElement() and
       not exists(PreSsa::Definition def |
         adef = def.getAPhiInput+().getDefinition() and

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaDef.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaDef.expected
@@ -49,10 +49,12 @@
 | Capture.cs:94:13:94:13 | y | Capture.cs:94:13:94:18 | SSA def(y) |
 | Capture.cs:94:13:94:13 | y | Capture.cs:96:12:100:9 | SSA capture def(y) |
 | Capture.cs:98:17:98:17 | x | Capture.cs:98:17:98:21 | SSA def(x) |
+| Capture.cs:102:13:102:13 | z | Capture.cs:102:13:102:18 | SSA def(z) |
 | Capture.cs:102:13:102:13 | z | Capture.cs:105:13:105:17 | SSA def(z) |
 | Capture.cs:114:13:114:13 | a | Capture.cs:114:13:114:18 | SSA def(a) |
 | Capture.cs:114:13:114:13 | a | Capture.cs:115:9:119:9 | SSA capture def(a) |
 | Capture.cs:117:17:117:17 | x | Capture.cs:117:17:117:21 | SSA def(x) |
+| Capture.cs:122:13:122:13 | b | Capture.cs:122:13:122:18 | SSA def(b) |
 | Capture.cs:122:13:122:13 | b | Capture.cs:125:13:125:17 | SSA def(b) |
 | Capture.cs:130:13:130:13 | c | Capture.cs:130:13:130:18 | SSA def(c) |
 | Capture.cs:130:13:130:13 | c | Capture.cs:133:13:133:17 | SSA def(c) |
@@ -62,6 +64,7 @@
 | Capture.cs:139:13:139:13 | d | Capture.cs:144:9:144:12 | SSA call def(d) |
 | Capture.cs:147:13:147:13 | e | Capture.cs:148:9:152:9 | SSA capture def(e) |
 | Capture.cs:154:13:154:13 | f | Capture.cs:154:13:154:18 | SSA def(f) |
+| Capture.cs:154:13:154:13 | f | Capture.cs:158:13:158:17 | SSA def(f) |
 | Capture.cs:162:13:162:13 | g | Capture.cs:163:9:166:9 | SSA capture def(g) |
 | Capture.cs:168:13:168:13 | h | Capture.cs:171:13:171:17 | SSA def(h) |
 | Capture.cs:168:13:168:13 | h | Capture.cs:174:17:174:21 | SSA def(h) |
@@ -218,9 +221,9 @@
 | Fields.cs:107:33:107:33 | f | Fields.cs:107:33:107:33 | SSA param(f) |
 | Fields.cs:115:20:115:29 | this.Field | Fields.cs:109:10:109:10 | SSA entry def(this.Field) |
 | Fields.cs:115:20:115:29 | this.Field | Fields.cs:114:9:114:22 | SSA call def(this.Field) |
-| Fields.cs:115:20:115:35 | this.Field.Field | Fields.cs:109:10:109:10 | SSA entry def(this.Field.Field) |
+| Fields.cs:115:20:115:35 | this.Field.Field | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field) |
 | Fields.cs:115:20:115:35 | this.Field.Field | Fields.cs:114:9:114:22 | SSA call def(this.Field.Field) |
-| Fields.cs:116:21:116:39 | this.Field.Field.xs | Fields.cs:109:10:109:10 | SSA entry def(this.Field.Field.xs) |
+| Fields.cs:116:21:116:39 | this.Field.Field.xs | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field.xs) |
 | Fields.cs:116:21:116:39 | this.Field.Field.xs | Fields.cs:114:9:114:22 | SSA qualifier def(this.Field.Field.xs) |
 | OutRef.cs:9:13:9:13 | j | OutRef.cs:9:13:9:17 | SSA def(j) |
 | OutRef.cs:9:13:9:13 | j | OutRef.cs:10:32:10:32 | SSA def(j) |
@@ -299,9 +302,9 @@
 | Properties.cs:106:37:106:37 | p | Properties.cs:106:37:106:37 | SSA param(p) |
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:108:10:108:10 | SSA entry def(this.Props) |
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props) |
-| Properties.cs:114:20:114:35 | this.Props.Props | Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props) |
+| Properties.cs:114:20:114:35 | this.Props.Props | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props) |
 | Properties.cs:114:20:114:35 | this.Props.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props.Props) |
-| Properties.cs:115:21:115:39 | this.Props.Props.xs | Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props.xs) |
+| Properties.cs:115:21:115:39 | this.Props.Props.xs | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props.xs) |
 | Properties.cs:115:21:115:39 | this.Props.Props.xs | Properties.cs:113:9:113:22 | SSA qualifier def(this.Props.Props.xs) |
 | Splitting.cs:3:18:3:18 | b | Splitting.cs:3:18:3:18 | SSA param(b) |
 | Splitting.cs:5:13:5:13 | x | Splitting.cs:7:13:7:19 | [b (line 3): true] SSA def(x) |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaDef.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaDef.expected
@@ -193,11 +193,9 @@
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:49:17:49:28 | SSA call def(Fields.stat) |
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:50:9:50:17 | SSA phi(Fields.stat) |
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:51:9:51:20 | SSA call def(Fields.stat) |
-| Fields.cs:63:16:63:28 | this.VolatileField | Fields.cs:63:16:63:28 | SSA untracked def(this.VolatileField) |
-| Fields.cs:63:16:63:28 | this.VolatileField | Fields.cs:69:21:69:33 | SSA untracked def(this.VolatileField) |
 | Fields.cs:65:24:65:32 | this.LoopField | Fields.cs:61:17:61:17 | SSA entry def(this.LoopField) |
-| Fields.cs:71:17:71:35 | this.SingleAccessedField | Fields.cs:71:17:71:35 | SSA untracked def(this.SingleAccessedField) |
-| Fields.cs:76:20:76:38 | this.SingleAccessedField | Fields.cs:76:20:76:38 | SSA untracked def(this.SingleAccessedField) |
+| Fields.cs:71:17:71:35 | this.SingleAccessedField | Fields.cs:61:17:61:17 | SSA entry def(this.SingleAccessedField) |
+| Fields.cs:76:20:76:38 | this.SingleAccessedField | Fields.cs:74:17:74:17 | SSA entry def(this.SingleAccessedField) |
 | Fields.cs:77:13:77:13 | f | Fields.cs:77:13:77:45 | SSA def(f) |
 | Fields.cs:77:13:77:13 | f | Fields.cs:78:27:78:54 | SSA capture def(f) |
 | Fields.cs:78:23:78:23 | a | Fields.cs:78:23:78:54 | SSA def(a) |
@@ -283,8 +281,8 @@
 | Properties.cs:61:23:61:23 | i | Properties.cs:63:16:63:16 | SSA phi(i) |
 | Properties.cs:61:23:61:23 | i | Properties.cs:63:16:63:18 | SSA def(i) |
 | Properties.cs:65:24:65:31 | this.LoopProp | Properties.cs:61:17:61:17 | SSA entry def(this.LoopProp) |
-| Properties.cs:67:21:67:38 | this.SingleAccessedProp | Properties.cs:67:21:67:38 | SSA untracked def(this.SingleAccessedProp) |
-| Properties.cs:72:20:72:37 | this.SingleAccessedProp | Properties.cs:72:20:72:37 | SSA untracked def(this.SingleAccessedProp) |
+| Properties.cs:67:21:67:38 | this.SingleAccessedProp | Properties.cs:61:17:61:17 | SSA entry def(this.SingleAccessedProp) |
+| Properties.cs:72:20:72:37 | this.SingleAccessedProp | Properties.cs:70:17:70:17 | SSA entry def(this.SingleAccessedProp) |
 | Properties.cs:73:13:73:13 | f | Properties.cs:73:13:73:32 | SSA def(f) |
 | Properties.cs:73:13:73:13 | f | Properties.cs:74:27:74:54 | SSA capture def(f) |
 | Properties.cs:74:23:74:23 | a | Properties.cs:74:23:74:54 | SSA def(a) |
@@ -298,11 +296,6 @@
 | Properties.cs:76:9:76:12 | f.xs | Properties.cs:84:9:84:25 | SSA def(f.xs) |
 | Properties.cs:78:9:78:15 | this.xs | Properties.cs:81:9:81:22 | SSA def(this.xs) |
 | Properties.cs:78:9:78:15 | this.xs | Properties.cs:83:9:83:22 | SSA def(this.xs) |
-| Properties.cs:94:9:94:27 | this.NonTrivialProp | Properties.cs:95:20:95:38 | SSA untracked def(this.NonTrivialProp) |
-| Properties.cs:97:9:97:24 | this.VirtualProp | Properties.cs:98:16:98:31 | SSA untracked def(this.VirtualProp) |
-| Properties.cs:100:9:100:26 | this.VolatileField | Properties.cs:100:9:100:26 | SSA untracked def(this.VolatileField) |
-| Properties.cs:100:9:100:26 | this.VolatileField | Properties.cs:101:21:101:38 | SSA untracked def(this.VolatileField) |
-| Properties.cs:100:9:100:29 | this.VolatileField.xs | Properties.cs:101:21:101:41 | SSA untracked def(this.VolatileField.xs) |
 | Properties.cs:106:37:106:37 | p | Properties.cs:106:37:106:37 | SSA param(p) |
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:108:10:108:10 | SSA entry def(this.Props) |
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props) |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaDefElement.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaDefElement.expected
@@ -183,10 +183,8 @@
 | Fields.cs:49:17:49:28 | SSA call def(Fields.stat) | Fields.cs:49:17:49:28 | object creation of type Fields |
 | Fields.cs:51:9:51:20 | SSA call def(Fields.stat) | Fields.cs:51:9:51:20 | object creation of type Fields |
 | Fields.cs:61:17:61:17 | SSA entry def(this.LoopField) | Fields.cs:61:17:61:17 | H |
-| Fields.cs:63:16:63:28 | SSA untracked def(this.VolatileField) | Fields.cs:63:16:63:28 | this access |
-| Fields.cs:69:21:69:33 | SSA untracked def(this.VolatileField) | Fields.cs:69:21:69:33 | this access |
-| Fields.cs:71:17:71:35 | SSA untracked def(this.SingleAccessedField) | Fields.cs:71:17:71:35 | this access |
-| Fields.cs:76:20:76:38 | SSA untracked def(this.SingleAccessedField) | Fields.cs:76:20:76:38 | this access |
+| Fields.cs:61:17:61:17 | SSA entry def(this.SingleAccessedField) | Fields.cs:61:17:61:17 | H |
+| Fields.cs:74:17:74:17 | SSA entry def(this.SingleAccessedField) | Fields.cs:74:17:74:17 | I |
 | Fields.cs:77:13:77:45 | SSA def(f) | Fields.cs:77:13:77:45 | Fields f = ... |
 | Fields.cs:78:23:78:54 | SSA def(a) | Fields.cs:78:23:78:54 | Action a = ... |
 | Fields.cs:78:27:78:54 | SSA capture def(f) | Fields.cs:78:27:78:54 | (...) => ... |
@@ -264,10 +262,10 @@
 | Properties.cs:49:17:49:32 | SSA call def(Properties.stat) | Properties.cs:49:17:49:32 | object creation of type Properties |
 | Properties.cs:51:9:51:24 | SSA call def(Properties.stat) | Properties.cs:51:9:51:24 | object creation of type Properties |
 | Properties.cs:61:17:61:17 | SSA entry def(this.LoopProp) | Properties.cs:61:17:61:17 | H |
+| Properties.cs:61:17:61:17 | SSA entry def(this.SingleAccessedProp) | Properties.cs:61:17:61:17 | H |
 | Properties.cs:61:23:61:23 | SSA param(i) | Properties.cs:61:23:61:23 | i |
 | Properties.cs:63:16:63:18 | SSA def(i) | Properties.cs:63:16:63:18 | ...-- |
-| Properties.cs:67:21:67:38 | SSA untracked def(this.SingleAccessedProp) | Properties.cs:67:21:67:38 | this access |
-| Properties.cs:72:20:72:37 | SSA untracked def(this.SingleAccessedProp) | Properties.cs:72:20:72:37 | this access |
+| Properties.cs:70:17:70:17 | SSA entry def(this.SingleAccessedProp) | Properties.cs:70:17:70:17 | I |
 | Properties.cs:73:13:73:32 | SSA def(f) | Properties.cs:73:13:73:32 | Properties f = ... |
 | Properties.cs:74:23:74:54 | SSA def(a) | Properties.cs:74:23:74:54 | Action a = ... |
 | Properties.cs:74:27:74:54 | SSA capture def(f) | Properties.cs:74:27:74:54 | (...) => ... |
@@ -281,11 +279,6 @@
 | Properties.cs:83:9:83:22 | SSA def(this.xs) | Properties.cs:83:9:83:22 | ... = ... |
 | Properties.cs:84:9:84:25 | SSA def(f.xs) | Properties.cs:84:9:84:25 | ... = ... |
 | Properties.cs:85:24:85:46 | SSA capture def(b) | Properties.cs:85:24:85:46 | (...) => ... |
-| Properties.cs:95:20:95:38 | SSA untracked def(this.NonTrivialProp) | Properties.cs:95:20:95:23 | this access |
-| Properties.cs:98:16:98:31 | SSA untracked def(this.VirtualProp) | Properties.cs:98:16:98:19 | this access |
-| Properties.cs:100:9:100:26 | SSA untracked def(this.VolatileField) | Properties.cs:100:9:100:12 | this access |
-| Properties.cs:101:21:101:38 | SSA untracked def(this.VolatileField) | Properties.cs:101:21:101:24 | this access |
-| Properties.cs:101:21:101:41 | SSA untracked def(this.VolatileField.xs) | Properties.cs:101:21:101:38 | access to field VolatileField |
 | Properties.cs:106:37:106:37 | SSA param(p) | Properties.cs:106:37:106:37 | p |
 | Properties.cs:108:10:108:10 | SSA entry def(this.Props) | Properties.cs:108:10:108:10 | K |
 | Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props) | Properties.cs:108:10:108:10 | K |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaDefElement.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaDefElement.expected
@@ -49,10 +49,12 @@
 | Capture.cs:94:13:94:18 | SSA def(y) | Capture.cs:94:13:94:18 | Int32 y = ... |
 | Capture.cs:96:12:100:9 | SSA capture def(y) | Capture.cs:96:12:100:9 | (...) => ... |
 | Capture.cs:98:17:98:21 | SSA def(x) | Capture.cs:98:17:98:21 | Int32 x = ... |
+| Capture.cs:102:13:102:18 | SSA def(z) | Capture.cs:102:13:102:18 | Int32 z = ... |
 | Capture.cs:105:13:105:17 | SSA def(z) | Capture.cs:105:13:105:17 | ... = ... |
 | Capture.cs:114:13:114:18 | SSA def(a) | Capture.cs:114:13:114:18 | Int32 a = ... |
 | Capture.cs:115:9:119:9 | SSA capture def(a) | Capture.cs:115:9:119:9 | M1 |
 | Capture.cs:117:17:117:21 | SSA def(x) | Capture.cs:117:17:117:21 | Int32 x = ... |
+| Capture.cs:122:13:122:18 | SSA def(b) | Capture.cs:122:13:122:18 | Int32 b = ... |
 | Capture.cs:125:13:125:17 | SSA def(b) | Capture.cs:125:13:125:17 | ... = ... |
 | Capture.cs:130:13:130:18 | SSA def(c) | Capture.cs:130:13:130:18 | Int32 c = ... |
 | Capture.cs:133:13:133:17 | SSA def(c) | Capture.cs:133:13:133:17 | ... = ... |
@@ -62,6 +64,7 @@
 | Capture.cs:144:9:144:12 | SSA call def(d) | Capture.cs:144:9:144:12 | call to local function M4 |
 | Capture.cs:148:9:152:9 | SSA capture def(e) | Capture.cs:148:9:152:9 | M5 |
 | Capture.cs:154:13:154:18 | SSA def(f) | Capture.cs:154:13:154:18 | Int32 f = ... |
+| Capture.cs:158:13:158:17 | SSA def(f) | Capture.cs:158:13:158:17 | ... = ... |
 | Capture.cs:163:9:166:9 | SSA capture def(g) | Capture.cs:163:9:166:9 | M7 |
 | Capture.cs:171:13:171:17 | SSA def(h) | Capture.cs:171:13:171:17 | ... = ... |
 | Capture.cs:174:17:174:21 | SSA def(h) | Capture.cs:174:17:174:21 | ... = ... |
@@ -206,8 +209,6 @@
 | Fields.cs:102:9:102:28 | SSA def(this.Field) | Fields.cs:102:9:102:28 | ... = ... |
 | Fields.cs:107:33:107:33 | SSA param(f) | Fields.cs:107:33:107:33 | f |
 | Fields.cs:109:10:109:10 | SSA entry def(this.Field) | Fields.cs:109:10:109:10 | K |
-| Fields.cs:109:10:109:10 | SSA entry def(this.Field.Field) | Fields.cs:109:10:109:10 | K |
-| Fields.cs:109:10:109:10 | SSA entry def(this.Field.Field.xs) | Fields.cs:109:10:109:10 | K |
 | Fields.cs:114:9:114:22 | SSA call def(this.Field) | Fields.cs:114:9:114:22 | call to method SetField |
 | Fields.cs:114:9:114:22 | SSA call def(this.Field.Field) | Fields.cs:114:9:114:22 | call to method SetField |
 | Fields.cs:114:9:114:22 | SSA qualifier def(this.Field.Field.xs) | Fields.cs:114:9:114:22 | call to method SetField |
@@ -281,8 +282,6 @@
 | Properties.cs:85:24:85:46 | SSA capture def(b) | Properties.cs:85:24:85:46 | (...) => ... |
 | Properties.cs:106:37:106:37 | SSA param(p) | Properties.cs:106:37:106:37 | p |
 | Properties.cs:108:10:108:10 | SSA entry def(this.Props) | Properties.cs:108:10:108:10 | K |
-| Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props) | Properties.cs:108:10:108:10 | K |
-| Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props.xs) | Properties.cs:108:10:108:10 | K |
 | Properties.cs:113:9:113:22 | SSA call def(this.Props) | Properties.cs:113:9:113:22 | call to method SetProps |
 | Properties.cs:113:9:113:22 | SSA call def(this.Props.Props) | Properties.cs:113:9:113:22 | call to method SetProps |
 | Properties.cs:113:9:113:22 | SSA qualifier def(this.Props.Props.xs) | Properties.cs:113:9:113:22 | call to method SetProps |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaDefLastRead.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaDefLastRead.expected
@@ -151,6 +151,8 @@
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:38:9:38:13 | SSA call def(Fields.stat) | Fields.cs:41:13:41:16 | access to field stat |
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:51:9:51:20 | SSA call def(Fields.stat) | Fields.cs:54:13:54:16 | access to field stat |
 | Fields.cs:65:24:65:32 | this.LoopField | Fields.cs:61:17:61:17 | SSA entry def(this.LoopField) | Fields.cs:65:24:65:32 | access to field LoopField |
+| Fields.cs:71:17:71:35 | this.SingleAccessedField | Fields.cs:61:17:61:17 | SSA entry def(this.SingleAccessedField) | Fields.cs:71:17:71:35 | access to field SingleAccessedField |
+| Fields.cs:76:20:76:38 | this.SingleAccessedField | Fields.cs:74:17:74:17 | SSA entry def(this.SingleAccessedField) | Fields.cs:76:20:76:38 | access to field SingleAccessedField |
 | Fields.cs:77:13:77:13 | f | Fields.cs:77:13:77:45 | SSA def(f) | Fields.cs:90:19:90:19 | access to local variable f |
 | Fields.cs:77:13:77:13 | f | Fields.cs:78:27:78:54 | SSA capture def(f) | Fields.cs:78:35:78:35 | access to local variable f |
 | Fields.cs:78:23:78:23 | a | Fields.cs:78:23:78:54 | SSA def(a) | Fields.cs:81:9:81:9 | access to local variable a |
@@ -219,6 +221,8 @@
 | Properties.cs:33:19:33:22 | Properties.stat | Properties.cs:51:9:51:24 | SSA call def(Properties.stat) | Properties.cs:54:13:54:16 | access to property stat |
 | Properties.cs:61:23:61:23 | i | Properties.cs:63:16:63:16 | SSA phi(i) | Properties.cs:63:16:63:16 | access to parameter i |
 | Properties.cs:65:24:65:31 | this.LoopProp | Properties.cs:61:17:61:17 | SSA entry def(this.LoopProp) | Properties.cs:65:24:65:31 | access to property LoopProp |
+| Properties.cs:67:21:67:38 | this.SingleAccessedProp | Properties.cs:61:17:61:17 | SSA entry def(this.SingleAccessedProp) | Properties.cs:67:21:67:38 | access to property SingleAccessedProp |
+| Properties.cs:72:20:72:37 | this.SingleAccessedProp | Properties.cs:70:17:70:17 | SSA entry def(this.SingleAccessedProp) | Properties.cs:72:20:72:37 | access to property SingleAccessedProp |
 | Properties.cs:73:13:73:13 | f | Properties.cs:73:13:73:32 | SSA def(f) | Properties.cs:86:19:86:19 | access to local variable f |
 | Properties.cs:73:13:73:13 | f | Properties.cs:74:27:74:54 | SSA capture def(f) | Properties.cs:74:35:74:35 | access to local variable f |
 | Properties.cs:74:23:74:23 | a | Properties.cs:74:23:74:54 | SSA def(a) | Properties.cs:77:9:77:9 | access to local variable a |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaExplicitDef.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaExplicitDef.expected
@@ -33,15 +33,18 @@
 | Capture.cs:92:18:92:18 | d | Capture.cs:92:18:92:18 | SSA param(d) | Capture.cs:92:18:92:18 | d |
 | Capture.cs:94:13:94:13 | y | Capture.cs:94:13:94:18 | SSA def(y) | Capture.cs:94:13:94:18 | Int32 y = ... |
 | Capture.cs:98:17:98:17 | x | Capture.cs:98:17:98:21 | SSA def(x) | Capture.cs:98:17:98:21 | Int32 x = ... |
+| Capture.cs:102:13:102:13 | z | Capture.cs:102:13:102:18 | SSA def(z) | Capture.cs:102:13:102:18 | Int32 z = ... |
 | Capture.cs:102:13:102:13 | z | Capture.cs:105:13:105:17 | SSA def(z) | Capture.cs:105:13:105:17 | ... = ... |
 | Capture.cs:114:13:114:13 | a | Capture.cs:114:13:114:18 | SSA def(a) | Capture.cs:114:13:114:18 | Int32 a = ... |
 | Capture.cs:117:17:117:17 | x | Capture.cs:117:17:117:21 | SSA def(x) | Capture.cs:117:17:117:21 | Int32 x = ... |
+| Capture.cs:122:13:122:13 | b | Capture.cs:122:13:122:18 | SSA def(b) | Capture.cs:122:13:122:18 | Int32 b = ... |
 | Capture.cs:122:13:122:13 | b | Capture.cs:125:13:125:17 | SSA def(b) | Capture.cs:125:13:125:17 | ... = ... |
 | Capture.cs:130:13:130:13 | c | Capture.cs:130:13:130:18 | SSA def(c) | Capture.cs:130:13:130:18 | Int32 c = ... |
 | Capture.cs:130:13:130:13 | c | Capture.cs:133:13:133:17 | SSA def(c) | Capture.cs:133:13:133:17 | ... = ... |
 | Capture.cs:139:13:139:13 | d | Capture.cs:139:13:139:18 | SSA def(d) | Capture.cs:139:13:139:18 | Int32 d = ... |
 | Capture.cs:139:13:139:13 | d | Capture.cs:142:13:142:17 | SSA def(d) | Capture.cs:142:13:142:17 | ... = ... |
 | Capture.cs:154:13:154:13 | f | Capture.cs:154:13:154:18 | SSA def(f) | Capture.cs:154:13:154:18 | Int32 f = ... |
+| Capture.cs:154:13:154:13 | f | Capture.cs:158:13:158:17 | SSA def(f) | Capture.cs:158:13:158:17 | ... = ... |
 | Capture.cs:168:13:168:13 | h | Capture.cs:171:13:171:17 | SSA def(h) | Capture.cs:171:13:171:17 | ... = ... |
 | Capture.cs:168:13:168:13 | h | Capture.cs:174:17:174:21 | SSA def(h) | Capture.cs:174:17:174:21 | ... = ... |
 | Capture.cs:182:17:182:17 | i | Capture.cs:182:17:182:21 | SSA def(i) | Capture.cs:182:17:182:21 | Int32 i = ... |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaImplicitQualifier.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaImplicitQualifier.expected
@@ -4,8 +4,12 @@
 | Fields.cs:98:20:98:32 | f.Field.Field | Fields.cs:97:9:97:30 | SSA qualifier def(f.Field.Field) | Fields.cs:97:9:97:30 | SSA def(f.Field) |
 | Fields.cs:99:16:99:34 | f.Field.Field.Field | Fields.cs:97:9:97:30 | SSA qualifier def(f.Field.Field.Field) | Fields.cs:97:9:97:30 | SSA qualifier def(f.Field.Field) |
 | Fields.cs:100:16:100:40 | f.Field.Field.Field.Field | Fields.cs:97:9:97:30 | SSA qualifier def(f.Field.Field.Field.Field) | Fields.cs:97:9:97:30 | SSA qualifier def(f.Field.Field.Field) |
+| Fields.cs:115:20:115:35 | this.Field.Field | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field) | Fields.cs:109:10:109:10 | SSA entry def(this.Field) |
+| Fields.cs:116:21:116:39 | this.Field.Field.xs | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field.xs) | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field) |
 | Fields.cs:116:21:116:39 | this.Field.Field.xs | Fields.cs:114:9:114:22 | SSA qualifier def(this.Field.Field.xs) | Fields.cs:114:9:114:22 | SSA call def(this.Field.Field) |
 | OutRef.cs:19:32:19:38 | t.Field | OutRef.cs:18:13:18:28 | SSA qualifier def(t.Field) | OutRef.cs:18:13:18:28 | SSA def(t) |
 | Properties.cs:31:19:31:22 | f.xs | Properties.cs:30:13:30:32 | SSA qualifier def(f.xs) | Properties.cs:30:13:30:32 | SSA def(f) |
 | Properties.cs:31:19:31:22 | f.xs | Properties.cs:49:13:49:32 | SSA qualifier def(f.xs) | Properties.cs:49:13:49:32 | SSA def(f) |
+| Properties.cs:114:20:114:35 | this.Props.Props | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props) | Properties.cs:108:10:108:10 | SSA entry def(this.Props) |
+| Properties.cs:115:21:115:39 | this.Props.Props.xs | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props.xs) | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props) |
 | Properties.cs:115:21:115:39 | this.Props.Props.xs | Properties.cs:113:9:113:22 | SSA qualifier def(this.Props.Props.xs) | Properties.cs:113:9:113:22 | SSA call def(this.Props.Props) |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaRead.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaRead.expected
@@ -185,11 +185,9 @@
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:34:9:34:16 | SSA call def(Fields.stat) | Fields.cs:37:13:37:16 | access to field stat |
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:38:9:38:13 | SSA call def(Fields.stat) | Fields.cs:41:13:41:16 | access to field stat |
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:51:9:51:20 | SSA call def(Fields.stat) | Fields.cs:54:13:54:16 | access to field stat |
-| Fields.cs:63:16:63:28 | this.VolatileField | Fields.cs:63:16:63:28 | SSA untracked def(this.VolatileField) | Fields.cs:63:16:63:28 | access to field VolatileField |
-| Fields.cs:63:16:63:28 | this.VolatileField | Fields.cs:69:21:69:33 | SSA untracked def(this.VolatileField) | Fields.cs:69:21:69:33 | access to field VolatileField |
 | Fields.cs:65:24:65:32 | this.LoopField | Fields.cs:61:17:61:17 | SSA entry def(this.LoopField) | Fields.cs:65:24:65:32 | access to field LoopField |
-| Fields.cs:71:17:71:35 | this.SingleAccessedField | Fields.cs:71:17:71:35 | SSA untracked def(this.SingleAccessedField) | Fields.cs:71:17:71:35 | access to field SingleAccessedField |
-| Fields.cs:76:20:76:38 | this.SingleAccessedField | Fields.cs:76:20:76:38 | SSA untracked def(this.SingleAccessedField) | Fields.cs:76:20:76:38 | access to field SingleAccessedField |
+| Fields.cs:71:17:71:35 | this.SingleAccessedField | Fields.cs:61:17:61:17 | SSA entry def(this.SingleAccessedField) | Fields.cs:71:17:71:35 | access to field SingleAccessedField |
+| Fields.cs:76:20:76:38 | this.SingleAccessedField | Fields.cs:74:17:74:17 | SSA entry def(this.SingleAccessedField) | Fields.cs:76:20:76:38 | access to field SingleAccessedField |
 | Fields.cs:77:13:77:13 | f | Fields.cs:77:13:77:45 | SSA def(f) | Fields.cs:80:9:80:9 | access to local variable f |
 | Fields.cs:77:13:77:13 | f | Fields.cs:77:13:77:45 | SSA def(f) | Fields.cs:82:19:82:19 | access to local variable f |
 | Fields.cs:77:13:77:13 | f | Fields.cs:77:13:77:45 | SSA def(f) | Fields.cs:83:9:83:9 | access to local variable f |
@@ -302,8 +300,8 @@
 | Properties.cs:33:19:33:22 | Properties.stat | Properties.cs:51:9:51:24 | SSA call def(Properties.stat) | Properties.cs:54:13:54:16 | access to property stat |
 | Properties.cs:61:23:61:23 | i | Properties.cs:63:16:63:16 | SSA phi(i) | Properties.cs:63:16:63:16 | access to parameter i |
 | Properties.cs:65:24:65:31 | this.LoopProp | Properties.cs:61:17:61:17 | SSA entry def(this.LoopProp) | Properties.cs:65:24:65:31 | access to property LoopProp |
-| Properties.cs:67:21:67:38 | this.SingleAccessedProp | Properties.cs:67:21:67:38 | SSA untracked def(this.SingleAccessedProp) | Properties.cs:67:21:67:38 | access to property SingleAccessedProp |
-| Properties.cs:72:20:72:37 | this.SingleAccessedProp | Properties.cs:72:20:72:37 | SSA untracked def(this.SingleAccessedProp) | Properties.cs:72:20:72:37 | access to property SingleAccessedProp |
+| Properties.cs:67:21:67:38 | this.SingleAccessedProp | Properties.cs:61:17:61:17 | SSA entry def(this.SingleAccessedProp) | Properties.cs:67:21:67:38 | access to property SingleAccessedProp |
+| Properties.cs:72:20:72:37 | this.SingleAccessedProp | Properties.cs:70:17:70:17 | SSA entry def(this.SingleAccessedProp) | Properties.cs:72:20:72:37 | access to property SingleAccessedProp |
 | Properties.cs:73:13:73:13 | f | Properties.cs:73:13:73:32 | SSA def(f) | Properties.cs:76:9:76:9 | access to local variable f |
 | Properties.cs:73:13:73:13 | f | Properties.cs:73:13:73:32 | SSA def(f) | Properties.cs:78:19:78:19 | access to local variable f |
 | Properties.cs:73:13:73:13 | f | Properties.cs:73:13:73:32 | SSA def(f) | Properties.cs:79:9:79:9 | access to local variable f |
@@ -322,11 +320,6 @@
 | Properties.cs:76:9:76:12 | f.xs | Properties.cs:84:9:84:25 | SSA def(f.xs) | Properties.cs:86:19:86:22 | access to property xs |
 | Properties.cs:78:9:78:15 | this.xs | Properties.cs:81:9:81:22 | SSA def(this.xs) | Properties.cs:82:9:82:15 | access to property xs |
 | Properties.cs:78:9:78:15 | this.xs | Properties.cs:83:9:83:22 | SSA def(this.xs) | Properties.cs:85:9:85:15 | access to property xs |
-| Properties.cs:94:9:94:27 | this.NonTrivialProp | Properties.cs:95:20:95:38 | SSA untracked def(this.NonTrivialProp) | Properties.cs:95:20:95:38 | access to property NonTrivialProp |
-| Properties.cs:97:9:97:24 | this.VirtualProp | Properties.cs:98:16:98:31 | SSA untracked def(this.VirtualProp) | Properties.cs:98:16:98:31 | access to property VirtualProp |
-| Properties.cs:100:9:100:26 | this.VolatileField | Properties.cs:100:9:100:26 | SSA untracked def(this.VolatileField) | Properties.cs:100:9:100:26 | access to field VolatileField |
-| Properties.cs:100:9:100:26 | this.VolatileField | Properties.cs:101:21:101:38 | SSA untracked def(this.VolatileField) | Properties.cs:101:21:101:38 | access to field VolatileField |
-| Properties.cs:100:9:100:29 | this.VolatileField.xs | Properties.cs:101:21:101:41 | SSA untracked def(this.VolatileField.xs) | Properties.cs:101:21:101:41 | access to property xs |
 | Properties.cs:106:37:106:37 | p | Properties.cs:106:37:106:37 | SSA param(p) | Properties.cs:106:42:106:42 | access to parameter p |
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props) | Properties.cs:114:20:114:29 | access to field Props |
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props) | Properties.cs:115:21:115:30 | access to field Props |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaUltimateDef.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaUltimateDef.expected
@@ -56,10 +56,12 @@
 | Capture.cs:94:13:94:13 | y | Capture.cs:94:13:94:18 | SSA def(y) | Capture.cs:94:13:94:18 | SSA def(y) |
 | Capture.cs:94:13:94:13 | y | Capture.cs:96:12:100:9 | SSA capture def(y) | Capture.cs:96:12:100:9 | SSA capture def(y) |
 | Capture.cs:98:17:98:17 | x | Capture.cs:98:17:98:21 | SSA def(x) | Capture.cs:98:17:98:21 | SSA def(x) |
+| Capture.cs:102:13:102:13 | z | Capture.cs:102:13:102:18 | SSA def(z) | Capture.cs:102:13:102:18 | SSA def(z) |
 | Capture.cs:102:13:102:13 | z | Capture.cs:105:13:105:17 | SSA def(z) | Capture.cs:105:13:105:17 | SSA def(z) |
 | Capture.cs:114:13:114:13 | a | Capture.cs:114:13:114:18 | SSA def(a) | Capture.cs:114:13:114:18 | SSA def(a) |
 | Capture.cs:114:13:114:13 | a | Capture.cs:115:9:119:9 | SSA capture def(a) | Capture.cs:115:9:119:9 | SSA capture def(a) |
 | Capture.cs:117:17:117:17 | x | Capture.cs:117:17:117:21 | SSA def(x) | Capture.cs:117:17:117:21 | SSA def(x) |
+| Capture.cs:122:13:122:13 | b | Capture.cs:122:13:122:18 | SSA def(b) | Capture.cs:122:13:122:18 | SSA def(b) |
 | Capture.cs:122:13:122:13 | b | Capture.cs:125:13:125:17 | SSA def(b) | Capture.cs:125:13:125:17 | SSA def(b) |
 | Capture.cs:130:13:130:13 | c | Capture.cs:130:13:130:18 | SSA def(c) | Capture.cs:130:13:130:18 | SSA def(c) |
 | Capture.cs:130:13:130:13 | c | Capture.cs:133:13:133:17 | SSA def(c) | Capture.cs:133:13:133:17 | SSA def(c) |
@@ -71,6 +73,7 @@
 | Capture.cs:139:13:139:13 | d | Capture.cs:144:9:144:12 | SSA call def(d) | Capture.cs:144:9:144:12 | SSA call def(d) |
 | Capture.cs:147:13:147:13 | e | Capture.cs:148:9:152:9 | SSA capture def(e) | Capture.cs:148:9:152:9 | SSA capture def(e) |
 | Capture.cs:154:13:154:13 | f | Capture.cs:154:13:154:18 | SSA def(f) | Capture.cs:154:13:154:18 | SSA def(f) |
+| Capture.cs:154:13:154:13 | f | Capture.cs:158:13:158:17 | SSA def(f) | Capture.cs:158:13:158:17 | SSA def(f) |
 | Capture.cs:162:13:162:13 | g | Capture.cs:163:9:166:9 | SSA capture def(g) | Capture.cs:163:9:166:9 | SSA capture def(g) |
 | Capture.cs:168:13:168:13 | h | Capture.cs:171:13:171:17 | SSA def(h) | Capture.cs:171:13:171:17 | SSA def(h) |
 | Capture.cs:168:13:168:13 | h | Capture.cs:174:17:174:21 | SSA def(h) | Capture.cs:174:17:174:21 | SSA def(h) |
@@ -275,11 +278,11 @@
 | Fields.cs:115:20:115:29 | this.Field | Fields.cs:109:10:109:10 | SSA entry def(this.Field) | Fields.cs:109:10:109:10 | SSA entry def(this.Field) |
 | Fields.cs:115:20:115:29 | this.Field | Fields.cs:114:9:114:22 | SSA call def(this.Field) | Fields.cs:109:10:109:10 | SSA entry def(this.Field) |
 | Fields.cs:115:20:115:29 | this.Field | Fields.cs:114:9:114:22 | SSA call def(this.Field) | Fields.cs:114:9:114:22 | SSA call def(this.Field) |
-| Fields.cs:115:20:115:35 | this.Field.Field | Fields.cs:109:10:109:10 | SSA entry def(this.Field.Field) | Fields.cs:109:10:109:10 | SSA entry def(this.Field.Field) |
-| Fields.cs:115:20:115:35 | this.Field.Field | Fields.cs:114:9:114:22 | SSA call def(this.Field.Field) | Fields.cs:109:10:109:10 | SSA entry def(this.Field.Field) |
+| Fields.cs:115:20:115:35 | this.Field.Field | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field) | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field) |
+| Fields.cs:115:20:115:35 | this.Field.Field | Fields.cs:114:9:114:22 | SSA call def(this.Field.Field) | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field) |
 | Fields.cs:115:20:115:35 | this.Field.Field | Fields.cs:114:9:114:22 | SSA call def(this.Field.Field) | Fields.cs:114:9:114:22 | SSA call def(this.Field.Field) |
-| Fields.cs:116:21:116:39 | this.Field.Field.xs | Fields.cs:109:10:109:10 | SSA entry def(this.Field.Field.xs) | Fields.cs:109:10:109:10 | SSA entry def(this.Field.Field.xs) |
-| Fields.cs:116:21:116:39 | this.Field.Field.xs | Fields.cs:114:9:114:22 | SSA qualifier def(this.Field.Field.xs) | Fields.cs:109:10:109:10 | SSA entry def(this.Field.Field.xs) |
+| Fields.cs:116:21:116:39 | this.Field.Field.xs | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field.xs) | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field.xs) |
+| Fields.cs:116:21:116:39 | this.Field.Field.xs | Fields.cs:114:9:114:22 | SSA qualifier def(this.Field.Field.xs) | Fields.cs:109:10:109:10 | SSA qualifier def(this.Field.Field.xs) |
 | Fields.cs:116:21:116:39 | this.Field.Field.xs | Fields.cs:114:9:114:22 | SSA qualifier def(this.Field.Field.xs) | Fields.cs:114:9:114:22 | SSA qualifier def(this.Field.Field.xs) |
 | OutRef.cs:9:13:9:13 | j | OutRef.cs:9:13:9:17 | SSA def(j) | OutRef.cs:9:13:9:17 | SSA def(j) |
 | OutRef.cs:9:13:9:13 | j | OutRef.cs:10:32:10:32 | SSA def(j) | OutRef.cs:10:32:10:32 | SSA def(j) |
@@ -396,11 +399,11 @@
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:108:10:108:10 | SSA entry def(this.Props) | Properties.cs:108:10:108:10 | SSA entry def(this.Props) |
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props) | Properties.cs:108:10:108:10 | SSA entry def(this.Props) |
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props) | Properties.cs:113:9:113:22 | SSA call def(this.Props) |
-| Properties.cs:114:20:114:35 | this.Props.Props | Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props) | Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props) |
-| Properties.cs:114:20:114:35 | this.Props.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props.Props) | Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props) |
+| Properties.cs:114:20:114:35 | this.Props.Props | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props) | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props) |
+| Properties.cs:114:20:114:35 | this.Props.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props.Props) | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props) |
 | Properties.cs:114:20:114:35 | this.Props.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props.Props) | Properties.cs:113:9:113:22 | SSA call def(this.Props.Props) |
-| Properties.cs:115:21:115:39 | this.Props.Props.xs | Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props.xs) | Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props.xs) |
-| Properties.cs:115:21:115:39 | this.Props.Props.xs | Properties.cs:113:9:113:22 | SSA qualifier def(this.Props.Props.xs) | Properties.cs:108:10:108:10 | SSA entry def(this.Props.Props.xs) |
+| Properties.cs:115:21:115:39 | this.Props.Props.xs | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props.xs) | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props.xs) |
+| Properties.cs:115:21:115:39 | this.Props.Props.xs | Properties.cs:113:9:113:22 | SSA qualifier def(this.Props.Props.xs) | Properties.cs:108:10:108:10 | SSA qualifier def(this.Props.Props.xs) |
 | Properties.cs:115:21:115:39 | this.Props.Props.xs | Properties.cs:113:9:113:22 | SSA qualifier def(this.Props.Props.xs) | Properties.cs:113:9:113:22 | SSA qualifier def(this.Props.Props.xs) |
 | Splitting.cs:3:18:3:18 | b | Splitting.cs:3:18:3:18 | SSA param(b) | Splitting.cs:3:18:3:18 | SSA param(b) |
 | Splitting.cs:5:13:5:13 | x | Splitting.cs:7:13:7:19 | [b (line 3): true] SSA def(x) | Splitting.cs:7:13:7:19 | [b (line 3): true] SSA def(x) |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaUltimateDef.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaUltimateDef.expected
@@ -247,11 +247,9 @@
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:51:9:51:20 | SSA call def(Fields.stat) | Fields.cs:38:9:38:13 | SSA call def(Fields.stat) |
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:51:9:51:20 | SSA call def(Fields.stat) | Fields.cs:49:17:49:28 | SSA call def(Fields.stat) |
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:51:9:51:20 | SSA call def(Fields.stat) | Fields.cs:51:9:51:20 | SSA call def(Fields.stat) |
-| Fields.cs:63:16:63:28 | this.VolatileField | Fields.cs:63:16:63:28 | SSA untracked def(this.VolatileField) | Fields.cs:63:16:63:28 | SSA untracked def(this.VolatileField) |
-| Fields.cs:63:16:63:28 | this.VolatileField | Fields.cs:69:21:69:33 | SSA untracked def(this.VolatileField) | Fields.cs:69:21:69:33 | SSA untracked def(this.VolatileField) |
 | Fields.cs:65:24:65:32 | this.LoopField | Fields.cs:61:17:61:17 | SSA entry def(this.LoopField) | Fields.cs:61:17:61:17 | SSA entry def(this.LoopField) |
-| Fields.cs:71:17:71:35 | this.SingleAccessedField | Fields.cs:71:17:71:35 | SSA untracked def(this.SingleAccessedField) | Fields.cs:71:17:71:35 | SSA untracked def(this.SingleAccessedField) |
-| Fields.cs:76:20:76:38 | this.SingleAccessedField | Fields.cs:76:20:76:38 | SSA untracked def(this.SingleAccessedField) | Fields.cs:76:20:76:38 | SSA untracked def(this.SingleAccessedField) |
+| Fields.cs:71:17:71:35 | this.SingleAccessedField | Fields.cs:61:17:61:17 | SSA entry def(this.SingleAccessedField) | Fields.cs:61:17:61:17 | SSA entry def(this.SingleAccessedField) |
+| Fields.cs:76:20:76:38 | this.SingleAccessedField | Fields.cs:74:17:74:17 | SSA entry def(this.SingleAccessedField) | Fields.cs:74:17:74:17 | SSA entry def(this.SingleAccessedField) |
 | Fields.cs:77:13:77:13 | f | Fields.cs:77:13:77:45 | SSA def(f) | Fields.cs:77:13:77:45 | SSA def(f) |
 | Fields.cs:77:13:77:13 | f | Fields.cs:78:27:78:54 | SSA capture def(f) | Fields.cs:78:27:78:54 | SSA capture def(f) |
 | Fields.cs:78:23:78:23 | a | Fields.cs:78:23:78:54 | SSA def(a) | Fields.cs:78:23:78:54 | SSA def(a) |
@@ -377,8 +375,8 @@
 | Properties.cs:61:23:61:23 | i | Properties.cs:63:16:63:16 | SSA phi(i) | Properties.cs:63:16:63:18 | SSA def(i) |
 | Properties.cs:61:23:61:23 | i | Properties.cs:63:16:63:18 | SSA def(i) | Properties.cs:63:16:63:18 | SSA def(i) |
 | Properties.cs:65:24:65:31 | this.LoopProp | Properties.cs:61:17:61:17 | SSA entry def(this.LoopProp) | Properties.cs:61:17:61:17 | SSA entry def(this.LoopProp) |
-| Properties.cs:67:21:67:38 | this.SingleAccessedProp | Properties.cs:67:21:67:38 | SSA untracked def(this.SingleAccessedProp) | Properties.cs:67:21:67:38 | SSA untracked def(this.SingleAccessedProp) |
-| Properties.cs:72:20:72:37 | this.SingleAccessedProp | Properties.cs:72:20:72:37 | SSA untracked def(this.SingleAccessedProp) | Properties.cs:72:20:72:37 | SSA untracked def(this.SingleAccessedProp) |
+| Properties.cs:67:21:67:38 | this.SingleAccessedProp | Properties.cs:61:17:61:17 | SSA entry def(this.SingleAccessedProp) | Properties.cs:61:17:61:17 | SSA entry def(this.SingleAccessedProp) |
+| Properties.cs:72:20:72:37 | this.SingleAccessedProp | Properties.cs:70:17:70:17 | SSA entry def(this.SingleAccessedProp) | Properties.cs:70:17:70:17 | SSA entry def(this.SingleAccessedProp) |
 | Properties.cs:73:13:73:13 | f | Properties.cs:73:13:73:32 | SSA def(f) | Properties.cs:73:13:73:32 | SSA def(f) |
 | Properties.cs:73:13:73:13 | f | Properties.cs:74:27:74:54 | SSA capture def(f) | Properties.cs:74:27:74:54 | SSA capture def(f) |
 | Properties.cs:74:23:74:23 | a | Properties.cs:74:23:74:54 | SSA def(a) | Properties.cs:74:23:74:54 | SSA def(a) |
@@ -394,11 +392,6 @@
 | Properties.cs:76:9:76:12 | f.xs | Properties.cs:84:9:84:25 | SSA def(f.xs) | Properties.cs:84:9:84:25 | SSA def(f.xs) |
 | Properties.cs:78:9:78:15 | this.xs | Properties.cs:81:9:81:22 | SSA def(this.xs) | Properties.cs:81:9:81:22 | SSA def(this.xs) |
 | Properties.cs:78:9:78:15 | this.xs | Properties.cs:83:9:83:22 | SSA def(this.xs) | Properties.cs:83:9:83:22 | SSA def(this.xs) |
-| Properties.cs:94:9:94:27 | this.NonTrivialProp | Properties.cs:95:20:95:38 | SSA untracked def(this.NonTrivialProp) | Properties.cs:95:20:95:38 | SSA untracked def(this.NonTrivialProp) |
-| Properties.cs:97:9:97:24 | this.VirtualProp | Properties.cs:98:16:98:31 | SSA untracked def(this.VirtualProp) | Properties.cs:98:16:98:31 | SSA untracked def(this.VirtualProp) |
-| Properties.cs:100:9:100:26 | this.VolatileField | Properties.cs:100:9:100:26 | SSA untracked def(this.VolatileField) | Properties.cs:100:9:100:26 | SSA untracked def(this.VolatileField) |
-| Properties.cs:100:9:100:26 | this.VolatileField | Properties.cs:101:21:101:38 | SSA untracked def(this.VolatileField) | Properties.cs:101:21:101:38 | SSA untracked def(this.VolatileField) |
-| Properties.cs:100:9:100:29 | this.VolatileField.xs | Properties.cs:101:21:101:41 | SSA untracked def(this.VolatileField.xs) | Properties.cs:101:21:101:41 | SSA untracked def(this.VolatileField.xs) |
 | Properties.cs:106:37:106:37 | p | Properties.cs:106:37:106:37 | SSA param(p) | Properties.cs:106:37:106:37 | SSA param(p) |
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:108:10:108:10 | SSA entry def(this.Props) | Properties.cs:108:10:108:10 | SSA entry def(this.Props) |
 | Properties.cs:114:20:114:29 | this.Props | Properties.cs:113:9:113:22 | SSA call def(this.Props) | Properties.cs:108:10:108:10 | SSA entry def(this.Props) |

--- a/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.cs
+++ b/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.cs
@@ -194,7 +194,7 @@ public class Captured
 
     void M2()
     {
-        var x = M6(); // BAD
+        var x = M6(); // BAD [FALSE NEGATIVE]
         Action a = () =>
         {
             x = 1; // GOOD
@@ -208,7 +208,7 @@ public class Captured
         int x;
         Action a = () =>
         {
-            x = 1; // BAD
+            x = 1; // BAD [FALSE NEGATIVE]
         };
         a();
     }

--- a/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -7,8 +7,6 @@
 | DeadStoreOfLocal.cs:101:13:101:37 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:94:40:94:44 | extra | extra |
 | DeadStoreOfLocal.cs:104:13:104:37 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:94:16:94:20 | info1 | info1 |
 | DeadStoreOfLocal.cs:142:26:142:27 | Exception ex | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:142:26:142:27 | ex | ex |
-| DeadStoreOfLocal.cs:197:13:197:20 | Int32 x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:197:13:197:13 | x | x |
-| DeadStoreOfLocal.cs:211:13:211:17 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:208:13:208:13 | x | x |
 | DeadStoreOfLocal.cs:246:17:246:24 | Int32 y = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:246:17:246:17 | y | y |
 | DeadStoreOfLocal.cs:261:17:261:21 | Int32 x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:261:17:261:17 | x | x |
 | DeadStoreOfLocal.cs:289:23:289:28 | Object v1 | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:289:27:289:28 | v1 | v1 |


### PR DESCRIPTION
SSA refactorings in preparation for a shared SSA library implementation.

The first commit removes the class `ImplicitUntrackedDefinition`, which was used to generate SSA definitions for variables not amenable to SSA analysis. The class was never actually used.

The second commit unifies how SSA definitions are constructed, by collapsing the existing `TSsaExplicitDef`, `TSsaImplicitEntryDef`, `TSsaImplicitCallDef`, and `TSsaImplicitQualifierDef` IPA injectors into a single `TWriteDef` injector. This has the benefit that only `variableWrite()` is used to construct SSA definitions (a predicate similar to that will be part of the API for a shared implementation), and a common liveness analysis is applied in all cases (though in [some corner cases](https://github.com/github/codeql/pull/4923/files?file-filters%5B%5D=.cs#diff-137c00ebb76cb00f5d90ed4d749edfdd6df981b3d6972a24c81a8acd46c34152R102) this is less precise).

Liveness of writes to captured variables, where reads happen inside capturing callables, is ensured by adding a new (pseudo) read of kind `CapturedVarCallRead` at calls that may reach a read. This means that the common liveness analysis can be applied here as well. For example, in
```csharp
int M()
{
   var captured = 0;
   int Inner() => captured + 1;
   return Inner();
}
```
a pseudo read of `captured` is added at the call to `Inner`, which makes the write `captured = 0` live.

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/751/