### PR TITLE
Python: add missing postupdate nodes

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -77,7 +77,9 @@ class ReadPreUpdateNode extends NeedsSyntheticPostUpdateNode, CfgNode {
       a.getCtx() instanceof Load
     )
     or
-    exists(SubscriptNode s | node = s.getObject())
+    node = any(SubscriptNode s).getObject()
+    or
+    node.getNode() = any(Call call).getKwargs()
   }
 
   override string label() { result = "read" }

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -76,6 +76,8 @@ class ReadPreUpdateNode extends NeedsSyntheticPostUpdateNode, CfgNode {
       node = a.getObject().getAFlowNode() and
       a.getCtx() instanceof Load
     )
+    or
+    exists(SubscriptNode s | node = s.getObject())
   }
 
   override string label() { result = "read" }

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -69,7 +69,17 @@ class StorePreUpdateNode extends NeedsSyntheticPostUpdateNode, CfgNode {
   override string label() { result = "store" }
 }
 
-/** A node marking the state change of an object after a read. */
+/**
+ * A node marking the state change of an object after a read.
+ *
+ * A reverse read happens when the result of a read is modified, e.g. in
+ * ```python
+ * l = [ mutable ]
+ * l[0].mutate()
+ * ```
+ * we may now have changed the content of `l`. To track this, there must be
+ * a postupdate node for `l`.
+ */
 class ReadPreUpdateNode extends NeedsSyntheticPostUpdateNode, CfgNode {
   ReadPreUpdateNode() {
     exists(Attribute a |

--- a/python/ql/test/experimental/dataflow/coverage/localFlow.expected
+++ b/python/ql/test/experimental/dataflow/coverage/localFlow.expected
@@ -8,6 +8,7 @@
 | test.py:187:1:187:53 | GSSA Variable SINK | test.py:189:5:189:8 | ControlFlowNode for SINK |
 | test.py:187:1:187:53 | GSSA Variable SOURCE | test.py:188:25:188:30 | ControlFlowNode for SOURCE |
 | test.py:188:5:188:5 | SSA variable x | test.py:189:10:189:10 | ControlFlowNode for x |
+| test.py:188:9:188:68 | ControlFlowNode for .0 | test.py:188:9:188:68 | SSA variable .0 |
 | test.py:188:9:188:68 | ControlFlowNode for ListComp | test.py:188:5:188:5 | SSA variable x |
 | test.py:188:9:188:68 | SSA variable .0 | test.py:188:9:188:68 | ControlFlowNode for .0 |
 | test.py:188:16:188:16 | SSA variable v | test.py:188:45:188:45 | ControlFlowNode for v |

--- a/python/ql/test/experimental/dataflow/coverage/localFlow.expected
+++ b/python/ql/test/experimental/dataflow/coverage/localFlow.expected
@@ -8,7 +8,6 @@
 | test.py:187:1:187:53 | GSSA Variable SINK | test.py:189:5:189:8 | ControlFlowNode for SINK |
 | test.py:187:1:187:53 | GSSA Variable SOURCE | test.py:188:25:188:30 | ControlFlowNode for SOURCE |
 | test.py:188:5:188:5 | SSA variable x | test.py:189:10:189:10 | ControlFlowNode for x |
-| test.py:188:9:188:68 | ControlFlowNode for .0 | test.py:188:9:188:68 | SSA variable .0 |
 | test.py:188:9:188:68 | ControlFlowNode for ListComp | test.py:188:5:188:5 | SSA variable x |
 | test.py:188:9:188:68 | SSA variable .0 | test.py:188:9:188:68 | ControlFlowNode for .0 |
 | test.py:188:16:188:16 | SSA variable v | test.py:188:45:188:45 | ControlFlowNode for v |


### PR DESCRIPTION
Removing all 14909 inconsistency failures of type `reverseRead` from saltstack by adding missing postupdate nodes.

A reverse read happens when the result of a read is modified, e.g. in
```python
l = [ mutable ]
l[0].mutate()
```
we may now have changed the content of `l`. To track this, there must be a postupdate node for `l`.
The rule is that if the result of a read (here `mutable`) has a postupdate node, then so must the
object being read from (here `l`).
