### PR TITLE
JS: flag less overly general functions with js/unneeded-defensive-code

### DIFF
--- a/javascript/change-notes/2021-01-21-unneeded-defensive-code.md
+++ b/javascript/change-notes/2021-01-21-unneeded-defensive-code.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The query "Unneeded defensive code" (`js/unneeded-defensive-code`) no longer flags uses of function parameters.

--- a/javascript/ql/src/Expressions/UnneededDefensiveProgramming.ql
+++ b/javascript/ql/src/Expressions/UnneededDefensiveProgramming.ql
@@ -51,5 +51,8 @@ where
     or
     // too benign in practice
     e instanceof DefensiveExpressionTest::DefensiveInit
+    or
+    // functions might be written overly general
+    e.getALocalSource() instanceof DataFlow::ParameterNode
   )
 select e, "This guard always evaluates to " + cv + "."

--- a/javascript/ql/test/query-tests/Expressions/UnneededDefensiveProgramming/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/UnneededDefensiveProgramming/tst.js
@@ -176,4 +176,11 @@
 	u && (u.p, f()); // technically not OK, but it seems like an unlikely pattern
 	u && !u.p; // NOT OK
 	u && !u(); // NOT OK
+
+    
+    function hasCallbacks(success, error) {
+        if (success) success()
+        if (error) error()
+    }
+    hasCallbacks(() => {}, null);
 });


### PR DESCRIPTION
Inspired by [this anomalous query result](https://lgtm.com/projects/g/guardian/thrashers/alerts?id=js%2Funneeded-defensive-code&mode=list), which was not helpful. 