### PR TITLE
Javascript Extractor: Update <tt> tages to <code>

### DIFF
--- a/javascript/extractor/src/com/semmle/js/ast/DeclarationFlags.java
+++ b/javascript/extractor/src/com/semmle/js/ast/DeclarationFlags.java
@@ -88,59 +88,59 @@ public class DeclarationFlags {
     return (flags & declareKeyword) != 0;
   }
 
-  /** Returns a mask with the computed bit set to the value of <tt>enable</tt>. */
+  /** Returns a mask with the computed bit set to the value of <code>enable</code>. */
   public static int getComputed(boolean enable) {
     return enable ? computed : 0;
   }
 
-  /** Returns a mask with the abstract bit set to the value of <tt>enable</tt>. */
+  /** Returns a mask with the abstract bit set to the value of <code>enable</code>. */
   public static int getAbstract(boolean enable) {
     return enable ? abstract_ : 0;
   }
 
-  /** Returns a mask with the static bit set to the value of <tt>enable</tt>. */
+  /** Returns a mask with the static bit set to the value of <code>enable</code>. */
   public static int getStatic(boolean enable) {
     return enable ? static_ : 0;
   }
 
-  /** Returns a mask with the public bit set to the value of <tt>enable</tt>. */
+  /** Returns a mask with the public bit set to the value of <code>enable</code>. */
   public static int getPublic(boolean enable) {
     return enable ? public_ : 0;
   }
 
-  /** Returns a mask with the readonly bit set to the value of <tt>enable</tt>. */
+  /** Returns a mask with the readonly bit set to the value of <code>enable</code>. */
   public static int getReadonly(boolean enable) {
     return enable ? readonly : 0;
   }
 
-  /** Returns a mask with the private bit set to the value of <tt>enable</tt>. */
+  /** Returns a mask with the private bit set to the value of <code>enable</code>. */
   public static int getPrivate(boolean enable) {
     return enable ? private_ : 0;
   }
 
-  /** Returns a mask with the protected bit set to the value of <tt>enable</tt>. */
+  /** Returns a mask with the protected bit set to the value of <code>enable</code>. */
   public static int getProtected(boolean enable) {
     return enable ? protected_ : 0;
   }
 
-  /** Returns a mask with the optional bit set to the value of <tt>enable</tt>. */
+  /** Returns a mask with the optional bit set to the value of <code>enable</code>. */
   public static int getOptional(boolean enable) {
     return enable ? optional : 0;
   }
 
   /**
-   * Returns a mask with the definite assignment assertion bit set to the value of <tt>enable</tt>.
+   * Returns a mask with the definite assignment assertion bit set to the value of <code>enable</code>.
    */
   public static int getDefiniteAssignmentAssertion(boolean enable) {
     return enable ? definiteAssignmentAssertion : 0;
   }
 
-  /** Returns a mask with the declare keyword bit set to the value of <tt>enable</tt>. */
+  /** Returns a mask with the declare keyword bit set to the value of <code>enable</code>. */
   public static int getDeclareKeyword(boolean enable) {
     return enable ? declareKeyword : 0;
   }
 
-  /** Returns true if the <tt>n</tt>th bit is set in <tt>flags</tt>. */
+  /** Returns true if the <code>n</code>th bit is set in <code>flags</code>. */
   public static boolean hasNthFlag(int flags, int n) {
     return (flags & (1 << n)) != 0;
   }

--- a/javascript/extractor/src/com/semmle/js/ast/Literal.java
+++ b/javascript/extractor/src/com/semmle/js/ast/Literal.java
@@ -6,7 +6,7 @@ import com.semmle.ts.ast.ITypeExpression;
 /**
  * A literal constant.
  *
- * <p>A <tt>null</tt> literal may occur as a TypeScript type annotation - other literals are always
+ * <p>A <code>null</code> literal may occur as a TypeScript type annotation - other literals are always
  * expressions.
  */
 public class Literal extends Expression implements ITypeExpression {

--- a/javascript/extractor/src/com/semmle/js/ast/MemberDefinition.java
+++ b/javascript/extractor/src/com/semmle/js/ast/MemberDefinition.java
@@ -40,7 +40,7 @@ public abstract class MemberDefinition<V extends Expression> extends Node {
     return flags;
   }
 
-  /** Returns true if this has the <tt>static</tt> modifier. */
+  /** Returns true if this has the <code>static</code> modifier. */
   public boolean isStatic() {
     return DeclarationFlags.isStatic(flags);
   }
@@ -55,7 +55,7 @@ public abstract class MemberDefinition<V extends Expression> extends Node {
     return DeclarationFlags.isAbstract(flags);
   }
 
-  /** Returns true if has the <tt>public</tt> modifier (not true for implicitly public members). */
+  /** Returns true if has the <code>public</code> modifier (not true for implicitly public members). */
   public boolean hasPublicKeyword() {
     return DeclarationFlags.isPublic(flags);
   }
@@ -75,7 +75,7 @@ public abstract class MemberDefinition<V extends Expression> extends Node {
     return DeclarationFlags.isReadonly(flags);
   }
 
-  /** Returns true if this has the <tt>declare</tt> modifier. */
+  /** Returns true if this has the <code>declare</code> modifier. */
   public boolean hasDeclareKeyword() {
     return DeclarationFlags.hasDeclareKeyword(flags);
   }

--- a/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
@@ -253,7 +253,7 @@ public class ASTExtractor {
 
     /**
      * An identifier that refers to a variable from inside a type, i.e. the operand to a
-     * <tt>typeof</tt> type or left operand to an <tt>is</tt> type.
+     * <code>typeof</code> type or left operand to an <code>is</code> type.
      *
      * <p>This is generally treated as a type, except a variable binding will be emitted for it.
      */
@@ -288,7 +288,7 @@ public class ASTExtractor {
     VAR_AND_TYPE_AND_NAMESPACE_DECL,
 
     /**
-     * An identifier that occurs as part of a named export, such as <tt>export { A }</tt>.
+     * An identifier that occurs as part of a named export, such as <code>export { A }</code>.
      *
      * <p>This may refer to a variable, type, and/or a namespace, and will export exactly those that
      * can be resolved.
@@ -301,7 +301,7 @@ public class ASTExtractor {
 
     /**
      * An identifier that occurs as a qualified name in a default export expression, such as
-     * <tt>A</tt> in <tt>export default A.B</tt>.
+     * <code>A</code> in <code>export default A.B</code>.
      *
      * <p>This acts like {@link #EXPORT}, except it cannot refer to a type (i.e. it must be a
      * variable and/or a namespace).

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -722,13 +722,13 @@ public class AutoBuild {
   }
 
   /**
-   * Prepares <tt>package.json</tt> files in a virtual source root, and, if enabled,
+   * Prepares <code>package.json</code> files in a virtual source root, and, if enabled,
    * installs dependencies for use by the TypeScript type checker.
    * <p>
    * Some packages must be downloaded while others exist within the same repo ("monorepos")
    * but are not in a location where TypeScript would look for it.
    * <p>
-   * Downloaded packages are intalled under <tt>SCRATCH_DIR</tt>, in a mirrored directory hierarchy
+   * Downloaded packages are intalled under <code>SCRATCH_DIR</code>, in a mirrored directory hierarchy
    * we call the "virtual source root".
    * <p>
    * Packages that exists within the repo are not downloaded. Since they are part of the main source tree,

--- a/javascript/extractor/src/com/semmle/js/extractor/ScopeManager.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/ScopeManager.java
@@ -149,7 +149,7 @@ public class ScopeManager {
   }
 
   /**
-   * Enters a scope for a block of form <tt>declare global { ... }</tt>.
+   * Enters a scope for a block of form <code>declare global { ... }</code>.
    *
    * <p>Declarations in this block will contribute to the global scope, but references can still be
    * resolved in the scope enclosing the declaration itself. The scope itself does not have its own

--- a/javascript/extractor/src/com/semmle/js/parser/ParsedProject.java
+++ b/javascript/extractor/src/com/semmle/js/parser/ParsedProject.java
@@ -14,7 +14,7 @@ public class ParsedProject {
     this.allFiles = allFiles;
   }
 
-  /** Returns the <tt>tsconfig.json</tt> file that defines this project. */
+  /** Returns the <code>tsconfig.json</code> file that defines this project. */
   public File getTsConfigFile() {
     return tsConfigFile;
   }

--- a/javascript/extractor/src/com/semmle/ts/ast/ArrayTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/ArrayTypeExpr.java
@@ -4,7 +4,7 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
 /**
- * An array type, such as <tt>number[]</tt>, or in general <tt>T[]</tt> where <tt>T</tt> is a type.
+ * An array type, such as <code>number[]</code>, or in general <code>T[]</code> where <code>T</code> is a type.
  */
 public class ArrayTypeExpr extends TypeExpression {
   private final ITypeExpression elementType;

--- a/javascript/extractor/src/com/semmle/ts/ast/ConditionalTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/ConditionalTypeExpr.java
@@ -3,7 +3,7 @@ package com.semmle.ts.ast;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
-/** A conditional type annotation, such as <tt>T extends any[] ? A : B</tt>. */
+/** A conditional type annotation, such as <code>T extends any[] ? A : B</code>. */
 public class ConditionalTypeExpr extends TypeExpression {
   private ITypeExpression checkType;
   private ITypeExpression extendsType;

--- a/javascript/extractor/src/com/semmle/ts/ast/ExportAsNamespaceDeclaration.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/ExportAsNamespaceDeclaration.java
@@ -5,7 +5,7 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Statement;
 import com.semmle.js.ast.Visitor;
 
-/** A statement of form <tt>export as namespace X</tt> where <tt>X</tt> is an identifier. */
+/** A statement of form <code>export as namespace X</code> where <code>X</code> is an identifier. */
 public class ExportAsNamespaceDeclaration extends Statement {
   private Identifier id;
 

--- a/javascript/extractor/src/com/semmle/ts/ast/ExpressionWithTypeArguments.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/ExpressionWithTypeArguments.java
@@ -13,7 +13,7 @@ import java.util.List;
  * class StringList extends List&lt;string&gt; {}
  * </pre>
  *
- * Above, <tt>List</tt> is a concrete expression whereas its type argument is a type.
+ * Above, <code>List</code> is a concrete expression whereas its type argument is a type.
  */
 public class ExpressionWithTypeArguments extends Expression {
   private final Expression expression;

--- a/javascript/extractor/src/com/semmle/ts/ast/ExternalModuleDeclaration.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/ExternalModuleDeclaration.java
@@ -6,7 +6,7 @@ import com.semmle.js.ast.Statement;
 import com.semmle.js.ast.Visitor;
 import java.util.List;
 
-/** A statement of form <tt>declare module "X" {...}</tt>. */
+/** A statement of form <code>declare module "X" {...}</code>. */
 public class ExternalModuleDeclaration extends Statement {
   private final Literal name;
   private final List<Statement> body;

--- a/javascript/extractor/src/com/semmle/ts/ast/GenericTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/GenericTypeExpr.java
@@ -4,7 +4,7 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 import java.util.List;
 
-/** An instantiation of a named type, such as <tt>Array&lt;number&gt;</tt> */
+/** An instantiation of a named type, such as <code>Array&lt;number&gt;</code> */
 public class GenericTypeExpr extends TypeExpression {
   private final ITypeExpression typeName; // Always Identifier or MemberExpression
   private final List<ITypeExpression> typeArguments;

--- a/javascript/extractor/src/com/semmle/ts/ast/GlobalAugmentationDeclaration.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/GlobalAugmentationDeclaration.java
@@ -5,7 +5,7 @@ import com.semmle.js.ast.Statement;
 import com.semmle.js.ast.Visitor;
 import java.util.List;
 
-/** A statement of form: <tt>declare global { ... }</tt> */
+/** A statement of form: <code>declare global { ... }</code> */
 public class GlobalAugmentationDeclaration extends Statement {
   private final List<Statement> body;
 

--- a/javascript/extractor/src/com/semmle/ts/ast/INodeWithSymbol.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/INodeWithSymbol.java
@@ -8,7 +8,7 @@ package com.semmle.ts.ast;
  */
 public interface INodeWithSymbol {
   /**
-   * Gets a number identifying the symbol associated with this AST node, or <tt>-1</tt> if there is
+   * Gets a number identifying the symbol associated with this AST node, or <code>-1</code> if there is
    * no such symbol.
    */
   int getSymbol();

--- a/javascript/extractor/src/com/semmle/ts/ast/ITypeExpression.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/ITypeExpression.java
@@ -8,6 +8,6 @@ import com.semmle.js.ast.Literal;
  *
  * <p>At the QL level, expressions and type annotations are completely separate. In the extractor,
  * however, some expressions such as {@link Literal} type may occur in a type annotation because the
- * TypeScript AST does not distinguish <tt>null</tt> literals from the <tt>null</tt> type.
+ * TypeScript AST does not distinguish <code>null</code> literals from the <code>null</code> type.
  */
 public interface ITypeExpression extends INode, ITypedAstNode {}

--- a/javascript/extractor/src/com/semmle/ts/ast/ImportTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/ImportTypeExpr.java
@@ -4,7 +4,7 @@ import com.semmle.js.ast.Expression;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
-/** An import type such as in <tt>import("http").ServerRequest</tt>. */
+/** An import type such as in <code>import("http").ServerRequest</code>. */
 public class ImportTypeExpr extends Expression implements ITypeExpression {
   private final ITypeExpression path;
 

--- a/javascript/extractor/src/com/semmle/ts/ast/ImportWholeDeclaration.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/ImportWholeDeclaration.java
@@ -6,7 +6,7 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Statement;
 import com.semmle.js.ast.Visitor;
 
-/** An import of form <tt>import a = E</tt>. */
+/** An import of form <code>import a = E</code>. */
 public class ImportWholeDeclaration extends Statement {
   private final Identifier lhs;
   private final Expression rhs;

--- a/javascript/extractor/src/com/semmle/ts/ast/IndexedAccessTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/IndexedAccessTypeExpr.java
@@ -3,7 +3,7 @@ package com.semmle.ts.ast;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
-/** A type of form <tt>T[K]</tt> where <tt>T</tt> and <tt>K</tt> are types. */
+/** A type of form <code>T[K]</code> where <code>T</code> and <code>K</code> are types. */
 public class IndexedAccessTypeExpr extends TypeExpression {
   private final ITypeExpression objectType;
   private final ITypeExpression indexType;

--- a/javascript/extractor/src/com/semmle/ts/ast/InferTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/InferTypeExpr.java
@@ -3,7 +3,7 @@ package com.semmle.ts.ast;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
-/** A type annotation of form <tt>infer R</tt> */
+/** A type annotation of form <code>infer R</code> */
 public class InferTypeExpr extends TypeExpression {
   private TypeParameter typeParameter;
 

--- a/javascript/extractor/src/com/semmle/ts/ast/InterfaceTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/InterfaceTypeExpr.java
@@ -5,7 +5,7 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 import java.util.List;
 
-/** An inline interface type, such as <tt>{x: number; y: number}</tt>. */
+/** An inline interface type, such as <code>{x: number; y: number}</code>. */
 public class InterfaceTypeExpr extends TypeExpression {
   private final List<MemberDefinition<?>> body;
 

--- a/javascript/extractor/src/com/semmle/ts/ast/IntersectionTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/IntersectionTypeExpr.java
@@ -5,8 +5,8 @@ import com.semmle.js.ast.Visitor;
 import java.util.List;
 
 /**
- * An intersection type such as <tt>T&amp;S</tt>, denoting the intersection of type <tt>T</tt> and
- * type <tt>S</tt>.
+ * An intersection type such as <code>T&amp;S</code>, denoting the intersection of type <code>T</code> and
+ * type <code>S</code>.
  */
 public class IntersectionTypeExpr extends TypeExpression {
   private final List<ITypeExpression> elementTypes;

--- a/javascript/extractor/src/com/semmle/ts/ast/KeywordTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/KeywordTypeExpr.java
@@ -4,14 +4,14 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
 /**
- * One of the TypeScript keyword types, such as <tt>string</tt> or <tt>any</tt>.
+ * One of the TypeScript keyword types, such as <code>string</code> or <code>any</code>.
  *
- * <p>This includes the type <tt>unique symbol</tt> which consists of two keywords but is
+ * <p>This includes the type <code>unique symbol</code> which consists of two keywords but is
  * represented as a keyword single type expression.
  *
- * <p>At the QL level, the <tt>null</tt> type is also a keyword type. In the extractor, however,
+ * <p>At the QL level, the <code>null</code> type is also a keyword type. In the extractor, however,
  * this is represented by a Literal, because the TypeScript AST does not distinguish those two uses
- * of <tt>null</tt>.
+ * of <code>null</code>.
  */
 public class KeywordTypeExpr extends TypeExpression {
   private final String keyword;

--- a/javascript/extractor/src/com/semmle/ts/ast/MappedTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/MappedTypeExpr.java
@@ -4,10 +4,10 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
 /**
- * A type of form <tt>{ [K in C]: T }</tt>, where <tt>T</tt> is a type that may refer to <tt>K</tt>.
+ * A type of form <code>{ [K in C]: T }</code>, where <code>T</code> is a type that may refer to <code>K</code>.
  *
- * <p>As with the TypeScript AST, the <tt>K in C</tt> part is represented as a type parameter with
- * <tt>C</tt> as its upper bound.
+ * <p>As with the TypeScript AST, the <code>K in C</code> part is represented as a type parameter with
+ * <code>C</code> as its upper bound.
  */
 public class MappedTypeExpr extends TypeExpression {
   private final TypeParameter typeParameter;

--- a/javascript/extractor/src/com/semmle/ts/ast/NonNullAssertion.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/NonNullAssertion.java
@@ -4,7 +4,7 @@ import com.semmle.js.ast.Expression;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
-/** A TypeScript expression of form <tt>E!</tt>, asserting that <tt>E</tt> is not null. */
+/** A TypeScript expression of form <code>E!</code>, asserting that <code>E</code> is not null. */
 public class NonNullAssertion extends Expression {
   private final Expression expression;
 

--- a/javascript/extractor/src/com/semmle/ts/ast/OptionalTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/OptionalTypeExpr.java
@@ -3,7 +3,7 @@ package com.semmle.ts.ast;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
-/** An optional type in a tuple type, such as <tt>number?</tt> in <tt>[string, number?]</tt>. */
+/** An optional type in a tuple type, such as <code>number?</code> in <code>[string, number?]</code>. */
 public class OptionalTypeExpr extends TypeExpression {
   private final ITypeExpression elementType;
 

--- a/javascript/extractor/src/com/semmle/ts/ast/ParenthesizedTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/ParenthesizedTypeExpr.java
@@ -3,7 +3,7 @@ package com.semmle.ts.ast;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
-/** A type expression in parentheses, such as <tt>("foo" | "bar")</tt>. */
+/** A type expression in parentheses, such as <code>("foo" | "bar")</code>. */
 public class ParenthesizedTypeExpr extends TypeExpression {
   private final ITypeExpression elementType;
 

--- a/javascript/extractor/src/com/semmle/ts/ast/PredicateTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/PredicateTypeExpr.java
@@ -4,8 +4,8 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
 /**
- * A type of form <tt>E is T</tt>, <tt>asserts E is T</tt> or <tt>asserts E</tt> where <tt>E</tt> is
- * a parameter name or <tt>this</tt> and <tt>T</tt> is a type.
+ * A type of form <code>E is T</code>, <code>asserts E is T</code> or <code>asserts E</code> where <code>E</code> is
+ * a parameter name or <code>this</code> and <code>T</code> is a type.
  */
 public class PredicateTypeExpr extends TypeExpression {
   private final ITypeExpression expression;
@@ -23,12 +23,12 @@ public class PredicateTypeExpr extends TypeExpression {
     this.hasAssertsKeyword = hasAssertsKeyword;
   }
 
-  /** Returns the <tt>E</tt> in <tt>E is T</tt>. */
+  /** Returns the <code>E</code> in <code>E is T</code>. */
   public ITypeExpression getExpression() {
     return expression;
   }
 
-  /** Returns the <tt>T</tt> in <tt>E is T</tt>. */
+  /** Returns the <code>T</code> in <code>E is T</code>. */
   public ITypeExpression getTypeExpr() {
     return type;
   }

--- a/javascript/extractor/src/com/semmle/ts/ast/RestTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/RestTypeExpr.java
@@ -3,7 +3,7 @@ package com.semmle.ts.ast;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
-/** A rest type in a tuple type, such as <tt>number[]</tt> in <tt>[string, ...number[]]</tt>. */
+/** A rest type in a tuple type, such as <code>number[]</code> in <code>[string, ...number[]]</code>. */
 public class RestTypeExpr extends TypeExpression {
   private final ITypeExpression arrayType;
 

--- a/javascript/extractor/src/com/semmle/ts/ast/TupleTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/TupleTypeExpr.java
@@ -5,7 +5,7 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 import java.util.List;
 
-/** A tuple type, such as <tt>[number, string]</tt>. */
+/** A tuple type, such as <code>[number, string]</code>. */
 public class TupleTypeExpr extends TypeExpression {
   private final List<ITypeExpression> elementTypes;
   private final List<Identifier> elementNames;

--- a/javascript/extractor/src/com/semmle/ts/ast/TypeAssertion.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/TypeAssertion.java
@@ -30,7 +30,7 @@ public class TypeAssertion extends Expression {
   }
 
   /**
-   * True if this is an assertion of form <tt>E as T</tt>, as opposed to the old syntax <code>
+   * True if this is an assertion of form <code>E as T</code>, as opposed to the old syntax <code>
    * &lt;T&gt; E</code>.
    */
   public boolean isAsExpression() {

--- a/javascript/extractor/src/com/semmle/ts/ast/TypeParameter.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/TypeParameter.java
@@ -7,7 +7,7 @@ import com.semmle.js.ast.Visitor;
 /**
  * A type parameter declared on a class, interface, function, or type alias.
  *
- * <p>The general form of a type parameter is: <tt>S extends T = U</tt>.
+ * <p>The general form of a type parameter is: <code>S extends T = U</code>.
  */
 public class TypeParameter extends TypeExpression {
   private final Identifier id;
@@ -29,7 +29,7 @@ public class TypeParameter extends TypeExpression {
   /**
    * Returns the bound on the type parameter, or {@code null} if there is no bound.
    *
-   * <p>For example, in <tt>T extends Array = number[]</tt> the bound is <tt>Array</tt>.
+   * <p>For example, in <code>T extends Array = number[]</code> the bound is <code>Array</code>.
    */
   public ITypeExpression getBound() {
     return bound;
@@ -38,7 +38,7 @@ public class TypeParameter extends TypeExpression {
   /**
    * Returns the type parameter default, or {@code null} if there is no default,
    *
-   * <p>For example, in <tt>T extends Array = number[]</tt> the default is <tt>number[]</tt>.
+   * <p>For example, in <code>T extends Array = number[]</code> the default is <code>number[]</code>.
    */
   public ITypeExpression getDefault() {
     return default_;

--- a/javascript/extractor/src/com/semmle/ts/ast/TypeofTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/TypeofTypeExpr.java
@@ -4,7 +4,7 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 
 /**
- * A type of form <tt>typeof E</tt> where <tt>E</tt> is an expression that takes the form of a
+ * A type of form <code>typeof E</code> where <code>E</code> is an expression that takes the form of a
  * qualified name.
  */
 public class TypeofTypeExpr extends TypeExpression {

--- a/javascript/extractor/src/com/semmle/ts/ast/UnaryTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/UnaryTypeExpr.java
@@ -6,7 +6,7 @@ import com.semmle.js.ast.Visitor;
 /**
  * A unary operator applied to a type.
  *
- * <p>This can be <tt>keyof T</tt> or <tt>readonly T</tt>.
+ * <p>This can be <code>keyof T</code> or <code>readonly T</code>.
  */
 public class UnaryTypeExpr extends TypeExpression {
   private final ITypeExpression elementType;

--- a/javascript/extractor/src/com/semmle/ts/ast/UnionTypeExpr.java
+++ b/javascript/extractor/src/com/semmle/ts/ast/UnionTypeExpr.java
@@ -4,7 +4,7 @@ import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.Visitor;
 import java.util.List;
 
-/** A union type such as <tt>number | string | boolean</tt>. */
+/** A union type such as <code>number | string | boolean</code>. */
 public class UnionTypeExpr extends TypeExpression {
   private final List<ITypeExpression> elementTypes;
 

--- a/javascript/extractor/src/com/semmle/ts/extractor/TypeExtractor.java
+++ b/javascript/extractor/src/com/semmle/ts/extractor/TypeExtractor.java
@@ -12,7 +12,7 @@ import java.util.Map;
 /**
  * Extracts type and symbol information into TRAP files.
  *
- * <p>This is closely coupled with the <tt>type_table.ts</tt> file in the parser-wrapper. Type
+ * <p>This is closely coupled with the <code>type_table.ts</code> file in the parser-wrapper. Type
  * strings and symbol strings generated in that file are parsed here. See that file for reference
  * and documentation.
  */

--- a/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
+++ b/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
@@ -703,14 +703,14 @@ public class TypeScriptASTConverter {
   }
 
   /**
-   * Converts the given child to an AST node of the given type or <tt>null</tt>. A ParseError is
+   * Converts the given child to an AST node of the given type or <code>null</code>. A ParseError is
    * thrown if a different type of node was found.
    *
    * <p>This is used to detect syntax errors that are not reported as syntax errors by the
    * TypeScript parser. Usually they are reported as errors in a later compiler stage, which the
    * extractor does not run.
    *
-   * <p>Returns <tt>null</tt> if the child is absent.
+   * <p>Returns <code>null</code> if the child is absent.
    */
   @SuppressWarnings("unchecked")
   private <T extends Node> T tryConvertChild(JsonObject node, String prop, Class<T> expectedType)
@@ -2515,8 +2515,8 @@ public class TypeScriptASTConverter {
   }
 
   /**
-   * Returns a specific modifier from the given node (or <tt>null</tt> if absent), as defined by its
-   * <tt>modifiers</tt> property and the <tt>kind</tt> property of the modifier AST node.
+   * Returns a specific modifier from the given node (or <code>null</code> if absent), as defined by its
+   * <code>modifiers</code> property and the <code>kind</code> property of the modifier AST node.
    */
   private JsonObject getModifier(JsonObject node, String modKind) {
     for (JsonElement mod : getModifiers(node))
@@ -2526,8 +2526,8 @@ public class TypeScriptASTConverter {
   }
 
   /**
-   * Check whether a node has a particular modifier, as defined by its <tt>modifiers</tt> property
-   * and the <tt>kind</tt> property of the modifier AST node.
+   * Check whether a node has a particular modifier, as defined by its <code>modifiers</code> property
+   * and the <code>kind</code> property of the modifier AST node.
    */
   private boolean hasModifier(JsonObject node, String modKind) {
     return getModifier(node, modKind) != null;
@@ -2568,8 +2568,8 @@ public class TypeScriptASTConverter {
   }
 
   /**
-   * Check whether a node has a particular flag, as defined by its <tt>flags</tt> property and the
-   * <tt>ts.NodeFlags</tt> in enum.
+   * Check whether a node has a particular flag, as defined by its <code>flags</code> property and the
+   * <code>ts.NodeFlags</code> in enum.
    */
   private boolean hasFlag(JsonObject node, String flagName) {
     int flagId = metadata.getNodeFlagId(flagName);

--- a/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptParser.java
+++ b/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptParser.java
@@ -97,7 +97,7 @@ public class TypeScriptParser {
   public static final String TYPESCRIPT_RETRIES_VAR = "SEMMLE_TYPESCRIPT_RETRIES";
 
   /**
-   * An environment variable (without the <tt>SEMMLE_</tt> or <tt>LGTM_</tt> prefix), that can be
+   * An environment variable (without the <code>SEMMLE_</code> or <code>LGTM_</code> prefix), that can be
    * set to indicate the maximum heap space usable by the Node.js process, in addition to its
    * "reserve memory".
    *
@@ -106,7 +106,7 @@ public class TypeScriptParser {
   public static final String TYPESCRIPT_RAM_SUFFIX = "TYPESCRIPT_RAM";
 
   /**
-   * An environment variable (without the <tt>SEMMLE_</tt> or <tt>LGTM_</tt> prefix), that can be
+   * An environment variable (without the <code>SEMMLE_</code> or <code>LGTM_</code> prefix), that can be
    * set to indicate the amount of heap space the Node.js process should reserve for extracting
    * individual files.
    *

--- a/javascript/extractor/src/com/semmle/ts/extractor/TypeTable.java
+++ b/javascript/extractor/src/com/semmle/ts/extractor/TypeTable.java
@@ -4,9 +4,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 /**
- * Holds the output of the <tt>get-type-table</tt> command.
+ * Holds the output of the <code>get-type-table</code> command.
  *
- * <p>See documentation in <tt>parser-wrapper/src/type_table.ts</tt>.
+ * <p>See documentation in <code>parser-wrapper/src/type_table.ts</code>.
  */
 public class TypeTable {
   private final JsonArray typeStrings;


### PR DESCRIPTION
Newer versions of javadoc give a warning as `<tt>` is deprecated in HTML5. This switches to using the `<code>` tag which gives no warnings.