### PR TITLE
C# : Add improvements to the deserialization query

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/serialization/Deserializers.qll
+++ b/csharp/ql/src/semmle/code/csharp/serialization/Deserializers.qll
@@ -4,6 +4,7 @@
  */
 
 import csharp
+import semmle.code.csharp.frameworks.JsonNET::JsonNET
 
 /** An unsafe deserializer. */
 abstract class UnsafeDeserializer extends Callable { }
@@ -50,6 +51,11 @@ class MicrosoftDeserializer extends UnsafeDeserializer {
   MicrosoftDeserializer() {
     this.hasQualifiedName("Microsoft.Web.Design.Remote.ProxyObject", "DecodeValue")
   }
+}
+
+/** An unsafe deserializer method in the `Newton.Json.*` namespace. */
+class NewtonJsonDeserializer extends UnsafeDeserializer {
+  NewtonJsonDeserializer() { exists(JsonConvertClass c | c.getADeserializeMethod() = this) }
 }
 
 /**


### PR DESCRIPTION
Currently the unsafe deserialization query fails to detect `Newton.Json` sinks.
While `Newton.Json` is already modelled, the sinks for the same are not
included in the taint tracking config.

This PR addresses the same.

There is atleast one additional detection due to this change in
[chhans/Kurs19_Public](https://github.com/chhans/Kurs19_Public)