### PR TITLE
JS: Add `js/code-injection` sink for script tags in React

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
@@ -113,6 +113,17 @@ module CodeInjection {
   }
 
   /**
+   * A body element from a script tag inside React code.
+   */
+  class ReactScriptTag extends Sink {
+    ReactScriptTag() {
+      exists(JSXElement element | element.getName() = "script" |
+        this = element.getBodyElement(_).flow()
+      )
+    }
+  }
+
+  /**
    * An event handler attribute as a code injection sink.
    */
   class EventHandlerAttributeSink extends Sink {

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
@@ -118,6 +118,10 @@ nodes
 | react-native.js:8:32:8:38 | tainted |
 | react-native.js:10:23:10:29 | tainted |
 | react-native.js:10:23:10:29 | tainted |
+| react.js:10:56:10:72 | document.location |
+| react.js:10:56:10:72 | document.location |
+| react.js:10:56:10:77 | documen ... on.hash |
+| react.js:10:56:10:77 | documen ... on.hash |
 | template-sinks.js:12:9:12:31 | tainted |
 | template-sinks.js:12:19:12:31 | req.query.foo |
 | template-sinks.js:12:19:12:31 | req.query.foo |
@@ -275,6 +279,10 @@ edges
 | react-native.js:7:7:7:33 | tainted | react-native.js:10:23:10:29 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
+| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
+| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
+| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
+| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:15:16:15:22 | tainted |
@@ -352,6 +360,7 @@ edges
 | module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code | $@ flows to here and is interpreted as code. | module.js:9:16:9:29 | req.query.code | User-provided value |
 | react-native.js:8:32:8:38 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:8:32:8:38 | tainted | $@ flows to here and is interpreted as code. | react-native.js:7:17:7:33 | req.param("code") | User-provided value |
 | react-native.js:10:23:10:29 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:10:23:10:29 | tainted | $@ flows to here and is interpreted as code. | react-native.js:7:17:7:33 | req.param("code") | User-provided value |
+| react.js:10:56:10:77 | documen ... on.hash | react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash | $@ flows to here and is interpreted as code. | react.js:10:56:10:72 | document.location | User-provided value |
 | template-sinks.js:14:17:14:23 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:14:17:14:23 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
 | template-sinks.js:15:16:15:22 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:15:16:15:22 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
 | template-sinks.js:16:18:16:24 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:16:18:16:24 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
@@ -122,6 +122,10 @@ nodes
 | react-native.js:8:32:8:38 | tainted |
 | react-native.js:10:23:10:29 | tainted |
 | react-native.js:10:23:10:29 | tainted |
+| react.js:10:56:10:72 | document.location |
+| react.js:10:56:10:72 | document.location |
+| react.js:10:56:10:77 | documen ... on.hash |
+| react.js:10:56:10:77 | documen ... on.hash |
 | template-sinks.js:12:9:12:31 | tainted |
 | template-sinks.js:12:19:12:31 | req.query.foo |
 | template-sinks.js:12:19:12:31 | req.query.foo |
@@ -283,6 +287,10 @@ edges
 | react-native.js:7:7:7:33 | tainted | react-native.js:10:23:10:29 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
+| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
+| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
+| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
+| react.js:10:56:10:72 | document.location | react.js:10:56:10:77 | documen ... on.hash |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
 | template-sinks.js:12:9:12:31 | tainted | template-sinks.js:15:16:15:22 | tainted |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/react.js
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/react.js
@@ -1,0 +1,17 @@
+import React from "react";
+import {Helmet} from "react-helmet";
+ 
+class Application extends React.Component {
+  render () {
+    return (
+        <div className="application">
+            <Helmet>
+                <title>My unsafe</title>
+                <script type="application/javascript">{document.location.hash}</script>
+            </Helmet>
+        </div>
+    );
+  }
+};
+
+export default Application

--- a/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
@@ -3,6 +3,10 @@ nodes
 | electron.js:4:12:4:22 | window.name |
 | electron.js:7:20:7:29 | getTaint() |
 | electron.js:7:20:7:29 | getTaint() |
+| react.js:10:60:10:76 | document.location |
+| react.js:10:60:10:76 | document.location |
+| react.js:10:60:10:81 | documen ... on.hash |
+| react.js:10:60:10:81 | documen ... on.hash |
 | sanitizer.js:2:9:2:25 | url |
 | sanitizer.js:2:15:2:25 | window.name |
 | sanitizer.js:2:15:2:25 | window.name |
@@ -189,6 +193,10 @@ edges
 | electron.js:4:12:4:22 | window.name | electron.js:7:20:7:29 | getTaint() |
 | electron.js:4:12:4:22 | window.name | electron.js:7:20:7:29 | getTaint() |
 | electron.js:4:12:4:22 | window.name | electron.js:7:20:7:29 | getTaint() |
+| react.js:10:60:10:76 | document.location | react.js:10:60:10:81 | documen ... on.hash |
+| react.js:10:60:10:76 | document.location | react.js:10:60:10:81 | documen ... on.hash |
+| react.js:10:60:10:76 | document.location | react.js:10:60:10:81 | documen ... on.hash |
+| react.js:10:60:10:76 | document.location | react.js:10:60:10:81 | documen ... on.hash |
 | sanitizer.js:2:9:2:25 | url | sanitizer.js:4:27:4:29 | url |
 | sanitizer.js:2:9:2:25 | url | sanitizer.js:4:27:4:29 | url |
 | sanitizer.js:2:9:2:25 | url | sanitizer.js:16:27:16:29 | url |
@@ -358,6 +366,7 @@ edges
 | typed.ts:28:24:28:34 | redirectUri | typed.ts:29:33:29:43 | redirectUri |
 #select
 | electron.js:7:20:7:29 | getTaint() | electron.js:4:12:4:22 | window.name | electron.js:7:20:7:29 | getTaint() | Untrusted URL redirection due to $@. | electron.js:4:12:4:22 | window.name | user-provided value |
+| react.js:10:60:10:81 | documen ... on.hash | react.js:10:60:10:76 | document.location | react.js:10:60:10:81 | documen ... on.hash | Untrusted URL redirection due to $@. | react.js:10:60:10:76 | document.location | user-provided value |
 | sanitizer.js:4:27:4:29 | url | sanitizer.js:2:15:2:25 | window.name | sanitizer.js:4:27:4:29 | url | Untrusted URL redirection due to $@. | sanitizer.js:2:15:2:25 | window.name | user-provided value |
 | sanitizer.js:16:27:16:29 | url | sanitizer.js:2:15:2:25 | window.name | sanitizer.js:16:27:16:29 | url | Untrusted URL redirection due to $@. | sanitizer.js:2:15:2:25 | window.name | user-provided value |
 | sanitizer.js:19:27:19:29 | url | sanitizer.js:2:15:2:25 | window.name | sanitizer.js:19:27:19:29 | url | Untrusted URL redirection due to $@. | sanitizer.js:2:15:2:25 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/react.js
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/react.js
@@ -1,0 +1,17 @@
+import React from "react";
+import {Helmet} from "react-helmet";
+ 
+class Application extends React.Component {
+  render () {
+    return (
+        <div className="application">
+            <Helmet>
+                <title>My unsafe app</title>
+                <script type="application/javascript" src={document.location.hash}/>
+            </Helmet>
+        </div>
+    );
+  }
+};
+
+export default Application


### PR DESCRIPTION
Libraries like [`react-helmet`](https://www.npmjs.com/package/react-helmet) allows for writing header tags in React.   
I've therefore added the body of a `script` tag as a code-injection sink.  

(And I additionally added a test that `<script src="sink" />` in React was supported for `client-side-unvalidated-url-redirection`). 