### PR TITLE
JS: add support for unnamed/default exports in PackageExports.qll

### DIFF
--- a/javascript/ql/src/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/src/semmle/javascript/PackageExports.qll
@@ -78,10 +78,7 @@ private DataFlow::Node getAValueExportedByPackage() {
 private DataFlow::Node getAnExportFromModule(Module mod) {
   result.analyze().getAValue() = mod.(NodeModule).getAModuleExportsValue()
   or
-  exists(Variable var | var = mod.(Closure::ClosureModule).getExportsVariable() |
-    result.asExpr() = var.getAReference() or
-    result.asExpr() = var.getAnAssignedExpr()
-  )
+  result = mod.(Closure::ClosureModule).getExportsVariable().getAnAssignedExpr().flow()
   or
   result.analyze().getAValue() = mod.(AmdModule).getDefine().getAModuleExportsValue()
   or

--- a/javascript/ql/src/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/src/semmle/javascript/PackageExports.qll
@@ -78,5 +78,12 @@ private DataFlow::Node getAValueExportedByPackage() {
 private DataFlow::Node getAnExportFromModule(Module mod) {
   result.analyze().getAValue() = mod.(NodeModule).getAModuleExportsValue()
   or
+  exists(Variable var | var = mod.(Closure::ClosureModule).getExportsVariable() |
+    result.asExpr() = var.getAReference() or
+    result.asExpr() = var.getAnAssignedExpr()
+  )
+  or
+  result.analyze().getAValue() = mod.(AmdModule).getDefine().getAModuleExportsValue()
+  or
   result = mod.getAnExportedValue(_)
 }

--- a/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialBackTracking.expected
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialBackTracking.expected
@@ -24,6 +24,7 @@
 | highlight.js:38:54:38:59 | [^()]* | Strings starting with 'A((' and with many repetitions of ''' can start matching anywhere after the start of the preceeding [^()]* |
 | highlight.js:38:64:38:69 | [^()]* | Strings starting with 'A(' and with many repetitions of ''' can start matching anywhere after the start of the preceeding [^()]* |
 | highlight.js:39:22:39:24 | \\w* | Strings starting with 'A' and with many repetitions of 'A' can start matching anywhere after the start of the preceeding [a-zA-Z_]\\w*\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)\\s*\\{ |
+| lib/closure.js:4:6:4:7 | u* | Strings with many repetitions of 'u' can start matching anywhere after the start of the preceeding u*o |
 | lib/lib.js:1:15:1:16 | a* | Strings with many repetitions of 'a' can start matching anywhere after the start of the preceeding a*b |
 | lib/lib.js:8:3:8:4 | f* | Strings with many repetitions of 'f' can start matching anywhere after the start of the preceeding f*g |
 | polynomial-redos.js:7:24:7:26 | \\s+ | Strings with many repetitions of ' ' can start matching anywhere after the start of the preceeding \\s+$ |

--- a/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialBackTracking.expected
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialBackTracking.expected
@@ -25,6 +25,7 @@
 | highlight.js:38:64:38:69 | [^()]* | Strings starting with 'A(' and with many repetitions of ''' can start matching anywhere after the start of the preceeding [^()]* |
 | highlight.js:39:22:39:24 | \\w* | Strings starting with 'A' and with many repetitions of 'A' can start matching anywhere after the start of the preceeding [a-zA-Z_]\\w*\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)\\s*\\{ |
 | lib/lib.js:1:15:1:16 | a* | Strings with many repetitions of 'a' can start matching anywhere after the start of the preceeding a*b |
+| lib/lib.js:8:3:8:4 | f* | Strings with many repetitions of 'f' can start matching anywhere after the start of the preceeding f*g |
 | polynomial-redos.js:7:24:7:26 | \\s+ | Strings with many repetitions of ' ' can start matching anywhere after the start of the preceeding \\s+$ |
 | polynomial-redos.js:8:17:8:18 |  * | Strings with many repetitions of ' ' can start matching anywhere after the start of the preceeding  *, * |
 | polynomial-redos.js:9:19:9:21 | \\s* | Strings with many repetitions of ' ' can start matching anywhere after the start of the preceeding \\s*\\n\\s* |

--- a/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialReDoS.expected
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialReDoS.expected
@@ -3,6 +3,10 @@ nodes
 | lib/lib.js:3:28:3:31 | name |
 | lib/lib.js:4:14:4:17 | name |
 | lib/lib.js:4:14:4:17 | name |
+| lib/lib.js:7:19:7:22 | name |
+| lib/lib.js:7:19:7:22 | name |
+| lib/lib.js:8:13:8:16 | name |
+| lib/lib.js:8:13:8:16 | name |
 | polynomial-redos.js:5:6:5:32 | tainted |
 | polynomial-redos.js:5:16:5:32 | req.query.tainted |
 | polynomial-redos.js:5:16:5:32 | req.query.tainted |
@@ -150,6 +154,10 @@ edges
 | lib/lib.js:3:28:3:31 | name | lib/lib.js:4:14:4:17 | name |
 | lib/lib.js:3:28:3:31 | name | lib/lib.js:4:14:4:17 | name |
 | lib/lib.js:3:28:3:31 | name | lib/lib.js:4:14:4:17 | name |
+| lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name |
+| lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name |
+| lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name |
+| lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name |
 | polynomial-redos.js:5:6:5:32 | tainted | polynomial-redos.js:7:2:7:8 | tainted |
 | polynomial-redos.js:5:6:5:32 | tainted | polynomial-redos.js:7:2:7:8 | tainted |
 | polynomial-redos.js:5:6:5:32 | tainted | polynomial-redos.js:8:2:8:8 | tainted |
@@ -289,6 +297,7 @@ edges
 | polynomial-redos.js:123:13:123:20 | replaced | polynomial-redos.js:123:3:123:20 | result |
 #select
 | lib/lib.js:4:2:4:18 | regexp.test(name) | lib/lib.js:3:28:3:31 | name | lib/lib.js:4:14:4:17 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'a'. | lib/lib.js:1:15:1:16 | a* | regular expression | lib/lib.js:3:28:3:31 | name | library input |
+| lib/lib.js:8:2:8:17 | /f*g/.test(name) | lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'f'. | lib/lib.js:8:3:8:4 | f* | regular expression | lib/lib.js:7:19:7:22 | name | library input |
 | polynomial-redos.js:7:2:7:34 | tainted ... /g, '') | polynomial-redos.js:5:16:5:32 | req.query.tainted | polynomial-redos.js:7:2:7:8 | tainted | This $@ that depends on $@ may run slow on strings with many repetitions of ' '. | polynomial-redos.js:7:24:7:26 | \\s+ | regular expression | polynomial-redos.js:5:16:5:32 | req.query.tainted | a user-provided value |
 | polynomial-redos.js:8:2:8:23 | tainted ...  *, */) | polynomial-redos.js:5:16:5:32 | req.query.tainted | polynomial-redos.js:8:2:8:8 | tainted | This $@ that depends on $@ may run slow on strings with many repetitions of ' '. | polynomial-redos.js:8:17:8:18 |  * | regular expression | polynomial-redos.js:5:16:5:32 | req.query.tainted | a user-provided value |
 | polynomial-redos.js:9:2:9:34 | tainted ... g, ' ') | polynomial-redos.js:5:16:5:32 | req.query.tainted | polynomial-redos.js:9:2:9:8 | tainted | This $@ that depends on $@ may run slow on strings with many repetitions of ' '. | polynomial-redos.js:9:19:9:21 | \\s* | regular expression | polynomial-redos.js:5:16:5:32 | req.query.tainted | a user-provided value |

--- a/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialReDoS.expected
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialReDoS.expected
@@ -1,4 +1,8 @@
 nodes
+| lib/closure.js:3:21:3:21 | x |
+| lib/closure.js:3:21:3:21 | x |
+| lib/closure.js:4:16:4:16 | x |
+| lib/closure.js:4:16:4:16 | x |
 | lib/lib.js:3:28:3:31 | name |
 | lib/lib.js:3:28:3:31 | name |
 | lib/lib.js:4:14:4:17 | name |
@@ -150,6 +154,10 @@ nodes
 | polynomial-redos.js:124:12:124:17 | result |
 | polynomial-redos.js:124:12:124:17 | result |
 edges
+| lib/closure.js:3:21:3:21 | x | lib/closure.js:4:16:4:16 | x |
+| lib/closure.js:3:21:3:21 | x | lib/closure.js:4:16:4:16 | x |
+| lib/closure.js:3:21:3:21 | x | lib/closure.js:4:16:4:16 | x |
+| lib/closure.js:3:21:3:21 | x | lib/closure.js:4:16:4:16 | x |
 | lib/lib.js:3:28:3:31 | name | lib/lib.js:4:14:4:17 | name |
 | lib/lib.js:3:28:3:31 | name | lib/lib.js:4:14:4:17 | name |
 | lib/lib.js:3:28:3:31 | name | lib/lib.js:4:14:4:17 | name |
@@ -296,6 +304,7 @@ edges
 | polynomial-redos.js:123:3:123:20 | result | polynomial-redos.js:124:12:124:17 | result |
 | polynomial-redos.js:123:13:123:20 | replaced | polynomial-redos.js:123:3:123:20 | result |
 #select
+| lib/closure.js:4:5:4:17 | /u*o/.test(x) | lib/closure.js:3:21:3:21 | x | lib/closure.js:4:16:4:16 | x | This $@ that depends on $@ may run slow on strings with many repetitions of 'u'. | lib/closure.js:4:6:4:7 | u* | regular expression | lib/closure.js:3:21:3:21 | x | library input |
 | lib/lib.js:4:2:4:18 | regexp.test(name) | lib/lib.js:3:28:3:31 | name | lib/lib.js:4:14:4:17 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'a'. | lib/lib.js:1:15:1:16 | a* | regular expression | lib/lib.js:3:28:3:31 | name | library input |
 | lib/lib.js:8:2:8:17 | /f*g/.test(name) | lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'f'. | lib/lib.js:8:3:8:4 | f* | regular expression | lib/lib.js:7:19:7:22 | name | library input |
 | polynomial-redos.js:7:2:7:34 | tainted ... /g, '') | polynomial-redos.js:5:16:5:32 | req.query.tainted | polynomial-redos.js:7:2:7:8 | tainted | This $@ that depends on $@ may run slow on strings with many repetitions of ' '. | polynomial-redos.js:7:24:7:26 | \\s+ | regular expression | polynomial-redos.js:5:16:5:32 | req.query.tainted | a user-provided value |

--- a/javascript/ql/test/query-tests/Performance/ReDoS/lib/closure.js
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/lib/closure.js
@@ -1,0 +1,5 @@
+goog.module('x.y.z.closure2');
+
+exports = function (x) {
+    /u*o/.test(x); // NOT OK
+}

--- a/javascript/ql/test/query-tests/Performance/ReDoS/lib/lib.js
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/lib/lib.js
@@ -11,3 +11,5 @@ function bar(reg, name) {
 if (typeof define !== 'undefined' && define.amd) { // AMD
     define([], function () {return bar});
 }
+
+module.exports.closure = require("./closure")

--- a/javascript/ql/test/query-tests/Performance/ReDoS/lib/lib.js
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/lib/lib.js
@@ -3,3 +3,11 @@ var regexp = /a*b/;
 module.exports = function (name) {
 	regexp.test(name); // NOT OK
 };
+
+function bar(reg, name) {
+	/f*g/.test(name); // NOT OK
+}
+
+if (typeof define !== 'undefined' && define.amd) { // AMD
+    define([], function () {return bar});
+}


### PR DESCRIPTION
Gets a TP/TN for CVE-2017-16117 

The support already existed for NodeJS modules. This adds the same thing for AMD/Closure modules. 