### PR TITLE
Python: Add missing override annotation

### DIFF
--- a/python/ql/src/semmle/python/security/injection/Xml.qll
+++ b/python/ql/src/semmle/python/security/injection/Xml.qll
@@ -32,7 +32,7 @@ private class ExpatCreateParser extends TaintSource {
 
   override predicate isSourceOf(TaintKind kind) { kind instanceof ExpatParser }
 
-  string toString() { result = "expat.create.parser" }
+  override string toString() { result = "expat.create.parser" }
 }
 
 private FunctionObject xmlFromString() {


### PR DESCRIPTION
Found while browsing QLDoc coverage logs for a failing build