### PR TITLE
Fix broken links to QLDoc specification

### DIFF
--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -470,6 +470,8 @@ A QLDoc comment is a *qldoc comment start*, followed by a *qldoc comment body*, 
 
 The "content" of a QLDoc comment is the comment body of the comment, omitting the initial ``/**``, the trailing ``*/``, and the leading whitespace followed by ``*`` on each internal line.
 
+For more information about how the content is interpreted, see see "`QLDoc <#qldoc>`__" below.
+
 Keywords
 ~~~~~~~~
 

--- a/docs/qldoc-style-guide.md
+++ b/docs/qldoc-style-guide.md
@@ -6,7 +6,7 @@ Valid QL comments are known as QLDoc. This document describes the recommended st
 
 ### General requirements
 
-1. Documentation must adhere to the [QLDoc specification](https://help.semmle.com/QL/ql-handbook/qldoc.html).
+1. Documentation must adhere to the [QLDoc specification](https://codeql.github.com/docs/ql-language-reference/ql-language-specification/#qldoc).
 1. Documentation comments should be appropriate for users of the code.
 1. Documentation for maintainers of the code must use normal comments.
 1. Use `/** ... */` for documentation, even for single line comments.

--- a/docs/query-metadata-style-guide.md
+++ b/docs/query-metadata-style-guide.md
@@ -26,7 +26,7 @@ For examples of query files for the languages supported by CodeQL, visit the fol
 
 ## Metadata area
 
-Query file metadata contains important information that defines the identifier and purpose of the query. The metadata is included as the content of a valid [QLDoc](https://help.semmle.com/QL/ql-handbook/qldoc.html) comment, on lines with leading whitespace followed by `*`, between an initial `/**` and a trailing `*/`. For example:
+Query file metadata contains important information that defines the identifier and purpose of the query. The metadata is included as the content of a valid [QLDoc](https://codeql.github.com/docs/ql-language-reference/ql-language-specification/#qldoc) comment, on lines with leading whitespace followed by `*`, between an initial `/**` and a trailing `*/`. For example:
 
 ```
 /**


### PR DESCRIPTION
#4914 merged the QLDoc specification into the language specification but it appears some links referencing the QLDoc specification were overlooked, which are therefore now broken.
This pull request updates these links.

Additionally it might be useful to improve the "[QLDoc (qldoc)](https://codeql.github.com/docs/ql-language-reference/ql-language-specification/#qldoc-qldoc)" section of the language specification to refer to the [QLDoc section](https://codeql.github.com/docs/ql-language-reference/ql-language-specification/#qldoc) explaining how the documentation comment content is interpreted.
Otherwise a reader might stop at the first "QLDoc (qldoc)" section and not notice the second one.
However, I am not familiar enough with RST to do this, would be great if someone else could do this.