### PR TITLE
Docs: Use /blob/ instead of /tree/ for direct query link

### DIFF
--- a/docs/codeql/query-help-markdown.py
+++ b/docs/codeql/query-help-markdown.py
@@ -188,10 +188,10 @@ for lang in languages:
             # Build a link to the query source file for display in the query help
             if "go" in prefix_repo_nwo(queryfile):
                 transform_link = prefix_repo_nwo(queryfile).replace(
-                    "codeql-go", "codeql-go/tree/main").replace(" ", "%20").replace("\\", "/")
+                    "codeql-go", "codeql-go/blob/main").replace(" ", "%20").replace("\\", "/")
             else:
                 transform_link = prefix_repo_nwo(queryfile).replace(
-                    "codeql", "codeql/tree/main").replace(" ", "%20").replace("\\", "/")
+                    "codeql", "codeql/blob/main").replace(" ", "%20").replace("\\", "/")
             query_link = "[Click to see the query in the CodeQL repository](https://github.com/" + \
                 transform_link + ")\n"
             


### PR DESCRIPTION
It doesn't have a huge impact, since there is a working redirect in place, but still more correct to use /blob/ :)

For example,

https://github.com/github/codeql/tree/main/python/ql/src/Security/CWE-094/CodeInjection.ql

redirects to

https://github.com/github/codeql/blob/main/python/ql/src/Security/CWE-094/CodeInjection.ql