### PR TITLE
CPP: Add query for CWE-570 detect and handle memory allocation errors.

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.cpp
@@ -1,0 +1,32 @@
+// BAD: no memory allocation errors are detected
+void f(const int *array, std::size_t size) noexcept {
+  int *copy = new int[size];
+  std::memcpy(copy, array, size * sizeof(*copy));
+  // ...
+  delete [] copy;
+}
+// GOOD: memory allocation errors are detected
+void f(const int *array, std::size_t size) noexcept {
+  int *copy;
+  try {
+    copy = new int[size];
+  } catch(std::bad_alloc) {
+    // Handle error
+    return;
+  }
+  // At this point, copy has been initialized to allocated memory
+  std::memcpy(copy, array, size * sizeof(*copy));
+  // ...
+  delete [] copy;
+}
+// GOOD: memory allocation errors are detected
+void f(const int *array, std::size_t size) noexcept {
+  int *copy = new (std::nothrow) int[size];
+  if (!copy) {
+    // Handle error
+    return;
+  }
+  std::memcpy(copy, array, size * sizeof(*copy));
+  // ...
+  delete [] copy;
+}

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.cpp
@@ -8,7 +8,9 @@ void badFunction(const int *source, std::size_t length) noexcept {
 void goodFunction(const int *source, std::size_t length) noexcept {
   try {
        int * dest = new int[length];
-  } catch(std::bad_alloc)
+  } catch(std::bad_alloc) {
+    // ...
+  }
   std::memset(dest, 0, length);
 // ..
 }
@@ -16,7 +18,9 @@ void goodFunction(const int *source, std::size_t length) noexcept {
 void badFunction(const int *source, std::size_t length) noexcept {
   try {
        int * dest = new (std::nothrow) int[length];
-  } catch(std::bad_alloc)
+  } catch(std::bad_alloc) {
+    // ...
+  }
   std::memset(dest, 0, length);
 // ..
 }

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.cpp
@@ -1,32 +1,31 @@
-// BAD: no memory allocation errors are detected
-void f(const int *array, std::size_t size) noexcept {
-  int *copy = new int[size];
-  std::memcpy(copy, array, size * sizeof(*copy));
-  // ...
-  delete [] copy;
+// BAD: on memory allocation error, the program terminates.
+void badFunction(const int *source, std::size_t length) noexcept {
+  int * dest = new int[length];
+  std::memset(dest, 0, length);
+// ..
 }
-// GOOD: memory allocation errors are detected
-void f(const int *array, std::size_t size) noexcept {
-  int *copy;
+// GOOD: memory allocation error will be handled.
+void goodFunction(const int *source, std::size_t length) noexcept {
   try {
-    copy = new int[size];
-  } catch(std::bad_alloc) {
-    // Handle error
-    return;
-  }
-  // At this point, copy has been initialized to allocated memory
-  std::memcpy(copy, array, size * sizeof(*copy));
-  // ...
-  delete [] copy;
+       int * dest = new int[length];
+  } catch(std::bad_alloc)
+  std::memset(dest, 0, length);
+// ..
 }
-// GOOD: memory allocation errors are detected
-void f(const int *array, std::size_t size) noexcept {
-  int *copy = new (std::nothrow) int[size];
-  if (!copy) {
-    // Handle error
-    return;
+// BAD: memory allocation error will not be handled.
+void badFunction(const int *source, std::size_t length) noexcept {
+  try {
+       int * dest = new (std::nothrow) int[length];
+  } catch(std::bad_alloc)
+  std::memset(dest, 0, length);
+// ..
+}
+// GOOD: memory allocation error will be handled.
+void goodFunction(const int *source, std::size_t length) noexcept {
+  int * dest = new (std::nothrow) int[length];
+  if (!dest) {
+      return;
   }
-  std::memcpy(copy, array, size * sizeof(*copy));
-  // ...
-  delete [] copy;
+  std::memset(dest, 0, length);
+// ..
 }

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.qhelp
@@ -1,0 +1,29 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>when using the new operator to allocate memory, you need to pay attention to the different way of detecting errors. so <code> ::operator new(std::size_t) </code> throws an exception on error, and <code> ::operator new(std::size_t, const std::nothrow_t &) </code> returns zero on error. the programmer can get confused and check the error that occurs when allocating memory incorrectly. That can lead to an unhandled program termination or to a violation of the program logic.</p>
+
+<p>Loss of detection probably refers to use cases where memory allocation using your own solutions with strong nesting. It is also possible when using a buffer in the form of fields of different structures with the same names.</p>
+
+</overview>
+<recommendation>
+
+<p>We recommend using the error detection method, depending on the selected memory allocation method.</code>.</p>
+
+</recommendation>
+<example>
+<p>The following file demonstrates various approaches to detecting memory allocation errors using the new operator.</p>
+<sample src="WrongInDetectingAndHandlingMemoryAllocationErrors.cpp" />
+
+</example>
+<references>
+
+<li>
+  CERT C++ Coding Standard:
+<a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/MEM52-CPP.+Detect+and+handle+memory+allocation+errors">MEM52-CPP. Detect and handle memory allocation errors</a>.
+</li>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.qhelp
@@ -5,8 +5,6 @@
 <overview>
 <p>When using the <code>new</code> operator to allocate memory, you need to pay attention to the different ways of detecting errors. <code>::operator new(std::size_t)</code> throws an exception on error, whereas <code>::operator new(std::size_t, const std::nothrow_t &)</code> returns zero on error. The programmer can get confused and check the error that occurs when allocating memory incorrectly. That can lead to an unhandled program termination or to a violation of the program logic.</p>
 
-<p>Loss of detection probably refers to use cases where memory allocation using your own solutions with strong nesting. It is also possible when using a buffer in the form of fields of different structures with the same names.</p>
-
 </overview>
 <recommendation>
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.qhelp
@@ -3,7 +3,7 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>When using the <code>new</code> operator to allocate memory, you need to pay attention to the different ways of detecting errors. <code>::operator new(std::size_t)</code> throws an exception on error, whereas <code>::operator new(std::size_t, const std::nothrow_t &)</code> returns zero on error. The programmer can get confused and check the error that occurs when allocating memory incorrectly. That can lead to an unhandled program termination or to a violation of the program logic.</p>
+<p>When using the <code>new</code> operator to allocate memory, you need to pay attention to the different ways of detecting errors. <code>::operator new(std::size_t)</code> throws an exception on error, whereas <code>::operator new(std::size_t, const std::nothrow_t &amp;)</code> returns zero on error. The programmer can get confused and check the error that occurs when allocating memory incorrectly. That can lead to an unhandled program termination or to a violation of the program logic.</p>
 
 </overview>
 <recommendation>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.qhelp
@@ -3,18 +3,18 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>when using the new operator to allocate memory, you need to pay attention to the different way of detecting errors. so <code> ::operator new(std::size_t) </code> throws an exception on error, and <code> ::operator new(std::size_t, const std::nothrow_t &) </code> returns zero on error. the programmer can get confused and check the error that occurs when allocating memory incorrectly. That can lead to an unhandled program termination or to a violation of the program logic.</p>
+<p>When using the <code>new</code> operator to allocate memory, you need to pay attention to the different ways of detecting errors. <code>::operator new(std::size_t)</code> throws an exception on error, whereas <code>::operator new(std::size_t, const std::nothrow_t &)</code> returns zero on error. The programmer can get confused and check the error that occurs when allocating memory incorrectly. That can lead to an unhandled program termination or to a violation of the program logic.</p>
 
 <p>Loss of detection probably refers to use cases where memory allocation using your own solutions with strong nesting. It is also possible when using a buffer in the form of fields of different structures with the same names.</p>
 
 </overview>
 <recommendation>
 
-<p>We recommend using the error detection method, depending on the selected memory allocation method.</code>.</p>
+<p>Use the correct error detection method corresponding with the memory allocation.</p>
 
 </recommendation>
 <example>
-<p>The following file demonstrates various approaches to detecting memory allocation errors using the new operator.</p>
+<p>The following example demonstrates various approaches to detecting memory allocation errors using the <code>new</code> operator.</p>
 <sample src="WrongInDetectingAndHandlingMemoryAllocationErrors.cpp" />
 
 </example>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
@@ -44,14 +44,8 @@ class WrongCheckErrorOperatorNew extends FunctionCall {
    * Holds if handler `try ... catch` exists.
    */
   predicate isExistsTryCatchBlock() {
-    exists(TryStmt tb, AssignExpr aex, Initializer it |
-      tb.getAChild*() = exp
-      or
-      exp = it.getExpr() and
-      tb.getAChild*().(DeclStmt).getADeclaration() = it.getDeclaration()
-      or
-      aex.getAChild*() = exp and
-      tb.getAChild*().(AssignExpr) = aex
+    exists(TryStmt ts |
+      this.getEnclosingStmt() = ts.getStmt().getAChild*()
     )
   }
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
@@ -58,7 +58,7 @@ class WrongCheckErrorOperatorNew extends FunctionCall {
   predicate isExistsIfCondition() {
     exists(IfCompareWithZero ifc, AssignExpr aex, Initializer it |
       // call `operator new` directly from the condition of `operator if`.
-      this = ifc.getCondition().getAChild()
+      this = ifc.getCondition().getAChild*()
       or
       // check results call `operator new` with variable appropriation
       postDominates(ifc, this) and

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
@@ -2,7 +2,6 @@
  * @name Сonfusion In Detecting And Handling Memory Allocation Errors
  * @description --::operator new(std::size_t) throws an exception on error, and ::operator new(std::size_t, const std::nothrow_t &) returns zero on error.
  *              --the programmer can get confused when check the error that occurs when allocating memory incorrectly.
- *              --Making a call of this type may result in a zero byte being written just outside the buffer.
  * @kind problem
  * @id cpp/detect-and-handle-memory-allocation-errors
  * @problem.severity warning

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
@@ -1,5 +1,5 @@
 /**
- * @name Сonfusion In Detecting And Handling Memory Allocation Errors
+ * @name onfusion In Detecting And Handling Memory Allocation Errors
  * @description --::operator new(std::size_t) throws an exception on error, and ::operator new(std::size_t, const std::nothrow_t &) returns zero on error.
  *              --the programmer can get confused when check the error that occurs when allocating memory incorrectly.
  * @kind problem
@@ -47,9 +47,7 @@ class WrongCheckErrorOperatorNew extends FunctionCall {
    * Holds if handler `try ... catch` exists.
    */
   predicate isExistsTryCatchBlock() {
-    exists(TryStmt ts |
-      this.getEnclosingStmt() = ts.getStmt().getAChild*()
-    )
+    exists(TryStmt ts | this.getEnclosingStmt() = ts.getStmt().getAChild*())
   }
 
   /**

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
@@ -1,5 +1,5 @@
 /**
- * @name onfusion In Detecting And Handling Memory Allocation Errors
+ * @name Detect And Handle Memory Allocation Errors
  * @description --::operator new(std::size_t) throws an exception on error, and ::operator new(std::size_t, const std::nothrow_t &) returns zero on error.
  *              --the programmer can get confused when check the error that occurs when allocating memory incorrectly.
  * @kind problem

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
@@ -22,6 +22,9 @@ class IfCompareWithZero extends IfStmt {
     or
     this.getCondition().(NEExpr).getAChild().getValue() = "0" and
     this.hasElse()
+    or
+    this.getCondition().(NEExpr).getAChild().getValue() = "0" and
+    this.getThen().getAChild*() instanceof ReturnStmt
   }
 }
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
@@ -1,0 +1,93 @@
+/**
+ * @name Сonfusion In Detecting And Handling Memory Allocation Errors
+ * @description --::operator new(std::size_t) throws an exception on error, and ::operator new(std::size_t, const std::nothrow_t &) returns zero on error.
+ *              --the programmer can get confused when check the error that occurs when allocating memory incorrectly.
+ *              --Making a call of this type may result in a zero byte being written just outside the buffer.
+ * @kind problem
+ * @id cpp/detect-and-handle-memory-allocation-errors
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ *       security
+ *       external/cwe/cwe-570
+ */
+
+import cpp
+
+/**
+ * Lookup if condition compare with 0
+ */
+class IfCompareWithZero extends IfStmt {
+  IfCompareWithZero() {
+    this.getCondition().(EQExpr).getAChild().getValue() = "0"
+    or
+    this.getCondition().(NEExpr).getAChild().getValue() = "0" and
+    this.hasElse()
+  }
+}
+
+/**
+ * lookup for calls to `operator new`, with incorrect error handling.
+ */
+class WrongCheckErrorOperatorNew extends FunctionCall {
+  Expr exp;
+
+  WrongCheckErrorOperatorNew() {
+    this = exp.(NewOrNewArrayExpr).getAChild().(FunctionCall) and
+    (
+      this.getTarget().hasGlobalOrStdName("operator new")
+      or
+      this.getTarget().hasGlobalOrStdName("operator new[]")
+    )
+  }
+
+  /**
+   * Holds if handler `try ... catch` exists.
+   */
+  predicate isExistsTryCatchBlock() {
+    exists(TryStmt tb, AssignExpr aex, Initializer it |
+      tb.getAChild*() = exp
+      or
+      exp = it.getExpr() and
+      tb.getAChild*().(DeclStmt).getADeclaration() = it.getDeclaration()
+      or
+      aex.getAChild*() = exp and
+      tb.getAChild*().(AssignExpr) = aex
+    )
+  }
+
+  /**
+   * Holds if results call `operator new` check in `operator if`.
+   */
+  predicate isExistsIfCondition() {
+    exists(IfCompareWithZero ifc, AssignExpr aex, Initializer it |
+      // call `operator new` directly from the condition of `operator if`.
+      this = ifc.getCondition().getAChild()
+      or
+      // check results call `operator new` with variable appropriation
+      postDominates(ifc, this) and
+      aex.getAChild() = exp and
+      ifc.getCondition().getAChild().(VariableAccess).getTarget() =
+        aex.getLValue().(VariableAccess).getTarget()
+      or
+      // check results call `operator new` with declaration variable
+      postDominates(ifc, this) and
+      exp = it.getExpr() and
+      it.getDeclaration() = ifc.getCondition().getAChild().(VariableAccess).getTarget()
+    )
+  }
+
+  /**
+   * Holds if `(std::nothrow)` exists in call `operator new`.
+   */
+  predicate isExistsNothrow() { this.getAChild().toString() = "nothrow" }
+}
+
+from WrongCheckErrorOperatorNew op
+where
+  // use call `operator new` with `(std::nothrow)` and checking error using `try ... catch` block and not `operator if`
+  op.isExistsNothrow() and not op.isExistsIfCondition() and op.isExistsTryCatchBlock()
+  or
+  // use call `operator new` without `(std::nothrow)` and checking error using `operator if` and not  `try ... catch` block
+  not op.isExistsNothrow() and not op.isExistsTryCatchBlock() and op.isExistsIfCondition()
+select op, "memory allocation error check is incorrect or missing"

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/WrongInDetectingAndHandlingMemoryAllocationErrors.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/WrongInDetectingAndHandlingMemoryAllocationErrors.expected
@@ -1,0 +1,5 @@
+| test.cpp:30:15:30:26 | call to operator new[] | memory allocation error check is incorrect or missing |
+| test.cpp:38:9:38:20 | call to operator new[] | memory allocation error check is incorrect or missing |
+| test.cpp:50:13:50:38 | call to operator new[] | memory allocation error check is incorrect or missing |
+| test.cpp:51:22:51:47 | call to operator new[] | memory allocation error check is incorrect or missing |
+| test.cpp:53:18:53:43 | call to operator new[] | memory allocation error check is incorrect or missing |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/WrongInDetectingAndHandlingMemoryAllocationErrors.qlref
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/WrongInDetectingAndHandlingMemoryAllocationErrors.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/test.cpp
@@ -1,0 +1,97 @@
+#define NULL ((void*)0)
+class exception {};
+
+namespace std{
+  struct nothrow_t {};
+  typedef unsigned long size_t;
+  class bad_alloc{
+    const char* what() const throw();
+  };
+  extern const std::nothrow_t nothrow;
+}
+
+using namespace std;
+
+void* operator new(std::size_t _Size);
+void* operator new[](std::size_t _Size);
+void* operator new( std::size_t count, const std::nothrow_t& tag );
+void* operator new[]( std::size_t count, const std::nothrow_t& tag );
+
+void badNew_0_0()
+{
+    while (true) {
+        new int[100];
+        if(!(new int[100]))
+            return;
+    }
+}
+void badNew_0_1()
+{
+    int * i = new int[100];
+    if(i == 0)
+        return;
+    if(!i)
+        return;
+    if(i == NULL)
+        return;
+    int * j;
+    j = new int[100];
+    if(j == 0)
+        return;
+    if(!j)
+        return;
+    if(j == NULL)
+        return;
+}
+void badNew_1_0()
+{
+    try {
+        while (true) {
+            new(std::nothrow) int[100];
+            int* p = new(std::nothrow) int[100];
+            int* p1;
+            p1 = new(std::nothrow) int[100];
+        }
+    } catch (const exception &){//const std::bad_alloc& e) {
+//        std::cout << e.what() << '\n';
+    }
+}
+void badNew_1_1()
+{
+    while (true) {
+        int* p = new(std::nothrow) int[100];
+        new(std::nothrow) int[100];
+    }
+}
+
+void goodNew_0_0()
+{
+    try {
+        while (true) {
+            new int[100];
+        }
+    } catch (const exception &){//const std::bad_alloc& e) {
+//        std::cout << e.what() << '\n';
+    }
+}
+
+void goodNew_1_0()
+{
+    while (true) {
+        int* p = new(std::nothrow) int[100];
+        if (p == nullptr) {
+//            std::cout << "Allocation returned nullptr\n";
+            break;
+        }
+        int* p1;
+        p1 = new(std::nothrow) int[100];
+        if (p1 == nullptr) {
+//            std::cout << "Allocation returned nullptr\n";
+            break;
+        }
+        if (new(std::nothrow) int[100] == nullptr) {
+//            std::cout << "Allocation returned nullptr\n";
+            break;
+        }
+    }
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/test.cpp
@@ -20,14 +20,14 @@ void* operator new[]( std::size_t count, const std::nothrow_t& tag );
 void badNew_0_0()
 {
     while (true) {
-        new int[100];
-        if(!(new int[100]))
+        new int[100]; // BAD [NOT DETECTED]
+        if(!(new int[100])) // BAD [NOT DETECTED]
             return;
     }
 }
 void badNew_0_1()
 {
-    int * i = new int[100];
+    int * i = new int[100]; // BAD
     if(i == 0)
         return;
     if(!i)
@@ -35,7 +35,7 @@ void badNew_0_1()
     if(i == NULL)
         return;
     int * j;
-    j = new int[100];
+    j = new int[100]; // BAD
     if(j == 0)
         return;
     if(!j)
@@ -47,10 +47,10 @@ void badNew_1_0()
 {
     try {
         while (true) {
-            new(std::nothrow) int[100];
-            int* p = new(std::nothrow) int[100];
+            new(std::nothrow) int[100]; // BAD
+            int* p = new(std::nothrow) int[100]; // BAD
             int* p1;
-            p1 = new(std::nothrow) int[100];
+            p1 = new(std::nothrow) int[100]; // BAD
         }
     } catch (const exception &){//const std::bad_alloc& e) {
 //        std::cout << e.what() << '\n';
@@ -59,8 +59,8 @@ void badNew_1_0()
 void badNew_1_1()
 {
     while (true) {
-        int* p = new(std::nothrow) int[100];
-        new(std::nothrow) int[100];
+        int* p = new(std::nothrow) int[100]; // BAD [NOT DETECTED]
+        new(std::nothrow) int[100]; // BAD [NOT DETECTED]
     }
 }
 
@@ -68,7 +68,7 @@ void goodNew_0_0()
 {
     try {
         while (true) {
-            new int[100];
+            new int[100]; // GOOD
         }
     } catch (const exception &){//const std::bad_alloc& e) {
 //        std::cout << e.what() << '\n';
@@ -78,18 +78,18 @@ void goodNew_0_0()
 void goodNew_1_0()
 {
     while (true) {
-        int* p = new(std::nothrow) int[100];
+        int* p = new(std::nothrow) int[100]; // GOOD
         if (p == nullptr) {
 //            std::cout << "Allocation returned nullptr\n";
             break;
         }
         int* p1;
-        p1 = new(std::nothrow) int[100];
+        p1 = new(std::nothrow) int[100]; // GOOD
         if (p1 == nullptr) {
 //            std::cout << "Allocation returned nullptr\n";
             break;
         }
-        if (new(std::nothrow) int[100] == nullptr) {
+        if (new(std::nothrow) int[100] == nullptr) { // GOOD
 //            std::cout << "Allocation returned nullptr\n";
             break;
         }


### PR DESCRIPTION
In this query I am trying to find situations of incorrect handling of memory allocation using the new operator.
This error is quite common in projects and can lead to a violation of the logic of the program or to an unhandled crash.

of course, we can consider any selection without processing to be incorrect, but in this request I am considering exactly the situation of confusion. when the developer confused what kind of processing to apply. this allows us to understand that he tried to handle the case when the memory will not be allocated, but did not handle it correctly.

this is my first test file in C ++, it turned out to be rather weak, in the future I will think about improving it.