### PR TITLE
C++: Exclude custom vprintf implementations from primitiveVariadicFormatter.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -50,7 +50,10 @@ predicate primitiveVariadicFormatter(
     then formatParamIndex = f.getNumberOfParameters() - 3
     else formatParamIndex = f.getNumberOfParameters() - 2
   ) and
-  if type = "" then outputParamIndex = -1 else outputParamIndex = 0 // Conveniently, these buffer parameters are all at index 0.
+  (
+    if type = "" then outputParamIndex = -1 else outputParamIndex = 0 // Conveniently, these buffer parameters are all at index 0.
+  ) and
+  not exists(f.getBlock()) // exclude functions with an implementation in the snapshot as they may not be standard implementations.
 }
 
 private predicate callsVariadicFormatter(

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
@@ -1,3 +1,3 @@
-| printf.cpp:24:31:24:37 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
-| printf.cpp:36:29:36:35 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
-| printf.cpp:43:29:43:35 | test | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |
+| printf.cpp:31:31:31:37 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
+| printf.cpp:43:29:43:35 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
+| printf.cpp:50:29:50:35 | test | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
@@ -1,3 +1,2 @@
-| printf.cpp:33:31:33:37 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
+| printf.cpp:39:29:39:35 | test | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
 | printf.cpp:45:29:45:35 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
-| printf.cpp:52:29:52:35 | test | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
@@ -1,2 +1,3 @@
-| printf.cpp:39:29:39:35 | test | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
-| printf.cpp:45:29:45:35 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
+| printf.cpp:24:31:24:37 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
+| printf.cpp:36:29:36:35 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
+| printf.cpp:43:29:43:35 | test | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/formattingFunction.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/formattingFunction.expected
@@ -1,2 +1,1 @@
-| printf.cpp:15:5:15:12 | swprintf | char | char16_t | char16_t |
-| printf.cpp:26:5:26:11 | sprintf | char | char16_t | char16_t |
+| printf.cpp:26:5:26:11 | sprintf | char | wchar_t | wchar_t |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/formattingFunction.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/formattingFunction.expected
@@ -1,2 +1,2 @@
-| printf.cpp:15:5:15:12 | swprintf | char | char16_t | char16_t |
-| printf.cpp:17:5:17:11 | sprintf | char | char16_t | char16_t |
+| printf.cpp:13:5:13:12 | swprintf | char | char16_t | char16_t |
+| printf.cpp:24:5:24:11 | sprintf | char | char16_t | char16_t |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/formattingFunction.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/formattingFunction.expected
@@ -1,1 +1,2 @@
-| printf.cpp:26:5:26:11 | sprintf | char | wchar_t | wchar_t |
+| printf.cpp:15:5:15:12 | swprintf | char | char16_t | char16_t |
+| printf.cpp:17:5:17:11 | sprintf | char | char16_t | char16_t |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
@@ -12,16 +12,7 @@ int	vswprintf(WCHAR *dest, WCHAR *format, va_list args) {
 	return 0;
 }
 
-int swprintf(WCHAR *dest, WCHAR *format, ...) {
-	va_list args;
-	va_start(args, format);
-
-	int ret = vswprintf(dest, format, args);
-
-	va_end(args);
-
-	return ret;
-}
+int swprintf(WCHAR *dest, WCHAR *format, ...);
 
 int sprintf(char *dest, char *format, ...);
 
@@ -30,13 +21,13 @@ int sprintf(char *dest, char *format, ...);
 void test1() {
 	WCHAR string[20];
 
-	swprintf(string, u"test %s", u"test"); // BAD: `char16_t` string parameter read as `char` string [NOT DETECTED]
+	swprintf(string, u"test %s", u"test"); // BAD: `char16_t` string parameter read as `char` string
 }
 
 void test2() {
 	char string[20];
 
-	sprintf(string, "test %S", u"test"); // GOOD [FALSE POSITIVE]
+	sprintf(string, "test %S", u"test"); // GOOD
 }
 
 void test3() {
@@ -49,5 +40,5 @@ void test3() {
 void test4() {
 	char string[20];
 
-	sprintf(string, "test %S", L"test"); // BAD: `wchar_t` string parameter read as `char16_t` string [NOT DETECTED]
+	sprintf(string, "test %S", L"test"); // BAD: `wchar_t` string parameter read as `char16_t` string
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
@@ -8,11 +8,18 @@ typedef void *va_list;
 #define va_start(va, other)
 #define va_end(args)
 
-int	vswprintf(WCHAR *dest, WCHAR *format, va_list args) {
-	return 0;
-}
+int	vswprintf(WCHAR *dest, WCHAR *format, va_list args);
 
-int swprintf(WCHAR *dest, WCHAR *format, ...);
+int swprintf(WCHAR *dest, WCHAR *format, ...) {
+	va_list args;
+	va_start(args, format);
+
+	int ret = vswprintf(dest, format, args);
+
+	va_end(args);
+
+	return ret;
+}
 
 int sprintf(char *dest, char *format, ...);
 

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
@@ -30,13 +30,13 @@ int sprintf(char *dest, char *format, ...);
 void test1() {
 	WCHAR string[20];
 
-	swprintf(string, u"test %s", u"test"); // BAD: `char16_t` string parameter read as `char` string
+	swprintf(string, u"test %s", u"test"); // BAD: `char16_t` string parameter read as `char` string [NOT DETECTED]
 }
 
 void test2() {
 	char string[20];
 
-	sprintf(string, "test %S", u"test"); // GOOD
+	sprintf(string, "test %S", u"test"); // GOOD [FALSE POSITIVE]
 }
 
 void test3() {
@@ -49,5 +49,5 @@ void test3() {
 void test4() {
 	char string[20];
 
-	sprintf(string, "test %S", L"test"); // BAD: `wchar_t` string parameter read as `char16_t` string
+	sprintf(string, "test %S", L"test"); // BAD: `wchar_t` string parameter read as `char16_t` string [NOT DETECTED]
 }


### PR DESCRIPTION
This is my long awaited solution to the problems we've been seeing with `cpp/wrong-type-format-argument` producing false positives in the presence of certain `printf` implementations (see https://lgtm.com/projects/g/microsoft/ChakraCore/alerts/?mode=tree&ruleFocus=2160310550).

As it happens this change removes ALL results on ChakraCore for `cpp/wrong-type-format-argument` (and also `cpp/non-portable-printf`, which is not on LGTM anyway).  I believe that is what we want.  Results are preserved on the other projects I tried (`BOINC_boinc` and `godotengine_godot`) so I believe the change is functioning as intended.

I went with `exists(f.getBlock())` rather than `exists(f.getFile().getRelativePath())` because, in my tests, the former would exclude things I don't think we really need it to (where the header has been copied into the source directory but the corresponding source has not?).