### PR TITLE
Java: Track taint through Spring Java bean getters on super types

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -686,8 +686,7 @@ private class FormatterCallable extends TaintPreservingCallable {
     (
       this.hasName(["format", "out", "toString"])
       or
-      this
-          .(Constructor)
+      this.(Constructor)
           .getParameterType(0)
           .(RefType)
           .getASourceSupertype*()

--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -345,7 +345,9 @@ private predicate taintPreservingQualifierToMethod(Method m) {
   m.getDeclaringType() instanceof TypeUri and
   m.hasName("toURL")
   or
-  m instanceof GetterMethod and m.getDeclaringType() instanceof SpringUntrustedDataType
+  m instanceof GetterMethod and
+  m.getDeclaringType().getASubtype*() instanceof SpringUntrustedDataType and
+  not m.getDeclaringType() instanceof TypeObject
   or
   m.getDeclaringType() instanceof SpringHttpEntity and
   m.getName().regexpMatch("getBody|getHeaders")
@@ -684,7 +686,8 @@ private class FormatterCallable extends TaintPreservingCallable {
     (
       this.hasName(["format", "out", "toString"])
       or
-      this.(Constructor)
+      this
+          .(Constructor)
           .getParameterType(0)
           .(RefType)
           .getASourceSupertype*()


### PR DESCRIPTION
Consider [this example](https://github.com/spring-projects/spring-petclinic/blob/main/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java#L83) from [`spring-projects/spring-petclinic`](https://github.com/spring-projects/spring-petclinic):
```java
	@GetMapping("/owners")
	public String processFindForm(Owner owner, BindingResult result, Map<String, Object> model) {

                // ....<snip>...

		// find owners by last name
		Collection<Owner> results = this.owners.findByLastName(owner.getLastName());
```

The `owner` parameter is considered untrusted data, and so any getters on `Owner` should be considered as a taint step. This was already modeled in `TaintTrackingUtil` like this:
```
m instanceof GetterMethod and m.getDeclaringType() instanceof SpringUntrustedDataType
```

However, the petclinic snippet shows a call to `owner.getLastName()`, where `getLastName()` is not declared on `Owner`, but [the super class `Person`](https://github.com/spring-projects/spring-petclinic/blob/02babdd8cb0d494d043fdf35a24dd2127c5d5167/src/main/java/org/springframework/samples/petclinic/model/Person.java#L46). I've therefore updated the `TaintTrackingUtil` step to consider getter methods on supertypes as well. I've excluded `TypeObject`, so as to avoid accidentally adding unintended taint steps.