### PR TITLE
C++: Tidy up old QL headers

### DIFF
--- a/cpp/ql/src/Architecture/General Class-Level Information/ClassHierarchies.ql
+++ b/cpp/ql/src/Architecture/General Class-Level Information/ClassHierarchies.ql
@@ -4,9 +4,6 @@
  * @kind graph
  * @id cpp/architecture/class-hierarchies
  * @graph.layout organic
- * @workingset jhotdraw
- * @result succeed 48
- * @result_ondemand succeed 48
  * @tags maintainability
  */
 

--- a/cpp/ql/src/Architecture/General Class-Level Information/InheritanceDepthDistribution.ql
+++ b/cpp/ql/src/Architecture/General Class-Level Information/InheritanceDepthDistribution.ql
@@ -4,9 +4,6 @@
  * @kind chart
  * @id cpp/architecture/inheritance-depth-distribution
  * @chart.type line
- * @workingset jhotdraw
- * @result succeed 48
- * @result_ondemand succeed 48
  * @tags maintainability
  */
 

--- a/cpp/ql/src/Architecture/General Namespace-Level Information/GlobalNamespaceClasses.ql
+++ b/cpp/ql/src/Architecture/General Namespace-Level Information/GlobalNamespaceClasses.ql
@@ -1,7 +1,8 @@
 /**
  * @name Global namespace classes
  * @description Finds classes that belong to no namespace.
- * @kind table
+ * @kind problem
+ * @problem.severity recommendation
  * @id cpp/architecture/global-namespace-classes
  * @tags maintainability
  *       modularity

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyDependencies.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyDependencies.ql
@@ -4,9 +4,6 @@
  * @kind problem
  * @id cpp/architecture/classes-with-many-dependencies
  * @problem.severity recommendation
- * @workingset jhotdraw
- * @result succeed 20
- * @result_ondemand succeed 20
  * @tags maintainability
  *       statistical
  *       non-attributable


### PR DESCRIPTION
Tidy up some strange headers on old QL files.  See https://github.com/github/semmle-jira-migration/issues/294.