### PR TITLE
JS: Add models for server-side form/file parsing libraries

### DIFF
--- a/javascript/change-notes/2021-02-09-form-parsers.md
+++ b/javascript/change-notes/2021-02-09-form-parsers.md
@@ -1,0 +1,6 @@
+lgtm,codescanning
+* Server side form parsing libraries are now recognized as source of remote user input. 
+    [multer](https://www.npmjs.com/package/multer) and
+    [busboy](https://www.npmjs.com/package/busboy) and
+    [formidable](https://www.npmjs.com/package/formidable) and
+    [multiparty](https://www.npmjs.com/package/formidable)

--- a/javascript/change-notes/2021-02-09-form-parsers.md
+++ b/javascript/change-notes/2021-02-09-form-parsers.md
@@ -1,6 +1,7 @@
 lgtm,codescanning
 * Server side form parsing libraries are now recognized as source of remote user input. 
-    [multer](https://www.npmjs.com/package/multer) and
-    [busboy](https://www.npmjs.com/package/busboy) and
-    [formidable](https://www.npmjs.com/package/formidable) and
-    [multiparty](https://www.npmjs.com/package/formidable)
+  Affected packages are
+    [multer](https://www.npmjs.com/package/multer),
+    [busboy](https://www.npmjs.com/package/busboy),
+    [formidable](https://www.npmjs.com/package/formidable), and
+    [multiparty](https://www.npmjs.com/package/formidable).

--- a/javascript/ql/src/javascript.qll
+++ b/javascript/ql/src/javascript.qll
@@ -85,10 +85,11 @@ import semmle.javascript.frameworks.Electron
 import semmle.javascript.frameworks.EventEmitter
 import semmle.javascript.frameworks.Files
 import semmle.javascript.frameworks.Firebase
-import semmle.javascript.frameworks.Immutable
+import semmle.javascript.frameworks.FormParsers
 import semmle.javascript.frameworks.jQuery
 import semmle.javascript.frameworks.JWT
 import semmle.javascript.frameworks.Handlebars
+import semmle.javascript.frameworks.Immutable
 import semmle.javascript.frameworks.LazyCache
 import semmle.javascript.frameworks.LodashUnderscore
 import semmle.javascript.frameworks.Logging

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -509,8 +509,9 @@ module Express {
         this = request.getAPropertyRead("cookies")
         or
         // `req.files`, treated the same as `req.body`.
+        // `express-fileupload` uses .files, and `multer` uses .files or .file
         kind = "body" and
-        this = request.getAPropertyRead("files")
+        this = request.getAPropertyRead(["files", "file"])
       )
       or
       kind = "body" and

--- a/javascript/ql/src/semmle/javascript/frameworks/FormParsers.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/FormParsers.qll
@@ -7,7 +7,7 @@ import javascript
 /**
  * Classes and predicate modelling the `Busboy` library.
  */
-module Busboy {
+private module Busboy {
   /**
    * A `Busboy` instance that has request data flowing into it.
    */
@@ -27,4 +27,26 @@ module Busboy {
 
     override string getSourceType() { result = "Busbuy parsed user value" }
   }
+}
+
+/**
+ * A source of remote flow from the `Formidable` library parsing a HTTP request.
+ */
+private class FormidableRemoteFlow extends RemoteFlowSource {
+  FormidableRemoteFlow() {
+    exists(DataFlow::CallNode parse, DataFlow::InvokeNode formidable |
+      formidable = DataFlow::moduleImport("formidable").getACall()
+      or
+      formidable = DataFlow::moduleMember("formidable", "formidable").getACall()
+      or
+      formidable =
+        DataFlow::moduleMember("formidable", ["IncomingForm", "Formidable"]).getAnInstantiation()
+    |
+      parse = formidable.getAMemberCall("parse") and
+      parse.getArgument(0).asExpr() instanceof HTTP::RequestExpr and
+      this = parse.getABoundCallbackParameter(1, any(int i | i > 0))
+    )
+  }
+
+  override string getSourceType() { result = "Formidable parsed user value" }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/FormParsers.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/FormParsers.qll
@@ -1,0 +1,30 @@
+/**
+ * Provides classes for modelling the server-side form/file parsing libraries.
+ */
+
+import javascript
+
+/**
+ * Classes and predicate modelling the `Busboy` library.
+ */
+module Busboy {
+  /**
+   * A `Busboy` instance that has request data flowing into it.
+   */
+  private DataFlow::NewNode busboy() {
+    result = DataFlow::moduleImport("busboy").getAnInstantiation() and
+    exists(MethodCallExpr pipe |
+      pipe.calls(any(HTTP::RequestExpr req), "pipe") and
+      result.flowsToExpr(pipe.getArgument(0))
+    )
+  }
+
+  /**
+   * A source of remote flow from the `Busboy` library.
+   */
+  class BusBoyRemoteFlow extends RemoteFlowSource {
+    BusBoyRemoteFlow() { this = busboy().getAMemberCall("on").getABoundCallbackParameter(1, _) }
+
+    override string getSourceType() { result = "Busbuy parsed user value" }
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/FormParsers.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/FormParsers.qll
@@ -25,7 +25,7 @@ private module Busboy {
   class BusBoyRemoteFlow extends RemoteFlowSource {
     BusBoyRemoteFlow() { this = busboy().getAMemberCall("on").getABoundCallbackParameter(1, _) }
 
-    override string getSourceType() { result = "Busbuy parsed user value" }
+    override string getSourceType() { result = "parsed user value from Busbuy" }
   }
 }
 
@@ -48,5 +48,38 @@ private class FormidableRemoteFlow extends RemoteFlowSource {
     )
   }
 
-  override string getSourceType() { result = "Formidable parsed user value" }
+  override string getSourceType() { result = "parsed user value from Formidable" }
+}
+
+/**
+ * Predicates and classes modelling the `multiparty` library.
+ */
+private module Multiparty {
+  /**
+   * Gets an instance of of `Multiparty` form parser that parses a HTTP request object.
+   * The `parse` call is the method call that receives the HTTP request object.
+   */
+  private DataFlow::SourceNode form(DataFlow::MethodCallNode parse) {
+    result = DataFlow::moduleMember("multiparty", "Form").getAnInstantiation() and
+    parse = result.getAMethodCall("parse") and
+    parse.getArgument(0).asExpr() instanceof HTTP::RequestExpr
+  }
+
+  /**
+   * A source of remote flow from the `Multiparty` library.
+   */
+  class MultipartyRemoteFlow extends RemoteFlowSource {
+    MultipartyRemoteFlow() {
+      exists(DataFlow::MethodCallNode parse | exists(form(parse)) |
+        this = parse.getABoundCallbackParameter(1, any(int i | i > 0))
+      )
+      or
+      exists(DataFlow::MethodCallNode on | on = form(_).getAMethodCall("on") |
+        on.getArgument(0).mayHaveStringValue(["part", "file", "field"]) and
+        this = on.getABoundCallbackParameter(1, _)
+      )
+    }
+
+    override string getSourceType() { result = "parsed user value from Multiparty" }
+  }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -105,6 +105,18 @@ nodes
 | form-parsers.js:25:10:25:28 | "touch " + filename |
 | form-parsers.js:25:10:25:28 | "touch " + filename |
 | form-parsers.js:25:21:25:28 | filename |
+| form-parsers.js:35:25:35:30 | fields |
+| form-parsers.js:35:25:35:30 | fields |
+| form-parsers.js:36:10:36:31 | "touch  ... ds.name |
+| form-parsers.js:36:10:36:31 | "touch  ... ds.name |
+| form-parsers.js:36:21:36:26 | fields |
+| form-parsers.js:36:21:36:31 | fields.name |
+| form-parsers.js:40:26:40:31 | fields |
+| form-parsers.js:40:26:40:31 | fields |
+| form-parsers.js:41:10:41:31 | "touch  ... ds.name |
+| form-parsers.js:41:10:41:31 | "touch  ... ds.name |
+| form-parsers.js:41:21:41:26 | fields |
+| form-parsers.js:41:21:41:31 | fields.name |
 | lib/subLib/index.js:7:32:7:35 | name |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
@@ -253,6 +265,16 @@ edges
 | form-parsers.js:24:48:24:55 | filename | form-parsers.js:25:21:25:28 | filename |
 | form-parsers.js:25:21:25:28 | filename | form-parsers.js:25:10:25:28 | "touch " + filename |
 | form-parsers.js:25:21:25:28 | filename | form-parsers.js:25:10:25:28 | "touch " + filename |
+| form-parsers.js:35:25:35:30 | fields | form-parsers.js:36:21:36:26 | fields |
+| form-parsers.js:35:25:35:30 | fields | form-parsers.js:36:21:36:26 | fields |
+| form-parsers.js:36:21:36:26 | fields | form-parsers.js:36:21:36:31 | fields.name |
+| form-parsers.js:36:21:36:31 | fields.name | form-parsers.js:36:10:36:31 | "touch  ... ds.name |
+| form-parsers.js:36:21:36:31 | fields.name | form-parsers.js:36:10:36:31 | "touch  ... ds.name |
+| form-parsers.js:40:26:40:31 | fields | form-parsers.js:41:21:41:26 | fields |
+| form-parsers.js:40:26:40:31 | fields | form-parsers.js:41:21:41:26 | fields |
+| form-parsers.js:41:21:41:26 | fields | form-parsers.js:41:21:41:31 | fields.name |
+| form-parsers.js:41:21:41:31 | fields.name | form-parsers.js:41:10:41:31 | "touch  ... ds.name |
+| form-parsers.js:41:21:41:31 | fields.name | form-parsers.js:41:10:41:31 | "touch  ... ds.name |
 | lib/subLib/index.js:7:32:7:35 | name | lib/subLib/index.js:8:22:8:25 | name |
 | lib/subLib/index.js:8:22:8:25 | name | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
 | lib/subLib/index.js:8:22:8:25 | name | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
@@ -327,6 +349,8 @@ edges
 | form-parsers.js:9:8:9:39 | "touch  ... nalname | form-parsers.js:9:19:9:26 | req.file | form-parsers.js:9:8:9:39 | "touch  ... nalname | This command depends on $@. | form-parsers.js:9:19:9:26 | req.file | a user-provided value |
 | form-parsers.js:14:10:14:37 | "touch  ... nalname | form-parsers.js:13:3:13:11 | req.files | form-parsers.js:14:10:14:37 | "touch  ... nalname | This command depends on $@. | form-parsers.js:13:3:13:11 | req.files | a user-provided value |
 | form-parsers.js:25:10:25:28 | "touch " + filename | form-parsers.js:24:48:24:55 | filename | form-parsers.js:25:10:25:28 | "touch " + filename | This command depends on $@. | form-parsers.js:24:48:24:55 | filename | a user-provided value |
+| form-parsers.js:36:10:36:31 | "touch  ... ds.name | form-parsers.js:35:25:35:30 | fields | form-parsers.js:36:10:36:31 | "touch  ... ds.name | This command depends on $@. | form-parsers.js:35:25:35:30 | fields | a user-provided value |
+| form-parsers.js:41:10:41:31 | "touch  ... ds.name | form-parsers.js:40:26:40:31 | fields | form-parsers.js:41:10:41:31 | "touch  ... ds.name | This command depends on $@. | form-parsers.js:40:26:40:31 | fields | a user-provided value |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | This command depends on $@. | child_process-test.js:85:37:85:54 | req.query.fileName | a user-provided value |
 | other.js:7:33:7:35 | cmd | other.js:5:25:5:31 | req.url | other.js:7:33:7:35 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |
 | other.js:8:28:8:30 | cmd | other.js:5:25:5:31 | req.url | other.js:8:28:8:30 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -100,6 +100,11 @@ nodes
 | form-parsers.js:14:10:14:37 | "touch  ... nalname |
 | form-parsers.js:14:21:14:24 | file |
 | form-parsers.js:14:21:14:37 | file.originalname |
+| form-parsers.js:24:48:24:55 | filename |
+| form-parsers.js:24:48:24:55 | filename |
+| form-parsers.js:25:10:25:28 | "touch " + filename |
+| form-parsers.js:25:10:25:28 | "touch " + filename |
+| form-parsers.js:25:21:25:28 | filename |
 | lib/subLib/index.js:7:32:7:35 | name |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
@@ -244,6 +249,10 @@ edges
 | form-parsers.js:14:21:14:24 | file | form-parsers.js:14:21:14:37 | file.originalname |
 | form-parsers.js:14:21:14:37 | file.originalname | form-parsers.js:14:10:14:37 | "touch  ... nalname |
 | form-parsers.js:14:21:14:37 | file.originalname | form-parsers.js:14:10:14:37 | "touch  ... nalname |
+| form-parsers.js:24:48:24:55 | filename | form-parsers.js:25:21:25:28 | filename |
+| form-parsers.js:24:48:24:55 | filename | form-parsers.js:25:21:25:28 | filename |
+| form-parsers.js:25:21:25:28 | filename | form-parsers.js:25:10:25:28 | "touch " + filename |
+| form-parsers.js:25:21:25:28 | filename | form-parsers.js:25:10:25:28 | "touch " + filename |
 | lib/subLib/index.js:7:32:7:35 | name | lib/subLib/index.js:8:22:8:25 | name |
 | lib/subLib/index.js:8:22:8:25 | name | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
 | lib/subLib/index.js:8:22:8:25 | name | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
@@ -317,6 +326,7 @@ edges
 | execSeries.js:14:41:14:47 | command | execSeries.js:18:34:18:40 | req.url | execSeries.js:14:41:14:47 | command | This command depends on $@. | execSeries.js:18:34:18:40 | req.url | a user-provided value |
 | form-parsers.js:9:8:9:39 | "touch  ... nalname | form-parsers.js:9:19:9:26 | req.file | form-parsers.js:9:8:9:39 | "touch  ... nalname | This command depends on $@. | form-parsers.js:9:19:9:26 | req.file | a user-provided value |
 | form-parsers.js:14:10:14:37 | "touch  ... nalname | form-parsers.js:13:3:13:11 | req.files | form-parsers.js:14:10:14:37 | "touch  ... nalname | This command depends on $@. | form-parsers.js:13:3:13:11 | req.files | a user-provided value |
+| form-parsers.js:25:10:25:28 | "touch " + filename | form-parsers.js:24:48:24:55 | filename | form-parsers.js:25:10:25:28 | "touch " + filename | This command depends on $@. | form-parsers.js:24:48:24:55 | filename | a user-provided value |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | This command depends on $@. | child_process-test.js:85:37:85:54 | req.query.fileName | a user-provided value |
 | other.js:7:33:7:35 | cmd | other.js:5:25:5:31 | req.url | other.js:7:33:7:35 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |
 | other.js:8:28:8:30 | cmd | other.js:5:25:5:31 | req.url | other.js:8:28:8:30 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -117,6 +117,18 @@ nodes
 | form-parsers.js:41:10:41:31 | "touch  ... ds.name |
 | form-parsers.js:41:21:41:26 | fields |
 | form-parsers.js:41:21:41:31 | fields.name |
+| form-parsers.js:52:34:52:39 | fields |
+| form-parsers.js:52:34:52:39 | fields |
+| form-parsers.js:53:10:53:31 | "touch  ... ds.name |
+| form-parsers.js:53:10:53:31 | "touch  ... ds.name |
+| form-parsers.js:53:21:53:26 | fields |
+| form-parsers.js:53:21:53:31 | fields.name |
+| form-parsers.js:58:30:58:33 | part |
+| form-parsers.js:58:30:58:33 | part |
+| form-parsers.js:59:10:59:33 | "touch  ... ilename |
+| form-parsers.js:59:10:59:33 | "touch  ... ilename |
+| form-parsers.js:59:21:59:24 | part |
+| form-parsers.js:59:21:59:33 | part.filename |
 | lib/subLib/index.js:7:32:7:35 | name |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
@@ -275,6 +287,16 @@ edges
 | form-parsers.js:41:21:41:26 | fields | form-parsers.js:41:21:41:31 | fields.name |
 | form-parsers.js:41:21:41:31 | fields.name | form-parsers.js:41:10:41:31 | "touch  ... ds.name |
 | form-parsers.js:41:21:41:31 | fields.name | form-parsers.js:41:10:41:31 | "touch  ... ds.name |
+| form-parsers.js:52:34:52:39 | fields | form-parsers.js:53:21:53:26 | fields |
+| form-parsers.js:52:34:52:39 | fields | form-parsers.js:53:21:53:26 | fields |
+| form-parsers.js:53:21:53:26 | fields | form-parsers.js:53:21:53:31 | fields.name |
+| form-parsers.js:53:21:53:31 | fields.name | form-parsers.js:53:10:53:31 | "touch  ... ds.name |
+| form-parsers.js:53:21:53:31 | fields.name | form-parsers.js:53:10:53:31 | "touch  ... ds.name |
+| form-parsers.js:58:30:58:33 | part | form-parsers.js:59:21:59:24 | part |
+| form-parsers.js:58:30:58:33 | part | form-parsers.js:59:21:59:24 | part |
+| form-parsers.js:59:21:59:24 | part | form-parsers.js:59:21:59:33 | part.filename |
+| form-parsers.js:59:21:59:33 | part.filename | form-parsers.js:59:10:59:33 | "touch  ... ilename |
+| form-parsers.js:59:21:59:33 | part.filename | form-parsers.js:59:10:59:33 | "touch  ... ilename |
 | lib/subLib/index.js:7:32:7:35 | name | lib/subLib/index.js:8:22:8:25 | name |
 | lib/subLib/index.js:8:22:8:25 | name | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
 | lib/subLib/index.js:8:22:8:25 | name | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
@@ -351,6 +373,8 @@ edges
 | form-parsers.js:25:10:25:28 | "touch " + filename | form-parsers.js:24:48:24:55 | filename | form-parsers.js:25:10:25:28 | "touch " + filename | This command depends on $@. | form-parsers.js:24:48:24:55 | filename | a user-provided value |
 | form-parsers.js:36:10:36:31 | "touch  ... ds.name | form-parsers.js:35:25:35:30 | fields | form-parsers.js:36:10:36:31 | "touch  ... ds.name | This command depends on $@. | form-parsers.js:35:25:35:30 | fields | a user-provided value |
 | form-parsers.js:41:10:41:31 | "touch  ... ds.name | form-parsers.js:40:26:40:31 | fields | form-parsers.js:41:10:41:31 | "touch  ... ds.name | This command depends on $@. | form-parsers.js:40:26:40:31 | fields | a user-provided value |
+| form-parsers.js:53:10:53:31 | "touch  ... ds.name | form-parsers.js:52:34:52:39 | fields | form-parsers.js:53:10:53:31 | "touch  ... ds.name | This command depends on $@. | form-parsers.js:52:34:52:39 | fields | a user-provided value |
+| form-parsers.js:59:10:59:33 | "touch  ... ilename | form-parsers.js:58:30:58:33 | part | form-parsers.js:59:10:59:33 | "touch  ... ilename | This command depends on $@. | form-parsers.js:58:30:58:33 | part | a user-provided value |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | This command depends on $@. | child_process-test.js:85:37:85:54 | req.query.fileName | a user-provided value |
 | other.js:7:33:7:35 | cmd | other.js:5:25:5:31 | req.url | other.js:7:33:7:35 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |
 | other.js:8:28:8:30 | cmd | other.js:5:25:5:31 | req.url | other.js:8:28:8:30 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -88,6 +88,18 @@ nodes
 | execSeries.js:18:34:18:40 | req.url |
 | execSeries.js:19:12:19:16 | [cmd] |
 | execSeries.js:19:13:19:15 | cmd |
+| form-parsers.js:9:8:9:39 | "touch  ... nalname |
+| form-parsers.js:9:8:9:39 | "touch  ... nalname |
+| form-parsers.js:9:19:9:26 | req.file |
+| form-parsers.js:9:19:9:26 | req.file |
+| form-parsers.js:9:19:9:39 | req.fil ... nalname |
+| form-parsers.js:13:3:13:11 | req.files |
+| form-parsers.js:13:3:13:11 | req.files |
+| form-parsers.js:13:21:13:24 | file |
+| form-parsers.js:14:10:14:37 | "touch  ... nalname |
+| form-parsers.js:14:10:14:37 | "touch  ... nalname |
+| form-parsers.js:14:21:14:24 | file |
+| form-parsers.js:14:21:14:37 | file.originalname |
 | lib/subLib/index.js:7:32:7:35 | name |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
@@ -222,6 +234,16 @@ edges
 | execSeries.js:18:34:18:40 | req.url | execSeries.js:18:13:18:47 | require ... , true) |
 | execSeries.js:19:12:19:16 | [cmd] | execSeries.js:13:19:13:26 | commands |
 | execSeries.js:19:13:19:15 | cmd | execSeries.js:19:12:19:16 | [cmd] |
+| form-parsers.js:9:19:9:26 | req.file | form-parsers.js:9:19:9:39 | req.fil ... nalname |
+| form-parsers.js:9:19:9:26 | req.file | form-parsers.js:9:19:9:39 | req.fil ... nalname |
+| form-parsers.js:9:19:9:39 | req.fil ... nalname | form-parsers.js:9:8:9:39 | "touch  ... nalname |
+| form-parsers.js:9:19:9:39 | req.fil ... nalname | form-parsers.js:9:8:9:39 | "touch  ... nalname |
+| form-parsers.js:13:3:13:11 | req.files | form-parsers.js:13:21:13:24 | file |
+| form-parsers.js:13:3:13:11 | req.files | form-parsers.js:13:21:13:24 | file |
+| form-parsers.js:13:21:13:24 | file | form-parsers.js:14:21:14:24 | file |
+| form-parsers.js:14:21:14:24 | file | form-parsers.js:14:21:14:37 | file.originalname |
+| form-parsers.js:14:21:14:37 | file.originalname | form-parsers.js:14:10:14:37 | "touch  ... nalname |
+| form-parsers.js:14:21:14:37 | file.originalname | form-parsers.js:14:10:14:37 | "touch  ... nalname |
 | lib/subLib/index.js:7:32:7:35 | name | lib/subLib/index.js:8:22:8:25 | name |
 | lib/subLib/index.js:8:22:8:25 | name | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
 | lib/subLib/index.js:8:22:8:25 | name | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name |
@@ -293,6 +315,8 @@ edges
 | exec-sh2.js:10:12:10:57 | cp.spaw ... ptions) | exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:10:40:10:46 | command | This command depends on $@. | exec-sh2.js:14:25:14:31 | req.url | a user-provided value |
 | exec-sh.js:15:12:15:61 | cp.spaw ... ptions) | exec-sh.js:19:25:19:31 | req.url | exec-sh.js:15:44:15:50 | command | This command depends on $@. | exec-sh.js:19:25:19:31 | req.url | a user-provided value |
 | execSeries.js:14:41:14:47 | command | execSeries.js:18:34:18:40 | req.url | execSeries.js:14:41:14:47 | command | This command depends on $@. | execSeries.js:18:34:18:40 | req.url | a user-provided value |
+| form-parsers.js:9:8:9:39 | "touch  ... nalname | form-parsers.js:9:19:9:26 | req.file | form-parsers.js:9:8:9:39 | "touch  ... nalname | This command depends on $@. | form-parsers.js:9:19:9:26 | req.file | a user-provided value |
+| form-parsers.js:14:10:14:37 | "touch  ... nalname | form-parsers.js:13:3:13:11 | req.files | form-parsers.js:14:10:14:37 | "touch  ... nalname | This command depends on $@. | form-parsers.js:13:3:13:11 | req.files | a user-provided value |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | This command depends on $@. | child_process-test.js:85:37:85:54 | req.query.fileName | a user-provided value |
 | other.js:7:33:7:35 | cmd | other.js:5:25:5:31 | req.url | other.js:7:33:7:35 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |
 | other.js:8:28:8:30 | cmd | other.js:5:25:5:31 | req.url | other.js:8:28:8:30 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/form-parsers.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/form-parsers.js
@@ -41,3 +41,23 @@ app.post('/api/upload', (req, res, next) => {
     exec("touch " + fields.name); // NOT OK
   });
 });
+
+var multiparty = require('multiparty');
+var http = require('http');
+
+http.createServer(function (req, res) {
+  // parse a file upload
+  var form = new multiparty.Form();
+
+  form.parse(req, function (err, fields, files) {
+    exec("touch " + fields.name); // NOT OK
+  });
+
+
+  var form2 = new multiparty.Form();
+  form2.on('part', function (part) { // / file / field
+    exec("touch " + part.filename); // NOT OK
+  });
+  form2.parse(req);
+
+}).listen(8080);

--- a/javascript/ql/test/query-tests/Security/CWE-078/form-parsers.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/form-parsers.js
@@ -14,3 +14,15 @@ app.post('/photos/upload', upload.array('photos', 12), function (req, res, next)
     exec("touch " + file.originalname); // NOT OK
   })
 });
+
+
+var http = require('http');
+var Busboy = require('busboy');
+
+http.createServer(function (req, res) {
+  var busboy = new Busboy({ headers: req.headers });
+  busboy.on('file', function (fieldname, file, filename, encoding, mimetype) {
+    exec("touch " + filename); // NOT OK
+  });
+  req.pipe(busboy);
+}).listen(8000);

--- a/javascript/ql/test/query-tests/Security/CWE-078/form-parsers.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/form-parsers.js
@@ -26,3 +26,18 @@ http.createServer(function (req, res) {
   });
   req.pipe(busboy);
 }).listen(8000);
+
+
+const formidable = require('formidable'); 
+app.post('/api/upload', (req, res, next) => {
+  let form = formidable({ multiples: true });
+ 
+  form.parse(req, (err, fields, files) => {
+    exec("touch " + fields.name); // NOT OK
+  });
+
+  let form2 = new formidable.IncomingForm();
+  form2.parse(req, (err, fields, files) => {
+    exec("touch " + fields.name); // NOT OK
+  });
+});

--- a/javascript/ql/test/query-tests/Security/CWE-078/form-parsers.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/form-parsers.js
@@ -1,0 +1,16 @@
+var express = require('express');
+var multer  = require('multer');
+var upload = multer({ dest: 'uploads/' });
+ 
+var app = express();
+var exec = require("child_process").exec;
+ 
+app.post('/profile', upload.single('avatar'), function (req, res, next) {
+  exec("touch " + req.file.originalname); // NOT OK
+});
+ 
+app.post('/photos/upload', upload.array('photos', 12), function (req, res, next) {
+  req.files.forEach(file => {
+    exec("touch " + file.originalname); // NOT OK
+  })
+});


### PR DESCRIPTION
[Evaluation](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/parseForm-eval-1/reports) (and [a redo](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/parseForm-eval-4/reports)) looks OK in terms of performance. 
4 new TPs. 
(The `js/tainted-path` results are TPs because an uploaded file can be named `..`). 