### PR TITLE
C++: Add query author and link to original PR in change-note

### DIFF
--- a/cpp/change-notes/2020-02-04-unsigned-difference-expression-compared-zero.md
+++ b/cpp/change-notes/2020-02-04-unsigned-difference-expression-compared-zero.md
@@ -1,2 +1,2 @@
 lgtm
-* A new query (`cpp/unsigned-difference-expression-compared-zero`) has been added. The query finds unsigned subtractions used in relational comparisons with the value 0. This query was originally submitted as an experimental query by @ihsinme in https://github.com/github/codeql/pull/4745.
+* A new query (`cpp/unsigned-difference-expression-compared-zero`) is run but not yet displayed on LGTM. The query finds unsigned subtractions used in relational comparisons with the value 0. This query was originally submitted as an experimental query by @ihsinme in https://github.com/github/codeql/pull/4745.

--- a/cpp/change-notes/2020-02-04-unsigned-difference-expression-compared-zero.md
+++ b/cpp/change-notes/2020-02-04-unsigned-difference-expression-compared-zero.md
@@ -1,2 +1,2 @@
 lgtm
-* A new query (`cpp/unsigned-difference-expression-compared-zero`) has been added. The query finds unsigned subtractions used in relational comparisons with the value 0.
+* A new query (`cpp/unsigned-difference-expression-compared-zero`) has been added. The query finds unsigned subtractions used in relational comparisons with the value 0. This query was originally submitted as an experimental query by @ihsinme in https://github.com/github/codeql/pull/4745.


### PR DESCRIPTION
`@sj` and `@xcorail` suggested that we should include the query author and the original PR in the change-note.