### PR TITLE
Python: Only generate one post-update node, even if there are multiple reasons for doing so.

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -416,12 +416,6 @@ module ArgumentPassing {
    *
    * NOT SUPPORTED: Keyword-only parameters.
    */
-  Node testGetArg(CallNode call, int n, DataFlowCallable callable) {
-    result.getLocation().getStartLine() = 685 and
-    result.getLocation().getFile().getBaseName() = "ElementTree.py" and
-    result = getArg(call, TNoShift(), callable.getCallableValue(), n)
-  }
-
   Node getArg(CallNode call, ArgParamMapping mapping, CallableValue callable, int paramN) {
     connects(call, callable) and
     (


### PR DESCRIPTION
Some nodes would need a synthetic post-update node for multiple reasons. In this case, multiple nodes were created.
This was amplified by the recent treatment of reverse reads.
It was discovered by the consistency check for multiple `toString` methods for post-update nodes.﻿

### To consider:
- This PR refactors the code to deal with post-update nodes. It could be argued that the same refactor should be applied to pre-argument nodes, so they also get their own module.
- Would we actually like to also move `class SyntheticPostUpdateNode` (and `class SyntheticPreUpdateNode`) into those modules?