### PR TITLE
JS: Ignore Angular templates in a few non-security queries

### DIFF
--- a/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
@@ -68,5 +68,7 @@ where
       not exists(SsaImplicitInit init | init.getVariable().getSourceVariable() = v) // the variable is dead at the hoisted implicit initialization.
     then msg = "The initial value of " + v.getName() + " is unused, since it is always overwritten."
     else msg = "The value assigned to " + v.getName() + " here is unused."
-  )
+  ) and
+  // ignore Angular templates
+  not dead.(ASTNode).getTopLevel() instanceof Angular2::TemplateTopLevel
 select dead, msg

--- a/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
@@ -299,7 +299,9 @@ where
     assign1 instanceof CallToObjectDefineProperty
     implies
     assign1.(CallToObjectDefineProperty).hasPropertyAttributeWrite("value", _)
-  )
+  ) and
+  // ignore Angular templates
+  not assign1.getTopLevel() instanceof Angular2::TemplateTopLevel
 select assign1.getWriteNode(),
   "This write to property '" + name + "' is useless, since $@ always overrides it.",
   assign2.getWriteNode(), "another property write"

--- a/javascript/ql/src/Expressions/ExprHasNoEffect.qll
+++ b/javascript/ql/src/Expressions/ExprHasNoEffect.qll
@@ -164,5 +164,7 @@ predicate hasNoEffect(Expr e) {
     top = e.getParent().(ExprStmt).getParent() and
     top.getNumChild() = 1 and
     not exists(Function fun | fun.getEnclosingContainer() = top)
-  )
+  ) and
+  // ignore Angular templates
+  not e.getTopLevel() instanceof Angular2::TemplateTopLevel
 }

--- a/javascript/ql/src/LanguageFeatures/SyntaxError.ql
+++ b/javascript/ql/src/LanguageFeatures/SyntaxError.ql
@@ -13,4 +13,5 @@
 import javascript
 
 from JSParseError pe
+where not pe.getTopLevel() instanceof Angular2::TemplateTopLevel
 select pe, pe.getMessage()


### PR DESCRIPTION
Ignores some non-security alerts in Angular templates.