### PR TITLE
JS: Include modern Angular in list of supported frameworks

### DIFF
--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -93,7 +93,8 @@ JavaScript and TypeScript built-in support
    :widths: auto
 
    Name, Category
-   angularjs, HTML framework
+   angular (modern version), HTML framework
+   angular.js (legacy version), HTML framework
    axios, Network communicator
    browser, Runtime environment
    electron, Runtime environment


### PR DESCRIPTION
As usual Angular's confusing history makes this hard to phrase.