### PR TITLE
JS: Type inference wrongly assumed that all compound-assignments have type number

### DIFF
--- a/javascript/change-notes/2021-01-21-type-inference-compound.md
+++ b/javascript/change-notes/2021-01-21-type-inference-compound.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added support for modern compound assignments (`||=`, `&&=`, and `??=`) in the type inference. 

--- a/javascript/ql/src/Expressions/ImplicitOperandConversion.ql
+++ b/javascript/ql/src/Expressions/ImplicitOperandConversion.ql
@@ -130,13 +130,7 @@ class NumericConversion extends ImplicitConversion {
     or
     parent instanceof ArithmeticExpr and not parent instanceof AddExpr
     or
-    parent instanceof CompoundAssignExpr and
-    not (
-      parent instanceof AssignAddExpr or
-      parent instanceof AssignLogOrExpr or
-      parent instanceof AssignLogAndExpr or
-      parent instanceof AssignNullishCoalescingExpr
-    )
+    parent.(CompoundAssignExpr).isNumeric()
     or
     parent instanceof UpdateExpr
   }

--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -1921,6 +1921,18 @@ private class TCompoundAssignExpr =
  */
 class CompoundAssignExpr extends TCompoundAssignExpr, Assignment {
   override string getAPrimaryQlClass() { result = "CompoundAssignExpr" }
+
+  /**
+   * Holds if this compound assignment always returns a number value.
+   */
+  predicate isNumeric() {
+    not (
+      this instanceof AssignAddExpr or
+      this instanceof AssignLogOrExpr or
+      this instanceof AssignLogAndExpr or
+      this instanceof AssignNullishCoalescingExpr
+    )
+  }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
@@ -391,13 +391,15 @@ private class AnalyzedUpdateExpr extends DataFlow::AnalyzedValueNode {
 private class AnalyzedCompoundAssignExpr extends DataFlow::AnalyzedValueNode {
   override CompoundAssignExpr astNode;
 
+  AnalyzedCompoundAssignExpr() { astNode.isNumeric() }
+
   override AbstractValue getALocalValue() { result = abstractValueOfType(TTNumber()) }
 }
 
 /**
  * Flow analysis for add-assign.
  */
-private class AnalyzedAssignAddExpr extends AnalyzedCompoundAssignExpr {
+private class AnalyzedAssignAddExpr extends DataFlow::AnalyzedValueNode {
   override AssignAddExpr astNode;
 
   override AbstractValue getALocalValue() {

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
@@ -388,10 +388,10 @@ private class AnalyzedUpdateExpr extends DataFlow::AnalyzedValueNode {
 /**
  * Flow analysis for compound assignments.
  */
-private class AnalyzedCompoundAssignExpr extends DataFlow::AnalyzedValueNode {
+private class AnalyzedCompoundNumericAssignExpr extends DataFlow::AnalyzedValueNode {
   override CompoundAssignExpr astNode;
 
-  AnalyzedCompoundAssignExpr() { astNode.isNumeric() }
+  AnalyzedCompoundNumericAssignExpr() { astNode.isNumeric() }
 
   override AbstractValue getALocalValue() { result = abstractValueOfType(TTNumber()) }
 }

--- a/javascript/ql/test/query-tests/LanguageFeatures/PropertyWriteOnPrimitive/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/PropertyWriteOnPrimitive/tst.js
@@ -21,3 +21,9 @@ function g(b) {
   // OK: no types inferred for `z`, since this is dead code
   z.y = true;
 }
+
+function h() {
+  let tmp;
+  let obj = (tmp ||= {});
+  obj.p = 42;
+}


### PR DESCRIPTION
Fixes #4985. 