### PR TITLE
add .venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # Byte-compiled python files
 *.pyc
 
+# python virtual environment folder 
+.venv/
+
 # It's useful (though not required) to be able to unpack codeql in the ql checkout itself
 /codeql/
 


### PR DESCRIPTION
When I open a new Codespace the `.venv` folder is automatically created.   

This folder creates a whole bunch of noise for `git status`.  

I think it should be fine just to add the folder to `.gitignore`. 