### PR TITLE
JS: skip analyzing regular expressions in minified files for ReDoS

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/performance/ReDoSUtil.qll
+++ b/javascript/ql/src/semmle/javascript/security/performance/ReDoSUtil.qll
@@ -113,7 +113,7 @@ class RegExpRoot extends RegExpTerm {
     not exists(RegExpLookbehind lbh | getRoot(lbh) = this) and
     // is actually used as a RegExp
     isUsedAsRegExp() and
-    // is not inside a minified file.
+    // pragmatic performance optimization: ignore minified files.
     not getRootTerm().getParent().(Expr).getTopLevel().isMinified()
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/performance/ReDoSUtil.qll
+++ b/javascript/ql/src/semmle/javascript/security/performance/ReDoSUtil.qll
@@ -112,7 +112,9 @@ class RegExpRoot extends RegExpTerm {
     // there are no lookbehinds
     not exists(RegExpLookbehind lbh | getRoot(lbh) = this) and
     // is actually used as a RegExp
-    isUsedAsRegExp()
+    isUsedAsRegExp() and
+    // is not inside a minified file.
+    not getRootTerm().getParent().(Expr).getTopLevel().isMinified()
   }
 }
 


### PR DESCRIPTION
Has two benifits: 

- `js/polynomial-redos` now terminates on all projects on LGTM. 
- ReDoS results inside minified files have just been noise, so no need to analyze them. 