### PR TITLE
Python: Add locations for ESSA variables

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -134,7 +134,7 @@ class EssaNode extends Node, TEssaNode {
 
   override Scope getScope() { result = var.getScope() }
 
-  override Location getLocation() { result = var.getDefinition().getLocation() }
+  override Location getLocation() { result = var.getLocation() }
 }
 
 /** A data-flow node corresponding to a control-flow node. */

--- a/python/ql/src/semmle/python/essa/Essa.qll
+++ b/python/ql/src/semmle/python/essa/Essa.qll
@@ -61,6 +61,13 @@ class EssaVariable extends TEssaDefinition {
    * defined by `from ... import *` and the like.
    */
   predicate isMetaVariable() { this.getName() = "$" }
+
+  /**
+   * Gets the location of this variable.
+   *
+   * Yields the location of the corresponding definition of this variable.
+   */
+  Location getLocation() { result = this.getDefinition().getLocation() }
 }
 
 /*


### PR DESCRIPTION
This may be a slightly "bogus" location to provide for ESSA variables,
but it can be useful for debugging. For instance, where previously you
might just see

```
SSA variable x | ...
SSA variable x | ...
SSA variable x | ...
SSA variable x | ...
SSA variable x | ...
SSA variable x | ...
```

where each instance of `SSA variable x` was just a bare string, now
each occurrence will tell you (via its location) _where_ this variable
is being (re)defined.