### PR TITLE
Python: Fix query names with dunder (__)

### DIFF
--- a/python/ql/src/Classes/DefineEqualsWhenAddingAttributes.ql
+++ b/python/ql/src/Classes/DefineEqualsWhenAddingAttributes.ql
@@ -1,5 +1,5 @@
 /**
- * @name __eq__ not overridden when adding attributes
+ * @name `__eq__` not overridden when adding attributes
  * @description When adding new attributes to instances of a class, equality for that class needs to be defined.
  * @kind problem
  * @tags reliability

--- a/python/ql/src/Classes/InitCallsSubclassMethod.ql
+++ b/python/ql/src/Classes/InitCallsSubclassMethod.ql
@@ -1,6 +1,6 @@
 /**
- * @name __init__ method calls overridden method
- * @description Calling a method from __init__ that is overridden by a subclass may result in a partially
+ * @name `__init__` method calls overridden method
+ * @description Calling a method from `__init__` that is overridden by a subclass may result in a partially
  *              initialized instance being observed.
  * @kind problem
  * @tags reliability

--- a/python/ql/src/Classes/MaybeUndefinedClassAttribute.ql
+++ b/python/ql/src/Classes/MaybeUndefinedClassAttribute.ql
@@ -1,6 +1,6 @@
 /**
  * @name Maybe undefined class attribute
- * @description Accessing an attribute of 'self' that is not initialized in the __init__ method may cause an AttributeError at runtime
+ * @description Accessing an attribute of `self` that is not initialized in the `__init__` method may cause an AttributeError at runtime
  * @kind problem
  * @tags reliability
  *       correctness

--- a/python/ql/src/Classes/MissingCallToDel.ql
+++ b/python/ql/src/Classes/MissingCallToDel.ql
@@ -1,6 +1,6 @@
 /**
- * @name Missing call to __del__ during object destruction
- * @description An omitted call to a super-class __del__ method may lead to class instances not being cleaned up properly.
+ * @name Missing call to `__del__` during object destruction
+ * @description An omitted call to a super-class `__del__` method may lead to class instances not being cleaned up properly.
  * @kind problem
  * @tags efficiency
  *       correctness

--- a/python/ql/src/Classes/MissingCallToInit.ql
+++ b/python/ql/src/Classes/MissingCallToInit.ql
@@ -1,6 +1,6 @@
 /**
- * @name Missing call to __init__ during object initialization
- * @description An omitted call to a super-class __init__ method may lead to objects of this class not being fully initialized.
+ * @name Missing call to `__init__` during object initialization
+ * @description An omitted call to a super-class `__init__` method may lead to objects of this class not being fully initialized.
  * @kind problem
  * @tags reliability
  *       correctness

--- a/python/ql/src/Classes/MutatingDescriptor.ql
+++ b/python/ql/src/Classes/MutatingDescriptor.ql
@@ -1,5 +1,5 @@
 /**
- * @name Mutation of descriptor in __get__ or __set__ method.
+ * @name Mutation of descriptor in `__get__` or `__set__` method.
  * @description Descriptor objects can be shared across many instances. Mutating them can cause strange side effects or race conditions.
  * @kind problem
  * @tags reliability

--- a/python/ql/src/Classes/OverwritingAttributeInSuperClass.ql
+++ b/python/ql/src/Classes/OverwritingAttributeInSuperClass.ql
@@ -1,6 +1,6 @@
 /**
  * @name Overwriting attribute in super-class or sub-class
- * @description Assignment to self attribute overwrites attribute previously defined in subclass or superclass __init__ method.
+ * @description Assignment to self attribute overwrites attribute previously defined in subclass or superclass `__init__` method.
  * @kind problem
  * @tags reliability
  *       maintainability

--- a/python/ql/src/Classes/SlotsInOldStyleClass.qhelp
+++ b/python/ql/src/Classes/SlotsInOldStyleClass.qhelp
@@ -5,21 +5,21 @@
 
 <overview>
 <p>The ability to override the class dictionary using a <code>__slots__</code> declaration
-is supported only by new-style classes. When you add a <code>__slots__</code> declaration to an 
+is supported only by new-style classes. When you add a <code>__slots__</code> declaration to an
 old-style class it just creates a class attribute called <code>__slots__</code>.</p>
 
 </overview>
 <recommendation>
 
-<p>If you want to override the dictionary for a class, then ensure that the class is a new-style class. 
+<p>If you want to override the dictionary for a class, then ensure that the class is a new-style class.
 You can convert an old-style class to a new-style class by inheriting from <code>object</code>.</p>
 
 </recommendation>
 <example>
-<p>In the following example the <code>KeyedRef</code> class is an old-style class (no inheritance). The 
-dictionary is unaffected. The <code>KeyedRef2</code> class is a new-style class so the 
-<code>__slots__</code> declaration causes special compact attributes to be created for each name in 
+<p>In the following example the <code>KeyedRef</code> class is an old-style class (no inheritance). The
 <code>__slots__</code> declaration in this class creates a class attribute called <code>__slots__</code>, the class
+dictionary is unaffected. The <code>KeyedRef2</code> class is a new-style class so the
+<code>__slots__</code> declaration causes special compact attributes to be created for each name in
 the slots list and saves space by not creating attribute dictionaries.</p>
 
 <sample src="SlotsInOldStyleClass.py" />
@@ -28,7 +28,7 @@ the slots list and saves space by not creating attribute dictionaries.</p>
 <references>
 
 <li>Python Glossary: <a href="http://docs.python.org/glossary.html#term-new-style-class">New-style class</a>.</li>
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/datamodel.html#newstyle">New-style and classic 
+<li>Python Language Reference: <a href="http://docs.python.org/2/reference/datamodel.html#newstyle">New-style and classic
 classes</a>,
  <a href="http://docs.python.org/reference/datamodel.html#__slots__">__slots__</a>.</li>
 

--- a/python/ql/src/Classes/SlotsInOldStyleClass.qhelp
+++ b/python/ql/src/Classes/SlotsInOldStyleClass.qhelp
@@ -6,7 +6,7 @@
 <overview>
 <p>The ability to override the class dictionary using a <code>__slots__</code> declaration
 is supported only by new-style classes. When you add a <code>__slots__</code> declaration to an 
-old-style class it just creates a class attribute called '__slots__'.</p>
+old-style class it just creates a class attribute called <code>__slots__</code>.</p>
 
 </overview>
 <recommendation>
@@ -17,9 +17,9 @@ You can convert an old-style class to a new-style class by inheriting from <code
 </recommendation>
 <example>
 <p>In the following example the <code>KeyedRef</code> class is an old-style class (no inheritance). The 
-<code>__slots__</code> declaration in this class creates a class attribute called '__slots__', the class 
 dictionary is unaffected. The <code>KeyedRef2</code> class is a new-style class so the 
 <code>__slots__</code> declaration causes special compact attributes to be created for each name in 
+<code>__slots__</code> declaration in this class creates a class attribute called <code>__slots__</code>, the class
 the slots list and saves space by not creating attribute dictionaries.</p>
 
 <sample src="SlotsInOldStyleClass.py" />

--- a/python/ql/src/Classes/SlotsInOldStyleClass.qhelp
+++ b/python/ql/src/Classes/SlotsInOldStyleClass.qhelp
@@ -16,9 +16,9 @@ You can convert an old-style class to a new-style class by inheriting from <code
 
 </recommendation>
 <example>
-<p>In the following example the <code>KeyedRef</code> class is an old-style class (no inheritance). The
+<p>In the following example the <code>Point</code> class is an old-style class (no inheritance). The
 <code>__slots__</code> declaration in this class creates a class attribute called <code>__slots__</code>, the class
-dictionary is unaffected. The <code>KeyedRef2</code> class is a new-style class so the
+dictionary is unaffected. The <code>Point2</code> class is a new-style class so the
 <code>__slots__</code> declaration causes special compact attributes to be created for each name in
 the slots list and saves space by not creating attribute dictionaries.</p>
 

--- a/python/ql/src/Classes/SlotsInOldStyleClass.qhelp
+++ b/python/ql/src/Classes/SlotsInOldStyleClass.qhelp
@@ -16,7 +16,7 @@ You can convert an old-style class to a new-style class by inheriting from <code
 
 </recommendation>
 <example>
-<p>In the following example the <code>Point</code> class is an old-style class (no inheritance). The
+<p>In the following Python 2 example the <code>Point</code> class is an old-style class (no inheritance). The
 <code>__slots__</code> declaration in this class creates a class attribute called <code>__slots__</code>, the class
 dictionary is unaffected. The <code>Point2</code> class is a new-style class so the
 <code>__slots__</code> declaration causes special compact attributes to be created for each name in

--- a/python/ql/src/Classes/SlotsInOldStyleClass.ql
+++ b/python/ql/src/Classes/SlotsInOldStyleClass.ql
@@ -1,6 +1,6 @@
 /**
- * @name '__slots__' in old-style class
- * @description Overriding the class dictionary by declaring '__slots__' is not supported by old-style
+ * @name `__slots__` in old-style class
+ * @description Overriding the class dictionary by declaring `__slots__` is not supported by old-style
  *              classes.
  * @kind problem
  * @problem.severity error

--- a/python/ql/src/Classes/SuperclassDelCalledMultipleTimes.ql
+++ b/python/ql/src/Classes/SuperclassDelCalledMultipleTimes.ql
@@ -1,6 +1,6 @@
 /**
- * @name Multiple calls to __del__ during object destruction
- * @description A duplicated call to a super-class __del__ method may lead to class instances not be cleaned up properly.
+ * @name Multiple calls to `__del__` during object destruction
+ * @description A duplicated call to a super-class `__del__` method may lead to class instances not be cleaned up properly.
  * @kind problem
  * @tags efficiency
  *       correctness

--- a/python/ql/src/Classes/SuperclassInitCalledMultipleTimes.ql
+++ b/python/ql/src/Classes/SuperclassInitCalledMultipleTimes.ql
@@ -1,6 +1,6 @@
 /**
- * @name Multiple calls to __init__ during object initialization
- * @description A duplicated call to a super-class __init__ method may lead to objects of this class not being properly initialized.
+ * @name Multiple calls to `__init__` during object initialization
+ * @description A duplicated call to a super-class `__init__` method may lead to objects of this class not being properly initialized.
  * @kind problem
  * @tags reliability
  *       correctness

--- a/python/ql/src/Classes/UndefinedClassAttribute.ql
+++ b/python/ql/src/Classes/UndefinedClassAttribute.ql
@@ -1,6 +1,6 @@
 /**
  * @name Undefined class attribute
- * @description Accessing an attribute of 'self' that is not initialized anywhere in the class in the __init__ method may cause an AttributeError at runtime
+ * @description Accessing an attribute of `self` that is not initialized anywhere in the class in the `__init__` method may cause an AttributeError at runtime
  * @kind problem
  * @tags reliability
  *       correctness

--- a/python/ql/src/Classes/UselessClass.ql
+++ b/python/ql/src/Classes/UselessClass.ql
@@ -1,6 +1,6 @@
 /**
  * @name Useless class
- * @description Class only defines one public method (apart from __init__ or __new__) and should be replaced by a function
+ * @description Class only defines one public method (apart from `__init__` or `__new__`) and should be replaced by a function
  * @kind problem
  * @tags maintainability
  *       useless-code

--- a/python/ql/src/Classes/WrongNumberArgumentsInClassInstantiation.ql
+++ b/python/ql/src/Classes/WrongNumberArgumentsInClassInstantiation.ql
@@ -1,6 +1,6 @@
 /**
  * @name Wrong number of arguments in a class instantiation
- * @description Using too many or too few arguments in a call to the __init__
+ * @description Using too many or too few arguments in a call to the `__init__`
  *              method of a class will result in a TypeError at runtime.
  * @kind problem
  * @tags reliability

--- a/python/ql/src/Expressions/ExplicitCallToDel.ql
+++ b/python/ql/src/Expressions/ExplicitCallToDel.ql
@@ -1,6 +1,6 @@
 /**
- * @name __del__ is called explicitly
- * @description The __del__ special method is called by the virtual machine when an object is being finalized. It should not be called explicitly.
+ * @name `__del__` is called explicitly
+ * @description The `__del__` special method is called by the virtual machine when an object is being finalized. It should not be called explicitly.
  * @kind problem
  * @tags reliability
  *       correctness

--- a/python/ql/src/Expressions/IncorrectComparisonUsingIs.ql
+++ b/python/ql/src/Expressions/IncorrectComparisonUsingIs.ql
@@ -1,5 +1,5 @@
 /**
- * @name Comparison using is when operands support __eq__
+ * @name Comparison using is when operands support `__eq__`
  * @description Comparison using 'is' when equivalence is not the same as identity
  * @kind problem
  * @tags reliability

--- a/python/ql/src/Expressions/NonPortableComparisonUsingIs.ql
+++ b/python/ql/src/Expressions/NonPortableComparisonUsingIs.ql
@@ -1,5 +1,5 @@
 /**
- * @name Non-portable comparison using is when operands support __eq__
+ * @name Non-portable comparison using is when operands support `__eq__`
  * @description Comparison using 'is' when equivalence is not the same as identity and may not be portable.
  * @kind problem
  * @tags portability

--- a/python/ql/src/Functions/ExplicitReturnInInit.ql
+++ b/python/ql/src/Functions/ExplicitReturnInInit.ql
@@ -1,6 +1,6 @@
 /**
- * @name __init__ method returns a value
- * @description Explicitly returning a value from an __init__ method will raise a TypeError.
+ * @name `__init__` method returns a value
+ * @description Explicitly returning a value from an `__init__` method will raise a TypeError.
  * @kind problem
  * @tags reliability
  *       correctness

--- a/python/ql/src/Functions/InitIsGenerator.ql
+++ b/python/ql/src/Functions/InitIsGenerator.ql
@@ -1,6 +1,6 @@
 /**
- * @name __init__ method is a generator
- * @description __init__ method is a generator.
+ * @name `__init__` method is a generator
+ * @description `__init__` method is a generator.
  * @kind problem
  * @tags reliability
  *       correctness

--- a/python/ql/src/Functions/IterReturnsNonIterator.ql
+++ b/python/ql/src/Functions/IterReturnsNonIterator.ql
@@ -1,6 +1,6 @@
 /**
- * @name __iter__ method returns a non-iterator
- * @description The '__iter__' method returns a non-iterator which, if used in a 'for' loop, would raise a 'TypeError'.
+ * @name `__iter__` method returns a non-iterator
+ * @description The `__iter__` method returns a non-iterator which, if used in a 'for' loop, would raise a 'TypeError'.
  * @kind problem
  * @tags reliability
  *       correctness

--- a/python/ql/src/Functions/IterReturnsNonSelf.ql
+++ b/python/ql/src/Functions/IterReturnsNonSelf.ql
@@ -1,6 +1,6 @@
 /**
- * @name Iterator does not return self from __iter__ method
- * @description Iterator does not return self from __iter__ method, violating the iterator protocol.
+ * @name Iterator does not return self from `__iter__` method
+ * @description Iterator does not return self from `__iter__` method, violating the iterator protocol.
  * @kind problem
  * @tags reliability
  *       correctness

--- a/python/ql/src/Functions/OverlyComplexDelMethod.ql
+++ b/python/ql/src/Functions/OverlyComplexDelMethod.ql
@@ -1,6 +1,6 @@
 /**
- * @name Overly complex __del__ method
- * @description __del__ methods may be called at arbitrary times, perhaps never called at all, and should be simple.
+ * @name Overly complex `__del__` method
+ * @description `__del__` methods may be called at arbitrary times, perhaps never called at all, and should be simple.
  * @kind problem
  * @tags efficiency
  *       maintainability

--- a/python/ql/src/Imports/UnintentionalImport.ql
+++ b/python/ql/src/Imports/UnintentionalImport.ql
@@ -1,7 +1,7 @@
 /**
  * @name 'import *' may pollute namespace
  * @description Importing a module using 'import *' may unintentionally pollute the global
- *              namespace if the module does not define '__all__'
+ *              namespace if the module does not define `__all__`
  * @kind problem
  * @tags maintainability
  *       modularity

--- a/python/ql/src/Statements/TopLevelPrint.ql
+++ b/python/ql/src/Statements/TopLevelPrint.ql
@@ -1,6 +1,6 @@
 /**
  * @name Use of a print statement at module level
- * @description Using a print statement at module scope (except when guarded by if __name__ == '__main__') will cause surprising output when the module is imported.
+ * @description Using a print statement at module scope (except when guarded by `if __name__ == '__main__'`) will cause surprising output when the module is imported.
  * @kind problem
  * @tags reliability
  *       maintainability

--- a/python/ql/src/Variables/UndefinedExport.ql
+++ b/python/ql/src/Variables/UndefinedExport.ql
@@ -1,6 +1,6 @@
 /**
  * @name Explicit export is not defined
- * @description Including an undefined attribute in __all__ causes an exception when
+ * @description Including an undefined attribute in `__all__` causes an exception when
  *              the module is imported using '*'
  * @kind problem
  * @tags reliability


### PR DESCRIPTION
Currently https://codeql.github.com/codeql-query-help/python/py-slots-in-old-style-class/ renders the `__slots__` part as bold

![image](https://user-images.githubusercontent.com/1054041/106910487-8fcae880-6701-11eb-9e82-cc6080c8d893.png)

since the query name is written as

```
@name '__slots__' in old-style class
```

and not

```
@name `__slots__` in old-style class
```

---

Since I was reading the QHelp, I just spend a minute to fix that up a bit as well :shrug: 