### PR TITLE
Docs: Update copyright date in footer

### DIFF
--- a/docs/codeql/_templates/layout.html
+++ b/docs/codeql/_templates/layout.html
@@ -165,7 +165,7 @@
             </li>
         </ul>
         <ul class="list-style-none d-flex text-gray">
-            <li class="mr-3">&copy; 2020 GitHub, Inc.</li>
+            <li class="mr-3">&copy; 2021 GitHub, Inc.</li>
             <li class="mr-3"><a
                     href="https://docs.github.com/github/site-policy/github-terms-of-service"
                     class="link-gray">Terms </a></li>

--- a/docs/codeql/index.html
+++ b/docs/codeql/index.html
@@ -349,7 +349,7 @@
                     </li>
                 </ul>
                 <ul class="list-style-none d-flex text-gray">
-                    <li class="mr-3">&copy; 2020 GitHub, Inc.</li>
+                    <li class="mr-3">&copy; 2021 GitHub, Inc.</li>
                     <li class="mr-3"><a
                             href="https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-terms-of-service"
                             class="link-gray">Terms </a></li>


### PR DESCRIPTION
The footer still mentioned 2020 instead of 2021. Two instances to update:

- [`layout.html`](https://github.com/github/codeql/pull/5028/files#diff-db0723e55136b2bbd6cf8e7d90eec32ce535f6bd72ede07f13a68d8a64ec56ad) is the "template" page that gets used by all the other Sphinx-generated pages. 
- [`index.html`](https://github.com/github/codeql/pull/5028/files#diff-a294571ec6be05735ac055c91c64653cc58ff5943dae2a0272b73210fba353a0) is the landing page at https://codeql.github.com/docs/