### PR TITLE
C#: Adjust CFG for `{Recursive,Positional,Property}PatternExpr`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
@@ -477,6 +477,12 @@ module ConditionalCompletionSplitting {
         or
         last(succ.(OrPatternExpr).getAnOperand(), pred, c) and
         completion = c
+        or
+        last(succ.(RecursivePatternExpr).getAChildExpr(), pred, c) and
+        completion = c
+        or
+        last(succ.(PropertyPatternExpr).getPattern(_), pred, c) and
+        completion = c
       )
     }
 

--- a/csharp/ql/src/semmle/code/csharp/exprs/Expr.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Expr.qll
@@ -303,18 +303,18 @@ private predicate hasChildPattern(ControlFlowElement pm, Expr child) {
   exists(Expr mid |
     hasChildPattern(pm, mid) and
     mid instanceof @recursive_pattern_expr and
-    child = mid.getChild([2, 3])
+    child = mid.getAChildExpr()
   )
   or
   exists(Expr mid |
     hasChildPattern(pm, mid) and
     mid instanceof @unary_pattern_expr and
-    child = mid.getChild(0)
+    child = mid.getChildExpr(0)
   )
   or
   exists(Expr mid | hasChildPattern(pm, mid) and mid instanceof @binary_pattern_expr |
-    child = mid.getChild(0) or
-    child = mid.getChild(1)
+    child = mid.getChildExpr(0) or
+    child = mid.getChildExpr(1)
   )
 }
 

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -962,7 +962,11 @@
 | Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:14:51:21 | [no-match] not ... | 1 |
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:30 | ... is ... | 3 |
 | Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:39 | ... is ... | 3 |
-| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | exit M4 | 10 |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:18:54:37 | Patterns u | 3 |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:53:24:53:25 | exit M4 | 5 |
+| Patterns.cs:54:27:54:35 | [match] { ... } | Patterns.cs:54:27:54:35 | [match] { ... } | 1 |
+| Patterns.cs:54:27:54:35 | [no-match] { ... } | Patterns.cs:54:27:54:35 | [no-match] { ... } | 1 |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:33:54:33 | 1 | 1 |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:17:60:17 | 1 | 4 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | exit M5 | 4 |
 | Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:60:13:60:17 | [match] not ... | 1 |
@@ -1009,8 +1013,10 @@
 | Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:93:17:93:19 | exit M10 | 2 |
 | Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:95:13:95:40 | [false] ... is ... | 1 |
 | Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:95:13:95:40 | [true] ... is ... | 1 |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } | 1 |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } | 1 |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } | 1 |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } | 1 |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } | 1 |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } | 1 |
 | Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:29:95:38 | [match] ... or ... | 1 |
 | Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:29:95:38 | [no-match] ... or ... | 1 |
 | Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:36:95:38 | access to constant B | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -1859,6 +1859,11 @@ conditionBlock
 | Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:25:51:25 | access to parameter c | true |
 | Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:9:51:21 | [false] ... is ... | false |
 | Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:34:51:34 | access to parameter c | false |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:27:54:35 | [match] { ... } | true |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:27:54:35 | [no-match] { ... } | true |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:33:54:33 | 1 | true |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [match] { ... } | true |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [no-match] { ... } | false |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:13:60:17 | [match] not ... | false |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:13:60:17 | [no-match] not ... | true |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:22:60:28 | "not 1" | false |
@@ -1930,22 +1935,30 @@ conditionBlock
 | Patterns.cs:87:54:87:54 | 2 | Patterns.cs:87:50:87:54 | [match] not ... | false |
 | Patterns.cs:87:54:87:54 | 2 | Patterns.cs:87:50:87:54 | [no-match] not ... | true |
 | Patterns.cs:87:54:87:54 | 2 | Patterns.cs:87:58:87:60 | "1" | false |
+| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:13:95:40 | [false] ... is ... | false |
+| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:21:95:40 | [no-match] { ... } | false |
+| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:21:95:40 | [no-match] { ... } | false |
 | Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:29:95:38 | [no-match] ... or ... | false |
 | Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:36:95:38 | access to constant B | false |
 | Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:96:9:98:9 | {...} | true |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:93:17:93:19 | exit M10 (normal) | false |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:93:17:93:19 | exit M10 (normal) | true |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... | false |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... | false |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... | true |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... | false |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... | true |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... | true |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } | false |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } | true |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:96:9:98:9 | {...} | false |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:96:9:98:9 | {...} | true |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:96:9:98:9 | {...} | true |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... | true |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... | true |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } | true |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:96:9:98:9 | {...} | true |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:96:9:98:9 | {...} | true |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... | false |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... | false |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } | false |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:13:95:40 | [true] ... is ... | true |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:21:95:40 | [match] { ... } | true |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:21:95:40 | [match] { ... } | true |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:96:9:98:9 | {...} | true |
+| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:13:95:40 | [false] ... is ... | false |
+| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:21:95:40 | [no-match] { ... } | false |
+| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:21:95:40 | [no-match] { ... } | false |
+| Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:13:95:40 | [false] ... is ... | false |
+| Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:21:95:40 | [no-match] { ... } | false |
+| Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:21:95:40 | [no-match] { ... } | false |
 | Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:29:95:38 | [no-match] ... or ... | false |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | [false] ... is ... | false |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:12:13:12:21 | [true] ... is ... | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -3160,10 +3160,11 @@ dominance
 | Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:54:18:54:37 | Patterns u |
 | Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:53:24:53:25 | exit M4 (normal) |
 | Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:9:54:37 | ... is ... |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:18:54:37 | { ... } |
 | Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:33:54:33 | 1 |
 | Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:14:54:37 | not ... |
-| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:18:54:37 | { ... } |
-| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | { ... } |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [match] { ... } |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [no-match] { ... } |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:57:5:63:5 | {...} |
 | Patterns.cs:56:26:56:27 | exit M5 (normal) | Patterns.cs:56:26:56:27 | exit M5 |
 | Patterns.cs:57:5:63:5 | {...} | Patterns.cs:58:16:58:16 | access to parameter i |
@@ -3239,11 +3240,14 @@ dominance
 | Patterns.cs:95:9:98:9 | if (...) ... | Patterns.cs:95:13:95:16 | this access |
 | Patterns.cs:95:13:95:16 | this access | Patterns.cs:95:29:95:31 | access to constant A |
 | Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:96:9:98:9 | {...} |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } |
 | Patterns.cs:95:29:95:31 | access to constant A | Patterns.cs:95:29:95:38 | [match] ... or ... |
 | Patterns.cs:95:29:95:31 | access to constant A | Patterns.cs:95:36:95:38 | access to constant B |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:21:95:40 | [no-match] { ... } |
 | Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
 | Patterns.cs:96:9:98:9 | {...} | Patterns.cs:97:13:97:39 | ...; |
 | Patterns.cs:97:13:97:39 | ...; | Patterns.cs:97:31:97:37 | "not C" |
@@ -7223,9 +7227,9 @@ postDominance
 | Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:54:14:54:37 | not ... |
 | Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:18:54:37 | { ... } |
 | Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:9:54:9 | access to parameter c |
-| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:27:54:35 | { ... } |
-| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:33:54:33 | 1 |
-| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:18:54:37 | Patterns u |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:18:54:37 | Patterns u |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:27:54:35 | [match] { ... } |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:27:54:35 | [no-match] { ... } |
 | Patterns.cs:56:26:56:27 | exit M5 | Patterns.cs:56:26:56:27 | exit M5 (normal) |
 | Patterns.cs:56:26:56:27 | exit M5 (normal) | Patterns.cs:58:9:62:10 | return ...; |
 | Patterns.cs:57:5:63:5 | {...} | Patterns.cs:56:26:56:27 | enter M5 |
@@ -7297,9 +7301,12 @@ postDominance
 | Patterns.cs:94:5:99:5 | {...} | Patterns.cs:93:17:93:19 | enter M10 |
 | Patterns.cs:95:9:98:9 | if (...) ... | Patterns.cs:94:5:99:5 | {...} |
 | Patterns.cs:95:13:95:16 | this access | Patterns.cs:95:9:98:9 | if (...) ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:29:95:38 | [match] ... or ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
+| Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:29:95:38 | [match] ... or ... |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
 | Patterns.cs:95:29:95:31 | access to constant A | Patterns.cs:95:13:95:16 | this access |
 | Patterns.cs:96:9:98:9 | {...} | Patterns.cs:95:13:95:40 | [true] ... is ... |
 | Patterns.cs:97:13:97:38 | call to method WriteLine | Patterns.cs:97:31:97:37 | "not C" |
@@ -11797,6 +11804,16 @@ blockDominance
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:25:51:25 | access to parameter c |
 | Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:34 | access to parameter c |
 | Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | enter M4 |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:18:54:37 | { ... } |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:27:54:35 | [match] { ... } |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:27:54:35 | [no-match] { ... } |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:33:54:33 | 1 |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:18:54:37 | { ... } |
+| Patterns.cs:54:27:54:35 | [match] { ... } | Patterns.cs:54:27:54:35 | [match] { ... } |
+| Patterns.cs:54:27:54:35 | [no-match] { ... } | Patterns.cs:54:27:54:35 | [no-match] { ... } |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [match] { ... } |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [no-match] { ... } |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:33:54:33 | 1 |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | enter M5 |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:58:16:62:9 | ... switch { ... } |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:60:13:60:17 | [match] not ... |
@@ -11924,8 +11941,10 @@ blockDominance
 | Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:93:17:93:19 | exit M10 (normal) |
 | Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:13:95:40 | [false] ... is ... |
 | Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:13:95:40 | [true] ... is ... |
-| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:21:95:40 | { ... } |
-| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:21:95:40 | { ... } |
+| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:21:95:40 | [no-match] { ... } |
 | Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:29:95:38 | [match] ... or ... |
 | Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
 | Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:95:36:95:38 | access to constant B |
@@ -11934,19 +11953,30 @@ blockDominance
 | Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:95:13:95:40 | [false] ... is ... |
 | Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:95:13:95:40 | [true] ... is ... |
 | Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:96:9:98:9 | {...} |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:93:17:93:19 | exit M10 (normal) |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:93:17:93:19 | exit M10 (normal) |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:96:9:98:9 | {...} |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:96:9:98:9 | {...} |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:96:9:98:9 | {...} |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:96:9:98:9 | {...} |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:13:95:40 | [true] ... is ... |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:21:95:40 | [match] { ... } |
 | Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:29:95:38 | [match] ... or ... |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:96:9:98:9 | {...} |
+| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:13:95:40 | [false] ... is ... |
+| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:21:95:40 | [no-match] { ... } |
 | Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
+| Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:13:95:40 | [false] ... is ... |
+| Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:21:95:40 | [no-match] { ... } |
 | Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
 | Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:36:95:38 | access to constant B |
 | Patterns.cs:96:9:98:9 | {...} | Patterns.cs:96:9:98:9 | {...} |
@@ -15269,6 +15299,14 @@ postBlockDominance
 | Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:14:51:21 | [no-match] not ... |
 | Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:34:51:34 | access to parameter c |
 | Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | enter M4 |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:53:24:53:25 | enter M4 |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:18:54:37 | { ... } |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:27:54:35 | [match] { ... } |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:27:54:35 | [no-match] { ... } |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:33:54:33 | 1 |
+| Patterns.cs:54:27:54:35 | [match] { ... } | Patterns.cs:54:27:54:35 | [match] { ... } |
+| Patterns.cs:54:27:54:35 | [no-match] { ... } | Patterns.cs:54:27:54:35 | [no-match] { ... } |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:33:54:33 | 1 |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | enter M5 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | enter M5 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:16:62:9 | ... switch { ... } |
@@ -15385,29 +15423,39 @@ postBlockDominance
 | Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:93:17:93:19 | exit M10 (normal) |
 | Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:13:95:40 | [false] ... is ... |
 | Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:13:95:40 | [true] ... is ... |
-| Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:21:95:40 | { ... } |
-| Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:21:95:40 | { ... } |
+| Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:21:95:40 | [no-match] { ... } |
 | Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:29:95:38 | [match] ... or ... |
 | Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
 | Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:95:36:95:38 | access to constant B |
 | Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:96:9:98:9 | {...} |
 | Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:95:13:95:40 | [false] ... is ... |
+| Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
 | Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:95:13:95:40 | [true] ... is ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:93:17:93:19 | enter M10 |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:93:17:93:19 | enter M10 |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:29:95:38 | [match] ... or ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:29:95:38 | [match] ... or ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:36:95:38 | access to constant B |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:36:95:38 | access to constant B |
+| Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:95:29:95:38 | [match] ... or ... |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:29:95:38 | [match] ... or ... |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:29:95:38 | [match] ... or ... |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
 | Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:29:95:38 | [match] ... or ... |
 | Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:29:95:38 | [no-match] ... or ... |
 | Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:36:95:38 | access to constant B |
 | Patterns.cs:96:9:98:9 | {...} | Patterns.cs:95:13:95:40 | [true] ... is ... |
+| Patterns.cs:96:9:98:9 | {...} | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:96:9:98:9 | {...} | Patterns.cs:95:21:95:40 | [match] { ... } |
+| Patterns.cs:96:9:98:9 | {...} | Patterns.cs:95:29:95:38 | [match] ... or ... |
 | Patterns.cs:96:9:98:9 | {...} | Patterns.cs:96:9:98:9 | {...} |
 | PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:5:10:5:11 | enter M1 |
 | PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:10:10:10:11 | enter M2 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -3605,7 +3605,8 @@ nodeEnclosing
 | Patterns.cs:54:14:54:37 | not ... | Patterns.cs:53:24:53:25 | M4 |
 | Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:53:24:53:25 | M4 |
 | Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:53:24:53:25 | M4 |
-| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:27:54:35 | [match] { ... } | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:27:54:35 | [no-match] { ... } | Patterns.cs:53:24:53:25 | M4 |
 | Patterns.cs:54:33:54:33 | 1 | Patterns.cs:53:24:53:25 | M4 |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:56:26:56:27 | exit M5 | Patterns.cs:56:26:56:27 | M5 |
@@ -3693,8 +3694,10 @@ nodeEnclosing
 | Patterns.cs:95:13:95:16 | this access | Patterns.cs:93:17:93:19 | M10 |
 | Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:93:17:93:19 | M10 |
 | Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:93:17:93:19 | M10 |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:93:17:93:19 | M10 |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:93:17:93:19 | M10 |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:93:17:93:19 | M10 |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:93:17:93:19 | M10 |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:93:17:93:19 | M10 |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:93:17:93:19 | M10 |
 | Patterns.cs:95:29:95:31 | access to constant A | Patterns.cs:93:17:93:19 | M10 |
 | Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:93:17:93:19 | M10 |
 | Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:93:17:93:19 | M10 |
@@ -5821,6 +5824,10 @@ blockEnclosing
 | Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:50:24:50:25 | M3 |
 | Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:27:54:35 | [match] { ... } | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:27:54:35 | [no-match] { ... } | Patterns.cs:53:24:53:25 | M4 |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:53:24:53:25 | M4 |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:56:26:56:27 | M5 |
@@ -5867,8 +5874,10 @@ blockEnclosing
 | Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:93:17:93:19 | M10 |
 | Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:93:17:93:19 | M10 |
 | Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:93:17:93:19 | M10 |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:93:17:93:19 | M10 |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:93:17:93:19 | M10 |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:93:17:93:19 | M10 |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:93:17:93:19 | M10 |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:93:17:93:19 | M10 |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:93:17:93:19 | M10 |
 | Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:93:17:93:19 | M10 |
 | Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:93:17:93:19 | M10 |
 | Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:93:17:93:19 | M10 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -2242,6 +2242,7 @@
 | Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:54:9:54:9 | access to parameter c |
 | Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:54:9:54:9 | access to parameter c |
 | Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:18:54:37 | Patterns u |
+| Patterns.cs:54:18:54:25 | access to type Patterns | Patterns.cs:54:18:54:25 | access to type Patterns |
 | Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:18:54:37 | Patterns u |
 | Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:18:54:37 | Patterns u |
 | Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:33:54:33 | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -2942,10 +2942,15 @@
 | Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:54:9:54:9 | access to parameter c | normal |
 | Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:54:9:54:37 | ... is ... | normal |
 | Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:14:54:37 | not ... | normal |
-| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:18:54:37 | Patterns u | normal |
+| Patterns.cs:54:18:54:25 | access to type Patterns | Patterns.cs:54:18:54:25 | access to type Patterns | match |
+| Patterns.cs:54:18:54:25 | access to type Patterns | Patterns.cs:54:18:54:25 | access to type Patterns | no-match |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:18:54:37 | Patterns u | match |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:18:54:37 | Patterns u | no-match |
 | Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:18:54:37 | { ... } | normal |
-| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:27:54:35 | { ... } | normal |
-| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:33:54:33 | 1 | normal |
+| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:27:54:35 | { ... } | match |
+| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:27:54:35 | { ... } | no-match |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:33:54:33 | 1 | match |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:33:54:33 | 1 | no-match |
 | Patterns.cs:57:5:63:5 | {...} | Patterns.cs:58:9:62:10 | return ...; | return |
 | Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:58:9:62:10 | return ...; | return |
 | Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:58:16:58:16 | access to parameter i | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -3635,10 +3635,13 @@
 | Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:54:18:54:37 | Patterns u | semmle.label | successor |
 | Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:53:24:53:25 | exit M4 (normal) | semmle.label | successor |
 | Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:9:54:37 | ... is ... | semmle.label | successor |
-| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:33:54:33 | 1 | semmle.label | successor |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:18:54:37 | { ... } | semmle.label | no-match |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:33:54:33 | 1 | semmle.label | match |
 | Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:14:54:37 | not ... | semmle.label | successor |
-| Patterns.cs:54:27:54:35 | { ... } | Patterns.cs:54:18:54:37 | { ... } | semmle.label | successor |
-| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | { ... } | semmle.label | successor |
+| Patterns.cs:54:27:54:35 | [match] { ... } | Patterns.cs:54:18:54:37 | { ... } | semmle.label | match |
+| Patterns.cs:54:27:54:35 | [no-match] { ... } | Patterns.cs:54:18:54:37 | { ... } | semmle.label | no-match |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [match] { ... } | semmle.label | match |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [no-match] { ... } | semmle.label | no-match |
 | Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:57:5:63:5 | {...} | semmle.label | successor |
 | Patterns.cs:56:26:56:27 | exit M5 (normal) | Patterns.cs:56:26:56:27 | exit M5 | semmle.label | successor |
 | Patterns.cs:57:5:63:5 | {...} | Patterns.cs:58:16:58:16 | access to parameter i | semmle.label | successor |
@@ -3727,14 +3730,14 @@
 | Patterns.cs:95:13:95:16 | this access | Patterns.cs:95:29:95:31 | access to constant A | semmle.label | successor |
 | Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:93:17:93:19 | exit M10 (normal) | semmle.label | false |
 | Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:96:9:98:9 | {...} | semmle.label | true |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... | semmle.label | no-match |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... | semmle.label | match |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } | semmle.label | match |
-| Patterns.cs:95:21:95:40 | { ... } | Patterns.cs:95:21:95:40 | { ... } | semmle.label | no-match |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... | semmle.label | match |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } | semmle.label | match |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... | semmle.label | no-match |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } | semmle.label | no-match |
 | Patterns.cs:95:29:95:31 | access to constant A | Patterns.cs:95:29:95:38 | [match] ... or ... | semmle.label | match |
 | Patterns.cs:95:29:95:31 | access to constant A | Patterns.cs:95:36:95:38 | access to constant B | semmle.label | no-match |
-| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:21:95:40 | { ... } | semmle.label | match |
-| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:21:95:40 | { ... } | semmle.label | no-match |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:21:95:40 | [match] { ... } | semmle.label | match |
+| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:21:95:40 | [no-match] { ... } | semmle.label | no-match |
 | Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:29:95:38 | [match] ... or ... | semmle.label | match |
 | Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:29:95:38 | [no-match] ... or ... | semmle.label | no-match |
 | Patterns.cs:96:9:98:9 | {...} | Patterns.cs:97:13:97:39 | ...; | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp8/PrintAst.expected
@@ -754,8 +754,8 @@ patterns.cs:
 #   13|             0: [IsExpr] ... is ...
 #   13|               0: [LocalVariableAccess] access to local variable o
 #   13|               1: [RecursivePatternExpr] { ... }
-#   13|                 0: [LocalVariableDeclExpr] MyStruct s
-#   13|                 1: [TypeAccess] access to type MyStruct
+#   13|                 0: [VariablePatternExpr] MyStruct s
+#   13|                 1: [TypeAccessPatternExpr] access to type MyStruct
 #   13|                   0: [TypeMention] MyStruct
 #   13|                 3: [PropertyPatternExpr] { ... }
 #   13|                   0: [LabeledPatternExpr,VariablePatternExpr] Int32 x
@@ -772,14 +772,14 @@ patterns.cs:
 #   17|         0: [IsExpr] ... is ...
 #   17|           0: [LocalVariableAccess] access to local variable o
 #   17|           1: [RecursivePatternExpr] { ... }
-#   17|             0: [LocalVariableDeclExpr] Object p
+#   17|             0: [VariablePatternExpr] Object p
 #   17|             3: [PropertyPatternExpr] { ... }
 #   18|         1: [BlockStmt] {...}
 #   22|       4: [IfStmt] if (...) ...
 #   22|         0: [IsExpr] ... is ...
 #   22|           0: [LocalVariableAccess] access to local variable o
 #   22|           1: [RecursivePatternExpr] { ... }
-#   22|             1: [TypeAccess] access to type MyStruct
+#   22|             1: [TypeAccessPatternExpr] access to type MyStruct
 #   22|               0: [TypeMention] MyStruct
 #   22|             3: [PropertyPatternExpr] { ... }
 #   22|               0: [ConstantPatternExpr,IntLiteral,LabeledPatternExpr] 12
@@ -791,13 +791,13 @@ patterns.cs:
 #   27|         0: [IsExpr] ... is ...
 #   27|           0: [LocalVariableAccess] access to local variable o
 #   27|           1: [RecursivePatternExpr] { ... }
-#   27|             1: [TypeAccess] access to type MyStruct
+#   27|             1: [TypeAccessPatternExpr] access to type MyStruct
 #   27|               0: [TypeMention] MyStruct
 #   27|             3: [PropertyPatternExpr] { ... }
 #   27|               0: [ConstantPatternExpr,IntLiteral,LabeledPatternExpr] 12
 #   27|               1: [LabeledPatternExpr,RecursivePatternExpr] { ... }
-#   27|                 0: [LocalVariableDeclExpr] MyStruct ms
-#   27|                 1: [TypeAccess] access to type MyStruct
+#   27|                 0: [VariablePatternExpr] MyStruct ms
+#   27|                 1: [TypeAccessPatternExpr] access to type MyStruct
 #   27|                   0: [TypeMention] MyStruct
 #   27|                 3: [PropertyPatternExpr] { ... }
 #   27|                   0: [DiscardPatternExpr,LabeledPatternExpr] _
@@ -847,7 +847,7 @@ patterns.cs:
 #   46|         0: [LocalVariableAccess] access to local variable s
 #   48|         0: [CaseStmt] case ...:
 #   48|           0: [RecursivePatternExpr] { ... }
-#   48|             1: [TypeAccess] access to type MyStruct
+#   48|             1: [TypeAccessPatternExpr] access to type MyStruct
 #   48|               0: [TypeMention] MyStruct
 #   48|             3: [PropertyPatternExpr] { ... }
 #   48|               0: [LabeledPatternExpr,VariablePatternExpr] Int32 x
@@ -863,8 +863,8 @@ patterns.cs:
 #   50|         2: [BreakStmt] break;
 #   51|         3: [CaseStmt] case ...:
 #   51|           0: [RecursivePatternExpr] { ... }
-#   51|             0: [LocalVariableDeclExpr] MyStruct ms
-#   51|             1: [TypeAccess] access to type MyStruct
+#   51|             0: [VariablePatternExpr] MyStruct ms
+#   51|             1: [TypeAccessPatternExpr] access to type MyStruct
 #   51|               0: [TypeMention] MyStruct
 #   51|             3: [PropertyPatternExpr] { ... }
 #   51|               0: [ConstantPatternExpr,IntLiteral,LabeledPatternExpr] 10
@@ -905,7 +905,7 @@ patterns.cs:
 #   65|         0: [LocalVariableAccess] access to local variable s
 #   67|         0: [CaseStmt] case ...:
 #   67|           0: [RecursivePatternExpr] { ... }
-#   67|             1: [TypeAccess] access to type MyStruct
+#   67|             1: [TypeAccessPatternExpr] access to type MyStruct
 #   67|               0: [TypeMention] MyStruct
 #   67|             3: [PropertyPatternExpr] { ... }
 #   67|               0: [LabeledPatternExpr,VariablePatternExpr] Int32 x
@@ -921,8 +921,8 @@ patterns.cs:
 #   69|         2: [BreakStmt] break;
 #   70|         3: [CaseStmt] case ...:
 #   70|           0: [RecursivePatternExpr] { ... }
-#   70|             0: [LocalVariableDeclExpr] MyStruct ms
-#   70|             1: [TypeAccess] access to type MyStruct
+#   70|             0: [VariablePatternExpr] MyStruct ms
+#   70|             1: [TypeAccessPatternExpr] access to type MyStruct
 #   70|               0: [TypeMention] MyStruct
 #   70|             3: [PropertyPatternExpr] { ... }
 #   70|               0: [ConstantPatternExpr,IntLiteral,LabeledPatternExpr] 10
@@ -1098,7 +1098,7 @@ patterns.cs:
 #  126|             -1: [LocalVariableAccess] access to local variable s
 #  128|             0: [SwitchCaseExpr] ... => ...
 #  128|               0: [RecursivePatternExpr] { ... }
-#  128|                 1: [TypeAccess] access to type MyStruct
+#  128|                 1: [TypeAccessPatternExpr] access to type MyStruct
 #  128|                   0: [TypeMention] MyStruct
 #  128|                 3: [PropertyPatternExpr] { ... }
 #  128|                   0: [LabeledPatternExpr,VariablePatternExpr] Int32 x
@@ -1109,8 +1109,8 @@ patterns.cs:
 #  128|               2: [IntLiteral] 0
 #  129|             1: [SwitchCaseExpr] ... => ...
 #  129|               0: [RecursivePatternExpr] { ... }
-#  129|                 0: [LocalVariableDeclExpr] MyStruct ms
-#  129|                 1: [TypeAccess] access to type MyStruct
+#  129|                 0: [VariablePatternExpr] MyStruct ms
+#  129|                 1: [TypeAccessPatternExpr] access to type MyStruct
 #  129|                   0: [TypeMention] MyStruct
 #  129|                 3: [PropertyPatternExpr] { ... }
 #  129|                   0: [ConstantPatternExpr,IntLiteral,LabeledPatternExpr] 10
@@ -1155,7 +1155,7 @@ patterns.cs:
 #  141|                   2: [IntLiteral] 5
 #  142|                 4: [SwitchCaseExpr] ... => ...
 #  142|                   0: [RecursivePatternExpr] { ... }
-#  142|                     1: [TypeAccess] access to type MyStruct
+#  142|                     1: [TypeAccessPatternExpr] access to type MyStruct
 #  142|                       0: [TypeMention] MyStruct
 #  142|                     3: [PropertyPatternExpr] { ... }
 #  142|                       0: [ConstantPatternExpr,IntLiteral,LabeledPatternExpr] 10

--- a/csharp/ql/test/library-tests/csharp8/ispatternflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/ispatternflow.expected
@@ -23,13 +23,14 @@
 | patterns.cs:13:13:13:47 | [true] ... && ... | patterns.cs:13:52:13:52 | access to local variable s | semmle.label | true |
 | patterns.cs:13:13:13:56 | [false] ... && ... | patterns.cs:17:9:19:9 | if (...) ... | semmle.label | false |
 | patterns.cs:13:13:13:56 | [true] ... && ... | patterns.cs:14:9:15:9 | {...} | semmle.label | true |
-| patterns.cs:13:18:13:40 | MyStruct s | patterns.cs:13:32:13:36 | Int32 x | semmle.label | successor |
-| patterns.cs:13:18:13:40 | { ... } | patterns.cs:13:13:13:40 | [false] ... is ... | semmle.label | no-match |
-| patterns.cs:13:18:13:40 | { ... } | patterns.cs:13:13:13:40 | [true] ... is ... | semmle.label | match |
-| patterns.cs:13:27:13:38 | { ... } | patterns.cs:13:18:13:40 | { ... } | semmle.label | match |
-| patterns.cs:13:27:13:38 | { ... } | patterns.cs:13:18:13:40 | { ... } | semmle.label | no-match |
-| patterns.cs:13:32:13:36 | Int32 x | patterns.cs:13:27:13:38 | { ... } | semmle.label | match |
-| patterns.cs:13:32:13:36 | Int32 x | patterns.cs:13:27:13:38 | { ... } | semmle.label | no-match |
+| patterns.cs:13:18:13:40 | MyStruct s | patterns.cs:13:18:13:40 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:13:18:13:40 | MyStruct s | patterns.cs:13:32:13:36 | Int32 x | semmle.label | match |
+| patterns.cs:13:18:13:40 | [match] { ... } | patterns.cs:13:13:13:40 | [true] ... is ... | semmle.label | match |
+| patterns.cs:13:18:13:40 | [no-match] { ... } | patterns.cs:13:13:13:40 | [false] ... is ... | semmle.label | no-match |
+| patterns.cs:13:27:13:38 | [match] { ... } | patterns.cs:13:18:13:40 | [match] { ... } | semmle.label | match |
+| patterns.cs:13:27:13:38 | [no-match] { ... } | patterns.cs:13:18:13:40 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:13:32:13:36 | Int32 x | patterns.cs:13:27:13:38 | [match] { ... } | semmle.label | match |
+| patterns.cs:13:32:13:36 | Int32 x | patterns.cs:13:27:13:38 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:13:45:13:45 | access to local variable x | patterns.cs:13:47:13:47 | 4 | semmle.label | successor |
 | patterns.cs:13:45:13:47 | ... < ... | patterns.cs:13:13:13:47 | [false] ... && ... | semmle.label | false |
 | patterns.cs:13:45:13:47 | ... < ... | patterns.cs:13:13:13:47 | [true] ... && ... | semmle.label | true |
@@ -44,43 +45,48 @@
 | patterns.cs:17:13:17:13 | access to local variable o | patterns.cs:17:18:17:21 | Object p | semmle.label | successor |
 | patterns.cs:17:13:17:21 | [false] ... is ... | patterns.cs:22:9:24:9 | if (...) ... | semmle.label | false |
 | patterns.cs:17:13:17:21 | [true] ... is ... | patterns.cs:18:9:19:9 | {...} | semmle.label | true |
-| patterns.cs:17:18:17:19 | { ... } | patterns.cs:17:18:17:21 | { ... } | semmle.label | match |
-| patterns.cs:17:18:17:19 | { ... } | patterns.cs:17:18:17:21 | { ... } | semmle.label | no-match |
-| patterns.cs:17:18:17:21 | Object p | patterns.cs:17:18:17:19 | { ... } | semmle.label | successor |
-| patterns.cs:17:18:17:21 | { ... } | patterns.cs:17:13:17:21 | [false] ... is ... | semmle.label | no-match |
-| patterns.cs:17:18:17:21 | { ... } | patterns.cs:17:13:17:21 | [true] ... is ... | semmle.label | match |
+| patterns.cs:17:18:17:19 | { ... } | patterns.cs:17:18:17:21 | [match] { ... } | semmle.label | match |
+| patterns.cs:17:18:17:19 | { ... } | patterns.cs:17:18:17:21 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:17:18:17:21 | Object p | patterns.cs:17:18:17:19 | { ... } | semmle.label | match |
+| patterns.cs:17:18:17:21 | Object p | patterns.cs:17:18:17:21 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:17:18:17:21 | [match] { ... } | patterns.cs:17:13:17:21 | [true] ... is ... | semmle.label | match |
+| patterns.cs:17:18:17:21 | [no-match] { ... } | patterns.cs:17:13:17:21 | [false] ... is ... | semmle.label | no-match |
 | patterns.cs:18:9:19:9 | {...} | patterns.cs:22:9:24:9 | if (...) ... | semmle.label | successor |
 | patterns.cs:22:9:24:9 | if (...) ... | patterns.cs:22:13:22:13 | access to local variable o | semmle.label | successor |
-| patterns.cs:22:13:22:13 | access to local variable o | patterns.cs:22:31:22:32 | 12 | semmle.label | successor |
+| patterns.cs:22:13:22:13 | access to local variable o | patterns.cs:22:18:22:25 | access to type MyStruct | semmle.label | successor |
 | patterns.cs:22:13:22:53 | [false] ... is ... | patterns.cs:27:9:29:9 | if (...) ... | semmle.label | false |
 | patterns.cs:22:13:22:53 | [true] ... is ... | patterns.cs:23:9:24:9 | {...} | semmle.label | true |
-| patterns.cs:22:18:22:53 | { ... } | patterns.cs:22:13:22:53 | [false] ... is ... | semmle.label | no-match |
-| patterns.cs:22:18:22:53 | { ... } | patterns.cs:22:13:22:53 | [true] ... is ... | semmle.label | match |
-| patterns.cs:22:27:22:53 | { ... } | patterns.cs:22:18:22:53 | { ... } | semmle.label | match |
-| patterns.cs:22:27:22:53 | { ... } | patterns.cs:22:18:22:53 | { ... } | semmle.label | no-match |
+| patterns.cs:22:18:22:25 | access to type MyStruct | patterns.cs:22:18:22:53 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:22:18:22:25 | access to type MyStruct | patterns.cs:22:31:22:32 | 12 | semmle.label | match |
+| patterns.cs:22:18:22:53 | [match] { ... } | patterns.cs:22:13:22:53 | [true] ... is ... | semmle.label | match |
+| patterns.cs:22:18:22:53 | [no-match] { ... } | patterns.cs:22:13:22:53 | [false] ... is ... | semmle.label | no-match |
+| patterns.cs:22:27:22:53 | [match] { ... } | patterns.cs:22:18:22:53 | [match] { ... } | semmle.label | match |
+| patterns.cs:22:27:22:53 | [no-match] { ... } | patterns.cs:22:18:22:53 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:22:31:22:32 | 12 | patterns.cs:22:27:22:53 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:22:31:22:32 | 12 | patterns.cs:22:42:22:49 | Int32 subX | semmle.label | match |
-| patterns.cs:22:31:22:32 | 12 | patterns.cs:22:42:22:49 | Int32 subX | semmle.label | no-match |
-| patterns.cs:22:38:22:51 | { ... } | patterns.cs:22:27:22:53 | { ... } | semmle.label | match |
-| patterns.cs:22:38:22:51 | { ... } | patterns.cs:22:27:22:53 | { ... } | semmle.label | no-match |
-| patterns.cs:22:38:22:51 | { ... } | patterns.cs:22:38:22:51 | { ... } | semmle.label | match |
-| patterns.cs:22:38:22:51 | { ... } | patterns.cs:22:38:22:51 | { ... } | semmle.label | no-match |
-| patterns.cs:22:42:22:49 | Int32 subX | patterns.cs:22:38:22:51 | { ... } | semmle.label | match |
-| patterns.cs:22:42:22:49 | Int32 subX | patterns.cs:22:38:22:51 | { ... } | semmle.label | no-match |
+| patterns.cs:22:38:22:51 | [match] { ... } | patterns.cs:22:27:22:53 | [match] { ... } | semmle.label | match |
+| patterns.cs:22:38:22:51 | [match] { ... } | patterns.cs:22:38:22:51 | [match] { ... } | semmle.label | match |
+| patterns.cs:22:38:22:51 | [no-match] { ... } | patterns.cs:22:27:22:53 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:22:38:22:51 | [no-match] { ... } | patterns.cs:22:38:22:51 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:22:42:22:49 | Int32 subX | patterns.cs:22:38:22:51 | [match] { ... } | semmle.label | match |
+| patterns.cs:22:42:22:49 | Int32 subX | patterns.cs:22:38:22:51 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:23:9:24:9 | {...} | patterns.cs:27:9:29:9 | if (...) ... | semmle.label | successor |
 | patterns.cs:27:9:29:9 | if (...) ... | patterns.cs:27:13:27:13 | access to local variable o | semmle.label | successor |
-| patterns.cs:27:13:27:13 | access to local variable o | patterns.cs:27:31:27:32 | 12 | semmle.label | successor |
+| patterns.cs:27:13:27:13 | access to local variable o | patterns.cs:27:18:27:25 | access to type MyStruct | semmle.label | successor |
 | patterns.cs:27:13:27:58 | [false] ... is ... | patterns.cs:5:10:5:19 | exit IsPatterns (normal) | semmle.label | false |
 | patterns.cs:27:13:27:58 | [true] ... is ... | patterns.cs:28:9:29:9 | {...} | semmle.label | true |
-| patterns.cs:27:18:27:58 | { ... } | patterns.cs:27:13:27:58 | [false] ... is ... | semmle.label | no-match |
-| patterns.cs:27:18:27:58 | { ... } | patterns.cs:27:13:27:58 | [true] ... is ... | semmle.label | match |
-| patterns.cs:27:27:27:58 | { ... } | patterns.cs:27:18:27:58 | { ... } | semmle.label | match |
-| patterns.cs:27:27:27:58 | { ... } | patterns.cs:27:18:27:58 | { ... } | semmle.label | no-match |
+| patterns.cs:27:18:27:25 | access to type MyStruct | patterns.cs:27:18:27:58 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:27:18:27:25 | access to type MyStruct | patterns.cs:27:31:27:32 | 12 | semmle.label | match |
+| patterns.cs:27:18:27:58 | [match] { ... } | patterns.cs:27:13:27:58 | [true] ... is ... | semmle.label | match |
+| patterns.cs:27:18:27:58 | [no-match] { ... } | patterns.cs:27:13:27:58 | [false] ... is ... | semmle.label | no-match |
+| patterns.cs:27:27:27:58 | [match] { ... } | patterns.cs:27:18:27:58 | [match] { ... } | semmle.label | match |
+| patterns.cs:27:27:27:58 | [no-match] { ... } | patterns.cs:27:18:27:58 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:27:31:27:32 | 12 | patterns.cs:27:27:27:58 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:27:31:27:32 | 12 | patterns.cs:27:38:27:56 | MyStruct ms | semmle.label | match |
-| patterns.cs:27:31:27:32 | 12 | patterns.cs:27:38:27:56 | MyStruct ms | semmle.label | no-match |
-| patterns.cs:27:38:27:56 | MyStruct ms | patterns.cs:27:51:27:51 | _ | semmle.label | successor |
-| patterns.cs:27:38:27:56 | { ... } | patterns.cs:27:27:27:58 | { ... } | semmle.label | match |
-| patterns.cs:27:38:27:56 | { ... } | patterns.cs:27:27:27:58 | { ... } | semmle.label | no-match |
-| patterns.cs:27:47:27:53 | { ... } | patterns.cs:27:38:27:56 | { ... } | semmle.label | match |
-| patterns.cs:27:47:27:53 | { ... } | patterns.cs:27:38:27:56 | { ... } | semmle.label | no-match |
-| patterns.cs:27:51:27:51 | _ | patterns.cs:27:47:27:53 | { ... } | semmle.label | match |
+| patterns.cs:27:38:27:56 | MyStruct ms | patterns.cs:27:38:27:56 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:27:38:27:56 | MyStruct ms | patterns.cs:27:51:27:51 | _ | semmle.label | match |
+| patterns.cs:27:38:27:56 | [match] { ... } | patterns.cs:27:27:27:58 | [match] { ... } | semmle.label | match |
+| patterns.cs:27:38:27:56 | [no-match] { ... } | patterns.cs:27:27:27:58 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:27:47:27:53 | [match] { ... } | patterns.cs:27:38:27:56 | [match] { ... } | semmle.label | match |
+| patterns.cs:27:51:27:51 | _ | patterns.cs:27:47:27:53 | [match] { ... } | semmle.label | match |
 | patterns.cs:28:9:29:9 | {...} | patterns.cs:5:10:5:19 | exit IsPatterns (normal) | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/switchexprcontrolflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/switchexprcontrolflow.expected
@@ -27,70 +27,76 @@
 | patterns.cs:108:9:112:10 | ...; | patterns.cs:108:14:108:15 | Int32 x1 | semmle.label | successor |
 | patterns.cs:108:14:108:15 | Int32 x1 | patterns.cs:108:18:108:19 | Int32 y1 | semmle.label | successor |
 | patterns.cs:108:18:108:19 | Int32 y1 | patterns.cs:108:9:108:20 | (..., ...) | semmle.label | successor |
-| patterns.cs:108:24:108:31 | (..., ...) | patterns.cs:110:14:110:14 | 0 | semmle.label | successor |
+| patterns.cs:108:24:108:31 | (..., ...) | patterns.cs:110:13:110:17 | ( ... ) | semmle.label | successor |
 | patterns.cs:108:24:112:9 | ... switch { ... } | patterns.cs:108:9:112:9 | ... = ... | semmle.label | successor |
 | patterns.cs:108:25:108:26 | access to local variable x0 | patterns.cs:108:29:108:30 | access to local variable y0 | semmle.label | successor |
 | patterns.cs:108:29:108:30 | access to local variable y0 | patterns.cs:108:24:108:31 | (..., ...) | semmle.label | successor |
-| patterns.cs:110:13:110:17 | ( ... ) | patterns.cs:110:13:110:17 | { ... } | semmle.label | match |
-| patterns.cs:110:13:110:17 | ( ... ) | patterns.cs:110:13:110:17 | { ... } | semmle.label | no-match |
-| patterns.cs:110:13:110:17 | { ... } | patterns.cs:110:23:110:23 | 1 | semmle.label | match |
-| patterns.cs:110:13:110:17 | { ... } | patterns.cs:111:14:111:14 | 1 | semmle.label | no-match |
+| patterns.cs:110:13:110:17 | ( ... ) | patterns.cs:110:13:110:17 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:110:13:110:17 | ( ... ) | patterns.cs:110:14:110:14 | 0 | semmle.label | match |
+| patterns.cs:110:13:110:17 | [match] { ... } | patterns.cs:110:23:110:23 | 1 | semmle.label | match |
+| patterns.cs:110:13:110:17 | [no-match] { ... } | patterns.cs:111:13:111:17 | ( ... ) | semmle.label | no-match |
 | patterns.cs:110:13:110:26 | ... => ... | patterns.cs:108:24:112:9 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:110:14:110:14 | 0 | patterns.cs:110:13:110:17 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:110:14:110:14 | 0 | patterns.cs:110:16:110:16 | 1 | semmle.label | match |
-| patterns.cs:110:14:110:14 | 0 | patterns.cs:110:16:110:16 | 1 | semmle.label | no-match |
-| patterns.cs:110:16:110:16 | 1 | patterns.cs:110:13:110:17 | ( ... ) | semmle.label | match |
-| patterns.cs:110:16:110:16 | 1 | patterns.cs:110:13:110:17 | ( ... ) | semmle.label | no-match |
+| patterns.cs:110:16:110:16 | 1 | patterns.cs:110:13:110:17 | [match] { ... } | semmle.label | match |
+| patterns.cs:110:16:110:16 | 1 | patterns.cs:110:13:110:17 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:110:22:110:26 | (..., ...) | patterns.cs:110:13:110:26 | ... => ... | semmle.label | successor |
 | patterns.cs:110:23:110:23 | 1 | patterns.cs:110:25:110:25 | 0 | semmle.label | successor |
 | patterns.cs:110:25:110:25 | 0 | patterns.cs:110:22:110:26 | (..., ...) | semmle.label | successor |
-| patterns.cs:111:13:111:17 | ( ... ) | patterns.cs:111:13:111:17 | { ... } | semmle.label | match |
-| patterns.cs:111:13:111:17 | ( ... ) | patterns.cs:111:13:111:17 | { ... } | semmle.label | no-match |
-| patterns.cs:111:13:111:17 | { ... } | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | semmle.label | exception(InvalidOperationException) |
-| patterns.cs:111:13:111:17 | { ... } | patterns.cs:111:23:111:23 | 0 | semmle.label | match |
+| patterns.cs:111:13:111:17 | ( ... ) | patterns.cs:111:13:111:17 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:111:13:111:17 | ( ... ) | patterns.cs:111:14:111:14 | 1 | semmle.label | match |
+| patterns.cs:111:13:111:17 | [match] { ... } | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | semmle.label | exception(InvalidOperationException) |
+| patterns.cs:111:13:111:17 | [match] { ... } | patterns.cs:111:23:111:23 | 0 | semmle.label | match |
+| patterns.cs:111:13:111:17 | [no-match] { ... } | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | semmle.label | exception(InvalidOperationException) |
 | patterns.cs:111:13:111:26 | ... => ... | patterns.cs:108:24:112:9 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:111:14:111:14 | 1 | patterns.cs:111:13:111:17 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:111:14:111:14 | 1 | patterns.cs:111:16:111:16 | 0 | semmle.label | match |
-| patterns.cs:111:14:111:14 | 1 | patterns.cs:111:16:111:16 | 0 | semmle.label | no-match |
-| patterns.cs:111:16:111:16 | 0 | patterns.cs:111:13:111:17 | ( ... ) | semmle.label | match |
-| patterns.cs:111:16:111:16 | 0 | patterns.cs:111:13:111:17 | ( ... ) | semmle.label | no-match |
+| patterns.cs:111:16:111:16 | 0 | patterns.cs:111:13:111:17 | [match] { ... } | semmle.label | match |
+| patterns.cs:111:16:111:16 | 0 | patterns.cs:111:13:111:17 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:111:22:111:26 | (..., ...) | patterns.cs:111:13:111:26 | ... => ... | semmle.label | successor |
 | patterns.cs:111:23:111:23 | 0 | patterns.cs:111:25:111:25 | 1 | semmle.label | successor |
 | patterns.cs:111:25:111:25 | 1 | patterns.cs:111:22:111:26 | (..., ...) | semmle.label | successor |
 | patterns.cs:115:9:115:16 | (..., ...) | patterns.cs:115:21:115:22 | access to local variable x0 | semmle.label | successor |
 | patterns.cs:115:9:120:9 | ... = ... | patterns.cs:98:10:98:20 | exit Expressions (normal) | semmle.label | successor |
 | patterns.cs:115:9:120:10 | ...; | patterns.cs:115:9:115:16 | (..., ...) | semmle.label | successor |
-| patterns.cs:115:20:115:27 | (..., ...) | patterns.cs:117:14:117:14 | 0 | semmle.label | successor |
+| patterns.cs:115:20:115:27 | (..., ...) | patterns.cs:117:13:117:22 | ( ... ) | semmle.label | successor |
 | patterns.cs:115:20:120:9 | ... switch { ... } | patterns.cs:115:9:120:9 | ... = ... | semmle.label | successor |
 | patterns.cs:115:21:115:22 | access to local variable x0 | patterns.cs:115:25:115:26 | access to local variable y0 | semmle.label | successor |
 | patterns.cs:115:25:115:26 | access to local variable y0 | patterns.cs:115:20:115:27 | (..., ...) | semmle.label | successor |
-| patterns.cs:117:13:117:22 | ( ... ) | patterns.cs:117:13:117:22 | { ... } | semmle.label | match |
-| patterns.cs:117:13:117:22 | ( ... ) | patterns.cs:117:13:117:22 | { ... } | semmle.label | no-match |
-| patterns.cs:117:13:117:22 | { ... } | patterns.cs:117:28:117:29 | access to local variable y2 | semmle.label | match |
-| patterns.cs:117:13:117:22 | { ... } | patterns.cs:118:14:118:19 | Int32 x2 | semmle.label | no-match |
+| patterns.cs:117:13:117:22 | ( ... ) | patterns.cs:117:13:117:22 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:117:13:117:22 | ( ... ) | patterns.cs:117:14:117:14 | 0 | semmle.label | match |
+| patterns.cs:117:13:117:22 | [match] { ... } | patterns.cs:117:28:117:29 | access to local variable y2 | semmle.label | match |
+| patterns.cs:117:13:117:22 | [no-match] { ... } | patterns.cs:118:13:118:23 | ( ... ) | semmle.label | no-match |
 | patterns.cs:117:13:117:33 | ... => ... | patterns.cs:115:20:120:9 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:117:14:117:14 | 0 | patterns.cs:117:13:117:22 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:117:14:117:14 | 0 | patterns.cs:117:16:117:21 | Int32 y2 | semmle.label | match |
-| patterns.cs:117:14:117:14 | 0 | patterns.cs:117:16:117:21 | Int32 y2 | semmle.label | no-match |
-| patterns.cs:117:16:117:21 | Int32 y2 | patterns.cs:117:13:117:22 | ( ... ) | semmle.label | no-match |
+| patterns.cs:117:16:117:21 | Int32 y2 | patterns.cs:117:13:117:22 | [match] { ... } | semmle.label | match |
+| patterns.cs:117:16:117:21 | Int32 y2 | patterns.cs:117:13:117:22 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:117:27:117:33 | (..., ...) | patterns.cs:117:13:117:33 | ... => ... | semmle.label | successor |
 | patterns.cs:117:28:117:29 | access to local variable y2 | patterns.cs:117:32:117:32 | 0 | semmle.label | successor |
 | patterns.cs:117:32:117:32 | 0 | patterns.cs:117:27:117:33 | (..., ...) | semmle.label | successor |
-| patterns.cs:118:13:118:23 | ( ... ) | patterns.cs:118:13:118:23 | { ... } | semmle.label | match |
-| patterns.cs:118:13:118:23 | ( ... ) | patterns.cs:118:13:118:23 | { ... } | semmle.label | no-match |
-| patterns.cs:118:13:118:23 | { ... } | patterns.cs:118:29:118:29 | 0 | semmle.label | match |
-| patterns.cs:118:13:118:23 | { ... } | patterns.cs:119:14:119:19 | Int32 x2 | semmle.label | no-match |
+| patterns.cs:118:13:118:23 | ( ... ) | patterns.cs:118:13:118:23 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:118:13:118:23 | ( ... ) | patterns.cs:118:14:118:19 | Int32 x2 | semmle.label | match |
+| patterns.cs:118:13:118:23 | [match] { ... } | patterns.cs:118:29:118:29 | 0 | semmle.label | match |
+| patterns.cs:118:13:118:23 | [no-match] { ... } | patterns.cs:119:13:119:28 | ( ... ) | semmle.label | no-match |
 | patterns.cs:118:13:118:34 | ... => ... | patterns.cs:115:20:120:9 | ... switch { ... } | semmle.label | successor |
-| patterns.cs:118:14:118:19 | Int32 x2 | patterns.cs:118:22:118:22 | 0 | semmle.label | no-match |
-| patterns.cs:118:22:118:22 | 0 | patterns.cs:118:13:118:23 | ( ... ) | semmle.label | match |
-| patterns.cs:118:22:118:22 | 0 | patterns.cs:118:13:118:23 | ( ... ) | semmle.label | no-match |
+| patterns.cs:118:14:118:19 | Int32 x2 | patterns.cs:118:13:118:23 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:118:14:118:19 | Int32 x2 | patterns.cs:118:22:118:22 | 0 | semmle.label | match |
+| patterns.cs:118:22:118:22 | 0 | patterns.cs:118:13:118:23 | [match] { ... } | semmle.label | match |
+| patterns.cs:118:22:118:22 | 0 | patterns.cs:118:13:118:23 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:118:28:118:34 | (..., ...) | patterns.cs:118:13:118:34 | ... => ... | semmle.label | successor |
 | patterns.cs:118:29:118:29 | 0 | patterns.cs:118:32:118:33 | access to local variable x2 | semmle.label | successor |
 | patterns.cs:118:32:118:33 | access to local variable x2 | patterns.cs:118:28:118:34 | (..., ...) | semmle.label | successor |
-| patterns.cs:119:13:119:28 | ( ... ) | patterns.cs:119:13:119:28 | { ... } | semmle.label | match |
-| patterns.cs:119:13:119:28 | ( ... ) | patterns.cs:119:13:119:28 | { ... } | semmle.label | no-match |
-| patterns.cs:119:13:119:28 | { ... } | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | semmle.label | exception(InvalidOperationException) |
-| patterns.cs:119:13:119:28 | { ... } | patterns.cs:119:34:119:34 | 0 | semmle.label | match |
+| patterns.cs:119:13:119:28 | ( ... ) | patterns.cs:119:13:119:28 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:119:13:119:28 | ( ... ) | patterns.cs:119:14:119:19 | Int32 x2 | semmle.label | match |
+| patterns.cs:119:13:119:28 | [match] { ... } | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | semmle.label | exception(InvalidOperationException) |
+| patterns.cs:119:13:119:28 | [match] { ... } | patterns.cs:119:34:119:34 | 0 | semmle.label | match |
+| patterns.cs:119:13:119:28 | [no-match] { ... } | patterns.cs:98:10:98:20 | exit Expressions (abnormal) | semmle.label | exception(InvalidOperationException) |
 | patterns.cs:119:13:119:38 | ... => ... | patterns.cs:115:20:120:9 | ... switch { ... } | semmle.label | successor |
-| patterns.cs:119:14:119:19 | Int32 x2 | patterns.cs:119:22:119:27 | Int32 y2 | semmle.label | no-match |
-| patterns.cs:119:22:119:27 | Int32 y2 | patterns.cs:119:13:119:28 | ( ... ) | semmle.label | no-match |
+| patterns.cs:119:14:119:19 | Int32 x2 | patterns.cs:119:13:119:28 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:119:14:119:19 | Int32 x2 | patterns.cs:119:22:119:27 | Int32 y2 | semmle.label | match |
+| patterns.cs:119:22:119:27 | Int32 y2 | patterns.cs:119:13:119:28 | [match] { ... } | semmle.label | match |
+| patterns.cs:119:22:119:27 | Int32 y2 | patterns.cs:119:13:119:28 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:119:33:119:38 | (..., ...) | patterns.cs:119:13:119:38 | ... => ... | semmle.label | successor |
 | patterns.cs:119:34:119:34 | 0 | patterns.cs:119:37:119:37 | 0 | semmle.label | successor |
 | patterns.cs:119:37:119:37 | 0 | patterns.cs:119:33:119:38 | (..., ...) | semmle.label | successor |
@@ -106,37 +112,41 @@
 | patterns.cs:125:36:125:36 | 0 | patterns.cs:125:32:125:36 | ... = ... | semmle.label | successor |
 | patterns.cs:126:9:132:10 | ... ...; | patterns.cs:126:17:126:17 | access to local variable s | semmle.label | successor |
 | patterns.cs:126:13:132:9 | Int32 r = ... | patterns.cs:134:9:148:9 | try {...} ... | semmle.label | successor |
-| patterns.cs:126:17:126:17 | access to local variable s | patterns.cs:128:27:128:31 | Int32 x | semmle.label | successor |
+| patterns.cs:126:17:126:17 | access to local variable s | patterns.cs:128:13:128:20 | access to type MyStruct | semmle.label | successor |
 | patterns.cs:126:17:132:9 | ... switch { ... } | patterns.cs:126:13:132:9 | Int32 r = ... | semmle.label | successor |
-| patterns.cs:128:13:128:33 | { ... } | patterns.cs:128:40:128:40 | access to local variable x | semmle.label | match |
-| patterns.cs:128:13:128:33 | { ... } | patterns.cs:129:13:129:33 | MyStruct ms | semmle.label | no-match |
+| patterns.cs:128:13:128:20 | access to type MyStruct | patterns.cs:128:13:128:33 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:128:13:128:20 | access to type MyStruct | patterns.cs:128:27:128:31 | Int32 x | semmle.label | match |
+| patterns.cs:128:13:128:33 | [match] { ... } | patterns.cs:128:40:128:40 | access to local variable x | semmle.label | match |
+| patterns.cs:128:13:128:33 | [no-match] { ... } | patterns.cs:129:13:129:33 | MyStruct ms | semmle.label | no-match |
 | patterns.cs:128:13:128:49 | ... => ... | patterns.cs:126:17:132:9 | ... switch { ... } | semmle.label | successor |
-| patterns.cs:128:22:128:33 | { ... } | patterns.cs:128:13:128:33 | { ... } | semmle.label | match |
-| patterns.cs:128:22:128:33 | { ... } | patterns.cs:128:13:128:33 | { ... } | semmle.label | no-match |
-| patterns.cs:128:27:128:31 | Int32 x | patterns.cs:128:22:128:33 | { ... } | semmle.label | no-match |
+| patterns.cs:128:22:128:33 | [match] { ... } | patterns.cs:128:13:128:33 | [match] { ... } | semmle.label | match |
+| patterns.cs:128:22:128:33 | [no-match] { ... } | patterns.cs:128:13:128:33 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:128:27:128:31 | Int32 x | patterns.cs:128:22:128:33 | [match] { ... } | semmle.label | match |
+| patterns.cs:128:27:128:31 | Int32 x | patterns.cs:128:22:128:33 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:128:40:128:40 | access to local variable x | patterns.cs:128:44:128:44 | 2 | semmle.label | successor |
 | patterns.cs:128:40:128:44 | ... > ... | patterns.cs:128:49:128:49 | 0 | semmle.label | true |
 | patterns.cs:128:40:128:44 | ... > ... | patterns.cs:129:13:129:33 | MyStruct ms | semmle.label | false |
 | patterns.cs:128:44:128:44 | 2 | patterns.cs:128:40:128:44 | ... > ... | semmle.label | successor |
 | patterns.cs:128:49:128:49 | 0 | patterns.cs:128:13:128:49 | ... => ... | semmle.label | successor |
-| patterns.cs:129:13:129:33 | MyStruct ms | patterns.cs:129:27:129:28 | 10 | semmle.label | successor |
-| patterns.cs:129:13:129:33 | { ... } | patterns.cs:129:38:129:38 | 1 | semmle.label | match |
-| patterns.cs:129:13:129:33 | { ... } | patterns.cs:130:14:130:14 | 1 | semmle.label | no-match |
+| patterns.cs:129:13:129:33 | MyStruct ms | patterns.cs:129:13:129:33 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:129:13:129:33 | MyStruct ms | patterns.cs:129:27:129:28 | 10 | semmle.label | match |
+| patterns.cs:129:13:129:33 | [match] { ... } | patterns.cs:129:38:129:38 | 1 | semmle.label | match |
+| patterns.cs:129:13:129:33 | [no-match] { ... } | patterns.cs:130:13:130:18 | ( ... ) | semmle.label | no-match |
 | patterns.cs:129:13:129:38 | ... => ... | patterns.cs:126:17:132:9 | ... switch { ... } | semmle.label | successor |
-| patterns.cs:129:22:129:30 | { ... } | patterns.cs:129:13:129:33 | { ... } | semmle.label | match |
-| patterns.cs:129:22:129:30 | { ... } | patterns.cs:129:13:129:33 | { ... } | semmle.label | no-match |
-| patterns.cs:129:27:129:28 | 10 | patterns.cs:129:22:129:30 | { ... } | semmle.label | match |
-| patterns.cs:129:27:129:28 | 10 | patterns.cs:129:22:129:30 | { ... } | semmle.label | no-match |
+| patterns.cs:129:22:129:30 | [match] { ... } | patterns.cs:129:13:129:33 | [match] { ... } | semmle.label | match |
+| patterns.cs:129:22:129:30 | [no-match] { ... } | patterns.cs:129:13:129:33 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:129:27:129:28 | 10 | patterns.cs:129:22:129:30 | [match] { ... } | semmle.label | match |
+| patterns.cs:129:27:129:28 | 10 | patterns.cs:129:22:129:30 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:129:38:129:38 | 1 | patterns.cs:129:13:129:38 | ... => ... | semmle.label | successor |
-| patterns.cs:130:13:130:18 | ( ... ) | patterns.cs:130:13:130:18 | { ... } | semmle.label | match |
-| patterns.cs:130:13:130:18 | ( ... ) | patterns.cs:130:13:130:18 | { ... } | semmle.label | no-match |
-| patterns.cs:130:13:130:18 | { ... } | patterns.cs:130:23:130:23 | 2 | semmle.label | match |
-| patterns.cs:130:13:130:18 | { ... } | patterns.cs:131:18:131:18 | Int32 x | semmle.label | no-match |
+| patterns.cs:130:13:130:18 | ( ... ) | patterns.cs:130:13:130:18 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:130:13:130:18 | ( ... ) | patterns.cs:130:14:130:14 | 1 | semmle.label | match |
+| patterns.cs:130:13:130:18 | [match] { ... } | patterns.cs:130:23:130:23 | 2 | semmle.label | match |
+| patterns.cs:130:13:130:18 | [no-match] { ... } | patterns.cs:131:18:131:18 | Int32 x | semmle.label | no-match |
 | patterns.cs:130:13:130:23 | ... => ... | patterns.cs:126:17:132:9 | ... switch { ... } | semmle.label | successor |
+| patterns.cs:130:14:130:14 | 1 | patterns.cs:130:13:130:18 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:130:14:130:14 | 1 | patterns.cs:130:17:130:17 | 2 | semmle.label | match |
-| patterns.cs:130:14:130:14 | 1 | patterns.cs:130:17:130:17 | 2 | semmle.label | no-match |
-| patterns.cs:130:17:130:17 | 2 | patterns.cs:130:13:130:18 | ( ... ) | semmle.label | match |
-| patterns.cs:130:17:130:17 | 2 | patterns.cs:130:13:130:18 | ( ... ) | semmle.label | no-match |
+| patterns.cs:130:17:130:17 | 2 | patterns.cs:130:13:130:18 | [match] { ... } | semmle.label | match |
+| patterns.cs:130:17:130:17 | 2 | patterns.cs:130:13:130:18 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:130:23:130:23 | 2 | patterns.cs:130:13:130:23 | ... => ... | semmle.label | successor |
 | patterns.cs:131:13:131:22 | (..., ...) | patterns.cs:123:10:123:21 | exit Expressions2 (abnormal) | semmle.label | exception(InvalidOperationException) |
 | patterns.cs:131:13:131:22 | (..., ...) | patterns.cs:131:27:131:27 | 3 | semmle.label | match |
@@ -165,22 +175,25 @@
 | patterns.cs:140:31:140:31 | access to local variable y | patterns.cs:140:36:140:37 | { ... } | semmle.label | successor |
 | patterns.cs:140:31:140:37 | [false] ... is ... | patterns.cs:141:17:141:22 | access to type String | semmle.label | false |
 | patterns.cs:140:31:140:37 | [true] ... is ... | patterns.cs:140:42:140:42 | 4 | semmle.label | true |
-| patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:31:140:37 | [false] ... is ... | semmle.label | no-match |
-| patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:31:140:37 | [true] ... is ... | semmle.label | match |
-| patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:36:140:37 | { ... } | semmle.label | match |
-| patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:36:140:37 | { ... } | semmle.label | no-match |
+| patterns.cs:140:36:140:37 | [match] { ... } | patterns.cs:140:31:140:37 | [true] ... is ... | semmle.label | match |
+| patterns.cs:140:36:140:37 | [no-match] { ... } | patterns.cs:140:31:140:37 | [false] ... is ... | semmle.label | no-match |
+| patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:36:140:37 | [match] { ... } | semmle.label | match |
+| patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:36:140:37 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:140:42:140:42 | 4 | patterns.cs:140:17:140:42 | ... => ... | semmle.label | successor |
 | patterns.cs:141:17:141:22 | access to type String | patterns.cs:141:29:141:29 | 5 | semmle.label | match |
-| patterns.cs:141:17:141:22 | access to type String | patterns.cs:142:31:142:32 | 10 | semmle.label | no-match |
+| patterns.cs:141:17:141:22 | access to type String | patterns.cs:142:17:142:24 | access to type MyStruct | semmle.label | no-match |
 | patterns.cs:141:17:141:29 | ... => ... | patterns.cs:136:17:143:13 | ... switch { ... } | semmle.label | successor |
 | patterns.cs:141:29:141:29 | 5 | patterns.cs:141:17:141:29 | ... => ... | semmle.label | successor |
-| patterns.cs:142:17:142:36 | { ... } | patterns.cs:142:41:142:41 | 6 | semmle.label | match |
-| patterns.cs:142:17:142:36 | { ... } | patterns.cs:145:9:148:9 | [exception: InvalidOperationException] catch (...) {...} | semmle.label | exception(InvalidOperationException) |
+| patterns.cs:142:17:142:24 | access to type MyStruct | patterns.cs:142:17:142:36 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:142:17:142:24 | access to type MyStruct | patterns.cs:142:31:142:32 | 10 | semmle.label | match |
+| patterns.cs:142:17:142:36 | [match] { ... } | patterns.cs:142:41:142:41 | 6 | semmle.label | match |
+| patterns.cs:142:17:142:36 | [match] { ... } | patterns.cs:145:9:148:9 | [exception: InvalidOperationException] catch (...) {...} | semmle.label | exception(InvalidOperationException) |
+| patterns.cs:142:17:142:36 | [no-match] { ... } | patterns.cs:145:9:148:9 | [exception: InvalidOperationException] catch (...) {...} | semmle.label | exception(InvalidOperationException) |
 | patterns.cs:142:17:142:41 | ... => ... | patterns.cs:136:17:143:13 | ... switch { ... } | semmle.label | successor |
-| patterns.cs:142:26:142:34 | { ... } | patterns.cs:142:17:142:36 | { ... } | semmle.label | match |
-| patterns.cs:142:26:142:34 | { ... } | patterns.cs:142:17:142:36 | { ... } | semmle.label | no-match |
-| patterns.cs:142:31:142:32 | 10 | patterns.cs:142:26:142:34 | { ... } | semmle.label | match |
-| patterns.cs:142:31:142:32 | 10 | patterns.cs:142:26:142:34 | { ... } | semmle.label | no-match |
+| patterns.cs:142:26:142:34 | [match] { ... } | patterns.cs:142:17:142:36 | [match] { ... } | semmle.label | match |
+| patterns.cs:142:26:142:34 | [no-match] { ... } | patterns.cs:142:17:142:36 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:142:31:142:32 | 10 | patterns.cs:142:26:142:34 | [match] { ... } | semmle.label | match |
+| patterns.cs:142:31:142:32 | 10 | patterns.cs:142:26:142:34 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:142:41:142:41 | 6 | patterns.cs:142:17:142:41 | ... => ... | semmle.label | successor |
 | patterns.cs:145:9:148:9 | [exception: ArgumentException] catch (...) {...} | patterns.cs:123:10:123:21 | exit Expressions2 (abnormal) | semmle.label | exception(ArgumentException) |
 | patterns.cs:145:9:148:9 | [exception: Exception] catch (...) {...} | patterns.cs:123:10:123:21 | exit Expressions2 (abnormal) | semmle.label | exception(Exception) |

--- a/csharp/ql/test/library-tests/csharp8/switchstmtctrlflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/switchstmtctrlflow.expected
@@ -35,12 +35,15 @@
 | patterns.cs:43:17:43:22 | break; | patterns.cs:46:9:63:9 | switch (...) {...} | semmle.label | break |
 | patterns.cs:46:9:63:9 | switch (...) {...} | patterns.cs:46:17:46:17 | access to local variable s | semmle.label | successor |
 | patterns.cs:46:17:46:17 | access to local variable s | patterns.cs:48:13:48:50 | case ...: | semmle.label | successor |
-| patterns.cs:48:13:48:50 | case ...: | patterns.cs:48:32:48:36 | Int32 x | semmle.label | successor |
-| patterns.cs:48:18:48:38 | { ... } | patterns.cs:48:45:48:45 | access to local variable x | semmle.label | match |
-| patterns.cs:48:18:48:38 | { ... } | patterns.cs:51:13:51:39 | case ...: | semmle.label | no-match |
-| patterns.cs:48:27:48:38 | { ... } | patterns.cs:48:18:48:38 | { ... } | semmle.label | match |
-| patterns.cs:48:27:48:38 | { ... } | patterns.cs:48:18:48:38 | { ... } | semmle.label | no-match |
-| patterns.cs:48:32:48:36 | Int32 x | patterns.cs:48:27:48:38 | { ... } | semmle.label | no-match |
+| patterns.cs:48:13:48:50 | case ...: | patterns.cs:48:18:48:25 | access to type MyStruct | semmle.label | successor |
+| patterns.cs:48:18:48:25 | access to type MyStruct | patterns.cs:48:18:48:38 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:48:18:48:25 | access to type MyStruct | patterns.cs:48:32:48:36 | Int32 x | semmle.label | match |
+| patterns.cs:48:18:48:38 | [match] { ... } | patterns.cs:48:45:48:45 | access to local variable x | semmle.label | match |
+| patterns.cs:48:18:48:38 | [no-match] { ... } | patterns.cs:51:13:51:39 | case ...: | semmle.label | no-match |
+| patterns.cs:48:27:48:38 | [match] { ... } | patterns.cs:48:18:48:38 | [match] { ... } | semmle.label | match |
+| patterns.cs:48:27:48:38 | [no-match] { ... } | patterns.cs:48:18:48:38 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:48:32:48:36 | Int32 x | patterns.cs:48:27:48:38 | [match] { ... } | semmle.label | match |
+| patterns.cs:48:32:48:36 | Int32 x | patterns.cs:48:27:48:38 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:48:45:48:45 | access to local variable x | patterns.cs:48:49:48:49 | 2 | semmle.label | successor |
 | patterns.cs:48:45:48:49 | ... > ... | patterns.cs:49:17:49:37 | ...; | semmle.label | true |
 | patterns.cs:48:45:48:49 | ... > ... | patterns.cs:51:13:51:39 | case ...: | semmle.label | false |
@@ -50,23 +53,25 @@
 | patterns.cs:49:35:49:35 | access to local variable x | patterns.cs:49:17:49:36 | call to method WriteLine | semmle.label | successor |
 | patterns.cs:50:17:50:22 | break; | patterns.cs:65:9:73:9 | switch (...) {...} | semmle.label | break |
 | patterns.cs:51:13:51:39 | case ...: | patterns.cs:51:18:51:38 | MyStruct ms | semmle.label | successor |
-| patterns.cs:51:18:51:38 | MyStruct ms | patterns.cs:51:32:51:33 | 10 | semmle.label | successor |
-| patterns.cs:51:18:51:38 | { ... } | patterns.cs:52:17:52:56 | ...; | semmle.label | match |
-| patterns.cs:51:18:51:38 | { ... } | patterns.cs:54:13:54:43 | case ...: | semmle.label | no-match |
-| patterns.cs:51:27:51:35 | { ... } | patterns.cs:51:18:51:38 | { ... } | semmle.label | match |
-| patterns.cs:51:27:51:35 | { ... } | patterns.cs:51:18:51:38 | { ... } | semmle.label | no-match |
-| patterns.cs:51:32:51:33 | 10 | patterns.cs:51:27:51:35 | { ... } | semmle.label | match |
-| patterns.cs:51:32:51:33 | 10 | patterns.cs:51:27:51:35 | { ... } | semmle.label | no-match |
+| patterns.cs:51:18:51:38 | MyStruct ms | patterns.cs:51:18:51:38 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:51:18:51:38 | MyStruct ms | patterns.cs:51:32:51:33 | 10 | semmle.label | match |
+| patterns.cs:51:18:51:38 | [match] { ... } | patterns.cs:52:17:52:56 | ...; | semmle.label | match |
+| patterns.cs:51:18:51:38 | [no-match] { ... } | patterns.cs:54:13:54:43 | case ...: | semmle.label | no-match |
+| patterns.cs:51:27:51:35 | [match] { ... } | patterns.cs:51:18:51:38 | [match] { ... } | semmle.label | match |
+| patterns.cs:51:27:51:35 | [no-match] { ... } | patterns.cs:51:18:51:38 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:51:32:51:33 | 10 | patterns.cs:51:27:51:35 | [match] { ... } | semmle.label | match |
+| patterns.cs:51:32:51:33 | 10 | patterns.cs:51:27:51:35 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:52:17:52:55 | call to method WriteLine | patterns.cs:53:17:53:22 | break; | semmle.label | successor |
 | patterns.cs:52:17:52:56 | ...; | patterns.cs:52:35:52:54 | "Hit the breakpoint" | semmle.label | successor |
 | patterns.cs:52:35:52:54 | "Hit the breakpoint" | patterns.cs:52:17:52:55 | call to method WriteLine | semmle.label | successor |
 | patterns.cs:53:17:53:22 | break; | patterns.cs:65:9:73:9 | switch (...) {...} | semmle.label | break |
 | patterns.cs:54:13:54:43 | case ...: | patterns.cs:54:23:54:28 | Int32 x2 | semmle.label | successor |
-| patterns.cs:54:18:54:30 | { ... } | patterns.cs:54:18:54:30 | { ... } | semmle.label | match |
-| patterns.cs:54:18:54:30 | { ... } | patterns.cs:54:18:54:30 | { ... } | semmle.label | no-match |
-| patterns.cs:54:18:54:30 | { ... } | patterns.cs:54:37:54:38 | access to local variable x2 | semmle.label | match |
-| patterns.cs:54:18:54:30 | { ... } | patterns.cs:57:13:57:24 | case ...: | semmle.label | no-match |
-| patterns.cs:54:23:54:28 | Int32 x2 | patterns.cs:54:18:54:30 | { ... } | semmle.label | no-match |
+| patterns.cs:54:18:54:30 | [match] { ... } | patterns.cs:54:18:54:30 | [match] { ... } | semmle.label | match |
+| patterns.cs:54:18:54:30 | [match] { ... } | patterns.cs:54:37:54:38 | access to local variable x2 | semmle.label | match |
+| patterns.cs:54:18:54:30 | [no-match] { ... } | patterns.cs:54:18:54:30 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:54:18:54:30 | [no-match] { ... } | patterns.cs:57:13:57:24 | case ...: | semmle.label | no-match |
+| patterns.cs:54:23:54:28 | Int32 x2 | patterns.cs:54:18:54:30 | [match] { ... } | semmle.label | match |
+| patterns.cs:54:23:54:28 | Int32 x2 | patterns.cs:54:18:54:30 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:54:37:54:38 | access to local variable x2 | patterns.cs:54:42:54:42 | 2 | semmle.label | successor |
 | patterns.cs:54:37:54:42 | ... > ... | patterns.cs:55:17:55:38 | ...; | semmle.label | true |
 | patterns.cs:54:37:54:42 | ... > ... | patterns.cs:57:13:57:24 | case ...: | semmle.label | false |
@@ -75,15 +80,15 @@
 | patterns.cs:55:17:55:38 | ...; | patterns.cs:55:35:55:36 | access to local variable x2 | semmle.label | successor |
 | patterns.cs:55:35:55:36 | access to local variable x2 | patterns.cs:55:17:55:37 | call to method WriteLine | semmle.label | successor |
 | patterns.cs:56:17:56:22 | break; | patterns.cs:65:9:73:9 | switch (...) {...} | semmle.label | break |
-| patterns.cs:57:13:57:24 | case ...: | patterns.cs:57:19:57:19 | 1 | semmle.label | successor |
-| patterns.cs:57:18:57:23 | ( ... ) | patterns.cs:57:18:57:23 | { ... } | semmle.label | match |
-| patterns.cs:57:18:57:23 | ( ... ) | patterns.cs:57:18:57:23 | { ... } | semmle.label | no-match |
-| patterns.cs:57:18:57:23 | { ... } | patterns.cs:58:17:58:22 | break; | semmle.label | match |
-| patterns.cs:57:18:57:23 | { ... } | patterns.cs:59:13:59:28 | case ...: | semmle.label | no-match |
+| patterns.cs:57:13:57:24 | case ...: | patterns.cs:57:18:57:23 | ( ... ) | semmle.label | successor |
+| patterns.cs:57:18:57:23 | ( ... ) | patterns.cs:57:18:57:23 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:57:18:57:23 | ( ... ) | patterns.cs:57:19:57:19 | 1 | semmle.label | match |
+| patterns.cs:57:18:57:23 | [match] { ... } | patterns.cs:58:17:58:22 | break; | semmle.label | match |
+| patterns.cs:57:18:57:23 | [no-match] { ... } | patterns.cs:59:13:59:28 | case ...: | semmle.label | no-match |
+| patterns.cs:57:19:57:19 | 1 | patterns.cs:57:18:57:23 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:57:19:57:19 | 1 | patterns.cs:57:22:57:22 | 2 | semmle.label | match |
-| patterns.cs:57:19:57:19 | 1 | patterns.cs:57:22:57:22 | 2 | semmle.label | no-match |
-| patterns.cs:57:22:57:22 | 2 | patterns.cs:57:18:57:23 | ( ... ) | semmle.label | match |
-| patterns.cs:57:22:57:22 | 2 | patterns.cs:57:18:57:23 | ( ... ) | semmle.label | no-match |
+| patterns.cs:57:22:57:22 | 2 | patterns.cs:57:18:57:23 | [match] { ... } | semmle.label | match |
+| patterns.cs:57:22:57:22 | 2 | patterns.cs:57:18:57:23 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:58:17:58:22 | break; | patterns.cs:65:9:73:9 | switch (...) {...} | semmle.label | break |
 | patterns.cs:59:13:59:28 | case ...: | patterns.cs:59:23:59:23 | Int32 x | semmle.label | successor |
 | patterns.cs:59:18:59:27 | (..., ...) | patterns.cs:60:17:60:22 | break; | semmle.label | match |
@@ -95,12 +100,15 @@
 | patterns.cs:62:17:62:22 | break; | patterns.cs:65:9:73:9 | switch (...) {...} | semmle.label | break |
 | patterns.cs:65:9:73:9 | switch (...) {...} | patterns.cs:65:17:65:17 | access to local variable s | semmle.label | successor |
 | patterns.cs:65:17:65:17 | access to local variable s | patterns.cs:67:13:67:50 | case ...: | semmle.label | successor |
-| patterns.cs:67:13:67:50 | case ...: | patterns.cs:67:32:67:36 | Int32 x | semmle.label | successor |
-| patterns.cs:67:18:67:38 | { ... } | patterns.cs:67:45:67:45 | access to local variable x | semmle.label | match |
-| patterns.cs:67:18:67:38 | { ... } | patterns.cs:70:13:70:51 | case ...: | semmle.label | no-match |
-| patterns.cs:67:27:67:38 | { ... } | patterns.cs:67:18:67:38 | { ... } | semmle.label | match |
-| patterns.cs:67:27:67:38 | { ... } | patterns.cs:67:18:67:38 | { ... } | semmle.label | no-match |
-| patterns.cs:67:32:67:36 | Int32 x | patterns.cs:67:27:67:38 | { ... } | semmle.label | no-match |
+| patterns.cs:67:13:67:50 | case ...: | patterns.cs:67:18:67:25 | access to type MyStruct | semmle.label | successor |
+| patterns.cs:67:18:67:25 | access to type MyStruct | patterns.cs:67:18:67:38 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:67:18:67:25 | access to type MyStruct | patterns.cs:67:32:67:36 | Int32 x | semmle.label | match |
+| patterns.cs:67:18:67:38 | [match] { ... } | patterns.cs:67:45:67:45 | access to local variable x | semmle.label | match |
+| patterns.cs:67:18:67:38 | [no-match] { ... } | patterns.cs:70:13:70:51 | case ...: | semmle.label | no-match |
+| patterns.cs:67:27:67:38 | [match] { ... } | patterns.cs:67:18:67:38 | [match] { ... } | semmle.label | match |
+| patterns.cs:67:27:67:38 | [no-match] { ... } | patterns.cs:67:18:67:38 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:67:32:67:36 | Int32 x | patterns.cs:67:27:67:38 | [match] { ... } | semmle.label | match |
+| patterns.cs:67:32:67:36 | Int32 x | patterns.cs:67:27:67:38 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:67:45:67:45 | access to local variable x | patterns.cs:67:49:67:49 | 2 | semmle.label | successor |
 | patterns.cs:67:45:67:49 | ... > ... | patterns.cs:68:17:68:37 | ...; | semmle.label | true |
 | patterns.cs:67:45:67:49 | ... > ... | patterns.cs:70:13:70:51 | case ...: | semmle.label | false |
@@ -110,13 +118,14 @@
 | patterns.cs:68:35:68:35 | access to local variable x | patterns.cs:68:17:68:36 | call to method WriteLine | semmle.label | successor |
 | patterns.cs:69:17:69:22 | break; | patterns.cs:76:9:84:9 | switch (...) {...} | semmle.label | break |
 | patterns.cs:70:13:70:51 | case ...: | patterns.cs:70:18:70:38 | MyStruct ms | semmle.label | successor |
-| patterns.cs:70:18:70:38 | MyStruct ms | patterns.cs:70:32:70:33 | 10 | semmle.label | successor |
-| patterns.cs:70:18:70:38 | { ... } | patterns.cs:70:45:70:45 | access to local variable s | semmle.label | match |
-| patterns.cs:70:18:70:38 | { ... } | patterns.cs:76:9:84:9 | switch (...) {...} | semmle.label | no-match |
-| patterns.cs:70:27:70:35 | { ... } | patterns.cs:70:18:70:38 | { ... } | semmle.label | match |
-| patterns.cs:70:27:70:35 | { ... } | patterns.cs:70:18:70:38 | { ... } | semmle.label | no-match |
-| patterns.cs:70:32:70:33 | 10 | patterns.cs:70:27:70:35 | { ... } | semmle.label | match |
-| patterns.cs:70:32:70:33 | 10 | patterns.cs:70:27:70:35 | { ... } | semmle.label | no-match |
+| patterns.cs:70:18:70:38 | MyStruct ms | patterns.cs:70:18:70:38 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:70:18:70:38 | MyStruct ms | patterns.cs:70:32:70:33 | 10 | semmle.label | match |
+| patterns.cs:70:18:70:38 | [match] { ... } | patterns.cs:70:45:70:45 | access to local variable s | semmle.label | match |
+| patterns.cs:70:18:70:38 | [no-match] { ... } | patterns.cs:76:9:84:9 | switch (...) {...} | semmle.label | no-match |
+| patterns.cs:70:27:70:35 | [match] { ... } | patterns.cs:70:18:70:38 | [match] { ... } | semmle.label | match |
+| patterns.cs:70:27:70:35 | [no-match] { ... } | patterns.cs:70:18:70:38 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:70:32:70:33 | 10 | patterns.cs:70:27:70:35 | [match] { ... } | semmle.label | match |
+| patterns.cs:70:32:70:33 | 10 | patterns.cs:70:27:70:35 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:70:45:70:45 | access to local variable s | patterns.cs:70:45:70:47 | access to field X | semmle.label | successor |
 | patterns.cs:70:45:70:47 | access to field X | patterns.cs:70:50:70:50 | 0 | semmle.label | successor |
 | patterns.cs:70:45:70:50 | ... == ... | patterns.cs:71:17:71:56 | ...; | semmle.label | true |
@@ -128,15 +137,15 @@
 | patterns.cs:72:17:72:22 | break; | patterns.cs:76:9:84:9 | switch (...) {...} | semmle.label | break |
 | patterns.cs:76:9:84:9 | switch (...) {...} | patterns.cs:76:17:76:28 | object creation of type Object | semmle.label | successor |
 | patterns.cs:76:17:76:28 | object creation of type Object | patterns.cs:78:13:78:43 | case ...: | semmle.label | successor |
-| patterns.cs:78:13:78:43 | case ...: | patterns.cs:78:19:78:23 | Int32 x | semmle.label | successor |
-| patterns.cs:78:18:78:33 | ( ... ) | patterns.cs:78:18:78:33 | { ... } | semmle.label | match |
-| patterns.cs:78:18:78:33 | ( ... ) | patterns.cs:78:18:78:33 | { ... } | semmle.label | no-match |
-| patterns.cs:78:18:78:33 | { ... } | patterns.cs:78:40:78:40 | access to local variable x | semmle.label | match |
-| patterns.cs:78:18:78:33 | { ... } | patterns.cs:80:13:80:20 | case ...: | semmle.label | no-match |
+| patterns.cs:78:13:78:43 | case ...: | patterns.cs:78:18:78:33 | ( ... ) | semmle.label | successor |
+| patterns.cs:78:18:78:33 | ( ... ) | patterns.cs:78:18:78:33 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:78:18:78:33 | ( ... ) | patterns.cs:78:19:78:23 | Int32 x | semmle.label | match |
+| patterns.cs:78:18:78:33 | [match] { ... } | patterns.cs:78:40:78:40 | access to local variable x | semmle.label | match |
+| patterns.cs:78:18:78:33 | [no-match] { ... } | patterns.cs:80:13:80:20 | case ...: | semmle.label | no-match |
+| patterns.cs:78:19:78:23 | Int32 x | patterns.cs:78:18:78:33 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:78:19:78:23 | Int32 x | patterns.cs:78:26:78:32 | Single y | semmle.label | match |
-| patterns.cs:78:19:78:23 | Int32 x | patterns.cs:78:26:78:32 | Single y | semmle.label | no-match |
-| patterns.cs:78:26:78:32 | Single y | patterns.cs:78:18:78:33 | ( ... ) | semmle.label | match |
-| patterns.cs:78:26:78:32 | Single y | patterns.cs:78:18:78:33 | ( ... ) | semmle.label | no-match |
+| patterns.cs:78:26:78:32 | Single y | patterns.cs:78:18:78:33 | [match] { ... } | semmle.label | match |
+| patterns.cs:78:26:78:32 | Single y | patterns.cs:78:18:78:33 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:78:40:78:40 | (...) ... | patterns.cs:78:42:78:42 | access to local variable y | semmle.label | successor |
 | patterns.cs:78:40:78:40 | access to local variable x | patterns.cs:78:40:78:40 | (...) ... | semmle.label | successor |
 | patterns.cs:78:40:78:42 | ... < ... | patterns.cs:79:17:79:22 | break; | semmle.label | true |
@@ -144,50 +153,48 @@
 | patterns.cs:78:42:78:42 | access to local variable y | patterns.cs:78:40:78:42 | ... < ... | semmle.label | successor |
 | patterns.cs:79:17:79:22 | break; | patterns.cs:86:9:89:9 | switch (...) {...} | semmle.label | break |
 | patterns.cs:80:13:80:20 | case ...: | patterns.cs:80:18:80:19 | ( ... ) | semmle.label | successor |
-| patterns.cs:80:18:80:19 | ( ... ) | patterns.cs:80:18:80:19 | { ... } | semmle.label | match |
-| patterns.cs:80:18:80:19 | ( ... ) | patterns.cs:80:18:80:19 | { ... } | semmle.label | no-match |
-| patterns.cs:80:18:80:19 | { ... } | patterns.cs:81:17:81:22 | break; | semmle.label | match |
-| patterns.cs:80:18:80:19 | { ... } | patterns.cs:82:13:82:20 | case ...: | semmle.label | no-match |
-| patterns.cs:81:17:81:22 | break; | patterns.cs:86:9:89:9 | switch (...) {...} | semmle.label | break |
+| patterns.cs:80:18:80:19 | ( ... ) | patterns.cs:80:18:80:19 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:80:18:80:19 | [no-match] { ... } | patterns.cs:82:13:82:20 | case ...: | semmle.label | no-match |
 | patterns.cs:82:13:82:20 | case ...: | patterns.cs:82:18:82:19 | { ... } | semmle.label | successor |
-| patterns.cs:82:18:82:19 | { ... } | patterns.cs:82:18:82:19 | { ... } | semmle.label | match |
-| patterns.cs:82:18:82:19 | { ... } | patterns.cs:82:18:82:19 | { ... } | semmle.label | no-match |
-| patterns.cs:82:18:82:19 | { ... } | patterns.cs:83:17:83:22 | break; | semmle.label | match |
-| patterns.cs:82:18:82:19 | { ... } | patterns.cs:86:9:89:9 | switch (...) {...} | semmle.label | no-match |
+| patterns.cs:82:18:82:19 | [match] { ... } | patterns.cs:83:17:83:22 | break; | semmle.label | match |
+| patterns.cs:82:18:82:19 | [no-match] { ... } | patterns.cs:86:9:89:9 | switch (...) {...} | semmle.label | no-match |
+| patterns.cs:82:18:82:19 | { ... } | patterns.cs:82:18:82:19 | [match] { ... } | semmle.label | match |
+| patterns.cs:82:18:82:19 | { ... } | patterns.cs:82:18:82:19 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:83:17:83:22 | break; | patterns.cs:86:9:89:9 | switch (...) {...} | semmle.label | break |
 | patterns.cs:86:9:89:9 | switch (...) {...} | patterns.cs:86:16:86:16 | 1 | semmle.label | successor |
 | patterns.cs:86:15:86:19 | (..., ...) | patterns.cs:88:13:88:24 | case ...: | semmle.label | successor |
 | patterns.cs:86:16:86:16 | 1 | patterns.cs:86:18:86:18 | 2 | semmle.label | successor |
 | patterns.cs:86:18:86:18 | 2 | patterns.cs:86:15:86:19 | (..., ...) | semmle.label | successor |
-| patterns.cs:88:13:88:24 | case ...: | patterns.cs:88:19:88:19 | 1 | semmle.label | successor |
-| patterns.cs:88:18:88:23 | ( ... ) | patterns.cs:88:18:88:23 | { ... } | semmle.label | match |
-| patterns.cs:88:18:88:23 | ( ... ) | patterns.cs:88:18:88:23 | { ... } | semmle.label | no-match |
-| patterns.cs:88:18:88:23 | { ... } | patterns.cs:88:26:88:31 | break; | semmle.label | match |
-| patterns.cs:88:18:88:23 | { ... } | patterns.cs:91:9:95:9 | switch (...) {...} | semmle.label | no-match |
+| patterns.cs:88:13:88:24 | case ...: | patterns.cs:88:18:88:23 | ( ... ) | semmle.label | successor |
+| patterns.cs:88:18:88:23 | ( ... ) | patterns.cs:88:18:88:23 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:88:18:88:23 | ( ... ) | patterns.cs:88:19:88:19 | 1 | semmle.label | match |
+| patterns.cs:88:18:88:23 | [match] { ... } | patterns.cs:88:26:88:31 | break; | semmle.label | match |
+| patterns.cs:88:18:88:23 | [no-match] { ... } | patterns.cs:91:9:95:9 | switch (...) {...} | semmle.label | no-match |
+| patterns.cs:88:19:88:19 | 1 | patterns.cs:88:18:88:23 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:88:19:88:19 | 1 | patterns.cs:88:22:88:22 | 2 | semmle.label | match |
-| patterns.cs:88:19:88:19 | 1 | patterns.cs:88:22:88:22 | 2 | semmle.label | no-match |
-| patterns.cs:88:22:88:22 | 2 | patterns.cs:88:18:88:23 | ( ... ) | semmle.label | match |
-| patterns.cs:88:22:88:22 | 2 | patterns.cs:88:18:88:23 | ( ... ) | semmle.label | no-match |
+| patterns.cs:88:22:88:22 | 2 | patterns.cs:88:18:88:23 | [match] { ... } | semmle.label | match |
+| patterns.cs:88:22:88:22 | 2 | patterns.cs:88:18:88:23 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:88:26:88:31 | break; | patterns.cs:91:9:95:9 | switch (...) {...} | semmle.label | break |
 | patterns.cs:91:9:95:9 | switch (...) {...} | patterns.cs:91:17:91:17 | 1 | semmle.label | successor |
 | patterns.cs:91:16:91:20 | (..., ...) | patterns.cs:93:13:93:28 | case ...: | semmle.label | successor |
 | patterns.cs:91:17:91:17 | 1 | patterns.cs:91:19:91:19 | 2 | semmle.label | successor |
 | patterns.cs:91:19:91:19 | 2 | patterns.cs:91:16:91:20 | (..., ...) | semmle.label | successor |
-| patterns.cs:93:13:93:28 | case ...: | patterns.cs:93:19:93:19 | 1 | semmle.label | successor |
-| patterns.cs:93:18:93:27 | ( ... ) | patterns.cs:93:18:93:27 | { ... } | semmle.label | match |
-| patterns.cs:93:18:93:27 | ( ... ) | patterns.cs:93:18:93:27 | { ... } | semmle.label | no-match |
-| patterns.cs:93:18:93:27 | { ... } | patterns.cs:93:30:93:35 | break; | semmle.label | match |
-| patterns.cs:93:18:93:27 | { ... } | patterns.cs:94:13:94:24 | case ...: | semmle.label | no-match |
+| patterns.cs:93:13:93:28 | case ...: | patterns.cs:93:18:93:27 | ( ... ) | semmle.label | successor |
+| patterns.cs:93:18:93:27 | ( ... ) | patterns.cs:93:18:93:27 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:93:18:93:27 | ( ... ) | patterns.cs:93:19:93:19 | 1 | semmle.label | match |
+| patterns.cs:93:18:93:27 | [match] { ... } | patterns.cs:93:30:93:35 | break; | semmle.label | match |
+| patterns.cs:93:18:93:27 | [no-match] { ... } | patterns.cs:94:13:94:24 | case ...: | semmle.label | no-match |
+| patterns.cs:93:19:93:19 | 1 | patterns.cs:93:18:93:27 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:93:19:93:19 | 1 | patterns.cs:93:22:93:26 | Int32 x | semmle.label | match |
-| patterns.cs:93:19:93:19 | 1 | patterns.cs:93:22:93:26 | Int32 x | semmle.label | no-match |
-| patterns.cs:93:22:93:26 | Int32 x | patterns.cs:93:18:93:27 | ( ... ) | semmle.label | no-match |
+| patterns.cs:93:22:93:26 | Int32 x | patterns.cs:93:18:93:27 | [match] { ... } | semmle.label | match |
+| patterns.cs:93:22:93:26 | Int32 x | patterns.cs:93:18:93:27 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:93:30:93:35 | break; | patterns.cs:32:10:32:25 | exit SwitchStatements (normal) | semmle.label | break |
-| patterns.cs:94:13:94:24 | case ...: | patterns.cs:94:19:94:19 | 2 | semmle.label | successor |
-| patterns.cs:94:18:94:23 | ( ... ) | patterns.cs:94:18:94:23 | { ... } | semmle.label | match |
-| patterns.cs:94:18:94:23 | ( ... ) | patterns.cs:94:18:94:23 | { ... } | semmle.label | no-match |
-| patterns.cs:94:18:94:23 | { ... } | patterns.cs:32:10:32:25 | exit SwitchStatements (normal) | semmle.label | no-match |
-| patterns.cs:94:18:94:23 | { ... } | patterns.cs:94:26:94:31 | break; | semmle.label | match |
+| patterns.cs:94:13:94:24 | case ...: | patterns.cs:94:18:94:23 | ( ... ) | semmle.label | successor |
+| patterns.cs:94:18:94:23 | ( ... ) | patterns.cs:94:18:94:23 | [no-match] { ... } | semmle.label | no-match |
+| patterns.cs:94:18:94:23 | ( ... ) | patterns.cs:94:19:94:19 | 2 | semmle.label | match |
+| patterns.cs:94:18:94:23 | [match] { ... } | patterns.cs:94:26:94:31 | break; | semmle.label | match |
+| patterns.cs:94:18:94:23 | [no-match] { ... } | patterns.cs:32:10:32:25 | exit SwitchStatements (normal) | semmle.label | no-match |
+| patterns.cs:94:19:94:19 | 2 | patterns.cs:94:18:94:23 | [no-match] { ... } | semmle.label | no-match |
 | patterns.cs:94:19:94:19 | 2 | patterns.cs:94:22:94:22 | _ | semmle.label | match |
-| patterns.cs:94:19:94:19 | 2 | patterns.cs:94:22:94:22 | _ | semmle.label | no-match |
-| patterns.cs:94:22:94:22 | _ | patterns.cs:94:18:94:23 | ( ... ) | semmle.label | match |
+| patterns.cs:94:22:94:22 | _ | patterns.cs:94:18:94:23 | [match] { ... } | semmle.label | match |
 | patterns.cs:94:26:94:31 | break; | patterns.cs:32:10:32:25 | exit SwitchStatements (normal) | semmle.label | break |

--- a/csharp/ql/test/library-tests/csharp9/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp9/PrintAst.expected
@@ -83,8 +83,8 @@ BinaryPattern.cs:
 #   10|         0: [VariablePatternExpr] Object o
 #   10|           0: [TypeMention] object
 #   10|         1: [RecursivePatternExpr] { ... }
-#   10|           0: [LocalVariableDeclExpr] BinaryPattern u
-#   10|           1: [TypeAccess] access to type BinaryPattern
+#   10|           0: [VariablePatternExpr] BinaryPattern u
+#   10|           1: [TypeAccessPatternExpr] access to type BinaryPattern
 #   10|             0: [TypeMention] BinaryPattern
 #   10|           3: [PropertyPatternExpr] { ... }
 #   10|             0: [ConstantPatternExpr,IntLiteral,LabeledPatternExpr] 1
@@ -608,14 +608,14 @@ ParenthesizedPattern.cs:
 #    9|         0: [IsExpr] ... is ...
 #    9|           0: [ParameterAccess] access to parameter o
 #    9|           1: [RecursivePatternExpr] { ... }
-#    9|             0: [LocalVariableDeclExpr] Object p1
+#    9|             0: [VariablePatternExpr] Object p1
 #    9|             3: [PropertyPatternExpr] { ... }
 #   10|         1: [BlockStmt] {...}
 #   13|       1: [IfStmt] if (...) ...
 #   13|         0: [IsExpr] ... is ...
 #   13|           0: [ParameterAccess] access to parameter o
 #   13|           1: [RecursivePatternExpr] { ... }
-#   13|             0: [LocalVariableDeclExpr] Object p2
+#   13|             0: [VariablePatternExpr] Object p2
 #   13|             3: [PropertyPatternExpr] { ... }
 #   14|         1: [BlockStmt] {...}
 #   19|   6: [Method] M2
@@ -1039,8 +1039,8 @@ UnaryPattern.cs:
 #   12|       0: [ParameterAccess] access to parameter c
 #   12|       1: [NotPatternExpr] not ...
 #   12|         0: [RecursivePatternExpr] { ... }
-#   12|           0: [LocalVariableDeclExpr] UnaryPattern u
-#   12|           1: [TypeAccess] access to type UnaryPattern
+#   12|           0: [VariablePatternExpr] UnaryPattern u
+#   12|           1: [TypeAccessPatternExpr] access to type UnaryPattern
 #   12|             0: [TypeMention] UnaryPattern
 #   12|           3: [PropertyPatternExpr] { ... }
 #   12|             0: [ConstantPatternExpr,IntLiteral,LabeledPatternExpr] 1

--- a/csharp/ql/test/library-tests/csharp9/typePattern.expected
+++ b/csharp/ql/test/library-tests/csharp9/typePattern.expected
@@ -1,6 +1,10 @@
 | BinaryPattern.cs:10:14:10:21 | Object o | Object |
+| BinaryPattern.cs:10:27:10:39 | access to type BinaryPattern | BinaryPattern |
+| BinaryPattern.cs:10:27:10:51 | BinaryPattern u | BinaryPattern |
 | BinaryPattern.cs:12:14:12:21 | Object o | Object |
 | BinaryPattern.cs:12:27:12:41 | BinaryPattern u | BinaryPattern |
+| ParenthesizedPattern.cs:9:18:9:22 | Object p1 | Object |
+| ParenthesizedPattern.cs:13:19:13:23 | Object p2 | Object |
 | ParenthesizedPattern.cs:25:13:25:15 | T t | T |
 | ParenthesizedPattern.cs:26:14:26:22 | Object o1 | Object |
 | ParenthesizedPattern.cs:27:14:27:19 | access to type String | String |
@@ -10,3 +14,5 @@
 | TypePattern.cs:12:13:12:20 | Double d | Double |
 | TypePattern.cs:13:13:13:25 | access to type String | String |
 | TypePattern.cs:14:13:14:27 | Object o | Object |
+| UnaryPattern.cs:12:18:12:29 | access to type UnaryPattern | UnaryPattern |
+| UnaryPattern.cs:12:18:12:41 | UnaryPattern u | UnaryPattern |


### PR DESCRIPTION
Follows up on https://github.com/github/codeql/pull/5018, which revealed problems with how we model `RecursivePatternExpr`, `PositionalPatternExpr`, and `PropertyPatternExpr` in the CFG. As an example, the CFG for
```csharp
public void M10()
{
    if (this is { Prop: E.A or E.B })
    {
        Console.WriteLine("not C");
    }
}
```

changes from

![before](https://user-images.githubusercontent.com/3667920/106461435-0e6f1e00-6495-11eb-8b1d-83510bb5ebe8.png)

to

![after](https://user-images.githubusercontent.com/3667920/106461442-10d17800-6495-11eb-87fa-a1e44e89a5f2.png)

Positional pattern expressions are, unlike other compound patterns, modelled in pre-order. This (hopefully) matches evaluation, as a pattern `x is (4, 5)` will first have to check for a relevant destructuring method before it can match recursively on `4` and `5`.

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/818/