### PR TITLE
Javascript: Improve performance of ExplicitInvokeNode::getArgument

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -1079,8 +1079,19 @@ module DataFlow {
 
       override DataFlow::Node getCalleeNode() { result = DataFlow::valueNode(astNode.getCallee()) }
 
+      /**
+       * Whether i is an index that occurs after a spread argument.
+       */
+      pragma[nomagic]
+      private predicate isIndexAfterSpread(int i) {
+        astNode.isSpreadArgument(i)
+        or
+        exists(astNode.getArgument(i)) and
+        isIndexAfterSpread(i - 1)
+      }
+
       override DataFlow::Node getArgument(int i) {
-        not astNode.isSpreadArgument([0 .. i]) and
+        not isIndexAfterSpread(i) and
         result = DataFlow::valueNode(astNode.getArgument(i))
       }
 


### PR DESCRIPTION
The previous version would end up taking the join with all previous arguments. In pathological examples with many arguments this can be large. This PR refactors it to be linear in the number of arguments after a spread argument which is linear in the worst case and extremely small in most cases.

On an old ChakraCoreDatabase this predicate goes from 4min to 1sec.