### PR TITLE
Java: Query to detect weak encryption: insufficient key size

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.java
@@ -1,0 +1,37 @@
+public class InsufficientKeySize {
+    public void CryptoMethod() {
+        KeyGenerator keyGen1 = KeyGenerator.getInstance("AES");
+        // BAD: Key size is less than 128
+        keyGen1.init(64);
+
+        KeyGenerator keyGen2 = KeyGenerator.getInstance("AES");
+        // GOOD: Key size is no less than 128
+        keyGen2.init(128);
+
+        KeyPairGenerator keyPairGen1 = KeyPairGenerator.getInstance("RSA");
+        // BAD: Key size is less than 2048
+        keyPairGen1.initialize(1024);
+
+        KeyPairGenerator keyPairGen2 = KeyPairGenerator.getInstance("RSA");
+        // GOOD: Key size is no less than 2048
+        keyPairGen2.initialize(2048);
+
+        KeyPairGenerator keyPairGen3 = KeyPairGenerator.getInstance("DSA");
+        // BAD: Key size is less than 2048
+        keyPairGen3.initialize(1024);
+
+        KeyPairGenerator keyPairGen4 = KeyPairGenerator.getInstance("DSA");
+        // GOOD: Key size is no less than 2048
+        keyPairGen4.initialize(2048);
+
+        KeyPairGenerator keyPairGen5 = KeyPairGenerator.getInstance("EC");
+        // BAD: Key size is less than 224
+        ECGenParameterSpec ecSpec1 = new ECGenParameterSpec("secp112r1");
+        keyPairGen5.initialize(ecSpec1);
+
+        KeyPairGenerator keyPairGen6 = KeyPairGenerator.getInstance("EC");
+        // GOOD: Key size is no less than 224
+        ECGenParameterSpec ecSpec2 = new ECGenParameterSpec("secp256r1");
+        keyPairGen6.initialize(ecSpec2);
+    }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.java
@@ -25,12 +25,12 @@ public class InsufficientKeySize {
         keyPairGen4.initialize(2048);
 
         KeyPairGenerator keyPairGen5 = KeyPairGenerator.getInstance("EC");
-        // BAD: Key size is less than 224
+        // BAD: Key size is less than 256
         ECGenParameterSpec ecSpec1 = new ECGenParameterSpec("secp112r1");
         keyPairGen5.initialize(ecSpec1);
 
         KeyPairGenerator keyPairGen6 = KeyPairGenerator.getInstance("EC");
-        // GOOD: Key size is no less than 224
+        // GOOD: Key size is no less than 256
         ECGenParameterSpec ecSpec2 = new ECGenParameterSpec("secp256r1");
         keyPairGen6.initialize(ecSpec2);
     }

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.qhelp
@@ -6,7 +6,7 @@ are vulnerable to brute force attack when too small a key size is used.</p>
     </overview>
 
     <recommendation>
-        <p>The key should be at least 2048 bits long when using RSA and DSA encryption, 224 bits long when using EC encryption, and 128 bits long when using 
+        <p>The key should be at least 2048 bits long when using RSA and DSA encryption, 256 bits long when using EC encryption, and 128 bits long when using 
 symmetric encryption.</p>
     </recommendation>
     

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.qhelp
@@ -6,7 +6,7 @@ are vulnerable to brute force attack when too small a key size is used.</p>
     </overview>
 
     <recommendation>
-        <p>The key should be at least 2048-bit long when using RSA and DSA encryption, 224-bit long when using EC encryption, and 128-bit long when using 
+        <p>The key should be at least 2048 bits long when using RSA and DSA encryption, 224 bits long when using EC encryption, and 128 bits long when using 
 symmetric encryption.</p>
     </recommendation>
     
@@ -23,10 +23,6 @@ symmetric encryption.</p>
         <li>
             CWE.
             <a href="https://cwe.mitre.org/data/definitions/326.html">CWE-326: Inadequate Encryption Strength</a>
-        </li>
-        <li>
-            C# implementation of CodeQL
-            <a href="https://github.com/github/codeql/blob/df29a1636555465527d17668c19c202e365cf502/csharp/ql/src/Security%20Features/InsufficientKeySize.ql">codeql/csharp/ql/src/Security Features/InsufficientKeySize.ql</a>
         </li>
  
     </references>

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.qhelp
@@ -1,0 +1,33 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+    <overview>
+        <p>This rule finds uses of encryption algorithms with too small a key size. Encryption algorithms 
+are vulnerable to brute force attack when too small a key size is used.</p>
+    </overview>
+
+    <recommendation>
+        <p>The key should be at least 2048-bit long when using RSA and DSA encryption, 224-bit long when using EC encryption, and 128-bit long when using 
+symmetric encryption.</p>
+    </recommendation>
+    
+    <references>
+
+        <li>
+            Wikipedia.
+            <a href="http://en.wikipedia.org/wiki/Key_size">Key size</a>
+        </li>
+        <li>
+            SonarSource.
+            <a href="https://rules.sonarsource.com/java/type/Vulnerability/RSPEC-4426">Cryptographic keys should be robust</a>
+        </li>
+        <li>
+            CWE.
+            <a href="https://cwe.mitre.org/data/definitions/326.html">CWE-326: Inadequate Encryption Strength</a>
+        </li>
+        <li>
+            C# implementation of CodeQL
+            <a href="https://github.com/github/codeql/blob/df29a1636555465527d17668c19c202e365cf502/csharp/ql/src/Security%20Features/InsufficientKeySize.ql">codeql/csharp/ql/src/Security Features/InsufficientKeySize.ql</a>
+        </li>
+ 
+    </references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
@@ -74,7 +74,7 @@ class KeyPairGeneratorInitConfiguration extends TaintTracking::Configuration {
   }
 }
 
-/** Holds if a symmetric `KeyGenerator` is initialized with an insufficient key size. */
+/** Holds if a symmetric `KeyGenerator` implementing encryption algorithm `type` and initialized by `ma` uses an insufficient key size. `msg` provides a human-readable description of the problem. */
 bindingset[type]
 predicate hasShortSymmetricKey(MethodAccess ma, string msg, string type) {
   ma.getMethod() instanceof KeyGeneratorInitMethod and
@@ -91,10 +91,10 @@ predicate hasShortSymmetricKey(MethodAccess ma, string msg, string type) {
   msg = "Key size should be at least 128 bits for " + type + " encryption."
 }
 
-/** Holds if an AES `KeyGenerator` is initialized with an insufficient key size. */
+/** Holds if an AES `KeyGenerator` initialized by `ma` uses an insufficient key size. `msg` provides a human-readable description of the problem. */
 predicate hasShortAESKey(MethodAccess ma, string msg) { hasShortSymmetricKey(ma, msg, "AES") }
 
-/** Holds if an asymmetric `KeyPairGenerator` is initialized with an insufficient key size. */
+/** Holds if an asymmetric `KeyPairGenerator` implementing encryption algorithm `type` and initialized by `ma` uses an insufficient key size. `msg` provides a human-readable description of the problem. */
 bindingset[type]
 predicate hasShortAsymmetricKeyPair(MethodAccess ma, string msg, string type) {
   ma.getMethod() instanceof KeyPairGeneratorInitMethod and
@@ -111,24 +111,24 @@ predicate hasShortAsymmetricKeyPair(MethodAccess ma, string msg, string type) {
   msg = "Key size should be at least 2048 bits for " + type + " encryption."
 }
 
-/** Holds if a DSA `KeyPairGenerator` is initialized with an insufficient key size. */
+/** Holds if a DSA `KeyPairGenerator` initialized by `ma` uses an insufficient key size. `msg` provides a human-readable description of the problem. */
 predicate hasShortDSAKeyPair(MethodAccess ma, string msg) {
   hasShortAsymmetricKeyPair(ma, msg, "DSA")
 }
 
-/** Holds if a RSA `KeyPairGenerator` is initialized with an insufficient key size. */
+/** Holds if a RSA `KeyPairGenerator` initialized by `ma` uses an insufficient key size. `msg` provides a human-readable description of the problem. */
 predicate hasShortRSAKeyPair(MethodAccess ma, string msg) {
   hasShortAsymmetricKeyPair(ma, msg, "RSA")
 }
 
-/** Holds if an EC `KeyPairGenerator` is initialized with an insufficient key size. */
+/** Holds if an EC `KeyPairGenerator` initialized by `ma` uses an insufficient key size. `msg` provides a human-readable description of the problem. */
 predicate hasShortECKeyPair(MethodAccess ma, string msg) {
   ma.getMethod() instanceof KeyPairGeneratorInitMethod and
   exists(
     JavaSecurityKeyPairGenerator jpg, KeyPairGeneratorInitConfiguration kc,
     DataFlow::PathNode source, DataFlow::PathNode dest, ClassInstanceExpr cie
   |
-    jpg.getAlgoSpec().(StringLiteral).getValue().matches("EC%") and //ECC variants such as ECDH and ECDSA
+    jpg.getAlgoSpec().(StringLiteral).getValue().matches("EC%") and // ECC variants such as ECDH and ECDSA
     source.getNode().asExpr() = jpg and
     dest.getNode().asExpr() = ma.getQualifier() and
     kc.hasFlowPath(source, dest) and

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
@@ -1,0 +1,155 @@
+/**
+ * @name Weak encryption: Insufficient key size
+ * @description Finds uses of encryption algorithms with too small a key size
+ * @kind problem
+ * @id java/insufficient-key-size
+ * @tags security
+ *       external/cwe/cwe-326
+ */
+
+import java
+import semmle.code.java.security.Encryption
+import semmle.code.java.dataflow.TaintTracking
+
+/** The Java class `javax.crypto.KeyGenerator`. */
+class KeyGenerator extends RefType {
+  KeyGenerator() { this.hasQualifiedName("javax.crypto", "KeyGenerator") }
+}
+
+/** The Java class `javax.crypto.KeyGenerator`. */
+class KeyPairGenerator extends RefType {
+  KeyPairGenerator() { this.hasQualifiedName("java.security", "KeyPairGenerator") }
+}
+
+/** The Java class `java.security.spec.ECGenParameterSpec`. */
+class ECGenParameterSpec extends RefType {
+  ECGenParameterSpec() { this.hasQualifiedName("java.security.spec", "ECGenParameterSpec") }
+}
+
+/** The `init` method declared in `javax.crypto.KeyGenerator`. */
+class KeyGeneratorInitMethod extends Method {
+  KeyGeneratorInitMethod() {
+    getDeclaringType() instanceof KeyGenerator and
+    hasName("init")
+  }
+}
+
+/** The `initialize` method declared in `java.security.KeyPairGenerator`. */
+class KeyPairGeneratorInitMethod extends Method {
+  KeyPairGeneratorInitMethod() {
+    getDeclaringType() instanceof KeyPairGenerator and
+    hasName("initialize")
+  }
+}
+
+/** Taint configuration tracking flow from a key generator to a `init` method call. */
+class CryptoKeyGeneratorConfiguration extends TaintTracking::Configuration {
+  CryptoKeyGeneratorConfiguration() { this = "CryptoKeyGeneratorConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) {
+    exists(JavaxCryptoKeyGenerator jcg | jcg = source.asExpr())
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma |
+      ma.getMethod() instanceof KeyGeneratorInitMethod and
+      sink.asExpr() = ma.getQualifier()
+    )
+  }
+}
+
+/** Taint configuration tracking flow from a keypair generator to a `initialize` method call. */
+class KeyPairGeneratorConfiguration extends TaintTracking::Configuration {
+  KeyPairGeneratorConfiguration() { this = "KeyPairGeneratorConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) {
+    exists(JavaSecurityKeyPairGenerator jkg | jkg = source.asExpr())
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma |
+      ma.getMethod() instanceof KeyPairGeneratorInitMethod and
+      sink.asExpr() = ma.getQualifier()
+    )
+  }
+}
+
+/** Holds if an AES `KeyGenerator` is initialized with an insufficient key size. */
+predicate incorrectUseOfAES(MethodAccess ma, string msg) {
+  ma.getMethod() instanceof KeyGeneratorInitMethod and
+  exists(
+    JavaxCryptoKeyGenerator jcg, CryptoKeyGeneratorConfiguration cc, DataFlow::PathNode source,
+    DataFlow::PathNode dest
+  |
+    jcg.getAlgoSpec().(StringLiteral).getValue() = "AES" and
+    source.getNode().asExpr() = jcg and
+    dest.getNode().asExpr() = ma.getQualifier() and
+    cc.hasFlowPath(source, dest)
+  ) and
+  ma.getArgument(0).(IntegerLiteral).getIntValue() < 128 and
+  msg = "Key size should be at least 128 bits for AES encryption."
+}
+
+/** Holds if a DSA `KeyPairGenerator` is initialized with an insufficient key size. */
+predicate incorrectUseOfDSA(MethodAccess ma, string msg) {
+  ma.getMethod() instanceof KeyPairGeneratorInitMethod and
+  exists(
+    JavaSecurityKeyPairGenerator jpg, KeyPairGeneratorConfiguration kc, DataFlow::PathNode source,
+    DataFlow::PathNode dest
+  |
+    jpg.getAlgoSpec().(StringLiteral).getValue() = "DSA" and
+    source.getNode().asExpr() = jpg and
+    dest.getNode().asExpr() = ma.getQualifier() and
+    kc.hasFlowPath(source, dest)
+  ) and
+  ma.getArgument(0).(IntegerLiteral).getIntValue() < 2048 and
+  msg = "Key size should be at least 2048 bits for DSA encryption."
+}
+
+/** Holds if a RSA `KeyPairGenerator` is initialized with an insufficient key size. */
+predicate incorrectUseOfRSA(MethodAccess ma, string msg) {
+  ma.getMethod() instanceof KeyPairGeneratorInitMethod and
+  exists(
+    JavaSecurityKeyPairGenerator jpg, KeyPairGeneratorConfiguration kc, DataFlow::PathNode source,
+    DataFlow::PathNode dest
+  |
+    jpg.getAlgoSpec().(StringLiteral).getValue() = "RSA" and
+    source.getNode().asExpr() = jpg and
+    dest.getNode().asExpr() = ma.getQualifier() and
+    kc.hasFlowPath(source, dest)
+  ) and
+  ma.getArgument(0).(IntegerLiteral).getIntValue() < 2048 and
+  msg = "Key size should be at least 2048 bits for RSA encryption."
+}
+
+/** Holds if an EC `KeyPairGenerator` is initialized with an insufficient key size. */
+predicate incorrectUseOfEC(MethodAccess ma, string msg) {
+  ma.getMethod() instanceof KeyPairGeneratorInitMethod and
+  exists(
+    JavaSecurityKeyPairGenerator jpg, KeyPairGeneratorConfiguration kc, DataFlow::PathNode source,
+    DataFlow::PathNode dest, ClassInstanceExpr cie
+  |
+    jpg.getAlgoSpec().(StringLiteral).getValue().matches("EC%") and //ECC variants such as ECDH and ECDSA
+    source.getNode().asExpr() = jpg and
+    dest.getNode().asExpr() = ma.getQualifier() and
+    kc.hasFlowPath(source, dest) and
+    exists(VariableAssign va |
+      ma.getArgument(0).(VarAccess).getVariable() = va.getDestVar() and
+      va.getSource() = cie and
+      cie.getArgument(0)
+          .(StringLiteral)
+          .getRepresentedString()
+          .regexpCapture(".*[a-zA-Z]+([0-9]+)[a-zA-Z]+.*", 1)
+          .toInt() < 224
+    )
+  ) and
+  msg = "Key size should be at least 224 bits for EC encryption."
+}
+
+from Expr e, string msg
+where
+  incorrectUseOfAES(e, msg) or
+  incorrectUseOfDSA(e, msg) or
+  incorrectUseOfRSA(e, msg) or
+  incorrectUseOfEC(e, msg)
+select e, msg

--- a/java/ql/src/semmle/code/java/security/Encryption.qll
+++ b/java/ql/src/semmle/code/java/security/Encryption.qll
@@ -315,7 +315,7 @@ class JavaSecuritySignature extends JavaSecurityAlgoSpec {
   override Expr getAlgoSpec() { result = this.(ConstructorCall).getArgument(0) }
 }
 
-/** Method call to the Java class `java.security.KeyPairGenerator`. */
+/** A method call to the Java class `java.security.KeyPairGenerator`. */
 class JavaSecurityKeyPairGenerator extends JavaxCryptoAlgoSpec {
   JavaSecurityKeyPairGenerator() {
     exists(Method m | m.getAReference() = this |

--- a/java/ql/src/semmle/code/java/security/Encryption.qll
+++ b/java/ql/src/semmle/code/java/security/Encryption.qll
@@ -38,6 +38,16 @@ class HostnameVerifier extends RefType {
   HostnameVerifier() { hasQualifiedName("javax.net.ssl", "HostnameVerifier") }
 }
 
+/** The Java class `javax.crypto.KeyGenerator`. */
+class KeyGenerator extends RefType {
+  KeyGenerator() { this.hasQualifiedName("javax.crypto", "KeyGenerator") }
+}
+
+/** The Java class `java.security.KeyPairGenerator`. */
+class KeyPairGenerator extends RefType {
+  KeyPairGenerator() { this.hasQualifiedName("java.security", "KeyPairGenerator") }
+}
+
 /** The `verify` method of the class `javax.net.ssl.HostnameVerifier`. */
 class HostnameVerifierVerify extends Method {
   HostnameVerifierVerify() {
@@ -248,7 +258,7 @@ class JavaxCryptoSecretKey extends JavaxCryptoAlgoSpec {
 class JavaxCryptoKeyGenerator extends JavaxCryptoAlgoSpec {
   JavaxCryptoKeyGenerator() {
     exists(Method m | m.getAReference() = this |
-      m.getDeclaringType().getQualifiedName() = "javax.crypto.KeyGenerator" and
+      m.getDeclaringType() instanceof KeyGenerator and
       m.getName() = "getInstance"
     )
   }
@@ -309,7 +319,7 @@ class JavaSecuritySignature extends JavaSecurityAlgoSpec {
 class JavaSecurityKeyPairGenerator extends JavaxCryptoAlgoSpec {
   JavaSecurityKeyPairGenerator() {
     exists(Method m | m.getAReference() = this |
-      m.getDeclaringType().getQualifiedName() = "java.security.KeyPairGenerator" and
+      m.getDeclaringType() instanceof KeyPairGenerator and
       m.getName() = "getInstance"
     )
   }

--- a/java/ql/src/semmle/code/java/security/Encryption.qll
+++ b/java/ql/src/semmle/code/java/security/Encryption.qll
@@ -304,3 +304,15 @@ class JavaSecuritySignature extends JavaSecurityAlgoSpec {
 
   override Expr getAlgoSpec() { result = this.(ConstructorCall).getArgument(0) }
 }
+
+/** Method call to the Java class `java.security.KeyPairGenerator`. */
+class JavaSecurityKeyPairGenerator extends JavaxCryptoAlgoSpec {
+  JavaSecurityKeyPairGenerator() {
+    exists(Method m | m.getAReference() = this |
+      m.getDeclaringType().getQualifiedName() = "java.security.KeyPairGenerator" and
+      m.getName() = "getInstance"
+    )
+  }
+
+  override Expr getAlgoSpec() { result = this.(MethodAccess).getArgument(0) }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.expected
@@ -2,3 +2,7 @@
 | InsufficientKeySize.java:17:9:17:36 | initialize(...) | Key size should be at least 2048 bits for RSA encryption. |
 | InsufficientKeySize.java:25:9:25:36 | initialize(...) | Key size should be at least 2048 bits for DSA encryption. |
 | InsufficientKeySize.java:34:9:34:39 | initialize(...) | Key size should be at least 224 bits for EC encryption. |
+| InsufficientKeySize.java:38:9:38:67 | initialize(...) | Key size should be at least 224 bits for EC encryption. |
+| InsufficientKeySize.java:48:9:48:39 | initialize(...) | Key size should be at least 224 bits for EC encryption. |
+| InsufficientKeySize.java:53:9:53:39 | initialize(...) | Key size should be at least 224 bits for EC encryption. |
+| InsufficientKeySize.java:58:9:58:40 | initialize(...) | Key size should be at least 224 bits for EC encryption. |

--- a/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.expected
@@ -1,0 +1,4 @@
+| InsufficientKeySize.java:9:9:9:24 | init(...) | Key size should be at least 128 bits for AES encryption. |
+| InsufficientKeySize.java:17:9:17:36 | initialize(...) | Key size should be at least 2048 bits for RSA encryption. |
+| InsufficientKeySize.java:25:9:25:36 | initialize(...) | Key size should be at least 2048 bits for DSA encryption. |
+| InsufficientKeySize.java:34:9:34:39 | initialize(...) | Key size should be at least 224 bits for EC encryption. |

--- a/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.expected
@@ -1,8 +1,11 @@
 | InsufficientKeySize.java:9:9:9:24 | init(...) | Key size should be at least 128 bits for AES encryption. |
 | InsufficientKeySize.java:17:9:17:36 | initialize(...) | Key size should be at least 2048 bits for RSA encryption. |
 | InsufficientKeySize.java:25:9:25:36 | initialize(...) | Key size should be at least 2048 bits for DSA encryption. |
-| InsufficientKeySize.java:34:9:34:39 | initialize(...) | Key size should be at least 224 bits for EC encryption. |
-| InsufficientKeySize.java:38:9:38:67 | initialize(...) | Key size should be at least 224 bits for EC encryption. |
-| InsufficientKeySize.java:48:9:48:39 | initialize(...) | Key size should be at least 224 bits for EC encryption. |
-| InsufficientKeySize.java:53:9:53:39 | initialize(...) | Key size should be at least 224 bits for EC encryption. |
-| InsufficientKeySize.java:58:9:58:40 | initialize(...) | Key size should be at least 224 bits for EC encryption. |
+| InsufficientKeySize.java:34:9:34:39 | initialize(...) | Key size should be at least 256 bits for EC encryption. |
+| InsufficientKeySize.java:38:9:38:67 | initialize(...) | Key size should be at least 256 bits for EC encryption. |
+| InsufficientKeySize.java:48:9:48:39 | initialize(...) | Key size should be at least 256 bits for EC encryption. |
+| InsufficientKeySize.java:53:9:53:39 | initialize(...) | Key size should be at least 256 bits for EC encryption. |
+| InsufficientKeySize.java:58:9:58:40 | initialize(...) | Key size should be at least 256 bits for EC encryption. |
+| InsufficientKeySize.java:68:9:68:40 | initialize(...) | Key size should be at least 256 bits for EC encryption. |
+| InsufficientKeySize.java:78:9:78:40 | initialize(...) | Key size should be at least 256 bits for EC encryption. |
+| InsufficientKeySize.java:87:9:87:37 | initialize(...) | Key size should be at least 2048 bits for DH encryption. |

--- a/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.java
@@ -56,5 +56,10 @@ public class InsufficientKeySize {
         // BAD: Key size is less than 224
         ECGenParameterSpec ecSpec5 = new ECGenParameterSpec("sect163k1");
         keyPairGen10.initialize(ecSpec5);
+
+        KeyPairGenerator keyPairGen11 = KeyPairGenerator.getInstance("EC");
+        // GOOD: Key size is no less than 224
+        ECGenParameterSpec ecSpec6 = new ECGenParameterSpec("X9.62 c2tnb359v1");
+        keyPairGen11.initialize(ecSpec6);
     }
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.java
@@ -34,8 +34,27 @@ public class InsufficientKeySize {
         keyPairGen5.initialize(ecSpec1);
 
         KeyPairGenerator keyPairGen6 = KeyPairGenerator.getInstance("EC");
+        // BAD: Key size is less than 224
+        keyPairGen6.initialize(new ECGenParameterSpec("secp112r1"));
+
+        KeyPairGenerator keyPairGen7 = KeyPairGenerator.getInstance("EC");
         // GOOD: Key size is no less than 224
         ECGenParameterSpec ecSpec2 = new ECGenParameterSpec("secp256r1");
-        keyPairGen6.initialize(ecSpec2);
+        keyPairGen7.initialize(ecSpec2);
+
+        KeyPairGenerator keyPairGen8 = KeyPairGenerator.getInstance("EC");
+        // BAD: Key size is less than 224
+        ECGenParameterSpec ecSpec3 = new ECGenParameterSpec("X9.62 prime192v2");
+        keyPairGen8.initialize(ecSpec3);
+
+        KeyPairGenerator keyPairGen9 = KeyPairGenerator.getInstance("EC");
+        // BAD: Key size is less than 224
+        ECGenParameterSpec ecSpec4 = new ECGenParameterSpec("X9.62 c2tnb191v3");
+        keyPairGen9.initialize(ecSpec4);
+
+        KeyPairGenerator keyPairGen10 = KeyPairGenerator.getInstance("EC");
+        // BAD: Key size is less than 224
+        ECGenParameterSpec ecSpec5 = new ECGenParameterSpec("sect163k1");
+        keyPairGen10.initialize(ecSpec5);
     }
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.java
@@ -29,37 +29,65 @@ public class InsufficientKeySize {
         keyPairGen4.initialize(2048);
 
         KeyPairGenerator keyPairGen5 = KeyPairGenerator.getInstance("EC");
-        // BAD: Key size is less than 224
+        // BAD: Key size is less than 256
         ECGenParameterSpec ecSpec1 = new ECGenParameterSpec("secp112r1");
         keyPairGen5.initialize(ecSpec1);
 
         KeyPairGenerator keyPairGen6 = KeyPairGenerator.getInstance("EC");
-        // BAD: Key size is less than 224
+        // BAD: Key size is less than 256
         keyPairGen6.initialize(new ECGenParameterSpec("secp112r1"));
 
         KeyPairGenerator keyPairGen7 = KeyPairGenerator.getInstance("EC");
-        // GOOD: Key size is no less than 224
+        // GOOD: Key size is no less than 256
         ECGenParameterSpec ecSpec2 = new ECGenParameterSpec("secp256r1");
         keyPairGen7.initialize(ecSpec2);
 
         KeyPairGenerator keyPairGen8 = KeyPairGenerator.getInstance("EC");
-        // BAD: Key size is less than 224
+        // BAD: Key size is less than 256
         ECGenParameterSpec ecSpec3 = new ECGenParameterSpec("X9.62 prime192v2");
         keyPairGen8.initialize(ecSpec3);
 
         KeyPairGenerator keyPairGen9 = KeyPairGenerator.getInstance("EC");
-        // BAD: Key size is less than 224
+        // BAD: Key size is less than 256
         ECGenParameterSpec ecSpec4 = new ECGenParameterSpec("X9.62 c2tnb191v3");
         keyPairGen9.initialize(ecSpec4);
 
         KeyPairGenerator keyPairGen10 = KeyPairGenerator.getInstance("EC");
-        // BAD: Key size is less than 224
+        // BAD: Key size is less than 256
         ECGenParameterSpec ecSpec5 = new ECGenParameterSpec("sect163k1");
         keyPairGen10.initialize(ecSpec5);
 
         KeyPairGenerator keyPairGen11 = KeyPairGenerator.getInstance("EC");
-        // GOOD: Key size is no less than 224
+        // GOOD: Key size is no less than 256
         ECGenParameterSpec ecSpec6 = new ECGenParameterSpec("X9.62 c2tnb359v1");
         keyPairGen11.initialize(ecSpec6);
+
+        KeyPairGenerator keyPairGen12 = KeyPairGenerator.getInstance("EC");
+        // BAD: Key size is less than 256
+        ECGenParameterSpec ecSpec7 = new ECGenParameterSpec("prime192v2");
+        keyPairGen12.initialize(ecSpec7);
+
+        KeyPairGenerator keyPairGen13 = KeyPairGenerator.getInstance("EC");
+        // BAD: Key size is no less than 256
+        ECGenParameterSpec ecSpec8 = new ECGenParameterSpec("prime256v1");
+        keyPairGen13.initialize(ecSpec8);
+
+        KeyPairGenerator keyPairGen14 = KeyPairGenerator.getInstance("EC");
+        // BAD: Key size is less than 256
+        ECGenParameterSpec ecSpec9 = new ECGenParameterSpec("c2tnb191v1");
+        keyPairGen14.initialize(ecSpec9);
+
+        KeyPairGenerator keyPairGen15 = KeyPairGenerator.getInstance("EC");
+        // BAD: Key size is no less than 256
+        ECGenParameterSpec ecSpec10 = new ECGenParameterSpec("c2tnb431r1");
+        keyPairGen15.initialize(ecSpec10);
+
+        KeyPairGenerator keyPairGen16 = KeyPairGenerator.getInstance("dh");
+        // BAD: Key size is less than 2048
+        keyPairGen16.initialize(1024);
+
+        KeyPairGenerator keyPairGen17 = KeyPairGenerator.getInstance("DH");
+        // GOOD: Key size is no less than 2048
+        keyPairGen17.initialize(2048);
     }
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.java
@@ -1,0 +1,41 @@
+import java.security.KeyPairGenerator;
+import java.security.spec.ECGenParameterSpec;
+import javax.crypto.KeyGenerator;
+
+public class InsufficientKeySize {
+    public void CryptoMethod() {
+        KeyGenerator keyGen1 = KeyGenerator.getInstance("AES");
+        // BAD: Key size is less than 128
+        keyGen1.init(64);
+
+        KeyGenerator keyGen2 = KeyGenerator.getInstance("AES");
+        // GOOD: Key size is no less than 128
+        keyGen2.init(128);
+
+        KeyPairGenerator keyPairGen1 = KeyPairGenerator.getInstance("RSA");
+        // BAD: Key size is less than 2048
+        keyPairGen1.initialize(1024);
+
+        KeyPairGenerator keyPairGen2 = KeyPairGenerator.getInstance("RSA");
+        // GOOD: Key size is no less than 2048
+        keyPairGen2.initialize(2048);
+
+        KeyPairGenerator keyPairGen3 = KeyPairGenerator.getInstance("DSA");
+        // BAD: Key size is less than 2048
+        keyPairGen3.initialize(1024);
+
+        KeyPairGenerator keyPairGen4 = KeyPairGenerator.getInstance("DSA");
+        // GOOD: Key size is no less than 2048
+        keyPairGen4.initialize(2048);
+
+        KeyPairGenerator keyPairGen5 = KeyPairGenerator.getInstance("EC");
+        // BAD: Key size is less than 224
+        ECGenParameterSpec ecSpec1 = new ECGenParameterSpec("secp112r1");
+        keyPairGen5.initialize(ecSpec1);
+
+        KeyPairGenerator keyPairGen6 = KeyPairGenerator.getInstance("EC");
+        // GOOD: Key size is no less than 224
+        ECGenParameterSpec ecSpec2 = new ECGenParameterSpec("secp256r1");
+        keyPairGen6.initialize(ecSpec2);
+    }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/InsufficientKeySize.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-326/InsufficientKeySize.ql


### PR DESCRIPTION
Strength of cryptographic algorithms depends on a sufficient key size to be robust against brute-force attacks. A theoretically sound encryption scheme with an insufficient key size can still be subjected to brute force attacks that have a reasonable chance of succeeding using current attack methods and resources.

This type of issues is categorized as [CWE-326: Inadequate Encryption Strength](https://cwe.mitre.org/data/definitions/326.html).

This query finds uses of strong encryption algorithms (AES, DSA, RSA, and EC) with too small a key size. 

Please consider to merge the PR. Thanks.