### PR TITLE
JS: Add taint steps for markdown parsers

### DIFF
--- a/javascript/change-notes/2021-02-10-markdown.md
+++ b/javascript/change-notes/2021-02-10-markdown.md
@@ -1,5 +1,5 @@
 lgtm,codescanning
-* The dataflow libraries now model dataflow in markdown parses.
+* The dataflow libraries now model dataflow in markdown parsers.
   Affected packages are
     [marked](https://npmjs.com/package/marked), 
     [markdown-table](https://npmjs.com/package/markdown-table), 

--- a/javascript/change-notes/2021-02-10-markdown.md
+++ b/javascript/change-notes/2021-02-10-markdown.md
@@ -1,0 +1,8 @@
+lgtm,codescanning
+* The dataflow libraries now model dataflow in markdown parses.
+  Affected packages are
+    [marked](https://npmjs.com/package/marked), 
+    [markdown-table](https://npmjs.com/package/markdown-table), 
+    [showdown](https://npmjs.com/package/showdown), 
+    [unified](https://npmjs.com/package/unified), and
+    [remark](https://npmjs.com/package/remark)

--- a/javascript/change-notes/2021-02-10-markdown.md
+++ b/javascript/change-notes/2021-02-10-markdown.md
@@ -4,5 +4,6 @@ lgtm,codescanning
     [marked](https://npmjs.com/package/marked), 
     [markdown-table](https://npmjs.com/package/markdown-table), 
     [showdown](https://npmjs.com/package/showdown), 
+    [snarkdown](https://npmjs.com/package/snarkdown), 
     [unified](https://npmjs.com/package/unified), and
     [remark](https://npmjs.com/package/remark)

--- a/javascript/change-notes/2021-02-10-markdown.md
+++ b/javascript/change-notes/2021-02-10-markdown.md
@@ -1,5 +1,5 @@
 lgtm,codescanning
-* The dataflow libraries now model dataflow in markdown parsers.
+* The security queries now track taint through markdown parsers.
   Affected packages are
     [marked](https://npmjs.com/package/marked), 
     [markdown-table](https://npmjs.com/package/markdown-table), 

--- a/javascript/ql/src/javascript.qll
+++ b/javascript/ql/src/javascript.qll
@@ -93,6 +93,7 @@ import semmle.javascript.frameworks.LazyCache
 import semmle.javascript.frameworks.LodashUnderscore
 import semmle.javascript.frameworks.Logging
 import semmle.javascript.frameworks.HttpFrameworks
+import semmle.javascript.frameworks.Markdown
 import semmle.javascript.frameworks.NoSQL
 import semmle.javascript.frameworks.PkgCloud
 import semmle.javascript.frameworks.PropertyProjection

--- a/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
@@ -31,3 +31,20 @@ private class MarkdownTableStep extends TaintTracking::AdditionalTaintStep, Data
     pred = this.getArgument(0)
   }
 }
+
+/**
+ * A taint step for the `showdown` library.
+ */
+private class ShowDownStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
+  ShowDownStep() {
+    this =
+      [DataFlow::globalVarRef("showdown"), DataFlow::moduleImport("showdown")]
+          .getAConstructorInvocation("Converter")
+          .getAMemberCall(["makeHtml", "makeMd"])
+  }
+
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    succ = this and
+    pred = this.getArgument(0)
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
@@ -16,6 +16,18 @@ private class MarkedStep extends TaintTracking::AdditionalTaintStep, DataFlow::C
 
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     succ = this and
-    pred = this.getAnArgument()
+    pred = this.getArgument(0)
+  }
+}
+
+/**
+ * A taint step for the `markdown-table` library.
+ */
+private class MarkdownTableStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
+  MarkdownTableStep() { this = DataFlow::moduleImport("markdown-table").getACall() }
+
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    succ = this and
+    pred = this.getArgument(0)
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
@@ -1,0 +1,21 @@
+/**
+ * Provides classes for modelling common markdown parsers and generators.
+ */
+
+import javascript
+
+/**
+ * A taint step for the `marked` library, that converts markdown to HTML.
+ */
+private class MarkedStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
+  MarkedStep() {
+    this = DataFlow::globalVarRef("marked").getACall()
+    or
+    this = DataFlow::moduleImport("marked").getACall()
+  }
+
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    succ = this and
+    pred = this.getAnArgument()
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
@@ -48,3 +48,61 @@ private class ShowDownStep extends TaintTracking::AdditionalTaintStep, DataFlow:
     pred = this.getArgument(0)
   }
 }
+
+/**
+ * Classes and predicates for modelling taint steps in `unified` and `remark`.
+ */
+private module Unified {
+  /**
+   * The creation of a parser from `unified`.
+   * The `remark` module is a shorthand that initializes `unified` with a markdown parser.
+   */
+  DataFlow::CallNode unified() { result = DataFlow::moduleImport(["unified", "remark"]).getACall() }
+
+  /**
+   * A chain of method calls that process an input with `unified`.
+   */
+  class UnifiedChain extends DataFlow::CallNode {
+    DataFlow::CallNode root;
+
+    UnifiedChain() {
+      root = unified() and
+      this = root.getAChainedMethodCall(["process", "processSync"])
+    }
+
+    /**
+     * Gets a plugin that is used in this chain.
+     */
+    DataFlow::Node getAUsedPlugin() { result = root.getAChainedMethodCall("use").getArgument(0) }
+
+    /**
+     * Gets the input that is processed.
+     */
+    DataFlow::Node getInput() { result = getArgument(0) }
+
+    /**
+     * Gets the processed output.
+     */
+    DataFlow::Node getOutput() {
+      this.getCalleeName() = "process" and result = getABoundCallbackParameter(1, 1)
+      or
+      this.getCalleeName() = "processSync" and result = this
+    }
+  }
+
+  /**
+   * A taint step for the `unified` library.
+   */
+  class UnifiedStep extends TaintTracking::AdditionalTaintStep, UnifiedChain {
+    UnifiedStep() {
+      // sanitizer. Mostly looking for `rehype-sanitize`, but also other plugins with `sanitize` in their name.
+      not this.getAUsedPlugin().getALocalSource() =
+        DataFlow::moduleImport(any(string s | s.matches("%sanitize%")))
+    }
+
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      pred = getInput() and
+      succ = getOutput()
+    }
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
@@ -106,3 +106,15 @@ private module Unified {
     }
   }
 }
+
+/**
+ * A taint step for the `snarkdown` library.
+ */
+private class SnarkdownStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
+  SnarkdownStep() { this = DataFlow::moduleImport("snarkdown").getACall() }
+
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    this = succ and
+    pred = this.getArgument(0)
+  }
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -32,6 +32,29 @@ nodes
 | ReflectedXss.js:42:12:42:39 | convert ... q.body) |
 | ReflectedXss.js:42:31:42:38 | req.body |
 | ReflectedXss.js:42:31:42:38 | req.body |
+| ReflectedXss.js:56:12:56:19 | req.body |
+| ReflectedXss.js:56:12:56:19 | req.body |
+| ReflectedXss.js:56:12:56:19 | req.body |
+| ReflectedXss.js:64:14:64:21 | req.body |
+| ReflectedXss.js:64:14:64:21 | req.body |
+| ReflectedXss.js:64:39:64:42 | file |
+| ReflectedXss.js:65:16:65:19 | file |
+| ReflectedXss.js:65:16:65:19 | file |
+| ReflectedXss.js:68:12:68:41 | remark( ... q.body) |
+| ReflectedXss.js:68:12:68:52 | remark( ... tring() |
+| ReflectedXss.js:68:12:68:52 | remark( ... tring() |
+| ReflectedXss.js:68:33:68:40 | req.body |
+| ReflectedXss.js:68:33:68:40 | req.body |
+| ReflectedXss.js:72:12:72:56 | unified ... q.body) |
+| ReflectedXss.js:72:12:72:65 | unified ... oString |
+| ReflectedXss.js:72:12:72:65 | unified ... oString |
+| ReflectedXss.js:72:48:72:55 | req.body |
+| ReflectedXss.js:72:48:72:55 | req.body |
+| ReflectedXss.js:74:20:74:27 | req.body |
+| ReflectedXss.js:74:20:74:27 | req.body |
+| ReflectedXss.js:74:34:74:34 | f |
+| ReflectedXss.js:75:14:75:14 | f |
+| ReflectedXss.js:75:14:75:14 | f |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id |
@@ -143,6 +166,23 @@ edges
 | ReflectedXss.js:42:31:42:38 | req.body | ReflectedXss.js:42:12:42:39 | convert ... q.body) |
 | ReflectedXss.js:42:31:42:38 | req.body | ReflectedXss.js:42:12:42:39 | convert ... q.body) |
 | ReflectedXss.js:42:31:42:38 | req.body | ReflectedXss.js:42:12:42:39 | convert ... q.body) |
+| ReflectedXss.js:56:12:56:19 | req.body | ReflectedXss.js:56:12:56:19 | req.body |
+| ReflectedXss.js:64:14:64:21 | req.body | ReflectedXss.js:64:39:64:42 | file |
+| ReflectedXss.js:64:14:64:21 | req.body | ReflectedXss.js:64:39:64:42 | file |
+| ReflectedXss.js:64:39:64:42 | file | ReflectedXss.js:65:16:65:19 | file |
+| ReflectedXss.js:64:39:64:42 | file | ReflectedXss.js:65:16:65:19 | file |
+| ReflectedXss.js:68:12:68:41 | remark( ... q.body) | ReflectedXss.js:68:12:68:52 | remark( ... tring() |
+| ReflectedXss.js:68:12:68:41 | remark( ... q.body) | ReflectedXss.js:68:12:68:52 | remark( ... tring() |
+| ReflectedXss.js:68:33:68:40 | req.body | ReflectedXss.js:68:12:68:41 | remark( ... q.body) |
+| ReflectedXss.js:68:33:68:40 | req.body | ReflectedXss.js:68:12:68:41 | remark( ... q.body) |
+| ReflectedXss.js:72:12:72:56 | unified ... q.body) | ReflectedXss.js:72:12:72:65 | unified ... oString |
+| ReflectedXss.js:72:12:72:56 | unified ... q.body) | ReflectedXss.js:72:12:72:65 | unified ... oString |
+| ReflectedXss.js:72:48:72:55 | req.body | ReflectedXss.js:72:12:72:56 | unified ... q.body) |
+| ReflectedXss.js:72:48:72:55 | req.body | ReflectedXss.js:72:12:72:56 | unified ... q.body) |
+| ReflectedXss.js:74:20:74:27 | req.body | ReflectedXss.js:74:34:74:34 | f |
+| ReflectedXss.js:74:20:74:27 | req.body | ReflectedXss.js:74:34:74:34 | f |
+| ReflectedXss.js:74:34:74:34 | f | ReflectedXss.js:75:14:75:14 | f |
+| ReflectedXss.js:74:34:74:34 | f | ReflectedXss.js:75:14:75:14 | f |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
@@ -227,6 +267,11 @@ edges
 | ReflectedXss.js:34:12:34:18 | mytable | ReflectedXss.js:32:14:32:21 | req.body | ReflectedXss.js:34:12:34:18 | mytable | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:32:14:32:21 | req.body | user-provided value |
 | ReflectedXss.js:41:12:41:19 | req.body | ReflectedXss.js:41:12:41:19 | req.body | ReflectedXss.js:41:12:41:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:41:12:41:19 | req.body | user-provided value |
 | ReflectedXss.js:42:12:42:39 | convert ... q.body) | ReflectedXss.js:42:31:42:38 | req.body | ReflectedXss.js:42:12:42:39 | convert ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:42:31:42:38 | req.body | user-provided value |
+| ReflectedXss.js:56:12:56:19 | req.body | ReflectedXss.js:56:12:56:19 | req.body | ReflectedXss.js:56:12:56:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:56:12:56:19 | req.body | user-provided value |
+| ReflectedXss.js:65:16:65:19 | file | ReflectedXss.js:64:14:64:21 | req.body | ReflectedXss.js:65:16:65:19 | file | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:64:14:64:21 | req.body | user-provided value |
+| ReflectedXss.js:68:12:68:52 | remark( ... tring() | ReflectedXss.js:68:33:68:40 | req.body | ReflectedXss.js:68:12:68:52 | remark( ... tring() | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:68:33:68:40 | req.body | user-provided value |
+| ReflectedXss.js:72:12:72:65 | unified ... oString | ReflectedXss.js:72:48:72:55 | req.body | ReflectedXss.js:72:12:72:65 | unified ... oString | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:72:48:72:55 | req.body | user-provided value |
+| ReflectedXss.js:75:14:75:14 | f | ReflectedXss.js:74:20:74:27 | req.body | ReflectedXss.js:75:14:75:14 | f | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:74:20:74:27 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -7,6 +7,13 @@ nodes
 | ReflectedXss.js:17:12:17:39 | "Unknow ... rams.id |
 | ReflectedXss.js:17:31:17:39 | params.id |
 | ReflectedXss.js:17:31:17:39 | params.id |
+| ReflectedXss.js:22:12:22:19 | req.body |
+| ReflectedXss.js:22:12:22:19 | req.body |
+| ReflectedXss.js:22:12:22:19 | req.body |
+| ReflectedXss.js:23:12:23:27 | marked(req.body) |
+| ReflectedXss.js:23:12:23:27 | marked(req.body) |
+| ReflectedXss.js:23:19:23:26 | req.body |
+| ReflectedXss.js:23:19:23:26 | req.body |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id |
@@ -100,6 +107,11 @@ edges
 | ReflectedXss.js:17:31:17:39 | params.id | ReflectedXss.js:17:12:17:39 | "Unknow ... rams.id |
 | ReflectedXss.js:17:31:17:39 | params.id | ReflectedXss.js:17:12:17:39 | "Unknow ... rams.id |
 | ReflectedXss.js:17:31:17:39 | params.id | ReflectedXss.js:17:12:17:39 | "Unknow ... rams.id |
+| ReflectedXss.js:22:12:22:19 | req.body | ReflectedXss.js:22:12:22:19 | req.body |
+| ReflectedXss.js:23:19:23:26 | req.body | ReflectedXss.js:23:12:23:27 | marked(req.body) |
+| ReflectedXss.js:23:19:23:26 | req.body | ReflectedXss.js:23:12:23:27 | marked(req.body) |
+| ReflectedXss.js:23:19:23:26 | req.body | ReflectedXss.js:23:12:23:27 | marked(req.body) |
+| ReflectedXss.js:23:19:23:26 | req.body | ReflectedXss.js:23:12:23:27 | marked(req.body) |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
@@ -178,6 +190,8 @@ edges
 #select
 | ReflectedXss.js:8:14:8:45 | "Unknow ... rams.id | ReflectedXss.js:8:33:8:45 | req.params.id | ReflectedXss.js:8:14:8:45 | "Unknow ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:8:33:8:45 | req.params.id | user-provided value |
 | ReflectedXss.js:17:12:17:39 | "Unknow ... rams.id | ReflectedXss.js:17:31:17:39 | params.id | ReflectedXss.js:17:12:17:39 | "Unknow ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:17:31:17:39 | params.id | user-provided value |
+| ReflectedXss.js:22:12:22:19 | req.body | ReflectedXss.js:22:12:22:19 | req.body | ReflectedXss.js:22:12:22:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:22:12:22:19 | req.body | user-provided value |
+| ReflectedXss.js:23:12:23:27 | marked(req.body) | ReflectedXss.js:23:19:23:26 | req.body | ReflectedXss.js:23:12:23:27 | marked(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:23:19:23:26 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -14,6 +14,17 @@ nodes
 | ReflectedXss.js:23:12:23:27 | marked(req.body) |
 | ReflectedXss.js:23:19:23:26 | req.body |
 | ReflectedXss.js:23:19:23:26 | req.body |
+| ReflectedXss.js:29:12:29:19 | req.body |
+| ReflectedXss.js:29:12:29:19 | req.body |
+| ReflectedXss.js:29:12:29:19 | req.body |
+| ReflectedXss.js:30:7:33:4 | mytable |
+| ReflectedXss.js:30:17:33:4 | table([ ... y]\\n  ]) |
+| ReflectedXss.js:30:23:33:3 | [\\n    [ ... dy]\\n  ] |
+| ReflectedXss.js:32:5:32:22 | ['body', req.body] |
+| ReflectedXss.js:32:14:32:21 | req.body |
+| ReflectedXss.js:32:14:32:21 | req.body |
+| ReflectedXss.js:34:12:34:18 | mytable |
+| ReflectedXss.js:34:12:34:18 | mytable |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id |
@@ -112,6 +123,14 @@ edges
 | ReflectedXss.js:23:19:23:26 | req.body | ReflectedXss.js:23:12:23:27 | marked(req.body) |
 | ReflectedXss.js:23:19:23:26 | req.body | ReflectedXss.js:23:12:23:27 | marked(req.body) |
 | ReflectedXss.js:23:19:23:26 | req.body | ReflectedXss.js:23:12:23:27 | marked(req.body) |
+| ReflectedXss.js:29:12:29:19 | req.body | ReflectedXss.js:29:12:29:19 | req.body |
+| ReflectedXss.js:30:7:33:4 | mytable | ReflectedXss.js:34:12:34:18 | mytable |
+| ReflectedXss.js:30:7:33:4 | mytable | ReflectedXss.js:34:12:34:18 | mytable |
+| ReflectedXss.js:30:17:33:4 | table([ ... y]\\n  ]) | ReflectedXss.js:30:7:33:4 | mytable |
+| ReflectedXss.js:30:23:33:3 | [\\n    [ ... dy]\\n  ] | ReflectedXss.js:30:17:33:4 | table([ ... y]\\n  ]) |
+| ReflectedXss.js:32:5:32:22 | ['body', req.body] | ReflectedXss.js:30:23:33:3 | [\\n    [ ... dy]\\n  ] |
+| ReflectedXss.js:32:14:32:21 | req.body | ReflectedXss.js:32:5:32:22 | ['body', req.body] |
+| ReflectedXss.js:32:14:32:21 | req.body | ReflectedXss.js:32:5:32:22 | ['body', req.body] |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
@@ -192,6 +211,8 @@ edges
 | ReflectedXss.js:17:12:17:39 | "Unknow ... rams.id | ReflectedXss.js:17:31:17:39 | params.id | ReflectedXss.js:17:12:17:39 | "Unknow ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:17:31:17:39 | params.id | user-provided value |
 | ReflectedXss.js:22:12:22:19 | req.body | ReflectedXss.js:22:12:22:19 | req.body | ReflectedXss.js:22:12:22:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:22:12:22:19 | req.body | user-provided value |
 | ReflectedXss.js:23:12:23:27 | marked(req.body) | ReflectedXss.js:23:19:23:26 | req.body | ReflectedXss.js:23:12:23:27 | marked(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:23:19:23:26 | req.body | user-provided value |
+| ReflectedXss.js:29:12:29:19 | req.body | ReflectedXss.js:29:12:29:19 | req.body | ReflectedXss.js:29:12:29:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:29:12:29:19 | req.body | user-provided value |
+| ReflectedXss.js:34:12:34:18 | mytable | ReflectedXss.js:32:14:32:21 | req.body | ReflectedXss.js:34:12:34:18 | mytable | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:32:14:32:21 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -25,6 +25,13 @@ nodes
 | ReflectedXss.js:32:14:32:21 | req.body |
 | ReflectedXss.js:34:12:34:18 | mytable |
 | ReflectedXss.js:34:12:34:18 | mytable |
+| ReflectedXss.js:41:12:41:19 | req.body |
+| ReflectedXss.js:41:12:41:19 | req.body |
+| ReflectedXss.js:41:12:41:19 | req.body |
+| ReflectedXss.js:42:12:42:39 | convert ... q.body) |
+| ReflectedXss.js:42:12:42:39 | convert ... q.body) |
+| ReflectedXss.js:42:31:42:38 | req.body |
+| ReflectedXss.js:42:31:42:38 | req.body |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id |
@@ -131,6 +138,11 @@ edges
 | ReflectedXss.js:32:5:32:22 | ['body', req.body] | ReflectedXss.js:30:23:33:3 | [\\n    [ ... dy]\\n  ] |
 | ReflectedXss.js:32:14:32:21 | req.body | ReflectedXss.js:32:5:32:22 | ['body', req.body] |
 | ReflectedXss.js:32:14:32:21 | req.body | ReflectedXss.js:32:5:32:22 | ['body', req.body] |
+| ReflectedXss.js:41:12:41:19 | req.body | ReflectedXss.js:41:12:41:19 | req.body |
+| ReflectedXss.js:42:31:42:38 | req.body | ReflectedXss.js:42:12:42:39 | convert ... q.body) |
+| ReflectedXss.js:42:31:42:38 | req.body | ReflectedXss.js:42:12:42:39 | convert ... q.body) |
+| ReflectedXss.js:42:31:42:38 | req.body | ReflectedXss.js:42:12:42:39 | convert ... q.body) |
+| ReflectedXss.js:42:31:42:38 | req.body | ReflectedXss.js:42:12:42:39 | convert ... q.body) |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
@@ -213,6 +225,8 @@ edges
 | ReflectedXss.js:23:12:23:27 | marked(req.body) | ReflectedXss.js:23:19:23:26 | req.body | ReflectedXss.js:23:12:23:27 | marked(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:23:19:23:26 | req.body | user-provided value |
 | ReflectedXss.js:29:12:29:19 | req.body | ReflectedXss.js:29:12:29:19 | req.body | ReflectedXss.js:29:12:29:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:29:12:29:19 | req.body | user-provided value |
 | ReflectedXss.js:34:12:34:18 | mytable | ReflectedXss.js:32:14:32:21 | req.body | ReflectedXss.js:34:12:34:18 | mytable | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:32:14:32:21 | req.body | user-provided value |
+| ReflectedXss.js:41:12:41:19 | req.body | ReflectedXss.js:41:12:41:19 | req.body | ReflectedXss.js:41:12:41:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:41:12:41:19 | req.body | user-provided value |
+| ReflectedXss.js:42:12:42:39 | convert ... q.body) | ReflectedXss.js:42:31:42:38 | req.body | ReflectedXss.js:42:12:42:39 | convert ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:42:31:42:38 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -55,6 +55,17 @@ nodes
 | ReflectedXss.js:74:34:74:34 | f |
 | ReflectedXss.js:75:14:75:14 | f |
 | ReflectedXss.js:75:14:75:14 | f |
+| ReflectedXss.js:83:12:83:19 | req.body |
+| ReflectedXss.js:83:12:83:19 | req.body |
+| ReflectedXss.js:83:12:83:19 | req.body |
+| ReflectedXss.js:84:12:84:30 | snarkdown(req.body) |
+| ReflectedXss.js:84:12:84:30 | snarkdown(req.body) |
+| ReflectedXss.js:84:22:84:29 | req.body |
+| ReflectedXss.js:84:22:84:29 | req.body |
+| ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
+| ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
+| ReflectedXss.js:85:23:85:30 | req.body |
+| ReflectedXss.js:85:23:85:30 | req.body |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id |
@@ -183,6 +194,15 @@ edges
 | ReflectedXss.js:74:20:74:27 | req.body | ReflectedXss.js:74:34:74:34 | f |
 | ReflectedXss.js:74:34:74:34 | f | ReflectedXss.js:75:14:75:14 | f |
 | ReflectedXss.js:74:34:74:34 | f | ReflectedXss.js:75:14:75:14 | f |
+| ReflectedXss.js:83:12:83:19 | req.body | ReflectedXss.js:83:12:83:19 | req.body |
+| ReflectedXss.js:84:22:84:29 | req.body | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) |
+| ReflectedXss.js:84:22:84:29 | req.body | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) |
+| ReflectedXss.js:84:22:84:29 | req.body | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) |
+| ReflectedXss.js:84:22:84:29 | req.body | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) |
+| ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
+| ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
+| ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
+| ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
@@ -272,6 +292,9 @@ edges
 | ReflectedXss.js:68:12:68:52 | remark( ... tring() | ReflectedXss.js:68:33:68:40 | req.body | ReflectedXss.js:68:12:68:52 | remark( ... tring() | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:68:33:68:40 | req.body | user-provided value |
 | ReflectedXss.js:72:12:72:65 | unified ... oString | ReflectedXss.js:72:48:72:55 | req.body | ReflectedXss.js:72:12:72:65 | unified ... oString | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:72:48:72:55 | req.body | user-provided value |
 | ReflectedXss.js:75:14:75:14 | f | ReflectedXss.js:74:20:74:27 | req.body | ReflectedXss.js:75:14:75:14 | f | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:74:20:74:27 | req.body | user-provided value |
+| ReflectedXss.js:83:12:83:19 | req.body | ReflectedXss.js:83:12:83:19 | req.body | ReflectedXss.js:83:12:83:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:83:12:83:19 | req.body | user-provided value |
+| ReflectedXss.js:84:12:84:30 | snarkdown(req.body) | ReflectedXss.js:84:22:84:29 | req.body | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:84:22:84:29 | req.body | user-provided value |
+| ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) | ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:85:23:85:30 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
@@ -22,3 +22,14 @@ app.get('/user/:id', function(req, res) {
   res.send(req.body); // NOT OK
   res.send(marked(req.body)); // NOT OK
 });
+
+
+var table = require('markdown-table')
+app.get('/user/:id', function(req, res) {
+  res.send(req.body); // NOT OK
+  var mytable = table([
+    ['Name', 'Content'],
+    ['body', req.body]
+  ]);
+  res.send(mytable); // NOT OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
@@ -16,3 +16,9 @@ app.get('/user/:id', function(req, res) {
 function moreBadStuff(params, res) {
   res.send("Unknown user: " + params.id); // NOT OK
 }
+
+var marked = require("marked");
+app.get('/user/:id', function(req, res) {
+  res.send(req.body); // NOT OK
+  res.send(marked(req.body)); // NOT OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
@@ -41,3 +41,37 @@ app.get('/user/:id', function(req, res) {
   res.send(req.body); // NOT OK
   res.send(converter.makeHtml(req.body)); // NOT OK
 });
+
+var unified = require('unified');
+var markdown = require('remark-parse');
+var remark2rehype = require('remark-rehype');
+var doc = require('rehype-document');
+var format = require('rehype-format');
+var html = require('rehype-stringify');
+var remark = require("remark");
+var sanitize = require("rehype-sanitize");
+const { resetExtensions } = require('showdown');
+
+app.get('/user/:id', function (req, res) {
+  res.send(req.body); // NOT OK
+
+  unified()
+    .use(markdown)
+    .use(remark2rehype)
+    .use(doc, { title: '👋🌍' })
+    .use(format)
+    .use(html)
+    .process(req.body, function (err, file) {
+      res.send(file); // NOT OK
+    });
+
+  res.send(remark().processSync(req.body).toString()); // NOT OK
+
+  res.send(remark().use(sanitize).processSync(req.body).toString()); // OK
+
+  res.send(unified().use(markdown).processSync(req.body).toString); // NOT OK
+
+  remark().process(req.body, (e, f) => {
+    res.send(f); // NOT OK
+  })
+});

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
@@ -33,3 +33,11 @@ app.get('/user/:id', function(req, res) {
   ]);
   res.send(mytable); // NOT OK
 });
+
+var showdown  = require('showdown');
+var converter = new showdown.Converter();
+
+app.get('/user/:id', function(req, res) {
+  res.send(req.body); // NOT OK
+  res.send(converter.makeHtml(req.body)); // NOT OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
@@ -75,3 +75,12 @@ app.get('/user/:id', function (req, res) {
     res.send(f); // NOT OK
   })
 });
+
+import snarkdown from 'snarkdown';
+var snarkdown2 = require("snarkdown");
+
+app.get('/user/:id', function (req, res) {
+  res.send(req.body); // NOT OK
+  res.send(snarkdown(req.body)); // NOT OK
+  res.send(snarkdown2(req.body)); // NOT OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
@@ -6,6 +6,11 @@
 | ReflectedXss.js:34:12:34:18 | mytable | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:32:14:32:21 | req.body | user-provided value |
 | ReflectedXss.js:41:12:41:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:41:12:41:19 | req.body | user-provided value |
 | ReflectedXss.js:42:12:42:39 | convert ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:42:31:42:38 | req.body | user-provided value |
+| ReflectedXss.js:56:12:56:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:56:12:56:19 | req.body | user-provided value |
+| ReflectedXss.js:65:16:65:19 | file | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:64:14:64:21 | req.body | user-provided value |
+| ReflectedXss.js:68:12:68:52 | remark( ... tring() | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:68:33:68:40 | req.body | user-provided value |
+| ReflectedXss.js:72:12:72:65 | unified ... oString | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:72:48:72:55 | req.body | user-provided value |
+| ReflectedXss.js:75:14:75:14 | f | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:74:20:74:27 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
@@ -2,6 +2,8 @@
 | ReflectedXss.js:17:12:17:39 | "Unknow ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:17:31:17:39 | params.id | user-provided value |
 | ReflectedXss.js:22:12:22:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:22:12:22:19 | req.body | user-provided value |
 | ReflectedXss.js:23:12:23:27 | marked(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:23:19:23:26 | req.body | user-provided value |
+| ReflectedXss.js:29:12:29:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:29:12:29:19 | req.body | user-provided value |
+| ReflectedXss.js:34:12:34:18 | mytable | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:32:14:32:21 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
@@ -1,5 +1,7 @@
 | ReflectedXss.js:8:14:8:45 | "Unknow ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:8:33:8:45 | req.params.id | user-provided value |
 | ReflectedXss.js:17:12:17:39 | "Unknow ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:17:31:17:39 | params.id | user-provided value |
+| ReflectedXss.js:22:12:22:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:22:12:22:19 | req.body | user-provided value |
+| ReflectedXss.js:23:12:23:27 | marked(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:23:19:23:26 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
@@ -4,6 +4,8 @@
 | ReflectedXss.js:23:12:23:27 | marked(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:23:19:23:26 | req.body | user-provided value |
 | ReflectedXss.js:29:12:29:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:29:12:29:19 | req.body | user-provided value |
 | ReflectedXss.js:34:12:34:18 | mytable | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:32:14:32:21 | req.body | user-provided value |
+| ReflectedXss.js:41:12:41:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:41:12:41:19 | req.body | user-provided value |
+| ReflectedXss.js:42:12:42:39 | convert ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:42:31:42:38 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
@@ -11,6 +11,9 @@
 | ReflectedXss.js:68:12:68:52 | remark( ... tring() | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:68:33:68:40 | req.body | user-provided value |
 | ReflectedXss.js:72:12:72:65 | unified ... oString | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:72:48:72:55 | req.body | user-provided value |
 | ReflectedXss.js:75:14:75:14 | f | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:74:20:74:27 | req.body | user-provided value |
+| ReflectedXss.js:83:12:83:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:83:12:83:19 | req.body | user-provided value |
+| ReflectedXss.js:84:12:84:30 | snarkdown(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:84:22:84:29 | req.body | user-provided value |
+| ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:85:23:85:30 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |


### PR DESCRIPTION
Adds taint-steps for markdown to HTML converters that doesn't sanitize their outputs. 

[Evaluation looks fine](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/mark-eval-1/reports), with one new TP. 