### PR TITLE
C++: Test of taint through ConstructorDelegationInit.

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/taint-tests/constructor_delegation.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/constructor_delegation.cpp
@@ -1,0 +1,47 @@
+
+int source();
+void sink(...);
+
+class MyValue
+{
+public:
+	MyValue(int _x) : x(_x) {}; // taint flows directly from _x to x
+	MyValue(int _x, bool ex) : MyValue(_x) {}; // taint flows indirectly from _x to x
+	MyValue(int _x, int _y) : MyValue(_x + _y) {}; // taint flows indirectly from _x to x
+	MyValue(int _x, bool ex1, bool ex2) : MyValue(0) {}; // taint doesn't flow to _x
+
+	int x;
+};
+
+class MyDerivedValue : public MyValue
+{
+public:
+	MyDerivedValue(bool ex, int _x) : MyValue(_x) {}; // taint flows indirectly from _x to x
+};
+
+void test_inits()
+{
+	MyValue v1(0);
+	MyValue v2(source());
+	MyValue v3(0, true);
+	MyValue v4(source(), true);
+	MyValue v5(0, 1);
+	MyValue v6(source(), 1);
+	MyValue v7(0, source());
+	MyValue v8(0, true, true);
+	MyValue v9(source(), true, true);
+	MyDerivedValue v10(true, 0);
+	MyDerivedValue v11(true, source());
+
+	sink(v1.x);
+	sink(v2.x); // $ ast,ir
+	sink(v3.x);
+	sink(v4.x); // $ ir MISSING: ast
+	sink(v5.x);
+	sink(v6.x); // $ ir MISSING: ast
+	sink(v7.x); // $ ir MISSING: ast
+	sink(v8.x);
+	sink(v9.x);
+	sink(v10.x);
+	sink(v11.x); // $ ir MISSING: ast
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/constructor_delegation.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/constructor_delegation.cpp
@@ -5,10 +5,10 @@ void sink(...);
 class MyValue
 {
 public:
-	MyValue(int _x) : x(_x) {}; // taint flows directly from _x to x
-	MyValue(int _x, bool ex) : MyValue(_x) {}; // taint flows indirectly from _x to x
-	MyValue(int _x, int _y) : MyValue(_x + _y) {}; // taint flows indirectly from _x to x
-	MyValue(int _x, bool ex1, bool ex2) : MyValue(0) {}; // taint doesn't flow to _x
+	MyValue(int _x) : x(_x) {}; // taint flows from parameter `_x` to member variable `x`
+	MyValue(int _x, bool ex) : MyValue(_x) {}; // taint flows from parameter `_x` to member variable `x`
+	MyValue(int _x, int _y) : MyValue(_x + _y) {}; // taint flows from parameters `_x` and `_y` to member variable `x`
+	MyValue(int _x, bool ex1, bool ex2) : MyValue(0) {}; // taint doesn't flow from parameter `_x`
 
 	int x;
 };
@@ -16,7 +16,7 @@ public:
 class MyDerivedValue : public MyValue
 {
 public:
-	MyDerivedValue(bool ex, int _x) : MyValue(_x) {}; // taint flows indirectly from _x to x
+	MyDerivedValue(bool ex, int _x) : MyValue(_x) {}; // taint flows from parameter `_x` to member variable `x`
 };
 
 void test_inits()

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -135,6 +135,28 @@
 | arrayassignment.cpp:145:12:145:12 | 5 | arrayassignment.cpp:145:7:145:13 | access to array | TAINT |
 | arrayassignment.cpp:146:7:146:10 | arr3 | arrayassignment.cpp:146:7:146:13 | access to array |  |
 | arrayassignment.cpp:146:12:146:12 | 5 | arrayassignment.cpp:146:7:146:13 | access to array | TAINT |
+| constructor_delegation.cpp:8:2:8:8 | this | constructor_delegation.cpp:8:20:8:24 | constructor init of field x [pre-this] |  |
+| constructor_delegation.cpp:8:14:8:15 | _x | constructor_delegation.cpp:8:22:8:23 | _x |  |
+| constructor_delegation.cpp:8:22:8:23 | _x | constructor_delegation.cpp:8:20:8:24 | constructor init of field x | TAINT |
+| constructor_delegation.cpp:9:37:9:38 | _x | constructor_delegation.cpp:9:29:9:39 | call to MyValue | TAINT |
+| constructor_delegation.cpp:10:36:10:37 | _x | constructor_delegation.cpp:10:36:10:42 | ... + ... | TAINT |
+| constructor_delegation.cpp:10:36:10:42 | ... + ... | constructor_delegation.cpp:10:28:10:43 | call to MyValue | TAINT |
+| constructor_delegation.cpp:10:41:10:42 | _y | constructor_delegation.cpp:10:36:10:42 | ... + ... | TAINT |
+| constructor_delegation.cpp:11:48:11:48 | 0 | constructor_delegation.cpp:11:40:11:49 | call to MyValue | TAINT |
+| constructor_delegation.cpp:19:44:19:45 | _x | constructor_delegation.cpp:19:36:19:46 | call to MyValue | TAINT |
+| constructor_delegation.cpp:24:13:24:13 | 0 | constructor_delegation.cpp:24:13:24:14 | call to MyValue | TAINT |
+| constructor_delegation.cpp:24:13:24:14 | call to MyValue | constructor_delegation.cpp:36:7:36:8 | v1 |  |
+| constructor_delegation.cpp:25:13:25:18 | call to source | constructor_delegation.cpp:25:13:25:21 | call to MyValue | TAINT |
+| constructor_delegation.cpp:25:13:25:21 | call to MyValue | constructor_delegation.cpp:37:7:37:8 | v2 |  |
+| constructor_delegation.cpp:26:13:26:20 | call to MyValue | constructor_delegation.cpp:38:7:38:8 | v3 |  |
+| constructor_delegation.cpp:27:13:27:27 | call to MyValue | constructor_delegation.cpp:39:7:39:8 | v4 |  |
+| constructor_delegation.cpp:28:13:28:17 | call to MyValue | constructor_delegation.cpp:40:7:40:8 | v5 |  |
+| constructor_delegation.cpp:29:13:29:24 | call to MyValue | constructor_delegation.cpp:41:7:41:8 | v6 |  |
+| constructor_delegation.cpp:30:13:30:24 | call to MyValue | constructor_delegation.cpp:42:7:42:8 | v7 |  |
+| constructor_delegation.cpp:31:13:31:26 | call to MyValue | constructor_delegation.cpp:43:7:43:8 | v8 |  |
+| constructor_delegation.cpp:32:13:32:33 | call to MyValue | constructor_delegation.cpp:44:7:44:8 | v9 |  |
+| constructor_delegation.cpp:33:21:33:28 | call to MyDerivedValue | constructor_delegation.cpp:45:7:45:9 | v10 |  |
+| constructor_delegation.cpp:34:21:34:35 | call to MyDerivedValue | constructor_delegation.cpp:46:7:46:9 | v11 |  |
 | copyableclass.cpp:8:2:8:16 | this | copyableclass.cpp:8:28:8:32 | constructor init of field v [pre-this] |  |
 | copyableclass.cpp:8:22:8:23 | _v | copyableclass.cpp:8:30:8:31 | _v |  |
 | copyableclass.cpp:8:30:8:31 | _v | copyableclass.cpp:8:28:8:32 | constructor init of field v | TAINT |


### PR DESCRIPTION
Add taint tests for `ConstructorDelegationInit`, which appears to be working well for IR taint but not so well in AST taint.  This test related to an old issue (https://github.com/github/semmle-jira-migration/issues/401) that I think we can close.