### PR TITLE
JS: Add more models for XML parsers

### DIFF
--- a/javascript/change-notes/2021-02-08-xml-parser-taint.md
+++ b/javascript/change-notes/2021-02-08-xml-parser-taint.md
@@ -1,0 +1,8 @@
+lgtm,codescanning
+* The security queries now track taint through XML parsers. 
+  Affected packages are
+    [xml2js](https://www.npmjs.com/package/xml2js) and
+    [sax](https://www.npmjs.com/package/sax) and
+    [xml-js](https://www.npmjs.com/package/xml-js) and
+    [htmlparser2](https://www.npmjs.com/package/htmlparser2) and
+    [node-expat](https://www.npmjs.com/package/node-expat)

--- a/javascript/change-notes/2021-02-08-xml-parser-taint.md
+++ b/javascript/change-notes/2021-02-08-xml-parser-taint.md
@@ -1,8 +1,8 @@
 lgtm,codescanning
 * The security queries now track taint through XML parsers. 
   Affected packages are
-    [xml2js](https://www.npmjs.com/package/xml2js) and
-    [sax](https://www.npmjs.com/package/sax) and
-    [xml-js](https://www.npmjs.com/package/xml-js) and
-    [htmlparser2](https://www.npmjs.com/package/htmlparser2) and
+    [xml2js](https://www.npmjs.com/package/xml2js),
+    [sax](https://www.npmjs.com/package/sax),
+    [xml-js](https://www.npmjs.com/package/xml-js),
+    [htmlparser2](https://www.npmjs.com/package/htmlparser2), and
     [node-expat](https://www.npmjs.com/package/node-expat)

--- a/javascript/ql/src/semmle/javascript/frameworks/XmlParsers.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/XmlParsers.qll
@@ -169,6 +169,31 @@ module XML {
     override predicate resolvesEntities(XML::EntityKind kind) { kind = InternalEntity() }
   }
 
+  /**
+   * An invocation of `xml2js`.
+   */
+  private class Xml2JSInvocation extends XML::ParserInvocation {
+    js::DataFlow::CallNode call;
+
+    Xml2JSInvocation() {
+      exists(js::API::Node imp | imp = js::API::moduleImport("xml2js") |
+        call = [imp, imp.getMember("Parser").getInstance()].getMember("parseString").getACall() and
+        this = call.asExpr()
+      )
+    }
+
+    override js::Expr getSourceArgument() { result = getArgument(0) }
+
+    override predicate resolvesEntities(XML::EntityKind kind) {
+      // sax-js (the parser used) does not expand entities.
+      none()
+    }
+
+    override js::DataFlow::Node getAResult() {
+      result = call.getABoundCallbackParameter(call.getNumArgument() - 1, 1)
+    }
+  }
+
   private class XMLParserTaintStep extends js::TaintTracking::AdditionalTaintStep {
     XML::ParserInvocation parser;
 

--- a/javascript/ql/src/semmle/javascript/frameworks/XmlParsers.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/XmlParsers.qll
@@ -226,6 +226,27 @@ module XML {
     }
   }
 
+  /**
+   * An invocation of `xml-js`.
+   */
+  private class XmlJSInvocation extends XML::ParserInvocation {
+    XmlJSInvocation() {
+      this =
+        js::DataFlow::moduleMember("xml-js", ["xml2json", "xml2js", "json2xml", "js2xml"])
+            .getACall()
+            .asExpr()
+    }
+
+    override js::Expr getSourceArgument() { result = getArgument(0) }
+
+    override predicate resolvesEntities(XML::EntityKind kind) {
+      // xml-js does not expand custom entities.
+      none()
+    }
+
+    override js::DataFlow::Node getAResult() { result.asExpr() = this }
+  }
+
   private class XMLParserTaintStep extends js::TaintTracking::AdditionalTaintStep {
     XML::ParserInvocation parser;
 

--- a/javascript/ql/src/semmle/javascript/frameworks/XmlParsers.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/XmlParsers.qll
@@ -247,6 +247,35 @@ module XML {
     override js::DataFlow::Node getAResult() { result.asExpr() = this }
   }
 
+  /**
+   * An invocation of `htmlparser2`.
+   */
+  private class HtmlParser2Invocation extends XML::ParserInvocation {
+    js::DataFlow::NewNode parser;
+
+    HtmlParser2Invocation() {
+      parser = js::DataFlow::moduleMember("htmlparser2", "Parser").getAnInstantiation() and
+      this = parser.getAMemberCall("write").asExpr()
+    }
+
+    override js::Expr getSourceArgument() { result = getArgument(0) }
+
+    override predicate resolvesEntities(XML::EntityKind kind) {
+      // htmlparser2 does not expand entities.
+      none()
+    }
+
+    override js::DataFlow::Node getAResult() {
+      result =
+        parser
+            .getArgument(0)
+            .getALocalSource()
+            .getAPropertySource()
+            .getAFunctionValue()
+            .getAParameter()
+    }
+  }
+
   private class XMLParserTaintStep extends js::TaintTracking::AdditionalTaintStep {
     XML::ParserInvocation parser;
 

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -145,3 +145,4 @@ typeInferenceMismatch
 | tst.js:2:13:2:20 | source() | tst.js:45:10:45:24 | x.map(x2 => x2) |
 | tst.js:2:13:2:20 | source() | tst.js:47:10:47:30 | Buffer. ...  'hex') |
 | tst.js:2:13:2:20 | source() | tst.js:48:10:48:22 | new Buffer(x) |
+| xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -148,3 +148,4 @@ typeInferenceMismatch
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |
 | xml.js:12:17:12:24 | source() | xml.js:13:14:13:19 | result |
 | xml.js:23:18:23:25 | source() | xml.js:20:14:20:17 | attr |
+| xml.js:26:27:26:34 | source() | xml.js:26:10:26:39 | convert ... (), {}) |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -149,3 +149,4 @@ typeInferenceMismatch
 | xml.js:12:17:12:24 | source() | xml.js:13:14:13:19 | result |
 | xml.js:23:18:23:25 | source() | xml.js:20:14:20:17 | attr |
 | xml.js:26:27:26:34 | source() | xml.js:26:10:26:39 | convert ... (), {}) |
+| xml.js:34:18:34:25 | source() | xml.js:31:18:31:21 | name |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -146,3 +146,4 @@ typeInferenceMismatch
 | tst.js:2:13:2:20 | source() | tst.js:47:10:47:30 | Buffer. ...  'hex') |
 | tst.js:2:13:2:20 | source() | tst.js:48:10:48:22 | new Buffer(x) |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |
+| xml.js:12:17:12:24 | source() | xml.js:13:14:13:19 | result |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -147,3 +147,4 @@ typeInferenceMismatch
 | tst.js:2:13:2:20 | source() | tst.js:48:10:48:22 | new Buffer(x) |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |
 | xml.js:12:17:12:24 | source() | xml.js:13:14:13:19 | result |
+| xml.js:23:18:23:25 | source() | xml.js:20:14:20:17 | attr |

--- a/javascript/ql/test/library-tests/TaintTracking/xml.js
+++ b/javascript/ql/test/library-tests/TaintTracking/xml.js
@@ -25,4 +25,13 @@
     var convert = require('xml-js');
     sink(convert.xml2json(source(), {})); // NOT OK
 
+    const htmlparser2 = require("htmlparser2");
+    const parser = new htmlparser2.Parser({
+        onopentag(name, attributes) {
+            sink(name) // NOT OK
+        }
+    });
+    parser.write(source());
+    parser.end();
+
 })();

--- a/javascript/ql/test/library-tests/TaintTracking/xml.js
+++ b/javascript/ql/test/library-tests/TaintTracking/xml.js
@@ -1,0 +1,10 @@
+(function () {
+    var Parser = require("node-expat").Parser
+    var parser = new Parser();
+
+    parser.write(source());
+
+    parser.on("text", text => {
+        sink(text); // NOT OK
+    });
+})();

--- a/javascript/ql/test/library-tests/TaintTracking/xml.js
+++ b/javascript/ql/test/library-tests/TaintTracking/xml.js
@@ -12,4 +12,14 @@
     parseString(source(), function (err, result) {
         sink(result); // NOT OK
     });
+
+    var sax = require("sax");
+    var parser = sax.parser(strict);
+    
+    parser.onattribute = function (attr) {
+        sink(attr); // NOT OK
+    };
+    
+    parser.write(source()).close();
+
 })();

--- a/javascript/ql/test/library-tests/TaintTracking/xml.js
+++ b/javascript/ql/test/library-tests/TaintTracking/xml.js
@@ -22,4 +22,7 @@
     
     parser.write(source()).close();
 
+    var convert = require('xml-js');
+    sink(convert.xml2json(source(), {})); // NOT OK
+
 })();

--- a/javascript/ql/test/library-tests/TaintTracking/xml.js
+++ b/javascript/ql/test/library-tests/TaintTracking/xml.js
@@ -7,4 +7,9 @@
     parser.on("text", text => {
         sink(text); // NOT OK
     });
+
+    var parseString = require('xml2js').parseString;
+    parseString(source(), function (err, result) {
+        sink(result); // NOT OK
+    });
 })();


### PR DESCRIPTION
The parsers added to the model are not vulnerable to XML-entity expansion (I tried).   

But they have taint-steps.   
I have not added taint-steps for the parsers that return a instance of some `Document` class, because it's only by calling e.g. `.getText()` on that class that you get a tainted value. (See [`libxmljs`](https://www.npmjs.com/package/libxmljs) for library that behaves like that). 

[An evaluation looks ok](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/xml2js-eval-3/reports). 