### PR TITLE
C++: Uniform treatment of parameters and qualifiers in model dataflow

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -887,21 +887,15 @@ private predicate modelFlow(Operand opFrom, Instruction iTo) {
       iTo = call
       or
       exists(int index, WriteSideEffectInstruction outNode |
-        modelOut.isParameterDeref(index) and
+        modelOut.isParameterDerefOrQualifierObject(index) and
         iTo = outNode and
         outNode = getSideEffectFor(call, index)
-      )
-      or
-      exists(WriteSideEffectInstruction outNode |
-        modelOut.isQualifierObject() and
-        iTo = outNode and
-        outNode = getSideEffectFor(call, -1)
       )
     ) and
     (
       exists(int index |
-        modelIn.isParameter(index) and
-        opFrom = call.getPositionalArgumentOperand(index)
+        modelIn.isParameterOrQualifierAddress(index) and
+        opFrom = call.getArgumentOperand(index)
       )
       or
       exists(int index, ReadSideEffectInstruction read |
@@ -909,9 +903,6 @@ private predicate modelFlow(Operand opFrom, Instruction iTo) {
         read = getSideEffectFor(call, index) and
         opFrom = read.getSideEffectOperand()
       )
-      or
-      modelIn.isQualifierAddress() and
-      opFrom = call.getThisArgumentOperand()
       or
       exists(ReadSideEffectInstruction read |
         modelIn.isQualifierObject() and


### PR DESCRIPTION
We could reduce the number of cases in `modelFlow` even more by creating an `isParameterDerefOrQualifierObject` predicate on `FunctionInput`s (similarly to the `isParameterOrQualifierAddress` predicate we already have).