### PR TITLE
Python: Callable for lambdas

### DIFF
--- a/python/ql/src/semmle/python/Function.qll
+++ b/python/ql/src/semmle/python/Function.qll
@@ -42,8 +42,8 @@ class Function extends Function_, Scope, AstNode {
   /**
    * Holds if this function represents a lambda.
    *
-   * The extractor reifies each lambda expression as a (local) function with the name 
-   * "lambda". As `lambda` is a keyword in Python, it's impossible to create a function with this 
+   * The extractor reifies each lambda expression as a (local) function with the name
+   * "lambda". As `lambda` is a keyword in Python, it's impossible to create a function with this
    * name otherwise, and so it's impossible to get a non-lambda function accidentally
    * classified as a lambda.
    */

--- a/python/ql/src/semmle/python/Function.qll
+++ b/python/ql/src/semmle/python/Function.qll
@@ -40,8 +40,12 @@ class Function extends Function_, Scope, AstNode {
   }
 
   /**
-   * Whether this is a lambda.
-   * We detect this by comparing its name to the one the extractor gives to lambdas.
+   * Holds if this function represents a lambda.
+   *
+   * The extractor reifies each lambda expression as a (local) function with the name 
+   * "lambda". As `lambda` is a keyword in Python, it's impossible to create a function with this 
+   * name otherwise, and so it's impossible to get a non-lambda function accidentally
+   * classified as a lambda.
    */
   predicate isLambda() { this.getName() = "lambda" }
 

--- a/python/ql/src/semmle/python/Function.qll
+++ b/python/ql/src/semmle/python/Function.qll
@@ -39,6 +39,12 @@ class Function extends Function_, Scope, AstNode {
     exists(YieldFrom y | y.getScope() = this)
   }
 
+  /**
+   * Whether this is a lambda.
+   * We detect this by comparing its name to the one the extractor gives to lambdas.
+   */
+  predicate isLambda() { this.getName() = "lambda" }
+
   /** Whether this function is declared in a class and is named `__init__` */
   predicate isInitMethod() { this.isMethod() and this.getName() = "__init__" }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -498,10 +498,13 @@ import ArgumentPassing
  */
 newtype TDataFlowCallable =
   TCallableValue(CallableValue callable) {
-    callable instanceof FunctionValue
+    callable instanceof FunctionValue and
+    // TODO: push into FunctionValue
+    not callable.(FunctionValue).getOrigin().getNode() instanceof Lambda
     or
     callable instanceof ClassValue
   } or
+  TLambda(Function lambda) { lambda.getName() = "lambda" } or
   TModule(Module m)
 
 /** Represents a callable. */
@@ -542,6 +545,27 @@ class DataFlowCallableValue extends DataFlowCallable, TCallableValue {
   override string getName() { result = callable.getName() }
 
   override CallableValue getCallableValue() { result = callable }
+}
+
+/** A class representing a callable lambda. */
+class DataFlowLambda extends DataFlowCallable, TLambda {
+  Function lambda;
+
+  DataFlowLambda() { this = TLambda(lambda) }
+
+  override string toString() { result = lambda.toString() }
+
+  override CallNode getACall() { result = getCallableValue().getACall() }
+
+  override Scope getScope() { result = lambda.getEvaluatingScope() }
+
+  override NameNode getParameter(int n) { result = getParameter(getCallableValue(), n) }
+
+  override string getName() { result = "Lambda callable" }
+
+  override CallableValue getCallableValue() {
+    result.(FunctionValue).getOrigin().getNode() = lambda.getDefinition()
+  }
 }
 
 /** A class representing the scope in which a `ModuleVariableNode` appears. */

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -499,12 +499,11 @@ import ArgumentPassing
 newtype TDataFlowCallable =
   TCallableValue(CallableValue callable) {
     callable instanceof FunctionValue and
-    // TODO: push into FunctionValue
-    not callable.(FunctionValue).getOrigin().getNode() instanceof Lambda
+    not callable.(FunctionValue).isLambda()
     or
     callable instanceof ClassValue
   } or
-  TLambda(Function lambda) { lambda.getName() = "lambda" } or
+  TLambda(Function lambda) { lambda.isLambda() } or
   TModule(Module m)
 
 /** Represents a callable. */

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -562,8 +562,8 @@ class DataFlowLambda extends DataFlowCallable, TLambda {
 
   override string getName() { result = "Lambda callable" }
 
-  override CallableValue getCallableValue() {
-    result.(FunctionValue).getOrigin().getNode() = lambda.getDefinition()
+  override FunctionValue getCallableValue() {
+    result.getOrigin().getNode() = lambda.getDefinition()
   }
 }
 

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -721,7 +721,7 @@ abstract class FunctionValue extends CallableValue {
   /** Gets a class that this function may return */
   abstract ClassValue getAnInferredReturnType();
 
-  /** Wheter this is a lambda function */
+  /** Holds if this function represents a lambda. */
   predicate isLambda() { this.getOrigin().getNode() instanceof Lambda }
 }
 

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -720,6 +720,9 @@ abstract class FunctionValue extends CallableValue {
 
   /** Gets a class that this function may return */
   abstract ClassValue getAnInferredReturnType();
+
+  /** Wheter this is a lambda function */
+  predicate isLambda() { this.getOrigin().getNode() instanceof Lambda }
 }
 
 /** Class representing Python functions */

--- a/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
@@ -1,11 +1,16 @@
 uniqueEnclosingCallable
+| test.py:256:18:256:18 | ControlFlowNode for x | Node should have one enclosing callable but has 2. |
+| test.py:256:18:256:18 | SSA variable x | Node should have one enclosing callable but has 2. |
+| test.py:256:21:256:25 | ControlFlowNode for False | Node should have one enclosing callable but has 2. |
 uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
 missingToString
 parameterCallable
+| test.py:256:18:256:18 | ControlFlowNode for x | Callable mismatch for parameter. |
 localFlowIsLocal
+| test.py:256:18:256:18 | ControlFlowNode for x | test.py:256:18:256:18 | SSA variable x | Local flow step does not preserve enclosing callable. |
 compatibleTypesReflexive
 unreachableNodeCCtx
 localCallNodes

--- a/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
@@ -1,16 +1,11 @@
 uniqueEnclosingCallable
-| test.py:256:18:256:18 | ControlFlowNode for x | Node should have one enclosing callable but has 2. |
-| test.py:256:18:256:18 | SSA variable x | Node should have one enclosing callable but has 2. |
-| test.py:256:21:256:25 | ControlFlowNode for False | Node should have one enclosing callable but has 2. |
 uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
 missingToString
 parameterCallable
-| test.py:256:18:256:18 | ControlFlowNode for x | Callable mismatch for parameter. |
 localFlowIsLocal
-| test.py:256:18:256:18 | ControlFlowNode for x | test.py:256:18:256:18 | SSA variable x | Local flow step does not preserve enclosing callable. |
 compatibleTypesReflexive
 unreachableNodeCCtx
 localCallNodes

--- a/python/ql/test/experimental/dataflow/consistency/test.py
+++ b/python/ql/test/experimental/dataflow/consistency/test.py
@@ -249,3 +249,10 @@ def synth_arg_kwOverflow():
 
 def synth_arg_kwUnpacked():
     overflowCallee(**{"p": "42"})
+
+def split_lambda(cond):
+    if cond:
+        pass
+    foo = lambda x: False
+    if cond:
+        pass


### PR DESCRIPTION
Separate callable for lambdas. Since lambdas are split, but their children are not, we use the Function as the callable.
