### PR TITLE
JS: Recognize DomSanitizer from @angular/core

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/Angular2.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Angular2.qll
@@ -120,7 +120,7 @@ module Angular2 {
 
   /** Gets a reference to a `DomSanitizer` object. */
   DataFlow::SourceNode domSanitizer() {
-    result.hasUnderlyingType("@angular/platform-browser", "DomSanitizer")
+    result.hasUnderlyingType(["@angular/platform-browser", "@angular/core"], "DomSanitizer")
   }
 
   /** A value that is about to be promoted to a trusted HTML or CSS value. */

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -56,6 +56,9 @@ nodes
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:40:45:40:59 | this.router.url |
+| angular2-client.ts:40:45:40:59 | this.router.url |
+| angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
@@ -697,6 +700,7 @@ edges
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:38:44:38:58 | this.router.url | angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:40:45:40:59 | this.router.url | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | classnames.js:7:47:7:69 | classNa ... w.name) | classnames.js:7:31:7:84 | `<span  ... <span>` |
 | classnames.js:7:47:7:69 | classNa ... w.name) | classnames.js:7:31:7:84 | `<span  ... <span>` |
@@ -1238,6 +1242,7 @@ edges
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | user-provided value |
 | angular2-client.ts:36:44:36:91 | this.ro ... arams.x | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x | Cross-site scripting vulnerability due to $@. | angular2-client.ts:36:44:36:89 | this.ro ... .params | user-provided value |
 | angular2-client.ts:38:44:38:58 | this.router.url | angular2-client.ts:38:44:38:58 | this.router.url | angular2-client.ts:38:44:38:58 | this.router.url | Cross-site scripting vulnerability due to $@. | angular2-client.ts:38:44:38:58 | this.router.url | user-provided value |
+| angular2-client.ts:40:45:40:59 | this.router.url | angular2-client.ts:40:45:40:59 | this.router.url | angular2-client.ts:40:45:40:59 | this.router.url | Cross-site scripting vulnerability due to $@. | angular2-client.ts:40:45:40:59 | this.router.url | user-provided value |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | user-provided value |
 | classnames.js:7:31:7:84 | `<span  ... <span>` | classnames.js:7:58:7:68 | window.name | classnames.js:7:31:7:84 | `<span  ... <span>` | Cross-site scripting vulnerability due to $@. | classnames.js:7:58:7:68 | window.name | user-provided value |
 | classnames.js:8:31:8:85 | `<span  ... <span>` | classnames.js:8:59:8:69 | window.name | classnames.js:8:31:8:85 | `<span  ... <span>` | Cross-site scripting vulnerability due to $@. | classnames.js:8:59:8:69 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -15,50 +15,50 @@ nodes
 | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() |
-| angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params |
-| angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams |
-| angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:25:44:25:71 | this.ro ... ragment |
-| angular2-client.ts:25:44:25:71 | this.ro ... ragment |
-| angular2-client.ts:25:44:25:71 | this.ro ... ragment |
-| angular2-client.ts:26:44:26:82 | this.ro ... ('foo') |
-| angular2-client.ts:26:44:26:82 | this.ro ... ('foo') |
-| angular2-client.ts:26:44:26:82 | this.ro ... ('foo') |
-| angular2-client.ts:27:44:27:87 | this.ro ... ('foo') |
-| angular2-client.ts:27:44:27:87 | this.ro ... ('foo') |
-| angular2-client.ts:27:44:27:87 | this.ro ... ('foo') |
-| angular2-client.ts:29:46:29:59 | map.get('foo') |
-| angular2-client.ts:29:46:29:59 | map.get('foo') |
-| angular2-client.ts:29:46:29:59 | map.get('foo') |
-| angular2-client.ts:32:44:32:74 | this.ro ... 1].path |
-| angular2-client.ts:32:44:32:74 | this.ro ... 1].path |
-| angular2-client.ts:32:44:32:74 | this.ro ... 1].path |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters |
-| angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:34:44:34:91 | this.ro ... et('x') |
-| angular2-client.ts:34:44:34:91 | this.ro ... et('x') |
-| angular2-client.ts:34:44:34:91 | this.ro ... et('x') |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params |
-| angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:37:44:37:58 | this.router.url |
-| angular2-client.ts:37:44:37:58 | this.router.url |
-| angular2-client.ts:37:44:37:58 | this.router.url |
-| angular2-client.ts:41:44:41:76 | routeSn ... ('foo') |
-| angular2-client.ts:41:44:41:76 | routeSn ... ('foo') |
-| angular2-client.ts:41:44:41:76 | routeSn ... ('foo') |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams |
+| angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters |
+| angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params |
+| angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | classnames.js:7:31:7:84 | `<span  ... <span>` |
 | classnames.js:7:31:7:84 | `<span  ... <span>` |
 | classnames.js:7:47:7:69 | classNa ... w.name) |
@@ -670,34 +670,34 @@ edges
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() | angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() | angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() | angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() | angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params | angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params | angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params | angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params | angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams | angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams | angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams | angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams | angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:25:44:25:71 | this.ro ... ragment | angular2-client.ts:25:44:25:71 | this.ro ... ragment |
-| angular2-client.ts:26:44:26:82 | this.ro ... ('foo') | angular2-client.ts:26:44:26:82 | this.ro ... ('foo') |
-| angular2-client.ts:27:44:27:87 | this.ro ... ('foo') | angular2-client.ts:27:44:27:87 | this.ro ... ('foo') |
-| angular2-client.ts:29:46:29:59 | map.get('foo') | angular2-client.ts:29:46:29:59 | map.get('foo') |
-| angular2-client.ts:32:44:32:74 | this.ro ... 1].path | angular2-client.ts:32:44:32:74 | this.ro ... 1].path |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters | angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters | angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters | angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters | angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:34:44:34:91 | this.ro ... et('x') | angular2-client.ts:34:44:34:91 | this.ro ... et('x') |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params | angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params | angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params | angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params | angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:37:44:37:58 | this.router.url | angular2-client.ts:37:44:37:58 | this.router.url |
-| angular2-client.ts:41:44:41:76 | routeSn ... ('foo') | angular2-client.ts:41:44:41:76 | routeSn ... ('foo') |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment | angular2-client.ts:26:44:26:71 | this.ro ... ragment |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') | angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:38:44:38:58 | this.router.url | angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | classnames.js:7:47:7:69 | classNa ... w.name) | classnames.js:7:31:7:84 | `<span  ... <span>` |
 | classnames.js:7:47:7:69 | classNa ... w.name) | classnames.js:7:31:7:84 | `<span  ... <span>` |
 | classnames.js:7:58:7:68 | window.name | classnames.js:7:47:7:69 | classNa ... w.name) |
@@ -1226,19 +1226,19 @@ edges
 | addEventListener.js:2:20:2:29 | event.data | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:29 | event.data | Cross-site scripting vulnerability due to $@. | addEventListener.js:1:43:1:47 | event | user-provided value |
 | addEventListener.js:6:20:6:23 | data | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:6:20:6:23 | data | Cross-site scripting vulnerability due to $@. | addEventListener.js:5:43:5:48 | {data} | user-provided value |
 | addEventListener.js:12:24:12:33 | event.data | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:33 | event.data | Cross-site scripting vulnerability due to $@. | addEventListener.js:10:21:10:25 | event | user-provided value |
-| angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href | angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() | angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href | Cross-site scripting vulnerability due to $@. | angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() | user-provided value |
-| angular2-client.ts:23:44:23:73 | this.ro ... ams.foo | angular2-client.ts:23:44:23:69 | this.ro ... .params | angular2-client.ts:23:44:23:73 | this.ro ... ams.foo | Cross-site scripting vulnerability due to $@. | angular2-client.ts:23:44:23:69 | this.ro ... .params | user-provided value |
-| angular2-client.ts:24:44:24:78 | this.ro ... ams.foo | angular2-client.ts:24:44:24:74 | this.ro ... yParams | angular2-client.ts:24:44:24:78 | this.ro ... ams.foo | Cross-site scripting vulnerability due to $@. | angular2-client.ts:24:44:24:74 | this.ro ... yParams | user-provided value |
-| angular2-client.ts:25:44:25:71 | this.ro ... ragment | angular2-client.ts:25:44:25:71 | this.ro ... ragment | angular2-client.ts:25:44:25:71 | this.ro ... ragment | Cross-site scripting vulnerability due to $@. | angular2-client.ts:25:44:25:71 | this.ro ... ragment | user-provided value |
-| angular2-client.ts:26:44:26:82 | this.ro ... ('foo') | angular2-client.ts:26:44:26:82 | this.ro ... ('foo') | angular2-client.ts:26:44:26:82 | this.ro ... ('foo') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:26:44:26:82 | this.ro ... ('foo') | user-provided value |
-| angular2-client.ts:27:44:27:87 | this.ro ... ('foo') | angular2-client.ts:27:44:27:87 | this.ro ... ('foo') | angular2-client.ts:27:44:27:87 | this.ro ... ('foo') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:27:44:27:87 | this.ro ... ('foo') | user-provided value |
-| angular2-client.ts:29:46:29:59 | map.get('foo') | angular2-client.ts:29:46:29:59 | map.get('foo') | angular2-client.ts:29:46:29:59 | map.get('foo') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:29:46:29:59 | map.get('foo') | user-provided value |
-| angular2-client.ts:32:44:32:74 | this.ro ... 1].path | angular2-client.ts:32:44:32:74 | this.ro ... 1].path | angular2-client.ts:32:44:32:74 | this.ro ... 1].path | Cross-site scripting vulnerability due to $@. | angular2-client.ts:32:44:32:74 | this.ro ... 1].path | user-provided value |
-| angular2-client.ts:33:44:33:82 | this.ro ... eters.x | angular2-client.ts:33:44:33:80 | this.ro ... ameters | angular2-client.ts:33:44:33:82 | this.ro ... eters.x | Cross-site scripting vulnerability due to $@. | angular2-client.ts:33:44:33:80 | this.ro ... ameters | user-provided value |
-| angular2-client.ts:34:44:34:91 | this.ro ... et('x') | angular2-client.ts:34:44:34:91 | this.ro ... et('x') | angular2-client.ts:34:44:34:91 | this.ro ... et('x') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:34:44:34:91 | this.ro ... et('x') | user-provided value |
-| angular2-client.ts:35:44:35:91 | this.ro ... arams.x | angular2-client.ts:35:44:35:89 | this.ro ... .params | angular2-client.ts:35:44:35:91 | this.ro ... arams.x | Cross-site scripting vulnerability due to $@. | angular2-client.ts:35:44:35:89 | this.ro ... .params | user-provided value |
-| angular2-client.ts:37:44:37:58 | this.router.url | angular2-client.ts:37:44:37:58 | this.router.url | angular2-client.ts:37:44:37:58 | this.router.url | Cross-site scripting vulnerability due to $@. | angular2-client.ts:37:44:37:58 | this.router.url | user-provided value |
-| angular2-client.ts:41:44:41:76 | routeSn ... ('foo') | angular2-client.ts:41:44:41:76 | routeSn ... ('foo') | angular2-client.ts:41:44:41:76 | routeSn ... ('foo') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:41:44:41:76 | routeSn ... ('foo') | user-provided value |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | Cross-site scripting vulnerability due to $@. | angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | user-provided value |
+| angular2-client.ts:24:44:24:73 | this.ro ... ams.foo | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo | Cross-site scripting vulnerability due to $@. | angular2-client.ts:24:44:24:69 | this.ro ... .params | user-provided value |
+| angular2-client.ts:25:44:25:78 | this.ro ... ams.foo | angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo | Cross-site scripting vulnerability due to $@. | angular2-client.ts:25:44:25:74 | this.ro ... yParams | user-provided value |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment | angular2-client.ts:26:44:26:71 | this.ro ... ragment | angular2-client.ts:26:44:26:71 | this.ro ... ragment | Cross-site scripting vulnerability due to $@. | angular2-client.ts:26:44:26:71 | this.ro ... ragment | user-provided value |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') | user-provided value |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') | user-provided value |
+| angular2-client.ts:30:46:30:59 | map.get('foo') | angular2-client.ts:30:46:30:59 | map.get('foo') | angular2-client.ts:30:46:30:59 | map.get('foo') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:30:46:30:59 | map.get('foo') | user-provided value |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path | angular2-client.ts:33:44:33:74 | this.ro ... 1].path | angular2-client.ts:33:44:33:74 | this.ro ... 1].path | Cross-site scripting vulnerability due to $@. | angular2-client.ts:33:44:33:74 | this.ro ... 1].path | user-provided value |
+| angular2-client.ts:34:44:34:82 | this.ro ... eters.x | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x | Cross-site scripting vulnerability due to $@. | angular2-client.ts:34:44:34:80 | this.ro ... ameters | user-provided value |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | user-provided value |
+| angular2-client.ts:36:44:36:91 | this.ro ... arams.x | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x | Cross-site scripting vulnerability due to $@. | angular2-client.ts:36:44:36:89 | this.ro ... .params | user-provided value |
+| angular2-client.ts:38:44:38:58 | this.router.url | angular2-client.ts:38:44:38:58 | this.router.url | angular2-client.ts:38:44:38:58 | this.router.url | Cross-site scripting vulnerability due to $@. | angular2-client.ts:38:44:38:58 | this.router.url | user-provided value |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | Cross-site scripting vulnerability due to $@. | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | user-provided value |
 | classnames.js:7:31:7:84 | `<span  ... <span>` | classnames.js:7:58:7:68 | window.name | classnames.js:7:31:7:84 | `<span  ... <span>` | Cross-site scripting vulnerability due to $@. | classnames.js:7:58:7:68 | window.name | user-provided value |
 | classnames.js:8:31:8:85 | `<span  ... <span>` | classnames.js:8:59:8:69 | window.name | classnames.js:8:31:8:85 | `<span  ... <span>` | Cross-site scripting vulnerability due to $@. | classnames.js:8:59:8:69 | window.name | user-provided value |
 | classnames.js:9:31:9:85 | `<span  ... <span>` | classnames.js:9:59:9:69 | window.name | classnames.js:9:31:9:85 | `<span  ... <span>` | Cross-site scripting vulnerability due to $@. | classnames.js:9:59:9:69 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -56,6 +56,9 @@ nodes
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:40:45:40:59 | this.router.url |
+| angular2-client.ts:40:45:40:59 | this.router.url |
+| angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
@@ -708,6 +711,7 @@ edges
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:38:44:38:58 | this.router.url | angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:40:45:40:59 | this.router.url | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | classnames.js:7:47:7:69 | classNa ... w.name) | classnames.js:7:31:7:84 | `<span  ... <span>` |
 | classnames.js:7:47:7:69 | classNa ... w.name) | classnames.js:7:31:7:84 | `<span  ... <span>` |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -15,50 +15,50 @@ nodes
 | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() |
-| angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params |
-| angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams |
-| angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:25:44:25:71 | this.ro ... ragment |
-| angular2-client.ts:25:44:25:71 | this.ro ... ragment |
-| angular2-client.ts:25:44:25:71 | this.ro ... ragment |
-| angular2-client.ts:26:44:26:82 | this.ro ... ('foo') |
-| angular2-client.ts:26:44:26:82 | this.ro ... ('foo') |
-| angular2-client.ts:26:44:26:82 | this.ro ... ('foo') |
-| angular2-client.ts:27:44:27:87 | this.ro ... ('foo') |
-| angular2-client.ts:27:44:27:87 | this.ro ... ('foo') |
-| angular2-client.ts:27:44:27:87 | this.ro ... ('foo') |
-| angular2-client.ts:29:46:29:59 | map.get('foo') |
-| angular2-client.ts:29:46:29:59 | map.get('foo') |
-| angular2-client.ts:29:46:29:59 | map.get('foo') |
-| angular2-client.ts:32:44:32:74 | this.ro ... 1].path |
-| angular2-client.ts:32:44:32:74 | this.ro ... 1].path |
-| angular2-client.ts:32:44:32:74 | this.ro ... 1].path |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters |
-| angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:34:44:34:91 | this.ro ... et('x') |
-| angular2-client.ts:34:44:34:91 | this.ro ... et('x') |
-| angular2-client.ts:34:44:34:91 | this.ro ... et('x') |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params |
-| angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:37:44:37:58 | this.router.url |
-| angular2-client.ts:37:44:37:58 | this.router.url |
-| angular2-client.ts:37:44:37:58 | this.router.url |
-| angular2-client.ts:41:44:41:76 | routeSn ... ('foo') |
-| angular2-client.ts:41:44:41:76 | routeSn ... ('foo') |
-| angular2-client.ts:41:44:41:76 | routeSn ... ('foo') |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams |
+| angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters |
+| angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params |
+| angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | classnames.js:7:31:7:84 | `<span  ... <span>` |
 | classnames.js:7:31:7:84 | `<span  ... <span>` |
 | classnames.js:7:47:7:69 | classNa ... w.name) |
@@ -681,34 +681,34 @@ edges
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() | angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() | angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() | angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:21:44:21:66 | \\u0275getDOM ... ation() | angular2-client.ts:21:44:21:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params | angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params | angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params | angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:23:44:23:69 | this.ro ... .params | angular2-client.ts:23:44:23:73 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams | angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams | angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams | angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:24:44:24:74 | this.ro ... yParams | angular2-client.ts:24:44:24:78 | this.ro ... ams.foo |
-| angular2-client.ts:25:44:25:71 | this.ro ... ragment | angular2-client.ts:25:44:25:71 | this.ro ... ragment |
-| angular2-client.ts:26:44:26:82 | this.ro ... ('foo') | angular2-client.ts:26:44:26:82 | this.ro ... ('foo') |
-| angular2-client.ts:27:44:27:87 | this.ro ... ('foo') | angular2-client.ts:27:44:27:87 | this.ro ... ('foo') |
-| angular2-client.ts:29:46:29:59 | map.get('foo') | angular2-client.ts:29:46:29:59 | map.get('foo') |
-| angular2-client.ts:32:44:32:74 | this.ro ... 1].path | angular2-client.ts:32:44:32:74 | this.ro ... 1].path |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters | angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters | angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters | angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:33:44:33:80 | this.ro ... ameters | angular2-client.ts:33:44:33:82 | this.ro ... eters.x |
-| angular2-client.ts:34:44:34:91 | this.ro ... et('x') | angular2-client.ts:34:44:34:91 | this.ro ... et('x') |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params | angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params | angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params | angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:35:44:35:89 | this.ro ... .params | angular2-client.ts:35:44:35:91 | this.ro ... arams.x |
-| angular2-client.ts:37:44:37:58 | this.router.url | angular2-client.ts:37:44:37:58 | this.router.url |
-| angular2-client.ts:41:44:41:76 | routeSn ... ('foo') | angular2-client.ts:41:44:41:76 | routeSn ... ('foo') |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment | angular2-client.ts:26:44:26:71 | this.ro ... ragment |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') | angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:38:44:38:58 | this.router.url | angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | classnames.js:7:47:7:69 | classNa ... w.name) | classnames.js:7:31:7:84 | `<span  ... <span>` |
 | classnames.js:7:47:7:69 | classNa ... w.name) | classnames.js:7:31:7:84 | `<span  ... <span>` |
 | classnames.js:7:58:7:68 | window.name | classnames.js:7:47:7:69 | classNa ... w.name) |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/angular2-client.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/angular2-client.ts
@@ -15,7 +15,7 @@ export class AppComponent implements OnInit {
     private route: ActivatedRoute,
     private sanitizer: DomSanitizer,
     private router: Router,
-    // private sanitizer2: DomSanitizer2
+    private sanitizer2: DomSanitizer2
   ) {}
 
   ngOnInit() {
@@ -37,7 +37,7 @@ export class AppComponent implements OnInit {
 
     this.sanitizer.bypassSecurityTrustHtml(this.router.url); // NOT OK
 
-    // this.sanitizer2.bypassSecurityTrustHtml(this.router.url); // NOT OK
+    this.sanitizer2.bypassSecurityTrustHtml(this.router.url); // NOT OK
   }
 
   someMethod(routeSnapshot: ActivatedRouteSnapshot) {

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/angular2-client.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/angular2-client.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, DomSanitizer as DomSanitizer2 } from '@angular/core';
 import { ɵgetDOM } from '@angular/common';
 import { ActivatedRoute, ActivatedRouteSnapshot, Router } from '@angular/router';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -14,7 +14,8 @@ export class AppComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private sanitizer: DomSanitizer,
-    private router: Router
+    private router: Router,
+    // private sanitizer2: DomSanitizer2
   ) {}
 
   ngOnInit() {
@@ -35,6 +36,8 @@ export class AppComponent implements OnInit {
     this.sanitizer.bypassSecurityTrustHtml(this.route.snapshot.url[1].parameterMap.params.x); // NOT OK
 
     this.sanitizer.bypassSecurityTrustHtml(this.router.url); // NOT OK
+
+    // this.sanitizer2.bypassSecurityTrustHtml(this.router.url); // NOT OK
   }
 
   someMethod(routeSnapshot: ActivatedRouteSnapshot) {


### PR DESCRIPTION
As brought to our attention by @mrthankyou in https://github.com/github/codeql/issues/4967, `DomSanitizer` can be imported from either `@angular/platform-browser` or `@angular/core` but we didn't recognize it when imported from `@angular/core`.

Fixes https://github.com/github/codeql/issues/4967