### PR TITLE
C++: Remove linear scan of functions table

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strcpy.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strcpy.qll
@@ -40,9 +40,7 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction, Sid
   /**
    * Holds if this is one of the `strcpy_s` variants.
    */
-  private predicate isSVariant() {
-    exists(string name | name = getName() | name.suffix(name.length() - 2) = "_s")
-  }
+  private predicate isSVariant() { getName().matches("%\\_s") }
 
   /**
    * Gets the index of the parameter that is the maximum size of the copy (in characters).


### PR DESCRIPTION
Tested on ChakraCore.

Before:
```
Tuple counts for Strcpy::StrcpyFunction::isSVariant_dispred#f/1@a95335:
191475 ~0%     {2} r1 = SCAN functions AS I OUTPUT I.<0> 'this', I.<1>
7      ~0%     {4} r2 = JOIN r1 WITH Strcpy::StrcpyFunction#class#f AS R ON FIRST 1 OUTPUT r1.<0> 'this', r1.<1>, (length(r1.<1>) - 2), suffix(r1.<1>,(length(r1.<1>) - 2))
2      ~0%     {4} r3 = SELECT r2 ON r2.<3> = "_s"
2      ~0%     {1} r4 = SCAN r3 OUTPUT r3.<0> 'this'
                return r4
```

After:
```
Tuple counts for Strcpy::StrcpyFunction::isSVariant_dispred#f/1@a5f595:
274    ~0%     {3} r1 = SELECT functions AS I ON I.<1> endsWith "_s"
274    ~1%     {1} r2 = SCAN r1 OUTPUT r1.<0> 'this'
2      ~0%     {1} r3 = JOIN r2 WITH Strcpy::StrcpyFunction#class#f AS R ON FIRST 1 OUTPUT r2.<0> 'this'
                return r3
```