### PR TITLE
JS: Add test that depends on getAQlClass

### DIFF
--- a/javascript/ql/test/library-tests/DataFlow/tests.expected
+++ b/javascript/ql/test/library-tests/DataFlow/tests.expected
@@ -1573,3 +1573,5 @@ sources
 | tst.js:117:10:117:20 | Object.seal |
 | tst.js:117:10:117:24 | Object.seal(x1) |
 | tst.js:117:22:117:23 | x1 |
+stress_getAQlClass
+| OK |

--- a/javascript/ql/test/library-tests/DataFlow/tests.ql
+++ b/javascript/ql/test/library-tests/DataFlow/tests.ql
@@ -28,3 +28,10 @@ query predicate noBasicBlock(DataFlow::Node node) { not exists(node.getBasicBloc
 query predicate parameters(DataFlow::ParameterNode param) { any() }
 
 query predicate sources(DataFlow::SourceNode src) { any() }
+
+query predicate stress_getAQlClass(string msg) {
+  // Compile and evaluate `getAQlClass` so we get notified of potential problems with BDD size.
+  // Avoid outputting its result, however, as the output would constantly need to be updated.
+  count(DataFlow::Node node, string cls | cls = node.getAQlClass()) >= 42 and
+  msg = "OK"
+}


### PR DESCRIPTION
As discussed, adds a test to warn about problems when compiling `getAQlClass` for `DataFlow::Node`.