### PR TITLE
C++: Further improvements to experimental query cpp/memory-leak-on-failed-call-to-realloc

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-401/MemoryLeakOnFailedCallToRealloc.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-401/MemoryLeakOnFailedCallToRealloc.ql
@@ -12,6 +12,7 @@
  */
 
 import cpp
+import semmle.code.cpp.controlflow.Guards
 
 /**
  * A function call that potentially does not return (such as `exit`).
@@ -48,7 +49,11 @@ class ReallocCallLeak extends FunctionCall {
    * example a call to `exit()`.
    */
   predicate mayHandleByTermination() {
-    this.(ControlFlowNode).getASuccessor*() instanceof CallMayNotReturn
+    exists(GuardCondition guard, CallMayNotReturn exit |
+      this.(ControlFlowNode).getASuccessor*() = guard and
+      guard.getAChild*() = v.getAnAccess() and
+      guard.controls(exit.getBasicBlock(), _)
+    )
   }
 }
 

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-401/semmle/tests/MemoryLeakOnFailedCallToRealloc.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-401/semmle/tests/MemoryLeakOnFailedCallToRealloc.expected
@@ -4,3 +4,5 @@
 | test.c:186:29:186:35 | call to realloc | possible loss of original pointer on unsuccessful call realloc |
 | test.c:282:29:282:35 | call to realloc | possible loss of original pointer on unsuccessful call realloc |
 | test.c:299:26:299:32 | call to realloc | possible loss of original pointer on unsuccessful call realloc |
+| test.c:328:29:328:35 | call to realloc | possible loss of original pointer on unsuccessful call realloc |
+| test.c:342:29:342:35 | call to realloc | possible loss of original pointer on unsuccessful call realloc |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-401/semmle/tests/test.c
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-401/semmle/tests/test.c
@@ -319,3 +319,28 @@ unsigned char *noBadResize_4_1(unsigned char *buffer, size_t currentSize, size_t
 
 	return buffer;
 }
+
+unsigned char * badResize_5_2(unsigned char *buffer, size_t currentSize, size_t newSize, int cond)
+{
+	// BAD: on unsuccessful call to realloc, we will lose a pointer to a valid memory block [NOT DETECTED]
+	if (currentSize < newSize)
+	{
+		buffer = (unsigned char *)realloc(buffer, newSize);
+	}
+	if (cond)
+	{
+		abort(); // irrelevant
+	}
+	return buffer;
+}
+
+unsigned char * badResize_5_1(unsigned char *buffer, size_t currentSize, size_t newSize, int cond)
+{
+	// BAD: on unsuccessful call to realloc, we will lose a pointer to a valid memory block [NOT DETECTED]
+	if (currentSize < newSize)
+	{
+		buffer = (unsigned char *)realloc(buffer, newSize);
+		assert(cond); // irrelevant
+	}
+	return buffer;
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-401/semmle/tests/test.c
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-401/semmle/tests/test.c
@@ -322,7 +322,7 @@ unsigned char *noBadResize_4_1(unsigned char *buffer, size_t currentSize, size_t
 
 unsigned char * badResize_5_2(unsigned char *buffer, size_t currentSize, size_t newSize, int cond)
 {
-	// BAD: on unsuccessful call to realloc, we will lose a pointer to a valid memory block [NOT DETECTED]
+	// BAD: on unsuccessful call to realloc, we will lose a pointer to a valid memory block
 	if (currentSize < newSize)
 	{
 		buffer = (unsigned char *)realloc(buffer, newSize);
@@ -336,7 +336,7 @@ unsigned char * badResize_5_2(unsigned char *buffer, size_t currentSize, size_t 
 
 unsigned char * badResize_5_1(unsigned char *buffer, size_t currentSize, size_t newSize, int cond)
 {
-	// BAD: on unsuccessful call to realloc, we will lose a pointer to a valid memory block [NOT DETECTED]
+	// BAD: on unsuccessful call to realloc, we will lose a pointer to a valid memory block
 	if (currentSize < newSize)
 	{
 		buffer = (unsigned char *)realloc(buffer, newSize);


### PR DESCRIPTION
There's been some discussion on https://github.com/github/codeql/pull/4881 following https://github.com/github/codeql/pull/4979.  I said:

> I see what you mean, p_malloc contains a call to i_panic (which seems to call abort or exit) in the case of an allocation failure, but it's very different to the conditional termination of, say, an assert. I'll look into reintroducing some more of your constraints (but we're not very keen on keeping getStartLine and toString as in your original solution, both are problematic).

This PR narrows the exclusion, requiring that program termination be guarded by a condition that references the buffer.  For example:
```
buffer = realloc(buffer, ...); // realloc buffer
if (!buffer) // guard that references buffer
  abort(); // terminate
```
I believe this improves accuracy in the kinds of cases that have been discussed - see the two new test cases, and an LGTM query exploring when the three versions of this code differ: https://lgtm.com/query/5221953584618553467/ .

Thanks to @ihsinme for pointing out the weaknesses I'd introduced in my last iteration.