### PR TITLE
C#: Add Asp.Net Core redirect sinks

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
@@ -195,7 +195,13 @@ class MicrosoftAspNetCoreMvcController extends Class {
   /** Gets a `Redirect*` method. */
   Method getARedirectMethod() {
     result = this.getAMethod() and
-    result.getName().matches("Redirect%")
+    (
+      result.getName().matches("Redirect%")
+      or
+      result.getName().matches("Accepted%")
+      or
+      result.getName().matches("Created%")
+    )
   }
 }
 


### PR DESCRIPTION
Both the familiy of `Accepted` and `Created` methods set the location
header based on provided input. If this is untrusted input this can
result in an URL redirect attack.