### PR TITLE
Javascript: Add query for Angular2 ElementRef.nativeElement code injection

### DIFF
--- a/javascript/ql/src/experimental/Security/CWE-094/AngularNativeElementInjection.qhelp
+++ b/javascript/ql/src/experimental/Security/CWE-094/AngularNativeElementInjection.qhelp
@@ -1,0 +1,52 @@
+<!DOCTYPE qhelp SYSTEM "qhelp.dtd">
+<qhelp>
+  <overview>
+    <p>
+      By directly updating a DOM element via ElementRef's nativeElement property in Angular2,
+      a developer may make their application more vulnerable to code injection, assuming
+      user input is directly injected into the nativeElement property without proper
+      sanitization.
+    </p>
+  </overview>
+
+  <recommendation>
+    <p>
+      When updating a DOM element, avoid using ElementRef's nativeElement.
+      Instead, utilize Renderer2 to properly update the DOM element instead of ElementRef's
+      nativeElement.
+    </p>
+
+    <p>
+      If you must use ElementRef's nativeElement to update a DOM element, use Angular's
+      DOMSanitizer to sanitize input before passing it into ElementRef's nativeElement object.
+    </p>
+  </recommendation>
+
+  <example>
+    <p>
+      In the example below the <code>el</code> object, an instance of <code>ElementRef</code>, is
+      updated via the <code>nativeElement</code> property object. This can result in a Javascript
+      code injection.
+    </p>
+
+    <sample src="AngularNativeElementBad.js" />
+
+    <p>The corrected version utilizes Renderer2 to update the DOM element.</p>
+
+    <sample src="AngularNativeElementGood.js" />
+
+    <p>
+    An alternative corrected version utilizes DomSanitizer to sanitize the input
+    before injecting input into ElementRef's nativeElement property.
+    </p>
+
+    <sample src="AngularNativeElementGood2.js" />
+  </example>
+
+  <references>
+    <li>
+      Angular 2 Documentation:
+      <a href="https://angular.io/api/core/ElementRef#properties">ElementRef nativeElement property</a>.
+    </li>
+  </references>
+</qhelp>

--- a/javascript/ql/src/experimental/Security/CWE-094/AngularNativeElementInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-094/AngularNativeElementInjection.ql
@@ -1,0 +1,46 @@
+/**
+ * @name Abusing Angular2's ElementRef nativeElement property
+ * @description Passing user input into Angular2's ElementRef nativeElement property can cause code injection.
+ * @kind path-problem
+ * @problem.severity error
+ * @id js/angular-js/native-element-code-injection
+ * @tags security
+ *       external/cwe/cwe-094
+ * @precision low
+ */
+
+import javascript
+import semmle.javascript.frameworks.Angular2
+
+class AngularNativeElementInjectionConfiguration extends DataFlow::Configuration {
+  AngularNativeElementInjectionConfiguration() {
+    this = "AngularNativeElementInjectionConfiguration"
+  }
+
+  override predicate isSource(DataFlow::Node source) {
+    // I am having a REAL hard time identifying sources in Angular 2. For now this predicate
+    // doesn't work.
+    source instanceof DataFlow::Node and
+    not (
+      source.(DataFlow::FunctionNode).getCalleeName() = "sanitize" and
+      // I understand that this is similar to Angular2#domSanitizer(), however in VSCode the query
+      // can't identify the Angular2 module. For now I've left importing the Angular2 module. I will
+      // resolve this before the PR is merged in.
+      source
+          .(DataFlow::MethodCallNode)
+          .getReceiver()
+          .hasUnderlyingType("@angular/core", "DomSanitizer")
+    )
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    sink.(DataFlow::PropRead).getPropertyName() = "nativeElement" and
+    exists(sink.(DataFlow::PropRead).getALocalSource().getAPropertyRead*().getAPropertyWrite*())
+  }
+}
+
+from AngularNativeElementInjectionConfiguration dataflow, DataFlow::Node source, DataFlow::Node sink
+where dataflow.hasFlow(source, sink)
+select sink.getNode(), source, sink,
+  "$@ flows to " + sink.getNode().(Sink).getMessageSuffix() + ".", source.getNode(),
+  "User-provided value"

--- a/javascript/ql/src/experimental/Security/CWE-094/AngularNativeElementInjectionBad.js
+++ b/javascript/ql/src/experimental/Security/CWE-094/AngularNativeElementInjectionBad.js
@@ -1,0 +1,18 @@
+import { Directive, ElementRef, AfterViewInit, Input } from '@angular/core';
+
+@Directive({
+  selector: '[appCat]'
+})
+export class CatDirective implements AfterViewInit {
+  @Input() altImg: string;
+
+  constructor(
+    private el: ElementRef
+  ) { }
+
+  ngAfterViewInit() {
+    // BAD: this.altImg can contain malicious code that results in XSS. For example,
+    // this.altImg can lead to XSS if it equaled '" onerror="alert(\'XSS Attack\')'
+    this.el.nativeElement.innerHTML = '<img src="/cat.jpg" alt="' + this.altImg + '">'
+  }
+}

--- a/javascript/ql/src/experimental/Security/CWE-094/AngularNativeElementInjectionGood.js
+++ b/javascript/ql/src/experimental/Security/CWE-094/AngularNativeElementInjectionGood.js
@@ -1,0 +1,21 @@
+import { Directive, AfterViewInit, Input, Renderer2 } from '@angular/core';
+
+@Directive({
+  selector: '[appCat]'
+})
+export class CatDirective implements AfterViewInit {
+  @Input() altImg: string;
+
+  constructor(
+    private renderer: Renderer2
+  ) { }
+
+  ngAfterViewInit() {
+    const img = this.renderer.createElement('img');
+    this.renderer.setAttribute(img, 'src', '/cat.jpg');
+    this.renderer.setAttribute(img, 'alt', this.altImg);
+
+    // GOOD: Utilizing Renderer2 ensures that any input is properly sanitized.
+    this.renderer.appendChild(this.el.nativeElement, img);
+  }
+}

--- a/javascript/ql/src/experimental/Security/CWE-094/AngularNativeElementInjectionGood2.js
+++ b/javascript/ql/src/experimental/Security/CWE-094/AngularNativeElementInjectionGood2.js
@@ -1,0 +1,21 @@
+import { Directive, ElementRef, AfterViewInit, Input, DomSanitizer, SecurityContext } from '@angular/core';
+
+@Directive({
+  selector: '[appCat]'
+})
+
+export class CatDirective implements AfterViewInit {
+  @Input() altImg: string;
+
+  constructor(
+    private el: ElementRef,
+    private sanitizer: DomSanitizer
+  ) { }
+
+  ngAfterViewInit() {
+    var sanitizedAltImg = this.sanitizer.sanitize(SecurityContext.HTML, this.altImg)
+
+    // GOOD: this.altImg is properly sanitized.
+    this.el.nativeElement.innerHTML = '<img src="/cat.jpg" alt="' + sanitizedAltImg + '">'
+  }
+}


### PR DESCRIPTION
### What Does This PR Do

Angular2 has a wrapper module for native DOM elements called ElementRef. If a developer updates Angular2's ElementRef's nativeElement property with user input that doesn't have proper sanitization, there is a risk of code injection.

This PR adds a query that detects for instances of property writes on ElementRef's nativeElement property based on the following assumptions:

- ElementRef's nativeElement property is updated with user input
- User input is not sanitized with DomSanitizer

### Anything else we should know
- This is my first query and PR and I feel like I'm in the deep end and I don't know how to swim. I imagine there are lots of things wrong here. I apologize for that and thank you for my patience.
- The `isSource` predicate is practically broken. I have no idea how to check for sources in Angular2. Esben suggested I go ahead and create a PR to talk about it, so here's what I have.
- I want to write tests for this, even though I know this is going into experimental. Because the query's `isSource` doesn't even work, for now I haven't added tests. If we can get the query running, I'm happy to write tests.
- I have no idea if this is even close to being something eligible for a bug bounty. I don't even know if there are real-world projects that have this issue. Any direction as to whether or not this is eligible for bounty would be much appreciated in my future efforts here.