### PR TITLE
Python: Disregard unresolved parameters

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -179,7 +179,11 @@ ExprNode exprNode(DataFlowExpr e) { result.getNode().getNode() = e }
 class ParameterNode extends CfgNode {
   ParameterDefinition def;
 
-  ParameterNode() { node = def.getDefiningNode() }
+  ParameterNode() {
+    node = def.getDefiningNode() and
+    // Disregard parameters to the function the extractor has synthesised for comprehensions
+    not def.getScope() = any(Comp comp).getNthInnerLoop(0).getIter().getScope()
+  }
 
   /**
    * Holds if this node is the parameter of callable `c` at the

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -181,8 +181,8 @@ class ParameterNode extends CfgNode {
 
   ParameterNode() {
     node = def.getDefiningNode() and
-    // Disregard parameters to the function the extractor has synthesised for comprehensions
-    not def.getScope() = any(Comp comp).getNthInnerLoop(0).getIter().getScope()
+    // Disregard parameters that we cannot resolve
+    exists(DataFlowCallable c | node = c.getParameter(_))
   }
 
   /**

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -182,6 +182,7 @@ class ParameterNode extends CfgNode {
   ParameterNode() {
     node = def.getDefiningNode() and
     // Disregard parameters that we cannot resolve
+    // TODO: Make this unnecessary
     exists(DataFlowCallable c | node = c.getParameter(_))
   }
 

--- a/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
@@ -1,5 +1,4 @@
 uniqueEnclosingCallable
-| test.py:239:27:239:27 | ControlFlowNode for p | Node should have one enclosing callable but has 0. |
 uniqueType
 uniqueNodeLocation
 missingLocation

--- a/python/ql/test/experimental/dataflow/consistency/modeling-consistency.expected
+++ b/python/ql/test/experimental/dataflow/consistency/modeling-consistency.expected
@@ -1,0 +1,1 @@
+| test.py:239:27:239:27 | Parameter | There is no `ParameterNode` associated with this parameter. |

--- a/python/ql/test/experimental/dataflow/consistency/modeling-consistency.ql
+++ b/python/ql/test/experimental/dataflow/consistency/modeling-consistency.ql
@@ -1,0 +1,7 @@
+import python
+import semmle.python.dataflow.new.DataFlow
+
+query predicate parameterWithoutNode(Parameter p, string msg) {
+  not exists(DataFlow::ParameterNode node | p = node.getParameter()) and
+  msg = "There is no `ParameterNode` associated with this parameter."
+}

--- a/python/ql/test/experimental/dataflow/coverage/localFlow.expected
+++ b/python/ql/test/experimental/dataflow/coverage/localFlow.expected
@@ -8,6 +8,7 @@
 | test.py:187:1:187:53 | GSSA Variable SINK | test.py:189:5:189:8 | ControlFlowNode for SINK |
 | test.py:187:1:187:53 | GSSA Variable SOURCE | test.py:188:25:188:30 | ControlFlowNode for SOURCE |
 | test.py:188:5:188:5 | SSA variable x | test.py:189:10:189:10 | ControlFlowNode for x |
+| test.py:188:9:188:68 | ControlFlowNode for .0 | test.py:188:9:188:68 | SSA variable .0 |
 | test.py:188:9:188:68 | ControlFlowNode for ListComp | test.py:188:5:188:5 | SSA variable x |
 | test.py:188:9:188:68 | SSA variable .0 | test.py:188:9:188:68 | ControlFlowNode for .0 |
 | test.py:188:16:188:16 | SSA variable v | test.py:188:45:188:45 | ControlFlowNode for v |


### PR DESCRIPTION
Some parameters are not resolved correctly. These include
- parameters appearing after a starred parameter. Those are simply not recognised in `ArgumentPassing::getParameter`.
- parameters to the functions synthesised in the extractor for comprehensions. Those do not have an associated dataflow callable.

These parameters should be resolved, but until they are, the corresponding nodes should not be marked as parameter nodes as this confuses the data-flow analysis (as seen by failing inconsistency checks). This PR excludes such nodes from the charpred of `ParameterNode`.

It currently drops the number of inconsistency alerts of type `UniqueEnclosingCallable` on saltstack from 4026 to 134﻿.
