### PR TITLE
Remove sanitizing condition which does not prevent vulnerability.

### DIFF
--- a/java/change-notes/2021-02-15-snakeyaml-fn-fix.md
+++ b/java/change-notes/2021-02-15-snakeyaml-fn-fix.md
@@ -1,0 +1,5 @@
+lgtm,codescanning
+* The query "Unsafe Deserialization" (`java/unsafe-deserialization`) has been
+  improved to report those cases where SnakeYaml `Constructor` is used to fix
+  the unmarshaled object graph root's type but injection is still possible in
+  nested nodes of the object graph.

--- a/java/ql/src/semmle/code/java/frameworks/SnakeYaml.qll
+++ b/java/ql/src/semmle/code/java/frameworks/SnakeYaml.qll
@@ -8,13 +8,6 @@ import semmle.code.java.dataflow.DataFlow2
 import semmle.code.java.dataflow.DataFlow3
 
 /**
- * The class `org.yaml.snakeyaml.constructor.Constructor`.
- */
-class SnakeYamlConstructor extends RefType {
-  SnakeYamlConstructor() { this.hasQualifiedName("org.yaml.snakeyaml.constructor", "Constructor") }
-}
-
-/**
  * The class `org.yaml.snakeyaml.constructor.SafeConstructor`.
  */
 class SnakeYamlSafeConstructor extends RefType {
@@ -24,14 +17,11 @@ class SnakeYamlSafeConstructor extends RefType {
 }
 
 /**
- * An instance of `SafeConstructor` or a `Constructor` that only allows the type that is passed into its argument.
+ * An instance of `SafeConstructor`
  */
 class SafeSnakeYamlConstruction extends ClassInstanceExpr {
   SafeSnakeYamlConstruction() {
     this.getConstructedType() instanceof SnakeYamlSafeConstructor
-    or
-    this.getConstructedType() instanceof SnakeYamlConstructor and
-    this.getNumArgument() > 0
   }
 }
 

--- a/java/ql/src/semmle/code/java/frameworks/SnakeYaml.qll
+++ b/java/ql/src/semmle/code/java/frameworks/SnakeYaml.qll
@@ -17,12 +17,10 @@ class SnakeYamlSafeConstructor extends RefType {
 }
 
 /**
- * An instance of `SafeConstructor`
+ * An instance of `SafeConstructor`.
  */
 class SafeSnakeYamlConstruction extends ClassInstanceExpr {
-  SafeSnakeYamlConstruction() {
-    this.getConstructedType() instanceof SnakeYamlSafeConstructor
-  }
+  SafeSnakeYamlConstruction() { this.getConstructedType() instanceof SnakeYamlSafeConstructor }
 }
 
 /**

--- a/java/ql/test/query-tests/security/CWE-502/A.java
+++ b/java/ql/test/query-tests/security/CWE-502/A.java
@@ -88,10 +88,10 @@ public class A {
   public void deserializeSnakeYaml4(Socket sock) {
     Yaml yaml = new Yaml(new Constructor(A.class));
     InputStream input = sock.getInputStream();
-    Object o = yaml.load(input); //OK
-    Object o2 = yaml.loadAll(input); //OK
-    Object o3 = yaml.parse(new InputStreamReader(input)); //OK
-    A o4 = yaml.loadAs(input, A.class); //OK
-    A o5 = yaml.loadAs(new InputStreamReader(input), A.class); //OK
+    Object o = yaml.load(input); //unsafe
+    Object o2 = yaml.loadAll(input); //unsafe
+    Object o3 = yaml.parse(new InputStreamReader(input)); //unsafe
+    A o4 = yaml.loadAs(input, A.class); //unsafe
+    A o5 = yaml.loadAs(new InputStreamReader(input), A.class); //unsafe
   }
 }

--- a/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
+++ b/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
@@ -16,6 +16,11 @@ edges
 | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:73:28:73:55 | new InputStreamReader(...) |
 | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:74:24:74:28 | input |
 | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:75:24:75:51 | new InputStreamReader(...) |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:91:26:91:30 | input |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:92:30:92:34 | input |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:93:28:93:55 | new InputStreamReader(...) |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:94:24:94:28 | input |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:95:24:95:51 | new InputStreamReader(...) |
 | B.java:7:31:7:51 | getInputStream(...) : InputStream | B.java:8:29:8:39 | inputStream |
 | B.java:12:31:12:51 | getInputStream(...) : InputStream | B.java:15:23:15:27 | bytes |
 | B.java:19:31:19:51 | getInputStream(...) : InputStream | B.java:23:29:23:29 | s |
@@ -46,6 +51,12 @@ nodes
 | A.java:73:28:73:55 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
 | A.java:74:24:74:28 | input | semmle.label | input |
 | A.java:75:24:75:51 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| A.java:91:26:91:30 | input | semmle.label | input |
+| A.java:92:30:92:34 | input | semmle.label | input |
+| A.java:93:28:93:55 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:94:24:94:28 | input | semmle.label | input |
+| A.java:95:24:95:51 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
 | B.java:7:31:7:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | B.java:8:29:8:39 | inputStream | semmle.label | inputStream |
 | B.java:12:31:12:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
@@ -74,6 +85,11 @@ nodes
 | A.java:73:17:73:56 | parse(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:73:28:73:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
 | A.java:74:12:74:38 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:74:24:74:28 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
 | A.java:75:12:75:61 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:75:24:75:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| A.java:91:16:91:31 | load(...) | A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:91:26:91:30 | input | Unsafe deserialization of $@. | A.java:90:25:90:45 | getInputStream(...) | user input |
+| A.java:92:17:92:35 | loadAll(...) | A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:92:30:92:34 | input | Unsafe deserialization of $@. | A.java:90:25:90:45 | getInputStream(...) | user input |
+| A.java:93:17:93:56 | parse(...) | A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:93:28:93:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:90:25:90:45 | getInputStream(...) | user input |
+| A.java:94:12:94:38 | loadAs(...) | A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:94:24:94:28 | input | Unsafe deserialization of $@. | A.java:90:25:90:45 | getInputStream(...) | user input |
+| A.java:95:12:95:61 | loadAs(...) | A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:95:24:95:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:90:25:90:45 | getInputStream(...) | user input |
 | B.java:8:12:8:46 | parseObject(...) | B.java:7:31:7:51 | getInputStream(...) : InputStream | B.java:8:29:8:39 | inputStream | Unsafe deserialization of $@. | B.java:7:31:7:51 | getInputStream(...) | user input |
 | B.java:15:12:15:28 | parse(...) | B.java:12:31:12:51 | getInputStream(...) : InputStream | B.java:15:23:15:27 | bytes | Unsafe deserialization of $@. | B.java:12:31:12:51 | getInputStream(...) | user input |
 | B.java:23:12:23:30 | parseObject(...) | B.java:19:31:19:51 | getInputStream(...) : InputStream | B.java:23:29:23:29 | s | Unsafe deserialization of $@. | B.java:19:31:19:51 | getInputStream(...) | user input |


### PR DESCRIPTION
By using a `Constructor` SnakeYAML allows to specify a root type which is actually used. Nested properties, however, are not type checked and therefore they can be used to embed the payload