### PR TITLE
Update CodeQL Style guide to mention acronyms

### DIFF
--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -212,7 +212,7 @@ class Type extends ... {
   /** ... */
   Type getATypeParameter() { ... }
   
-  /** ... */
+  /** Gets the HTTP connection ... */
   predicate getHttpConnection() { ... }
 }
 ```

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -173,7 +173,7 @@ private predicate foo(Expr e, Expr p) {
 1. Use [camelCase](https://en.wikipedia.org/wiki/Camel_case) for:
    - Predicate names
    - Variable names
-1. Abbreviations and acronyms *should* use normal PascalCase/camelCase (if there are only two letters, it is generally ok to use all uppercase letters).
+1. Abbreviations and acronyms *should* use normal PascalCase/camelCase (as an exception, if there are only two letters then using all uppercase letters is acceptable).
 1. Newtype predicate names *should* begin with `T`.
 1. Predicates that have a result *should* be named `get...`
 1. Predicates that can return multiple results *should* be named `getA...` or `getAn...`

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -173,6 +173,7 @@ private predicate foo(Expr e, Expr p) {
 1. Use [camelCase](https://en.wikipedia.org/wiki/Camel_case) for:
    - Predicate names
    - Variable names
+1. Abbreviations and acronyms *should* use normal PascalCase/camelCase (if there are only two letters, it is generally ok to use all uppercase letters).
 1. Newtype predicate names *should* begin with `T`.
 1. Predicates that have a result *should* be named `get...`
 1. Predicates that can return multiple results *should* be named `getA...` or `getAn...`
@@ -182,6 +183,7 @@ private predicate foo(Expr e, Expr p) {
 1. Short or single letter names for parameters and *quantifiers* *may* be used provided that they are sufficiently clear.
 1. Use names as they are used in the target-language specification.
 1. Use American English.
+
 
 ### Examples
 
@@ -209,6 +211,9 @@ class Type extends ... {
 
   /** ... */
   Type getATypeParameter() { ... }
+  
+  /** ... */
+  predicate getHttpConnection() { ... }
 }
 ```
 

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -212,8 +212,8 @@ class Type extends ... {
   /** ... */
   Type getATypeParameter() { ... }
   
-  /** Gets the HTTP connection ... */
-  predicate getHttpConnection() { ... }
+  /** Gets the SSA variable ... */
+  predicate getSsaVariable() { ... }
 }
 ```
 

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -173,7 +173,7 @@ private predicate foo(Expr e, Expr p) {
 1. Use [camelCase](https://en.wikipedia.org/wiki/Camel_case) for:
    - Predicate names
    - Variable names
-1. Abbreviations and acronyms *should* use normal PascalCase/camelCase (as an exception, if there are only two letters then using all uppercase letters is acceptable).
+1. Acronyms *should* use normal PascalCase/camelCase (as an exception, if there are only two letters then using all uppercase letters is acceptable).
 1. Newtype predicate names *should* begin with `T`.
 1. Predicates that have a result *should* be named `get...`
 1. Predicates that can return multiple results *should* be named `getA...` or `getAn...`


### PR DESCRIPTION
Adding this after asking how to do this internally. My initial suggestion was based on https://dart.dev/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words

~Creating as draft, so we don't accidentally merge without giving a chance to hear opposing opinions.~

After internal discussion, we've agreed to proceed with this style guide change. The argument was to pick the style that is consistent with style that QL already follows. So we're matching what is done in Java/C# .NET, which incidentally is the same as in Dart: https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions