### PR TITLE
JS: Add ClientSideRemoteFlowSource

### DIFF
--- a/javascript/change-notes/2021-03-15-client-side-remote-flow-sources.md
+++ b/javascript/change-notes/2021-03-15-client-side-remote-flow-sources.md
@@ -1,0 +1,6 @@
+lgtm,codescanning
+* The security queries now distinguish more clearly between different parts of `window.locaton`.
+  When the taint source of an alert is based on `window.location`, the source will usually
+  occur closer to where user-controlled data is obtained, such as at `location.hash`.
+* `js/request-forgery` no longer considers client-side path parameters to be a source due to
+  the restricted character set usable in a path, resulting in fewer false-positive results.

--- a/javascript/change-notes/2021-03-15-client-side-remote-flow-sources.md
+++ b/javascript/change-notes/2021-03-15-client-side-remote-flow-sources.md
@@ -1,5 +1,5 @@
 lgtm,codescanning
-* The security queries now distinguish more clearly between different parts of `window.locaton`.
+* The security queries now distinguish more clearly between different parts of `window.location`.
   When the taint source of an alert is based on `window.location`, the source will usually
   occur closer to where user-controlled data is obtained, such as at `location.hash`.
 * `js/request-forgery` no longer considers client-side path parameters to be a source due to

--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -130,9 +130,7 @@ module Closure {
   }
 
   pragma[noinline]
-  private ClosureRequireCall getARequireInTopLevel(ClosureModule m) {
-    result.getTopLevel() = m
-  }
+  private ClosureRequireCall getARequireInTopLevel(ClosureModule m) { result.getTopLevel() = m }
 
   /**
    * A module using the Closure module system, declared using `goog.module()` or `goog.declareModuleId()`.
@@ -151,7 +149,8 @@ module Closure {
     string getClosureNamespace() { result = getModuleDeclaration().getClosureNamespace() }
 
     override Module getAnImportedModule() {
-      result.(ClosureModule).getClosureNamespace() = getARequireInTopLevel(this).getClosureNamespace()
+      result.(ClosureModule).getClosureNamespace() =
+        getARequireInTopLevel(this).getClosureNamespace()
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -129,6 +129,11 @@ module Closure {
     container = result.getContainer()
   }
 
+  pragma[noinline]
+  private ClosureRequireCall getARequireInTopLevel(ClosureModule m) {
+    result.getTopLevel() = m
+  }
+
   /**
    * A module using the Closure module system, declared using `goog.module()` or `goog.declareModuleId()`.
    */
@@ -146,10 +151,7 @@ module Closure {
     string getClosureNamespace() { result = getModuleDeclaration().getClosureNamespace() }
 
     override Module getAnImportedModule() {
-      exists(ClosureRequireCall imprt |
-        imprt.getTopLevel() = this and
-        result.(ClosureModule).getClosureNamespace() = imprt.getClosureNamespace()
-      )
+      result.(ClosureModule).getClosureNamespace() = getARequireInTopLevel(this).getClosureNamespace()
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/src/semmle/javascript/ES2015Modules.qll
@@ -1,6 +1,7 @@
 /** Provides classes for working with ECMAScript 2015 modules. */
 
 import javascript
+private import semmle.javascript.internal.CachedStages
 
 /**
  * An ECMAScript 2015 module.
@@ -654,7 +655,9 @@ abstract class ReExportDeclaration extends ExportDeclaration {
   ES2015Module getReExportedES2015Module() { result = getReExportedModule() }
 
   /** Gets the module from which this declaration re-exports. */
+  cached
   Module getReExportedModule() {
+    Stages::Imports::ref() and
     result.getFile() = getEnclosingModule().resolve(getImportedPath().(PathExpr))
     or
     result = resolveFromTypeRoot()

--- a/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
@@ -636,7 +636,7 @@ private class LocationFlowSource extends RemoteFlowSource {
  *
  * See https://docs.angularjs.org/api/ngRoute/service/$routeParams for more details.
  */
-private class RouteParamSource extends RemoteFlowSource {
+private class RouteParamSource extends ClientSideRemoteFlowSource {
   RouteParamSource() {
     exists(ServiceReference service |
       service.getName() = "$routeParams" and
@@ -645,6 +645,8 @@ private class RouteParamSource extends RemoteFlowSource {
   }
 
   override string getSourceType() { result = "$routeParams" }
+
+  override ClientSideRemoteFlowKind getKind() { result.isPath() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/React.qll
@@ -686,14 +686,24 @@ private DataFlow::SourceNode reactRouterDom() {
   result = DataFlow::moduleImport("react-router-dom")
 }
 
-private class ReactRouterSource extends RemoteFlowSource {
+private class ReactRouterSource extends ClientSideRemoteFlowSource {
+  ClientSideRemoteFlowKind kind;
+
   ReactRouterSource() {
-    this = reactRouterDom().getAMemberCall("useParams")
+    this = reactRouterDom().getAMemberCall("useParams") and kind.isPath()
     or
-    this = reactRouterDom().getAMemberCall("useRouteMatch").getAPropertyRead(["params", "url"])
+    exists(string prop |
+      this = reactRouterDom().getAMemberCall("useRouteMatch").getAPropertyRead(prop)
+    |
+      prop = "params" and kind.isPath()
+      or
+      prop = "url" and kind.isUrl()
+    )
   }
 
   override string getSourceType() { result = "react-router path parameters" }
+
+  override ClientSideRemoteFlowKind getKind() { result = kind }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
+++ b/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
@@ -162,6 +162,8 @@ module Stages {
       exists(any(Import i).getImportedModule())
       or
       exists(DataFlow::moduleImport(_))
+      or
+      exists(any(ReExportDeclaration d).getReExportedModule())
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
@@ -25,11 +25,8 @@ module ClientSideUrlRedirect {
   class Configuration extends TaintTracking::Configuration {
     Configuration() { this = "ClientSideUrlRedirect" }
 
-    override predicate isSource(DataFlow::Node source) { source instanceof Source }
-
     override predicate isSource(DataFlow::Node source, DataFlow::FlowLabel lbl) {
-      source = DOM::locationSource() and
-      lbl instanceof DocumentUrl
+      source.(Source).getAFlowLabel() = lbl
     }
 
     override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
@@ -43,7 +43,7 @@ module ClientSideUrlRedirect {
     override predicate isAdditionalFlowStep(
       DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel f, DataFlow::FlowLabel g
     ) {
-      queryAccess(pred, succ) and
+      untrustedUrlSubstring(pred, succ) and
       f instanceof DocumentUrl and
       g.isTaint()
       or

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -13,7 +13,10 @@ module ClientSideUrlRedirect {
   /**
    * A data flow source for unvalidated URL redirect vulnerabilities.
    */
-  abstract class Source extends DataFlow::Node { }
+  abstract class Source extends DataFlow::Node {
+    /** Gets a flow label to associate with this source. */
+    DataFlow::FlowLabel getAFlowLabel() { result.isTaint() }
+  }
 
   /**
    * A data flow sink for unvalidated URL redirect vulnerabilities.
@@ -35,22 +38,32 @@ module ClientSideUrlRedirect {
 
   /** A source of remote user input, considered as a flow source for unvalidated URL redirects. */
   class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
+    RemoteFlowSourceAsSource() {
+      this instanceof RemoteFlowSource and
+      not this.(ClientSideRemoteFlowSource).getKind().isPath()
+    }
+
+    override DataFlow::FlowLabel getAFlowLabel() {
+      if this.(ClientSideRemoteFlowSource).getKind().isUrl()
+      then result instanceof DocumentUrl
+      else result.isTaint()
+    }
   }
 
   /**
-   * Holds if `queryAccess` is an expression that may access the query string
-   * of a URL that flows into `nd` (that is, the part after the `?`).
+   * DEPRECATED. Can usually be replaced with `untrustedUrlSubstring`.
+   * Query accesses via `location.hash` or `location.search` are now independent
+   * `RemoteFlowSource` instances, and only substrings of `location` need to be handled via steps.
    */
-  predicate queryAccess(DataFlow::Node nd, DataFlow::Node queryAccess) {
-    exists(string propertyName |
-      queryAccess.asExpr().(PropAccess).accesses(nd.asExpr(), propertyName)
-    |
-      propertyName = "search" or propertyName = "hash"
-    )
-    or
+  deprecated predicate queryAccess = untrustedUrlSubstring/2;
+
+  /**
+   * Holds if `substring` refers to a substring of `base` which is considered untrusted
+   * when `base` is the current URL.
+   */
+  predicate untrustedUrlSubstring(DataFlow::Node base, DataFlow::Node substring) {
     exists(MethodCallExpr mce, string methodName |
-      mce = queryAccess.asExpr() and mce.calls(nd.asExpr(), methodName)
+      mce = substring.asExpr() and mce.calls(base.asExpr(), methodName)
     |
       methodName = "split" and
       // exclude all splits where only the prefix is accessed, which is safe for url-redirects.
@@ -63,16 +76,11 @@ module ClientSideUrlRedirect {
     )
     or
     exists(MethodCallExpr mce |
-      queryAccess.asExpr() = mce and
+      substring.asExpr() = mce and
       mce = any(DataFlow::RegExpCreationNode re).getAMethodCall("exec").asExpr() and
-      nd.asExpr() = mce.getArgument(0)
+      base.asExpr() = mce.getArgument(0)
     )
   }
-
-  /**
-   * A sanitizer that reads the first part a location split by "?", e.g. `location.href.split('?')[0]`.
-   */
-  class QueryPrefixSanitizer extends Sanitizer, DomBasedXss::QueryPrefixSanitizer { }
 
   /**
    * A sink which is used to set the window location.

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjection.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjection.qll
@@ -24,7 +24,6 @@ module CodeInjection {
 
     override predicate isSanitizer(DataFlow::Node node) {
       super.isSanitizer(node) or
-      isSafeLocationProperty(node.asExpr()) or
       node instanceof Sanitizer
     }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
@@ -33,13 +33,6 @@ module CodeInjection {
   }
 
   /**
-   * An access to a property that may hold (parts of) the document URL.
-   */
-  class LocationSource extends Source {
-    LocationSource() { this = DOM::locationSource() }
-  }
-
-  /**
    * An expression which may be interpreted as an AngularJS expression.
    */
   class AngularJSExpressionSink extends Sink, DataFlow::ValueNode {

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CommandInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CommandInjectionCustomizations.qll
@@ -28,7 +28,10 @@ module CommandInjection {
 
   /** A source of remote user input, considered as a flow source for command injection. */
   class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
+    RemoteFlowSourceAsSource() {
+      this instanceof RemoteFlowSource and
+      not this instanceof ClientSideRemoteFlowSource
+    }
 
     override string getSourceType() { result = "a user-provided value" }
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CorsMisconfigurationForCredentialsCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CorsMisconfigurationForCredentialsCustomizations.qll
@@ -29,7 +29,10 @@ module CorsMisconfigurationForCredentials {
 
   /** A source of remote user input, considered as a flow source for CORS misconfiguration. */
   class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
+    RemoteFlowSourceAsSource() {
+      this instanceof RemoteFlowSource and
+      not this instanceof ClientSideRemoteFlowSource
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
@@ -40,11 +40,14 @@ predicate isDocument(Expr e) { DOM::documentRef().flowsToExpr(e) }
 predicate isDocumentURL(Expr e) { e.flow() = DOM::locationSource() }
 
 /**
+ * DEPRECATED. In most cases, a sanitizer based on this predicate can be removed, as
+ * taint tracking no longer step through the properties of the location object by default.
+ *
  * Holds if `pacc` accesses a part of `document.location` that is
  * not considered user-controlled, that is, anything except
  * `href`, `hash` and `search`.
  */
-predicate isSafeLocationProperty(PropAccess pacc) {
+deprecated predicate isSafeLocationProperty(PropAccess pacc) {
   exists(string prop | pacc = DOM::locationRef().getAPropertyRead(prop).asExpr() |
     prop != "href" and prop != "hash" and prop != "search"
   )
@@ -224,7 +227,7 @@ private class PostMessageEventParameter extends RemoteFlowSource {
  * An access to `window.name`, which can be controlled by the opener of the window,
  * even if the window is opened from a foreign domain.
  */
-private class WindowNameAccess extends RemoteFlowSource {
+private class WindowNameAccess extends ClientSideRemoteFlowSource {
   pragma[nomagic, noinline]
   WindowNameAccess() {
     this = DataFlow::globalObjectRef().getAPropertyRead("name")
@@ -238,4 +241,26 @@ private class WindowNameAccess extends RemoteFlowSource {
   }
 
   override string getSourceType() { result = "Window name" }
+
+  override ClientSideRemoteFlowKind getKind() { result.isWindowName() }
+}
+
+private class WindowLocationFlowSource extends ClientSideRemoteFlowSource {
+  ClientSideRemoteFlowKind kind;
+
+  WindowLocationFlowSource() {
+    this = DOM::locationSource() and kind.isUrl()
+    or
+    // Add separate sources for the properties of window.location as they are excluded
+    // from the default taint steps.
+    this = DOM::locationRef().getAPropertyRead("hash") and kind.isFragment()
+    or
+    this = DOM::locationRef().getAPropertyRead("search") and kind.isQuery()
+    or
+    this = DOM::locationRef().getAPropertyRead("href") and kind.isUrl()
+  }
+
+  override string getSourceType() { result = "Window location" }
+
+  override ClientSideRemoteFlowKind getKind() { result = kind }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
@@ -53,7 +53,7 @@ module DomBasedXss {
     override predicate isSource(DataFlow::Node source, DataFlow::FlowLabel label) {
       // Reuse any source not derived from location
       source instanceof Source and
-      not source = DOM::locationRef() and
+      not source = [DOM::locationRef(), DOM::locationRef().getAPropertyRead()] and
       label.isTaint()
       or
       source = DOM::locationSource() and

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
@@ -12,11 +12,4 @@ module DomBasedXss {
   class RemoteFlowSourceAsSource extends Source {
     RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
   }
-
-  /**
-   * An access of the URL of this page, or of the referrer to this page.
-   */
-  class LocationSource extends Source {
-    LocationSource() { this = DOM::locationSource() }
-  }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
@@ -59,14 +59,6 @@ module ExternalAPIUsedWithUntrustedData {
     RemoteFlowAsSource() { this instanceof RemoteFlowSource }
   }
 
-  private class LocationSource extends Source {
-    LocationSource() {
-      this = DOM::locationRef().getAPropertyRead(["hash", "search"])
-      or
-      this = DOM::locationSource()
-    }
-  }
-
   /**
    * A package name whose entire API is considered "safe" for the purpose of this query.
    */

--- a/javascript/ql/src/semmle/javascript/security/dataflow/LogInjection.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/LogInjection.qll
@@ -40,7 +40,9 @@ module LogInjection {
    * A source of remote user controlled input.
    */
   class RemoteSource extends Source {
-    RemoteSource() { this instanceof RemoteFlowSource }
+    RemoteSource() {
+      this instanceof RemoteFlowSource and not this instanceof ClientSideRemoteFlowSource
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/PrototypePollutingAssignmentCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/PrototypePollutingAssignmentCustomizations.qll
@@ -51,10 +51,6 @@ module PrototypePollutingAssignment {
 
   /** A remote flow source or location.{hash,search} as a taint source. */
   private class DefaultSource extends Source {
-    DefaultSource() {
-      this instanceof RemoteFlowSource
-      or
-      this = DOM::locationRef().getAPropertyRead(["hash", "search"])
-    }
+    DefaultSource() { this instanceof RemoteFlowSource }
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RegExpInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RegExpInjectionCustomizations.qll
@@ -27,7 +27,10 @@ module RegExpInjection {
    * expression injection.
    */
   class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
+    RemoteFlowSourceAsSource() {
+      this instanceof RemoteFlowSource and
+      not this instanceof ClientSideRemoteFlowSource
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
@@ -10,7 +10,7 @@ private import semmle.javascript.internal.CachedStages
 /** A data flow source of remote user input. */
 cached
 abstract class RemoteFlowSource extends DataFlow::Node {
-  /** Gets a string that describes the type of this remote flow source. */
+  /** Gets a human-readable string that describes the type of this remote flow source. */
   cached
   abstract string getSourceType();
 
@@ -19,6 +19,57 @@ abstract class RemoteFlowSource extends DataFlow::Node {
    */
   cached
   predicate isUserControlledObject() { none() }
+}
+
+/**
+ * A type of remote flow source that is specific to the browser environment.
+ */
+class ClientSideRemoteFlowKind extends string {
+  ClientSideRemoteFlowKind() { this = ["query", "fragment", "path", "url", "name"] }
+
+  /**
+   * Holds if this is the `query` kind, describing sources derived from the query parameters of the browser URL,
+   * such as `location.search`.
+   */
+  predicate isQuery() { this = "query" }
+
+  /**
+   * Holds if this is the `frgament` kind, describing sources derived from the fragment part of the browser URL,
+   * such as `location.hash`.
+   */
+  predicate isFragment() { this = "fragment" }
+
+  /**
+   * Holds if this is the `path` kind, describing sources derived from the pathname of the browser URL,
+   * such as `location.pathname`.
+   */
+  predicate isPath() { this = "path" }
+
+  /**
+   * Holds if this is the `url` kind, describing sources derived from the browser URL,
+   * where the untrusted part of the URL is prefixed by trusted data, such as the scheme and hostname.
+   */
+  predicate isUrl() { this = "url" }
+
+  /** Holds if this is the `query` or `fragment` kind. */
+  predicate isQueryOrFragment() { this.isQuery() or this.isFragment() }
+
+  /** Holds if this is the `path`, `query`, or `fragment` kind. */
+  predicate isPathOrQueryOrFragment() { this.isPath() or this.isQuery() or this.isFragment() }
+
+  /** Holds if this is the `path` or `url` kind. */
+  predicate isPathOrUrl() { this.isPath() or this.isUrl() }
+
+  /** Holds if this is the `name` kind, describing sources derived from the window name, such as `window.name`. */
+  predicate isWindowName() { this = "name" }
+}
+
+/**
+ * A source of remote input in a web browser environment.
+ */
+abstract class ClientSideRemoteFlowSource extends RemoteFlowSource {
+  /** Gets a string indicating what part of the browser environment this was derived from. */
+  abstract ClientSideRemoteFlowKind getKind();
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
@@ -7,19 +7,34 @@ import semmle.javascript.frameworks.HTTP
 import semmle.javascript.security.dataflow.DOM
 private import semmle.javascript.internal.CachedStages
 
-/** A data flow source of remote user input. */
 cached
-abstract class RemoteFlowSource extends DataFlow::Node {
-  /** Gets a human-readable string that describes the type of this remote flow source. */
+private module Cached {
+  /** A data flow source of remote user input. */
   cached
-  abstract string getSourceType();
+  abstract class RemoteFlowSource extends DataFlow::Node {
+    /** Gets a human-readable string that describes the type of this remote flow source. */
+    cached
+    abstract string getSourceType();
+
+    /**
+     * Holds if this can be a user-controlled object, such as a JSON object parsed from user-controlled data.
+     */
+    cached
+    predicate isUserControlledObject() { none() }
+  }
 
   /**
-   * Holds if this can be a user-controlled object, such as a JSON object parsed from user-controlled data.
+   * A source of remote input in a web browser environment.
    */
   cached
-  predicate isUserControlledObject() { none() }
+  abstract class ClientSideRemoteFlowSource extends RemoteFlowSource {
+    /** Gets a string indicating what part of the browser environment this was derived from. */
+    cached
+    abstract ClientSideRemoteFlowKind getKind();
+  }
 }
+
+import Cached
 
 /**
  * A type of remote flow source that is specific to the browser environment.
@@ -62,14 +77,6 @@ class ClientSideRemoteFlowKind extends string {
 
   /** Holds if this is the `name` kind, describing sources derived from the window name, such as `window.name`. */
   predicate isWindowName() { this = "name" }
-}
-
-/**
- * A source of remote input in a web browser environment.
- */
-abstract class ClientSideRemoteFlowSource extends RemoteFlowSource {
-  /** Gets a string indicating what part of the browser environment this was derived from. */
-  abstract ClientSideRemoteFlowKind getKind();
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RequestForgeryCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RequestForgeryCustomizations.qll
@@ -33,7 +33,13 @@ module RequestForgery {
 
   /** A source of remote user input, considered as a flow source for request forgery. */
   private class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
+    RemoteFlowSourceAsSource() {
+      // Reduce FPs by excluding sources from client-side path or URL
+      exists(RemoteFlowSource src |
+        this = src and
+        not src.(ClientSideRemoteFlowSource).getKind().isPathOrUrl()
+      )
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -557,7 +557,12 @@ module TaintedPath {
    * tainted-path vulnerabilities.
    */
   class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
+    RemoteFlowSourceAsSource() {
+      exists(RemoteFlowSource src |
+        this = src and
+        not src instanceof ClientSideRemoteFlowSource
+      )
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeDynamicMethodAccessCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeDynamicMethodAccessCustomizations.qll
@@ -59,13 +59,6 @@ module UnsafeDynamicMethodAccess {
   }
 
   /**
-   * The page URL considered as a flow source for unsafe dynamic method access.
-   */
-  class DocumentUrlAsSource extends Source {
-    DocumentUrlAsSource() { this = DOM::locationSource() }
-  }
-
-  /**
    * A function invocation of an unsafe function, as a sink for remote unsafe dynamic method access.
    */
   class CalleeAsSink extends Sink {

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -383,25 +383,7 @@ module DomBasedXss {
    */
   class SafePropertyReadSanitizer extends Sanitizer, DataFlow::Node {
     SafePropertyReadSanitizer() {
-      exists(PropAccess pacc | pacc = this.asExpr() |
-        isSafeLocationProperty(pacc)
-        or
-        pacc.getPropertyName() = "length"
-      )
-    }
-  }
-
-  /**
-   * A sanitizer that reads the first part a location split by "?", e.g. `location.href.split('?')[0]`.
-   */
-  class QueryPrefixSanitizer extends Sanitizer {
-    StringSplitCall splitCall;
-
-    QueryPrefixSanitizer() {
-      this = splitCall.getASubstringRead(0) and
-      splitCall.getSeparator() = "?" and
-      splitCall.getBaseString().getALocalSource() =
-        [DOM::locationRef(), DOM::locationRef().getAPropertyRead("href")]
+      exists(PropAccess pacc | pacc = this.asExpr() | pacc.getPropertyName() = "length")
     }
   }
 

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -15,8 +15,7 @@ nodes
 | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
@@ -104,8 +103,7 @@ nodes
 | d3.js:21:15:21:24 | getTaint() |
 | dates.js:9:9:9:69 | taint |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) |
-| dates.js:9:36:9:50 | window.location |
-| dates.js:9:36:9:50 | window.location |
+| dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:11:31:11:70 | `Time i ... aint)}` |
@@ -130,16 +128,14 @@ nodes
 | dates.js:18:59:18:63 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
-| event-handler-receiver.js:2:49:2:56 | location |
-| event-handler-receiver.js:2:49:2:56 | location |
+| event-handler-receiver.js:2:49:2:61 | location.href |
 | event-handler-receiver.js:2:49:2:61 | location.href |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:17:2:33 | document.location |
-| jquery.js:2:17:2:33 | document.location |
+| jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
@@ -156,13 +152,11 @@ nodes
 | jquery.js:10:13:10:31 | location.toString() |
 | jquery.js:14:19:14:58 | decodeU ... n.hash) |
 | jquery.js:14:19:14:58 | decodeU ... n.hash) |
-| jquery.js:14:38:14:52 | window.location |
-| jquery.js:14:38:14:52 | window.location |
+| jquery.js:14:38:14:57 | window.location.hash |
 | jquery.js:14:38:14:57 | window.location.hash |
 | jquery.js:15:19:15:60 | decodeU ... search) |
 | jquery.js:15:19:15:60 | decodeU ... search) |
-| jquery.js:15:38:15:52 | window.location |
-| jquery.js:15:38:15:52 | window.location |
+| jquery.js:15:38:15:59 | window. ... .search |
 | jquery.js:15:38:15:59 | window. ... .search |
 | jquery.js:16:19:16:64 | decodeU ... ring()) |
 | jquery.js:16:19:16:64 | decodeU ... ring()) |
@@ -182,8 +176,7 @@ nodes
 | nodemailer.js:13:50:13:66 | req.query.message |
 | nodemailer.js:13:50:13:66 | req.query.message |
 | optionalSanitizer.js:2:7:2:39 | target |
-| optionalSanitizer.js:2:16:2:32 | document.location |
-| optionalSanitizer.js:2:16:2:32 | document.location |
+| optionalSanitizer.js:2:16:2:39 | documen ... .search |
 | optionalSanitizer.js:2:16:2:39 | documen ... .search |
 | optionalSanitizer.js:6:18:6:23 | target |
 | optionalSanitizer.js:6:18:6:23 | target |
@@ -196,8 +189,7 @@ nodes
 | optionalSanitizer.js:17:20:17:20 | x |
 | optionalSanitizer.js:17:20:17:20 | x |
 | optionalSanitizer.js:26:7:26:39 | target |
-| optionalSanitizer.js:26:16:26:32 | document.location |
-| optionalSanitizer.js:26:16:26:32 | document.location |
+| optionalSanitizer.js:26:16:26:39 | documen ... .search |
 | optionalSanitizer.js:26:16:26:39 | documen ... .search |
 | optionalSanitizer.js:31:7:31:23 | tainted2 |
 | optionalSanitizer.js:31:18:31:23 | target |
@@ -277,11 +269,9 @@ nodes
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted |
-| stored-xss.js:2:39:2:55 | document.location |
-| stored-xss.js:2:39:2:55 | document.location |
 | stored-xss.js:2:39:2:62 | documen ... .search |
-| stored-xss.js:3:35:3:51 | document.location |
-| stored-xss.js:3:35:3:51 | document.location |
+| stored-xss.js:2:39:2:62 | documen ... .search |
+| stored-xss.js:3:35:3:58 | documen ... .search |
 | stored-xss.js:3:35:3:58 | documen ... .search |
 | stored-xss.js:5:20:5:52 | session ... ssion') |
 | stored-xss.js:5:20:5:52 | session ... ssion') |
@@ -295,43 +285,35 @@ nodes
 | string-manipulations.js:3:16:3:32 | document.location |
 | string-manipulations.js:3:16:3:32 | document.location |
 | string-manipulations.js:3:16:3:32 | document.location |
-| string-manipulations.js:4:16:4:32 | document.location |
-| string-manipulations.js:4:16:4:32 | document.location |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:5:16:5:32 | document.location |
-| string-manipulations.js:5:16:5:32 | document.location |
+| string-manipulations.js:4:16:4:37 | documen ... on.href |
+| string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:6:16:6:32 | document.location |
-| string-manipulations.js:6:16:6:32 | document.location |
+| string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:7:16:7:32 | document.location |
-| string-manipulations.js:7:16:7:32 | document.location |
+| string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:8:16:8:32 | document.location |
-| string-manipulations.js:8:16:8:32 | document.location |
+| string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:9:36:9:52 | document.location |
-| string-manipulations.js:9:36:9:52 | document.location |
+| string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
-| string-manipulations.js:10:23:10:39 | document.location |
-| string-manipulations.js:10:23:10:39 | document.location |
+| string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | translate.js:6:7:6:39 | target |
-| translate.js:6:16:6:32 | document.location |
-| translate.js:6:16:6:32 | document.location |
+| translate.js:6:16:6:39 | documen ... .search |
 | translate.js:6:16:6:39 | documen ... .search |
 | translate.js:7:42:7:47 | target |
 | translate.js:7:42:7:60 | target.substring(1) |
@@ -339,8 +321,7 @@ nodes
 | translate.js:9:27:9:50 | searchP ... 'term') |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
 | tst3.js:2:23:2:74 | decodeU ... str(1)) |
-| tst3.js:2:42:2:56 | window.location |
-| tst3.js:2:42:2:56 | window.location |
+| tst3.js:2:42:2:63 | window. ... .search |
 | tst3.js:2:42:2:63 | window. ... .search |
 | tst3.js:2:42:2:73 | window. ... bstr(1) |
 | tst3.js:4:25:4:28 | data |
@@ -360,8 +341,7 @@ nodes
 | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:32 | document.location |
-| tst.js:2:16:2:32 | document.location |
+| tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
@@ -369,8 +349,7 @@ nodes
 | tst.js:5:18:5:23 | target |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
-| tst.js:8:37:8:53 | document.location |
-| tst.js:8:37:8:53 | document.location |
+| tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
@@ -387,33 +366,27 @@ nodes
 | tst.js:24:14:24:19 | target |
 | tst.js:26:18:26:23 | target |
 | tst.js:26:18:26:23 | target |
-| tst.js:28:5:28:21 | document.location |
-| tst.js:28:5:28:21 | document.location |
 | tst.js:28:5:28:28 | documen ... .search |
-| tst.js:31:10:31:26 | document.location |
-| tst.js:31:10:31:26 | document.location |
+| tst.js:28:5:28:28 | documen ... .search |
+| tst.js:31:10:31:33 | documen ... .search |
 | tst.js:31:10:31:33 | documen ... .search |
 | tst.js:34:16:34:20 | bar() |
 | tst.js:34:16:34:20 | bar() |
 | tst.js:40:16:40:44 | baz(doc ... search) |
 | tst.js:40:16:40:44 | baz(doc ... search) |
-| tst.js:40:20:40:36 | document.location |
-| tst.js:40:20:40:36 | document.location |
+| tst.js:40:20:40:43 | documen ... .search |
 | tst.js:40:20:40:43 | documen ... .search |
 | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:16:46:45 | wrap(do ... search) |
-| tst.js:46:21:46:37 | document.location |
-| tst.js:46:21:46:37 | document.location |
+| tst.js:46:21:46:44 | documen ... .search |
 | tst.js:46:21:46:44 | documen ... .search |
 | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:16:54:45 | chop(do ... search) |
-| tst.js:54:21:54:37 | document.location |
-| tst.js:54:21:54:37 | document.location |
+| tst.js:54:21:54:44 | documen ... .search |
 | tst.js:54:21:54:44 | documen ... .search |
 | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:16:56:45 | chop(do ... search) |
-| tst.js:56:21:56:37 | document.location |
-| tst.js:56:21:56:37 | document.location |
+| tst.js:56:21:56:44 | documen ... .search |
 | tst.js:56:21:56:44 | documen ... .search |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
@@ -422,82 +395,66 @@ nodes
 | tst.js:60:34:60:34 | s |
 | tst.js:62:18:62:18 | s |
 | tst.js:62:18:62:18 | s |
-| tst.js:64:25:64:41 | document.location |
-| tst.js:64:25:64:41 | document.location |
 | tst.js:64:25:64:48 | documen ... .search |
-| tst.js:65:25:65:41 | document.location |
-| tst.js:65:25:65:41 | document.location |
+| tst.js:64:25:64:48 | documen ... .search |
+| tst.js:65:25:65:48 | documen ... .search |
 | tst.js:65:25:65:48 | documen ... .search |
 | tst.js:68:16:68:20 | bar() |
 | tst.js:68:16:68:20 | bar() |
 | tst.js:70:1:70:27 | [,docum ... search] |
-| tst.js:70:3:70:19 | document.location |
-| tst.js:70:3:70:19 | document.location |
+| tst.js:70:3:70:26 | documen ... .search |
 | tst.js:70:3:70:26 | documen ... .search |
 | tst.js:70:46:70:46 | x |
 | tst.js:73:20:73:20 | x |
 | tst.js:73:20:73:20 | x |
-| tst.js:77:49:77:65 | document.location |
-| tst.js:77:49:77:65 | document.location |
 | tst.js:77:49:77:72 | documen ... .search |
 | tst.js:77:49:77:72 | documen ... .search |
-| tst.js:81:26:81:42 | document.location |
-| tst.js:81:26:81:42 | document.location |
+| tst.js:77:49:77:72 | documen ... .search |
 | tst.js:81:26:81:49 | documen ... .search |
 | tst.js:81:26:81:49 | documen ... .search |
-| tst.js:82:25:82:41 | document.location |
-| tst.js:82:25:82:41 | document.location |
+| tst.js:81:26:81:49 | documen ... .search |
 | tst.js:82:25:82:48 | documen ... .search |
 | tst.js:82:25:82:48 | documen ... .search |
-| tst.js:84:33:84:49 | document.location |
-| tst.js:84:33:84:49 | document.location |
+| tst.js:82:25:82:48 | documen ... .search |
 | tst.js:84:33:84:56 | documen ... .search |
 | tst.js:84:33:84:56 | documen ... .search |
-| tst.js:85:32:85:48 | document.location |
-| tst.js:85:32:85:48 | document.location |
+| tst.js:84:33:84:56 | documen ... .search |
 | tst.js:85:32:85:55 | documen ... .search |
 | tst.js:85:32:85:55 | documen ... .search |
-| tst.js:90:39:90:55 | document.location |
-| tst.js:90:39:90:55 | document.location |
+| tst.js:85:32:85:55 | documen ... .search |
 | tst.js:90:39:90:62 | documen ... .search |
 | tst.js:90:39:90:62 | documen ... .search |
-| tst.js:96:30:96:46 | document.location |
-| tst.js:96:30:96:46 | document.location |
+| tst.js:90:39:90:62 | documen ... .search |
 | tst.js:96:30:96:53 | documen ... .search |
 | tst.js:96:30:96:53 | documen ... .search |
-| tst.js:102:25:102:41 | document.location |
-| tst.js:102:25:102:41 | document.location |
+| tst.js:96:30:96:53 | documen ... .search |
+| tst.js:102:25:102:48 | documen ... .search |
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v |
-| tst.js:107:11:107:27 | document.location |
-| tst.js:107:11:107:27 | document.location |
+| tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:110:18:110:18 | v |
 | tst.js:110:18:110:18 | v |
 | tst.js:136:18:136:18 | v |
 | tst.js:136:18:136:18 | v |
-| tst.js:148:29:148:43 | window.location |
-| tst.js:148:29:148:43 | window.location |
+| tst.js:148:29:148:50 | window. ... .search |
 | tst.js:148:29:148:50 | window. ... .search |
 | tst.js:151:29:151:29 | v |
 | tst.js:151:49:151:49 | v |
 | tst.js:151:49:151:49 | v |
 | tst.js:155:29:155:46 | xssSourceService() |
 | tst.js:155:29:155:46 | xssSourceService() |
-| tst.js:158:40:158:54 | window.location |
-| tst.js:158:40:158:54 | window.location |
+| tst.js:158:40:158:61 | window. ... .search |
 | tst.js:158:40:158:61 | window. ... .search |
 | tst.js:177:9:177:41 | target |
-| tst.js:177:18:177:34 | document.location |
-| tst.js:177:18:177:34 | document.location |
+| tst.js:177:18:177:41 | documen ... .search |
 | tst.js:177:18:177:41 | documen ... .search |
 | tst.js:180:28:180:33 | target |
 | tst.js:180:28:180:33 | target |
 | tst.js:184:9:184:42 | tainted |
-| tst.js:184:19:184:35 | document.location |
-| tst.js:184:19:184:35 | document.location |
+| tst.js:184:19:184:42 | documen ... .search |
 | tst.js:184:19:184:42 | documen ... .search |
 | tst.js:186:31:186:37 | tainted |
 | tst.js:186:31:186:37 | tainted |
@@ -512,8 +469,7 @@ nodes
 | tst.js:193:49:193:55 | tainted |
 | tst.js:193:49:193:55 | tainted |
 | tst.js:197:9:197:42 | tainted |
-| tst.js:197:19:197:35 | document.location |
-| tst.js:197:19:197:35 | document.location |
+| tst.js:197:19:197:42 | documen ... .search |
 | tst.js:197:19:197:42 | documen ... .search |
 | tst.js:199:67:199:73 | tainted |
 | tst.js:199:67:199:73 | tainted |
@@ -587,14 +543,12 @@ nodes
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target |
-| tst.js:348:16:348:32 | document.location |
-| tst.js:348:16:348:32 | document.location |
+| tst.js:348:16:348:39 | documen ... .search |
 | tst.js:348:16:348:39 | documen ... .search |
 | tst.js:349:12:349:17 | target |
 | tst.js:349:12:349:17 | target |
 | tst.js:355:10:355:42 | target |
-| tst.js:355:19:355:35 | document.location |
-| tst.js:355:19:355:35 | document.location |
+| tst.js:355:19:355:42 | documen ... .search |
 | tst.js:355:19:355:42 | documen ... .search |
 | tst.js:356:16:356:21 | target |
 | tst.js:356:16:356:21 | target |
@@ -603,22 +557,19 @@ nodes
 | tst.js:363:18:363:23 | target |
 | tst.js:363:18:363:23 | target |
 | tst.js:371:7:371:39 | target |
-| tst.js:371:16:371:32 | document.location |
-| tst.js:371:16:371:32 | document.location |
+| tst.js:371:16:371:39 | documen ... .search |
 | tst.js:371:16:371:39 | documen ... .search |
 | tst.js:374:18:374:23 | target |
 | tst.js:374:18:374:23 | target |
 | tst.js:381:7:381:39 | target |
-| tst.js:381:16:381:32 | document.location |
-| tst.js:381:16:381:32 | document.location |
+| tst.js:381:16:381:39 | documen ... .search |
 | tst.js:381:16:381:39 | documen ... .search |
 | tst.js:384:18:384:23 | target |
 | tst.js:384:18:384:23 | target |
 | tst.js:386:18:386:23 | target |
 | tst.js:386:18:386:29 | target.taint |
 | tst.js:386:18:386:29 | target.taint |
-| tst.js:391:19:391:35 | document.location |
-| tst.js:391:19:391:35 | document.location |
+| tst.js:391:19:391:42 | documen ... .search |
 | tst.js:391:19:391:42 | documen ... .search |
 | tst.js:392:18:392:30 | target.taint3 |
 | tst.js:392:18:392:30 | target.taint3 |
@@ -633,36 +584,31 @@ nodes
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload |
-| tst.js:416:17:416:31 | window.location |
-| tst.js:416:17:416:31 | window.location |
+| tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:46 | window. ... bstr(1) |
 | tst.js:417:18:417:24 | payload |
 | tst.js:417:18:417:24 | payload |
 | tst.js:419:7:419:55 | match |
-| tst.js:419:15:419:29 | window.location |
-| tst.js:419:15:419:29 | window.location |
+| tst.js:419:15:419:34 | window.location.hash |
 | tst.js:419:15:419:34 | window.location.hash |
 | tst.js:419:15:419:55 | window. ... (\\w+)/) |
 | tst.js:421:20:421:24 | match |
 | tst.js:421:20:421:27 | match[1] |
 | tst.js:421:20:421:27 | match[1] |
-| tst.js:424:18:424:32 | window.location |
-| tst.js:424:18:424:32 | window.location |
+| tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target |
-| tst.js:428:16:428:32 | document.location |
-| tst.js:428:16:428:32 | document.location |
+| tst.js:428:16:428:39 | documen ... .search |
 | tst.js:428:16:428:39 | documen ... .search |
 | tst.js:430:18:430:23 | target |
 | tst.js:430:18:430:89 | target. ... data>') |
 | tst.js:430:18:430:89 | target. ... data>') |
 | typeahead.js:20:13:20:45 | target |
-| typeahead.js:20:22:20:38 | document.location |
-| typeahead.js:20:22:20:38 | document.location |
+| typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:21:12:21:17 | target |
 | typeahead.js:24:30:24:32 | val |
@@ -714,8 +660,7 @@ nodes
 | various-concat-obfuscations.js:21:17:21:40 | documen ... .search |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
 | winjs.js:2:7:2:53 | tainted |
-| winjs.js:2:17:2:33 | document.location |
-| winjs.js:2:17:2:33 | document.location |
+| winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:3:43:3:49 | tainted |
@@ -736,10 +681,7 @@ edges
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
@@ -811,8 +753,7 @@ edges
 | dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
-| dates.js:9:36:9:50 | window.location | dates.js:9:36:9:55 | window.location.hash |
-| dates.js:9:36:9:50 | window.location | dates.js:9:36:9:55 | window.location.hash |
+| dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:9:36:9:68 | window. ... ring(1) | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
@@ -830,15 +771,14 @@ edges
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
-| event-handler-receiver.js:2:49:2:56 | location | event-handler-receiver.js:2:49:2:61 | location.href |
-| event-handler-receiver.js:2:49:2:56 | location | event-handler-receiver.js:2:49:2:61 | location.href |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
-| jquery.js:2:17:2:33 | document.location | jquery.js:2:17:2:40 | documen ... .search |
-| jquery.js:2:17:2:33 | document.location | jquery.js:2:17:2:40 | documen ... .search |
+| jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
@@ -850,12 +790,12 @@ edges
 | jquery.js:10:13:10:20 | location | jquery.js:10:13:10:31 | location.toString() |
 | jquery.js:10:13:10:31 | location.toString() | jquery.js:10:5:10:40 | "<b>" + ...  "</b>" |
 | jquery.js:10:13:10:31 | location.toString() | jquery.js:10:5:10:40 | "<b>" + ...  "</b>" |
-| jquery.js:14:38:14:52 | window.location | jquery.js:14:38:14:57 | window.location.hash |
-| jquery.js:14:38:14:52 | window.location | jquery.js:14:38:14:57 | window.location.hash |
 | jquery.js:14:38:14:57 | window.location.hash | jquery.js:14:19:14:58 | decodeU ... n.hash) |
 | jquery.js:14:38:14:57 | window.location.hash | jquery.js:14:19:14:58 | decodeU ... n.hash) |
-| jquery.js:15:38:15:52 | window.location | jquery.js:15:38:15:59 | window. ... .search |
-| jquery.js:15:38:15:52 | window.location | jquery.js:15:38:15:59 | window. ... .search |
+| jquery.js:14:38:14:57 | window.location.hash | jquery.js:14:19:14:58 | decodeU ... n.hash) |
+| jquery.js:14:38:14:57 | window.location.hash | jquery.js:14:19:14:58 | decodeU ... n.hash) |
+| jquery.js:15:38:15:59 | window. ... .search | jquery.js:15:19:15:60 | decodeU ... search) |
+| jquery.js:15:38:15:59 | window. ... .search | jquery.js:15:19:15:60 | decodeU ... search) |
 | jquery.js:15:38:15:59 | window. ... .search | jquery.js:15:19:15:60 | decodeU ... search) |
 | jquery.js:15:38:15:59 | window. ... .search | jquery.js:15:19:15:60 | decodeU ... search) |
 | jquery.js:16:38:16:52 | window.location | jquery.js:16:38:16:63 | window. ... tring() |
@@ -877,8 +817,7 @@ edges
 | optionalSanitizer.js:2:7:2:39 | target | optionalSanitizer.js:6:18:6:23 | target |
 | optionalSanitizer.js:2:7:2:39 | target | optionalSanitizer.js:8:17:8:22 | target |
 | optionalSanitizer.js:2:7:2:39 | target | optionalSanitizer.js:15:9:15:14 | target |
-| optionalSanitizer.js:2:16:2:32 | document.location | optionalSanitizer.js:2:16:2:39 | documen ... .search |
-| optionalSanitizer.js:2:16:2:32 | document.location | optionalSanitizer.js:2:16:2:39 | documen ... .search |
+| optionalSanitizer.js:2:16:2:39 | documen ... .search | optionalSanitizer.js:2:7:2:39 | target |
 | optionalSanitizer.js:2:16:2:39 | documen ... .search | optionalSanitizer.js:2:7:2:39 | target |
 | optionalSanitizer.js:8:7:8:22 | tainted | optionalSanitizer.js:9:18:9:24 | tainted |
 | optionalSanitizer.js:8:7:8:22 | tainted | optionalSanitizer.js:9:18:9:24 | tainted |
@@ -890,8 +829,7 @@ edges
 | optionalSanitizer.js:26:7:26:39 | target | optionalSanitizer.js:38:18:38:23 | target |
 | optionalSanitizer.js:26:7:26:39 | target | optionalSanitizer.js:45:41:45:46 | target |
 | optionalSanitizer.js:26:7:26:39 | target | optionalSanitizer.js:45:51:45:56 | target |
-| optionalSanitizer.js:26:16:26:32 | document.location | optionalSanitizer.js:26:16:26:39 | documen ... .search |
-| optionalSanitizer.js:26:16:26:32 | document.location | optionalSanitizer.js:26:16:26:39 | documen ... .search |
+| optionalSanitizer.js:26:16:26:39 | documen ... .search | optionalSanitizer.js:26:7:26:39 | target |
 | optionalSanitizer.js:26:16:26:39 | documen ... .search | optionalSanitizer.js:26:7:26:39 | target |
 | optionalSanitizer.js:31:7:31:23 | tainted2 | optionalSanitizer.js:32:18:32:25 | tainted2 |
 | optionalSanitizer.js:31:7:31:23 | tainted2 | optionalSanitizer.js:32:18:32:25 | tainted2 |
@@ -963,51 +901,48 @@ edges
 | sanitiser.js:38:29:38:35 | tainted | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
-| stored-xss.js:2:39:2:55 | document.location | stored-xss.js:2:39:2:62 | documen ... .search |
-| stored-xss.js:2:39:2:55 | document.location | stored-xss.js:2:39:2:62 | documen ... .search |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
-| stored-xss.js:3:35:3:51 | document.location | stored-xss.js:3:35:3:58 | documen ... .search |
-| stored-xss.js:3:35:3:51 | document.location | stored-xss.js:3:35:3:58 | documen ... .search |
+| stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
+| stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
 | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:8:20:8:48 | localSt ... local') |
 | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:8:20:8:48 | localSt ... local') |
+| stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:8:20:8:48 | localSt ... local') |
+| stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:8:20:8:48 | localSt ... local') |
+| stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:10:16:10:44 | localSt ... local') |
 | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:10:16:10:44 | localSt ... local') |
 | stored-xss.js:10:9:10:44 | href | stored-xss.js:12:35:12:38 | href |
 | stored-xss.js:10:16:10:44 | localSt ... local') | stored-xss.js:10:9:10:44 | href |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | string-manipulations.js:3:16:3:32 | document.location | string-manipulations.js:3:16:3:32 | document.location |
-| string-manipulations.js:4:16:4:32 | document.location | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:4:16:4:32 | document.location | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:4:16:4:32 | document.location | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:4:16:4:32 | document.location | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:5:16:5:32 | document.location | string-manipulations.js:5:16:5:37 | documen ... on.href |
-| string-manipulations.js:5:16:5:32 | document.location | string-manipulations.js:5:16:5:37 | documen ... on.href |
+| string-manipulations.js:4:16:4:37 | documen ... on.href | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:6:16:6:32 | document.location | string-manipulations.js:6:16:6:37 | documen ... on.href |
-| string-manipulations.js:6:16:6:32 | document.location | string-manipulations.js:6:16:6:37 | documen ... on.href |
+| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:7:16:7:32 | document.location | string-manipulations.js:7:16:7:37 | documen ... on.href |
-| string-manipulations.js:7:16:7:32 | document.location | string-manipulations.js:7:16:7:37 | documen ... on.href |
+| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
+| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:8:16:8:32 | document.location | string-manipulations.js:8:16:8:37 | documen ... on.href |
-| string-manipulations.js:8:16:8:32 | document.location | string-manipulations.js:8:16:8:37 | documen ... on.href |
+| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
-| string-manipulations.js:9:36:9:52 | document.location | string-manipulations.js:9:36:9:57 | documen ... on.href |
-| string-manipulations.js:9:36:9:52 | document.location | string-manipulations.js:9:36:9:57 | documen ... on.href |
+| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
+| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:10:23:10:39 | document.location | string-manipulations.js:10:23:10:44 | documen ... on.href |
-| string-manipulations.js:10:23:10:39 | document.location | string-manipulations.js:10:23:10:44 | documen ... on.href |
+| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | translate.js:6:7:6:39 | target | translate.js:7:42:7:47 | target |
-| translate.js:6:16:6:32 | document.location | translate.js:6:16:6:39 | documen ... .search |
-| translate.js:6:16:6:32 | document.location | translate.js:6:16:6:39 | documen ... .search |
+| translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
 | translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
@@ -1018,8 +953,7 @@ edges
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:9:37:9:40 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:10:38:10:41 | data |
 | tst3.js:2:23:2:74 | decodeU ... str(1)) | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
-| tst3.js:2:42:2:56 | window.location | tst3.js:2:42:2:63 | window. ... .search |
-| tst3.js:2:42:2:56 | window.location | tst3.js:2:42:2:63 | window. ... .search |
+| tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
 | tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
 | tst3.js:2:42:2:73 | window. ... bstr(1) | tst3.js:2:23:2:74 | decodeU ... str(1)) |
 | tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
@@ -1036,13 +970,11 @@ edges
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:12:28:12:33 | target |
 | tst.js:2:7:2:39 | target | tst.js:20:42:20:47 | target |
-| tst.js:2:16:2:32 | document.location | tst.js:2:16:2:39 | documen ... .search |
-| tst.js:2:16:2:32 | document.location | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
-| tst.js:8:37:8:53 | document.location | tst.js:8:37:8:58 | documen ... on.href |
-| tst.js:8:37:8:53 | document.location | tst.js:8:37:8:58 | documen ... on.href |
+| tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
@@ -1057,30 +989,32 @@ edges
 | tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
-| tst.js:28:5:28:21 | document.location | tst.js:28:5:28:28 | documen ... .search |
-| tst.js:28:5:28:21 | document.location | tst.js:28:5:28:28 | documen ... .search |
 | tst.js:28:5:28:28 | documen ... .search | tst.js:24:14:24:19 | target |
-| tst.js:31:10:31:26 | document.location | tst.js:31:10:31:33 | documen ... .search |
-| tst.js:31:10:31:26 | document.location | tst.js:31:10:31:33 | documen ... .search |
+| tst.js:28:5:28:28 | documen ... .search | tst.js:24:14:24:19 | target |
+| tst.js:31:10:31:33 | documen ... .search | tst.js:34:16:34:20 | bar() |
+| tst.js:31:10:31:33 | documen ... .search | tst.js:34:16:34:20 | bar() |
 | tst.js:31:10:31:33 | documen ... .search | tst.js:34:16:34:20 | bar() |
 | tst.js:31:10:31:33 | documen ... .search | tst.js:34:16:34:20 | bar() |
 | tst.js:31:10:31:33 | documen ... .search | tst.js:58:26:58:30 | bar() |
+| tst.js:31:10:31:33 | documen ... .search | tst.js:58:26:58:30 | bar() |
 | tst.js:31:10:31:33 | documen ... .search | tst.js:68:16:68:20 | bar() |
 | tst.js:31:10:31:33 | documen ... .search | tst.js:68:16:68:20 | bar() |
-| tst.js:40:20:40:36 | document.location | tst.js:40:20:40:43 | documen ... .search |
-| tst.js:40:20:40:36 | document.location | tst.js:40:20:40:43 | documen ... .search |
+| tst.js:31:10:31:33 | documen ... .search | tst.js:68:16:68:20 | bar() |
+| tst.js:31:10:31:33 | documen ... .search | tst.js:68:16:68:20 | bar() |
 | tst.js:40:20:40:43 | documen ... .search | tst.js:40:16:40:44 | baz(doc ... search) |
 | tst.js:40:20:40:43 | documen ... .search | tst.js:40:16:40:44 | baz(doc ... search) |
-| tst.js:46:21:46:37 | document.location | tst.js:46:21:46:44 | documen ... .search |
-| tst.js:46:21:46:37 | document.location | tst.js:46:21:46:44 | documen ... .search |
+| tst.js:40:20:40:43 | documen ... .search | tst.js:40:16:40:44 | baz(doc ... search) |
+| tst.js:40:20:40:43 | documen ... .search | tst.js:40:16:40:44 | baz(doc ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
-| tst.js:54:21:54:37 | document.location | tst.js:54:21:54:44 | documen ... .search |
-| tst.js:54:21:54:37 | document.location | tst.js:54:21:54:44 | documen ... .search |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
-| tst.js:56:21:56:37 | document.location | tst.js:56:21:56:44 | documen ... .search |
-| tst.js:56:21:56:37 | document.location | tst.js:56:21:56:44 | documen ... .search |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
@@ -1088,72 +1022,43 @@ edges
 | tst.js:58:26:58:30 | bar() | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
-| tst.js:64:25:64:41 | document.location | tst.js:64:25:64:48 | documen ... .search |
-| tst.js:64:25:64:41 | document.location | tst.js:64:25:64:48 | documen ... .search |
 | tst.js:64:25:64:48 | documen ... .search | tst.js:60:34:60:34 | s |
-| tst.js:65:25:65:41 | document.location | tst.js:65:25:65:48 | documen ... .search |
-| tst.js:65:25:65:41 | document.location | tst.js:65:25:65:48 | documen ... .search |
+| tst.js:64:25:64:48 | documen ... .search | tst.js:60:34:60:34 | s |
+| tst.js:65:25:65:48 | documen ... .search | tst.js:60:34:60:34 | s |
 | tst.js:65:25:65:48 | documen ... .search | tst.js:60:34:60:34 | s |
 | tst.js:70:1:70:27 | [,docum ... search] | tst.js:70:46:70:46 | x |
-| tst.js:70:3:70:19 | document.location | tst.js:70:3:70:26 | documen ... .search |
-| tst.js:70:3:70:19 | document.location | tst.js:70:3:70:26 | documen ... .search |
 | tst.js:70:3:70:26 | documen ... .search | tst.js:70:1:70:27 | [,docum ... search] |
+| tst.js:70:3:70:26 | documen ... .search | tst.js:70:1:70:27 | [,docum ... search] |
+| tst.js:70:3:70:26 | documen ... .search | tst.js:70:46:70:46 | x |
 | tst.js:70:3:70:26 | documen ... .search | tst.js:70:46:70:46 | x |
 | tst.js:70:46:70:46 | x | tst.js:73:20:73:20 | x |
 | tst.js:70:46:70:46 | x | tst.js:73:20:73:20 | x |
-| tst.js:77:49:77:65 | document.location | tst.js:77:49:77:72 | documen ... .search |
-| tst.js:77:49:77:65 | document.location | tst.js:77:49:77:72 | documen ... .search |
-| tst.js:77:49:77:65 | document.location | tst.js:77:49:77:72 | documen ... .search |
-| tst.js:77:49:77:65 | document.location | tst.js:77:49:77:72 | documen ... .search |
-| tst.js:81:26:81:42 | document.location | tst.js:81:26:81:49 | documen ... .search |
-| tst.js:81:26:81:42 | document.location | tst.js:81:26:81:49 | documen ... .search |
-| tst.js:81:26:81:42 | document.location | tst.js:81:26:81:49 | documen ... .search |
-| tst.js:81:26:81:42 | document.location | tst.js:81:26:81:49 | documen ... .search |
-| tst.js:82:25:82:41 | document.location | tst.js:82:25:82:48 | documen ... .search |
-| tst.js:82:25:82:41 | document.location | tst.js:82:25:82:48 | documen ... .search |
-| tst.js:82:25:82:41 | document.location | tst.js:82:25:82:48 | documen ... .search |
-| tst.js:82:25:82:41 | document.location | tst.js:82:25:82:48 | documen ... .search |
-| tst.js:84:33:84:49 | document.location | tst.js:84:33:84:56 | documen ... .search |
-| tst.js:84:33:84:49 | document.location | tst.js:84:33:84:56 | documen ... .search |
-| tst.js:84:33:84:49 | document.location | tst.js:84:33:84:56 | documen ... .search |
-| tst.js:84:33:84:49 | document.location | tst.js:84:33:84:56 | documen ... .search |
-| tst.js:85:32:85:48 | document.location | tst.js:85:32:85:55 | documen ... .search |
-| tst.js:85:32:85:48 | document.location | tst.js:85:32:85:55 | documen ... .search |
-| tst.js:85:32:85:48 | document.location | tst.js:85:32:85:55 | documen ... .search |
-| tst.js:85:32:85:48 | document.location | tst.js:85:32:85:55 | documen ... .search |
-| tst.js:90:39:90:55 | document.location | tst.js:90:39:90:62 | documen ... .search |
-| tst.js:90:39:90:55 | document.location | tst.js:90:39:90:62 | documen ... .search |
-| tst.js:90:39:90:55 | document.location | tst.js:90:39:90:62 | documen ... .search |
-| tst.js:90:39:90:55 | document.location | tst.js:90:39:90:62 | documen ... .search |
-| tst.js:96:30:96:46 | document.location | tst.js:96:30:96:53 | documen ... .search |
-| tst.js:96:30:96:46 | document.location | tst.js:96:30:96:53 | documen ... .search |
-| tst.js:96:30:96:46 | document.location | tst.js:96:30:96:53 | documen ... .search |
-| tst.js:96:30:96:46 | document.location | tst.js:96:30:96:53 | documen ... .search |
-| tst.js:102:25:102:41 | document.location | tst.js:102:25:102:48 | documen ... .search |
-| tst.js:102:25:102:41 | document.location | tst.js:102:25:102:48 | documen ... .search |
-| tst.js:102:25:102:41 | document.location | tst.js:102:25:102:48 | documen ... .search |
-| tst.js:102:25:102:41 | document.location | tst.js:102:25:102:48 | documen ... .search |
+| tst.js:77:49:77:72 | documen ... .search | tst.js:77:49:77:72 | documen ... .search |
+| tst.js:81:26:81:49 | documen ... .search | tst.js:81:26:81:49 | documen ... .search |
+| tst.js:82:25:82:48 | documen ... .search | tst.js:82:25:82:48 | documen ... .search |
+| tst.js:84:33:84:56 | documen ... .search | tst.js:84:33:84:56 | documen ... .search |
+| tst.js:85:32:85:55 | documen ... .search | tst.js:85:32:85:55 | documen ... .search |
+| tst.js:90:39:90:62 | documen ... .search | tst.js:90:39:90:62 | documen ... .search |
+| tst.js:96:30:96:53 | documen ... .search | tst.js:96:30:96:53 | documen ... .search |
+| tst.js:102:25:102:48 | documen ... .search | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
-| tst.js:107:11:107:27 | document.location | tst.js:107:11:107:34 | documen ... .search |
-| tst.js:107:11:107:27 | document.location | tst.js:107:11:107:34 | documen ... .search |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
-| tst.js:148:29:148:43 | window.location | tst.js:148:29:148:50 | window. ... .search |
-| tst.js:148:29:148:43 | window.location | tst.js:148:29:148:50 | window. ... .search |
+| tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
 | tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
 | tst.js:151:29:151:29 | v | tst.js:151:49:151:49 | v |
 | tst.js:151:29:151:29 | v | tst.js:151:49:151:49 | v |
-| tst.js:158:40:158:54 | window.location | tst.js:158:40:158:61 | window. ... .search |
-| tst.js:158:40:158:54 | window.location | tst.js:158:40:158:61 | window. ... .search |
+| tst.js:158:40:158:61 | window. ... .search | tst.js:155:29:155:46 | xssSourceService() |
+| tst.js:158:40:158:61 | window. ... .search | tst.js:155:29:155:46 | xssSourceService() |
 | tst.js:158:40:158:61 | window. ... .search | tst.js:155:29:155:46 | xssSourceService() |
 | tst.js:158:40:158:61 | window. ... .search | tst.js:155:29:155:46 | xssSourceService() |
 | tst.js:177:9:177:41 | target | tst.js:180:28:180:33 | target |
 | tst.js:177:9:177:41 | target | tst.js:180:28:180:33 | target |
-| tst.js:177:18:177:34 | document.location | tst.js:177:18:177:41 | documen ... .search |
-| tst.js:177:18:177:34 | document.location | tst.js:177:18:177:41 | documen ... .search |
+| tst.js:177:18:177:41 | documen ... .search | tst.js:177:9:177:41 | target |
 | tst.js:177:18:177:41 | documen ... .search | tst.js:177:9:177:41 | target |
 | tst.js:184:9:184:42 | tainted | tst.js:186:31:186:37 | tainted |
 | tst.js:184:9:184:42 | tainted | tst.js:186:31:186:37 | tainted |
@@ -1167,8 +1072,7 @@ edges
 | tst.js:184:9:184:42 | tainted | tst.js:192:45:192:51 | tainted |
 | tst.js:184:9:184:42 | tainted | tst.js:193:49:193:55 | tainted |
 | tst.js:184:9:184:42 | tainted | tst.js:193:49:193:55 | tainted |
-| tst.js:184:19:184:35 | document.location | tst.js:184:19:184:42 | documen ... .search |
-| tst.js:184:19:184:35 | document.location | tst.js:184:19:184:42 | documen ... .search |
+| tst.js:184:19:184:42 | documen ... .search | tst.js:184:9:184:42 | tainted |
 | tst.js:184:19:184:42 | documen ... .search | tst.js:184:9:184:42 | tainted |
 | tst.js:197:9:197:42 | tainted | tst.js:199:67:199:73 | tainted |
 | tst.js:197:9:197:42 | tainted | tst.js:199:67:199:73 | tainted |
@@ -1183,8 +1087,7 @@ edges
 | tst.js:197:9:197:42 | tainted | tst.js:240:23:240:29 | tainted |
 | tst.js:197:9:197:42 | tainted | tst.js:241:23:241:29 | tainted |
 | tst.js:197:9:197:42 | tainted | tst.js:255:23:255:29 | tainted |
-| tst.js:197:19:197:35 | document.location | tst.js:197:19:197:42 | documen ... .search |
-| tst.js:197:19:197:35 | document.location | tst.js:197:19:197:42 | documen ... .search |
+| tst.js:197:19:197:42 | documen ... .search | tst.js:197:9:197:42 | tainted |
 | tst.js:197:19:197:42 | documen ... .search | tst.js:197:9:197:42 | tainted |
 | tst.js:204:35:204:41 | tainted | tst.js:212:28:212:46 | this.state.tainted1 |
 | tst.js:204:35:204:41 | tainted | tst.js:212:28:212:46 | this.state.tainted1 |
@@ -1232,8 +1135,7 @@ edges
 | tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target | tst.js:349:12:349:17 | target |
 | tst.js:348:7:348:39 | target | tst.js:349:12:349:17 | target |
-| tst.js:348:16:348:32 | document.location | tst.js:348:16:348:39 | documen ... .search |
-| tst.js:348:16:348:32 | document.location | tst.js:348:16:348:39 | documen ... .search |
+| tst.js:348:16:348:39 | documen ... .search | tst.js:348:7:348:39 | target |
 | tst.js:348:16:348:39 | documen ... .search | tst.js:348:7:348:39 | target |
 | tst.js:355:10:355:42 | target | tst.js:356:16:356:21 | target |
 | tst.js:355:10:355:42 | target | tst.js:356:16:356:21 | target |
@@ -1241,13 +1143,11 @@ edges
 | tst.js:355:10:355:42 | target | tst.js:360:21:360:26 | target |
 | tst.js:355:10:355:42 | target | tst.js:363:18:363:23 | target |
 | tst.js:355:10:355:42 | target | tst.js:363:18:363:23 | target |
-| tst.js:355:19:355:35 | document.location | tst.js:355:19:355:42 | documen ... .search |
-| tst.js:355:19:355:35 | document.location | tst.js:355:19:355:42 | documen ... .search |
+| tst.js:355:19:355:42 | documen ... .search | tst.js:355:10:355:42 | target |
 | tst.js:355:19:355:42 | documen ... .search | tst.js:355:10:355:42 | target |
 | tst.js:371:7:371:39 | target | tst.js:374:18:374:23 | target |
 | tst.js:371:7:371:39 | target | tst.js:374:18:374:23 | target |
-| tst.js:371:16:371:32 | document.location | tst.js:371:16:371:39 | documen ... .search |
-| tst.js:371:16:371:32 | document.location | tst.js:371:16:371:39 | documen ... .search |
+| tst.js:371:16:371:39 | documen ... .search | tst.js:371:7:371:39 | target |
 | tst.js:371:16:371:39 | documen ... .search | tst.js:371:7:371:39 | target |
 | tst.js:381:7:381:39 | target | tst.js:384:18:384:23 | target |
 | tst.js:381:7:381:39 | target | tst.js:384:18:384:23 | target |
@@ -1255,13 +1155,12 @@ edges
 | tst.js:381:7:381:39 | target | tst.js:397:18:397:23 | target |
 | tst.js:381:7:381:39 | target | tst.js:406:18:406:23 | target |
 | tst.js:381:7:381:39 | target | tst.js:408:19:408:24 | target |
-| tst.js:381:16:381:32 | document.location | tst.js:381:16:381:39 | documen ... .search |
-| tst.js:381:16:381:32 | document.location | tst.js:381:16:381:39 | documen ... .search |
+| tst.js:381:16:381:39 | documen ... .search | tst.js:381:7:381:39 | target |
 | tst.js:381:16:381:39 | documen ... .search | tst.js:381:7:381:39 | target |
 | tst.js:386:18:386:23 | target | tst.js:386:18:386:29 | target.taint |
 | tst.js:386:18:386:23 | target | tst.js:386:18:386:29 | target.taint |
-| tst.js:391:19:391:35 | document.location | tst.js:391:19:391:42 | documen ... .search |
-| tst.js:391:19:391:35 | document.location | tst.js:391:19:391:42 | documen ... .search |
+| tst.js:391:19:391:42 | documen ... .search | tst.js:392:18:392:30 | target.taint3 |
+| tst.js:391:19:391:42 | documen ... .search | tst.js:392:18:392:30 | target.taint3 |
 | tst.js:391:19:391:42 | documen ... .search | tst.js:392:18:392:30 | target.taint3 |
 | tst.js:391:19:391:42 | documen ... .search | tst.js:392:18:392:30 | target.taint3 |
 | tst.js:397:18:397:23 | target | tst.js:397:18:397:30 | target.taint5 |
@@ -1274,31 +1173,26 @@ edges
 | tst.js:408:19:408:31 | target.taint8 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
-| tst.js:416:17:416:31 | window.location | tst.js:416:17:416:36 | window.location.hash |
-| tst.js:416:17:416:31 | window.location | tst.js:416:17:416:36 | window.location.hash |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
 | tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
 | tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
 | tst.js:419:7:419:55 | match | tst.js:421:20:421:24 | match |
-| tst.js:419:15:419:29 | window.location | tst.js:419:15:419:34 | window.location.hash |
-| tst.js:419:15:419:29 | window.location | tst.js:419:15:419:34 | window.location.hash |
+| tst.js:419:15:419:34 | window.location.hash | tst.js:419:15:419:55 | window. ... (\\w+)/) |
 | tst.js:419:15:419:34 | window.location.hash | tst.js:419:15:419:55 | window. ... (\\w+)/) |
 | tst.js:419:15:419:55 | window. ... (\\w+)/) | tst.js:419:7:419:55 | match |
 | tst.js:421:20:421:24 | match | tst.js:421:20:421:27 | match[1] |
 | tst.js:421:20:421:24 | match | tst.js:421:20:421:27 | match[1] |
-| tst.js:424:18:424:32 | window.location | tst.js:424:18:424:37 | window.location.hash |
-| tst.js:424:18:424:32 | window.location | tst.js:424:18:424:37 | window.location.hash |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target | tst.js:430:18:430:23 | target |
-| tst.js:428:16:428:32 | document.location | tst.js:428:16:428:39 | documen ... .search |
-| tst.js:428:16:428:32 | document.location | tst.js:428:16:428:39 | documen ... .search |
+| tst.js:428:16:428:39 | documen ... .search | tst.js:428:7:428:39 | target |
 | tst.js:428:16:428:39 | documen ... .search | tst.js:428:7:428:39 | target |
 | tst.js:430:18:430:23 | target | tst.js:430:18:430:89 | target. ... data>') |
 | tst.js:430:18:430:23 | target | tst.js:430:18:430:89 | target. ... data>') |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
-| typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
-| typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
+| typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
 | typeahead.js:21:12:21:17 | target | typeahead.js:24:30:24:32 | val |
 | typeahead.js:24:30:24:32 | val | typeahead.js:25:18:25:20 | val |
@@ -1349,15 +1243,14 @@ edges
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
-| winjs.js:2:17:2:33 | document.location | winjs.js:2:17:2:40 | documen ... .search |
-| winjs.js:2:17:2:33 | document.location | winjs.js:2:17:2:40 | documen ... .search |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
 #select
 | addEventListener.js:2:20:2:29 | event.data | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:29 | event.data | Cross-site scripting vulnerability due to $@. | addEventListener.js:1:43:1:47 | event | user-provided value |
 | addEventListener.js:6:20:6:23 | data | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:6:20:6:23 | data | Cross-site scripting vulnerability due to $@. | addEventListener.js:5:43:5:48 | {data} | user-provided value |
 | addEventListener.js:12:24:12:33 | event.data | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:33 | event.data | Cross-site scripting vulnerability due to $@. | addEventListener.js:10:21:10:25 | event | user-provided value |
-| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | Cross-site scripting vulnerability due to $@. | angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | user-provided value |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | Cross-site scripting vulnerability due to $@. | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | user-provided value |
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo | Cross-site scripting vulnerability due to $@. | angular2-client.ts:24:44:24:69 | this.ro ... .params | user-provided value |
 | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo | angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo | Cross-site scripting vulnerability due to $@. | angular2-client.ts:25:44:25:74 | this.ro ... yParams | user-provided value |
 | angular2-client.ts:26:44:26:71 | this.ro ... ragment | angular2-client.ts:26:44:26:71 | this.ro ... ragment | angular2-client.ts:26:44:26:71 | this.ro ... ragment | Cross-site scripting vulnerability due to $@. | angular2-client.ts:26:44:26:71 | this.ro ... ragment | user-provided value |
@@ -1381,29 +1274,29 @@ edges
 | d3.js:12:20:12:29 | getTaint() | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() | Cross-site scripting vulnerability due to $@. | d3.js:4:12:4:22 | window.name | user-provided value |
 | d3.js:14:20:14:29 | getTaint() | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() | Cross-site scripting vulnerability due to $@. | d3.js:4:12:4:22 | window.name | user-provided value |
 | d3.js:21:15:21:24 | getTaint() | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() | Cross-site scripting vulnerability due to $@. | d3.js:4:12:4:22 | window.name | user-provided value |
-| dates.js:11:31:11:70 | `Time i ... aint)}` | dates.js:9:36:9:50 | window.location | dates.js:11:31:11:70 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:50 | window.location | user-provided value |
-| dates.js:12:31:12:73 | `Time i ... aint)}` | dates.js:9:36:9:50 | window.location | dates.js:12:31:12:73 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:50 | window.location | user-provided value |
-| dates.js:13:31:13:72 | `Time i ... time)}` | dates.js:9:36:9:50 | window.location | dates.js:13:31:13:72 | `Time i ... time)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:50 | window.location | user-provided value |
-| dates.js:16:31:16:69 | `Time i ... aint)}` | dates.js:9:36:9:50 | window.location | dates.js:16:31:16:69 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:50 | window.location | user-provided value |
-| dates.js:18:31:18:66 | `Time i ... aint)}` | dates.js:9:36:9:50 | window.location | dates.js:18:31:18:66 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:50 | window.location | user-provided value |
-| event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | event-handler-receiver.js:2:49:2:56 | location | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | Cross-site scripting vulnerability due to $@. | event-handler-receiver.js:2:49:2:56 | location | user-provided value |
+| dates.js:11:31:11:70 | `Time i ... aint)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:11:31:11:70 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
+| dates.js:12:31:12:73 | `Time i ... aint)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:12:31:12:73 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
+| dates.js:13:31:13:72 | `Time i ... time)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:13:31:13:72 | `Time i ... time)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
+| dates.js:16:31:16:69 | `Time i ... aint)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:16:31:16:69 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
+| dates.js:18:31:18:66 | `Time i ... aint)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:18:31:18:66 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
+| event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | Cross-site scripting vulnerability due to $@. | event-handler-receiver.js:2:49:2:61 | location.href | user-provided value |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") | Cross-site scripting vulnerability due to $@. | express.js:7:15:7:33 | req.param("wobble") | user-provided value |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" | jquery.js:2:17:2:40 | documen ... .search | jquery.js:7:5:7:34 | "<div i ... + "\\">" | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:40 | documen ... .search | user-provided value |
-| jquery.js:8:18:8:34 | "XSS: " + tainted | jquery.js:2:17:2:33 | document.location | jquery.js:8:18:8:34 | "XSS: " + tainted | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:33 | document.location | user-provided value |
+| jquery.js:8:18:8:34 | "XSS: " + tainted | jquery.js:2:17:2:40 | documen ... .search | jquery.js:8:18:8:34 | "XSS: " + tainted | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:40 | documen ... .search | user-provided value |
 | jquery.js:10:5:10:40 | "<b>" + ...  "</b>" | jquery.js:10:13:10:20 | location | jquery.js:10:5:10:40 | "<b>" + ...  "</b>" | Cross-site scripting vulnerability due to $@. | jquery.js:10:13:10:20 | location | user-provided value |
-| jquery.js:14:19:14:58 | decodeU ... n.hash) | jquery.js:14:38:14:52 | window.location | jquery.js:14:19:14:58 | decodeU ... n.hash) | Cross-site scripting vulnerability due to $@. | jquery.js:14:38:14:52 | window.location | user-provided value |
-| jquery.js:15:19:15:60 | decodeU ... search) | jquery.js:15:38:15:52 | window.location | jquery.js:15:19:15:60 | decodeU ... search) | Cross-site scripting vulnerability due to $@. | jquery.js:15:38:15:52 | window.location | user-provided value |
+| jquery.js:14:19:14:58 | decodeU ... n.hash) | jquery.js:14:38:14:57 | window.location.hash | jquery.js:14:19:14:58 | decodeU ... n.hash) | Cross-site scripting vulnerability due to $@. | jquery.js:14:38:14:57 | window.location.hash | user-provided value |
+| jquery.js:15:19:15:60 | decodeU ... search) | jquery.js:15:38:15:59 | window. ... .search | jquery.js:15:19:15:60 | decodeU ... search) | Cross-site scripting vulnerability due to $@. | jquery.js:15:38:15:59 | window. ... .search | user-provided value |
 | jquery.js:16:19:16:64 | decodeU ... ring()) | jquery.js:16:38:16:52 | window.location | jquery.js:16:19:16:64 | decodeU ... ring()) | Cross-site scripting vulnerability due to $@. | jquery.js:16:38:16:52 | window.location | user-provided value |
 | jwt-server.js:11:19:11:29 | decoded.foo | jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:11:19:11:29 | decoded.foo | Cross-site scripting vulnerability due to $@. | jwt-server.js:7:17:7:35 | req.param("wobble") | user-provided value |
 | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` | nodemailer.js:13:50:13:66 | req.query.message | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` | HTML injection vulnerability due to $@. | nodemailer.js:13:50:13:66 | req.query.message | user-provided value |
-| optionalSanitizer.js:6:18:6:23 | target | optionalSanitizer.js:2:16:2:32 | document.location | optionalSanitizer.js:6:18:6:23 | target | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:2:16:2:32 | document.location | user-provided value |
-| optionalSanitizer.js:9:18:9:24 | tainted | optionalSanitizer.js:2:16:2:32 | document.location | optionalSanitizer.js:9:18:9:24 | tainted | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:2:16:2:32 | document.location | user-provided value |
-| optionalSanitizer.js:17:20:17:20 | x | optionalSanitizer.js:2:16:2:32 | document.location | optionalSanitizer.js:17:20:17:20 | x | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:2:16:2:32 | document.location | user-provided value |
-| optionalSanitizer.js:32:18:32:25 | tainted2 | optionalSanitizer.js:26:16:26:32 | document.location | optionalSanitizer.js:32:18:32:25 | tainted2 | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:26:16:26:32 | document.location | user-provided value |
-| optionalSanitizer.js:36:18:36:25 | tainted2 | optionalSanitizer.js:26:16:26:32 | document.location | optionalSanitizer.js:36:18:36:25 | tainted2 | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:26:16:26:32 | document.location | user-provided value |
-| optionalSanitizer.js:39:18:39:25 | tainted3 | optionalSanitizer.js:26:16:26:32 | document.location | optionalSanitizer.js:39:18:39:25 | tainted3 | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:26:16:26:32 | document.location | user-provided value |
-| optionalSanitizer.js:43:18:43:25 | tainted3 | optionalSanitizer.js:26:16:26:32 | document.location | optionalSanitizer.js:43:18:43:25 | tainted3 | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:26:16:26:32 | document.location | user-provided value |
-| optionalSanitizer.js:45:18:45:56 | sanitiz ...  target | optionalSanitizer.js:26:16:26:32 | document.location | optionalSanitizer.js:45:18:45:56 | sanitiz ...  target | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:26:16:26:32 | document.location | user-provided value |
+| optionalSanitizer.js:6:18:6:23 | target | optionalSanitizer.js:2:16:2:39 | documen ... .search | optionalSanitizer.js:6:18:6:23 | target | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:2:16:2:39 | documen ... .search | user-provided value |
+| optionalSanitizer.js:9:18:9:24 | tainted | optionalSanitizer.js:2:16:2:39 | documen ... .search | optionalSanitizer.js:9:18:9:24 | tainted | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:2:16:2:39 | documen ... .search | user-provided value |
+| optionalSanitizer.js:17:20:17:20 | x | optionalSanitizer.js:2:16:2:39 | documen ... .search | optionalSanitizer.js:17:20:17:20 | x | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:2:16:2:39 | documen ... .search | user-provided value |
+| optionalSanitizer.js:32:18:32:25 | tainted2 | optionalSanitizer.js:26:16:26:39 | documen ... .search | optionalSanitizer.js:32:18:32:25 | tainted2 | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:26:16:26:39 | documen ... .search | user-provided value |
+| optionalSanitizer.js:36:18:36:25 | tainted2 | optionalSanitizer.js:26:16:26:39 | documen ... .search | optionalSanitizer.js:36:18:36:25 | tainted2 | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:26:16:26:39 | documen ... .search | user-provided value |
+| optionalSanitizer.js:39:18:39:25 | tainted3 | optionalSanitizer.js:26:16:26:39 | documen ... .search | optionalSanitizer.js:39:18:39:25 | tainted3 | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:26:16:26:39 | documen ... .search | user-provided value |
+| optionalSanitizer.js:43:18:43:25 | tainted3 | optionalSanitizer.js:26:16:26:39 | documen ... .search | optionalSanitizer.js:43:18:43:25 | tainted3 | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:26:16:26:39 | documen ... .search | user-provided value |
+| optionalSanitizer.js:45:18:45:56 | sanitiz ...  target | optionalSanitizer.js:26:16:26:39 | documen ... .search | optionalSanitizer.js:45:18:45:56 | sanitiz ...  target | Cross-site scripting vulnerability due to $@. | optionalSanitizer.js:26:16:26:39 | documen ... .search | user-provided value |
 | react-native.js:8:18:8:24 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:8:18:8:24 | tainted | Cross-site scripting vulnerability due to $@. | react-native.js:7:17:7:33 | req.param("code") | user-provided value |
 | react-native.js:9:27:9:33 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:9:27:9:33 | tainted | Cross-site scripting vulnerability due to $@. | react-native.js:7:17:7:33 | req.param("code") | user-provided value |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name | Cross-site scripting vulnerability due to $@. | react-use-context.js:10:22:10:32 | window.name | user-provided value |
@@ -1417,69 +1310,69 @@ edges
 | sanitiser.js:33:21:33:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:33:21:33:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
 | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
-| stored-xss.js:5:20:5:52 | session ... ssion') | stored-xss.js:2:39:2:55 | document.location | stored-xss.js:5:20:5:52 | session ... ssion') | Cross-site scripting vulnerability due to $@. | stored-xss.js:2:39:2:55 | document.location | user-provided value |
-| stored-xss.js:8:20:8:48 | localSt ... local') | stored-xss.js:3:35:3:51 | document.location | stored-xss.js:8:20:8:48 | localSt ... local') | Cross-site scripting vulnerability due to $@. | stored-xss.js:3:35:3:51 | document.location | user-provided value |
-| stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" | stored-xss.js:3:35:3:51 | document.location | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" | Cross-site scripting vulnerability due to $@. | stored-xss.js:3:35:3:51 | document.location | user-provided value |
+| stored-xss.js:5:20:5:52 | session ... ssion') | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') | Cross-site scripting vulnerability due to $@. | stored-xss.js:2:39:2:62 | documen ... .search | user-provided value |
+| stored-xss.js:8:20:8:48 | localSt ... local') | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:8:20:8:48 | localSt ... local') | Cross-site scripting vulnerability due to $@. | stored-xss.js:3:35:3:58 | documen ... .search | user-provided value |
+| stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" | Cross-site scripting vulnerability due to $@. | stored-xss.js:3:35:3:58 | documen ... .search | user-provided value |
 | string-manipulations.js:3:16:3:32 | document.location | string-manipulations.js:3:16:3:32 | document.location | string-manipulations.js:3:16:3:32 | document.location | Cross-site scripting vulnerability due to $@. | string-manipulations.js:3:16:3:32 | document.location | user-provided value |
-| string-manipulations.js:4:16:4:37 | documen ... on.href | string-manipulations.js:4:16:4:32 | document.location | string-manipulations.js:4:16:4:37 | documen ... on.href | Cross-site scripting vulnerability due to $@. | string-manipulations.js:4:16:4:32 | document.location | user-provided value |
-| string-manipulations.js:5:16:5:47 | documen ... lueOf() | string-manipulations.js:5:16:5:32 | document.location | string-manipulations.js:5:16:5:47 | documen ... lueOf() | Cross-site scripting vulnerability due to $@. | string-manipulations.js:5:16:5:32 | document.location | user-provided value |
-| string-manipulations.js:6:16:6:43 | documen ... f.sup() | string-manipulations.js:6:16:6:32 | document.location | string-manipulations.js:6:16:6:43 | documen ... f.sup() | Cross-site scripting vulnerability due to $@. | string-manipulations.js:6:16:6:32 | document.location | user-provided value |
-| string-manipulations.js:7:16:7:51 | documen ... rCase() | string-manipulations.js:7:16:7:32 | document.location | string-manipulations.js:7:16:7:51 | documen ... rCase() | Cross-site scripting vulnerability due to $@. | string-manipulations.js:7:16:7:32 | document.location | user-provided value |
-| string-manipulations.js:8:16:8:48 | documen ... mLeft() | string-manipulations.js:8:16:8:32 | document.location | string-manipulations.js:8:16:8:48 | documen ... mLeft() | Cross-site scripting vulnerability due to $@. | string-manipulations.js:8:16:8:32 | document.location | user-provided value |
-| string-manipulations.js:9:16:9:58 | String. ... n.href) | string-manipulations.js:9:36:9:52 | document.location | string-manipulations.js:9:16:9:58 | String. ... n.href) | Cross-site scripting vulnerability due to $@. | string-manipulations.js:9:36:9:52 | document.location | user-provided value |
-| string-manipulations.js:10:16:10:45 | String( ... n.href) | string-manipulations.js:10:23:10:39 | document.location | string-manipulations.js:10:16:10:45 | String( ... n.href) | Cross-site scripting vulnerability due to $@. | string-manipulations.js:10:23:10:39 | document.location | user-provided value |
-| translate.js:9:27:9:50 | searchP ... 'term') | translate.js:6:16:6:32 | document.location | translate.js:9:27:9:50 | searchP ... 'term') | Cross-site scripting vulnerability due to $@. | translate.js:6:16:6:32 | document.location | user-provided value |
-| tst3.js:4:25:4:32 | data.src | tst3.js:2:42:2:56 | window.location | tst3.js:4:25:4:32 | data.src | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
-| tst3.js:5:26:5:31 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:5:26:5:31 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
-| tst3.js:7:32:7:37 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:7:32:7:37 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
-| tst3.js:9:37:9:42 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:9:37:9:42 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
-| tst3.js:10:38:10:43 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:10:38:10:43 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
-| tst.js:5:18:5:23 | target | tst.js:2:16:2:32 | document.location | tst.js:5:18:5:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:32 | document.location | user-provided value |
-| tst.js:8:18:8:126 | "<OPTIO ... PTION>" | tst.js:8:37:8:53 | document.location | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | Cross-site scripting vulnerability due to $@. | tst.js:8:37:8:53 | document.location | user-provided value |
+| string-manipulations.js:4:16:4:37 | documen ... on.href | string-manipulations.js:4:16:4:37 | documen ... on.href | string-manipulations.js:4:16:4:37 | documen ... on.href | Cross-site scripting vulnerability due to $@. | string-manipulations.js:4:16:4:37 | documen ... on.href | user-provided value |
+| string-manipulations.js:5:16:5:47 | documen ... lueOf() | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() | Cross-site scripting vulnerability due to $@. | string-manipulations.js:5:16:5:37 | documen ... on.href | user-provided value |
+| string-manipulations.js:6:16:6:43 | documen ... f.sup() | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() | Cross-site scripting vulnerability due to $@. | string-manipulations.js:6:16:6:37 | documen ... on.href | user-provided value |
+| string-manipulations.js:7:16:7:51 | documen ... rCase() | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() | Cross-site scripting vulnerability due to $@. | string-manipulations.js:7:16:7:37 | documen ... on.href | user-provided value |
+| string-manipulations.js:8:16:8:48 | documen ... mLeft() | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() | Cross-site scripting vulnerability due to $@. | string-manipulations.js:8:16:8:37 | documen ... on.href | user-provided value |
+| string-manipulations.js:9:16:9:58 | String. ... n.href) | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) | Cross-site scripting vulnerability due to $@. | string-manipulations.js:9:36:9:57 | documen ... on.href | user-provided value |
+| string-manipulations.js:10:16:10:45 | String( ... n.href) | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) | Cross-site scripting vulnerability due to $@. | string-manipulations.js:10:23:10:44 | documen ... on.href | user-provided value |
+| translate.js:9:27:9:50 | searchP ... 'term') | translate.js:6:16:6:39 | documen ... .search | translate.js:9:27:9:50 | searchP ... 'term') | Cross-site scripting vulnerability due to $@. | translate.js:6:16:6:39 | documen ... .search | user-provided value |
+| tst3.js:4:25:4:32 | data.src | tst3.js:2:42:2:63 | window. ... .search | tst3.js:4:25:4:32 | data.src | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
+| tst3.js:5:26:5:31 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:5:26:5:31 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
+| tst3.js:7:32:7:37 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:7:32:7:37 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
+| tst3.js:9:37:9:42 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:9:37:9:42 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
+| tst3.js:10:38:10:43 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:10:38:10:43 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
+| tst.js:5:18:5:23 | target | tst.js:2:16:2:39 | documen ... .search | tst.js:5:18:5:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:39 | documen ... .search | user-provided value |
+| tst.js:8:18:8:126 | "<OPTIO ... PTION>" | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | Cross-site scripting vulnerability due to $@. | tst.js:8:37:8:58 | documen ... on.href | user-provided value |
 | tst.js:12:5:12:42 | '<div s ...  'px">' | tst.js:2:16:2:39 | documen ... .search | tst.js:12:5:12:42 | '<div s ...  'px">' | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:39 | documen ... .search | user-provided value |
 | tst.js:18:18:18:35 | params.get('name') | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') | Cross-site scripting vulnerability due to $@. | tst.js:17:25:17:41 | document.location | user-provided value |
-| tst.js:21:18:21:41 | searchP ... 'name') | tst.js:2:16:2:32 | document.location | tst.js:21:18:21:41 | searchP ... 'name') | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:32 | document.location | user-provided value |
-| tst.js:26:18:26:23 | target | tst.js:28:5:28:21 | document.location | tst.js:26:18:26:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:28:5:28:21 | document.location | user-provided value |
-| tst.js:34:16:34:20 | bar() | tst.js:31:10:31:26 | document.location | tst.js:34:16:34:20 | bar() | Cross-site scripting vulnerability due to $@. | tst.js:31:10:31:26 | document.location | user-provided value |
-| tst.js:40:16:40:44 | baz(doc ... search) | tst.js:40:20:40:36 | document.location | tst.js:40:16:40:44 | baz(doc ... search) | Cross-site scripting vulnerability due to $@. | tst.js:40:20:40:36 | document.location | user-provided value |
-| tst.js:46:16:46:45 | wrap(do ... search) | tst.js:46:21:46:37 | document.location | tst.js:46:16:46:45 | wrap(do ... search) | Cross-site scripting vulnerability due to $@. | tst.js:46:21:46:37 | document.location | user-provided value |
-| tst.js:54:16:54:45 | chop(do ... search) | tst.js:54:21:54:37 | document.location | tst.js:54:16:54:45 | chop(do ... search) | Cross-site scripting vulnerability due to $@. | tst.js:54:21:54:37 | document.location | user-provided value |
-| tst.js:56:16:56:45 | chop(do ... search) | tst.js:56:21:56:37 | document.location | tst.js:56:16:56:45 | chop(do ... search) | Cross-site scripting vulnerability due to $@. | tst.js:56:21:56:37 | document.location | user-provided value |
-| tst.js:58:16:58:32 | wrap(chop(bar())) | tst.js:31:10:31:26 | document.location | tst.js:58:16:58:32 | wrap(chop(bar())) | Cross-site scripting vulnerability due to $@. | tst.js:31:10:31:26 | document.location | user-provided value |
-| tst.js:62:18:62:18 | s | tst.js:64:25:64:41 | document.location | tst.js:62:18:62:18 | s | Cross-site scripting vulnerability due to $@. | tst.js:64:25:64:41 | document.location | user-provided value |
-| tst.js:62:18:62:18 | s | tst.js:65:25:65:41 | document.location | tst.js:62:18:62:18 | s | Cross-site scripting vulnerability due to $@. | tst.js:65:25:65:41 | document.location | user-provided value |
-| tst.js:68:16:68:20 | bar() | tst.js:31:10:31:26 | document.location | tst.js:68:16:68:20 | bar() | Cross-site scripting vulnerability due to $@. | tst.js:31:10:31:26 | document.location | user-provided value |
-| tst.js:73:20:73:20 | x | tst.js:70:3:70:19 | document.location | tst.js:73:20:73:20 | x | Cross-site scripting vulnerability due to $@. | tst.js:70:3:70:19 | document.location | user-provided value |
-| tst.js:77:49:77:72 | documen ... .search | tst.js:77:49:77:65 | document.location | tst.js:77:49:77:72 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:77:49:77:65 | document.location | user-provided value |
-| tst.js:81:26:81:49 | documen ... .search | tst.js:81:26:81:42 | document.location | tst.js:81:26:81:49 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:81:26:81:42 | document.location | user-provided value |
-| tst.js:82:25:82:48 | documen ... .search | tst.js:82:25:82:41 | document.location | tst.js:82:25:82:48 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:82:25:82:41 | document.location | user-provided value |
-| tst.js:84:33:84:56 | documen ... .search | tst.js:84:33:84:49 | document.location | tst.js:84:33:84:56 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:84:33:84:49 | document.location | user-provided value |
-| tst.js:85:32:85:55 | documen ... .search | tst.js:85:32:85:48 | document.location | tst.js:85:32:85:55 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:85:32:85:48 | document.location | user-provided value |
-| tst.js:90:39:90:62 | documen ... .search | tst.js:90:39:90:55 | document.location | tst.js:90:39:90:62 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:90:39:90:55 | document.location | user-provided value |
-| tst.js:96:30:96:53 | documen ... .search | tst.js:96:30:96:46 | document.location | tst.js:96:30:96:53 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:96:30:96:46 | document.location | user-provided value |
-| tst.js:102:25:102:48 | documen ... .search | tst.js:102:25:102:41 | document.location | tst.js:102:25:102:48 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:102:25:102:41 | document.location | user-provided value |
-| tst.js:110:18:110:18 | v | tst.js:107:11:107:27 | document.location | tst.js:110:18:110:18 | v | Cross-site scripting vulnerability due to $@. | tst.js:107:11:107:27 | document.location | user-provided value |
-| tst.js:136:18:136:18 | v | tst.js:107:11:107:27 | document.location | tst.js:136:18:136:18 | v | Cross-site scripting vulnerability due to $@. | tst.js:107:11:107:27 | document.location | user-provided value |
-| tst.js:151:49:151:49 | v | tst.js:148:29:148:43 | window.location | tst.js:151:49:151:49 | v | Cross-site scripting vulnerability due to $@. | tst.js:148:29:148:43 | window.location | user-provided value |
-| tst.js:155:29:155:46 | xssSourceService() | tst.js:158:40:158:54 | window.location | tst.js:155:29:155:46 | xssSourceService() | Cross-site scripting vulnerability due to $@. | tst.js:158:40:158:54 | window.location | user-provided value |
-| tst.js:180:28:180:33 | target | tst.js:177:18:177:34 | document.location | tst.js:180:28:180:33 | target | Cross-site scripting vulnerability due to $@. | tst.js:177:18:177:34 | document.location | user-provided value |
-| tst.js:186:31:186:37 | tainted | tst.js:184:19:184:35 | document.location | tst.js:186:31:186:37 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:35 | document.location | user-provided value |
-| tst.js:188:42:188:48 | tainted | tst.js:184:19:184:35 | document.location | tst.js:188:42:188:48 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:35 | document.location | user-provided value |
-| tst.js:189:33:189:39 | tainted | tst.js:184:19:184:35 | document.location | tst.js:189:33:189:39 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:35 | document.location | user-provided value |
-| tst.js:191:54:191:60 | tainted | tst.js:184:19:184:35 | document.location | tst.js:191:54:191:60 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:35 | document.location | user-provided value |
-| tst.js:192:45:192:51 | tainted | tst.js:184:19:184:35 | document.location | tst.js:192:45:192:51 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:35 | document.location | user-provided value |
-| tst.js:193:49:193:55 | tainted | tst.js:184:19:184:35 | document.location | tst.js:193:49:193:55 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:35 | document.location | user-provided value |
-| tst.js:199:67:199:73 | tainted | tst.js:197:19:197:35 | document.location | tst.js:199:67:199:73 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
-| tst.js:200:67:200:73 | tainted | tst.js:197:19:197:35 | document.location | tst.js:200:67:200:73 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
-| tst.js:212:28:212:46 | this.state.tainted1 | tst.js:197:19:197:35 | document.location | tst.js:212:28:212:46 | this.state.tainted1 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
-| tst.js:213:28:213:46 | this.state.tainted2 | tst.js:197:19:197:35 | document.location | tst.js:213:28:213:46 | this.state.tainted2 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
-| tst.js:214:28:214:46 | this.state.tainted3 | tst.js:197:19:197:35 | document.location | tst.js:214:28:214:46 | this.state.tainted3 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
-| tst.js:218:32:218:49 | prevState.tainted4 | tst.js:197:19:197:35 | document.location | tst.js:218:32:218:49 | prevState.tainted4 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
-| tst.js:225:28:225:46 | this.props.tainted1 | tst.js:197:19:197:35 | document.location | tst.js:225:28:225:46 | this.props.tainted1 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
-| tst.js:226:28:226:46 | this.props.tainted2 | tst.js:197:19:197:35 | document.location | tst.js:226:28:226:46 | this.props.tainted2 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
-| tst.js:227:28:227:46 | this.props.tainted3 | tst.js:197:19:197:35 | document.location | tst.js:227:28:227:46 | this.props.tainted3 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
-| tst.js:231:32:231:49 | prevProps.tainted4 | tst.js:197:19:197:35 | document.location | tst.js:231:32:231:49 | prevProps.tainted4 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
-| tst.js:251:60:251:82 | this.st ... Tainted | tst.js:197:19:197:35 | document.location | tst.js:251:60:251:82 | this.st ... Tainted | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:35 | document.location | user-provided value |
+| tst.js:21:18:21:41 | searchP ... 'name') | tst.js:2:16:2:39 | documen ... .search | tst.js:21:18:21:41 | searchP ... 'name') | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:39 | documen ... .search | user-provided value |
+| tst.js:26:18:26:23 | target | tst.js:28:5:28:28 | documen ... .search | tst.js:26:18:26:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:28:5:28:28 | documen ... .search | user-provided value |
+| tst.js:34:16:34:20 | bar() | tst.js:31:10:31:33 | documen ... .search | tst.js:34:16:34:20 | bar() | Cross-site scripting vulnerability due to $@. | tst.js:31:10:31:33 | documen ... .search | user-provided value |
+| tst.js:40:16:40:44 | baz(doc ... search) | tst.js:40:20:40:43 | documen ... .search | tst.js:40:16:40:44 | baz(doc ... search) | Cross-site scripting vulnerability due to $@. | tst.js:40:20:40:43 | documen ... .search | user-provided value |
+| tst.js:46:16:46:45 | wrap(do ... search) | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) | Cross-site scripting vulnerability due to $@. | tst.js:46:21:46:44 | documen ... .search | user-provided value |
+| tst.js:54:16:54:45 | chop(do ... search) | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) | Cross-site scripting vulnerability due to $@. | tst.js:54:21:54:44 | documen ... .search | user-provided value |
+| tst.js:56:16:56:45 | chop(do ... search) | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) | Cross-site scripting vulnerability due to $@. | tst.js:56:21:56:44 | documen ... .search | user-provided value |
+| tst.js:58:16:58:32 | wrap(chop(bar())) | tst.js:31:10:31:33 | documen ... .search | tst.js:58:16:58:32 | wrap(chop(bar())) | Cross-site scripting vulnerability due to $@. | tst.js:31:10:31:33 | documen ... .search | user-provided value |
+| tst.js:62:18:62:18 | s | tst.js:64:25:64:48 | documen ... .search | tst.js:62:18:62:18 | s | Cross-site scripting vulnerability due to $@. | tst.js:64:25:64:48 | documen ... .search | user-provided value |
+| tst.js:62:18:62:18 | s | tst.js:65:25:65:48 | documen ... .search | tst.js:62:18:62:18 | s | Cross-site scripting vulnerability due to $@. | tst.js:65:25:65:48 | documen ... .search | user-provided value |
+| tst.js:68:16:68:20 | bar() | tst.js:31:10:31:33 | documen ... .search | tst.js:68:16:68:20 | bar() | Cross-site scripting vulnerability due to $@. | tst.js:31:10:31:33 | documen ... .search | user-provided value |
+| tst.js:73:20:73:20 | x | tst.js:70:3:70:26 | documen ... .search | tst.js:73:20:73:20 | x | Cross-site scripting vulnerability due to $@. | tst.js:70:3:70:26 | documen ... .search | user-provided value |
+| tst.js:77:49:77:72 | documen ... .search | tst.js:77:49:77:72 | documen ... .search | tst.js:77:49:77:72 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:77:49:77:72 | documen ... .search | user-provided value |
+| tst.js:81:26:81:49 | documen ... .search | tst.js:81:26:81:49 | documen ... .search | tst.js:81:26:81:49 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:81:26:81:49 | documen ... .search | user-provided value |
+| tst.js:82:25:82:48 | documen ... .search | tst.js:82:25:82:48 | documen ... .search | tst.js:82:25:82:48 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:82:25:82:48 | documen ... .search | user-provided value |
+| tst.js:84:33:84:56 | documen ... .search | tst.js:84:33:84:56 | documen ... .search | tst.js:84:33:84:56 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:84:33:84:56 | documen ... .search | user-provided value |
+| tst.js:85:32:85:55 | documen ... .search | tst.js:85:32:85:55 | documen ... .search | tst.js:85:32:85:55 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:85:32:85:55 | documen ... .search | user-provided value |
+| tst.js:90:39:90:62 | documen ... .search | tst.js:90:39:90:62 | documen ... .search | tst.js:90:39:90:62 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:90:39:90:62 | documen ... .search | user-provided value |
+| tst.js:96:30:96:53 | documen ... .search | tst.js:96:30:96:53 | documen ... .search | tst.js:96:30:96:53 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:96:30:96:53 | documen ... .search | user-provided value |
+| tst.js:102:25:102:48 | documen ... .search | tst.js:102:25:102:48 | documen ... .search | tst.js:102:25:102:48 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:102:25:102:48 | documen ... .search | user-provided value |
+| tst.js:110:18:110:18 | v | tst.js:107:11:107:34 | documen ... .search | tst.js:110:18:110:18 | v | Cross-site scripting vulnerability due to $@. | tst.js:107:11:107:34 | documen ... .search | user-provided value |
+| tst.js:136:18:136:18 | v | tst.js:107:11:107:34 | documen ... .search | tst.js:136:18:136:18 | v | Cross-site scripting vulnerability due to $@. | tst.js:107:11:107:34 | documen ... .search | user-provided value |
+| tst.js:151:49:151:49 | v | tst.js:148:29:148:50 | window. ... .search | tst.js:151:49:151:49 | v | Cross-site scripting vulnerability due to $@. | tst.js:148:29:148:50 | window. ... .search | user-provided value |
+| tst.js:155:29:155:46 | xssSourceService() | tst.js:158:40:158:61 | window. ... .search | tst.js:155:29:155:46 | xssSourceService() | Cross-site scripting vulnerability due to $@. | tst.js:158:40:158:61 | window. ... .search | user-provided value |
+| tst.js:180:28:180:33 | target | tst.js:177:18:177:41 | documen ... .search | tst.js:180:28:180:33 | target | Cross-site scripting vulnerability due to $@. | tst.js:177:18:177:41 | documen ... .search | user-provided value |
+| tst.js:186:31:186:37 | tainted | tst.js:184:19:184:42 | documen ... .search | tst.js:186:31:186:37 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:42 | documen ... .search | user-provided value |
+| tst.js:188:42:188:48 | tainted | tst.js:184:19:184:42 | documen ... .search | tst.js:188:42:188:48 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:42 | documen ... .search | user-provided value |
+| tst.js:189:33:189:39 | tainted | tst.js:184:19:184:42 | documen ... .search | tst.js:189:33:189:39 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:42 | documen ... .search | user-provided value |
+| tst.js:191:54:191:60 | tainted | tst.js:184:19:184:42 | documen ... .search | tst.js:191:54:191:60 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:42 | documen ... .search | user-provided value |
+| tst.js:192:45:192:51 | tainted | tst.js:184:19:184:42 | documen ... .search | tst.js:192:45:192:51 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:42 | documen ... .search | user-provided value |
+| tst.js:193:49:193:55 | tainted | tst.js:184:19:184:42 | documen ... .search | tst.js:193:49:193:55 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:184:19:184:42 | documen ... .search | user-provided value |
+| tst.js:199:67:199:73 | tainted | tst.js:197:19:197:42 | documen ... .search | tst.js:199:67:199:73 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
+| tst.js:200:67:200:73 | tainted | tst.js:197:19:197:42 | documen ... .search | tst.js:200:67:200:73 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
+| tst.js:212:28:212:46 | this.state.tainted1 | tst.js:197:19:197:42 | documen ... .search | tst.js:212:28:212:46 | this.state.tainted1 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
+| tst.js:213:28:213:46 | this.state.tainted2 | tst.js:197:19:197:42 | documen ... .search | tst.js:213:28:213:46 | this.state.tainted2 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
+| tst.js:214:28:214:46 | this.state.tainted3 | tst.js:197:19:197:42 | documen ... .search | tst.js:214:28:214:46 | this.state.tainted3 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
+| tst.js:218:32:218:49 | prevState.tainted4 | tst.js:197:19:197:42 | documen ... .search | tst.js:218:32:218:49 | prevState.tainted4 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
+| tst.js:225:28:225:46 | this.props.tainted1 | tst.js:197:19:197:42 | documen ... .search | tst.js:225:28:225:46 | this.props.tainted1 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
+| tst.js:226:28:226:46 | this.props.tainted2 | tst.js:197:19:197:42 | documen ... .search | tst.js:226:28:226:46 | this.props.tainted2 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
+| tst.js:227:28:227:46 | this.props.tainted3 | tst.js:197:19:197:42 | documen ... .search | tst.js:227:28:227:46 | this.props.tainted3 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
+| tst.js:231:32:231:49 | prevProps.tainted4 | tst.js:197:19:197:42 | documen ... .search | tst.js:231:32:231:49 | prevProps.tainted4 | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
+| tst.js:251:60:251:82 | this.st ... Tainted | tst.js:197:19:197:42 | documen ... .search | tst.js:251:60:251:82 | this.st ... Tainted | Cross-site scripting vulnerability due to $@. | tst.js:197:19:197:42 | documen ... .search | user-provided value |
 | tst.js:259:7:259:17 | window.name | tst.js:259:7:259:17 | window.name | tst.js:259:7:259:17 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:259:7:259:17 | window.name | user-provided value |
 | tst.js:260:7:260:10 | name | tst.js:260:7:260:10 | name | tst.js:260:7:260:10 | name | Cross-site scripting vulnerability due to $@. | tst.js:260:7:260:10 | name | user-provided value |
 | tst.js:264:11:264:21 | window.name | tst.js:264:11:264:21 | window.name | tst.js:264:11:264:21 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:264:11:264:21 | window.name | user-provided value |
@@ -1490,22 +1383,22 @@ edges
 | tst.js:316:35:316:42 | location | tst.js:316:35:316:42 | location | tst.js:316:35:316:42 | location | Cross-site scripting vulnerability due to $@. | tst.js:316:35:316:42 | location | user-provided value |
 | tst.js:332:18:332:35 | params.get('name') | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') | Cross-site scripting vulnerability due to $@. | tst.js:327:18:327:34 | document.location | user-provided value |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) | tst.js:341:20:341:36 | document.location | tst.js:343:5:343:30 | getUrl( ... ring(1) | Cross-site scripting vulnerability due to $@. | tst.js:341:20:341:36 | document.location | user-provided value |
-| tst.js:349:12:349:17 | target | tst.js:348:16:348:32 | document.location | tst.js:349:12:349:17 | target | Cross-site scripting vulnerability due to $@. | tst.js:348:16:348:32 | document.location | user-provided value |
-| tst.js:356:16:356:21 | target | tst.js:355:19:355:35 | document.location | tst.js:356:16:356:21 | target | Cross-site scripting vulnerability due to $@. | tst.js:355:19:355:35 | document.location | user-provided value |
-| tst.js:360:21:360:26 | target | tst.js:355:19:355:35 | document.location | tst.js:360:21:360:26 | target | Cross-site scripting vulnerability due to $@. | tst.js:355:19:355:35 | document.location | user-provided value |
-| tst.js:363:18:363:23 | target | tst.js:355:19:355:35 | document.location | tst.js:363:18:363:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:355:19:355:35 | document.location | user-provided value |
-| tst.js:374:18:374:23 | target | tst.js:371:16:371:32 | document.location | tst.js:374:18:374:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:371:16:371:32 | document.location | user-provided value |
-| tst.js:384:18:384:23 | target | tst.js:381:16:381:32 | document.location | tst.js:384:18:384:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:381:16:381:32 | document.location | user-provided value |
-| tst.js:386:18:386:29 | target.taint | tst.js:381:16:381:32 | document.location | tst.js:386:18:386:29 | target.taint | Cross-site scripting vulnerability due to $@. | tst.js:381:16:381:32 | document.location | user-provided value |
-| tst.js:392:18:392:30 | target.taint3 | tst.js:391:19:391:35 | document.location | tst.js:392:18:392:30 | target.taint3 | Cross-site scripting vulnerability due to $@. | tst.js:391:19:391:35 | document.location | user-provided value |
-| tst.js:397:18:397:30 | target.taint5 | tst.js:381:16:381:32 | document.location | tst.js:397:18:397:30 | target.taint5 | Cross-site scripting vulnerability due to $@. | tst.js:381:16:381:32 | document.location | user-provided value |
-| tst.js:406:18:406:30 | target.taint7 | tst.js:381:16:381:32 | document.location | tst.js:406:18:406:30 | target.taint7 | Cross-site scripting vulnerability due to $@. | tst.js:381:16:381:32 | document.location | user-provided value |
-| tst.js:409:18:409:30 | target.taint8 | tst.js:381:16:381:32 | document.location | tst.js:409:18:409:30 | target.taint8 | Cross-site scripting vulnerability due to $@. | tst.js:381:16:381:32 | document.location | user-provided value |
-| tst.js:417:18:417:24 | payload | tst.js:416:17:416:31 | window.location | tst.js:417:18:417:24 | payload | Cross-site scripting vulnerability due to $@. | tst.js:416:17:416:31 | window.location | user-provided value |
-| tst.js:421:20:421:27 | match[1] | tst.js:419:15:419:29 | window.location | tst.js:421:20:421:27 | match[1] | Cross-site scripting vulnerability due to $@. | tst.js:419:15:419:29 | window.location | user-provided value |
-| tst.js:424:18:424:51 | window. ... '#')[1] | tst.js:424:18:424:32 | window.location | tst.js:424:18:424:51 | window. ... '#')[1] | Cross-site scripting vulnerability due to $@. | tst.js:424:18:424:32 | window.location | user-provided value |
-| tst.js:430:18:430:89 | target. ... data>') | tst.js:428:16:428:32 | document.location | tst.js:430:18:430:89 | target. ... data>') | Cross-site scripting vulnerability due to $@. | tst.js:428:16:428:32 | document.location | user-provided value |
-| typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:38 | document.location | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:38 | document.location | user-provided value |
+| tst.js:349:12:349:17 | target | tst.js:348:16:348:39 | documen ... .search | tst.js:349:12:349:17 | target | Cross-site scripting vulnerability due to $@. | tst.js:348:16:348:39 | documen ... .search | user-provided value |
+| tst.js:356:16:356:21 | target | tst.js:355:19:355:42 | documen ... .search | tst.js:356:16:356:21 | target | Cross-site scripting vulnerability due to $@. | tst.js:355:19:355:42 | documen ... .search | user-provided value |
+| tst.js:360:21:360:26 | target | tst.js:355:19:355:42 | documen ... .search | tst.js:360:21:360:26 | target | Cross-site scripting vulnerability due to $@. | tst.js:355:19:355:42 | documen ... .search | user-provided value |
+| tst.js:363:18:363:23 | target | tst.js:355:19:355:42 | documen ... .search | tst.js:363:18:363:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:355:19:355:42 | documen ... .search | user-provided value |
+| tst.js:374:18:374:23 | target | tst.js:371:16:371:39 | documen ... .search | tst.js:374:18:374:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:371:16:371:39 | documen ... .search | user-provided value |
+| tst.js:384:18:384:23 | target | tst.js:381:16:381:39 | documen ... .search | tst.js:384:18:384:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:381:16:381:39 | documen ... .search | user-provided value |
+| tst.js:386:18:386:29 | target.taint | tst.js:381:16:381:39 | documen ... .search | tst.js:386:18:386:29 | target.taint | Cross-site scripting vulnerability due to $@. | tst.js:381:16:381:39 | documen ... .search | user-provided value |
+| tst.js:392:18:392:30 | target.taint3 | tst.js:391:19:391:42 | documen ... .search | tst.js:392:18:392:30 | target.taint3 | Cross-site scripting vulnerability due to $@. | tst.js:391:19:391:42 | documen ... .search | user-provided value |
+| tst.js:397:18:397:30 | target.taint5 | tst.js:381:16:381:39 | documen ... .search | tst.js:397:18:397:30 | target.taint5 | Cross-site scripting vulnerability due to $@. | tst.js:381:16:381:39 | documen ... .search | user-provided value |
+| tst.js:406:18:406:30 | target.taint7 | tst.js:381:16:381:39 | documen ... .search | tst.js:406:18:406:30 | target.taint7 | Cross-site scripting vulnerability due to $@. | tst.js:381:16:381:39 | documen ... .search | user-provided value |
+| tst.js:409:18:409:30 | target.taint8 | tst.js:381:16:381:39 | documen ... .search | tst.js:409:18:409:30 | target.taint8 | Cross-site scripting vulnerability due to $@. | tst.js:381:16:381:39 | documen ... .search | user-provided value |
+| tst.js:417:18:417:24 | payload | tst.js:416:17:416:36 | window.location.hash | tst.js:417:18:417:24 | payload | Cross-site scripting vulnerability due to $@. | tst.js:416:17:416:36 | window.location.hash | user-provided value |
+| tst.js:421:20:421:27 | match[1] | tst.js:419:15:419:34 | window.location.hash | tst.js:421:20:421:27 | match[1] | Cross-site scripting vulnerability due to $@. | tst.js:419:15:419:34 | window.location.hash | user-provided value |
+| tst.js:424:18:424:51 | window. ... '#')[1] | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:51 | window. ... '#')[1] | Cross-site scripting vulnerability due to $@. | tst.js:424:18:424:37 | window.location.hash | user-provided value |
+| tst.js:430:18:430:89 | target. ... data>') | tst.js:428:16:428:39 | documen ... .search | tst.js:430:18:430:89 | target. ... data>') | Cross-site scripting vulnerability due to $@. | tst.js:428:16:428:39 | documen ... .search | user-provided value |
+| typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:45 | documen ... .search | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
 | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
 | various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
@@ -1517,5 +1410,5 @@ edges
 | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
 | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) | various-concat-obfuscations.js:20:17:20:40 | documen ... .search | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:20:17:20:40 | documen ... .search | user-provided value |
 | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) | various-concat-obfuscations.js:21:17:21:40 | documen ... .search | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:21:17:21:40 | documen ... .search | user-provided value |
-| winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |
-| winjs.js:4:43:4:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:4:43:4:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |
+| winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:40 | documen ... .search | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:40 | documen ... .search | user-provided value |
+| winjs.js:4:43:4:49 | tainted | winjs.js:2:17:2:40 | documen ... .search | winjs.js:4:43:4:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:40 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -128,8 +128,7 @@ nodes
 | dates.js:18:59:18:63 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
-| event-handler-receiver.js:2:49:2:56 | location |
-| event-handler-receiver.js:2:49:2:56 | location |
+| event-handler-receiver.js:2:49:2:61 | location.href |
 | event-handler-receiver.js:2:49:2:61 | location.href |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
@@ -791,8 +790,8 @@ edges
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
-| event-handler-receiver.js:2:49:2:56 | location | event-handler-receiver.js:2:49:2:61 | location.href |
-| event-handler-receiver.js:2:49:2:56 | location | event-handler-receiver.js:2:49:2:61 | location.href |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -15,8 +15,7 @@ nodes
 | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
@@ -104,8 +103,7 @@ nodes
 | d3.js:21:15:21:24 | getTaint() |
 | dates.js:9:9:9:69 | taint |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) |
-| dates.js:9:36:9:50 | window.location |
-| dates.js:9:36:9:50 | window.location |
+| dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:11:31:11:70 | `Time i ... aint)}` |
@@ -138,8 +136,7 @@ nodes
 | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:17:2:33 | document.location |
-| jquery.js:2:17:2:33 | document.location |
+| jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
@@ -156,13 +153,11 @@ nodes
 | jquery.js:10:13:10:31 | location.toString() |
 | jquery.js:14:19:14:58 | decodeU ... n.hash) |
 | jquery.js:14:19:14:58 | decodeU ... n.hash) |
-| jquery.js:14:38:14:52 | window.location |
-| jquery.js:14:38:14:52 | window.location |
+| jquery.js:14:38:14:57 | window.location.hash |
 | jquery.js:14:38:14:57 | window.location.hash |
 | jquery.js:15:19:15:60 | decodeU ... search) |
 | jquery.js:15:19:15:60 | decodeU ... search) |
-| jquery.js:15:38:15:52 | window.location |
-| jquery.js:15:38:15:52 | window.location |
+| jquery.js:15:38:15:59 | window. ... .search |
 | jquery.js:15:38:15:59 | window. ... .search |
 | jquery.js:16:19:16:64 | decodeU ... ring()) |
 | jquery.js:16:19:16:64 | decodeU ... ring()) |
@@ -189,8 +184,7 @@ nodes
 | nodemailer.js:13:50:13:66 | req.query.message |
 | nodemailer.js:13:50:13:66 | req.query.message |
 | optionalSanitizer.js:2:7:2:39 | target |
-| optionalSanitizer.js:2:16:2:32 | document.location |
-| optionalSanitizer.js:2:16:2:32 | document.location |
+| optionalSanitizer.js:2:16:2:39 | documen ... .search |
 | optionalSanitizer.js:2:16:2:39 | documen ... .search |
 | optionalSanitizer.js:6:18:6:23 | target |
 | optionalSanitizer.js:6:18:6:23 | target |
@@ -203,8 +197,7 @@ nodes
 | optionalSanitizer.js:17:20:17:20 | x |
 | optionalSanitizer.js:17:20:17:20 | x |
 | optionalSanitizer.js:26:7:26:39 | target |
-| optionalSanitizer.js:26:16:26:32 | document.location |
-| optionalSanitizer.js:26:16:26:32 | document.location |
+| optionalSanitizer.js:26:16:26:39 | documen ... .search |
 | optionalSanitizer.js:26:16:26:39 | documen ... .search |
 | optionalSanitizer.js:31:7:31:23 | tainted2 |
 | optionalSanitizer.js:31:18:31:23 | target |
@@ -284,11 +277,9 @@ nodes
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted |
-| stored-xss.js:2:39:2:55 | document.location |
-| stored-xss.js:2:39:2:55 | document.location |
 | stored-xss.js:2:39:2:62 | documen ... .search |
-| stored-xss.js:3:35:3:51 | document.location |
-| stored-xss.js:3:35:3:51 | document.location |
+| stored-xss.js:2:39:2:62 | documen ... .search |
+| stored-xss.js:3:35:3:58 | documen ... .search |
 | stored-xss.js:3:35:3:58 | documen ... .search |
 | stored-xss.js:5:20:5:52 | session ... ssion') |
 | stored-xss.js:5:20:5:52 | session ... ssion') |
@@ -302,43 +293,35 @@ nodes
 | string-manipulations.js:3:16:3:32 | document.location |
 | string-manipulations.js:3:16:3:32 | document.location |
 | string-manipulations.js:3:16:3:32 | document.location |
-| string-manipulations.js:4:16:4:32 | document.location |
-| string-manipulations.js:4:16:4:32 | document.location |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:5:16:5:32 | document.location |
-| string-manipulations.js:5:16:5:32 | document.location |
+| string-manipulations.js:4:16:4:37 | documen ... on.href |
+| string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:6:16:6:32 | document.location |
-| string-manipulations.js:6:16:6:32 | document.location |
+| string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:7:16:7:32 | document.location |
-| string-manipulations.js:7:16:7:32 | document.location |
+| string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:8:16:8:32 | document.location |
-| string-manipulations.js:8:16:8:32 | document.location |
+| string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:9:36:9:52 | document.location |
-| string-manipulations.js:9:36:9:52 | document.location |
+| string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
-| string-manipulations.js:10:23:10:39 | document.location |
-| string-manipulations.js:10:23:10:39 | document.location |
+| string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | translate.js:6:7:6:39 | target |
-| translate.js:6:16:6:32 | document.location |
-| translate.js:6:16:6:32 | document.location |
+| translate.js:6:16:6:39 | documen ... .search |
 | translate.js:6:16:6:39 | documen ... .search |
 | translate.js:7:42:7:47 | target |
 | translate.js:7:42:7:60 | target.substring(1) |
@@ -346,8 +329,7 @@ nodes
 | translate.js:9:27:9:50 | searchP ... 'term') |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
 | tst3.js:2:23:2:74 | decodeU ... str(1)) |
-| tst3.js:2:42:2:56 | window.location |
-| tst3.js:2:42:2:56 | window.location |
+| tst3.js:2:42:2:63 | window. ... .search |
 | tst3.js:2:42:2:63 | window. ... .search |
 | tst3.js:2:42:2:73 | window. ... bstr(1) |
 | tst3.js:4:25:4:28 | data |
@@ -367,8 +349,7 @@ nodes
 | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:32 | document.location |
-| tst.js:2:16:2:32 | document.location |
+| tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
@@ -376,8 +357,7 @@ nodes
 | tst.js:5:18:5:23 | target |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
-| tst.js:8:37:8:53 | document.location |
-| tst.js:8:37:8:53 | document.location |
+| tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
@@ -394,33 +374,27 @@ nodes
 | tst.js:24:14:24:19 | target |
 | tst.js:26:18:26:23 | target |
 | tst.js:26:18:26:23 | target |
-| tst.js:28:5:28:21 | document.location |
-| tst.js:28:5:28:21 | document.location |
 | tst.js:28:5:28:28 | documen ... .search |
-| tst.js:31:10:31:26 | document.location |
-| tst.js:31:10:31:26 | document.location |
+| tst.js:28:5:28:28 | documen ... .search |
+| tst.js:31:10:31:33 | documen ... .search |
 | tst.js:31:10:31:33 | documen ... .search |
 | tst.js:34:16:34:20 | bar() |
 | tst.js:34:16:34:20 | bar() |
 | tst.js:40:16:40:44 | baz(doc ... search) |
 | tst.js:40:16:40:44 | baz(doc ... search) |
-| tst.js:40:20:40:36 | document.location |
-| tst.js:40:20:40:36 | document.location |
+| tst.js:40:20:40:43 | documen ... .search |
 | tst.js:40:20:40:43 | documen ... .search |
 | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:16:46:45 | wrap(do ... search) |
-| tst.js:46:21:46:37 | document.location |
-| tst.js:46:21:46:37 | document.location |
+| tst.js:46:21:46:44 | documen ... .search |
 | tst.js:46:21:46:44 | documen ... .search |
 | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:16:54:45 | chop(do ... search) |
-| tst.js:54:21:54:37 | document.location |
-| tst.js:54:21:54:37 | document.location |
+| tst.js:54:21:54:44 | documen ... .search |
 | tst.js:54:21:54:44 | documen ... .search |
 | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:16:56:45 | chop(do ... search) |
-| tst.js:56:21:56:37 | document.location |
-| tst.js:56:21:56:37 | document.location |
+| tst.js:56:21:56:44 | documen ... .search |
 | tst.js:56:21:56:44 | documen ... .search |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
@@ -429,82 +403,66 @@ nodes
 | tst.js:60:34:60:34 | s |
 | tst.js:62:18:62:18 | s |
 | tst.js:62:18:62:18 | s |
-| tst.js:64:25:64:41 | document.location |
-| tst.js:64:25:64:41 | document.location |
 | tst.js:64:25:64:48 | documen ... .search |
-| tst.js:65:25:65:41 | document.location |
-| tst.js:65:25:65:41 | document.location |
+| tst.js:64:25:64:48 | documen ... .search |
+| tst.js:65:25:65:48 | documen ... .search |
 | tst.js:65:25:65:48 | documen ... .search |
 | tst.js:68:16:68:20 | bar() |
 | tst.js:68:16:68:20 | bar() |
 | tst.js:70:1:70:27 | [,docum ... search] |
-| tst.js:70:3:70:19 | document.location |
-| tst.js:70:3:70:19 | document.location |
+| tst.js:70:3:70:26 | documen ... .search |
 | tst.js:70:3:70:26 | documen ... .search |
 | tst.js:70:46:70:46 | x |
 | tst.js:73:20:73:20 | x |
 | tst.js:73:20:73:20 | x |
-| tst.js:77:49:77:65 | document.location |
-| tst.js:77:49:77:65 | document.location |
 | tst.js:77:49:77:72 | documen ... .search |
 | tst.js:77:49:77:72 | documen ... .search |
-| tst.js:81:26:81:42 | document.location |
-| tst.js:81:26:81:42 | document.location |
+| tst.js:77:49:77:72 | documen ... .search |
 | tst.js:81:26:81:49 | documen ... .search |
 | tst.js:81:26:81:49 | documen ... .search |
-| tst.js:82:25:82:41 | document.location |
-| tst.js:82:25:82:41 | document.location |
+| tst.js:81:26:81:49 | documen ... .search |
 | tst.js:82:25:82:48 | documen ... .search |
 | tst.js:82:25:82:48 | documen ... .search |
-| tst.js:84:33:84:49 | document.location |
-| tst.js:84:33:84:49 | document.location |
+| tst.js:82:25:82:48 | documen ... .search |
 | tst.js:84:33:84:56 | documen ... .search |
 | tst.js:84:33:84:56 | documen ... .search |
-| tst.js:85:32:85:48 | document.location |
-| tst.js:85:32:85:48 | document.location |
+| tst.js:84:33:84:56 | documen ... .search |
 | tst.js:85:32:85:55 | documen ... .search |
 | tst.js:85:32:85:55 | documen ... .search |
-| tst.js:90:39:90:55 | document.location |
-| tst.js:90:39:90:55 | document.location |
+| tst.js:85:32:85:55 | documen ... .search |
 | tst.js:90:39:90:62 | documen ... .search |
 | tst.js:90:39:90:62 | documen ... .search |
-| tst.js:96:30:96:46 | document.location |
-| tst.js:96:30:96:46 | document.location |
+| tst.js:90:39:90:62 | documen ... .search |
 | tst.js:96:30:96:53 | documen ... .search |
 | tst.js:96:30:96:53 | documen ... .search |
-| tst.js:102:25:102:41 | document.location |
-| tst.js:102:25:102:41 | document.location |
+| tst.js:96:30:96:53 | documen ... .search |
+| tst.js:102:25:102:48 | documen ... .search |
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v |
-| tst.js:107:11:107:27 | document.location |
-| tst.js:107:11:107:27 | document.location |
+| tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:110:18:110:18 | v |
 | tst.js:110:18:110:18 | v |
 | tst.js:136:18:136:18 | v |
 | tst.js:136:18:136:18 | v |
-| tst.js:148:29:148:43 | window.location |
-| tst.js:148:29:148:43 | window.location |
+| tst.js:148:29:148:50 | window. ... .search |
 | tst.js:148:29:148:50 | window. ... .search |
 | tst.js:151:29:151:29 | v |
 | tst.js:151:49:151:49 | v |
 | tst.js:151:49:151:49 | v |
 | tst.js:155:29:155:46 | xssSourceService() |
 | tst.js:155:29:155:46 | xssSourceService() |
-| tst.js:158:40:158:54 | window.location |
-| tst.js:158:40:158:54 | window.location |
+| tst.js:158:40:158:61 | window. ... .search |
 | tst.js:158:40:158:61 | window. ... .search |
 | tst.js:177:9:177:41 | target |
-| tst.js:177:18:177:34 | document.location |
-| tst.js:177:18:177:34 | document.location |
+| tst.js:177:18:177:41 | documen ... .search |
 | tst.js:177:18:177:41 | documen ... .search |
 | tst.js:180:28:180:33 | target |
 | tst.js:180:28:180:33 | target |
 | tst.js:184:9:184:42 | tainted |
-| tst.js:184:19:184:35 | document.location |
-| tst.js:184:19:184:35 | document.location |
+| tst.js:184:19:184:42 | documen ... .search |
 | tst.js:184:19:184:42 | documen ... .search |
 | tst.js:186:31:186:37 | tainted |
 | tst.js:186:31:186:37 | tainted |
@@ -519,8 +477,7 @@ nodes
 | tst.js:193:49:193:55 | tainted |
 | tst.js:193:49:193:55 | tainted |
 | tst.js:197:9:197:42 | tainted |
-| tst.js:197:19:197:35 | document.location |
-| tst.js:197:19:197:35 | document.location |
+| tst.js:197:19:197:42 | documen ... .search |
 | tst.js:197:19:197:42 | documen ... .search |
 | tst.js:199:67:199:73 | tainted |
 | tst.js:199:67:199:73 | tainted |
@@ -594,14 +551,12 @@ nodes
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target |
-| tst.js:348:16:348:32 | document.location |
-| tst.js:348:16:348:32 | document.location |
+| tst.js:348:16:348:39 | documen ... .search |
 | tst.js:348:16:348:39 | documen ... .search |
 | tst.js:349:12:349:17 | target |
 | tst.js:349:12:349:17 | target |
 | tst.js:355:10:355:42 | target |
-| tst.js:355:19:355:35 | document.location |
-| tst.js:355:19:355:35 | document.location |
+| tst.js:355:19:355:42 | documen ... .search |
 | tst.js:355:19:355:42 | documen ... .search |
 | tst.js:356:16:356:21 | target |
 | tst.js:356:16:356:21 | target |
@@ -610,22 +565,19 @@ nodes
 | tst.js:363:18:363:23 | target |
 | tst.js:363:18:363:23 | target |
 | tst.js:371:7:371:39 | target |
-| tst.js:371:16:371:32 | document.location |
-| tst.js:371:16:371:32 | document.location |
+| tst.js:371:16:371:39 | documen ... .search |
 | tst.js:371:16:371:39 | documen ... .search |
 | tst.js:374:18:374:23 | target |
 | tst.js:374:18:374:23 | target |
 | tst.js:381:7:381:39 | target |
-| tst.js:381:16:381:32 | document.location |
-| tst.js:381:16:381:32 | document.location |
+| tst.js:381:16:381:39 | documen ... .search |
 | tst.js:381:16:381:39 | documen ... .search |
 | tst.js:384:18:384:23 | target |
 | tst.js:384:18:384:23 | target |
 | tst.js:386:18:386:23 | target |
 | tst.js:386:18:386:29 | target.taint |
 | tst.js:386:18:386:29 | target.taint |
-| tst.js:391:19:391:35 | document.location |
-| tst.js:391:19:391:35 | document.location |
+| tst.js:391:19:391:42 | documen ... .search |
 | tst.js:391:19:391:42 | documen ... .search |
 | tst.js:392:18:392:30 | target.taint3 |
 | tst.js:392:18:392:30 | target.taint3 |
@@ -640,22 +592,19 @@ nodes
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload |
-| tst.js:416:17:416:31 | window.location |
-| tst.js:416:17:416:31 | window.location |
+| tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:46 | window. ... bstr(1) |
 | tst.js:417:18:417:24 | payload |
 | tst.js:417:18:417:24 | payload |
 | tst.js:419:7:419:55 | match |
-| tst.js:419:15:419:29 | window.location |
-| tst.js:419:15:419:29 | window.location |
+| tst.js:419:15:419:34 | window.location.hash |
 | tst.js:419:15:419:34 | window.location.hash |
 | tst.js:419:15:419:55 | window. ... (\\w+)/) |
 | tst.js:421:20:421:24 | match |
 | tst.js:421:20:421:27 | match[1] |
 | tst.js:421:20:421:27 | match[1] |
-| tst.js:424:18:424:32 | window.location |
-| tst.js:424:18:424:32 | window.location |
+| tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
@@ -672,8 +621,7 @@ nodes
 | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:20:13:20:45 | target |
-| typeahead.js:20:22:20:38 | document.location |
-| typeahead.js:20:22:20:38 | document.location |
+| typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:21:12:21:17 | target |
 | typeahead.js:24:30:24:32 | val |
@@ -725,8 +673,7 @@ nodes
 | various-concat-obfuscations.js:21:17:21:40 | documen ... .search |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
 | winjs.js:2:7:2:53 | tainted |
-| winjs.js:2:17:2:33 | document.location |
-| winjs.js:2:17:2:33 | document.location |
+| winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:3:43:3:49 | tainted |
@@ -754,10 +701,7 @@ edges
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:22:44:22:66 | \\u0275getDOM ... ation() | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
@@ -829,8 +773,7 @@ edges
 | dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
-| dates.js:9:36:9:50 | window.location | dates.js:9:36:9:55 | window.location.hash |
-| dates.js:9:36:9:50 | window.location | dates.js:9:36:9:55 | window.location.hash |
+| dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:9:36:9:68 | window. ... ring(1) | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
@@ -855,8 +798,7 @@ edges
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
-| jquery.js:2:17:2:33 | document.location | jquery.js:2:17:2:40 | documen ... .search |
-| jquery.js:2:17:2:33 | document.location | jquery.js:2:17:2:40 | documen ... .search |
+| jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
@@ -868,12 +810,12 @@ edges
 | jquery.js:10:13:10:20 | location | jquery.js:10:13:10:31 | location.toString() |
 | jquery.js:10:13:10:31 | location.toString() | jquery.js:10:5:10:40 | "<b>" + ...  "</b>" |
 | jquery.js:10:13:10:31 | location.toString() | jquery.js:10:5:10:40 | "<b>" + ...  "</b>" |
-| jquery.js:14:38:14:52 | window.location | jquery.js:14:38:14:57 | window.location.hash |
-| jquery.js:14:38:14:52 | window.location | jquery.js:14:38:14:57 | window.location.hash |
 | jquery.js:14:38:14:57 | window.location.hash | jquery.js:14:19:14:58 | decodeU ... n.hash) |
 | jquery.js:14:38:14:57 | window.location.hash | jquery.js:14:19:14:58 | decodeU ... n.hash) |
-| jquery.js:15:38:15:52 | window.location | jquery.js:15:38:15:59 | window. ... .search |
-| jquery.js:15:38:15:52 | window.location | jquery.js:15:38:15:59 | window. ... .search |
+| jquery.js:14:38:14:57 | window.location.hash | jquery.js:14:19:14:58 | decodeU ... n.hash) |
+| jquery.js:14:38:14:57 | window.location.hash | jquery.js:14:19:14:58 | decodeU ... n.hash) |
+| jquery.js:15:38:15:59 | window. ... .search | jquery.js:15:19:15:60 | decodeU ... search) |
+| jquery.js:15:38:15:59 | window. ... .search | jquery.js:15:19:15:60 | decodeU ... search) |
 | jquery.js:15:38:15:59 | window. ... .search | jquery.js:15:19:15:60 | decodeU ... search) |
 | jquery.js:15:38:15:59 | window. ... .search | jquery.js:15:19:15:60 | decodeU ... search) |
 | jquery.js:16:38:16:52 | window.location | jquery.js:16:38:16:63 | window. ... tring() |
@@ -901,8 +843,7 @@ edges
 | optionalSanitizer.js:2:7:2:39 | target | optionalSanitizer.js:6:18:6:23 | target |
 | optionalSanitizer.js:2:7:2:39 | target | optionalSanitizer.js:8:17:8:22 | target |
 | optionalSanitizer.js:2:7:2:39 | target | optionalSanitizer.js:15:9:15:14 | target |
-| optionalSanitizer.js:2:16:2:32 | document.location | optionalSanitizer.js:2:16:2:39 | documen ... .search |
-| optionalSanitizer.js:2:16:2:32 | document.location | optionalSanitizer.js:2:16:2:39 | documen ... .search |
+| optionalSanitizer.js:2:16:2:39 | documen ... .search | optionalSanitizer.js:2:7:2:39 | target |
 | optionalSanitizer.js:2:16:2:39 | documen ... .search | optionalSanitizer.js:2:7:2:39 | target |
 | optionalSanitizer.js:8:7:8:22 | tainted | optionalSanitizer.js:9:18:9:24 | tainted |
 | optionalSanitizer.js:8:7:8:22 | tainted | optionalSanitizer.js:9:18:9:24 | tainted |
@@ -914,8 +855,7 @@ edges
 | optionalSanitizer.js:26:7:26:39 | target | optionalSanitizer.js:38:18:38:23 | target |
 | optionalSanitizer.js:26:7:26:39 | target | optionalSanitizer.js:45:41:45:46 | target |
 | optionalSanitizer.js:26:7:26:39 | target | optionalSanitizer.js:45:51:45:56 | target |
-| optionalSanitizer.js:26:16:26:32 | document.location | optionalSanitizer.js:26:16:26:39 | documen ... .search |
-| optionalSanitizer.js:26:16:26:32 | document.location | optionalSanitizer.js:26:16:26:39 | documen ... .search |
+| optionalSanitizer.js:26:16:26:39 | documen ... .search | optionalSanitizer.js:26:7:26:39 | target |
 | optionalSanitizer.js:26:16:26:39 | documen ... .search | optionalSanitizer.js:26:7:26:39 | target |
 | optionalSanitizer.js:31:7:31:23 | tainted2 | optionalSanitizer.js:32:18:32:25 | tainted2 |
 | optionalSanitizer.js:31:7:31:23 | tainted2 | optionalSanitizer.js:32:18:32:25 | tainted2 |
@@ -987,51 +927,48 @@ edges
 | sanitiser.js:38:29:38:35 | tainted | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
-| stored-xss.js:2:39:2:55 | document.location | stored-xss.js:2:39:2:62 | documen ... .search |
-| stored-xss.js:2:39:2:55 | document.location | stored-xss.js:2:39:2:62 | documen ... .search |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
-| stored-xss.js:3:35:3:51 | document.location | stored-xss.js:3:35:3:58 | documen ... .search |
-| stored-xss.js:3:35:3:51 | document.location | stored-xss.js:3:35:3:58 | documen ... .search |
+| stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
+| stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
 | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:8:20:8:48 | localSt ... local') |
 | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:8:20:8:48 | localSt ... local') |
+| stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:8:20:8:48 | localSt ... local') |
+| stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:8:20:8:48 | localSt ... local') |
+| stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:10:16:10:44 | localSt ... local') |
 | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:10:16:10:44 | localSt ... local') |
 | stored-xss.js:10:9:10:44 | href | stored-xss.js:12:35:12:38 | href |
 | stored-xss.js:10:16:10:44 | localSt ... local') | stored-xss.js:10:9:10:44 | href |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | string-manipulations.js:3:16:3:32 | document.location | string-manipulations.js:3:16:3:32 | document.location |
-| string-manipulations.js:4:16:4:32 | document.location | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:4:16:4:32 | document.location | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:4:16:4:32 | document.location | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:4:16:4:32 | document.location | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:5:16:5:32 | document.location | string-manipulations.js:5:16:5:37 | documen ... on.href |
-| string-manipulations.js:5:16:5:32 | document.location | string-manipulations.js:5:16:5:37 | documen ... on.href |
+| string-manipulations.js:4:16:4:37 | documen ... on.href | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:6:16:6:32 | document.location | string-manipulations.js:6:16:6:37 | documen ... on.href |
-| string-manipulations.js:6:16:6:32 | document.location | string-manipulations.js:6:16:6:37 | documen ... on.href |
+| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:7:16:7:32 | document.location | string-manipulations.js:7:16:7:37 | documen ... on.href |
-| string-manipulations.js:7:16:7:32 | document.location | string-manipulations.js:7:16:7:37 | documen ... on.href |
+| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
+| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:8:16:8:32 | document.location | string-manipulations.js:8:16:8:37 | documen ... on.href |
-| string-manipulations.js:8:16:8:32 | document.location | string-manipulations.js:8:16:8:37 | documen ... on.href |
+| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
-| string-manipulations.js:9:36:9:52 | document.location | string-manipulations.js:9:36:9:57 | documen ... on.href |
-| string-manipulations.js:9:36:9:52 | document.location | string-manipulations.js:9:36:9:57 | documen ... on.href |
+| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
+| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:10:23:10:39 | document.location | string-manipulations.js:10:23:10:44 | documen ... on.href |
-| string-manipulations.js:10:23:10:39 | document.location | string-manipulations.js:10:23:10:44 | documen ... on.href |
+| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | translate.js:6:7:6:39 | target | translate.js:7:42:7:47 | target |
-| translate.js:6:16:6:32 | document.location | translate.js:6:16:6:39 | documen ... .search |
-| translate.js:6:16:6:32 | document.location | translate.js:6:16:6:39 | documen ... .search |
+| translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
 | translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
@@ -1042,8 +979,7 @@ edges
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:9:37:9:40 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:10:38:10:41 | data |
 | tst3.js:2:23:2:74 | decodeU ... str(1)) | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
-| tst3.js:2:42:2:56 | window.location | tst3.js:2:42:2:63 | window. ... .search |
-| tst3.js:2:42:2:56 | window.location | tst3.js:2:42:2:63 | window. ... .search |
+| tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
 | tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
 | tst3.js:2:42:2:73 | window. ... bstr(1) | tst3.js:2:23:2:74 | decodeU ... str(1)) |
 | tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
@@ -1060,13 +996,11 @@ edges
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:12:28:12:33 | target |
 | tst.js:2:7:2:39 | target | tst.js:20:42:20:47 | target |
-| tst.js:2:16:2:32 | document.location | tst.js:2:16:2:39 | documen ... .search |
-| tst.js:2:16:2:32 | document.location | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
-| tst.js:8:37:8:53 | document.location | tst.js:8:37:8:58 | documen ... on.href |
-| tst.js:8:37:8:53 | document.location | tst.js:8:37:8:58 | documen ... on.href |
+| tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
@@ -1081,30 +1015,32 @@ edges
 | tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
-| tst.js:28:5:28:21 | document.location | tst.js:28:5:28:28 | documen ... .search |
-| tst.js:28:5:28:21 | document.location | tst.js:28:5:28:28 | documen ... .search |
 | tst.js:28:5:28:28 | documen ... .search | tst.js:24:14:24:19 | target |
-| tst.js:31:10:31:26 | document.location | tst.js:31:10:31:33 | documen ... .search |
-| tst.js:31:10:31:26 | document.location | tst.js:31:10:31:33 | documen ... .search |
+| tst.js:28:5:28:28 | documen ... .search | tst.js:24:14:24:19 | target |
+| tst.js:31:10:31:33 | documen ... .search | tst.js:34:16:34:20 | bar() |
+| tst.js:31:10:31:33 | documen ... .search | tst.js:34:16:34:20 | bar() |
 | tst.js:31:10:31:33 | documen ... .search | tst.js:34:16:34:20 | bar() |
 | tst.js:31:10:31:33 | documen ... .search | tst.js:34:16:34:20 | bar() |
 | tst.js:31:10:31:33 | documen ... .search | tst.js:58:26:58:30 | bar() |
+| tst.js:31:10:31:33 | documen ... .search | tst.js:58:26:58:30 | bar() |
 | tst.js:31:10:31:33 | documen ... .search | tst.js:68:16:68:20 | bar() |
 | tst.js:31:10:31:33 | documen ... .search | tst.js:68:16:68:20 | bar() |
-| tst.js:40:20:40:36 | document.location | tst.js:40:20:40:43 | documen ... .search |
-| tst.js:40:20:40:36 | document.location | tst.js:40:20:40:43 | documen ... .search |
+| tst.js:31:10:31:33 | documen ... .search | tst.js:68:16:68:20 | bar() |
+| tst.js:31:10:31:33 | documen ... .search | tst.js:68:16:68:20 | bar() |
 | tst.js:40:20:40:43 | documen ... .search | tst.js:40:16:40:44 | baz(doc ... search) |
 | tst.js:40:20:40:43 | documen ... .search | tst.js:40:16:40:44 | baz(doc ... search) |
-| tst.js:46:21:46:37 | document.location | tst.js:46:21:46:44 | documen ... .search |
-| tst.js:46:21:46:37 | document.location | tst.js:46:21:46:44 | documen ... .search |
+| tst.js:40:20:40:43 | documen ... .search | tst.js:40:16:40:44 | baz(doc ... search) |
+| tst.js:40:20:40:43 | documen ... .search | tst.js:40:16:40:44 | baz(doc ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
-| tst.js:54:21:54:37 | document.location | tst.js:54:21:54:44 | documen ... .search |
-| tst.js:54:21:54:37 | document.location | tst.js:54:21:54:44 | documen ... .search |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
-| tst.js:56:21:56:37 | document.location | tst.js:56:21:56:44 | documen ... .search |
-| tst.js:56:21:56:37 | document.location | tst.js:56:21:56:44 | documen ... .search |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
@@ -1112,72 +1048,43 @@ edges
 | tst.js:58:26:58:30 | bar() | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
-| tst.js:64:25:64:41 | document.location | tst.js:64:25:64:48 | documen ... .search |
-| tst.js:64:25:64:41 | document.location | tst.js:64:25:64:48 | documen ... .search |
 | tst.js:64:25:64:48 | documen ... .search | tst.js:60:34:60:34 | s |
-| tst.js:65:25:65:41 | document.location | tst.js:65:25:65:48 | documen ... .search |
-| tst.js:65:25:65:41 | document.location | tst.js:65:25:65:48 | documen ... .search |
+| tst.js:64:25:64:48 | documen ... .search | tst.js:60:34:60:34 | s |
+| tst.js:65:25:65:48 | documen ... .search | tst.js:60:34:60:34 | s |
 | tst.js:65:25:65:48 | documen ... .search | tst.js:60:34:60:34 | s |
 | tst.js:70:1:70:27 | [,docum ... search] | tst.js:70:46:70:46 | x |
-| tst.js:70:3:70:19 | document.location | tst.js:70:3:70:26 | documen ... .search |
-| tst.js:70:3:70:19 | document.location | tst.js:70:3:70:26 | documen ... .search |
 | tst.js:70:3:70:26 | documen ... .search | tst.js:70:1:70:27 | [,docum ... search] |
+| tst.js:70:3:70:26 | documen ... .search | tst.js:70:1:70:27 | [,docum ... search] |
+| tst.js:70:3:70:26 | documen ... .search | tst.js:70:46:70:46 | x |
 | tst.js:70:3:70:26 | documen ... .search | tst.js:70:46:70:46 | x |
 | tst.js:70:46:70:46 | x | tst.js:73:20:73:20 | x |
 | tst.js:70:46:70:46 | x | tst.js:73:20:73:20 | x |
-| tst.js:77:49:77:65 | document.location | tst.js:77:49:77:72 | documen ... .search |
-| tst.js:77:49:77:65 | document.location | tst.js:77:49:77:72 | documen ... .search |
-| tst.js:77:49:77:65 | document.location | tst.js:77:49:77:72 | documen ... .search |
-| tst.js:77:49:77:65 | document.location | tst.js:77:49:77:72 | documen ... .search |
-| tst.js:81:26:81:42 | document.location | tst.js:81:26:81:49 | documen ... .search |
-| tst.js:81:26:81:42 | document.location | tst.js:81:26:81:49 | documen ... .search |
-| tst.js:81:26:81:42 | document.location | tst.js:81:26:81:49 | documen ... .search |
-| tst.js:81:26:81:42 | document.location | tst.js:81:26:81:49 | documen ... .search |
-| tst.js:82:25:82:41 | document.location | tst.js:82:25:82:48 | documen ... .search |
-| tst.js:82:25:82:41 | document.location | tst.js:82:25:82:48 | documen ... .search |
-| tst.js:82:25:82:41 | document.location | tst.js:82:25:82:48 | documen ... .search |
-| tst.js:82:25:82:41 | document.location | tst.js:82:25:82:48 | documen ... .search |
-| tst.js:84:33:84:49 | document.location | tst.js:84:33:84:56 | documen ... .search |
-| tst.js:84:33:84:49 | document.location | tst.js:84:33:84:56 | documen ... .search |
-| tst.js:84:33:84:49 | document.location | tst.js:84:33:84:56 | documen ... .search |
-| tst.js:84:33:84:49 | document.location | tst.js:84:33:84:56 | documen ... .search |
-| tst.js:85:32:85:48 | document.location | tst.js:85:32:85:55 | documen ... .search |
-| tst.js:85:32:85:48 | document.location | tst.js:85:32:85:55 | documen ... .search |
-| tst.js:85:32:85:48 | document.location | tst.js:85:32:85:55 | documen ... .search |
-| tst.js:85:32:85:48 | document.location | tst.js:85:32:85:55 | documen ... .search |
-| tst.js:90:39:90:55 | document.location | tst.js:90:39:90:62 | documen ... .search |
-| tst.js:90:39:90:55 | document.location | tst.js:90:39:90:62 | documen ... .search |
-| tst.js:90:39:90:55 | document.location | tst.js:90:39:90:62 | documen ... .search |
-| tst.js:90:39:90:55 | document.location | tst.js:90:39:90:62 | documen ... .search |
-| tst.js:96:30:96:46 | document.location | tst.js:96:30:96:53 | documen ... .search |
-| tst.js:96:30:96:46 | document.location | tst.js:96:30:96:53 | documen ... .search |
-| tst.js:96:30:96:46 | document.location | tst.js:96:30:96:53 | documen ... .search |
-| tst.js:96:30:96:46 | document.location | tst.js:96:30:96:53 | documen ... .search |
-| tst.js:102:25:102:41 | document.location | tst.js:102:25:102:48 | documen ... .search |
-| tst.js:102:25:102:41 | document.location | tst.js:102:25:102:48 | documen ... .search |
-| tst.js:102:25:102:41 | document.location | tst.js:102:25:102:48 | documen ... .search |
-| tst.js:102:25:102:41 | document.location | tst.js:102:25:102:48 | documen ... .search |
+| tst.js:77:49:77:72 | documen ... .search | tst.js:77:49:77:72 | documen ... .search |
+| tst.js:81:26:81:49 | documen ... .search | tst.js:81:26:81:49 | documen ... .search |
+| tst.js:82:25:82:48 | documen ... .search | tst.js:82:25:82:48 | documen ... .search |
+| tst.js:84:33:84:56 | documen ... .search | tst.js:84:33:84:56 | documen ... .search |
+| tst.js:85:32:85:55 | documen ... .search | tst.js:85:32:85:55 | documen ... .search |
+| tst.js:90:39:90:62 | documen ... .search | tst.js:90:39:90:62 | documen ... .search |
+| tst.js:96:30:96:53 | documen ... .search | tst.js:96:30:96:53 | documen ... .search |
+| tst.js:102:25:102:48 | documen ... .search | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
-| tst.js:107:11:107:27 | document.location | tst.js:107:11:107:34 | documen ... .search |
-| tst.js:107:11:107:27 | document.location | tst.js:107:11:107:34 | documen ... .search |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
-| tst.js:148:29:148:43 | window.location | tst.js:148:29:148:50 | window. ... .search |
-| tst.js:148:29:148:43 | window.location | tst.js:148:29:148:50 | window. ... .search |
+| tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
 | tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
 | tst.js:151:29:151:29 | v | tst.js:151:49:151:49 | v |
 | tst.js:151:29:151:29 | v | tst.js:151:49:151:49 | v |
-| tst.js:158:40:158:54 | window.location | tst.js:158:40:158:61 | window. ... .search |
-| tst.js:158:40:158:54 | window.location | tst.js:158:40:158:61 | window. ... .search |
+| tst.js:158:40:158:61 | window. ... .search | tst.js:155:29:155:46 | xssSourceService() |
+| tst.js:158:40:158:61 | window. ... .search | tst.js:155:29:155:46 | xssSourceService() |
 | tst.js:158:40:158:61 | window. ... .search | tst.js:155:29:155:46 | xssSourceService() |
 | tst.js:158:40:158:61 | window. ... .search | tst.js:155:29:155:46 | xssSourceService() |
 | tst.js:177:9:177:41 | target | tst.js:180:28:180:33 | target |
 | tst.js:177:9:177:41 | target | tst.js:180:28:180:33 | target |
-| tst.js:177:18:177:34 | document.location | tst.js:177:18:177:41 | documen ... .search |
-| tst.js:177:18:177:34 | document.location | tst.js:177:18:177:41 | documen ... .search |
+| tst.js:177:18:177:41 | documen ... .search | tst.js:177:9:177:41 | target |
 | tst.js:177:18:177:41 | documen ... .search | tst.js:177:9:177:41 | target |
 | tst.js:184:9:184:42 | tainted | tst.js:186:31:186:37 | tainted |
 | tst.js:184:9:184:42 | tainted | tst.js:186:31:186:37 | tainted |
@@ -1191,8 +1098,7 @@ edges
 | tst.js:184:9:184:42 | tainted | tst.js:192:45:192:51 | tainted |
 | tst.js:184:9:184:42 | tainted | tst.js:193:49:193:55 | tainted |
 | tst.js:184:9:184:42 | tainted | tst.js:193:49:193:55 | tainted |
-| tst.js:184:19:184:35 | document.location | tst.js:184:19:184:42 | documen ... .search |
-| tst.js:184:19:184:35 | document.location | tst.js:184:19:184:42 | documen ... .search |
+| tst.js:184:19:184:42 | documen ... .search | tst.js:184:9:184:42 | tainted |
 | tst.js:184:19:184:42 | documen ... .search | tst.js:184:9:184:42 | tainted |
 | tst.js:197:9:197:42 | tainted | tst.js:199:67:199:73 | tainted |
 | tst.js:197:9:197:42 | tainted | tst.js:199:67:199:73 | tainted |
@@ -1207,8 +1113,7 @@ edges
 | tst.js:197:9:197:42 | tainted | tst.js:240:23:240:29 | tainted |
 | tst.js:197:9:197:42 | tainted | tst.js:241:23:241:29 | tainted |
 | tst.js:197:9:197:42 | tainted | tst.js:255:23:255:29 | tainted |
-| tst.js:197:19:197:35 | document.location | tst.js:197:19:197:42 | documen ... .search |
-| tst.js:197:19:197:35 | document.location | tst.js:197:19:197:42 | documen ... .search |
+| tst.js:197:19:197:42 | documen ... .search | tst.js:197:9:197:42 | tainted |
 | tst.js:197:19:197:42 | documen ... .search | tst.js:197:9:197:42 | tainted |
 | tst.js:204:35:204:41 | tainted | tst.js:212:28:212:46 | this.state.tainted1 |
 | tst.js:204:35:204:41 | tainted | tst.js:212:28:212:46 | this.state.tainted1 |
@@ -1256,8 +1161,7 @@ edges
 | tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target | tst.js:349:12:349:17 | target |
 | tst.js:348:7:348:39 | target | tst.js:349:12:349:17 | target |
-| tst.js:348:16:348:32 | document.location | tst.js:348:16:348:39 | documen ... .search |
-| tst.js:348:16:348:32 | document.location | tst.js:348:16:348:39 | documen ... .search |
+| tst.js:348:16:348:39 | documen ... .search | tst.js:348:7:348:39 | target |
 | tst.js:348:16:348:39 | documen ... .search | tst.js:348:7:348:39 | target |
 | tst.js:355:10:355:42 | target | tst.js:356:16:356:21 | target |
 | tst.js:355:10:355:42 | target | tst.js:356:16:356:21 | target |
@@ -1265,13 +1169,11 @@ edges
 | tst.js:355:10:355:42 | target | tst.js:360:21:360:26 | target |
 | tst.js:355:10:355:42 | target | tst.js:363:18:363:23 | target |
 | tst.js:355:10:355:42 | target | tst.js:363:18:363:23 | target |
-| tst.js:355:19:355:35 | document.location | tst.js:355:19:355:42 | documen ... .search |
-| tst.js:355:19:355:35 | document.location | tst.js:355:19:355:42 | documen ... .search |
+| tst.js:355:19:355:42 | documen ... .search | tst.js:355:10:355:42 | target |
 | tst.js:355:19:355:42 | documen ... .search | tst.js:355:10:355:42 | target |
 | tst.js:371:7:371:39 | target | tst.js:374:18:374:23 | target |
 | tst.js:371:7:371:39 | target | tst.js:374:18:374:23 | target |
-| tst.js:371:16:371:32 | document.location | tst.js:371:16:371:39 | documen ... .search |
-| tst.js:371:16:371:32 | document.location | tst.js:371:16:371:39 | documen ... .search |
+| tst.js:371:16:371:39 | documen ... .search | tst.js:371:7:371:39 | target |
 | tst.js:371:16:371:39 | documen ... .search | tst.js:371:7:371:39 | target |
 | tst.js:381:7:381:39 | target | tst.js:384:18:384:23 | target |
 | tst.js:381:7:381:39 | target | tst.js:384:18:384:23 | target |
@@ -1279,13 +1181,12 @@ edges
 | tst.js:381:7:381:39 | target | tst.js:397:18:397:23 | target |
 | tst.js:381:7:381:39 | target | tst.js:406:18:406:23 | target |
 | tst.js:381:7:381:39 | target | tst.js:408:19:408:24 | target |
-| tst.js:381:16:381:32 | document.location | tst.js:381:16:381:39 | documen ... .search |
-| tst.js:381:16:381:32 | document.location | tst.js:381:16:381:39 | documen ... .search |
+| tst.js:381:16:381:39 | documen ... .search | tst.js:381:7:381:39 | target |
 | tst.js:381:16:381:39 | documen ... .search | tst.js:381:7:381:39 | target |
 | tst.js:386:18:386:23 | target | tst.js:386:18:386:29 | target.taint |
 | tst.js:386:18:386:23 | target | tst.js:386:18:386:29 | target.taint |
-| tst.js:391:19:391:35 | document.location | tst.js:391:19:391:42 | documen ... .search |
-| tst.js:391:19:391:35 | document.location | tst.js:391:19:391:42 | documen ... .search |
+| tst.js:391:19:391:42 | documen ... .search | tst.js:392:18:392:30 | target.taint3 |
+| tst.js:391:19:391:42 | documen ... .search | tst.js:392:18:392:30 | target.taint3 |
 | tst.js:391:19:391:42 | documen ... .search | tst.js:392:18:392:30 | target.taint3 |
 | tst.js:391:19:391:42 | documen ... .search | tst.js:392:18:392:30 | target.taint3 |
 | tst.js:397:18:397:23 | target | tst.js:397:18:397:30 | target.taint5 |
@@ -1298,19 +1199,16 @@ edges
 | tst.js:408:19:408:31 | target.taint8 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
-| tst.js:416:17:416:31 | window.location | tst.js:416:17:416:36 | window.location.hash |
-| tst.js:416:17:416:31 | window.location | tst.js:416:17:416:36 | window.location.hash |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
 | tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
 | tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
 | tst.js:419:7:419:55 | match | tst.js:421:20:421:24 | match |
-| tst.js:419:15:419:29 | window.location | tst.js:419:15:419:34 | window.location.hash |
-| tst.js:419:15:419:29 | window.location | tst.js:419:15:419:34 | window.location.hash |
+| tst.js:419:15:419:34 | window.location.hash | tst.js:419:15:419:55 | window. ... (\\w+)/) |
 | tst.js:419:15:419:34 | window.location.hash | tst.js:419:15:419:55 | window. ... (\\w+)/) |
 | tst.js:419:15:419:55 | window. ... (\\w+)/) | tst.js:419:7:419:55 | match |
 | tst.js:421:20:421:24 | match | tst.js:421:20:421:27 | match[1] |
 | tst.js:421:20:421:24 | match | tst.js:421:20:421:27 | match[1] |
-| tst.js:424:18:424:32 | window.location | tst.js:424:18:424:37 | window.location.hash |
-| tst.js:424:18:424:32 | window.location | tst.js:424:18:424:37 | window.location.hash |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
@@ -1325,8 +1223,7 @@ edges
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
-| typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
-| typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
+| typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
 | typeahead.js:21:12:21:17 | target | typeahead.js:24:30:24:32 | val |
 | typeahead.js:24:30:24:32 | val | typeahead.js:25:18:25:20 | val |
@@ -1377,8 +1274,7 @@ edges
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
-| winjs.js:2:17:2:33 | document.location | winjs.js:2:17:2:40 | documen ... .search |
-| winjs.js:2:17:2:33 | document.location | winjs.js:2:17:2:40 | documen ... .search |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
 | xmlRequest.js:8:13:8:47 | json | xmlRequest.js:9:28:9:31 | json |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -609,8 +609,7 @@ nodes
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target |
-| tst.js:428:16:428:32 | document.location |
-| tst.js:428:16:428:32 | document.location |
+| tst.js:428:16:428:39 | documen ... .search |
 | tst.js:428:16:428:39 | documen ... .search |
 | tst.js:430:18:430:23 | target |
 | tst.js:430:18:430:89 | target. ... data>') |
@@ -1212,8 +1211,7 @@ edges
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target | tst.js:430:18:430:23 | target |
-| tst.js:428:16:428:32 | document.location | tst.js:428:16:428:39 | documen ... .search |
-| tst.js:428:16:428:32 | document.location | tst.js:428:16:428:39 | documen ... .search |
+| tst.js:428:16:428:39 | documen ... .search | tst.js:428:7:428:39 | target |
 | tst.js:428:16:428:39 | documen ... .search | tst.js:428:7:428:39 | target |
 | tst.js:430:18:430:23 | target | tst.js:430:18:430:89 | target. ... data>') |
 | tst.js:430:18:430:23 | target | tst.js:430:18:430:89 | target. ... data>') |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ExceptionXss/ExceptionXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ExceptionXss/ExceptionXss.expected
@@ -55,8 +55,7 @@ nodes
 | exception-xss.js:119:12:119:28 | "Exception: " + e |
 | exception-xss.js:119:12:119:28 | "Exception: " + e |
 | exception-xss.js:119:28:119:28 | e |
-| exception-xss.js:125:45:125:61 | document.location |
-| exception-xss.js:125:45:125:61 | document.location |
+| exception-xss.js:125:45:125:68 | documen ... .search |
 | exception-xss.js:125:45:125:68 | documen ... .search |
 | exception-xss.js:128:11:128:52 | session ... ssion') |
 | exception-xss.js:129:11:129:11 | e |
@@ -68,8 +67,7 @@ nodes
 | exception-xss.js:138:19:138:23 | error |
 | exception-xss.js:138:19:138:23 | error |
 | exception-xss.js:146:6:146:35 | foo |
-| exception-xss.js:146:12:146:28 | document.location |
-| exception-xss.js:146:12:146:28 | document.location |
+| exception-xss.js:146:12:146:35 | documen ... .search |
 | exception-xss.js:146:12:146:35 | documen ... .search |
 | exception-xss.js:148:33:148:35 | foo |
 | exception-xss.js:148:55:148:55 | e |
@@ -142,8 +140,7 @@ edges
 | exception-xss.js:118:11:118:11 | e | exception-xss.js:119:28:119:28 | e |
 | exception-xss.js:119:28:119:28 | e | exception-xss.js:119:12:119:28 | "Exception: " + e |
 | exception-xss.js:119:28:119:28 | e | exception-xss.js:119:12:119:28 | "Exception: " + e |
-| exception-xss.js:125:45:125:61 | document.location | exception-xss.js:125:45:125:68 | documen ... .search |
-| exception-xss.js:125:45:125:61 | document.location | exception-xss.js:125:45:125:68 | documen ... .search |
+| exception-xss.js:125:45:125:68 | documen ... .search | exception-xss.js:128:11:128:52 | session ... ssion') |
 | exception-xss.js:125:45:125:68 | documen ... .search | exception-xss.js:128:11:128:52 | session ... ssion') |
 | exception-xss.js:128:11:128:52 | session ... ssion') | exception-xss.js:129:11:129:11 | e |
 | exception-xss.js:129:11:129:11 | e | exception-xss.js:130:18:130:18 | e |
@@ -155,8 +152,7 @@ edges
 | exception-xss.js:146:6:146:35 | foo | exception-xss.js:148:33:148:35 | foo |
 | exception-xss.js:146:6:146:35 | foo | exception-xss.js:153:8:153:10 | foo |
 | exception-xss.js:146:6:146:35 | foo | exception-xss.js:174:31:174:33 | foo |
-| exception-xss.js:146:12:146:28 | document.location | exception-xss.js:146:12:146:35 | documen ... .search |
-| exception-xss.js:146:12:146:28 | document.location | exception-xss.js:146:12:146:35 | documen ... .search |
+| exception-xss.js:146:12:146:35 | documen ... .search | exception-xss.js:146:6:146:35 | foo |
 | exception-xss.js:146:12:146:35 | documen ... .search | exception-xss.js:146:6:146:35 | foo |
 | exception-xss.js:148:33:148:35 | foo | exception-xss.js:148:55:148:55 | e |
 | exception-xss.js:148:55:148:55 | e | exception-xss.js:149:18:149:18 | e |
@@ -184,9 +180,9 @@ edges
 | exception-xss.js:97:18:97:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:97:18:97:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |
 | exception-xss.js:107:18:107:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:107:18:107:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |
 | exception-xss.js:119:12:119:28 | "Exception: " + e | exception-xss.js:117:11:117:23 | req.params.id | exception-xss.js:119:12:119:28 | "Exception: " + e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:117:11:117:23 | req.params.id | Exception text |
-| exception-xss.js:130:18:130:18 | e | exception-xss.js:125:45:125:61 | document.location | exception-xss.js:130:18:130:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:125:45:125:61 | document.location | Exception text |
+| exception-xss.js:130:18:130:18 | e | exception-xss.js:125:45:125:68 | documen ... .search | exception-xss.js:130:18:130:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:125:45:125:68 | documen ... .search | Exception text |
 | exception-xss.js:138:19:138:23 | error | exception-xss.js:136:10:136:22 | req.params.id | exception-xss.js:138:19:138:23 | error | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:136:10:136:22 | req.params.id | Exception text |
-| exception-xss.js:149:18:149:18 | e | exception-xss.js:146:12:146:28 | document.location | exception-xss.js:149:18:149:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:146:12:146:28 | document.location | Exception text |
-| exception-xss.js:155:18:155:18 | e | exception-xss.js:146:12:146:28 | document.location | exception-xss.js:155:18:155:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:146:12:146:28 | document.location | Exception text |
-| exception-xss.js:175:18:175:18 | e | exception-xss.js:146:12:146:28 | document.location | exception-xss.js:175:18:175:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:146:12:146:28 | document.location | Exception text |
+| exception-xss.js:149:18:149:18 | e | exception-xss.js:146:12:146:35 | documen ... .search | exception-xss.js:149:18:149:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:146:12:146:35 | documen ... .search | Exception text |
+| exception-xss.js:155:18:155:18 | e | exception-xss.js:146:12:146:35 | documen ... .search | exception-xss.js:155:18:155:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:146:12:146:35 | documen ... .search | Exception text |
+| exception-xss.js:175:18:175:18 | e | exception-xss.js:146:12:146:35 | documen ... .search | exception-xss.js:175:18:175:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:146:12:146:35 | documen ... .search | Exception text |
 | exception-xss.js:182:19:182:23 | error | exception-xss.js:180:10:180:22 | req.params.id | exception-xss.js:182:19:182:23 | error | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:180:10:180:22 | req.params.id | Exception text |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
@@ -13,60 +13,46 @@ nodes
 | NoSQLCodeInjection.js:22:36:22:43 | req.body |
 | NoSQLCodeInjection.js:22:36:22:43 | req.body |
 | NoSQLCodeInjection.js:22:36:22:48 | req.body.name |
-| angularjs.js:10:22:10:29 | location |
-| angularjs.js:10:22:10:29 | location |
 | angularjs.js:10:22:10:36 | location.search |
 | angularjs.js:10:22:10:36 | location.search |
-| angularjs.js:13:23:13:30 | location |
-| angularjs.js:13:23:13:30 | location |
+| angularjs.js:10:22:10:36 | location.search |
 | angularjs.js:13:23:13:37 | location.search |
 | angularjs.js:13:23:13:37 | location.search |
-| angularjs.js:16:28:16:35 | location |
-| angularjs.js:16:28:16:35 | location |
+| angularjs.js:13:23:13:37 | location.search |
 | angularjs.js:16:28:16:42 | location.search |
 | angularjs.js:16:28:16:42 | location.search |
-| angularjs.js:19:22:19:29 | location |
-| angularjs.js:19:22:19:29 | location |
+| angularjs.js:16:28:16:42 | location.search |
 | angularjs.js:19:22:19:36 | location.search |
 | angularjs.js:19:22:19:36 | location.search |
-| angularjs.js:22:27:22:34 | location |
-| angularjs.js:22:27:22:34 | location |
+| angularjs.js:19:22:19:36 | location.search |
 | angularjs.js:22:27:22:41 | location.search |
 | angularjs.js:22:27:22:41 | location.search |
-| angularjs.js:25:23:25:30 | location |
-| angularjs.js:25:23:25:30 | location |
+| angularjs.js:22:27:22:41 | location.search |
 | angularjs.js:25:23:25:37 | location.search |
 | angularjs.js:25:23:25:37 | location.search |
-| angularjs.js:28:33:28:40 | location |
-| angularjs.js:28:33:28:40 | location |
+| angularjs.js:25:23:25:37 | location.search |
 | angularjs.js:28:33:28:47 | location.search |
 | angularjs.js:28:33:28:47 | location.search |
-| angularjs.js:31:28:31:35 | location |
-| angularjs.js:31:28:31:35 | location |
+| angularjs.js:28:33:28:47 | location.search |
 | angularjs.js:31:28:31:42 | location.search |
 | angularjs.js:31:28:31:42 | location.search |
-| angularjs.js:34:18:34:25 | location |
-| angularjs.js:34:18:34:25 | location |
+| angularjs.js:31:28:31:42 | location.search |
 | angularjs.js:34:18:34:32 | location.search |
 | angularjs.js:34:18:34:32 | location.search |
-| angularjs.js:40:18:40:25 | location |
-| angularjs.js:40:18:40:25 | location |
+| angularjs.js:34:18:34:32 | location.search |
 | angularjs.js:40:18:40:32 | location.search |
 | angularjs.js:40:18:40:32 | location.search |
-| angularjs.js:44:17:44:24 | location |
-| angularjs.js:44:17:44:24 | location |
+| angularjs.js:40:18:40:32 | location.search |
 | angularjs.js:44:17:44:31 | location.search |
 | angularjs.js:44:17:44:31 | location.search |
-| angularjs.js:47:16:47:23 | location |
-| angularjs.js:47:16:47:23 | location |
+| angularjs.js:44:17:44:31 | location.search |
 | angularjs.js:47:16:47:30 | location.search |
 | angularjs.js:47:16:47:30 | location.search |
-| angularjs.js:50:22:50:29 | location |
-| angularjs.js:50:22:50:29 | location |
+| angularjs.js:47:16:47:30 | location.search |
 | angularjs.js:50:22:50:36 | location.search |
 | angularjs.js:50:22:50:36 | location.search |
-| angularjs.js:53:32:53:39 | location |
-| angularjs.js:53:32:53:39 | location |
+| angularjs.js:50:22:50:36 | location.search |
+| angularjs.js:53:32:53:46 | location.search |
 | angularjs.js:53:32:53:46 | location.search |
 | angularjs.js:53:32:53:46 | location.search |
 | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` |
@@ -118,8 +104,7 @@ nodes
 | react-native.js:8:32:8:38 | tainted |
 | react-native.js:10:23:10:29 | tainted |
 | react-native.js:10:23:10:29 | tainted |
-| react.js:10:56:10:72 | document.location |
-| react.js:10:56:10:72 | document.location |
+| react.js:10:56:10:77 | documen ... on.hash |
 | react.js:10:56:10:77 | documen ... on.hash |
 | react.js:10:56:10:77 | documen ... on.hash |
 | template-sinks.js:12:9:12:31 | tainted |
@@ -141,36 +126,29 @@ nodes
 | template-sinks.js:20:27:20:33 | tainted |
 | template-sinks.js:21:21:21:27 | tainted |
 | template-sinks.js:21:21:21:27 | tainted |
-| tst.js:2:6:2:22 | document.location |
-| tst.js:2:6:2:22 | document.location |
+| tst.js:2:6:2:27 | documen ... on.href |
 | tst.js:2:6:2:27 | documen ... on.href |
 | tst.js:2:6:2:83 | documen ... t=")+8) |
 | tst.js:2:6:2:83 | documen ... t=")+8) |
-| tst.js:5:12:5:28 | document.location |
-| tst.js:5:12:5:28 | document.location |
 | tst.js:5:12:5:33 | documen ... on.hash |
 | tst.js:5:12:5:33 | documen ... on.hash |
-| tst.js:14:10:14:26 | document.location |
-| tst.js:14:10:14:26 | document.location |
+| tst.js:5:12:5:33 | documen ... on.hash |
+| tst.js:14:10:14:33 | documen ... .search |
 | tst.js:14:10:14:33 | documen ... .search |
 | tst.js:14:10:14:74 | documen ... , "$1") |
 | tst.js:14:10:14:74 | documen ... , "$1") |
-| tst.js:17:21:17:37 | document.location |
-| tst.js:17:21:17:37 | document.location |
 | tst.js:17:21:17:42 | documen ... on.hash |
 | tst.js:17:21:17:42 | documen ... on.hash |
-| tst.js:20:30:20:46 | document.location |
-| tst.js:20:30:20:46 | document.location |
+| tst.js:17:21:17:42 | documen ... on.hash |
+| tst.js:20:30:20:51 | documen ... on.hash |
 | tst.js:20:30:20:51 | documen ... on.hash |
 | tst.js:20:30:20:51 | documen ... on.hash |
 | tst.js:23:6:23:46 | atob(do ... ing(1)) |
 | tst.js:23:6:23:46 | atob(do ... ing(1)) |
-| tst.js:23:11:23:27 | document.location |
-| tst.js:23:11:23:27 | document.location |
+| tst.js:23:11:23:32 | documen ... on.hash |
 | tst.js:23:11:23:32 | documen ... on.hash |
 | tst.js:23:11:23:45 | documen ... ring(1) |
-| tst.js:26:26:26:33 | location |
-| tst.js:26:26:26:33 | location |
+| tst.js:26:26:26:40 | location.search |
 | tst.js:26:26:26:40 | location.search |
 | tst.js:26:26:26:53 | locatio ... ring(1) |
 | tst.js:26:26:26:53 | locatio ... ring(1) |
@@ -187,62 +165,20 @@ edges
 | NoSQLCodeInjection.js:22:36:22:43 | req.body | NoSQLCodeInjection.js:22:36:22:48 | req.body.name |
 | NoSQLCodeInjection.js:22:36:22:48 | req.body.name | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
 | NoSQLCodeInjection.js:22:36:22:48 | req.body.name | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
-| angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
-| angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
-| angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
-| angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
-| angularjs.js:13:23:13:30 | location | angularjs.js:13:23:13:37 | location.search |
-| angularjs.js:13:23:13:30 | location | angularjs.js:13:23:13:37 | location.search |
-| angularjs.js:13:23:13:30 | location | angularjs.js:13:23:13:37 | location.search |
-| angularjs.js:13:23:13:30 | location | angularjs.js:13:23:13:37 | location.search |
-| angularjs.js:16:28:16:35 | location | angularjs.js:16:28:16:42 | location.search |
-| angularjs.js:16:28:16:35 | location | angularjs.js:16:28:16:42 | location.search |
-| angularjs.js:16:28:16:35 | location | angularjs.js:16:28:16:42 | location.search |
-| angularjs.js:16:28:16:35 | location | angularjs.js:16:28:16:42 | location.search |
-| angularjs.js:19:22:19:29 | location | angularjs.js:19:22:19:36 | location.search |
-| angularjs.js:19:22:19:29 | location | angularjs.js:19:22:19:36 | location.search |
-| angularjs.js:19:22:19:29 | location | angularjs.js:19:22:19:36 | location.search |
-| angularjs.js:19:22:19:29 | location | angularjs.js:19:22:19:36 | location.search |
-| angularjs.js:22:27:22:34 | location | angularjs.js:22:27:22:41 | location.search |
-| angularjs.js:22:27:22:34 | location | angularjs.js:22:27:22:41 | location.search |
-| angularjs.js:22:27:22:34 | location | angularjs.js:22:27:22:41 | location.search |
-| angularjs.js:22:27:22:34 | location | angularjs.js:22:27:22:41 | location.search |
-| angularjs.js:25:23:25:30 | location | angularjs.js:25:23:25:37 | location.search |
-| angularjs.js:25:23:25:30 | location | angularjs.js:25:23:25:37 | location.search |
-| angularjs.js:25:23:25:30 | location | angularjs.js:25:23:25:37 | location.search |
-| angularjs.js:25:23:25:30 | location | angularjs.js:25:23:25:37 | location.search |
-| angularjs.js:28:33:28:40 | location | angularjs.js:28:33:28:47 | location.search |
-| angularjs.js:28:33:28:40 | location | angularjs.js:28:33:28:47 | location.search |
-| angularjs.js:28:33:28:40 | location | angularjs.js:28:33:28:47 | location.search |
-| angularjs.js:28:33:28:40 | location | angularjs.js:28:33:28:47 | location.search |
-| angularjs.js:31:28:31:35 | location | angularjs.js:31:28:31:42 | location.search |
-| angularjs.js:31:28:31:35 | location | angularjs.js:31:28:31:42 | location.search |
-| angularjs.js:31:28:31:35 | location | angularjs.js:31:28:31:42 | location.search |
-| angularjs.js:31:28:31:35 | location | angularjs.js:31:28:31:42 | location.search |
-| angularjs.js:34:18:34:25 | location | angularjs.js:34:18:34:32 | location.search |
-| angularjs.js:34:18:34:25 | location | angularjs.js:34:18:34:32 | location.search |
-| angularjs.js:34:18:34:25 | location | angularjs.js:34:18:34:32 | location.search |
-| angularjs.js:34:18:34:25 | location | angularjs.js:34:18:34:32 | location.search |
-| angularjs.js:40:18:40:25 | location | angularjs.js:40:18:40:32 | location.search |
-| angularjs.js:40:18:40:25 | location | angularjs.js:40:18:40:32 | location.search |
-| angularjs.js:40:18:40:25 | location | angularjs.js:40:18:40:32 | location.search |
-| angularjs.js:40:18:40:25 | location | angularjs.js:40:18:40:32 | location.search |
-| angularjs.js:44:17:44:24 | location | angularjs.js:44:17:44:31 | location.search |
-| angularjs.js:44:17:44:24 | location | angularjs.js:44:17:44:31 | location.search |
-| angularjs.js:44:17:44:24 | location | angularjs.js:44:17:44:31 | location.search |
-| angularjs.js:44:17:44:24 | location | angularjs.js:44:17:44:31 | location.search |
-| angularjs.js:47:16:47:23 | location | angularjs.js:47:16:47:30 | location.search |
-| angularjs.js:47:16:47:23 | location | angularjs.js:47:16:47:30 | location.search |
-| angularjs.js:47:16:47:23 | location | angularjs.js:47:16:47:30 | location.search |
-| angularjs.js:47:16:47:23 | location | angularjs.js:47:16:47:30 | location.search |
-| angularjs.js:50:22:50:29 | location | angularjs.js:50:22:50:36 | location.search |
-| angularjs.js:50:22:50:29 | location | angularjs.js:50:22:50:36 | location.search |
-| angularjs.js:50:22:50:29 | location | angularjs.js:50:22:50:36 | location.search |
-| angularjs.js:50:22:50:29 | location | angularjs.js:50:22:50:36 | location.search |
-| angularjs.js:53:32:53:39 | location | angularjs.js:53:32:53:46 | location.search |
-| angularjs.js:53:32:53:39 | location | angularjs.js:53:32:53:46 | location.search |
-| angularjs.js:53:32:53:39 | location | angularjs.js:53:32:53:46 | location.search |
-| angularjs.js:53:32:53:39 | location | angularjs.js:53:32:53:46 | location.search |
+| angularjs.js:10:22:10:36 | location.search | angularjs.js:10:22:10:36 | location.search |
+| angularjs.js:13:23:13:37 | location.search | angularjs.js:13:23:13:37 | location.search |
+| angularjs.js:16:28:16:42 | location.search | angularjs.js:16:28:16:42 | location.search |
+| angularjs.js:19:22:19:36 | location.search | angularjs.js:19:22:19:36 | location.search |
+| angularjs.js:22:27:22:41 | location.search | angularjs.js:22:27:22:41 | location.search |
+| angularjs.js:25:23:25:37 | location.search | angularjs.js:25:23:25:37 | location.search |
+| angularjs.js:28:33:28:47 | location.search | angularjs.js:28:33:28:47 | location.search |
+| angularjs.js:31:28:31:42 | location.search | angularjs.js:31:28:31:42 | location.search |
+| angularjs.js:34:18:34:32 | location.search | angularjs.js:34:18:34:32 | location.search |
+| angularjs.js:40:18:40:32 | location.search | angularjs.js:40:18:40:32 | location.search |
+| angularjs.js:44:17:44:31 | location.search | angularjs.js:44:17:44:31 | location.search |
+| angularjs.js:47:16:47:30 | location.search | angularjs.js:47:16:47:30 | location.search |
+| angularjs.js:50:22:50:36 | location.search | angularjs.js:50:22:50:36 | location.search |
+| angularjs.js:53:32:53:46 | location.search | angularjs.js:53:32:53:46 | location.search |
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` |
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` |
 | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
@@ -279,10 +215,7 @@ edges
 | react-native.js:7:7:7:33 | tainted | react-native.js:10:23:10:29 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
-| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
-| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
-| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
-| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
+| react.js:10:56:10:77 | documen ... on.hash | react.js:10:56:10:77 | documen ... on.hash |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:15:16:15:22 | tainted |
@@ -301,53 +234,43 @@ edges
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:21:21:21:27 | tainted |
 | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:12:9:12:31 | tainted |
 | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:12:9:12:31 | tainted |
-| tst.js:2:6:2:22 | document.location | tst.js:2:6:2:27 | documen ... on.href |
-| tst.js:2:6:2:22 | document.location | tst.js:2:6:2:27 | documen ... on.href |
 | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
 | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
-| tst.js:5:12:5:28 | document.location | tst.js:5:12:5:33 | documen ... on.hash |
-| tst.js:5:12:5:28 | document.location | tst.js:5:12:5:33 | documen ... on.hash |
-| tst.js:5:12:5:28 | document.location | tst.js:5:12:5:33 | documen ... on.hash |
-| tst.js:5:12:5:28 | document.location | tst.js:5:12:5:33 | documen ... on.hash |
-| tst.js:14:10:14:26 | document.location | tst.js:14:10:14:33 | documen ... .search |
-| tst.js:14:10:14:26 | document.location | tst.js:14:10:14:33 | documen ... .search |
+| tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
+| tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
+| tst.js:5:12:5:33 | documen ... on.hash | tst.js:5:12:5:33 | documen ... on.hash |
 | tst.js:14:10:14:33 | documen ... .search | tst.js:14:10:14:74 | documen ... , "$1") |
 | tst.js:14:10:14:33 | documen ... .search | tst.js:14:10:14:74 | documen ... , "$1") |
-| tst.js:17:21:17:37 | document.location | tst.js:17:21:17:42 | documen ... on.hash |
-| tst.js:17:21:17:37 | document.location | tst.js:17:21:17:42 | documen ... on.hash |
-| tst.js:17:21:17:37 | document.location | tst.js:17:21:17:42 | documen ... on.hash |
-| tst.js:17:21:17:37 | document.location | tst.js:17:21:17:42 | documen ... on.hash |
-| tst.js:20:30:20:46 | document.location | tst.js:20:30:20:51 | documen ... on.hash |
-| tst.js:20:30:20:46 | document.location | tst.js:20:30:20:51 | documen ... on.hash |
-| tst.js:20:30:20:46 | document.location | tst.js:20:30:20:51 | documen ... on.hash |
-| tst.js:20:30:20:46 | document.location | tst.js:20:30:20:51 | documen ... on.hash |
-| tst.js:23:11:23:27 | document.location | tst.js:23:11:23:32 | documen ... on.hash |
-| tst.js:23:11:23:27 | document.location | tst.js:23:11:23:32 | documen ... on.hash |
+| tst.js:14:10:14:33 | documen ... .search | tst.js:14:10:14:74 | documen ... , "$1") |
+| tst.js:14:10:14:33 | documen ... .search | tst.js:14:10:14:74 | documen ... , "$1") |
+| tst.js:17:21:17:42 | documen ... on.hash | tst.js:17:21:17:42 | documen ... on.hash |
+| tst.js:20:30:20:51 | documen ... on.hash | tst.js:20:30:20:51 | documen ... on.hash |
+| tst.js:23:11:23:32 | documen ... on.hash | tst.js:23:11:23:45 | documen ... ring(1) |
 | tst.js:23:11:23:32 | documen ... on.hash | tst.js:23:11:23:45 | documen ... ring(1) |
 | tst.js:23:11:23:45 | documen ... ring(1) | tst.js:23:6:23:46 | atob(do ... ing(1)) |
 | tst.js:23:11:23:45 | documen ... ring(1) | tst.js:23:6:23:46 | atob(do ... ing(1)) |
-| tst.js:26:26:26:33 | location | tst.js:26:26:26:40 | location.search |
-| tst.js:26:26:26:33 | location | tst.js:26:26:26:40 | location.search |
+| tst.js:26:26:26:40 | location.search | tst.js:26:26:26:53 | locatio ... ring(1) |
+| tst.js:26:26:26:40 | location.search | tst.js:26:26:26:53 | locatio ... ring(1) |
 | tst.js:26:26:26:40 | location.search | tst.js:26:26:26:53 | locatio ... ring(1) |
 | tst.js:26:26:26:40 | location.search | tst.js:26:26:26:53 | locatio ... ring(1) |
 #select
 | NoSQLCodeInjection.js:18:24:18:37 | req.body.query | NoSQLCodeInjection.js:18:24:18:31 | req.body | NoSQLCodeInjection.js:18:24:18:37 | req.body.query | $@ flows to here and is interpreted as code. | NoSQLCodeInjection.js:18:24:18:31 | req.body | User-provided value |
 | NoSQLCodeInjection.js:19:24:19:48 | "name = ... dy.name | NoSQLCodeInjection.js:19:36:19:43 | req.body | NoSQLCodeInjection.js:19:24:19:48 | "name = ... dy.name | $@ flows to here and is interpreted as code. | NoSQLCodeInjection.js:19:36:19:43 | req.body | User-provided value |
 | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name | NoSQLCodeInjection.js:22:36:22:43 | req.body | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name | $@ flows to here and is interpreted as code. | NoSQLCodeInjection.js:22:36:22:43 | req.body | User-provided value |
-| angularjs.js:10:22:10:36 | location.search | angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:10:22:10:29 | location | User-provided value |
-| angularjs.js:13:23:13:37 | location.search | angularjs.js:13:23:13:30 | location | angularjs.js:13:23:13:37 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:13:23:13:30 | location | User-provided value |
-| angularjs.js:16:28:16:42 | location.search | angularjs.js:16:28:16:35 | location | angularjs.js:16:28:16:42 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:16:28:16:35 | location | User-provided value |
-| angularjs.js:19:22:19:36 | location.search | angularjs.js:19:22:19:29 | location | angularjs.js:19:22:19:36 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:19:22:19:29 | location | User-provided value |
-| angularjs.js:22:27:22:41 | location.search | angularjs.js:22:27:22:34 | location | angularjs.js:22:27:22:41 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:22:27:22:34 | location | User-provided value |
-| angularjs.js:25:23:25:37 | location.search | angularjs.js:25:23:25:30 | location | angularjs.js:25:23:25:37 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:25:23:25:30 | location | User-provided value |
-| angularjs.js:28:33:28:47 | location.search | angularjs.js:28:33:28:40 | location | angularjs.js:28:33:28:47 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:28:33:28:40 | location | User-provided value |
-| angularjs.js:31:28:31:42 | location.search | angularjs.js:31:28:31:35 | location | angularjs.js:31:28:31:42 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:31:28:31:35 | location | User-provided value |
-| angularjs.js:34:18:34:32 | location.search | angularjs.js:34:18:34:25 | location | angularjs.js:34:18:34:32 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:34:18:34:25 | location | User-provided value |
-| angularjs.js:40:18:40:32 | location.search | angularjs.js:40:18:40:25 | location | angularjs.js:40:18:40:32 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:40:18:40:25 | location | User-provided value |
-| angularjs.js:44:17:44:31 | location.search | angularjs.js:44:17:44:24 | location | angularjs.js:44:17:44:31 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:44:17:44:24 | location | User-provided value |
-| angularjs.js:47:16:47:30 | location.search | angularjs.js:47:16:47:23 | location | angularjs.js:47:16:47:30 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:47:16:47:23 | location | User-provided value |
-| angularjs.js:50:22:50:36 | location.search | angularjs.js:50:22:50:29 | location | angularjs.js:50:22:50:36 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:50:22:50:29 | location | User-provided value |
-| angularjs.js:53:32:53:46 | location.search | angularjs.js:53:32:53:39 | location | angularjs.js:53:32:53:46 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:53:32:53:39 | location | User-provided value |
+| angularjs.js:10:22:10:36 | location.search | angularjs.js:10:22:10:36 | location.search | angularjs.js:10:22:10:36 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:10:22:10:36 | location.search | User-provided value |
+| angularjs.js:13:23:13:37 | location.search | angularjs.js:13:23:13:37 | location.search | angularjs.js:13:23:13:37 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:13:23:13:37 | location.search | User-provided value |
+| angularjs.js:16:28:16:42 | location.search | angularjs.js:16:28:16:42 | location.search | angularjs.js:16:28:16:42 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:16:28:16:42 | location.search | User-provided value |
+| angularjs.js:19:22:19:36 | location.search | angularjs.js:19:22:19:36 | location.search | angularjs.js:19:22:19:36 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:19:22:19:36 | location.search | User-provided value |
+| angularjs.js:22:27:22:41 | location.search | angularjs.js:22:27:22:41 | location.search | angularjs.js:22:27:22:41 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:22:27:22:41 | location.search | User-provided value |
+| angularjs.js:25:23:25:37 | location.search | angularjs.js:25:23:25:37 | location.search | angularjs.js:25:23:25:37 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:25:23:25:37 | location.search | User-provided value |
+| angularjs.js:28:33:28:47 | location.search | angularjs.js:28:33:28:47 | location.search | angularjs.js:28:33:28:47 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:28:33:28:47 | location.search | User-provided value |
+| angularjs.js:31:28:31:42 | location.search | angularjs.js:31:28:31:42 | location.search | angularjs.js:31:28:31:42 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:31:28:31:42 | location.search | User-provided value |
+| angularjs.js:34:18:34:32 | location.search | angularjs.js:34:18:34:32 | location.search | angularjs.js:34:18:34:32 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:34:18:34:32 | location.search | User-provided value |
+| angularjs.js:40:18:40:32 | location.search | angularjs.js:40:18:40:32 | location.search | angularjs.js:40:18:40:32 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:40:18:40:32 | location.search | User-provided value |
+| angularjs.js:44:17:44:31 | location.search | angularjs.js:44:17:44:31 | location.search | angularjs.js:44:17:44:31 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:44:17:44:31 | location.search | User-provided value |
+| angularjs.js:47:16:47:30 | location.search | angularjs.js:47:16:47:30 | location.search | angularjs.js:47:16:47:30 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:47:16:47:30 | location.search | User-provided value |
+| angularjs.js:50:22:50:36 | location.search | angularjs.js:50:22:50:36 | location.search | angularjs.js:50:22:50:36 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:50:22:50:36 | location.search | User-provided value |
+| angularjs.js:53:32:53:46 | location.search | angularjs.js:53:32:53:46 | location.search | angularjs.js:53:32:53:46 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:53:32:53:46 | location.search | User-provided value |
 | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` | $@ flows to here and is interpreted as code. | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") | User-provided value |
 | bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` | bad-code-sanitization.js:56:16:56:23 | req.body | bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` | $@ flows to here and is interpreted as code. | bad-code-sanitization.js:56:16:56:23 | req.body | User-provided value |
 | express.js:7:24:7:69 | "return ...  + "];" | express.js:7:44:7:62 | req.param("wobble") | express.js:7:24:7:69 | "return ...  + "];" | $@ flows to here and is interpreted as code. | express.js:7:44:7:62 | req.param("wobble") | User-provided value |
@@ -360,7 +283,7 @@ edges
 | module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code | $@ flows to here and is interpreted as code. | module.js:9:16:9:29 | req.query.code | User-provided value |
 | react-native.js:8:32:8:38 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:8:32:8:38 | tainted | $@ flows to here and is interpreted as code. | react-native.js:7:17:7:33 | req.param("code") | User-provided value |
 | react-native.js:10:23:10:29 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:10:23:10:29 | tainted | $@ flows to here and is interpreted as code. | react-native.js:7:17:7:33 | req.param("code") | User-provided value |
-| react.js:10:56:10:77 | documen ... on.hash | react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash | $@ flows to here and is interpreted as code. | react.js:10:56:10:72 | document.location | User-provided value |
+| react.js:10:56:10:77 | documen ... on.hash | react.js:10:56:10:77 | documen ... on.hash | react.js:10:56:10:77 | documen ... on.hash | $@ flows to here and is interpreted as code. | react.js:10:56:10:77 | documen ... on.hash | User-provided value |
 | template-sinks.js:14:17:14:23 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:14:17:14:23 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
 | template-sinks.js:15:16:15:22 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:15:16:15:22 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
 | template-sinks.js:16:18:16:24 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:16:18:16:24 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
@@ -369,10 +292,10 @@ edges
 | template-sinks.js:19:16:19:22 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:19:16:19:22 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
 | template-sinks.js:20:27:20:33 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:20:27:20:33 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
 | template-sinks.js:21:21:21:27 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:21:21:21:27 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
-| tst.js:2:6:2:83 | documen ... t=")+8) | tst.js:2:6:2:22 | document.location | tst.js:2:6:2:83 | documen ... t=")+8) | $@ flows to here and is interpreted as code. | tst.js:2:6:2:22 | document.location | User-provided value |
-| tst.js:5:12:5:33 | documen ... on.hash | tst.js:5:12:5:28 | document.location | tst.js:5:12:5:33 | documen ... on.hash | $@ flows to here and is interpreted as code. | tst.js:5:12:5:28 | document.location | User-provided value |
-| tst.js:14:10:14:74 | documen ... , "$1") | tst.js:14:10:14:26 | document.location | tst.js:14:10:14:74 | documen ... , "$1") | $@ flows to here and is interpreted as code. | tst.js:14:10:14:26 | document.location | User-provided value |
-| tst.js:17:21:17:42 | documen ... on.hash | tst.js:17:21:17:37 | document.location | tst.js:17:21:17:42 | documen ... on.hash | $@ flows to here and is interpreted as code. | tst.js:17:21:17:37 | document.location | User-provided value |
-| tst.js:20:30:20:51 | documen ... on.hash | tst.js:20:30:20:46 | document.location | tst.js:20:30:20:51 | documen ... on.hash | $@ flows to here and is interpreted as code. | tst.js:20:30:20:46 | document.location | User-provided value |
-| tst.js:23:6:23:46 | atob(do ... ing(1)) | tst.js:23:11:23:27 | document.location | tst.js:23:6:23:46 | atob(do ... ing(1)) | $@ flows to here and is interpreted as code. | tst.js:23:11:23:27 | document.location | User-provided value |
-| tst.js:26:26:26:53 | locatio ... ring(1) | tst.js:26:26:26:33 | location | tst.js:26:26:26:53 | locatio ... ring(1) | $@ flows to here and is interpreted as code. | tst.js:26:26:26:33 | location | User-provided value |
+| tst.js:2:6:2:83 | documen ... t=")+8) | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) | $@ flows to here and is interpreted as code. | tst.js:2:6:2:27 | documen ... on.href | User-provided value |
+| tst.js:5:12:5:33 | documen ... on.hash | tst.js:5:12:5:33 | documen ... on.hash | tst.js:5:12:5:33 | documen ... on.hash | $@ flows to here and is interpreted as code. | tst.js:5:12:5:33 | documen ... on.hash | User-provided value |
+| tst.js:14:10:14:74 | documen ... , "$1") | tst.js:14:10:14:33 | documen ... .search | tst.js:14:10:14:74 | documen ... , "$1") | $@ flows to here and is interpreted as code. | tst.js:14:10:14:33 | documen ... .search | User-provided value |
+| tst.js:17:21:17:42 | documen ... on.hash | tst.js:17:21:17:42 | documen ... on.hash | tst.js:17:21:17:42 | documen ... on.hash | $@ flows to here and is interpreted as code. | tst.js:17:21:17:42 | documen ... on.hash | User-provided value |
+| tst.js:20:30:20:51 | documen ... on.hash | tst.js:20:30:20:51 | documen ... on.hash | tst.js:20:30:20:51 | documen ... on.hash | $@ flows to here and is interpreted as code. | tst.js:20:30:20:51 | documen ... on.hash | User-provided value |
+| tst.js:23:6:23:46 | atob(do ... ing(1)) | tst.js:23:11:23:32 | documen ... on.hash | tst.js:23:6:23:46 | atob(do ... ing(1)) | $@ flows to here and is interpreted as code. | tst.js:23:11:23:32 | documen ... on.hash | User-provided value |
+| tst.js:26:26:26:53 | locatio ... ring(1) | tst.js:26:26:26:40 | location.search | tst.js:26:26:26:53 | locatio ... ring(1) | $@ flows to here and is interpreted as code. | tst.js:26:26:26:40 | location.search | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
@@ -13,60 +13,46 @@ nodes
 | NoSQLCodeInjection.js:22:36:22:43 | req.body |
 | NoSQLCodeInjection.js:22:36:22:43 | req.body |
 | NoSQLCodeInjection.js:22:36:22:48 | req.body.name |
-| angularjs.js:10:22:10:29 | location |
-| angularjs.js:10:22:10:29 | location |
 | angularjs.js:10:22:10:36 | location.search |
 | angularjs.js:10:22:10:36 | location.search |
-| angularjs.js:13:23:13:30 | location |
-| angularjs.js:13:23:13:30 | location |
+| angularjs.js:10:22:10:36 | location.search |
 | angularjs.js:13:23:13:37 | location.search |
 | angularjs.js:13:23:13:37 | location.search |
-| angularjs.js:16:28:16:35 | location |
-| angularjs.js:16:28:16:35 | location |
+| angularjs.js:13:23:13:37 | location.search |
 | angularjs.js:16:28:16:42 | location.search |
 | angularjs.js:16:28:16:42 | location.search |
-| angularjs.js:19:22:19:29 | location |
-| angularjs.js:19:22:19:29 | location |
+| angularjs.js:16:28:16:42 | location.search |
 | angularjs.js:19:22:19:36 | location.search |
 | angularjs.js:19:22:19:36 | location.search |
-| angularjs.js:22:27:22:34 | location |
-| angularjs.js:22:27:22:34 | location |
+| angularjs.js:19:22:19:36 | location.search |
 | angularjs.js:22:27:22:41 | location.search |
 | angularjs.js:22:27:22:41 | location.search |
-| angularjs.js:25:23:25:30 | location |
-| angularjs.js:25:23:25:30 | location |
+| angularjs.js:22:27:22:41 | location.search |
 | angularjs.js:25:23:25:37 | location.search |
 | angularjs.js:25:23:25:37 | location.search |
-| angularjs.js:28:33:28:40 | location |
-| angularjs.js:28:33:28:40 | location |
+| angularjs.js:25:23:25:37 | location.search |
 | angularjs.js:28:33:28:47 | location.search |
 | angularjs.js:28:33:28:47 | location.search |
-| angularjs.js:31:28:31:35 | location |
-| angularjs.js:31:28:31:35 | location |
+| angularjs.js:28:33:28:47 | location.search |
 | angularjs.js:31:28:31:42 | location.search |
 | angularjs.js:31:28:31:42 | location.search |
-| angularjs.js:34:18:34:25 | location |
-| angularjs.js:34:18:34:25 | location |
+| angularjs.js:31:28:31:42 | location.search |
 | angularjs.js:34:18:34:32 | location.search |
 | angularjs.js:34:18:34:32 | location.search |
-| angularjs.js:40:18:40:25 | location |
-| angularjs.js:40:18:40:25 | location |
+| angularjs.js:34:18:34:32 | location.search |
 | angularjs.js:40:18:40:32 | location.search |
 | angularjs.js:40:18:40:32 | location.search |
-| angularjs.js:44:17:44:24 | location |
-| angularjs.js:44:17:44:24 | location |
+| angularjs.js:40:18:40:32 | location.search |
 | angularjs.js:44:17:44:31 | location.search |
 | angularjs.js:44:17:44:31 | location.search |
-| angularjs.js:47:16:47:23 | location |
-| angularjs.js:47:16:47:23 | location |
+| angularjs.js:44:17:44:31 | location.search |
 | angularjs.js:47:16:47:30 | location.search |
 | angularjs.js:47:16:47:30 | location.search |
-| angularjs.js:50:22:50:29 | location |
-| angularjs.js:50:22:50:29 | location |
+| angularjs.js:47:16:47:30 | location.search |
 | angularjs.js:50:22:50:36 | location.search |
 | angularjs.js:50:22:50:36 | location.search |
-| angularjs.js:53:32:53:39 | location |
-| angularjs.js:53:32:53:39 | location |
+| angularjs.js:50:22:50:36 | location.search |
+| angularjs.js:53:32:53:46 | location.search |
 | angularjs.js:53:32:53:46 | location.search |
 | angularjs.js:53:32:53:46 | location.search |
 | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` |
@@ -122,8 +108,7 @@ nodes
 | react-native.js:8:32:8:38 | tainted |
 | react-native.js:10:23:10:29 | tainted |
 | react-native.js:10:23:10:29 | tainted |
-| react.js:10:56:10:72 | document.location |
-| react.js:10:56:10:72 | document.location |
+| react.js:10:56:10:77 | documen ... on.hash |
 | react.js:10:56:10:77 | documen ... on.hash |
 | react.js:10:56:10:77 | documen ... on.hash |
 | template-sinks.js:12:9:12:31 | tainted |
@@ -145,36 +130,29 @@ nodes
 | template-sinks.js:20:27:20:33 | tainted |
 | template-sinks.js:21:21:21:27 | tainted |
 | template-sinks.js:21:21:21:27 | tainted |
-| tst.js:2:6:2:22 | document.location |
-| tst.js:2:6:2:22 | document.location |
+| tst.js:2:6:2:27 | documen ... on.href |
 | tst.js:2:6:2:27 | documen ... on.href |
 | tst.js:2:6:2:83 | documen ... t=")+8) |
 | tst.js:2:6:2:83 | documen ... t=")+8) |
-| tst.js:5:12:5:28 | document.location |
-| tst.js:5:12:5:28 | document.location |
 | tst.js:5:12:5:33 | documen ... on.hash |
 | tst.js:5:12:5:33 | documen ... on.hash |
-| tst.js:14:10:14:26 | document.location |
-| tst.js:14:10:14:26 | document.location |
+| tst.js:5:12:5:33 | documen ... on.hash |
+| tst.js:14:10:14:33 | documen ... .search |
 | tst.js:14:10:14:33 | documen ... .search |
 | tst.js:14:10:14:74 | documen ... , "$1") |
 | tst.js:14:10:14:74 | documen ... , "$1") |
-| tst.js:17:21:17:37 | document.location |
-| tst.js:17:21:17:37 | document.location |
 | tst.js:17:21:17:42 | documen ... on.hash |
 | tst.js:17:21:17:42 | documen ... on.hash |
-| tst.js:20:30:20:46 | document.location |
-| tst.js:20:30:20:46 | document.location |
+| tst.js:17:21:17:42 | documen ... on.hash |
+| tst.js:20:30:20:51 | documen ... on.hash |
 | tst.js:20:30:20:51 | documen ... on.hash |
 | tst.js:20:30:20:51 | documen ... on.hash |
 | tst.js:23:6:23:46 | atob(do ... ing(1)) |
 | tst.js:23:6:23:46 | atob(do ... ing(1)) |
-| tst.js:23:11:23:27 | document.location |
-| tst.js:23:11:23:27 | document.location |
+| tst.js:23:11:23:32 | documen ... on.hash |
 | tst.js:23:11:23:32 | documen ... on.hash |
 | tst.js:23:11:23:45 | documen ... ring(1) |
-| tst.js:26:26:26:33 | location |
-| tst.js:26:26:26:33 | location |
+| tst.js:26:26:26:40 | location.search |
 | tst.js:26:26:26:40 | location.search |
 | tst.js:26:26:26:53 | locatio ... ring(1) |
 | tst.js:26:26:26:53 | locatio ... ring(1) |
@@ -191,62 +169,20 @@ edges
 | NoSQLCodeInjection.js:22:36:22:43 | req.body | NoSQLCodeInjection.js:22:36:22:48 | req.body.name |
 | NoSQLCodeInjection.js:22:36:22:48 | req.body.name | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
 | NoSQLCodeInjection.js:22:36:22:48 | req.body.name | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
-| angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
-| angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
-| angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
-| angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
-| angularjs.js:13:23:13:30 | location | angularjs.js:13:23:13:37 | location.search |
-| angularjs.js:13:23:13:30 | location | angularjs.js:13:23:13:37 | location.search |
-| angularjs.js:13:23:13:30 | location | angularjs.js:13:23:13:37 | location.search |
-| angularjs.js:13:23:13:30 | location | angularjs.js:13:23:13:37 | location.search |
-| angularjs.js:16:28:16:35 | location | angularjs.js:16:28:16:42 | location.search |
-| angularjs.js:16:28:16:35 | location | angularjs.js:16:28:16:42 | location.search |
-| angularjs.js:16:28:16:35 | location | angularjs.js:16:28:16:42 | location.search |
-| angularjs.js:16:28:16:35 | location | angularjs.js:16:28:16:42 | location.search |
-| angularjs.js:19:22:19:29 | location | angularjs.js:19:22:19:36 | location.search |
-| angularjs.js:19:22:19:29 | location | angularjs.js:19:22:19:36 | location.search |
-| angularjs.js:19:22:19:29 | location | angularjs.js:19:22:19:36 | location.search |
-| angularjs.js:19:22:19:29 | location | angularjs.js:19:22:19:36 | location.search |
-| angularjs.js:22:27:22:34 | location | angularjs.js:22:27:22:41 | location.search |
-| angularjs.js:22:27:22:34 | location | angularjs.js:22:27:22:41 | location.search |
-| angularjs.js:22:27:22:34 | location | angularjs.js:22:27:22:41 | location.search |
-| angularjs.js:22:27:22:34 | location | angularjs.js:22:27:22:41 | location.search |
-| angularjs.js:25:23:25:30 | location | angularjs.js:25:23:25:37 | location.search |
-| angularjs.js:25:23:25:30 | location | angularjs.js:25:23:25:37 | location.search |
-| angularjs.js:25:23:25:30 | location | angularjs.js:25:23:25:37 | location.search |
-| angularjs.js:25:23:25:30 | location | angularjs.js:25:23:25:37 | location.search |
-| angularjs.js:28:33:28:40 | location | angularjs.js:28:33:28:47 | location.search |
-| angularjs.js:28:33:28:40 | location | angularjs.js:28:33:28:47 | location.search |
-| angularjs.js:28:33:28:40 | location | angularjs.js:28:33:28:47 | location.search |
-| angularjs.js:28:33:28:40 | location | angularjs.js:28:33:28:47 | location.search |
-| angularjs.js:31:28:31:35 | location | angularjs.js:31:28:31:42 | location.search |
-| angularjs.js:31:28:31:35 | location | angularjs.js:31:28:31:42 | location.search |
-| angularjs.js:31:28:31:35 | location | angularjs.js:31:28:31:42 | location.search |
-| angularjs.js:31:28:31:35 | location | angularjs.js:31:28:31:42 | location.search |
-| angularjs.js:34:18:34:25 | location | angularjs.js:34:18:34:32 | location.search |
-| angularjs.js:34:18:34:25 | location | angularjs.js:34:18:34:32 | location.search |
-| angularjs.js:34:18:34:25 | location | angularjs.js:34:18:34:32 | location.search |
-| angularjs.js:34:18:34:25 | location | angularjs.js:34:18:34:32 | location.search |
-| angularjs.js:40:18:40:25 | location | angularjs.js:40:18:40:32 | location.search |
-| angularjs.js:40:18:40:25 | location | angularjs.js:40:18:40:32 | location.search |
-| angularjs.js:40:18:40:25 | location | angularjs.js:40:18:40:32 | location.search |
-| angularjs.js:40:18:40:25 | location | angularjs.js:40:18:40:32 | location.search |
-| angularjs.js:44:17:44:24 | location | angularjs.js:44:17:44:31 | location.search |
-| angularjs.js:44:17:44:24 | location | angularjs.js:44:17:44:31 | location.search |
-| angularjs.js:44:17:44:24 | location | angularjs.js:44:17:44:31 | location.search |
-| angularjs.js:44:17:44:24 | location | angularjs.js:44:17:44:31 | location.search |
-| angularjs.js:47:16:47:23 | location | angularjs.js:47:16:47:30 | location.search |
-| angularjs.js:47:16:47:23 | location | angularjs.js:47:16:47:30 | location.search |
-| angularjs.js:47:16:47:23 | location | angularjs.js:47:16:47:30 | location.search |
-| angularjs.js:47:16:47:23 | location | angularjs.js:47:16:47:30 | location.search |
-| angularjs.js:50:22:50:29 | location | angularjs.js:50:22:50:36 | location.search |
-| angularjs.js:50:22:50:29 | location | angularjs.js:50:22:50:36 | location.search |
-| angularjs.js:50:22:50:29 | location | angularjs.js:50:22:50:36 | location.search |
-| angularjs.js:50:22:50:29 | location | angularjs.js:50:22:50:36 | location.search |
-| angularjs.js:53:32:53:39 | location | angularjs.js:53:32:53:46 | location.search |
-| angularjs.js:53:32:53:39 | location | angularjs.js:53:32:53:46 | location.search |
-| angularjs.js:53:32:53:39 | location | angularjs.js:53:32:53:46 | location.search |
-| angularjs.js:53:32:53:39 | location | angularjs.js:53:32:53:46 | location.search |
+| angularjs.js:10:22:10:36 | location.search | angularjs.js:10:22:10:36 | location.search |
+| angularjs.js:13:23:13:37 | location.search | angularjs.js:13:23:13:37 | location.search |
+| angularjs.js:16:28:16:42 | location.search | angularjs.js:16:28:16:42 | location.search |
+| angularjs.js:19:22:19:36 | location.search | angularjs.js:19:22:19:36 | location.search |
+| angularjs.js:22:27:22:41 | location.search | angularjs.js:22:27:22:41 | location.search |
+| angularjs.js:25:23:25:37 | location.search | angularjs.js:25:23:25:37 | location.search |
+| angularjs.js:28:33:28:47 | location.search | angularjs.js:28:33:28:47 | location.search |
+| angularjs.js:31:28:31:42 | location.search | angularjs.js:31:28:31:42 | location.search |
+| angularjs.js:34:18:34:32 | location.search | angularjs.js:34:18:34:32 | location.search |
+| angularjs.js:40:18:40:32 | location.search | angularjs.js:40:18:40:32 | location.search |
+| angularjs.js:44:17:44:31 | location.search | angularjs.js:44:17:44:31 | location.search |
+| angularjs.js:47:16:47:30 | location.search | angularjs.js:47:16:47:30 | location.search |
+| angularjs.js:50:22:50:36 | location.search | angularjs.js:50:22:50:36 | location.search |
+| angularjs.js:53:32:53:46 | location.search | angularjs.js:53:32:53:46 | location.search |
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` |
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` |
 | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
@@ -287,10 +223,7 @@ edges
 | react-native.js:7:7:7:33 | tainted | react-native.js:10:23:10:29 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
-| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
-| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
-| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
-| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
+| react.js:10:56:10:77 | documen ... on.hash | react.js:10:56:10:77 | documen ... on.hash |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:15:16:15:22 | tainted |
@@ -309,33 +242,23 @@ edges
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:21:21:21:27 | tainted |
 | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:12:9:12:31 | tainted |
 | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:12:9:12:31 | tainted |
-| tst.js:2:6:2:22 | document.location | tst.js:2:6:2:27 | documen ... on.href |
-| tst.js:2:6:2:22 | document.location | tst.js:2:6:2:27 | documen ... on.href |
 | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
 | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
-| tst.js:5:12:5:28 | document.location | tst.js:5:12:5:33 | documen ... on.hash |
-| tst.js:5:12:5:28 | document.location | tst.js:5:12:5:33 | documen ... on.hash |
-| tst.js:5:12:5:28 | document.location | tst.js:5:12:5:33 | documen ... on.hash |
-| tst.js:5:12:5:28 | document.location | tst.js:5:12:5:33 | documen ... on.hash |
-| tst.js:14:10:14:26 | document.location | tst.js:14:10:14:33 | documen ... .search |
-| tst.js:14:10:14:26 | document.location | tst.js:14:10:14:33 | documen ... .search |
+| tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
+| tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
+| tst.js:5:12:5:33 | documen ... on.hash | tst.js:5:12:5:33 | documen ... on.hash |
 | tst.js:14:10:14:33 | documen ... .search | tst.js:14:10:14:74 | documen ... , "$1") |
 | tst.js:14:10:14:33 | documen ... .search | tst.js:14:10:14:74 | documen ... , "$1") |
-| tst.js:17:21:17:37 | document.location | tst.js:17:21:17:42 | documen ... on.hash |
-| tst.js:17:21:17:37 | document.location | tst.js:17:21:17:42 | documen ... on.hash |
-| tst.js:17:21:17:37 | document.location | tst.js:17:21:17:42 | documen ... on.hash |
-| tst.js:17:21:17:37 | document.location | tst.js:17:21:17:42 | documen ... on.hash |
-| tst.js:20:30:20:46 | document.location | tst.js:20:30:20:51 | documen ... on.hash |
-| tst.js:20:30:20:46 | document.location | tst.js:20:30:20:51 | documen ... on.hash |
-| tst.js:20:30:20:46 | document.location | tst.js:20:30:20:51 | documen ... on.hash |
-| tst.js:20:30:20:46 | document.location | tst.js:20:30:20:51 | documen ... on.hash |
-| tst.js:23:11:23:27 | document.location | tst.js:23:11:23:32 | documen ... on.hash |
-| tst.js:23:11:23:27 | document.location | tst.js:23:11:23:32 | documen ... on.hash |
+| tst.js:14:10:14:33 | documen ... .search | tst.js:14:10:14:74 | documen ... , "$1") |
+| tst.js:14:10:14:33 | documen ... .search | tst.js:14:10:14:74 | documen ... , "$1") |
+| tst.js:17:21:17:42 | documen ... on.hash | tst.js:17:21:17:42 | documen ... on.hash |
+| tst.js:20:30:20:51 | documen ... on.hash | tst.js:20:30:20:51 | documen ... on.hash |
+| tst.js:23:11:23:32 | documen ... on.hash | tst.js:23:11:23:45 | documen ... ring(1) |
 | tst.js:23:11:23:32 | documen ... on.hash | tst.js:23:11:23:45 | documen ... ring(1) |
 | tst.js:23:11:23:45 | documen ... ring(1) | tst.js:23:6:23:46 | atob(do ... ing(1)) |
 | tst.js:23:11:23:45 | documen ... ring(1) | tst.js:23:6:23:46 | atob(do ... ing(1)) |
-| tst.js:26:26:26:33 | location | tst.js:26:26:26:40 | location.search |
-| tst.js:26:26:26:33 | location | tst.js:26:26:26:40 | location.search |
+| tst.js:26:26:26:40 | location.search | tst.js:26:26:26:53 | locatio ... ring(1) |
+| tst.js:26:26:26:40 | location.search | tst.js:26:26:26:53 | locatio ... ring(1) |
 | tst.js:26:26:26:40 | location.search | tst.js:26:26:26:53 | locatio ... ring(1) |
 | tst.js:26:26:26:40 | location.search | tst.js:26:26:26:53 | locatio ... ring(1) |
 #select

--- a/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
@@ -46,13 +46,10 @@ nodes
 | sanitizer.js:37:27:37:29 | url |
 | sanitizer.js:37:27:37:29 | url |
 | tst2.js:2:7:2:33 | href |
-| tst2.js:2:7:2:33 | href |
-| tst2.js:2:14:2:28 | window.location |
 | tst2.js:2:14:2:28 | window.location |
 | tst2.js:2:14:2:28 | window.location |
 | tst2.js:2:14:2:33 | window.location.href |
 | tst2.js:2:14:2:33 | window.location.href |
-| tst2.js:4:21:4:24 | href |
 | tst2.js:4:21:4:24 | href |
 | tst2.js:4:21:4:55 | href.su ... '?')+1) |
 | tst2.js:4:21:4:55 | href.su ... '?')+1) |
@@ -67,44 +64,34 @@ nodes
 | tst6.js:8:21:8:48 | $locati ... irect') |
 | tst6.js:8:21:8:56 | $locati ... + "foo" |
 | tst6.js:8:21:8:56 | $locati ... + "foo" |
-| tst7.js:2:12:2:28 | document.location |
-| tst7.js:2:12:2:28 | document.location |
 | tst7.js:2:12:2:35 | documen ... .search |
 | tst7.js:2:12:2:35 | documen ... .search |
-| tst7.js:5:27:5:43 | document.location |
-| tst7.js:5:27:5:43 | document.location |
+| tst7.js:2:12:2:35 | documen ... .search |
 | tst7.js:5:27:5:50 | documen ... .search |
 | tst7.js:5:27:5:50 | documen ... .search |
-| tst9.js:2:21:2:37 | document.location |
-| tst9.js:2:21:2:37 | document.location |
-| tst9.js:2:21:2:37 | document.location |
+| tst7.js:5:27:5:50 | documen ... .search |
+| tst9.js:2:21:2:42 | documen ... on.hash |
 | tst9.js:2:21:2:42 | documen ... on.hash |
 | tst9.js:2:21:2:55 | documen ... ring(1) |
 | tst9.js:2:21:2:55 | documen ... ring(1) |
 | tst10.js:5:17:5:46 | '/' + d ... .search |
 | tst10.js:5:17:5:46 | '/' + d ... .search |
-| tst10.js:5:23:5:39 | document.location |
-| tst10.js:5:23:5:39 | document.location |
+| tst10.js:5:23:5:46 | documen ... .search |
 | tst10.js:5:23:5:46 | documen ... .search |
 | tst10.js:8:17:8:47 | '//' +  ... .search |
 | tst10.js:8:17:8:47 | '//' +  ... .search |
-| tst10.js:8:24:8:40 | document.location |
-| tst10.js:8:24:8:40 | document.location |
+| tst10.js:8:24:8:47 | documen ... .search |
 | tst10.js:8:24:8:47 | documen ... .search |
 | tst10.js:11:17:11:50 | '//foo' ... .search |
 | tst10.js:11:17:11:50 | '//foo' ... .search |
-| tst10.js:11:27:11:43 | document.location |
-| tst10.js:11:27:11:43 | document.location |
+| tst10.js:11:27:11:50 | documen ... .search |
 | tst10.js:11:27:11:50 | documen ... .search |
 | tst10.js:14:17:14:56 | 'https: ... .search |
 | tst10.js:14:17:14:56 | 'https: ... .search |
-| tst10.js:14:33:14:49 | document.location |
-| tst10.js:14:33:14:49 | document.location |
+| tst10.js:14:33:14:56 | documen ... .search |
 | tst10.js:14:33:14:56 | documen ... .search |
 | tst12.js:3:9:3:50 | urlParts |
-| tst12.js:3:20:3:34 | window.location |
-| tst12.js:3:20:3:34 | window.location |
-| tst12.js:3:20:3:34 | window.location |
+| tst12.js:3:20:3:39 | window.location.hash |
 | tst12.js:3:20:3:39 | window.location.hash |
 | tst12.js:3:20:3:50 | window. ... it('?') |
 | tst12.js:4:9:4:45 | loc |
@@ -114,8 +101,7 @@ nodes
 | tst12.js:5:23:5:25 | loc |
 | tst12.js:5:23:5:25 | loc |
 | tst13.js:2:9:2:52 | payload |
-| tst13.js:2:19:2:35 | document.location |
-| tst13.js:2:19:2:35 | document.location |
+| tst13.js:2:19:2:42 | documen ... .search |
 | tst13.js:2:19:2:42 | documen ... .search |
 | tst13.js:2:19:2:52 | documen ... bstr(1) |
 | tst13.js:4:15:4:21 | payload |
@@ -154,11 +140,13 @@ nodes
 | tst.js:2:47:2:63 | document.location |
 | tst.js:2:47:2:63 | document.location |
 | tst.js:2:47:2:68 | documen ... on.href |
+| tst.js:2:47:2:68 | documen ... on.href |
 | tst.js:6:20:6:56 | indirec ... n.href) |
 | tst.js:6:20:6:59 | indirec ... ref)[1] |
 | tst.js:6:20:6:59 | indirec ... ref)[1] |
 | tst.js:6:34:6:50 | document.location |
 | tst.js:6:34:6:50 | document.location |
+| tst.js:6:34:6:55 | documen ... on.href |
 | tst.js:6:34:6:55 | documen ... on.href |
 | tst.js:10:19:10:81 | new Reg ... n.href) |
 | tst.js:10:19:10:84 | new Reg ... ref)[1] |
@@ -166,11 +154,13 @@ nodes
 | tst.js:10:59:10:75 | document.location |
 | tst.js:10:59:10:75 | document.location |
 | tst.js:10:59:10:80 | documen ... on.href |
+| tst.js:10:59:10:80 | documen ... on.href |
 | tst.js:14:20:14:56 | indirec ... n.href) |
 | tst.js:14:20:14:59 | indirec ... ref)[1] |
 | tst.js:14:20:14:59 | indirec ... ref)[1] |
 | tst.js:14:34:14:50 | document.location |
 | tst.js:14:34:14:50 | document.location |
+| tst.js:14:34:14:55 | documen ... on.href |
 | tst.js:14:34:14:55 | documen ... on.href |
 | tst.js:18:19:18:81 | new Reg ... n.href) |
 | tst.js:18:19:18:84 | new Reg ... ref)[1] |
@@ -178,31 +168,22 @@ nodes
 | tst.js:18:59:18:75 | document.location |
 | tst.js:18:59:18:75 | document.location |
 | tst.js:18:59:18:80 | documen ... on.href |
+| tst.js:18:59:18:80 | documen ... on.href |
 | tst.js:22:20:22:56 | indirec ... n.href) |
 | tst.js:22:20:22:59 | indirec ... ref)[1] |
 | tst.js:22:20:22:59 | indirec ... ref)[1] |
 | tst.js:22:34:22:50 | document.location |
 | tst.js:22:34:22:50 | document.location |
 | tst.js:22:34:22:55 | documen ... on.href |
-| typed.ts:3:15:3:72 | location |
-| typed.ts:3:17:3:24 | location |
-| typed.ts:3:17:3:24 | location |
+| tst.js:22:34:22:55 | documen ... on.href |
 | typed.ts:4:13:4:36 | params |
-| typed.ts:4:22:4:29 | location |
+| typed.ts:4:22:4:36 | location.search |
 | typed.ts:4:22:4:36 | location.search |
 | typed.ts:5:25:5:30 | params |
 | typed.ts:7:24:7:34 | redirectUri |
 | typed.ts:8:33:8:43 | redirectUri |
 | typed.ts:8:33:8:43 | redirectUri |
-| typed.ts:14:15:14:72 | location |
-| typed.ts:14:17:14:24 | location |
-| typed.ts:14:17:14:24 | location |
-| typed.ts:17:18:17:25 | location |
-| typed.ts:19:13:19:37 | secondLoc |
-| typed.ts:19:25:19:37 | container.loc |
-| typed.ts:21:33:21:41 | secondLoc |
-| typed.ts:24:32:24:34 | loc |
-| typed.ts:25:25:25:27 | loc |
+| typed.ts:25:25:25:34 | loc.search |
 | typed.ts:25:25:25:34 | loc.search |
 | typed.ts:28:24:28:34 | redirectUri |
 | typed.ts:29:33:29:43 | redirectUri |
@@ -251,17 +232,12 @@ edges
 | sanitizer.js:2:15:2:25 | window.name | sanitizer.js:2:9:2:25 | url |
 | sanitizer.js:2:15:2:25 | window.name | sanitizer.js:2:9:2:25 | url |
 | tst2.js:2:7:2:33 | href | tst2.js:4:21:4:24 | href |
-| tst2.js:2:7:2:33 | href | tst2.js:4:21:4:24 | href |
-| tst2.js:2:14:2:28 | window.location | tst2.js:2:14:2:33 | window.location.href |
 | tst2.js:2:14:2:28 | window.location | tst2.js:2:14:2:33 | window.location.href |
 | tst2.js:2:14:2:28 | window.location | tst2.js:2:14:2:33 | window.location.href |
 | tst2.js:2:14:2:33 | window.location.href | tst2.js:2:7:2:33 | href |
 | tst2.js:2:14:2:33 | window.location.href | tst2.js:2:7:2:33 | href |
 | tst2.js:4:21:4:24 | href | tst2.js:4:21:4:55 | href.su ... '?')+1) |
 | tst2.js:4:21:4:24 | href | tst2.js:4:21:4:55 | href.su ... '?')+1) |
-| tst2.js:4:21:4:24 | href | tst2.js:4:21:4:55 | href.su ... '?')+1) |
-| tst2.js:4:21:4:24 | href | tst2.js:4:21:4:55 | href.su ... '?')+1) |
-| tst2.js:4:21:4:55 | href.su ... '?')+1) | tst2.js:2:14:2:28 | window.location |
 | tst6.js:2:7:2:45 | redirect | tst6.js:4:21:4:28 | redirect |
 | tst6.js:2:7:2:45 | redirect | tst6.js:4:21:4:28 | redirect |
 | tst6.js:2:7:2:45 | redirect | tst6.js:6:17:6:24 | redirect |
@@ -272,40 +248,30 @@ edges
 | tst6.js:8:21:8:48 | $locati ... irect') | tst6.js:8:21:8:56 | $locati ... + "foo" |
 | tst6.js:8:21:8:48 | $locati ... irect') | tst6.js:8:21:8:56 | $locati ... + "foo" |
 | tst6.js:8:21:8:48 | $locati ... irect') | tst6.js:8:21:8:56 | $locati ... + "foo" |
-| tst7.js:2:12:2:28 | document.location | tst7.js:2:12:2:35 | documen ... .search |
-| tst7.js:2:12:2:28 | document.location | tst7.js:2:12:2:35 | documen ... .search |
-| tst7.js:2:12:2:28 | document.location | tst7.js:2:12:2:35 | documen ... .search |
-| tst7.js:2:12:2:28 | document.location | tst7.js:2:12:2:35 | documen ... .search |
-| tst7.js:5:27:5:43 | document.location | tst7.js:5:27:5:50 | documen ... .search |
-| tst7.js:5:27:5:43 | document.location | tst7.js:5:27:5:50 | documen ... .search |
-| tst7.js:5:27:5:43 | document.location | tst7.js:5:27:5:50 | documen ... .search |
-| tst7.js:5:27:5:43 | document.location | tst7.js:5:27:5:50 | documen ... .search |
-| tst9.js:2:21:2:37 | document.location | tst9.js:2:21:2:42 | documen ... on.hash |
-| tst9.js:2:21:2:37 | document.location | tst9.js:2:21:2:42 | documen ... on.hash |
-| tst9.js:2:21:2:37 | document.location | tst9.js:2:21:2:42 | documen ... on.hash |
+| tst7.js:2:12:2:35 | documen ... .search | tst7.js:2:12:2:35 | documen ... .search |
+| tst7.js:5:27:5:50 | documen ... .search | tst7.js:5:27:5:50 | documen ... .search |
 | tst9.js:2:21:2:42 | documen ... on.hash | tst9.js:2:21:2:55 | documen ... ring(1) |
 | tst9.js:2:21:2:42 | documen ... on.hash | tst9.js:2:21:2:55 | documen ... ring(1) |
-| tst9.js:2:21:2:55 | documen ... ring(1) | tst9.js:2:21:2:37 | document.location |
-| tst10.js:5:23:5:39 | document.location | tst10.js:5:23:5:46 | documen ... .search |
-| tst10.js:5:23:5:39 | document.location | tst10.js:5:23:5:46 | documen ... .search |
+| tst9.js:2:21:2:42 | documen ... on.hash | tst9.js:2:21:2:55 | documen ... ring(1) |
+| tst9.js:2:21:2:42 | documen ... on.hash | tst9.js:2:21:2:55 | documen ... ring(1) |
 | tst10.js:5:23:5:46 | documen ... .search | tst10.js:5:17:5:46 | '/' + d ... .search |
 | tst10.js:5:23:5:46 | documen ... .search | tst10.js:5:17:5:46 | '/' + d ... .search |
-| tst10.js:8:24:8:40 | document.location | tst10.js:8:24:8:47 | documen ... .search |
-| tst10.js:8:24:8:40 | document.location | tst10.js:8:24:8:47 | documen ... .search |
+| tst10.js:5:23:5:46 | documen ... .search | tst10.js:5:17:5:46 | '/' + d ... .search |
+| tst10.js:5:23:5:46 | documen ... .search | tst10.js:5:17:5:46 | '/' + d ... .search |
 | tst10.js:8:24:8:47 | documen ... .search | tst10.js:8:17:8:47 | '//' +  ... .search |
 | tst10.js:8:24:8:47 | documen ... .search | tst10.js:8:17:8:47 | '//' +  ... .search |
-| tst10.js:11:27:11:43 | document.location | tst10.js:11:27:11:50 | documen ... .search |
-| tst10.js:11:27:11:43 | document.location | tst10.js:11:27:11:50 | documen ... .search |
+| tst10.js:8:24:8:47 | documen ... .search | tst10.js:8:17:8:47 | '//' +  ... .search |
+| tst10.js:8:24:8:47 | documen ... .search | tst10.js:8:17:8:47 | '//' +  ... .search |
 | tst10.js:11:27:11:50 | documen ... .search | tst10.js:11:17:11:50 | '//foo' ... .search |
 | tst10.js:11:27:11:50 | documen ... .search | tst10.js:11:17:11:50 | '//foo' ... .search |
-| tst10.js:14:33:14:49 | document.location | tst10.js:14:33:14:56 | documen ... .search |
-| tst10.js:14:33:14:49 | document.location | tst10.js:14:33:14:56 | documen ... .search |
+| tst10.js:11:27:11:50 | documen ... .search | tst10.js:11:17:11:50 | '//foo' ... .search |
+| tst10.js:11:27:11:50 | documen ... .search | tst10.js:11:17:11:50 | '//foo' ... .search |
+| tst10.js:14:33:14:56 | documen ... .search | tst10.js:14:17:14:56 | 'https: ... .search |
+| tst10.js:14:33:14:56 | documen ... .search | tst10.js:14:17:14:56 | 'https: ... .search |
 | tst10.js:14:33:14:56 | documen ... .search | tst10.js:14:17:14:56 | 'https: ... .search |
 | tst10.js:14:33:14:56 | documen ... .search | tst10.js:14:17:14:56 | 'https: ... .search |
 | tst12.js:3:9:3:50 | urlParts | tst12.js:4:15:4:22 | urlParts |
-| tst12.js:3:20:3:34 | window.location | tst12.js:3:20:3:39 | window.location.hash |
-| tst12.js:3:20:3:34 | window.location | tst12.js:3:20:3:39 | window.location.hash |
-| tst12.js:3:20:3:34 | window.location | tst12.js:3:20:3:39 | window.location.hash |
+| tst12.js:3:20:3:39 | window.location.hash | tst12.js:3:20:3:50 | window. ... it('?') |
 | tst12.js:3:20:3:39 | window.location.hash | tst12.js:3:20:3:50 | window. ... it('?') |
 | tst12.js:3:20:3:50 | window. ... it('?') | tst12.js:3:9:3:50 | urlParts |
 | tst12.js:4:9:4:45 | loc | tst12.js:5:23:5:25 | loc |
@@ -313,7 +279,6 @@ edges
 | tst12.js:4:15:4:22 | urlParts | tst12.js:4:15:4:25 | urlParts[0] |
 | tst12.js:4:15:4:25 | urlParts[0] | tst12.js:4:15:4:45 | urlPart ... s.value |
 | tst12.js:4:15:4:45 | urlPart ... s.value | tst12.js:4:9:4:45 | loc |
-| tst12.js:5:23:5:25 | loc | tst12.js:3:20:3:34 | window.location |
 | tst13.js:2:9:2:52 | payload | tst13.js:4:15:4:21 | payload |
 | tst13.js:2:9:2:52 | payload | tst13.js:4:15:4:21 | payload |
 | tst13.js:2:9:2:52 | payload | tst13.js:8:21:8:27 | payload |
@@ -336,8 +301,7 @@ edges
 | tst13.js:2:9:2:52 | payload | tst13.js:40:15:40:21 | payload |
 | tst13.js:2:9:2:52 | payload | tst13.js:44:14:44:20 | payload |
 | tst13.js:2:9:2:52 | payload | tst13.js:44:14:44:20 | payload |
-| tst13.js:2:19:2:35 | document.location | tst13.js:2:19:2:42 | documen ... .search |
-| tst13.js:2:19:2:35 | document.location | tst13.js:2:19:2:42 | documen ... .search |
+| tst13.js:2:19:2:42 | documen ... .search | tst13.js:2:19:2:52 | documen ... bstr(1) |
 | tst13.js:2:19:2:42 | documen ... .search | tst13.js:2:19:2:52 | documen ... bstr(1) |
 | tst13.js:2:19:2:52 | documen ... bstr(1) | tst13.js:2:9:2:52 | payload |
 | tst13.js:49:32:49:32 | e | tst13.js:50:23:50:23 | e |
@@ -353,49 +317,44 @@ edges
 | tst.js:2:47:2:63 | document.location | tst.js:2:47:2:68 | documen ... on.href |
 | tst.js:2:47:2:63 | document.location | tst.js:2:47:2:68 | documen ... on.href |
 | tst.js:2:47:2:68 | documen ... on.href | tst.js:2:19:2:69 | /.*redi ... n.href) |
+| tst.js:2:47:2:68 | documen ... on.href | tst.js:2:19:2:69 | /.*redi ... n.href) |
 | tst.js:6:20:6:56 | indirec ... n.href) | tst.js:6:20:6:59 | indirec ... ref)[1] |
 | tst.js:6:20:6:56 | indirec ... n.href) | tst.js:6:20:6:59 | indirec ... ref)[1] |
 | tst.js:6:34:6:50 | document.location | tst.js:6:34:6:55 | documen ... on.href |
 | tst.js:6:34:6:50 | document.location | tst.js:6:34:6:55 | documen ... on.href |
+| tst.js:6:34:6:55 | documen ... on.href | tst.js:6:20:6:56 | indirec ... n.href) |
 | tst.js:6:34:6:55 | documen ... on.href | tst.js:6:20:6:56 | indirec ... n.href) |
 | tst.js:10:19:10:81 | new Reg ... n.href) | tst.js:10:19:10:84 | new Reg ... ref)[1] |
 | tst.js:10:19:10:81 | new Reg ... n.href) | tst.js:10:19:10:84 | new Reg ... ref)[1] |
 | tst.js:10:59:10:75 | document.location | tst.js:10:59:10:80 | documen ... on.href |
 | tst.js:10:59:10:75 | document.location | tst.js:10:59:10:80 | documen ... on.href |
 | tst.js:10:59:10:80 | documen ... on.href | tst.js:10:19:10:81 | new Reg ... n.href) |
+| tst.js:10:59:10:80 | documen ... on.href | tst.js:10:19:10:81 | new Reg ... n.href) |
 | tst.js:14:20:14:56 | indirec ... n.href) | tst.js:14:20:14:59 | indirec ... ref)[1] |
 | tst.js:14:20:14:56 | indirec ... n.href) | tst.js:14:20:14:59 | indirec ... ref)[1] |
 | tst.js:14:34:14:50 | document.location | tst.js:14:34:14:55 | documen ... on.href |
 | tst.js:14:34:14:50 | document.location | tst.js:14:34:14:55 | documen ... on.href |
+| tst.js:14:34:14:55 | documen ... on.href | tst.js:14:20:14:56 | indirec ... n.href) |
 | tst.js:14:34:14:55 | documen ... on.href | tst.js:14:20:14:56 | indirec ... n.href) |
 | tst.js:18:19:18:81 | new Reg ... n.href) | tst.js:18:19:18:84 | new Reg ... ref)[1] |
 | tst.js:18:19:18:81 | new Reg ... n.href) | tst.js:18:19:18:84 | new Reg ... ref)[1] |
 | tst.js:18:59:18:75 | document.location | tst.js:18:59:18:80 | documen ... on.href |
 | tst.js:18:59:18:75 | document.location | tst.js:18:59:18:80 | documen ... on.href |
 | tst.js:18:59:18:80 | documen ... on.href | tst.js:18:19:18:81 | new Reg ... n.href) |
+| tst.js:18:59:18:80 | documen ... on.href | tst.js:18:19:18:81 | new Reg ... n.href) |
 | tst.js:22:20:22:56 | indirec ... n.href) | tst.js:22:20:22:59 | indirec ... ref)[1] |
 | tst.js:22:20:22:56 | indirec ... n.href) | tst.js:22:20:22:59 | indirec ... ref)[1] |
 | tst.js:22:34:22:50 | document.location | tst.js:22:34:22:55 | documen ... on.href |
 | tst.js:22:34:22:50 | document.location | tst.js:22:34:22:55 | documen ... on.href |
 | tst.js:22:34:22:55 | documen ... on.href | tst.js:22:20:22:56 | indirec ... n.href) |
-| typed.ts:3:15:3:72 | location | typed.ts:4:22:4:29 | location |
-| typed.ts:3:17:3:24 | location | typed.ts:3:15:3:72 | location |
-| typed.ts:3:17:3:24 | location | typed.ts:3:15:3:72 | location |
+| tst.js:22:34:22:55 | documen ... on.href | tst.js:22:20:22:56 | indirec ... n.href) |
 | typed.ts:4:13:4:36 | params | typed.ts:5:25:5:30 | params |
-| typed.ts:4:22:4:29 | location | typed.ts:4:22:4:36 | location.search |
+| typed.ts:4:22:4:36 | location.search | typed.ts:4:13:4:36 | params |
 | typed.ts:4:22:4:36 | location.search | typed.ts:4:13:4:36 | params |
 | typed.ts:5:25:5:30 | params | typed.ts:7:24:7:34 | redirectUri |
 | typed.ts:7:24:7:34 | redirectUri | typed.ts:8:33:8:43 | redirectUri |
 | typed.ts:7:24:7:34 | redirectUri | typed.ts:8:33:8:43 | redirectUri |
-| typed.ts:14:15:14:72 | location | typed.ts:17:18:17:25 | location |
-| typed.ts:14:17:14:24 | location | typed.ts:14:15:14:72 | location |
-| typed.ts:14:17:14:24 | location | typed.ts:14:15:14:72 | location |
-| typed.ts:17:18:17:25 | location | typed.ts:19:25:19:37 | container.loc |
-| typed.ts:19:13:19:37 | secondLoc | typed.ts:21:33:21:41 | secondLoc |
-| typed.ts:19:25:19:37 | container.loc | typed.ts:19:13:19:37 | secondLoc |
-| typed.ts:21:33:21:41 | secondLoc | typed.ts:24:32:24:34 | loc |
-| typed.ts:24:32:24:34 | loc | typed.ts:25:25:25:27 | loc |
-| typed.ts:25:25:25:27 | loc | typed.ts:25:25:25:34 | loc.search |
+| typed.ts:25:25:25:34 | loc.search | typed.ts:28:24:28:34 | redirectUri |
 | typed.ts:25:25:25:34 | loc.search | typed.ts:28:24:28:34 | redirectUri |
 | typed.ts:28:24:28:34 | redirectUri | typed.ts:29:33:29:43 | redirectUri |
 | typed.ts:28:24:28:34 | redirectUri | typed.ts:29:33:29:43 | redirectUri |
@@ -415,35 +374,42 @@ edges
 | sanitizer.js:31:27:31:29 | url | sanitizer.js:2:15:2:25 | window.name | sanitizer.js:31:27:31:29 | url | Untrusted URL redirection due to $@. | sanitizer.js:2:15:2:25 | window.name | user-provided value |
 | sanitizer.js:37:27:37:29 | url | sanitizer.js:2:15:2:25 | window.name | sanitizer.js:37:27:37:29 | url | Untrusted URL redirection due to $@. | sanitizer.js:2:15:2:25 | window.name | user-provided value |
 | tst2.js:4:21:4:55 | href.su ... '?')+1) | tst2.js:2:14:2:28 | window.location | tst2.js:4:21:4:55 | href.su ... '?')+1) | Untrusted URL redirection due to $@. | tst2.js:2:14:2:28 | window.location | user-provided value |
+| tst2.js:4:21:4:55 | href.su ... '?')+1) | tst2.js:2:14:2:33 | window.location.href | tst2.js:4:21:4:55 | href.su ... '?')+1) | Untrusted URL redirection due to $@. | tst2.js:2:14:2:33 | window.location.href | user-provided value |
 | tst6.js:4:21:4:28 | redirect | tst6.js:2:18:2:45 | $locati ... irect') | tst6.js:4:21:4:28 | redirect | Untrusted URL redirection due to $@. | tst6.js:2:18:2:45 | $locati ... irect') | user-provided value |
 | tst6.js:6:17:6:24 | redirect | tst6.js:2:18:2:45 | $locati ... irect') | tst6.js:6:17:6:24 | redirect | Untrusted URL redirection due to $@. | tst6.js:2:18:2:45 | $locati ... irect') | user-provided value |
 | tst6.js:8:21:8:56 | $locati ... + "foo" | tst6.js:8:21:8:48 | $locati ... irect') | tst6.js:8:21:8:56 | $locati ... + "foo" | Untrusted URL redirection due to $@. | tst6.js:8:21:8:48 | $locati ... irect') | user-provided value |
-| tst7.js:2:12:2:35 | documen ... .search | tst7.js:2:12:2:28 | document.location | tst7.js:2:12:2:35 | documen ... .search | Untrusted URL redirection due to $@. | tst7.js:2:12:2:28 | document.location | user-provided value |
-| tst7.js:5:27:5:50 | documen ... .search | tst7.js:5:27:5:43 | document.location | tst7.js:5:27:5:50 | documen ... .search | Untrusted URL redirection due to $@. | tst7.js:5:27:5:43 | document.location | user-provided value |
-| tst9.js:2:21:2:55 | documen ... ring(1) | tst9.js:2:21:2:37 | document.location | tst9.js:2:21:2:55 | documen ... ring(1) | Untrusted URL redirection due to $@. | tst9.js:2:21:2:37 | document.location | user-provided value |
-| tst10.js:5:17:5:46 | '/' + d ... .search | tst10.js:5:23:5:39 | document.location | tst10.js:5:17:5:46 | '/' + d ... .search | Untrusted URL redirection due to $@. | tst10.js:5:23:5:39 | document.location | user-provided value |
-| tst10.js:8:17:8:47 | '//' +  ... .search | tst10.js:8:24:8:40 | document.location | tst10.js:8:17:8:47 | '//' +  ... .search | Untrusted URL redirection due to $@. | tst10.js:8:24:8:40 | document.location | user-provided value |
-| tst10.js:11:17:11:50 | '//foo' ... .search | tst10.js:11:27:11:43 | document.location | tst10.js:11:17:11:50 | '//foo' ... .search | Untrusted URL redirection due to $@. | tst10.js:11:27:11:43 | document.location | user-provided value |
-| tst10.js:14:17:14:56 | 'https: ... .search | tst10.js:14:33:14:49 | document.location | tst10.js:14:17:14:56 | 'https: ... .search | Untrusted URL redirection due to $@. | tst10.js:14:33:14:49 | document.location | user-provided value |
-| tst12.js:5:23:5:25 | loc | tst12.js:3:20:3:34 | window.location | tst12.js:5:23:5:25 | loc | Untrusted URL redirection due to $@. | tst12.js:3:20:3:34 | window.location | user-provided value |
-| tst13.js:4:15:4:21 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:4:15:4:21 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
-| tst13.js:8:21:8:27 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:8:21:8:27 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
-| tst13.js:12:14:12:20 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:12:14:12:20 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
-| tst13.js:16:17:16:23 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:16:17:16:23 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
-| tst13.js:20:14:20:20 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:20:14:20:20 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
-| tst13.js:24:14:24:20 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:24:14:24:20 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
-| tst13.js:28:21:28:27 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:28:21:28:27 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
-| tst13.js:32:17:32:23 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:32:17:32:23 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
-| tst13.js:36:21:36:27 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:36:21:36:27 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
-| tst13.js:40:15:40:21 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:40:15:40:21 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
-| tst13.js:44:14:44:20 | payload | tst13.js:2:19:2:35 | document.location | tst13.js:44:14:44:20 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:35 | document.location | user-provided value |
+| tst7.js:2:12:2:35 | documen ... .search | tst7.js:2:12:2:35 | documen ... .search | tst7.js:2:12:2:35 | documen ... .search | Untrusted URL redirection due to $@. | tst7.js:2:12:2:35 | documen ... .search | user-provided value |
+| tst7.js:5:27:5:50 | documen ... .search | tst7.js:5:27:5:50 | documen ... .search | tst7.js:5:27:5:50 | documen ... .search | Untrusted URL redirection due to $@. | tst7.js:5:27:5:50 | documen ... .search | user-provided value |
+| tst9.js:2:21:2:55 | documen ... ring(1) | tst9.js:2:21:2:42 | documen ... on.hash | tst9.js:2:21:2:55 | documen ... ring(1) | Untrusted URL redirection due to $@. | tst9.js:2:21:2:42 | documen ... on.hash | user-provided value |
+| tst10.js:5:17:5:46 | '/' + d ... .search | tst10.js:5:23:5:46 | documen ... .search | tst10.js:5:17:5:46 | '/' + d ... .search | Untrusted URL redirection due to $@. | tst10.js:5:23:5:46 | documen ... .search | user-provided value |
+| tst10.js:8:17:8:47 | '//' +  ... .search | tst10.js:8:24:8:47 | documen ... .search | tst10.js:8:17:8:47 | '//' +  ... .search | Untrusted URL redirection due to $@. | tst10.js:8:24:8:47 | documen ... .search | user-provided value |
+| tst10.js:11:17:11:50 | '//foo' ... .search | tst10.js:11:27:11:50 | documen ... .search | tst10.js:11:17:11:50 | '//foo' ... .search | Untrusted URL redirection due to $@. | tst10.js:11:27:11:50 | documen ... .search | user-provided value |
+| tst10.js:14:17:14:56 | 'https: ... .search | tst10.js:14:33:14:56 | documen ... .search | tst10.js:14:17:14:56 | 'https: ... .search | Untrusted URL redirection due to $@. | tst10.js:14:33:14:56 | documen ... .search | user-provided value |
+| tst12.js:5:23:5:25 | loc | tst12.js:3:20:3:39 | window.location.hash | tst12.js:5:23:5:25 | loc | Untrusted URL redirection due to $@. | tst12.js:3:20:3:39 | window.location.hash | user-provided value |
+| tst13.js:4:15:4:21 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:4:15:4:21 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
+| tst13.js:8:21:8:27 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:8:21:8:27 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
+| tst13.js:12:14:12:20 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:12:14:12:20 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
+| tst13.js:16:17:16:23 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:16:17:16:23 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
+| tst13.js:20:14:20:20 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:20:14:20:20 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
+| tst13.js:24:14:24:20 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:24:14:24:20 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
+| tst13.js:28:21:28:27 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:28:21:28:27 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
+| tst13.js:32:17:32:23 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:32:17:32:23 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
+| tst13.js:36:21:36:27 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:36:21:36:27 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
+| tst13.js:40:15:40:21 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:40:15:40:21 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
+| tst13.js:44:14:44:20 | payload | tst13.js:2:19:2:42 | documen ... .search | tst13.js:44:14:44:20 | payload | Untrusted URL redirection due to $@. | tst13.js:2:19:2:42 | documen ... .search | user-provided value |
 | tst13.js:50:23:50:23 | e | tst13.js:49:32:49:32 | e | tst13.js:50:23:50:23 | e | Untrusted URL redirection due to $@. | tst13.js:49:32:49:32 | e | user-provided value |
 | tst13.js:53:28:53:28 | e | tst13.js:52:34:52:34 | e | tst13.js:53:28:53:28 | e | Untrusted URL redirection due to $@. | tst13.js:52:34:52:34 | e | user-provided value |
 | tst.js:2:19:2:72 | /.*redi ... ref)[1] | tst.js:2:47:2:63 | document.location | tst.js:2:19:2:72 | /.*redi ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:2:47:2:63 | document.location | user-provided value |
+| tst.js:2:19:2:72 | /.*redi ... ref)[1] | tst.js:2:47:2:68 | documen ... on.href | tst.js:2:19:2:72 | /.*redi ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:2:47:2:68 | documen ... on.href | user-provided value |
 | tst.js:6:20:6:59 | indirec ... ref)[1] | tst.js:6:34:6:50 | document.location | tst.js:6:20:6:59 | indirec ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:6:34:6:50 | document.location | user-provided value |
+| tst.js:6:20:6:59 | indirec ... ref)[1] | tst.js:6:34:6:55 | documen ... on.href | tst.js:6:20:6:59 | indirec ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:6:34:6:55 | documen ... on.href | user-provided value |
 | tst.js:10:19:10:84 | new Reg ... ref)[1] | tst.js:10:59:10:75 | document.location | tst.js:10:19:10:84 | new Reg ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:10:59:10:75 | document.location | user-provided value |
+| tst.js:10:19:10:84 | new Reg ... ref)[1] | tst.js:10:59:10:80 | documen ... on.href | tst.js:10:19:10:84 | new Reg ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:10:59:10:80 | documen ... on.href | user-provided value |
 | tst.js:14:20:14:59 | indirec ... ref)[1] | tst.js:14:34:14:50 | document.location | tst.js:14:20:14:59 | indirec ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:14:34:14:50 | document.location | user-provided value |
+| tst.js:14:20:14:59 | indirec ... ref)[1] | tst.js:14:34:14:55 | documen ... on.href | tst.js:14:20:14:59 | indirec ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:14:34:14:55 | documen ... on.href | user-provided value |
 | tst.js:18:19:18:84 | new Reg ... ref)[1] | tst.js:18:59:18:75 | document.location | tst.js:18:19:18:84 | new Reg ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:18:59:18:75 | document.location | user-provided value |
+| tst.js:18:19:18:84 | new Reg ... ref)[1] | tst.js:18:59:18:80 | documen ... on.href | tst.js:18:19:18:84 | new Reg ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:18:59:18:80 | documen ... on.href | user-provided value |
 | tst.js:22:20:22:59 | indirec ... ref)[1] | tst.js:22:34:22:50 | document.location | tst.js:22:20:22:59 | indirec ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:22:34:22:50 | document.location | user-provided value |
-| typed.ts:8:33:8:43 | redirectUri | typed.ts:3:17:3:24 | location | typed.ts:8:33:8:43 | redirectUri | Untrusted URL redirection due to $@. | typed.ts:3:17:3:24 | location | user-provided value |
-| typed.ts:29:33:29:43 | redirectUri | typed.ts:14:17:14:24 | location | typed.ts:29:33:29:43 | redirectUri | Untrusted URL redirection due to $@. | typed.ts:14:17:14:24 | location | user-provided value |
+| tst.js:22:20:22:59 | indirec ... ref)[1] | tst.js:22:34:22:55 | documen ... on.href | tst.js:22:20:22:59 | indirec ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:22:34:22:55 | documen ... on.href | user-provided value |
+| typed.ts:8:33:8:43 | redirectUri | typed.ts:4:22:4:36 | location.search | typed.ts:8:33:8:43 | redirectUri | Untrusted URL redirection due to $@. | typed.ts:4:22:4:36 | location.search | user-provided value |
+| typed.ts:29:33:29:43 | redirectUri | typed.ts:25:25:25:34 | loc.search | typed.ts:29:33:29:43 | redirectUri | Untrusted URL redirection due to $@. | typed.ts:25:25:25:34 | loc.search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
@@ -3,26 +3,21 @@ nodes
 | electron.js:4:12:4:22 | window.name |
 | electron.js:7:20:7:29 | getTaint() |
 | electron.js:7:20:7:29 | getTaint() |
-| react.js:10:60:10:76 | document.location |
-| react.js:10:60:10:76 | document.location |
 | react.js:10:60:10:81 | documen ... on.hash |
 | react.js:10:60:10:81 | documen ... on.hash |
-| react.js:21:24:21:40 | document.location |
-| react.js:21:24:21:40 | document.location |
+| react.js:10:60:10:81 | documen ... on.hash |
 | react.js:21:24:21:45 | documen ... on.hash |
 | react.js:21:24:21:45 | documen ... on.hash |
-| react.js:28:43:28:59 | document.location |
-| react.js:28:43:28:59 | document.location |
+| react.js:21:24:21:45 | documen ... on.hash |
+| react.js:28:43:28:64 | documen ... on.hash |
 | react.js:28:43:28:64 | documen ... on.hash |
 | react.js:28:43:28:74 | documen ... bstr(1) |
 | react.js:28:43:28:74 | documen ... bstr(1) |
-| react.js:34:43:34:59 | document.location |
-| react.js:34:43:34:59 | document.location |
+| react.js:34:43:34:64 | documen ... on.hash |
 | react.js:34:43:34:64 | documen ... on.hash |
 | react.js:34:43:34:74 | documen ... bstr(1) |
 | react.js:34:43:34:74 | documen ... bstr(1) |
-| react.js:40:19:40:35 | document.location |
-| react.js:40:19:40:35 | document.location |
+| react.js:40:19:40:40 | documen ... on.hash |
 | react.js:40:19:40:40 | documen ... on.hash |
 | react.js:40:19:40:50 | documen ... bstr(1) |
 | react.js:40:19:40:50 | documen ... bstr(1) |
@@ -193,24 +188,18 @@ edges
 | electron.js:4:12:4:22 | window.name | electron.js:7:20:7:29 | getTaint() |
 | electron.js:4:12:4:22 | window.name | electron.js:7:20:7:29 | getTaint() |
 | electron.js:4:12:4:22 | window.name | electron.js:7:20:7:29 | getTaint() |
-| react.js:10:60:10:76 | document.location | react.js:10:60:10:81 | documen ... on.hash |
-| react.js:10:60:10:76 | document.location | react.js:10:60:10:81 | documen ... on.hash |
-| react.js:10:60:10:76 | document.location | react.js:10:60:10:81 | documen ... on.hash |
-| react.js:10:60:10:76 | document.location | react.js:10:60:10:81 | documen ... on.hash |
-| react.js:21:24:21:40 | document.location | react.js:21:24:21:45 | documen ... on.hash |
-| react.js:21:24:21:40 | document.location | react.js:21:24:21:45 | documen ... on.hash |
-| react.js:21:24:21:40 | document.location | react.js:21:24:21:45 | documen ... on.hash |
-| react.js:21:24:21:40 | document.location | react.js:21:24:21:45 | documen ... on.hash |
-| react.js:28:43:28:59 | document.location | react.js:28:43:28:64 | documen ... on.hash |
-| react.js:28:43:28:59 | document.location | react.js:28:43:28:64 | documen ... on.hash |
+| react.js:10:60:10:81 | documen ... on.hash | react.js:10:60:10:81 | documen ... on.hash |
+| react.js:21:24:21:45 | documen ... on.hash | react.js:21:24:21:45 | documen ... on.hash |
 | react.js:28:43:28:64 | documen ... on.hash | react.js:28:43:28:74 | documen ... bstr(1) |
 | react.js:28:43:28:64 | documen ... on.hash | react.js:28:43:28:74 | documen ... bstr(1) |
-| react.js:34:43:34:59 | document.location | react.js:34:43:34:64 | documen ... on.hash |
-| react.js:34:43:34:59 | document.location | react.js:34:43:34:64 | documen ... on.hash |
+| react.js:28:43:28:64 | documen ... on.hash | react.js:28:43:28:74 | documen ... bstr(1) |
+| react.js:28:43:28:64 | documen ... on.hash | react.js:28:43:28:74 | documen ... bstr(1) |
 | react.js:34:43:34:64 | documen ... on.hash | react.js:34:43:34:74 | documen ... bstr(1) |
 | react.js:34:43:34:64 | documen ... on.hash | react.js:34:43:34:74 | documen ... bstr(1) |
-| react.js:40:19:40:35 | document.location | react.js:40:19:40:40 | documen ... on.hash |
-| react.js:40:19:40:35 | document.location | react.js:40:19:40:40 | documen ... on.hash |
+| react.js:34:43:34:64 | documen ... on.hash | react.js:34:43:34:74 | documen ... bstr(1) |
+| react.js:34:43:34:64 | documen ... on.hash | react.js:34:43:34:74 | documen ... bstr(1) |
+| react.js:40:19:40:40 | documen ... on.hash | react.js:40:19:40:50 | documen ... bstr(1) |
+| react.js:40:19:40:40 | documen ... on.hash | react.js:40:19:40:50 | documen ... bstr(1) |
 | react.js:40:19:40:40 | documen ... on.hash | react.js:40:19:40:50 | documen ... bstr(1) |
 | react.js:40:19:40:40 | documen ... on.hash | react.js:40:19:40:50 | documen ... bstr(1) |
 | sanitizer.js:2:9:2:25 | url | sanitizer.js:4:27:4:29 | url |
@@ -360,11 +349,11 @@ edges
 | typed.ts:28:24:28:34 | redirectUri | typed.ts:29:33:29:43 | redirectUri |
 #select
 | electron.js:7:20:7:29 | getTaint() | electron.js:4:12:4:22 | window.name | electron.js:7:20:7:29 | getTaint() | Untrusted URL redirection due to $@. | electron.js:4:12:4:22 | window.name | user-provided value |
-| react.js:10:60:10:81 | documen ... on.hash | react.js:10:60:10:76 | document.location | react.js:10:60:10:81 | documen ... on.hash | Untrusted URL redirection due to $@. | react.js:10:60:10:76 | document.location | user-provided value |
-| react.js:21:24:21:45 | documen ... on.hash | react.js:21:24:21:40 | document.location | react.js:21:24:21:45 | documen ... on.hash | Untrusted URL redirection due to $@. | react.js:21:24:21:40 | document.location | user-provided value |
-| react.js:28:43:28:74 | documen ... bstr(1) | react.js:28:43:28:59 | document.location | react.js:28:43:28:74 | documen ... bstr(1) | Untrusted URL redirection due to $@. | react.js:28:43:28:59 | document.location | user-provided value |
-| react.js:34:43:34:74 | documen ... bstr(1) | react.js:34:43:34:59 | document.location | react.js:34:43:34:74 | documen ... bstr(1) | Untrusted URL redirection due to $@. | react.js:34:43:34:59 | document.location | user-provided value |
-| react.js:40:19:40:50 | documen ... bstr(1) | react.js:40:19:40:35 | document.location | react.js:40:19:40:50 | documen ... bstr(1) | Untrusted URL redirection due to $@. | react.js:40:19:40:35 | document.location | user-provided value |
+| react.js:10:60:10:81 | documen ... on.hash | react.js:10:60:10:81 | documen ... on.hash | react.js:10:60:10:81 | documen ... on.hash | Untrusted URL redirection due to $@. | react.js:10:60:10:81 | documen ... on.hash | user-provided value |
+| react.js:21:24:21:45 | documen ... on.hash | react.js:21:24:21:45 | documen ... on.hash | react.js:21:24:21:45 | documen ... on.hash | Untrusted URL redirection due to $@. | react.js:21:24:21:45 | documen ... on.hash | user-provided value |
+| react.js:28:43:28:74 | documen ... bstr(1) | react.js:28:43:28:64 | documen ... on.hash | react.js:28:43:28:74 | documen ... bstr(1) | Untrusted URL redirection due to $@. | react.js:28:43:28:64 | documen ... on.hash | user-provided value |
+| react.js:34:43:34:74 | documen ... bstr(1) | react.js:34:43:34:64 | documen ... on.hash | react.js:34:43:34:74 | documen ... bstr(1) | Untrusted URL redirection due to $@. | react.js:34:43:34:64 | documen ... on.hash | user-provided value |
+| react.js:40:19:40:50 | documen ... bstr(1) | react.js:40:19:40:40 | documen ... on.hash | react.js:40:19:40:50 | documen ... bstr(1) | Untrusted URL redirection due to $@. | react.js:40:19:40:40 | documen ... on.hash | user-provided value |
 | sanitizer.js:4:27:4:29 | url | sanitizer.js:2:15:2:25 | window.name | sanitizer.js:4:27:4:29 | url | Untrusted URL redirection due to $@. | sanitizer.js:2:15:2:25 | window.name | user-provided value |
 | sanitizer.js:16:27:16:29 | url | sanitizer.js:2:15:2:25 | window.name | sanitizer.js:16:27:16:29 | url | Untrusted URL redirection due to $@. | sanitizer.js:2:15:2:25 | window.name | user-provided value |
 | sanitizer.js:19:27:19:29 | url | sanitizer.js:2:15:2:25 | window.name | sanitizer.js:19:27:19:29 | url | Untrusted URL redirection due to $@. | sanitizer.js:2:15:2:25 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-611/Xxe.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-611/Xxe.expected
@@ -1,7 +1,6 @@
 nodes
 | domparser.js:2:7:2:36 | src |
-| domparser.js:2:13:2:29 | document.location |
-| domparser.js:2:13:2:29 | document.location |
+| domparser.js:2:13:2:36 | documen ... .search |
 | domparser.js:2:13:2:36 | documen ... .search |
 | domparser.js:11:55:11:57 | src |
 | domparser.js:11:55:11:57 | src |
@@ -33,8 +32,7 @@ edges
 | domparser.js:2:7:2:36 | src | domparser.js:11:55:11:57 | src |
 | domparser.js:2:7:2:36 | src | domparser.js:14:57:14:59 | src |
 | domparser.js:2:7:2:36 | src | domparser.js:14:57:14:59 | src |
-| domparser.js:2:13:2:29 | document.location | domparser.js:2:13:2:36 | documen ... .search |
-| domparser.js:2:13:2:29 | document.location | domparser.js:2:13:2:36 | documen ... .search |
+| domparser.js:2:13:2:36 | documen ... .search | domparser.js:2:7:2:36 | src |
 | domparser.js:2:13:2:36 | documen ... .search | domparser.js:2:7:2:36 | src |
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") |
 | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | libxml.noent.js:11:21:11:41 | req.par ... e-xml") |
@@ -47,8 +45,8 @@ edges
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | libxml.sax.js:6:22:6:42 | req.par ... e-xml") |
 | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") |
 #select
-| domparser.js:11:55:11:57 | src | domparser.js:2:13:2:29 | document.location | domparser.js:11:55:11:57 | src | A $@ is parsed as XML without guarding against external entity expansion. | domparser.js:2:13:2:29 | document.location | user-provided value |
-| domparser.js:14:57:14:59 | src | domparser.js:2:13:2:29 | document.location | domparser.js:14:57:14:59 | src | A $@ is parsed as XML without guarding against external entity expansion. | domparser.js:2:13:2:29 | document.location | user-provided value |
+| domparser.js:11:55:11:57 | src | domparser.js:2:13:2:36 | documen ... .search | domparser.js:11:55:11:57 | src | A $@ is parsed as XML without guarding against external entity expansion. | domparser.js:2:13:2:36 | documen ... .search | user-provided value |
+| domparser.js:14:57:14:59 | src | domparser.js:2:13:2:36 | documen ... .search | domparser.js:14:57:14:59 | src | A $@ is parsed as XML without guarding against external entity expansion. | domparser.js:2:13:2:36 | documen ... .search | user-provided value |
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | user-provided value |
 | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | user-provided value |
 | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-643/XpathInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-643/XpathInjection.expected
@@ -5,8 +5,7 @@ nodes
 | XpathInjectionBad.js:9:34:9:96 | "//user ... text()" |
 | XpathInjectionBad.js:9:34:9:96 | "//user ... text()" |
 | XpathInjectionBad.js:9:66:9:73 | userName |
-| tst2.js:1:13:1:29 | document.location |
-| tst2.js:1:13:1:29 | document.location |
+| tst2.js:1:13:1:34 | documen ... on.hash |
 | tst2.js:1:13:1:34 | documen ... on.hash |
 | tst2.js:1:13:1:47 | documen ... ring(1) |
 | tst2.js:2:27:2:31 | query |
@@ -30,8 +29,7 @@ edges
 | XpathInjectionBad.js:6:18:6:38 | req.par ... rName") | XpathInjectionBad.js:6:7:6:38 | userName |
 | XpathInjectionBad.js:9:66:9:73 | userName | XpathInjectionBad.js:9:34:9:96 | "//user ... text()" |
 | XpathInjectionBad.js:9:66:9:73 | userName | XpathInjectionBad.js:9:34:9:96 | "//user ... text()" |
-| tst2.js:1:13:1:29 | document.location | tst2.js:1:13:1:34 | documen ... on.hash |
-| tst2.js:1:13:1:29 | document.location | tst2.js:1:13:1:34 | documen ... on.hash |
+| tst2.js:1:13:1:34 | documen ... on.hash | tst2.js:1:13:1:47 | documen ... ring(1) |
 | tst2.js:1:13:1:34 | documen ... on.hash | tst2.js:1:13:1:47 | documen ... ring(1) |
 | tst2.js:1:13:1:47 | documen ... ring(1) | tst2.js:2:27:2:31 | query |
 | tst2.js:1:13:1:47 | documen ... ring(1) | tst2.js:2:27:2:31 | query |
@@ -49,8 +47,8 @@ edges
 | tst.js:6:17:6:37 | req.par ... rName") | tst.js:6:7:6:37 | tainted |
 #select
 | XpathInjectionBad.js:9:34:9:96 | "//user ... text()" | XpathInjectionBad.js:6:18:6:38 | req.par ... rName") | XpathInjectionBad.js:9:34:9:96 | "//user ... text()" | $@ flows here and is used in an XPath expression. | XpathInjectionBad.js:6:18:6:38 | req.par ... rName") | User-provided value |
-| tst2.js:2:27:2:31 | query | tst2.js:1:13:1:29 | document.location | tst2.js:2:27:2:31 | query | $@ flows here and is used in an XPath expression. | tst2.js:1:13:1:29 | document.location | User-provided value |
-| tst2.js:3:19:3:23 | query | tst2.js:1:13:1:29 | document.location | tst2.js:3:19:3:23 | query | $@ flows here and is used in an XPath expression. | tst2.js:1:13:1:29 | document.location | User-provided value |
+| tst2.js:2:27:2:31 | query | tst2.js:1:13:1:34 | documen ... on.hash | tst2.js:2:27:2:31 | query | $@ flows here and is used in an XPath expression. | tst2.js:1:13:1:34 | documen ... on.hash | User-provided value |
+| tst2.js:3:19:3:23 | query | tst2.js:1:13:1:34 | documen ... on.hash | tst2.js:3:19:3:23 | query | $@ flows here and is used in an XPath expression. | tst2.js:1:13:1:34 | documen ... on.hash | User-provided value |
 | tst.js:7:15:7:21 | tainted | tst.js:6:17:6:37 | req.par ... rName") | tst.js:7:15:7:21 | tainted | $@ flows here and is used in an XPath expression. | tst.js:6:17:6:37 | req.par ... rName") | User-provided value |
 | tst.js:8:16:8:22 | tainted | tst.js:6:17:6:37 | req.par ... rName") | tst.js:8:16:8:22 | tainted | $@ flows here and is used in an XPath expression. | tst.js:6:17:6:37 | req.par ... rName") | User-provided value |
 | tst.js:9:17:9:23 | tainted | tst.js:6:17:6:37 | req.par ... rName") | tst.js:9:17:9:23 | tainted | $@ flows here and is used in an XPath expression. | tst.js:6:17:6:37 | req.par ... rName") | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-730/client-side.js
+++ b/javascript/ql/test/query-tests/Security/CWE-730/client-side.js
@@ -1,0 +1,4 @@
+function foo() {
+    let taint = window.location.hash.substring(1);
+    new RegExp(taint); // OK - we do not flag RegExp injection on the client side as the impact is too low
+}

--- a/javascript/ql/test/query-tests/Security/CWE-776/XmlBomb.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-776/XmlBomb.expected
@@ -1,13 +1,11 @@
 nodes
 | closure.js:2:7:2:36 | src |
-| closure.js:2:13:2:29 | document.location |
-| closure.js:2:13:2:29 | document.location |
+| closure.js:2:13:2:36 | documen ... .search |
 | closure.js:2:13:2:36 | documen ... .search |
 | closure.js:4:24:4:26 | src |
 | closure.js:4:24:4:26 | src |
 | domparser.js:2:7:2:36 | src |
-| domparser.js:2:13:2:29 | document.location |
-| domparser.js:2:13:2:29 | document.location |
+| domparser.js:2:13:2:36 | documen ... .search |
 | domparser.js:2:13:2:36 | documen ... .search |
 | domparser.js:6:37:6:39 | src |
 | domparser.js:6:37:6:39 | src |
@@ -19,8 +17,7 @@ nodes
 | expat.js:6:16:6:36 | req.par ... e-xml") |
 | expat.js:6:16:6:36 | req.par ... e-xml") |
 | jquery.js:2:7:2:36 | src |
-| jquery.js:2:13:2:29 | document.location |
-| jquery.js:2:13:2:29 | document.location |
+| jquery.js:2:13:2:36 | documen ... .search |
 | jquery.js:2:13:2:36 | documen ... .search |
 | jquery.js:5:14:5:16 | src |
 | jquery.js:5:14:5:16 | src |
@@ -39,8 +36,7 @@ nodes
 edges
 | closure.js:2:7:2:36 | src | closure.js:4:24:4:26 | src |
 | closure.js:2:7:2:36 | src | closure.js:4:24:4:26 | src |
-| closure.js:2:13:2:29 | document.location | closure.js:2:13:2:36 | documen ... .search |
-| closure.js:2:13:2:29 | document.location | closure.js:2:13:2:36 | documen ... .search |
+| closure.js:2:13:2:36 | documen ... .search | closure.js:2:7:2:36 | src |
 | closure.js:2:13:2:36 | documen ... .search | closure.js:2:7:2:36 | src |
 | domparser.js:2:7:2:36 | src | domparser.js:6:37:6:39 | src |
 | domparser.js:2:7:2:36 | src | domparser.js:6:37:6:39 | src |
@@ -48,26 +44,24 @@ edges
 | domparser.js:2:7:2:36 | src | domparser.js:11:55:11:57 | src |
 | domparser.js:2:7:2:36 | src | domparser.js:14:57:14:59 | src |
 | domparser.js:2:7:2:36 | src | domparser.js:14:57:14:59 | src |
-| domparser.js:2:13:2:29 | document.location | domparser.js:2:13:2:36 | documen ... .search |
-| domparser.js:2:13:2:29 | document.location | domparser.js:2:13:2:36 | documen ... .search |
+| domparser.js:2:13:2:36 | documen ... .search | domparser.js:2:7:2:36 | src |
 | domparser.js:2:13:2:36 | documen ... .search | domparser.js:2:7:2:36 | src |
 | expat.js:6:16:6:36 | req.par ... e-xml") | expat.js:6:16:6:36 | req.par ... e-xml") |
 | jquery.js:2:7:2:36 | src | jquery.js:5:14:5:16 | src |
 | jquery.js:2:7:2:36 | src | jquery.js:5:14:5:16 | src |
-| jquery.js:2:13:2:29 | document.location | jquery.js:2:13:2:36 | documen ... .search |
-| jquery.js:2:13:2:29 | document.location | jquery.js:2:13:2:36 | documen ... .search |
+| jquery.js:2:13:2:36 | documen ... .search | jquery.js:2:7:2:36 | src |
 | jquery.js:2:13:2:36 | documen ... .search | jquery.js:2:7:2:36 | src |
 | libxml.js:6:21:6:41 | req.par ... e-xml") | libxml.js:6:21:6:41 | req.par ... e-xml") |
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | libxml.sax.js:6:22:6:42 | req.par ... e-xml") |
 | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") |
 #select
-| closure.js:4:24:4:26 | src | closure.js:2:13:2:29 | document.location | closure.js:4:24:4:26 | src | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | closure.js:2:13:2:29 | document.location | user-provided value |
-| domparser.js:6:37:6:39 | src | domparser.js:2:13:2:29 | document.location | domparser.js:6:37:6:39 | src | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | domparser.js:2:13:2:29 | document.location | user-provided value |
-| domparser.js:11:55:11:57 | src | domparser.js:2:13:2:29 | document.location | domparser.js:11:55:11:57 | src | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | domparser.js:2:13:2:29 | document.location | user-provided value |
-| domparser.js:14:57:14:59 | src | domparser.js:2:13:2:29 | document.location | domparser.js:14:57:14:59 | src | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | domparser.js:2:13:2:29 | document.location | user-provided value |
+| closure.js:4:24:4:26 | src | closure.js:2:13:2:36 | documen ... .search | closure.js:4:24:4:26 | src | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | closure.js:2:13:2:36 | documen ... .search | user-provided value |
+| domparser.js:6:37:6:39 | src | domparser.js:2:13:2:36 | documen ... .search | domparser.js:6:37:6:39 | src | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | domparser.js:2:13:2:36 | documen ... .search | user-provided value |
+| domparser.js:11:55:11:57 | src | domparser.js:2:13:2:36 | documen ... .search | domparser.js:11:55:11:57 | src | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | domparser.js:2:13:2:36 | documen ... .search | user-provided value |
+| domparser.js:14:57:14:59 | src | domparser.js:2:13:2:36 | documen ... .search | domparser.js:14:57:14:59 | src | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | domparser.js:2:13:2:36 | documen ... .search | user-provided value |
 | expat.js:6:16:6:36 | req.par ... e-xml") | expat.js:6:16:6:36 | req.par ... e-xml") | expat.js:6:16:6:36 | req.par ... e-xml") | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | expat.js:6:16:6:36 | req.par ... e-xml") | user-provided value |
-| jquery.js:5:14:5:16 | src | jquery.js:2:13:2:29 | document.location | jquery.js:5:14:5:16 | src | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | jquery.js:2:13:2:29 | document.location | user-provided value |
+| jquery.js:5:14:5:16 | src | jquery.js:2:13:2:36 | documen ... .search | jquery.js:5:14:5:16 | src | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | jquery.js:2:13:2:36 | documen ... .search | user-provided value |
 | libxml.js:6:21:6:41 | req.par ... e-xml") | libxml.js:6:21:6:41 | req.par ... e-xml") | libxml.js:6:21:6:41 | req.par ... e-xml") | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | libxml.js:6:21:6:41 | req.par ... e-xml") | user-provided value |
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | user-provided value |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | A $@ is parsed as XML without guarding against uncontrolled entity expansion. | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-918/clientSideParam.js
+++ b/javascript/ql/test/query-tests/Security/CWE-918/clientSideParam.js
@@ -1,0 +1,10 @@
+import * as React from "react";
+import { useParams } from "react-router-dom";
+import request from 'request';
+
+export function MyComponent() {
+    const params = useParams();
+
+    request('https://example.com/api/' + params.foo + '/id'); // OK - cannot manipulate path using `../`
+    request(params.foo); // Possibly problematic, but not currently flagged.
+}


### PR DESCRIPTION
Makes `window.location`-based sources part of `RemoteFlowSource` by introducing `ClientSideRemoteFlowSource`, with a `getKind()` predicate indicating it is (part of) the URL, path, query, fragment, or window name. (see qldoc for full details)

It's meant to address a few issues
1. Using `RemoteFlowSource` is now a reasonable default taint source for a new query; we don't have to teach users about `DOM::locationRef()` as well.
2. The framework models for Angular/React router contributed some remote flow sources for parameters extracted from the path. `RemoteFlowSource` thus contained some, but not all, client-side URL sources, which was a bit inconsistent.
3. For some queries we want to treat sources based on the path differently, because they cannot contain `../` sequences (the browser normalizes the path). In particular, request forgery has some FPs where the source is from the path. This PR disables that particular source for request forgery.

There are a few downsides to this approach:
- `new URL(window.location)` is not modelled very precisely.
- Queries that aren't interested in client-side URL sources should now explicitly opt out, and there isn't a particularly pretty way to do so. We could add something like `ServerSideRemoteFlowSource` but a truly good name for that class eludes me as we can't generally ensure that a given source occurs in a server (e.g. it could be in a library shared between client and server, or it could just be a CLI app that's not a web server).

Evaluation:
- [Code scanning queries on default slugs](https://github.com/dsp-testing/asgerf-dca/tree/run/js/generalized-remote-flow-source11/reports) looks good