### PR TITLE
Update the language specification to allow empty var_decls

### DIFF
--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -374,7 +374,7 @@ A *variable declaration list* provides a sequence of variables and a type for ea
 
 ::
 
-   var_decls ::= var_decl ("," var_decl)*
+   var_decls ::= (var_decl ("," var_decl)*)?
    var_decl ::= type simpleId
 
 A valid variable declaration list must not include two declarations with the same variable name. Moreover, if the declaration has a typing environment that applies, it must not use a variable name that is already present in that typing environment.
@@ -820,7 +820,7 @@ The head of the predicate gives a name, an optional *result type*, and a sequenc
 
 ::
 
-   head ::= ("predicate" | type) predicateName "(" (var_decls)? ")"
+   head ::= ("predicate" | type) predicateName "(" var_decls ")"
 
 The body of a predicate is of one of three forms:
 
@@ -1209,7 +1209,7 @@ An aggregation can be written in one of two forms:
 
 ::
 
-   aggregation ::= aggid ("[" expr "]")? "(" (var_decls)? ("|" (formula)? ("|" as_exprs ("order" "by" aggorderbys)?)?)? ")"
+   aggregation ::= aggid ("[" expr "]")? "(" var_decls ("|" (formula)? ("|" as_exprs ("order" "by" aggorderbys)?)?)? ")"
                |   aggid ("[" expr "]")? "(" as_exprs ("order" "by" aggorderbys)? ")"
                |   "unique" "(" var_decls "|" (formula)? ("|" as_exprs)? ")"
 
@@ -2046,7 +2046,7 @@ The complete grammar for QL is as follows:
                   |   "language" "[" "monotonicAggregates" "]"
                   |   "bindingset" "[" (variable ( "," variable)*)? "]"
 
-   head ::= ("predicate" | type) predicateName "(" (var_decls)? ")"
+   head ::= ("predicate" | type) predicateName "(" var_decls ")"
 
    optbody ::= ";"
            |  "{" formula "}" 
@@ -2070,7 +2070,7 @@ The complete grammar for QL is as follows:
          |  qldoc? annotations "class" classname "=" type ";"
          |  qldoc? annotations "module" modulename "=" moduleId ";"
          
-   var_decls ::= var_decl ("," var_decl)*
+   var_decls ::= (var_decl ("," var_decl)*)?
 
    var_decl ::= type simpleId
 
@@ -2157,7 +2157,7 @@ The complete grammar for QL is as follows:
 
    postfix_cast ::= primary "." "(" type ")"
 
-   aggregation ::= aggid ("[" expr "]")? "(" (var_decls)? ("|" (formula)? ("|" as_exprs ("order" "by" aggorderbys)?)?)? ")"
+   aggregation ::= aggid ("[" expr "]")? "(" var_decls ("|" (formula)? ("|" as_exprs ("order" "by" aggorderbys)?)?)? ")"
                |   aggid ("[" expr "]")? "(" as_exprs ("order" "by" aggorderbys)? ")"
                |   "unique" "(" var_decls "|" (formula)? ("|" as_exprs)? ")"
  


### PR DESCRIPTION
This is a degenerate form that is accepted in the compiler even if they don't make much sense. This now matches the actual implementation of this rule.

I'm not sure how much we want to adjust the text for this. Mostly it would be to emphasise that the lists could be empty. However the text for things like predicate declarations just implicitly accepts empty lists.

Fixes #5060