### PR TITLE
JS: Detect more route-handlers by adding a callgraphStep

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -1545,7 +1545,9 @@ module DataFlow {
    */
   predicate localFieldStep(DataFlow::Node pred, DataFlow::Node succ) {
     exists(ClassNode cls, string prop |
-      pred = cls.getAReceiverNode().getAPropertyWrite(prop).getRhs() and
+      pred = cls.getAReceiverNode().getAPropertyWrite(prop).getRhs() or
+      pred = cls.getInstanceMethod(prop)
+    |
       succ = cls.getAReceiverNode().getAPropertyRead(prop)
     )
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -1008,6 +1008,31 @@ class ClassNode extends DataFlow::SourceNode {
   }
 
   /**
+   * Gets a property read that accesses the property `name` on an instance of this class.
+   *
+   * Concretely, this holds when the base is an instance of this class or a subclass thereof.
+   */
+  pragma[nomagic]
+  DataFlow::PropRead getAnInstanceMemberAccess(string name, DataFlow::TypeTracker t) {
+    result = this.getAnInstanceReference(t.continue()).getAPropertyRead(name)
+    or
+    exists(DataFlow::ClassNode subclass |
+      result = subclass.getAnInstanceMemberAccess(name, t) and
+      not exists(subclass.getInstanceMember(name, _)) and
+      this = subclass.getADirectSuperClass()
+    )
+  }
+
+  /**
+   * Gets a property read that accesses the property `name` on an instance of this class.
+   *
+   * Concretely, this holds when the base is an instance of this class or a subclass thereof.
+   */
+  DataFlow::PropRead getAnInstanceMemberAccess(string name) {
+    result = this.getAnInstanceMemberAccess(name, DataFlow::TypeTracker::end())
+  }
+
+  /**
    * Gets an access to a static member of this class.
    */
   DataFlow::PropRead getAStaticMemberAccess(string name) {

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -57,7 +57,7 @@ module CallGraph {
     exists(DataFlow::ClassNode cls |
       exists(string name |
         function = cls.getInstanceMethod(name) and
-        getAnInstanceMemberAccess(cls, name, t.continue()).flowsTo(result)
+        cls.getAnInstanceMemberAccess(name, t.continue()).flowsTo(result)
         or
         function = cls.getStaticMethod(name) and
         cls.getAClassReference(t.continue()).getAPropertyRead(name).flowsTo(result)
@@ -130,26 +130,6 @@ module CallGraph {
       result = getABoundFunctionReferenceAux(function, boundArgs, t) and
       t.end() and
       contextDependent = t.hasCall()
-    )
-  }
-
-  /**
-   * Gets a property read that accesses the property `name` on an instance of this class.
-   *
-   * Concretely, this holds when the base is an instance of this class or a subclass thereof.
-   *
-   * This predicate may be overridden to customize the class hierarchy analysis.
-   */
-  pragma[nomagic]
-  private DataFlow::PropRead getAnInstanceMemberAccess(
-    DataFlow::ClassNode cls, string name, DataFlow::TypeTracker t
-  ) {
-    result = cls.getAnInstanceReference(t.continue()).getAPropertyRead(name)
-    or
-    exists(DataFlow::ClassNode subclass |
-      result = getAnInstanceMemberAccess(subclass, name, t) and
-      not exists(subclass.getInstanceMember(name, _)) and
-      cls = subclass.getADirectSuperClass()
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -59,7 +59,10 @@ module CallGraph {
 
   /**
    * Gets a reference to `function` type-tracked by `t`.
-   * Only considers callgraph specific steps.
+   *
+   * This only includes steps that aren't included in ordinary type-tracking.
+   * For example, this steps from a method definition to an access on an instance, but
+   * does not step through access paths, as those are included in type-tracking already.
    */
   cached
   DataFlow::SourceNode callgraphStep(DataFlow::FunctionNode function, DataFlow::TypeTracker t) {

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -54,27 +54,34 @@ module CallGraph {
     PreCallGraphStep::step(any(DataFlow::Node n | function.flowsTo(n)), result)
     or
     imprecision = 0 and
+    result = callgraphStep(function, t)
+  }
+
+  /**
+   * Gets a reference to `function` type-tracked by `t`.
+   * Only considers callgraph specific steps.
+   */
+  cached
+  DataFlow::SourceNode callgraphStep(DataFlow::FunctionNode function, DataFlow::TypeTracker t) {
     exists(DataFlow::ClassNode cls |
       exists(string name |
         function = cls.getInstanceMethod(name) and
-        cls.getAnInstanceMemberAccess(name, t.continue()).flowsTo(result)
+        cls.getAnInstanceMemberAccess(name, t.continue()) = result
         or
         function = cls.getStaticMethod(name) and
-        cls.getAClassReference(t.continue()).getAPropertyRead(name).flowsTo(result)
+        cls.getAClassReference(t.continue()).getAPropertyRead(name) = result
       )
       or
       function = cls.getConstructor() and
-      cls.getAClassReference(t.continue()).flowsTo(result)
+      cls.getAClassReference(t.continue()) = result
     )
     or
-    imprecision = 0 and
     exists(DataFlow::FunctionNode outer |
       result = getAFunctionReference(outer, 0, t.continue()).getAnInvocation() and
       locallyReturnedFunction(outer, function)
     )
   }
 
-  cached
   private predicate locallyReturnedFunction(
     DataFlow::FunctionNode outer, DataFlow::FunctionNode inner
   ) {

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -5,6 +5,7 @@
 import javascript
 private import semmle.javascript.DynamicPropertyAccess
 private import semmle.javascript.dataflow.internal.StepSummary
+private import semmle.javascript.dataflow.internal.CallGraphs
 
 module HTTP {
   /**
@@ -299,6 +300,9 @@ module HTTP {
     exists(DataFlow::PartialInvokeNode call |
       succ = call.getBoundFunction(any(DataFlow::Node n | pred.flowsTo(n)), 0)
     )
+    or
+    // references to class methods
+    succ = CallGraph::callgraphStep(pred, DataFlow::TypeTracker::end())
   }
 
   /**

--- a/javascript/ql/test/library-tests/TypeTracking/class.js
+++ b/javascript/ql/test/library-tests/TypeTracking/class.js
@@ -1,0 +1,7 @@
+class Foo {
+    foo() {} // name: foo
+
+    bar() {
+        this.foo; // track: foo
+    }
+}

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/createServer.js
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/createServer.js
@@ -13,3 +13,20 @@ const tls = require('tls');
 const server = (isSecure ? tls : net).createServer(options, (socket) => {
     socket.on("data", (data) => {})
 });
+
+
+const http = require("http");
+
+(function () {
+    function MyApp(data) {this.data = data};
+    MyApp.prototype.getRequestHandler = function () {
+        return this.handleRequest.bind(this)
+    }
+    MyApp.prototype.handleRequest = function (req, res) {
+        res.end(this.data);
+    }
+
+    var app = new MyApp("data");
+
+    const srv = http.createServer(app.getRequestHandler());
+})();

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -2,6 +2,7 @@ test_isCreateServer
 | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:1:3:45 | https.c ... es) {}) |
 | createServer.js:4:1:4:47 | require ...  => {}) |
+| createServer.js:31:17:31:58 | http.cr ... dler()) |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
 | src/http.js:57:1:57:31 | http.cr ... dler()) |
@@ -87,6 +88,7 @@ test_RouteSetup_getServer
 | createServer.js:2:1:2:42 | https.c ... es) {}) | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:1:3:45 | https.c ... es) {}) | createServer.js:3:1:3:45 | https.c ... es) {}) |
 | createServer.js:4:1:4:47 | require ...  => {}) | createServer.js:4:1:4:47 | require ...  => {}) |
+| createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:31:17:31:58 | http.cr ... dler()) |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
 | src/http.js:57:1:57:31 | http.cr ... dler()) | src/http.js:57:1:57:31 | http.cr ... dler()) |
@@ -114,6 +116,7 @@ test_ServerDefinition
 | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:1:3:45 | https.c ... es) {}) |
 | createServer.js:4:1:4:47 | require ...  => {}) |
+| createServer.js:31:17:31:58 | http.cr ... dler()) |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
 | src/http.js:57:1:57:31 | http.cr ... dler()) |
@@ -204,6 +207,10 @@ test_RouteSetup_getARouteHandler
 | createServer.js:2:1:2:42 | https.c ... es) {}) | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:1:3:45 | https.c ... es) {}) | createServer.js:3:23:3:44 | functio ... res) {} |
 | createServer.js:4:1:4:47 | require ...  => {}) | createServer.js:4:31:4:46 | (req, res) => {} |
+| createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:22:41:24:5 | return of anonymous function |
+| createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:23:16:23:33 | this.handleRequest |
+| createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:23:16:23:44 | this.ha ... d(this) |
+| createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:31:35:31:57 | app.get ... ndler() |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:57:1:57:31 | http.cr ... dler()) | src/http.js:54:1:56:1 | return of function getHandler |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -43,6 +43,8 @@ test_ResponseExpr
 | createServer.js:2:35:2:37 | res | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:38:3:40 | res | createServer.js:3:23:3:44 | functio ... res) {} |
 | createServer.js:4:37:4:39 | res | createServer.js:4:31:4:46 | (req, res) => {} |
+| createServer.js:25:52:25:54 | res | createServer.js:25:37:27:5 | functio ... ;\\n    } |
+| createServer.js:26:9:26:11 | res | createServer.js:25:37:27:5 | functio ... ;\\n    } |
 | src/http.js:4:46:4:48 | res | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:7:3:7:5 | res | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:12:33:12:35 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
@@ -142,6 +144,8 @@ test_RouteHandler_getAResponseExpr
 | createServer.js:2:20:2:41 | functio ... res) {} | createServer.js:2:35:2:37 | res |
 | createServer.js:3:23:3:44 | functio ... res) {} | createServer.js:3:38:3:40 | res |
 | createServer.js:4:31:4:46 | (req, res) => {} | createServer.js:4:37:4:39 | res |
+| createServer.js:25:37:27:5 | functio ... ;\\n    } | createServer.js:25:52:25:54 | res |
+| createServer.js:25:37:27:5 | functio ... ;\\n    } | createServer.js:26:9:26:11 | res |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:46:4:48 | res |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:7:3:7:5 | res |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:12:33:12:35 | res |
@@ -180,6 +184,7 @@ test_ServerDefinition_getARouteHandler
 | createServer.js:2:1:2:42 | https.c ... es) {}) | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:1:3:45 | https.c ... es) {}) | createServer.js:3:23:3:44 | functio ... res) {} |
 | createServer.js:4:1:4:47 | require ...  => {}) | createServer.js:4:31:4:46 | (req, res) => {} |
+| createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:25:37:27:5 | functio ... ;\\n    } |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:57:1:57:31 | http.cr ... dler()) | src/http.js:55:12:55:30 | function(req,res){} |
@@ -195,6 +200,7 @@ test_ServerDefinition_getARouteHandler
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:28:15:30:3 | functio ... ");\\n  } |
 test_ResponseSendArgument
+| createServer.js:26:17:26:25 | this.data | createServer.js:25:37:27:5 | functio ... ;\\n    } |
 | src/http.js:14:13:14:17 | "foo" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:15:11:15:15 | "bar" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:64:11:64:16 | "bar2" | src/http.js:62:19:65:1 | functio ... r2");\\n} |
@@ -210,6 +216,7 @@ test_RouteSetup_getARouteHandler
 | createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:22:41:24:5 | return of anonymous function |
 | createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:23:16:23:33 | this.handleRequest |
 | createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:23:16:23:44 | this.ha ... d(this) |
+| createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:25:37:27:5 | functio ... ;\\n    } |
 | createServer.js:31:17:31:58 | http.cr ... dler()) | createServer.js:31:35:31:57 | app.get ... ndler() |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) | src/http.js:12:19:16:1 | functio ... ar");\\n} |
@@ -258,6 +265,7 @@ test_RouteHandler
 | createServer.js:2:20:2:41 | functio ... res) {} | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:23:3:44 | functio ... res) {} | createServer.js:3:1:3:45 | https.c ... es) {}) |
 | createServer.js:4:31:4:46 | (req, res) => {} | createServer.js:4:1:4:47 | require ...  => {}) |
+| createServer.js:25:37:27:5 | functio ... ;\\n    } | createServer.js:31:17:31:58 | http.cr ... dler()) |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
 | src/http.js:55:12:55:30 | function(req,res){} | src/http.js:57:1:57:31 | http.cr ... dler()) |
@@ -276,6 +284,7 @@ test_RequestExpr
 | createServer.js:2:30:2:32 | req | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:33:3:35 | req | createServer.js:3:23:3:44 | functio ... res) {} |
 | createServer.js:4:32:4:34 | req | createServer.js:4:31:4:46 | (req, res) => {} |
+| createServer.js:25:47:25:49 | req | createServer.js:25:37:27:5 | functio ... ;\\n    } |
 | src/http.js:4:41:4:43 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:6:26:6:28 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:8:3:8:5 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
@@ -317,6 +326,7 @@ test_RouteHandler_getARequestExpr
 | createServer.js:2:20:2:41 | functio ... res) {} | createServer.js:2:30:2:32 | req |
 | createServer.js:3:23:3:44 | functio ... res) {} | createServer.js:3:33:3:35 | req |
 | createServer.js:4:31:4:46 | (req, res) => {} | createServer.js:4:32:4:34 | req |
+| createServer.js:25:37:27:5 | functio ... ;\\n    } | createServer.js:25:47:25:49 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:41:4:43 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:6:26:6:28 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:8:3:8:5 | req |


### PR DESCRIPTION
Detects the relevant route-handler for CVE-2020-15242 

Adds steps for referencing class methods in a `CallGraphs::callgraphStep`. E.g: 
```JavaScript
class MyClass {
  foo() { } // <- from here
  bar() {
    this.foo(); // <- to here
  }
}
```

I think this is the best solution, but there are multiple other options. 

--- 

An alternative is to add `pred = succ.getABoundFunctionValue(0)` to [`routeHandlerStep`](https://github.com/github/codeql/blob/main/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll#L299).    
But that way I'm adding the entire callgraph to a `step` relation, which seems wrong. 

--- 

Another alternative is to use `Callgraph::callgraphStep` in `StepStepSummary::smallStep`. 