### PR TITLE
C++: Fix FormattingFunction regression.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -53,7 +53,12 @@ predicate primitiveVariadicFormatter(
   (
     if type = "" then outputParamIndex = -1 else outputParamIndex = 0 // Conveniently, these buffer parameters are all at index 0.
   ) and
-  not exists(f.getBlock()) // exclude functions with an implementation in the snapshot as they may not be standard implementations.
+  not (
+    // exclude functions with an implementation in the snapshot source
+    // directory, as they may not be standard implementations.
+    exists(f.getBlock()) and
+    exists(f.getFile().getRelativePath())
+  )
 }
 
 private predicate callsVariadicFormatter(


### PR DESCRIPTION
Fix the `FormattingFunction` regression caused by https://github.com/github/codeql/pull/5059, and identified in the [CPP Differences](https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1691/) job yesterday.

---

Investigation:

boostorg/boost
 - 4 results for `cpp/wrong-type-format-argument`, all look correct but were removed by https://github.com/github/codeql/pull/5059
 - 1 result for `cpp/non-constant-format`, looks correct but removed by https://github.com/github/codeql/pull/5059
 - 1 result for `cpp/path-injection` on the diff that I can't reproduce locally
 - all of the results are on calls to a function `report_error`, which calls `vsnprintf`.
 - this snapshot has two implementations of `vsnprintf`, one has an implementation outside the source directory.

torvalds/linux
 - 10 results for `cpp/wrong-type-format-argument`, all were removed by https://github.com/github/codeql/pull/5059
 - 14 results for `cpp/non-constant-format`, not affected by the change
 - 23 results for `cpp/path-injection`, not affected by the change
 - 37 results for `cpp/overrunning-write`, all were removed by https://github.com/github/codeql/pull/5059
 - a sample of the lost results include calls to `die` (which calls `vfprintf`) and `sprintf` (which calls `vsnprintf`).
 - this snapshot has one implementation of `vfprintf`, that has  an implementation outside the source directory.
 - this snapshot has three implementations of `vsnprintf`, one has an implementation outside the source directory, one has only a declaration that is inside the source directory, and the last has an implementation inside the source directory (problematic).

My previous experiments suggested that the `exists(f.getBlock())` (having source not just a declaration) and `exists(f.getFile().getRelativePath())` (being outside the source directory) solutions both excluded the results we wanted to exclude with slightly different tradeoffs, so requiring both conditions to exclude results ought to preserve the changes we want while making the exclusion more precise.  In the case of Linux, one of the versions of `vsnprintf` (marked 'problematic' above) will still be excluded and we'll still lose results for it (all of the `cpp/overrunning-write` results as it happens).  Looking at the function in question I don't think there's any getting around this if we want to exclude custom printf variants, because it is one:
```
 * This function generally follows C99 vsnprintf, but has some
 * extensions and a few limitations:
...
```

---

TL;DR: this improvement should mostly, but not entirely, restore the cpp-differences we saw yesterday.  **Please wait for cpp-differences on this branch to confirm everything is as expected before merging.**