### PR TITLE
JS: recognize event emitters in nodejs client requests

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -1063,6 +1063,18 @@ module NodeJSLib {
     }
   }
 
+  /**
+   * An HTTP request event handler parameter as an EventEmitter, for
+   * example the function `emitter` in either of the following:
+   *
+   * ```
+   * http.request(x, emitter => {...})
+   * ```
+   *
+   * ```
+   * http.request(...).on(y, emitter => { ...})
+   * ```
+   */
   private class ClientRequestEventEmitter extends NodeJSEventEmitter {
     ClientRequestEventEmitter() {
       exists(ClientRequestHandler handler |

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/test.expected
@@ -1,3 +1,4 @@
+taintSteps
 | customEmitter.js:5:20:5:24 | "bar" | customEmitter.js:6:19:6:22 | data |
 | customEmitter.js:12:21:12:25 | "baz" | customEmitter.js:13:23:13:26 | data |
 | customEmitter.js:12:21:12:25 | "baz" | customEmitter.js:22:14:22:18 | yData |
@@ -15,3 +16,22 @@
 | tst.js:40:20:40:27 | "yabity" | tst.js:39:19:39:19 | x |
 | tst.js:46:28:46:38 | 'FirstData' | tst.js:43:45:43:49 | first |
 | tst.js:47:29:47:40 | 'SecondData' | tst.js:44:37:44:42 | second |
+eventEmitter
+| customEmitter.js:3:1:8:1 | class M ... );\\n\\t}\\n} |
+| customEmitter.js:17:9:17:29 | new MyS ... itter() |
+| customEmitter.js:20:9:20:29 | new MyS ... itter() |
+| tst2.js:6:12:6:42 | new Con ... , opts) |
+| tst2.js:16:10:16:24 | new Connector() |
+| tst2.js:22:12:24:2 | http.re ... {});\\n}) |
+| tst2.js:22:37:22:39 | res |
+| tst2.js:25:28:25:33 | socket |
+| tst2.js:29:12:31:2 | http.re ... {});\\n}) |
+| tst2.js:29:37:29:39 | res |
+| tst2.js:32:28:32:33 | socket |
+| tst.js:3:10:3:22 | new emitter() |
+| tst.js:13:11:13:23 | new emitter() |
+| tst.js:18:11:18:23 | new emitter() |
+| tst.js:24:11:24:23 | new emitter() |
+| tst.js:32:11:32:30 | new MyEventEmitter() |
+| tst.js:38:11:38:38 | new Ext ... itter() |
+| tst.js:42:15:42:32 | require('process') |

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/test.ql
@@ -3,3 +3,5 @@ import javascript
 query predicate taintSteps(DataFlow::Node pred, DataFlow::Node succ) {
   exists(DataFlow::AdditionalFlowStep step | step.step(pred, succ))
 }
+
+query predicate eventEmitter(EventEmitter e) { any() }

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/tst2.js
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/tst2.js
@@ -1,5 +1,5 @@
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
+var util = require("util");
+var EventEmitter = require("events").EventEmitter;
 
 var Connector = function() {
   if (!(this instanceof Connector)) {
@@ -16,3 +16,19 @@ Connector.prototype.foo = function() {};
 var em = new Connector();
 em.on("foo", bar => {});
 em.emit("foo", "bar");
+
+var http = require("http");
+
+let req1 = http.request(x, function(res) {
+  res.on("data", function(data) {});
+});
+req1.on("socket", function(socket) {
+  socket.on("data", function(data) {});
+});
+
+let req2 = http.request(x, function(res) {
+  res.on("error", function(error) {});
+});
+req2.on("socket", function(socket) {
+  socket.on("error", function(error) {});
+});

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/http.js
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/http.js
@@ -1,0 +1,2 @@
+var http = require("http");
+http.request(x, data => data.on("data", d => undefined));

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -96,6 +96,7 @@ test_RouteSetup_getServer
 | src/indirect2.js:18:14:18:35 | http.cr ... er(get) | src/indirect2.js:18:14:18:35 | http.cr ... er(get) |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:34:14:34:58 | http.cr ... dler()) |
 test_ClientRequest
+| http.js:2:1:2:56 | http.re ... fined)) |
 | src/http.js:18:1:18:30 | http.re ... uth" }) |
 | src/http.js:21:15:26:6 | http.re ... \\n    }) |
 | src/http.js:27:16:27:73 | http.re ... POST'}) |


### PR DESCRIPTION
This PR makes us recognize event emitters in nodejs client requests (from another old feature branch I had around)

Examples:

https://github.com/github/codeql/compare/main...esbena:js/nodejs-client-request-event-emitter?expand=1#diff-1bac3eff80ed451ecba434c38aa724bb8381e068aadab2a1c657e1039285445aR22-R34

(starting an evaluation)