### PR TITLE
Add "tests" fields to test qlpacks

### DIFF
--- a/cpp/ql/test/qlpack.yml
+++ b/cpp/ql/test/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-cpp-tests
 version: 0.0.0
 libraryPathDependencies: codeql-cpp
 extractor: cpp
+tests: .

--- a/csharp/ql/test/qlpack.yml
+++ b/csharp/ql/test/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-csharp-tests
 version: 0.0.0
 libraryPathDependencies: codeql-csharp
 extractor: csharp
+tests: .

--- a/java/ql/test/qlpack.yml
+++ b/java/ql/test/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-java-tests
 version: 0.0.0
 libraryPathDependencies: codeql-java
 extractor: java
+tests: .

--- a/javascript/ql/test/qlpack.yml
+++ b/javascript/ql/test/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-javascript-tests
 version: 0.0.0
 libraryPathDependencies: codeql-javascript
 extractor: javascript
+tests: .

--- a/python/ql/test/qlpack.yml
+++ b/python/ql/test/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-python-tests
 version: 0.0.0
 libraryPathDependencies: codeql-python
 extractor: python
+tests: .


### PR DESCRIPTION
This will allow `codeql resolve tests --ignore-dubious-cases` (and thus the VSCode extension) to recognize all `.ql` files in those packs as test cases, even if they don't have accompanying `.expected` files.

CLI versions prior to 2.1.0 will choke on this, but it's almost 10 months since that came out.