### PR TITLE
C++: Add more indirection flow in dataflow models

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -911,27 +911,6 @@ private predicate modelFlow(Operand opFrom, Instruction iTo) {
       )
     )
   )
-  or
-  impliedModelFlow(opFrom, iTo)
-}
-
-/**
- * When a `DataFlowFunction` specifies dataflow from a parameter `p` to the return value there should
- * also be dataflow from the parameter dereference (i.e., `*p`) to the return value dereference.
- */
-private predicate impliedModelFlow(Operand opFrom, Instruction iTo) {
-  exists(
-    CallInstruction call, DataFlowFunction func, FunctionInput modelIn, FunctionOutput modelOut,
-    int index
-  |
-    call.getStaticCallTarget() = func and
-    func.hasDataFlow(modelIn, modelOut)
-  |
-    modelIn.isParameterOrQualifierAddress(index) and
-    modelOut.isReturnValue() and
-    opFrom = getSideEffectFor(call, index).(ReadSideEffectInstruction).getSideEffectOperand() and
-    iTo = call // TODO: Add write side effects for return values
-  )
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/IdentityFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/IdentityFunction.qll
@@ -32,5 +32,7 @@ private class IdentityFunction extends DataFlowFunction, SideEffectFunction, Ali
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
     // These functions simply return the argument value.
     input.isParameter(0) and output.isReturnValue()
+    or
+    input.isParameterDeref(0) and output.isReturnValueDeref()
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
@@ -109,6 +109,8 @@ private class IteratorCrementOperator extends Operator, DataFlowFunction {
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
     input = iteratorInput and
     output.isReturnValue()
+    or
+    input.isParameterDeref(0) and output.isReturnValueDeref()
   }
 }
 
@@ -159,6 +161,8 @@ private class IteratorAssignArithmeticOperator extends Operator, DataFlowFunctio
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
     input.isParameter(0) and
     output.isReturnValue()
+    or
+    input.isParameterDeref(0) and output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -201,6 +205,9 @@ private class IteratorCrementMemberOperator extends MemberFunction, DataFlowFunc
     or
     input.isReturnValueDeref() and
     output.isQualifierObject()
+    or
+    input.isQualifierObject() and
+    output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
@@ -193,7 +193,7 @@ class StdVectorEmplace extends TaintFunction {
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from any parameter except the position iterator to qualifier and return value
     // (here we assume taint flow from any constructor parameter to the constructed object)
-    input.isParameter([1 .. getNumberOfParameters() - 1]) and
+    input.isParameterDeref([1 .. getNumberOfParameters() - 1]) and
     (
       output.isQualifierObject() or
       output.isReturnValue()
@@ -210,7 +210,7 @@ class StdVectorEmplaceBack extends TaintFunction {
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from any parameter to qualifier
     // (here we assume taint flow from any constructor parameter to the constructed object)
-    input.isParameter([0 .. getNumberOfParameters() - 1]) and
+    input.isParameterDeref([0 .. getNumberOfParameters() - 1]) and
     output.isQualifierObject()
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdString.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdString.qll
@@ -293,6 +293,9 @@ private class StdIStreamIn extends DataFlowFunction, TaintFunction {
     // returns reference to `*this`
     input.isQualifierAddress() and
     output.isReturnValue()
+    or
+    input.isQualifierObject() and
+    output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -319,6 +322,9 @@ private class StdIStreamInNonMember extends DataFlowFunction, TaintFunction {
     // flow from first parameter to return value
     input.isParameter(0) and
     output.isReturnValue()
+    or
+    input.isParameterDeref(0) and
+    output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -361,6 +367,9 @@ private class StdIStreamRead extends DataFlowFunction, TaintFunction {
     // returns reference to `*this`
     input.isQualifierAddress() and
     output.isReturnValue()
+    or
+    input.isQualifierObject() and
+    output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -397,6 +406,9 @@ private class StdIStreamPutBack extends DataFlowFunction, TaintFunction {
     // returns reference to `*this`
     input.isQualifierAddress() and
     output.isReturnValue()
+    or
+    input.isQualifierObject() and
+    output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -430,6 +442,9 @@ private class StdIStreamGetLine extends DataFlowFunction, TaintFunction {
     // returns reference to `*this`
     input.isQualifierAddress() and
     output.isReturnValue()
+    or
+    input.isQualifierObject() and
+    output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -453,6 +468,9 @@ private class StdGetLine extends DataFlowFunction, TaintFunction {
     // flow from first parameter to return value
     input.isParameter(0) and
     output.isReturnValue()
+    or
+    input.isParameterDeref(0) and
+    output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -486,6 +504,9 @@ private class StdOStreamOut extends DataFlowFunction, TaintFunction {
     // returns reference to `*this`
     input.isQualifierAddress() and
     output.isReturnValue()
+    or
+    input.isQualifierObject() and
+    output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -522,6 +543,9 @@ private class StdOStreamOutNonMember extends DataFlowFunction, TaintFunction {
     // flow from first parameter to return value
     input.isParameter(0) and
     output.isReturnValue()
+    or
+    input.isParameterDeref(0) and
+    output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -605,6 +629,9 @@ private class StdStreamFunction extends DataFlowFunction, TaintFunction {
     // returns reference to `*this`
     input.isQualifierAddress() and
     output.isReturnValue()
+    or
+    input.isQualifierObject() and
+    output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strset.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strset.qll
@@ -40,6 +40,9 @@ private class StrsetFunction extends ArrayFunction, DataFlowFunction, AliasFunct
     // flow from the input string to the output string
     input.isParameter(0) and
     output.isReturnValue()
+    or
+    input.isParameterDeref(0) and
+    output.isReturnValueDeref()
   }
 
   override predicate parameterNeverEscapes(int index) { none() }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strset.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strset.qll
@@ -40,9 +40,6 @@ private class StrsetFunction extends ArrayFunction, DataFlowFunction, AliasFunct
     // flow from the input string to the output string
     input.isParameter(0) and
     output.isReturnValue()
-    or
-    input.isParameterDeref(0) and
-    output.isReturnValueDeref()
   }
 
   override predicate parameterNeverEscapes(int index) { none() }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -491,8 +491,8 @@ void test_vector_emplace() {
 	std::vector<int> v1(10), v2(10);
 
 	v1.emplace_back(source());
-	sink(v1); // $ ast MISSING: ir
+	sink(v1); // $ ast,ir
 
 	v2.emplace(v2.begin(), source());
-	sink(v2); // $ ast MISSING: ir
+	sink(v2); // $ ast,ir
 }


### PR DESCRIPTION
I also reverted the additions to DataFlowUtil added in #5035 as they can add too much flow. We can't have this flow "for free", and Geoffrey had a good example of why that is the case:

> Thinking about this a bit more, I'm not sure these flows are strictly implied, at least for dataflow (I'm aware it was me that said they were). For example imagine we modelled a function char *stringToUpper(char *source) that upper cases a string in place and returns it. We would have dataflow from its argument to the return value but only taint flow (I think) from the dereferenced argument to the dereferenced return value (because it is returned in upper case and is thus not equal to the original input). In extreme cases (strcpy???) we might not even have taint flow.

So I think the lesson learned is that, whenever we add a model that implements `hasDataFlow` that specifies flow between two pointers without modifying the object they point to, that model should probably also specify flow between the pointer indirections.