### PR TITLE
C#: Ignore nullability when caching symbols during extraction

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
@@ -42,16 +42,16 @@ namespace Semmle.Extraction.CSharp.Entities
             if (initializer == null)
                 return;
 
-            Type initializerType;
+            ITypeSymbol initializerType;
             var symbolInfo = Context.GetSymbolInfo(initializer);
 
             switch (initializer.Kind())
             {
                 case SyntaxKind.BaseConstructorInitializer:
-                    initializerType = Type.Create(Context, symbol.ContainingType.BaseType);
+                    initializerType = symbol.ContainingType.BaseType;
                     break;
                 case SyntaxKind.ThisConstructorInitializer:
-                    initializerType = ContainingType;
+                    initializerType = symbol.ContainingType;
                     break;
                 default:
                     Context.ModelError(initializer, "Unknown initializer");
@@ -59,7 +59,7 @@ namespace Semmle.Extraction.CSharp.Entities
             }
 
             var initInfo = new ExpressionInfo(Context,
-                new AnnotatedType(initializerType, NullableAnnotation.None),
+                AnnotatedTypeSymbol.CreateNotAnnotated(initializerType),
                 Context.Create(initializer.ThisOrBaseKeyword.GetLocation()),
                 Kinds.ExprKind.CONSTRUCTOR_INIT,
                 this,

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.CSharp.Entities
     internal class Expression : FreshEntity, IExpressionParentEntity
     {
         private readonly IExpressionInfo info;
-        public AnnotatedType Type { get; }
+        public AnnotatedTypeSymbol? Type { get; }
         public Extraction.Entities.Location Location { get; }
         public ExprKind Kind { get; }
 
@@ -33,25 +33,23 @@ namespace Semmle.Extraction.CSharp.Entities
             Location = info.Location;
             Kind = info.Kind;
             Type = info.Type;
-            if (Type.Type is null)
-                Type = NullType.Create(cx);
 
             TryPopulate();
         }
 
         protected sealed override void Populate(TextWriter trapFile)
         {
-            trapFile.expressions(this, Kind, Type.Type.TypeRef);
+            var type = Type.HasValue ? Entities.Type.Create(cx, Type.Value) : NullType.Create(cx);
+            trapFile.expressions(this, Kind, type.TypeRef);
             if (info.Parent.IsTopLevelParent)
                 trapFile.expr_parent_top_level(this, info.Child, info.Parent);
             else
                 trapFile.expr_parent(this, info.Child, info.Parent);
             trapFile.expr_location(this, Location);
 
-            var annotatedType = Type.Symbol;
-            if (!annotatedType.HasObliviousNullability())
+            if (Type.HasValue && !Type.Value.HasObliviousNullability())
             {
-                var n = NullabilityEntity.Create(cx, Nullability.Create(annotatedType));
+                var n = NullabilityEntity.Create(cx, Nullability.Create(Type.Value));
                 trapFile.type_nullability(this, n);
             }
 
@@ -66,7 +64,7 @@ namespace Semmle.Extraction.CSharp.Entities
             if (info.ExprValue is string value)
                 trapFile.expr_value(this, value);
 
-            Type.Type.PopulateGenerics();
+            type.PopulateGenerics();
         }
 
         public override Microsoft.CodeAnalysis.Location ReportingLocation => Location.symbol;
@@ -367,7 +365,7 @@ namespace Semmle.Extraction.CSharp.Entities
         /// <summary>
         /// The type of the expression.
         /// </summary>
-        AnnotatedType Type { get; }
+        AnnotatedTypeSymbol? Type { get; }
 
         /// <summary>
         /// The location of the expression.
@@ -411,7 +409,7 @@ namespace Semmle.Extraction.CSharp.Entities
     internal class ExpressionInfo : IExpressionInfo
     {
         public Context Context { get; }
-        public AnnotatedType Type { get; }
+        public AnnotatedTypeSymbol? Type { get; }
         public Extraction.Entities.Location Location { get; }
         public ExprKind Kind { get; }
         public IExpressionParentEntity Parent { get; }
@@ -419,7 +417,7 @@ namespace Semmle.Extraction.CSharp.Entities
         public bool IsCompilerGenerated { get; }
         public string ExprValue { get; }
 
-        public ExpressionInfo(Context cx, AnnotatedType type, Extraction.Entities.Location location, ExprKind kind,
+        public ExpressionInfo(Context cx, AnnotatedTypeSymbol? type, Extraction.Entities.Location location, ExprKind kind,
             IExpressionParentEntity parent, int child, bool isCompilerGenerated, string value)
         {
             Context = cx;
@@ -466,10 +464,15 @@ namespace Semmle.Extraction.CSharp.Entities
         public AnnotatedTypeSymbol ResolvedType => new AnnotatedTypeSymbol(TypeInfo.Type.DisambiguateType(), TypeInfo.Nullability.Annotation);
         public AnnotatedTypeSymbol ConvertedType => new AnnotatedTypeSymbol(TypeInfo.ConvertedType.DisambiguateType(), TypeInfo.ConvertedNullability.Annotation);
 
-        public AnnotatedTypeSymbol ExpressionType
+        private AnnotatedTypeSymbol? cachedType;
+        private bool cachedTypeSet;
+        public AnnotatedTypeSymbol? Type
         {
             get
             {
+                if (cachedTypeSet)
+                    return cachedType;
+
                 var type = ResolvedType;
 
                 if (type.Symbol == null)
@@ -490,6 +493,9 @@ namespace Semmle.Extraction.CSharp.Entities
 
                     Context.ModelError(Node, "Failed to determine type");
                 }
+
+                cachedType = type;
+                cachedTypeSet = true;
 
                 return type;
             }
@@ -519,22 +525,6 @@ namespace Semmle.Extraction.CSharp.Entities
             {
                 var c = Model.GetConstantValue(Node);
                 return c.HasValue ? Expression.ValueAsString(c.Value) : null;
-            }
-        }
-
-        private AnnotatedType cachedType;
-
-        public AnnotatedType Type
-        {
-            get
-            {
-                if (cachedType.Type == null)
-                    cachedType = Entities.Type.Create(Context, ExpressionType);
-                return cachedType;
-            }
-            set
-            {
-                cachedType = value;
             }
         }
 
@@ -572,9 +562,10 @@ namespace Semmle.Extraction.CSharp.Entities
             return this;
         }
 
-        public ExpressionNodeInfo SetType(AnnotatedType type)
+        public ExpressionNodeInfo SetType(AnnotatedTypeSymbol? type)
         {
-            Type = type;
+            cachedType = type;
+            cachedTypeSet = true;
             return this;
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Access.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Access.cs
@@ -52,7 +52,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
             if (implicitThis && !symbol.IsStatic)
             {
-                This.CreateImplicit(cx, Entities.Type.Create(cx, symbol.ContainingType), Location, this, -1);
+                This.CreateImplicit(cx, symbol.ContainingType, Location, this, -1);
             }
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
@@ -90,7 +90,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             var info = new ExpressionInfo(
                 cx,
-                new AnnotatedType(Entities.Type.Create(cx, type), NullableAnnotation.None),
+                AnnotatedTypeSymbol.CreateNotAnnotated(type),
                 location,
                 ExprKind.ARRAY_CREATION,
                 parent,

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Cast.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Cast.cs
@@ -36,7 +36,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             var info = new ExpressionInfo(
                 cx,
-                new AnnotatedType(Entities.Type.Create(cx, type), Microsoft.CodeAnalysis.NullableAnnotation.None),
+                AnnotatedTypeSymbol.CreateNotAnnotated(type),
                 location,
                 ExprKind.CAST,
                 parent,

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Discard.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Discard.cs
@@ -12,7 +12,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         }
 
         private Discard(Context cx, CSharpSyntaxNode syntax, IExpressionParentEntity parent, int child) :
-            base(new ExpressionInfo(cx, Entities.Type.Create(cx, cx.GetType(syntax)), cx.Create(syntax.GetLocation()), ExprKind.DISCARD, parent, child, false, null))
+            base(new ExpressionInfo(cx, cx.GetType(syntax), cx.Create(syntax.GetLocation()), ExprKind.DISCARD, parent, child, false, null))
         {
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ImplicitCast.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ImplicitCast.cs
@@ -12,13 +12,13 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         }
 
         public ImplicitCast(ExpressionNodeInfo info)
-            : base(new ExpressionInfo(info.Context, Entities.Type.Create(info.Context, info.ConvertedType), info.Location, ExprKind.CAST, info.Parent, info.Child, true, info.ExprValue))
+            : base(new ExpressionInfo(info.Context, info.ConvertedType, info.Location, ExprKind.CAST, info.Parent, info.Child, true, info.ExprValue))
         {
             Expr = Factory.Create(new ExpressionNodeInfo(cx, info.Node, this, 0));
         }
 
         public ImplicitCast(ExpressionNodeInfo info, IMethodSymbol method)
-            : base(new ExpressionInfo(info.Context, Entities.Type.Create(info.Context, info.ConvertedType), info.Location, ExprKind.OPERATOR_INVOCATION, info.Parent, info.Child, true, info.ExprValue))
+            : base(new ExpressionInfo(info.Context, info.ConvertedType, info.Location, ExprKind.OPERATOR_INVOCATION, info.Parent, info.Child, true, info.ExprValue))
         {
             Expr = Factory.Create(info.SetParent(this, 0));
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Initializer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Initializer.cs
@@ -14,7 +14,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
     internal class ArrayInitializer : Expression<InitializerExpressionSyntax>
     {
-        private ArrayInitializer(ExpressionNodeInfo info) : base(info.SetType(NullType.Create(info.Context)).SetKind(ExprKind.ARRAY_INIT)) { }
+        private ArrayInitializer(ExpressionNodeInfo info) : base(info.SetType(null).SetKind(ExprKind.ARRAY_INIT)) { }
 
         public static Expression Create(ExpressionNodeInfo info) => new ArrayInitializer(info).TryPopulate();
 
@@ -40,7 +40,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             var info = new ExpressionInfo(
                 cx,
-                NullType.Create(cx),
+                null,
                 location,
                 ExprKind.ARRAY_INIT,
                 parent,
@@ -135,7 +135,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             {
                 var collectionInfo = cx.GetModel(Syntax).GetCollectionInitializerSymbolInfo(i);
                 var addMethod = Method.Create(cx, collectionInfo.Symbol as IMethodSymbol);
-                var voidType = Entities.Type.Create(cx, new AnnotatedTypeSymbol(cx.Compilation.GetSpecialType(SpecialType.System_Void), NullableAnnotation.None));
+                var voidType = AnnotatedTypeSymbol.CreateNotAnnotated(cx.Compilation.GetSpecialType(SpecialType.System_Void));
 
                 var invocation = new Expression(new ExpressionInfo(cx, voidType, cx.Create(i.GetLocation()), ExprKind.METHOD_INVOCATION, this, child++, false, null));
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Invocation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Invocation.cs
@@ -55,7 +55,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         // Implicit `this` qualifier; add explicitly
 
                         if (cx.GetModel(Syntax).GetEnclosingSymbol(Location.symbol.SourceSpan.Start) is IMethodSymbol callingMethod)
-                            This.CreateImplicit(cx, Entities.Type.Create(cx, callingMethod.ContainingType), Location, this, child++);
+                            This.CreateImplicit(cx, callingMethod.ContainingType, Location, this, child++);
                         else
                             cx.ModelError(Syntax, "Couldn't determine implicit this type");
                     }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Literal.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Literal.cs
@@ -21,11 +21,11 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 case SyntaxKind.DefaultLiteralExpression:
                     return ExprKind.DEFAULT;
                 case SyntaxKind.NullLiteralExpression:
-                    info.Type = Entities.NullType.Create(info.Context);  // Don't use converted type.
+                    info.SetType(null);  // Don't use converted type.
                     return ExprKind.NULL_LITERAL;
             }
 
-            var type = info.Type.Type.symbol;
+            var type = info.Type?.Symbol;
             return GetExprKind(type, info.Node, info.Context);
         }
 
@@ -82,7 +82,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             var info = new ExpressionInfo(
                 cx,
-                new AnnotatedType(Entities.Type.Create(cx, type), NullableAnnotation.None),
+                AnnotatedTypeSymbol.CreateNotAnnotated(type),
                 location,
                 GetExprKind(type, null, cx),
                 parent,
@@ -97,7 +97,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             var info = new ExpressionInfo(
                 cx,
-                NullType.Create(cx),
+                null,
                 location,
                 ExprKind.NULL_LITERAL,
                 parent,

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation/AnonymousObjectCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation/AnonymousObjectCreation.cs
@@ -35,7 +35,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 // Create an "assignment"
                 var property = cx.GetModel(init).GetDeclaredSymbol(init);
                 var propEntity = Property.Create(cx, property);
-                var type = Entities.Type.Create(cx, property.GetAnnotatedType());
+                var type = property.GetAnnotatedType();
                 var loc = cx.Create(init.GetLocation());
 
                 var assignment = new Expression(new ExpressionInfo(cx, type, loc, ExprKind.SIMPLE_ASSIGN, objectInitializer, child++, false, null));

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation/BaseObjectCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation/BaseObjectCreation.cs
@@ -46,10 +46,10 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 switch (Syntax.Initializer.Kind())
                 {
                     case SyntaxKind.CollectionInitializerExpression:
-                        CollectionInitializer.Create(new ExpressionNodeInfo(cx, Syntax.Initializer, this, -1) { Type = Type });
+                        CollectionInitializer.Create(new ExpressionNodeInfo(cx, Syntax.Initializer, this, -1).SetType(Type));
                         break;
                     case SyntaxKind.ObjectInitializerExpression:
-                        ObjectInitializer.Create(new ExpressionNodeInfo(cx, Syntax.Initializer, this, -1) { Type = Type });
+                        ObjectInitializer.Create(new ExpressionNodeInfo(cx, Syntax.Initializer, this, -1).SetType(Type));
                         break;
                     default:
                         cx.ModelError("Unhandled initializer in object creation");

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/Pattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/Pattern.cs
@@ -30,7 +30,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         {
                             if (cx.GetModel(syntax).GetDeclaredSymbol(designation) is ILocalSymbol symbol)
                             {
-                                var type = Type.Create(cx, symbol.GetAnnotatedType());
+                                var type = symbol.GetAnnotatedType();
                                 return VariableDeclaration.Create(cx, symbol, type, declPattern.Type, cx.Create(syntax.GetLocation()), false, parent, child);
                             }
                             if (designation is DiscardDesignationSyntax)
@@ -53,7 +53,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         case SingleVariableDesignationSyntax varDesignation:
                             if (cx.GetModel(syntax).GetDeclaredSymbol(varDesignation) is ILocalSymbol symbol)
                             {
-                                var type = Type.Create(cx, symbol.GetAnnotatedType());
+                                var type = symbol.GetAnnotatedType();
 
                                 return VariableDeclaration.Create(cx, symbol, type, null, cx.Create(syntax.GetLocation()), true, parent, child);
                             }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/PositionalPattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/PositionalPattern.cs
@@ -7,7 +7,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     internal class PositionalPattern : Expression
     {
         internal PositionalPattern(Context cx, PositionalPatternClauseSyntax posPc, IExpressionParentEntity parent, int child) :
-            base(new ExpressionInfo(cx, Entities.NullType.Create(cx), cx.Create(posPc.GetLocation()), ExprKind.POSITIONAL_PATTERN, parent, child, false, null))
+            base(new ExpressionInfo(cx, null, cx.Create(posPc.GetLocation()), ExprKind.POSITIONAL_PATTERN, parent, child, false, null))
         {
             child = 0;
             foreach (var sub in posPc.Subpatterns)

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/PropertyPattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/PropertyPattern.cs
@@ -7,7 +7,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     internal class PropertyPattern : Expression
     {
         internal PropertyPattern(Context cx, PropertyPatternClauseSyntax pp, IExpressionParentEntity parent, int child) :
-            base(new ExpressionInfo(cx, Entities.NullType.Create(cx), cx.Create(pp.GetLocation()), ExprKind.PROPERTY_PATTERN, parent, child, false, null))
+            base(new ExpressionInfo(cx, null, cx.Create(pp.GetLocation()), ExprKind.PROPERTY_PATTERN, parent, child, false, null))
         {
             child = 0;
             var trapFile = cx.TrapWriter.Writer;

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/RecursivePattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/RecursivePattern.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         /// <param name="child">The child index of this pattern.</param>
         /// <param name="isTopLevel">If this pattern is in the top level of a case/is. In that case, the variable and type access are populated elsewhere.</param>
         public RecursivePattern(Context cx, RecursivePatternSyntax syntax, IExpressionParentEntity parent, int child) :
-            base(new ExpressionInfo(cx, Entities.NullType.Create(cx), cx.Create(syntax.GetLocation()), ExprKind.RECURSIVE_PATTERN, parent, child, false, null))
+            base(new ExpressionInfo(cx, null, cx.Create(syntax.GetLocation()), ExprKind.RECURSIVE_PATTERN, parent, child, false, null))
         {
             // Extract the type access
             if (syntax.Type is TypeSyntax t)
@@ -26,7 +26,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             // Extract the local variable declaration
             if (syntax.Designation is VariableDesignationSyntax designation && cx.GetModel(syntax).GetDeclaredSymbol(designation) is ILocalSymbol symbol)
             {
-                var type = Entities.Type.Create(cx, symbol.GetAnnotatedType());
+                var type = symbol.GetAnnotatedType();
 
                 VariableDeclaration.Create(cx, symbol, type, null, cx.Create(syntax.GetLocation()), false, this, 0);
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/UnaryPattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/UnaryPattern.cs
@@ -7,7 +7,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     internal class UnaryPattern : Expression
     {
         public UnaryPattern(Context cx, UnaryPatternSyntax syntax, IExpressionParentEntity parent, int child) :
-            base(new ExpressionInfo(cx, NullType.Create(cx), cx.Create(syntax.GetLocation()), ExprKind.NOT_PATTERN, parent, child, false, null))
+            base(new ExpressionInfo(cx, null, cx.Create(syntax.GetLocation()), ExprKind.NOT_PATTERN, parent, child, false, null))
         {
             Pattern.Create(cx, syntax.Pattern, this, 0);
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Query.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Query.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         private class QueryCall : Expression
         {
             public QueryCall(Context cx, IMethodSymbol method, SyntaxNode clause, IExpressionParentEntity parent, int child)
-                : base(new ExpressionInfo(cx, method is null ? NullType.Create(cx) : Entities.Type.Create(cx, method.GetAnnotatedReturnType()),
+                : base(new ExpressionInfo(cx, method?.GetAnnotatedReturnType(),
                         cx.Create(clause.GetLocation()),
                         ExprKind.METHOD_INVOCATION, parent, child, false, null))
             {
@@ -63,21 +63,21 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
             protected Expression DeclareRangeVariable(Context cx, IExpressionParentEntity parent, int child, bool getElement, ISymbol variableSymbol, SyntaxToken name)
             {
-                var type = Type.Create(cx, cx.GetType(Expr));
+                var type = cx.GetType(Expr);
 
-                AnnotatedType declType;
+                AnnotatedTypeSymbol? declType;
                 TypeSyntax declTypeSyntax = null;
                 if (getElement)
                 {
                     if (node is FromClauseSyntax from && from.Type != null)
                     {
                         declTypeSyntax = from.Type;
-                        declType = Type.Create(cx, cx.GetType(from.Type));
+                        declType = cx.GetType(from.Type);
                     }
                     else
                     {
                         declTypeSyntax = null;
-                        declType = type.Type.ElementType;
+                        declType = GetElementType(cx, type.Symbol);
                     }
                 }
                 else
@@ -103,6 +103,36 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
                 return decl;
             }
+
+            private static AnnotatedTypeSymbol? GetEnumerableType(Context cx, INamedTypeSymbol type)
+            {
+                return type.SpecialType == SpecialType.System_Collections_IEnumerable
+                    ? cx.Compilation.ObjectType.WithAnnotation(NullableAnnotation.NotAnnotated)
+                    : type.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T
+                        ? type.GetAnnotatedTypeArguments().First()
+                        : (AnnotatedTypeSymbol?)null;
+            }
+
+            private static AnnotatedTypeSymbol? GetEnumerableElementType(Context cx, INamedTypeSymbol type)
+            {
+                var et = GetEnumerableType(cx, type);
+                if (et != null)
+                    return et;
+
+                return type.AllInterfaces
+                    .Where(i => i.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T)
+                    .Concat(type.AllInterfaces.Where(i => i.SpecialType == SpecialType.System_Collections_IEnumerable))
+                    .Select(i => GetEnumerableType(cx, i))
+                    .FirstOrDefault();
+            }
+
+            private static AnnotatedTypeSymbol? GetElementType(Context cx, ITypeSymbol symbol) =>
+                symbol switch
+                {
+                    IArrayTypeSymbol a => a.GetAnnotatedElementType(),
+                    INamedTypeSymbol n => GetEnumerableElementType(cx, n),
+                    _ => null
+                };
 
             protected void PopulateArguments(Context cx, QueryCall callExpr, int child)
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Switch.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Switch.cs
@@ -29,7 +29,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     {
         internal SwitchCase(Context cx, SwitchExpressionArmSyntax arm, Switch parent, int child) :
             base(new ExpressionInfo(
-                cx, Entities.Type.Create(cx, cx.GetType(arm.Expression)), cx.Create(arm.GetLocation()),
+                cx, cx.GetType(arm.Expression), cx.Create(arm.GetLocation()),
                 ExprKind.SWITCH_CASE, parent, child, false, null))
         {
             Expressions.Pattern.Create(cx, arm.Pattern, this, 0);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/This.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/This.cs
@@ -7,8 +7,8 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     {
         private This(IExpressionInfo info) : base(info) { }
 
-        public static This CreateImplicit(Context cx, Type @class, Extraction.Entities.Location loc, IExpressionParentEntity parent, int child) =>
-            new This(new ExpressionInfo(cx, new AnnotatedType(@class, NullableAnnotation.None), loc, Kinds.ExprKind.THIS_ACCESS, parent, child, true, null));
+        public static This CreateImplicit(Context cx, ITypeSymbol @class, Extraction.Entities.Location loc, IExpressionParentEntity parent, int child) =>
+            new This(new ExpressionInfo(cx, AnnotatedTypeSymbol.CreateNotAnnotated(@class), loc, Kinds.ExprKind.THIS_ACCESS, parent, child, true, null));
 
         public static This CreateExplicit(ExpressionNodeInfo info) => new This(info.SetKind(ExprKind.THIS_ACCESS));
     }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/TypeAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/TypeAccess.cs
@@ -15,7 +15,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             {
                 case SyntaxKind.SimpleMemberAccessExpression:
                     var maes = (MemberAccessExpressionSyntax)Syntax;
-                    if (Type.Type.ContainingType == null)
+                    if (Type?.Symbol.ContainingType is null)
                     {
                         // namespace qualifier
                         TypeMention.Create(cx, maes.Name, this, Type, Syntax.GetLocation());
@@ -39,7 +39,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             var typeAccessInfo = new ExpressionInfo(
                 cx,
-                new AnnotatedType(Entities.Type.Create(cx, type), Microsoft.CodeAnalysis.NullableAnnotation.None),
+                AnnotatedTypeSymbol.CreateNotAnnotated(type),
                 location,
                 ExprKind.TYPE_ACCESS,
                 parent,

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/TypeOf.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/TypeOf.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             var info = new ExpressionInfo(
                 cx,
-                new AnnotatedType(Entities.Type.Create(cx, type), Microsoft.CodeAnalysis.NullableAnnotation.None),
+                AnnotatedTypeSymbol.CreateNotAnnotated(type),
                 location,
                 ExprKind.TYPEOF,
                 parent,

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/VariableDeclaration.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/VariableDeclaration.cs
@@ -11,7 +11,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     {
         private VariableDeclaration(IExpressionInfo info) : base(info) { }
 
-        public static VariableDeclaration Create(Context cx, ISymbol symbol, AnnotatedType type, TypeSyntax optionalSyntax, Extraction.Entities.Location exprLocation, bool isVar, IExpressionParentEntity parent, int child)
+        public static VariableDeclaration Create(Context cx, ISymbol symbol, AnnotatedTypeSymbol? type, TypeSyntax optionalSyntax, Extraction.Entities.Location exprLocation, bool isVar, IExpressionParentEntity parent, int child)
         {
             var ret = new VariableDeclaration(new ExpressionInfo(cx, type, exprLocation, ExprKind.LOCAL_VAR_DECL, parent, child, false, null));
             cx.Try(null, null, () =>
@@ -30,10 +30,10 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             if (variableSymbol == null)
             {
                 cx.ModelError(node, "Failed to determine local variable");
-                return Create(cx, node, NullType.Create(cx), parent, child);
+                return Create(cx, node, (AnnotatedTypeSymbol?)null, parent, child);
             }
 
-            var type = Entities.Type.Create(cx, variableSymbol.GetAnnotatedType());
+            var type = variableSymbol.GetAnnotatedType();
             var ret = Create(cx, designation, type, parent, child);
             cx.Try(null, null, () =>
             {
@@ -49,7 +49,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         /// </summary>
         public static Expression CreateParenthesized(Context cx, DeclarationExpressionSyntax node, ParenthesizedVariableDesignationSyntax designation, IExpressionParentEntity parent, int child)
         {
-            var type = Entities.NullType.Create(cx); // Should ideally be a corresponding tuple type
+            AnnotatedTypeSymbol? type = null; // Should ideally be a corresponding tuple type
             var tuple = new Expression(new ExpressionInfo(cx, type, cx.Create(node.GetLocation()), ExprKind.TUPLE, parent, child, false, null));
 
             cx.Try(null, null, () =>
@@ -64,7 +64,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
         public static Expression CreateParenthesized(Context cx, VarPatternSyntax varPattern, ParenthesizedVariableDesignationSyntax designation, IExpressionParentEntity parent, int child)
         {
-            var type = NullType.Create(cx); // Should ideally be a corresponding tuple type
+            AnnotatedTypeSymbol? type = null; // Should ideally be a corresponding tuple type
             var tuple = new Expression(new ExpressionInfo(cx, type, cx.Create(varPattern.GetLocation()), ExprKind.TUPLE, parent, child, false, null));
 
             cx.Try(null, null, () =>
@@ -80,7 +80,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         case SingleVariableDesignationSyntax single:
                             if (cx.GetModel(variable).GetDeclaredSymbol(single) is ILocalSymbol local)
                             {
-                                var decl = Create(cx, variable, Entities.Type.Create(cx, local.GetAnnotatedType()), tuple, child0++);
+                                var decl = Create(cx, variable, local.GetAnnotatedType(), tuple, child0++);
                                 var l = LocalVariable.Create(cx, local);
                                 l.PopulateManual(decl, true);
                             }
@@ -111,25 +111,24 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 case ParenthesizedVariableDesignationSyntax paren:
                     return CreateParenthesized(cx, node, paren, parent, child);
                 case DiscardDesignationSyntax discard:
-                    var ti = cx.GetType(discard);
-                    var type = Entities.Type.Create(cx, ti);
+                    var type = cx.GetType(discard);
                     return Create(cx, node, type, parent, child);
                 default:
                     cx.ModelError(node, "Failed to determine designation type");
-                    return Create(cx, node, NullType.Create(cx), parent, child);
+                    return Create(cx, node, null, parent, child);
             }
         }
 
         public static Expression Create(Context cx, DeclarationExpressionSyntax node, IExpressionParentEntity parent, int child) =>
             Create(cx, node, node.Designation, parent, child);
 
-        public static VariableDeclaration Create(Context cx, CSharpSyntaxNode c, AnnotatedType type, IExpressionParentEntity parent, int child) =>
+        public static VariableDeclaration Create(Context cx, CSharpSyntaxNode c, AnnotatedTypeSymbol? type, IExpressionParentEntity parent, int child) =>
             new VariableDeclaration(new ExpressionInfo(cx, type, cx.Create(c.FixedLocation()), ExprKind.LOCAL_VAR_DECL, parent, child, false, null));
 
         public static VariableDeclaration Create(Context cx, CatchDeclarationSyntax d, bool isVar, IExpressionParentEntity parent, int child)
         {
             var symbol = cx.GetModel(d).GetDeclaredSymbol(d);
-            var type = Entities.Type.Create(cx, symbol.GetAnnotatedType());
+            var type = symbol.GetAnnotatedType();
             var ret = Create(cx, d, type, parent, child);
             cx.Try(d, null, () =>
             {
@@ -141,7 +140,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             return ret;
         }
 
-        public static VariableDeclaration CreateDeclarator(Context cx, VariableDeclaratorSyntax d, AnnotatedType type, bool isVar, IExpressionParentEntity parent, int child)
+        public static VariableDeclaration CreateDeclarator(Context cx, VariableDeclaratorSyntax d, AnnotatedTypeSymbol type, bool isVar, IExpressionParentEntity parent, int child)
         {
             var ret = Create(cx, d, type, parent, child);
             cx.Try(d, null, () =>
@@ -170,7 +169,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     {
         public static void Populate(Context cx, VariableDeclarationSyntax decl, IExpressionParentEntity parent, int child, int childIncrement = 1)
         {
-            var type = Type.Create(cx, cx.GetType(decl.Type));
+            var type = cx.GetType(decl.Type);
 
             foreach (var v in decl.Variables)
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Indexer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Indexer.cs
@@ -46,7 +46,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 {
                     // The expression may need to reference parameters in the getter.
                     // So we need to arrange that the expression is populated after the getter.
-                    Context.PopulateLater(() => Expression.CreateFromNode(new ExpressionNodeInfo(Context, expressionBody, this, 0) { Type = Type.Create(Context, symbol.GetAnnotatedType()) }));
+                    Context.PopulateLater(() => Expression.CreateFromNode(new ExpressionNodeInfo(Context, expressionBody, this, 0).SetType(symbol.GetAnnotatedType())));
                 }
             }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalVariable.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalVariable.cs
@@ -24,9 +24,9 @@ namespace Semmle.Extraction.CSharp.Entities
         {
             var trapFile = Context.TrapWriter.Writer;
             var (kind, type) = symbol is ILocalSymbol l
-                ? (l.IsRef ? 3 : l.IsConst ? 2 : 1, Type.Create(Context, l.GetAnnotatedType()))
+                ? (l.IsRef ? 3 : l.IsConst ? 2 : 1, l.GetAnnotatedType())
                 : (1, parent.Type);
-            trapFile.localvars(this, kind, symbol.Name, isVar ? 1 : 0, type.Type.TypeRef, parent);
+            trapFile.localvars(this, kind, symbol.Name, isVar ? 1 : 0, Type.Create(Context, type).TypeRef, parent);
 
             if (symbol is ILocalSymbol local)
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
@@ -85,14 +85,14 @@ namespace Semmle.Extraction.CSharp.Entities
                     Context.PopulateLater(() =>
                     {
                         var loc = Context.Create(initializer.GetLocation());
-                        var annotatedType = new AnnotatedType(type, NullableAnnotation.None);
+                        var annotatedType = AnnotatedTypeSymbol.CreateNotAnnotated(symbol.Type);
                         var simpleAssignExpr = new Expression(new ExpressionInfo(Context, annotatedType, loc, ExprKind.SIMPLE_ASSIGN, this, child++, false, null));
                         Expression.CreateFromNode(new ExpressionNodeInfo(Context, initializer.Value, simpleAssignExpr, 0));
                         var access = new Expression(new ExpressionInfo(Context, annotatedType, Location, ExprKind.PROPERTY_ACCESS, simpleAssignExpr, 1, false, null));
                         trapFile.expr_access(access, this);
                         if (!symbol.IsStatic)
                         {
-                            This.CreateImplicit(Context, Type.Create(Context, symbol.ContainingType), Location, access, -1);
+                            This.CreateImplicit(Context, symbol.ContainingType, Location, access, -1);
                         }
                     });
                 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Catch.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Catch.cs
@@ -20,11 +20,11 @@ namespace Semmle.Extraction.CSharp.Entities.Statements
             if (hasVariableDeclaration) // A catch clause of the form 'catch(Ex ex) { ... }'
             {
                 var decl = Expressions.VariableDeclaration.Create(cx, Stmt.Declaration, false, this, 0);
-                trapFile.catch_type(this, decl.Type.Type.TypeRef, true);
+                trapFile.catch_type(this, Type.Create(cx, decl.Type).TypeRef, true);
             }
             else if (isSpecificCatchClause) // A catch clause of the form 'catch(Ex) { ... }'
             {
-                trapFile.catch_type(this, Type.Create(cx, cx.GetType(Stmt.Declaration.Type)).Type.TypeRef, true);
+                trapFile.catch_type(this, Type.Create(cx, cx.GetType(Stmt.Declaration.Type)).TypeRef, true);
             }
             else // A catch clause of the form 'catch { ... }'
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/ForEach.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/ForEach.cs
@@ -23,7 +23,7 @@ namespace Semmle.Extraction.CSharp.Entities.Statements
             Expression.Create(cx, Stmt.Expression, this, 1);
 
             var typeSymbol = cx.GetModel(Stmt).GetDeclaredSymbol(Stmt);
-            var type = Type.Create(cx, typeSymbol.GetAnnotatedType());
+            var type = typeSymbol.GetAnnotatedType();
 
             var location = cx.Create(Stmt.Identifier.GetLocation());
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
@@ -47,7 +47,7 @@ namespace Semmle.Extraction.CSharp.Entities
             switch (type)
             {
                 case ArrayType at:
-                    return GetArrayElementType(at.ElementType.Type);
+                    return GetArrayElementType(at.ElementType);
                 case NamedType nt when nt.symbol.IsBoundSpan() ||
                                        nt.symbol.IsBoundReadOnlySpan():
                     return nt.TypeArguments.Single();
@@ -128,8 +128,8 @@ namespace Semmle.Extraction.CSharp.Entities
             return ret;
         }
 
-        public static TypeMention Create(Context cx, TypeSyntax syntax, IEntity parent, AnnotatedType type, Microsoft.CodeAnalysis.Location loc = null) =>
-            Create(cx, syntax, parent, type.Type, loc);
+        public static TypeMention Create(Context cx, TypeSyntax syntax, IEntity parent, AnnotatedTypeSymbol? type, Microsoft.CodeAnalysis.Location loc = null) =>
+            Create(cx, syntax, parent, Type.Create(cx, type?.Symbol), loc);
 
         public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
     }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/ArrayType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/ArrayType.cs
@@ -9,17 +9,16 @@ namespace Semmle.Extraction.CSharp.Entities
         private ArrayType(Context cx, IArrayTypeSymbol init)
             : base(cx, init)
         {
-            elementLazy = new Lazy<AnnotatedType>(() => Create(cx, symbol.GetAnnotatedElementType()));
+            elementLazy = new Lazy<Type>(() => Create(cx, symbol.ElementType));
         }
 
-        private readonly Lazy<AnnotatedType> elementLazy;
-        private AnnotatedType element => elementLazy.Value;
+        private readonly Lazy<Type> elementLazy;
 
         public int Rank => symbol.Rank;
 
-        public override AnnotatedType ElementType => element;
+        public Type ElementType => elementLazy.Value;
 
-        public override int Dimension => 1 + element.Type.Dimension;
+        public override int Dimension => 1 + ElementType.Dimension;
 
         // All array types are extracted because they won't
         // be extracted in their defining assembly.
@@ -27,23 +26,19 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void Populate(TextWriter trapFile)
         {
-            trapFile.array_element_type(this, Dimension, Rank, element.Type.TypeRef);
+            trapFile.array_element_type(this, Dimension, Rank, ElementType.TypeRef);
             PopulateType(trapFile);
         }
 
         public override void WriteId(TextWriter trapFile)
         {
-            trapFile.WriteSubId(element.Type);
+            trapFile.WriteSubId(ElementType);
             symbol.BuildArraySuffix(trapFile);
             trapFile.Write(";type");
         }
 
-        public static ArrayType Create(Context cx, IArrayTypeSymbol symbol)
-        {
-            var ret = ArrayTypeFactory.Instance.CreateEntityFromSymbol(cx, symbol);
-            ret.symbol = symbol;
-            return ret;
-        }
+        public static ArrayType Create(Context cx, IArrayTypeSymbol symbol) =>
+            ArrayTypeFactory.Instance.CreateEntityFromSymbol(cx, symbol);
 
         private class ArrayTypeFactory : ICachedEntityFactory<IArrayTypeSymbol, ArrayType>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
@@ -18,8 +18,12 @@ namespace Semmle.Extraction.CSharp.Entities
             this.constructUnderlyingTupleType = constructUnderlyingTupleType;
         }
 
-        public static NamedType Create(Context cx, INamedTypeSymbol type) =>
-            NamedTypeFactory.Instance.CreateEntityFromSymbol(cx, type);
+        public static NamedType Create(Context cx, INamedTypeSymbol type)
+        {
+            var ret = NamedTypeFactory.Instance.CreateEntityFromSymbol(cx, type);
+            ret.symbol = type;
+            return ret;
+        }
 
         /// <summary>
         /// Creates a named type entity from a tuple type. Unlike `Create`, this
@@ -27,8 +31,12 @@ namespace Semmle.Extraction.CSharp.Entities
         /// For example, `(int, string)` will result in an entity for
         /// `System.ValueTuple<int, string>`.
         /// </summary>
-        public static NamedType CreateNamedTypeFromTupleType(Context cx, INamedTypeSymbol type) =>
-            UnderlyingTupleTypeFactory.Instance.CreateEntity(cx, (new SymbolEqualityWrapper(type), typeof(TupleType)), type);
+        public static NamedType CreateNamedTypeFromTupleType(Context cx, INamedTypeSymbol type)
+        {
+            var ret = UnderlyingTupleTypeFactory.Instance.CreateEntity(cx, (new SymbolEqualityWrapper(type), typeof(TupleType)), type);
+            ret.symbol = type;
+            return ret;
+        }
 
         public override bool NeedsPopulation => base.NeedsPopulation || symbol.TypeKind == TypeKind.Error;
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
@@ -18,12 +18,8 @@ namespace Semmle.Extraction.CSharp.Entities
             this.constructUnderlyingTupleType = constructUnderlyingTupleType;
         }
 
-        public static NamedType Create(Context cx, INamedTypeSymbol type)
-        {
-            var ret = NamedTypeFactory.Instance.CreateEntityFromSymbol(cx, type);
-            ret.symbol = type;
-            return ret;
-        }
+        public static NamedType Create(Context cx, INamedTypeSymbol type) =>
+            NamedTypeFactory.Instance.CreateEntityFromSymbol(cx, type);
 
         /// <summary>
         /// Creates a named type entity from a tuple type. Unlike `Create`, this
@@ -31,12 +27,8 @@ namespace Semmle.Extraction.CSharp.Entities
         /// For example, `(int, string)` will result in an entity for
         /// `System.ValueTuple<int, string>`.
         /// </summary>
-        public static NamedType CreateNamedTypeFromTupleType(Context cx, INamedTypeSymbol type)
-        {
-            var ret = UnderlyingTupleTypeFactory.Instance.CreateEntity(cx, (new SymbolEqualityWrapper(type), typeof(TupleType)), type);
-            ret.symbol = type;
-            return ret;
-        }
+        public static NamedType CreateNamedTypeFromTupleType(Context cx, INamedTypeSymbol type) =>
+            UnderlyingTupleTypeFactory.Instance.CreateEntity(cx, (new SymbolEqualityWrapper(type), typeof(TupleType)), type);
 
         public override bool NeedsPopulation => base.NeedsPopulation || symbol.TypeKind == TypeKind.Error;
 
@@ -157,36 +149,6 @@ namespace Semmle.Extraction.CSharp.Entities
                 base.WriteQuotedId(trapFile);
         }
 
-        /// <summary>
-        /// Returns the element type in an Enumerable/IEnumerable
-        /// </summary>
-        /// <param name="cx">Extraction context.</param>
-        /// <param name="type">The enumerable type.</param>
-        /// <returns>The element type, or null.</returns>
-        private static AnnotatedTypeSymbol GetElementType(Context cx, INamedTypeSymbol type)
-        {
-            var et = GetEnumerableType(cx, type);
-            if (et.Symbol != null)
-                return et;
-
-            return type.AllInterfaces
-                .Where(i => i.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T)
-                .Concat(type.AllInterfaces.Where(i => i.SpecialType == SpecialType.System_Collections_IEnumerable))
-                .Select(i => GetEnumerableType(cx, i))
-                .FirstOrDefault();
-        }
-
-        private static AnnotatedTypeSymbol GetEnumerableType(Context cx, INamedTypeSymbol type)
-        {
-            return type.SpecialType == SpecialType.System_Collections_IEnumerable
-                ? cx.Compilation.ObjectType.WithAnnotation(NullableAnnotation.NotAnnotated)
-                : type.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T
-                    ? type.GetAnnotatedTypeArguments().First()
-                    : default(AnnotatedTypeSymbol);
-        }
-
-        public override AnnotatedType ElementType => Type.Create(Context, GetElementType(Context, symbol));
-
         private class NamedTypeFactory : ICachedEntityFactory<INamedTypeSymbol, NamedType>
         {
             public static NamedTypeFactory Instance { get; } = new NamedTypeFactory();
@@ -243,5 +205,5 @@ namespace Semmle.Extraction.CSharp.Entities
         {
             trapFile.typerefs(this, symbol.Name);
         }
-    };
+    }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NullType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NullType.cs
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.CSharp.Entities
             return obj != null && obj.GetType() == typeof(NullType);
         }
 
-        public static AnnotatedType Create(Context cx) => new AnnotatedType(NullTypeFactory.Instance.CreateEntity(cx, typeof(NullType), null), NullableAnnotation.None);
+        public static Type Create(Context cx) => NullTypeFactory.Instance.CreateEntity(cx, typeof(NullType), null);
 
         private class NullTypeFactory : ICachedEntityFactory<ITypeSymbol, NullType>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
@@ -59,6 +59,6 @@ namespace Semmle.Extraction.CSharp.Entities
         private readonly Lazy<Field[]> tupleElementsLazy;
         public Field[] TupleElements => tupleElementsLazy.Value;
 
-        public override IEnumerable<Type> TypeMentions => TupleElements.Select(e => e.Type.Type);
+        public override IEnumerable<Type> TypeMentions => TupleElements.Select(e => e.Type);
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
@@ -331,10 +331,10 @@ namespace Semmle.Extraction.CSharp.Entities
         public override bool Equals(object obj)
         {
             var other = obj as Type;
-            return other?.GetType() == GetType() && SymbolEqualityComparer.IncludeNullability.Equals(other.symbol, symbol);
+            return other?.GetType() == GetType() && SymbolEqualityComparer.Default.Equals(other.symbol, symbol);
         }
 
-        public override int GetHashCode() => SymbolEqualityComparer.IncludeNullability.GetHashCode(symbol);
+        public override int GetHashCode() => SymbolEqualityComparer.Default.GetHashCode(symbol);
     }
 
     internal abstract class Type<T> : Type where T : ITypeSymbol
@@ -342,6 +342,10 @@ namespace Semmle.Extraction.CSharp.Entities
         protected Type(Context cx, T init)
             : base(cx, init) { }
 
-        public new T symbol => (T)base.symbol;
+        public new T symbol
+        {
+            get => (T)base.symbol;
+            protected set => base.symbol = value;
+        }
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
@@ -7,36 +7,11 @@ using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Entities
 {
-    /// <summary>
-    /// Represents an annotated type consisting of a type entity and nullability information.
-    /// </summary>
-    public struct AnnotatedType
-    {
-        public AnnotatedType(Type t, NullableAnnotation n)
-        {
-            Type = t;
-            annotation = n;
-        }
-
-        /// <summary>
-        /// The underlying type.
-        /// </summary>
-        public Type Type { get; private set; }
-
-        private readonly NullableAnnotation annotation;
-
-        /// <summary>
-        /// Gets the annotated type symbol of this annotated type.
-        /// </summary>
-        public AnnotatedTypeSymbol Symbol => new AnnotatedTypeSymbol(Type.symbol, annotation);
-    }
-
     public abstract class Type : CachedSymbol<ITypeSymbol>
     {
         protected Type(Context cx, ITypeSymbol init)
             : base(cx, init) { }
 
-        public virtual AnnotatedType ElementType => default(AnnotatedType);
 
         public override bool NeedsPopulation =>
             base.NeedsPopulation || symbol.TypeKind == TypeKind.Dynamic || symbol.TypeKind == TypeKind.TypeParameter;
@@ -277,12 +252,12 @@ namespace Semmle.Extraction.CSharp.Entities
         {
             type = type.DisambiguateType();
             return type == null
-                ? NullType.Create(cx).Type
+                ? NullType.Create(cx)
                 : (Type)cx.CreateEntity(type);
         }
 
-        public static AnnotatedType Create(Context cx, AnnotatedTypeSymbol type) =>
-            new AnnotatedType(Create(cx, type.Symbol), type.Nullability);
+        public static Type Create(Context cx, AnnotatedTypeSymbol? type) =>
+            Create(cx, type?.Symbol);
 
         public virtual int Dimension => 0;
 
@@ -342,10 +317,6 @@ namespace Semmle.Extraction.CSharp.Entities
         protected Type(Context cx, T init)
             : base(cx, init) { }
 
-        public new T symbol
-        {
-            get => (T)base.symbol;
-            protected set => base.symbol = value;
-        }
+        public new T symbol => (T)base.symbol;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -23,6 +23,9 @@ namespace Semmle.Extraction.CSharp
             Symbol = symbol;
             Nullability = nullability;
         }
+
+        public static AnnotatedTypeSymbol? CreateNotAnnotated(ITypeSymbol symbol) =>
+            symbol is null ? (AnnotatedTypeSymbol?)null : new AnnotatedTypeSymbol(symbol, NullableAnnotation.None);
     }
 
     internal static class SymbolExtensions

--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -497,13 +497,13 @@ namespace Semmle.Extraction.CSharp
         /// <summary>
         /// Holds if this symbol is a source declaration.
         /// </summary>
-        public static bool IsSourceDeclaration(this ISymbol symbol) => SymbolEqualityComparer.IncludeNullability.Equals(symbol, symbol.OriginalDefinition);
+        public static bool IsSourceDeclaration(this ISymbol symbol) => SymbolEqualityComparer.Default.Equals(symbol, symbol.OriginalDefinition);
 
         /// <summary>
         /// Holds if this method is a source declaration.
         /// </summary>
         public static bool IsSourceDeclaration(this IMethodSymbol method) =>
-            IsSourceDeclaration((ISymbol)method) && SymbolEqualityComparer.IncludeNullability.Equals(method, method.ConstructedFrom) && method.ReducedFrom == null;
+            IsSourceDeclaration((ISymbol)method) && SymbolEqualityComparer.Default.Equals(method, method.ConstructedFrom) && method.ReducedFrom == null;
 
         /// <summary>
         /// Holds if this parameter is a source declaration.

--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -169,7 +169,7 @@ namespace Semmle.Extraction
 #endif
 
         private readonly IDictionary<object, ICachedEntity> objectEntityCache = new Dictionary<object, ICachedEntity>();
-        private readonly IDictionary<ISymbol, ICachedEntity> symbolEntityCache = new Dictionary<ISymbol, ICachedEntity>(10000, SymbolEqualityComparer.IncludeNullability);
+        private readonly IDictionary<ISymbol, ICachedEntity> symbolEntityCache = new Dictionary<ISymbol, ICachedEntity>(10000, SymbolEqualityComparer.Default);
         private readonly HashSet<Label> extractedGenerics = new HashSet<Label>();
 
         /// <summary>

--- a/csharp/extractor/Semmle.Extraction/Symbol.cs
+++ b/csharp/extractor/Semmle.Extraction/Symbol.cs
@@ -44,6 +44,8 @@ namespace Semmle.Extraction
         public TSymbol symbol
         {
             get;
+
+            protected set;
         }
 
         object? ICachedEntity.UnderlyingObject => symbol;
@@ -79,7 +81,7 @@ namespace Semmle.Extraction
     /// A class used to wrap an `ISymbol` object, which uses `SymbolEqualityComparer.Default`
     /// for comparison.
     /// </summary>
-    public sealed class SymbolEqualityWrapper
+    public struct SymbolEqualityWrapper
     {
         public ISymbol Symbol { get; }
 
@@ -88,6 +90,6 @@ namespace Semmle.Extraction
         public override bool Equals(object? other) =>
             other is SymbolEqualityWrapper sew && SymbolEqualityComparer.Default.Equals(Symbol, sew.Symbol);
 
-        public override int GetHashCode() => 11 * Symbol.GetHashCode();
+        public override int GetHashCode() => 11 * SymbolEqualityComparer.Default.GetHashCode(Symbol);
     }
 }

--- a/csharp/extractor/Semmle.Extraction/Symbol.cs
+++ b/csharp/extractor/Semmle.Extraction/Symbol.cs
@@ -44,8 +44,6 @@ namespace Semmle.Extraction
         public TSymbol symbol
         {
             get;
-
-            protected set;
         }
 
         object? ICachedEntity.UnderlyingObject => symbol;


### PR DESCRIPTION
An alternative to https://github.com/github/codeql/pull/4956, and rolls back https://github.com/github/codeql/pull/4952.