### PR TITLE
Add KeGetCurrentProcessorNumberEx to CWE-457 whitelist

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-457/InitializationFunctions.qll
+++ b/cpp/ql/src/Security/CWE/CWE-457/InitializationFunctions.qll
@@ -353,7 +353,9 @@ class InitializationFunction extends Function {
           // Destination range is zeroed out on failure, assuming first two parameters are valid
           "memcpy_s",
           // This zeroes the memory unconditionally
-          "SeCreateAccessState"
+          "SeCreateAccessState",
+          // Argument initialization is optional, but always succeeds
+          "KeGetCurrentProcessorNumberEx"
         ]
     )
   }


### PR DESCRIPTION
Windows driver developers may call KeGetCurrentProcessorNumberEx in their driver.  This function optionally may initialize a provided structure, but this initialization always occurs.  The return value is the current processor being run on.  As such, this query incorrectly marks calls to KeGetCurrentProcessorNumberEx that initialize a structure that is later used as risky if the return value is not checked, even though in reality the initialization always succeeds and the return value is not related to initialization.

See https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/nf-ntddk-kegetcurrentprocessornumberex