### PR TITLE
Java: Add Member.hasQualifiedName.

### DIFF
--- a/java/ql/src/semmle/code/java/Member.qll
+++ b/java/ql/src/semmle/code/java/Member.qll
@@ -23,6 +23,14 @@ class Member extends Element, Annotatable, Modifiable, @member {
   /** Gets the qualified name of this member. */
   string getQualifiedName() { result = getDeclaringType().getName() + "." + getName() }
 
+  /**
+   * Holds if this member has the specified name and is declared in the
+   * specified package and type.
+   */
+  predicate hasQualifiedName(string package, string type, string name) {
+    this.getDeclaringType().hasQualifiedName(package, type) and this.hasName(name)
+  }
+
   /** Holds if this member is package protected, that is, neither public nor private nor protected. */
   predicate isPackageProtected() {
     not isPrivate() and


### PR DESCRIPTION
`Member.getQualifiedName` should not be used to identify methods as it doesn't include the package name. Rather our canonical pattern is `m.getDeclaringType().hasQualifiedName("some.package", "SomeType") and m.hasName("name")`, but this isn't directly discoverable on `Member`, so this PR adds an easier-to-discover version of our canonical pattern, which incidentally may also be shorter, so could potentially become the new canonical pattern.