### PR TITLE
JS: add tests for some syntactic XSS vector obfuscations

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -650,6 +650,47 @@ nodes
 | v-html.vue:2:8:2:23 | v-html=tainted |
 | v-html.vue:6:42:6:58 | document.location |
 | v-html.vue:6:42:6:58 | document.location |
+| various-concat-obfuscations.js:2:6:2:39 | tainted |
+| various-concat-obfuscations.js:2:16:2:39 | documen ... .search |
+| various-concat-obfuscations.js:2:16:2:39 | documen ... .search |
+| various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" |
+| various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" |
+| various-concat-obfuscations.js:4:14:4:20 | tainted |
+| various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` |
+| various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` |
+| various-concat-obfuscations.js:5:12:5:18 | tainted |
+| various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) |
+| various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") |
+| various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") |
+| various-concat-obfuscations.js:6:19:6:25 | tainted |
+| various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] |
+| various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() |
+| various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() |
+| various-concat-obfuscations.js:7:14:7:20 | tainted |
+| various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" |
+| various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" |
+| various-concat-obfuscations.js:9:19:9:25 | tainted |
+| various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` |
+| various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` |
+| various-concat-obfuscations.js:10:16:10:22 | tainted |
+| various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) |
+| various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") |
+| various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") |
+| various-concat-obfuscations.js:11:24:11:30 | tainted |
+| various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] |
+| various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() |
+| various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() |
+| various-concat-obfuscations.js:12:19:12:25 | tainted |
+| various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:20:17:20:40 | documen ... .search |
+| various-concat-obfuscations.js:20:17:20:40 | documen ... .search |
+| various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs |
+| various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:21:17:21:40 | documen ... .search |
+| various-concat-obfuscations.js:21:17:21:40 | documen ... .search |
+| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
 | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:33 | document.location |
 | winjs.js:2:17:2:33 | document.location |
@@ -1218,6 +1259,44 @@ edges
 | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted |
 | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted |
 | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:4:14:4:20 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:5:12:5:18 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:6:19:6:25 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:7:14:7:20 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:9:19:9:25 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:10:16:10:22 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:11:24:11:30 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:12:19:12:25 | tainted |
+| various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:2:6:2:39 | tainted |
+| various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:2:6:2:39 | tainted |
+| various-concat-obfuscations.js:4:14:4:20 | tainted | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" |
+| various-concat-obfuscations.js:4:14:4:20 | tainted | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" |
+| various-concat-obfuscations.js:5:12:5:18 | tainted | various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` |
+| various-concat-obfuscations.js:5:12:5:18 | tainted | various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` |
+| various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") |
+| various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") |
+| various-concat-obfuscations.js:6:19:6:25 | tainted | various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) |
+| various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] | various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() |
+| various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] | various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() |
+| various-concat-obfuscations.js:7:14:7:20 | tainted | various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] |
+| various-concat-obfuscations.js:9:19:9:25 | tainted | various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" |
+| various-concat-obfuscations.js:9:19:9:25 | tainted | various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" |
+| various-concat-obfuscations.js:10:16:10:22 | tainted | various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` |
+| various-concat-obfuscations.js:10:16:10:22 | tainted | various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` |
+| various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") |
+| various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") |
+| various-concat-obfuscations.js:11:24:11:30 | tainted | various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) |
+| various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() |
+| various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() |
+| various-concat-obfuscations.js:12:19:12:25 | tainted | various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] |
+| various-concat-obfuscations.js:20:17:20:40 | documen ... .search | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs |
+| various-concat-obfuscations.js:20:17:20:40 | documen ... .search | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs |
+| various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:21:17:21:40 | documen ... .search | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
+| various-concat-obfuscations.js:21:17:21:40 | documen ... .search | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
+| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
@@ -1374,5 +1453,15 @@ edges
 | tst.js:424:18:424:51 | window. ... '#')[1] | tst.js:424:18:424:32 | window.location | tst.js:424:18:424:51 | window. ... '#')[1] | Cross-site scripting vulnerability due to $@. | tst.js:424:18:424:32 | window.location | user-provided value |
 | typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:38 | document.location | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:38 | document.location | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
+| various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
+| various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
+| various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
+| various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
+| various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
+| various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
+| various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
+| various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |
+| various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) | various-concat-obfuscations.js:20:17:20:40 | documen ... .search | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:20:17:20:40 | documen ... .search | user-provided value |
+| various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) | various-concat-obfuscations.js:21:17:21:40 | documen ... .search | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:21:17:21:40 | documen ... .search | user-provided value |
 | winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |
 | winjs.js:4:43:4:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:4:43:4:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -661,6 +661,47 @@ nodes
 | v-html.vue:2:8:2:23 | v-html=tainted |
 | v-html.vue:6:42:6:58 | document.location |
 | v-html.vue:6:42:6:58 | document.location |
+| various-concat-obfuscations.js:2:6:2:39 | tainted |
+| various-concat-obfuscations.js:2:16:2:39 | documen ... .search |
+| various-concat-obfuscations.js:2:16:2:39 | documen ... .search |
+| various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" |
+| various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" |
+| various-concat-obfuscations.js:4:14:4:20 | tainted |
+| various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` |
+| various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` |
+| various-concat-obfuscations.js:5:12:5:18 | tainted |
+| various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) |
+| various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") |
+| various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") |
+| various-concat-obfuscations.js:6:19:6:25 | tainted |
+| various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] |
+| various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() |
+| various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() |
+| various-concat-obfuscations.js:7:14:7:20 | tainted |
+| various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" |
+| various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" |
+| various-concat-obfuscations.js:9:19:9:25 | tainted |
+| various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` |
+| various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` |
+| various-concat-obfuscations.js:10:16:10:22 | tainted |
+| various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) |
+| various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") |
+| various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") |
+| various-concat-obfuscations.js:11:24:11:30 | tainted |
+| various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] |
+| various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() |
+| various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() |
+| various-concat-obfuscations.js:12:19:12:25 | tainted |
+| various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:20:17:20:40 | documen ... .search |
+| various-concat-obfuscations.js:20:17:20:40 | documen ... .search |
+| various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs |
+| various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:21:17:21:40 | documen ... .search |
+| various-concat-obfuscations.js:21:17:21:40 | documen ... .search |
+| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
 | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:33 | document.location |
 | winjs.js:2:17:2:33 | document.location |
@@ -1239,6 +1280,44 @@ edges
 | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted |
 | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted |
 | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:4:14:4:20 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:5:12:5:18 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:6:19:6:25 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:7:14:7:20 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:9:19:9:25 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:10:16:10:22 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:11:24:11:30 | tainted |
+| various-concat-obfuscations.js:2:6:2:39 | tainted | various-concat-obfuscations.js:12:19:12:25 | tainted |
+| various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:2:6:2:39 | tainted |
+| various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:2:6:2:39 | tainted |
+| various-concat-obfuscations.js:4:14:4:20 | tainted | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" |
+| various-concat-obfuscations.js:4:14:4:20 | tainted | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" |
+| various-concat-obfuscations.js:5:12:5:18 | tainted | various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` |
+| various-concat-obfuscations.js:5:12:5:18 | tainted | various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` |
+| various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") |
+| various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") |
+| various-concat-obfuscations.js:6:19:6:25 | tainted | various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) |
+| various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] | various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() |
+| various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] | various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() |
+| various-concat-obfuscations.js:7:14:7:20 | tainted | various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] |
+| various-concat-obfuscations.js:9:19:9:25 | tainted | various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" |
+| various-concat-obfuscations.js:9:19:9:25 | tainted | various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" |
+| various-concat-obfuscations.js:10:16:10:22 | tainted | various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` |
+| various-concat-obfuscations.js:10:16:10:22 | tainted | various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` |
+| various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") |
+| various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") |
+| various-concat-obfuscations.js:11:24:11:30 | tainted | various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) |
+| various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() |
+| various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() |
+| various-concat-obfuscations.js:12:19:12:25 | tainted | various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] |
+| various-concat-obfuscations.js:20:17:20:40 | documen ... .search | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs |
+| various-concat-obfuscations.js:20:17:20:40 | documen ... .search | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs |
+| various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:21:17:21:40 | documen ... .search | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
+| various-concat-obfuscations.js:21:17:21:40 | documen ... .search | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
+| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
+| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/various-concat-obfuscations.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/various-concat-obfuscations.js
@@ -1,0 +1,22 @@
+function test() {
+	let tainted = document.location.search;
+
+	$("<div>" + tainted + "</div>"); // NOT OK
+	$(`<div>${tainted}</div>`); // NOT OK
+	$("<div>".concat(tainted).concat("</div>")); // NOT OK
+	$(["<div>", tainted, "</div>"].join()); // NOT OK
+
+	$("<div id=\"" + tainted + "\"/>"); // NOT OK
+	$(`<div id="${tainted}"/>`); // NOT OK
+	$("<div id=\"".concat(tainted).concat("/>")); // NOT OK
+	$(["<div id=\"", tainted, "\"/>"].join()); // NOT OK
+
+	function indirection1(attrs) {
+		return '<div align="' + (attrs.defaultattr || 'left') + '">' + content + '</div>';
+	}
+	function indirection2(attrs) {
+		return '<div align="'.concat(attrs.defaultattr || 'left').concat('">'.concat(content)).concat('</div>');
+	}
+	$(indirection1(document.location.search.attrs)); // NOT OK
+	$(indirection2(document.location.search.attrs)); // NOT OK
+};


### PR DESCRIPTION
Adds test for ensuring that we do indeed support the anti-patterns discussed in <https://github.com/returntocorp/semgrep/issues/2409> and related links.

(this is more of a test for the taint tracking library than the syntactic pattern recognition that semgrep excels at)