### PR TITLE
C++: Add strsep model implementation.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strtok.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strtok.qll
@@ -47,3 +47,42 @@ private class Strtok extends ArrayFunction, AliasFunction, TaintFunction, SideEf
     i = [0, 1] and buffer = true
   }
 }
+
+/**
+ * The function `strtok` is a variant of `strtok` that takes a `char**` parameter instead of
+ * a `char*` as the first parameter.
+ */
+private class Strsep extends ArrayFunction, AliasFunction, TaintFunction, SideEffectFunction {
+  Strsep() { this.hasGlobalName("strsep") }
+
+  override predicate hasArrayWithNullTerminator(int bufParam) { bufParam = 1 }
+
+  override predicate hasArrayInput(int bufParam) { bufParam = 1 }
+
+  override predicate parameterNeverEscapes(int index) { index = [0, 1] }
+
+  override predicate parameterEscapesOnlyViaReturn(int index) { none() }
+
+  override predicate parameterIsAlwaysReturned(int index) { none() }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    // NOTE: What we really want here is: (input.isParameterDerefDeref(0) or input.isParameterDeref(1))
+    // as the first conjunct.
+    input.isParameterDeref([0, 1]) and
+    (output.isReturnValue() or output.isReturnValueDeref())
+  }
+
+  override predicate hasOnlySpecificReadSideEffects() { any() }
+
+  override predicate hasOnlySpecificWriteSideEffects() { any() }
+
+  override predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
+    i = 0 and buffer = false and mustWrite = false
+  }
+
+  override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
+    i = 0 and buffer = false
+    or
+    i = 1 and buffer = true
+  }
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -5952,6 +5952,20 @@
 | taint.cpp:560:8:560:12 | dest3 | taint.cpp:560:7:560:12 | * ... | TAINT |
 | taint.cpp:561:7:561:11 | ref arg dest4 | taint.cpp:562:8:562:12 | dest4 |  |
 | taint.cpp:562:8:562:12 | dest4 | taint.cpp:562:7:562:12 | * ... | TAINT |
+| taint.cpp:569:24:569:29 | source | taint.cpp:572:29:572:34 | source |  |
+| taint.cpp:570:23:570:30 | ,.-;:_ | taint.cpp:572:37:572:41 | delim |  |
+| taint.cpp:572:9:572:17 | tokenized | taint.cpp:572:9:572:42 | ... = ... |  |
+| taint.cpp:572:21:572:26 | call to strsep | taint.cpp:572:9:572:42 | ... = ... |  |
+| taint.cpp:572:21:572:26 | call to strsep | taint.cpp:573:10:573:18 | tokenized |  |
+| taint.cpp:572:21:572:26 | call to strsep | taint.cpp:574:11:574:19 | tokenized |  |
+| taint.cpp:572:28:572:34 | & ... | taint.cpp:572:21:572:26 | call to strsep | TAINT |
+| taint.cpp:572:28:572:34 | ref arg & ... | taint.cpp:572:29:572:34 | source |  |
+| taint.cpp:572:28:572:34 | ref arg & ... | taint.cpp:572:29:572:34 | source [inner post update] |  |
+| taint.cpp:572:29:572:34 | source | taint.cpp:572:21:572:26 | call to strsep | TAINT |
+| taint.cpp:572:29:572:34 | source | taint.cpp:572:28:572:34 | & ... |  |
+| taint.cpp:572:37:572:41 | delim | taint.cpp:572:21:572:26 | call to strsep | TAINT |
+| taint.cpp:573:10:573:18 | ref arg tokenized | taint.cpp:574:11:574:19 | tokenized |  |
+| taint.cpp:574:11:574:19 | tokenized | taint.cpp:574:10:574:19 | * ... | TAINT |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:17:26:17:32 | source1 |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:31:38:31:44 | source1 |  |
 | vector.cpp:17:21:17:33 | call to vector | vector.cpp:19:14:19:14 | v |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -561,3 +561,16 @@ void test__mbsncat_l(unsigned char* dest1, unsigned const char* ptr, unsigned ch
 	sink(dest4);
 	sink(*dest4);
 }
+
+// --- strsep ---
+
+char *strsep(char**, const char *);
+
+void test_strsep(char *source) {
+  const char* delim = ",.-;:_";
+  char* tokenized;
+  while(tokenized = strsep(&source, delim)) {
+    sink(tokenized); // $ ast,ir
+    sink(*tokenized); // $ ast,ir
+  }
+}


### PR DESCRIPTION
[The documentation for `strsep`](https://man7.org/linux/man-pages/man3/strsep.3.html) states that it's a good replacement of `strtok` so it would seem natural to keep it in the `Strtok` model implementation. Sadly, `strsep` takes a `char**` as the first parameter (and not a `char*` like `strtok`), so the implementation most of the predicates changes slightly.