### PR TITLE
JS: Add `js/xss-through-dom` sources for frontend form libraries

### DIFF
--- a/javascript/change-notes/2021-02-08-xss-through-dom-forms.md
+++ b/javascript/change-notes/2021-02-08-xss-through-dom-forms.md
@@ -1,0 +1,6 @@
+lgtm,codescanning
+* The `js/xss-through-dom` query now recognizes form inputs as sources.
+  Affected packages are
+    [formik](https://www.npmjs.com/package/formik) and
+    [react-final-form](https://www.npmjs.com/package/react-final-form) and
+    [react-hook-form](https://www.npmjs.com/package/react-hook-form)

--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -357,6 +357,15 @@ module DOM {
     }
   }
 
+  /**
+   * Gets a reference to a DOM event.
+   */
+  private DataFlow::SourceNode domEventSource() {
+    exists(JSXAttribute attr | attr.getName().matches("on%") |
+      result = attr.getValue().flow().getABoundFunctionValue(0).getParameter(0)
+    )
+  }
+
   /** Gets a data flow node that refers directly to a value from the DOM. */
   DataFlow::SourceNode domValueSource() { result instanceof DomValueSource::Range }
 
@@ -367,6 +376,10 @@ module DOM {
     or
     t.start() and
     result = domValueRef().getAMethodCall(["item", "namedItem"])
+    or
+    // e.g. <form onSubmit={e => e.target}/>
+    t.startInProp("target") and
+    result = domEventSource()
     or
     exists(DataFlow::TypeTracker t2 | result = domValueRef(t2).track(t2, t))
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/XssThroughDom.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/XssThroughDom.qll
@@ -11,8 +11,8 @@ private import semmle.javascript.dataflow.InferredTypes
  */
 module XssThroughDom {
   import Xss::XssThroughDom
+  private import XssThroughDomCustomizations::XssThroughDom
   private import semmle.javascript.security.dataflow.Xss::DomBasedXss as DomBasedXss
-  private import semmle.javascript.dataflow.InferredTypes
   private import semmle.javascript.security.dataflow.UnsafeJQueryPluginCustomizations::UnsafeJQueryPlugin as UnsafeJQuery
 
   /**
@@ -38,90 +38,6 @@ module XssThroughDom {
 
     override predicate isSanitizerEdge(DataFlow::Node pred, DataFlow::Node succ) {
       DomBasedXss::isOptionallySanitizedEdge(pred, succ)
-    }
-  }
-
-  /**
-   * Gets an attribute name that could store user-controlled data.
-   *
-   * Attributes such as "id", "href", and "src" are often used as input to HTML.
-   * However, they are either rarely controlable by a user, or already a sink for other XSS vulnerabilities.
-   * Such attributes are therefore ignored.
-   */
-  bindingset[result]
-  string unsafeAttributeName() {
-    result.regexpMatch("data-.*") or
-    result.regexpMatch("aria-.*") or
-    result = ["name", "value", "title", "alt"]
-  }
-
-  /**
-   * A source for text from the DOM from a JQuery method call.
-   */
-  class JQueryTextSource extends Source, JQuery::MethodCall {
-    JQueryTextSource() {
-      (
-        this.getMethodName() = ["text", "val"] and this.getNumArgument() = 0
-        or
-        this.getMethodName() = "attr" and
-        this.getNumArgument() = 1 and
-        forex(InferredType t | t = this.getArgument(0).analyze().getAType() | t = TTString()) and
-        this.getArgument(0).mayHaveStringValue(unsafeAttributeName())
-      ) and
-      // looks like a $("<p>" + ... ) source, which is benign for this query.
-      not exists(DataFlow::Node prefix |
-        DomBasedXss::isPrefixOfJQueryHtmlString(this.getReceiver()
-              .(DataFlow::CallNode)
-              .getAnArgument(), prefix)
-      |
-        prefix.getStringValue().regexpMatch("\\s*<.*")
-      )
-    }
-  }
-
-  /**
-   * A source for text from the DOM from a DOM property read or call to `getAttribute()`.
-   */
-  class DOMTextSource extends Source {
-    DOMTextSource() {
-      exists(DataFlow::PropRead read | read = this |
-        read.getBase().getALocalSource() = DOM::domValueRef() and
-        read.mayHavePropertyName(["innerText", "textContent", "value", "name"])
-      )
-      or
-      exists(DataFlow::MethodCallNode mcn | mcn = this |
-        mcn.getReceiver().getALocalSource() = DOM::domValueRef() and
-        mcn.getMethodName() = "getAttribute" and
-        mcn.getArgument(0).mayHaveStringValue(unsafeAttributeName())
-      )
-    }
-  }
-
-  /**
-   * A test of form `typeof x === "something"`, preventing `x` from being a string in some cases.
-   *
-   * This sanitizer helps prune infeasible paths in type-overloaded functions.
-   */
-  class TypeTestGuard extends TaintTracking::SanitizerGuardNode, DataFlow::ValueNode {
-    override EqualityTest astNode;
-    Expr operand;
-    boolean polarity;
-
-    TypeTestGuard() {
-      exists(TypeofTag tag | TaintTracking::isTypeofGuard(astNode, operand, tag) |
-        // typeof x === "string" sanitizes `x` when it evaluates to false
-        tag = "string" and
-        polarity = astNode.getPolarity().booleanNot()
-        or
-        // typeof x === "object" sanitizes `x` when it evaluates to true
-        tag != "string" and
-        polarity = astNode.getPolarity()
-      )
-    }
-
-    override predicate sanitizes(boolean outcome, Expr e) {
-      polarity = outcome and
-      e = operand
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
@@ -1,0 +1,99 @@
+/**
+ * Provides default sources for reasoning about
+ * cross-site scripting vulnerabilities through the DOM.
+ */
+
+import javascript
+
+/**
+ * Sources for cross-site scripting vulnerabilities through the DOM.
+ */
+module XssThroughDom {
+  import Xss::XssThroughDom
+  private import semmle.javascript.dataflow.InferredTypes
+  private import semmle.javascript.security.dataflow.Xss::DomBasedXss as DomBasedXss
+
+  /**
+   * Gets an attribute name that could store user-controlled data.
+   *
+   * Attributes such as "id", "href", and "src" are often used as input to HTML.
+   * However, they are either rarely controlable by a user, or already a sink for other XSS vulnerabilities.
+   * Such attributes are therefore ignored.
+   */
+  bindingset[result]
+  string unsafeAttributeName() {
+    result.regexpMatch("data-.*") or
+    result.regexpMatch("aria-.*") or
+    result = ["name", "value", "title", "alt"]
+  }
+
+  /**
+   * A source for text from the DOM from a JQuery method call.
+   */
+  class JQueryTextSource extends Source, JQuery::MethodCall {
+    JQueryTextSource() {
+      (
+        this.getMethodName() = ["text", "val"] and this.getNumArgument() = 0
+        or
+        this.getMethodName() = "attr" and
+        this.getNumArgument() = 1 and
+        forex(InferredType t | t = this.getArgument(0).analyze().getAType() | t = TTString()) and
+        this.getArgument(0).mayHaveStringValue(unsafeAttributeName())
+      ) and
+      // looks like a $("<p>" + ... ) source, which is benign for this query.
+      not exists(DataFlow::Node prefix |
+        DomBasedXss::isPrefixOfJQueryHtmlString(this.getReceiver()
+              .(DataFlow::CallNode)
+              .getAnArgument(), prefix)
+      |
+        prefix.getStringValue().regexpMatch("\\s*<.*")
+      )
+    }
+  }
+
+  /**
+   * A source for text from the DOM from a DOM property read or call to `getAttribute()`.
+   */
+  class DOMTextSource extends Source {
+    DOMTextSource() {
+      exists(DataFlow::PropRead read | read = this |
+        read.getBase().getALocalSource() = DOM::domValueRef() and
+        read.mayHavePropertyName(["innerText", "textContent", "value", "name"])
+      )
+      or
+      exists(DataFlow::MethodCallNode mcn | mcn = this |
+        mcn.getReceiver().getALocalSource() = DOM::domValueRef() and
+        mcn.getMethodName() = "getAttribute" and
+        mcn.getArgument(0).mayHaveStringValue(unsafeAttributeName())
+      )
+    }
+  }
+
+  /**
+   * A test of form `typeof x === "something"`, preventing `x` from being a string in some cases.
+   *
+   * This sanitizer helps prune infeasible paths in type-overloaded functions.
+   */
+  class TypeTestGuard extends TaintTracking::SanitizerGuardNode, DataFlow::ValueNode {
+    override EqualityTest astNode;
+    Expr operand;
+    boolean polarity;
+
+    TypeTestGuard() {
+      exists(TypeofTag tag | TaintTracking::isTypeofGuard(astNode, operand, tag) |
+        // typeof x === "string" sanitizes `x` when it evaluates to false
+        tag = "string" and
+        polarity = astNode.getPolarity().booleanNot()
+        or
+        // typeof x === "object" sanitizes `x` when it evaluates to true
+        tag != "string" and
+        polarity = astNode.getPolarity()
+      )
+    }
+
+    override predicate sanitizes(boolean outcome, Expr e) {
+      polarity = outcome and
+      e = operand
+    }
+  }
+}

--- a/javascript/ql/src/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
@@ -136,5 +136,23 @@ module XssThroughDom {
         this = formik().getAMemberCall("useFormikContext").getAPropertyRead("values")
       }
     }
+
+    /**
+     * An object containing input values from a form build with `react-final-form`.
+     */
+    class ReactFinalFormSource extends Source {
+      ReactFinalFormSource() {
+        exists(JSXElement elem |
+          DataFlow::moduleMember("react-final-form", "Form").flowsToExpr(elem.getNameExpr())
+        |
+          this =
+            elem.getAttributeByName("onSubmit")
+                .getValue()
+                .flow()
+                .getAFunctionValue()
+                .getParameter(0)
+        )
+      }
+    }
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
@@ -154,5 +154,21 @@ module XssThroughDom {
         )
       }
     }
+
+    /**
+     * An object containing input values from a form build with `react-hook-form`.
+     */
+    class ReactHookFormSource extends Source {
+      ReactHookFormSource() {
+        exists(API::Node useForm |
+          useForm = API::moduleImport("react-hook-form").getMember("useForm").getReturn()
+        |
+          this =
+            useForm.getMember("handleSubmit").getParameter(0).getParameter(0).getAnImmediateUse()
+          or
+          this = useForm.getMember("getValues").getACall()
+        )
+      }
+    }
   }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -30,6 +30,9 @@ nodes
 | forms.js:45:21:45:26 | values |
 | forms.js:45:21:45:33 | values.stooge |
 | forms.js:45:21:45:33 | values.stooge |
+| forms.js:57:19:57:32 | e.target.value |
+| forms.js:57:19:57:32 | e.target.value |
+| forms.js:57:19:57:32 | e.target.value |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
@@ -106,6 +109,7 @@ edges
 | forms.js:44:21:44:26 | values | forms.js:45:21:45:26 | values |
 | forms.js:45:21:45:26 | values | forms.js:45:21:45:33 | values.stooge |
 | forms.js:45:21:45:26 | values | forms.js:45:21:45:33 | values.stooge |
+| forms.js:57:19:57:32 | e.target.value | forms.js:57:19:57:32 | e.target.value |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() |
 | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") |
@@ -132,6 +136,7 @@ edges
 | forms.js:29:23:29:34 | values.email | forms.js:28:20:28:25 | values | forms.js:29:23:29:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:28:20:28:25 | values | DOM text |
 | forms.js:35:19:35:30 | values.email | forms.js:34:13:34:18 | values | forms.js:35:19:35:30 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:34:13:34:18 | values | DOM text |
 | forms.js:45:21:45:33 | values.stooge | forms.js:44:21:44:26 | values | forms.js:45:21:45:33 | values.stooge | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:44:21:44:26 | values | DOM text |
+| forms.js:57:19:57:32 | e.target.value | forms.js:57:19:57:32 | e.target.value | forms.js:57:19:57:32 | e.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:57:19:57:32 | e.target.value | DOM text |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:2:16:2:34 | $("textarea").val() | DOM text |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | DOM text |
 | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -33,6 +33,17 @@ nodes
 | forms.js:57:19:57:32 | e.target.value |
 | forms.js:57:19:57:32 | e.target.value |
 | forms.js:57:19:57:32 | e.target.value |
+| forms.js:71:21:71:24 | data |
+| forms.js:71:21:71:24 | data |
+| forms.js:72:19:72:22 | data |
+| forms.js:72:19:72:27 | data.name |
+| forms.js:72:19:72:27 | data.name |
+| forms.js:92:17:92:36 | values |
+| forms.js:92:26:92:36 | getValues() |
+| forms.js:92:26:92:36 | getValues() |
+| forms.js:93:25:93:30 | values |
+| forms.js:93:25:93:35 | values.name |
+| forms.js:93:25:93:35 | values.name |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
@@ -110,6 +121,15 @@ edges
 | forms.js:45:21:45:26 | values | forms.js:45:21:45:33 | values.stooge |
 | forms.js:45:21:45:26 | values | forms.js:45:21:45:33 | values.stooge |
 | forms.js:57:19:57:32 | e.target.value | forms.js:57:19:57:32 | e.target.value |
+| forms.js:71:21:71:24 | data | forms.js:72:19:72:22 | data |
+| forms.js:71:21:71:24 | data | forms.js:72:19:72:22 | data |
+| forms.js:72:19:72:22 | data | forms.js:72:19:72:27 | data.name |
+| forms.js:72:19:72:22 | data | forms.js:72:19:72:27 | data.name |
+| forms.js:92:17:92:36 | values | forms.js:93:25:93:30 | values |
+| forms.js:92:26:92:36 | getValues() | forms.js:92:17:92:36 | values |
+| forms.js:92:26:92:36 | getValues() | forms.js:92:17:92:36 | values |
+| forms.js:93:25:93:30 | values | forms.js:93:25:93:35 | values.name |
+| forms.js:93:25:93:30 | values | forms.js:93:25:93:35 | values.name |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() |
 | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") |
@@ -137,6 +157,8 @@ edges
 | forms.js:35:19:35:30 | values.email | forms.js:34:13:34:18 | values | forms.js:35:19:35:30 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:34:13:34:18 | values | DOM text |
 | forms.js:45:21:45:33 | values.stooge | forms.js:44:21:44:26 | values | forms.js:45:21:45:33 | values.stooge | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:44:21:44:26 | values | DOM text |
 | forms.js:57:19:57:32 | e.target.value | forms.js:57:19:57:32 | e.target.value | forms.js:57:19:57:32 | e.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:57:19:57:32 | e.target.value | DOM text |
+| forms.js:72:19:72:27 | data.name | forms.js:71:21:71:24 | data | forms.js:72:19:72:27 | data.name | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:71:21:71:24 | data | DOM text |
+| forms.js:93:25:93:35 | values.name | forms.js:92:26:92:36 | getValues() | forms.js:93:25:93:35 | values.name | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:92:26:92:36 | getValues() | DOM text |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:2:16:2:34 | $("textarea").val() | DOM text |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | DOM text |
 | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -1,4 +1,30 @@
 nodes
+| forms.js:8:23:8:28 | values |
+| forms.js:8:23:8:28 | values |
+| forms.js:9:31:9:36 | values |
+| forms.js:9:31:9:40 | values.foo |
+| forms.js:9:31:9:40 | values.foo |
+| forms.js:11:24:11:29 | values |
+| forms.js:11:24:11:29 | values |
+| forms.js:12:31:12:36 | values |
+| forms.js:12:31:12:40 | values.bar |
+| forms.js:12:31:12:40 | values.bar |
+| forms.js:24:15:24:20 | values |
+| forms.js:24:15:24:20 | values |
+| forms.js:25:23:25:28 | values |
+| forms.js:25:23:25:34 | values.email |
+| forms.js:25:23:25:34 | values.email |
+| forms.js:28:20:28:25 | values |
+| forms.js:28:20:28:25 | values |
+| forms.js:29:23:29:28 | values |
+| forms.js:29:23:29:34 | values.email |
+| forms.js:29:23:29:34 | values.email |
+| forms.js:34:11:34:53 | values |
+| forms.js:34:13:34:18 | values |
+| forms.js:34:13:34:18 | values |
+| forms.js:35:19:35:24 | values |
+| forms.js:35:19:35:30 | values.email |
+| forms.js:35:19:35:30 | values.email |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
@@ -50,6 +76,27 @@ nodes
 | xss-through-dom.js:79:4:79:34 | documen ... t.value |
 | xss-through-dom.js:79:4:79:34 | documen ... t.value |
 edges
+| forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
+| forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
+| forms.js:9:31:9:36 | values | forms.js:9:31:9:40 | values.foo |
+| forms.js:9:31:9:36 | values | forms.js:9:31:9:40 | values.foo |
+| forms.js:11:24:11:29 | values | forms.js:12:31:12:36 | values |
+| forms.js:11:24:11:29 | values | forms.js:12:31:12:36 | values |
+| forms.js:12:31:12:36 | values | forms.js:12:31:12:40 | values.bar |
+| forms.js:12:31:12:36 | values | forms.js:12:31:12:40 | values.bar |
+| forms.js:24:15:24:20 | values | forms.js:25:23:25:28 | values |
+| forms.js:24:15:24:20 | values | forms.js:25:23:25:28 | values |
+| forms.js:25:23:25:28 | values | forms.js:25:23:25:34 | values.email |
+| forms.js:25:23:25:28 | values | forms.js:25:23:25:34 | values.email |
+| forms.js:28:20:28:25 | values | forms.js:29:23:29:28 | values |
+| forms.js:28:20:28:25 | values | forms.js:29:23:29:28 | values |
+| forms.js:29:23:29:28 | values | forms.js:29:23:29:34 | values.email |
+| forms.js:29:23:29:28 | values | forms.js:29:23:29:34 | values.email |
+| forms.js:34:11:34:53 | values | forms.js:35:19:35:24 | values |
+| forms.js:34:13:34:18 | values | forms.js:34:11:34:53 | values |
+| forms.js:34:13:34:18 | values | forms.js:34:11:34:53 | values |
+| forms.js:35:19:35:24 | values | forms.js:35:19:35:30 | values.email |
+| forms.js:35:19:35:24 | values | forms.js:35:19:35:30 | values.email |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() |
 | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") |
@@ -70,6 +117,11 @@ edges
 | xss-through-dom.js:73:20:73:41 | $("inpu ... 0).name | xss-through-dom.js:73:9:73:41 | selector |
 | xss-through-dom.js:79:4:79:34 | documen ... t.value | xss-through-dom.js:79:4:79:34 | documen ... t.value |
 #select
+| forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
+| forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
+| forms.js:25:23:25:34 | values.email | forms.js:24:15:24:20 | values | forms.js:25:23:25:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:24:15:24:20 | values | DOM text |
+| forms.js:29:23:29:34 | values.email | forms.js:28:20:28:25 | values | forms.js:29:23:29:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:28:20:28:25 | values | DOM text |
+| forms.js:35:19:35:30 | values.email | forms.js:34:13:34:18 | values | forms.js:35:19:35:30 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:34:13:34:18 | values | DOM text |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:2:16:2:34 | $("textarea").val() | DOM text |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | DOM text |
 | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -44,6 +44,12 @@ nodes
 | forms.js:93:25:93:30 | values |
 | forms.js:93:25:93:35 | values.name |
 | forms.js:93:25:93:35 | values.name |
+| forms.js:103:23:103:36 | e.target.value |
+| forms.js:103:23:103:36 | e.target.value |
+| forms.js:103:23:103:36 | e.target.value |
+| forms.js:107:23:107:36 | e.target.value |
+| forms.js:107:23:107:36 | e.target.value |
+| forms.js:107:23:107:36 | e.target.value |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
@@ -130,6 +136,8 @@ edges
 | forms.js:92:26:92:36 | getValues() | forms.js:92:17:92:36 | values |
 | forms.js:93:25:93:30 | values | forms.js:93:25:93:35 | values.name |
 | forms.js:93:25:93:30 | values | forms.js:93:25:93:35 | values.name |
+| forms.js:103:23:103:36 | e.target.value | forms.js:103:23:103:36 | e.target.value |
+| forms.js:107:23:107:36 | e.target.value | forms.js:107:23:107:36 | e.target.value |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() |
 | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") |
@@ -159,6 +167,8 @@ edges
 | forms.js:57:19:57:32 | e.target.value | forms.js:57:19:57:32 | e.target.value | forms.js:57:19:57:32 | e.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:57:19:57:32 | e.target.value | DOM text |
 | forms.js:72:19:72:27 | data.name | forms.js:71:21:71:24 | data | forms.js:72:19:72:27 | data.name | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:71:21:71:24 | data | DOM text |
 | forms.js:93:25:93:35 | values.name | forms.js:92:26:92:36 | getValues() | forms.js:93:25:93:35 | values.name | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:92:26:92:36 | getValues() | DOM text |
+| forms.js:103:23:103:36 | e.target.value | forms.js:103:23:103:36 | e.target.value | forms.js:103:23:103:36 | e.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:103:23:103:36 | e.target.value | DOM text |
+| forms.js:107:23:107:36 | e.target.value | forms.js:107:23:107:36 | e.target.value | forms.js:107:23:107:36 | e.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:107:23:107:36 | e.target.value | DOM text |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:2:16:2:34 | $("textarea").val() | DOM text |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | DOM text |
 | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -25,6 +25,11 @@ nodes
 | forms.js:35:19:35:24 | values |
 | forms.js:35:19:35:30 | values.email |
 | forms.js:35:19:35:30 | values.email |
+| forms.js:44:21:44:26 | values |
+| forms.js:44:21:44:26 | values |
+| forms.js:45:21:45:26 | values |
+| forms.js:45:21:45:33 | values.stooge |
+| forms.js:45:21:45:33 | values.stooge |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
@@ -97,6 +102,10 @@ edges
 | forms.js:34:13:34:18 | values | forms.js:34:11:34:53 | values |
 | forms.js:35:19:35:24 | values | forms.js:35:19:35:30 | values.email |
 | forms.js:35:19:35:24 | values | forms.js:35:19:35:30 | values.email |
+| forms.js:44:21:44:26 | values | forms.js:45:21:45:26 | values |
+| forms.js:44:21:44:26 | values | forms.js:45:21:45:26 | values |
+| forms.js:45:21:45:26 | values | forms.js:45:21:45:33 | values.stooge |
+| forms.js:45:21:45:26 | values | forms.js:45:21:45:33 | values.stooge |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() |
 | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") |
@@ -122,6 +131,7 @@ edges
 | forms.js:25:23:25:34 | values.email | forms.js:24:15:24:20 | values | forms.js:25:23:25:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:24:15:24:20 | values | DOM text |
 | forms.js:29:23:29:34 | values.email | forms.js:28:20:28:25 | values | forms.js:29:23:29:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:28:20:28:25 | values | DOM text |
 | forms.js:35:19:35:30 | values.email | forms.js:34:13:34:18 | values | forms.js:35:19:35:30 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:34:13:34:18 | values | DOM text |
+| forms.js:45:21:45:33 | values.stooge | forms.js:44:21:44:26 | values | forms.js:45:21:45:33 | values.stooge | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:44:21:44:26 | values | DOM text |
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:2:16:2:34 | $("textarea").val() | DOM text |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | DOM text |
 | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:8:16:8:53 | $(".som ... arget") | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/forms.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/forms.js
@@ -37,3 +37,18 @@ const FormikEnhanced = withFormik({
     $("#id").html(submitForm.email); // OK 
 })
 
+import { Form } from 'react-final-form'
+
+const App = () => (
+  <Form
+    onSubmit={async values => {
+      $("#id").html(values.stooge); // NOT OK
+    }}
+    initialValues={{ stooge: 'larry', employed: false }}
+    render={({ handleSubmit, form, submitting, pristine, values }) => (
+      <form onSubmit={handleSubmit}>
+        <input type="text" name="stooge"></input>
+      </form>
+    )}
+  />
+)

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/forms.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/forms.js
@@ -63,3 +63,38 @@ const plainReact = () => (
         <input type="submit" value="Submit" />
     </form>
 )
+
+import { useForm } from 'react-hook-form';
+
+function HookForm() {
+  const { register, handleSubmit, errors } = useForm(); // initialize the hook
+  const onSubmit = (data) => {
+    $("#id").html(data.name); // NOT OK 
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+        <input name="name" ref={register({ required: true })} />
+        <input type="submit" />
+    </form>
+  );
+}
+
+function HookForm2() {
+  const { register, getValues } = useForm();
+  
+  return (
+    <form>
+      <input name="name" ref={register} />
+      <button
+        type="button"
+        onClick={() => {
+          const values = getValues(); // { test: "test-input", test1: "test1-input" }
+          $("#id").html(values.name); // NOT OK
+        }}
+      >
+      </button>
+    </form>
+  );
+}
+  

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/forms.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/forms.js
@@ -51,4 +51,15 @@ const App = () => (
       </form>
     )}
   />
+);
+
+function plainSubmit(e) {
+    $("#id").html(e.target.value); // NOT OK
+}
+
+const plainReact = () => (
+    <form onSubmit={e => plainSubmit(e)}>
+        <input type="text" value={this.state.value} onChange={this.handleChange} />
+        <input type="submit" value="Submit" />
+    </form>
 )

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/forms.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/forms.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Formik, withFormik, useFormikContext } from 'formik';
+
+const FormikBasic = () => (
+    <div>
+        <Formik
+            initialValues={{ email: '', password: '' }}
+            validate={values => {
+                $("#id").html(values.foo); // NOT OK
+            }}
+            onSubmit={(values, { setSubmitting }) => {
+                $("#id").html(values.bar); // NOT OK
+            }}
+        >
+            {(inputs) => (
+                <form onSubmit={handleSubmit}></form>
+            )}
+        </Formik>
+    </div>
+);
+
+const FormikEnhanced = withFormik({
+    mapPropsToValues: () => ({ name: '' }),
+    validate: values => {
+        $("#id").html(values.email); // NOT OK
+    },
+
+    handleSubmit: (values, { setSubmitting }) => {
+        $("#id").html(values.email); // NOT OK
+    }
+})(MyForm);
+
+(function () {
+    const { values, submitForm } = useFormikContext();
+    $("#id").html(values.email); // NOT OK
+
+    $("#id").html(submitForm.email); // OK 
+})
+

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/forms.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/forms.js
@@ -97,4 +97,13 @@ function HookForm2() {
     </form>
   );
 }
-  
+
+function vanillaJS() {
+    document.querySelector("form.myform").addEventListener("submit", e => {
+        $("#id").html(e.target.value); // NOT OK
+    });
+
+    document.querySelector("form.myform").onsubmit = function (e) {
+        $("#id").html(e.target.value); // NOT OK
+    }
+}


### PR DESCRIPTION
Adds inputs from form inputs. E.g. from HTML like `<input type="text" />`. 

[Evaluation looks OK](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/forms-eval-1/reports). 