### PR TITLE
C#: Remove duplicate named type population

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
@@ -30,8 +30,13 @@ namespace Semmle.Extraction.CSharp.Entities
         public static NamedType CreateNamedTypeFromTupleType(Context cx, INamedTypeSymbol type) =>
             UnderlyingTupleTypeFactory.Instance.CreateEntity(cx, (new SymbolEqualityWrapper(type), typeof(TupleType)), type);
 
-        public override bool NeedsPopulation => (base.NeedsPopulation || symbol.TypeKind == TypeKind.Error) &&
-            (!symbol.FromSource() || IsNullableOblivious(symbol.IsValueType, symbol.NullableAnnotation));
+        public override bool NeedsPopulation =>
+            (base.NeedsPopulation || symbol.TypeKind == TypeKind.Error) &&
+            (
+                !symbol.FromSource() ||
+                symbol.IsGenericType ||
+                IsNullableOblivious(symbol.IsValueType, symbol.NullableAnnotation)
+            );
 
         private static bool IsNullableOblivious(bool isValueType, NullableAnnotation nullableAnnotation) => isValueType
             ? nullableAnnotation == NullableAnnotation.NotAnnotated

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
@@ -30,7 +30,12 @@ namespace Semmle.Extraction.CSharp.Entities
         public static NamedType CreateNamedTypeFromTupleType(Context cx, INamedTypeSymbol type) =>
             UnderlyingTupleTypeFactory.Instance.CreateEntity(cx, (new SymbolEqualityWrapper(type), typeof(TupleType)), type);
 
-        public override bool NeedsPopulation => base.NeedsPopulation || symbol.TypeKind == TypeKind.Error;
+        public override bool NeedsPopulation => (base.NeedsPopulation || symbol.TypeKind == TypeKind.Error) &&
+            (!symbol.FromSource() || IsNullableOblivious(symbol.IsValueType, symbol.NullableAnnotation));
+
+        private static bool IsNullableOblivious(bool isValueType, NullableAnnotation nullableAnnotation) => isValueType
+            ? nullableAnnotation == NullableAnnotation.NotAnnotated
+            : nullableAnnotation == NullableAnnotation.None;
 
         public override void Populate(TextWriter trapFile)
         {


### PR DESCRIPTION
Named types might be populated multiple times due to `NullableAnnotation` being part of the symbol. For example, reference types can be extracted max. 3-times: for annotated, non-annotated, and oblivious (such as the declaration) nullable contexts. Ideally, we should populate types exactly once. If the declaration is from the source code, we can limit the processing to the oblivious context without any additional memory footprint. If the symbol is defined outside the current assembly, we're still populating all variants.

[Differences job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/760/)