### PR TITLE
C++: Add models for BSD-style send and recv functions

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-020/ExternalAPIsSpecific.qll
+++ b/cpp/ql/src/Security/CWE/CWE-020/ExternalAPIsSpecific.qll
@@ -46,7 +46,7 @@ class UntrustedDataToExternalAPIConfig extends TaintTracking::Configuration {
   UntrustedDataToExternalAPIConfig() { this = "UntrustedDataToExternalAPIConfig" }
 
   override predicate isSource(DataFlow::Node source) {
-    exists(RemoteFlowFunction remoteFlow |
+    exists(RemoteFlowSourceFunction remoteFlow |
       remoteFlow = source.asExpr().(Call).getTarget() and
       remoteFlow.hasRemoteFlowSource(_, _)
     )

--- a/cpp/ql/src/semmle/code/cpp/models/Models.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/Models.qll
@@ -28,3 +28,5 @@ private import implementations.Swap
 private import implementations.GetDelim
 private import implementations.SmartPointer
 private import implementations.Sscanf
+private import implementations.Send
+private import implementations.Recv

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Fread.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Fread.qll
@@ -1,7 +1,7 @@
 import semmle.code.cpp.models.interfaces.Alias
 import semmle.code.cpp.models.interfaces.FlowSource
 
-private class Fread extends AliasFunction, RemoteFlowFunction {
+private class Fread extends AliasFunction, RemoteFlowSourceFunction {
   Fread() { this.hasGlobalName("fread") }
 
   override predicate parameterNeverEscapes(int n) {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/GetDelim.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/GetDelim.qll
@@ -7,7 +7,7 @@ import semmle.code.cpp.models.interfaces.FlowSource
  * The standard functions `getdelim`, `getwdelim` and the glibc variant `__getdelim`.
  */
 private class GetDelimFunction extends TaintFunction, AliasFunction, SideEffectFunction,
-  RemoteFlowFunction {
+  RemoteFlowSourceFunction {
   GetDelimFunction() { hasGlobalName(["getdelim", "getwdelim", "__getdelim"]) }
 
   override predicate hasTaintFlow(FunctionInput i, FunctionOutput o) {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Getenv.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Getenv.qll
@@ -8,7 +8,7 @@ import semmle.code.cpp.models.interfaces.FlowSource
 /**
  * The POSIX function `getenv`.
  */
-class Getenv extends LocalFlowFunction {
+class Getenv extends LocalFlowSourceFunction {
   Getenv() { this.hasGlobalName("getenv") }
 
   override predicate hasLocalFlowSource(FunctionOutput output, string description) {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Gets.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Gets.qll
@@ -14,7 +14,7 @@ import semmle.code.cpp.models.interfaces.FlowSource
  * The standard functions `gets` and `fgets`.
  */
 private class GetsFunction extends DataFlowFunction, TaintFunction, ArrayFunction, AliasFunction,
-  SideEffectFunction, RemoteFlowFunction {
+  SideEffectFunction, RemoteFlowSourceFunction {
   GetsFunction() {
     // gets(str)
     // fgets(str, num, stream)

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Recv.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Recv.qll
@@ -1,0 +1,73 @@
+/**
+ * Provides implementation classes modeling `recv` and various similar
+ * functions. See `semmle.code.cpp.models.Models` for usage information.
+ */
+
+import semmle.code.cpp.models.interfaces.Taint
+import semmle.code.cpp.models.interfaces.ArrayFunction
+import semmle.code.cpp.models.interfaces.Alias
+import semmle.code.cpp.models.interfaces.FlowSource
+import semmle.code.cpp.models.interfaces.SideEffect
+
+/** The function `recv` and its assorted variants */
+private class Recv extends AliasFunction, ArrayFunction, SideEffectFunction, RemoteFlowFunction {
+  Recv() {
+    this.hasGlobalName([
+        "recv", // recv(socket, dest, len, flags)
+        "recvfrom", // recvfrom(socket, dest, len, flags, from, fromlen)
+        "read", // read(socket, dest, len)
+        "pread" // pread(socket, dest, len, offset)
+      ])
+  }
+
+  override predicate parameterNeverEscapes(int index) {
+    this.getParameter(index).getUnspecifiedType() instanceof PointerType
+  }
+
+  override predicate parameterEscapesOnlyViaReturn(int index) { none() }
+
+  override predicate parameterIsAlwaysReturned(int index) { none() }
+
+  override predicate hasArrayWithVariableSize(int bufParam, int countParam) {
+    bufParam = 1 and countParam = 2
+  }
+
+  override predicate hasArrayInput(int bufParam) { this.hasGlobalName("recvfrom") and bufParam = 4 }
+
+  override predicate hasArrayOutput(int bufParam) {
+    bufParam = 1
+    or
+    this.hasGlobalName("recvfrom") and bufParam = 4
+  }
+
+  override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
+    this.hasGlobalName("recvfrom") and
+    (
+      i = 4 and buffer = true
+      or
+      i = 5 and buffer = false
+    )
+  }
+
+  override ParameterIndex getParameterSizeIndex(ParameterIndex i) { i = 1 and result = 2 }
+
+  override predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
+    i = 1 and buffer = true and mustWrite = false
+    or
+    this.hasGlobalName("recvfrom") and
+    (
+      i = 4 and buffer = true and mustWrite = false
+      or
+      i = 5 and buffer = false and mustWrite = false
+    )
+  }
+
+  override predicate hasOnlySpecificReadSideEffects() { any() }
+
+  override predicate hasOnlySpecificWriteSideEffects() { any() }
+
+  override predicate hasRemoteFlowSource(FunctionOutput output, string description) {
+    output.isParameterDeref(1) and
+    description = "Buffer read by " + this.getName()
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Send.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Send.qll
@@ -1,0 +1,55 @@
+/**
+ * Provides implementation classes modeling `send` and various similar
+ * functions. See `semmle.code.cpp.models.Models` for usage information.
+ */
+
+import semmle.code.cpp.models.interfaces.Taint
+import semmle.code.cpp.models.interfaces.ArrayFunction
+import semmle.code.cpp.models.interfaces.Alias
+import semmle.code.cpp.models.interfaces.FlowSource
+import semmle.code.cpp.models.interfaces.SideEffect
+
+/** The function `send` and its assorted variants */
+private class Send extends AliasFunction, ArrayFunction, SideEffectFunction, RemoteFlowFunctionSink {
+  Send() {
+    this.hasGlobalName([
+        "send", // send(socket, buf, len, flags)
+        "sendto", // sendto(socket, buf, len, flags, to, tolen)
+        "write" // write(socket, buf, len);
+      ])
+  }
+
+  override predicate parameterNeverEscapes(int index) {
+    this.getParameter(index).getUnspecifiedType() instanceof PointerType
+  }
+
+  override predicate parameterEscapesOnlyViaReturn(int index) { none() }
+
+  override predicate parameterIsAlwaysReturned(int index) { none() }
+
+  override predicate hasArrayWithVariableSize(int bufParam, int countParam) {
+    bufParam = 1 and countParam = 2
+  }
+
+  override predicate hasArrayInput(int bufParam) { bufParam = 1 }
+
+  override predicate hasOnlySpecificReadSideEffects() { any() }
+
+  override predicate hasOnlySpecificWriteSideEffects() { any() }
+
+  override predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
+    none()
+  }
+
+  override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
+    i = 1 and buffer = true
+    or
+    exists(this.getParameter(4)) and i = 4 and buffer = false
+  }
+
+  override ParameterIndex getParameterSizeIndex(ParameterIndex i) { i = 1 and result = 2 }
+
+  override predicate hasRemoteFlowSink(FunctionInput input, string description) {
+    input.isParameterDeref(1) and description = "Buffer sent by " + this.getName()
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
@@ -21,6 +21,13 @@ abstract class RemoteFlowSourceFunction extends Function {
 }
 
 /**
+ * DEPRECATED: Use `RemoteFlowSourceFunction` instead.
+ *
+ * A library function that returns data that may be read from a network connection.
+ */
+deprecated class RemoteFlowFunction = RemoteFlowSourceFunction;
+
+/**
  * A library function that returns data that is directly controlled by a user.
  */
 abstract class LocalFlowSourceFunction extends Function {
@@ -29,6 +36,13 @@ abstract class LocalFlowSourceFunction extends Function {
    */
   abstract predicate hasLocalFlowSource(FunctionOutput output, string description);
 }
+
+/**
+ * DEPRECATED: Use `LocalFlowSourceFunction` instead.
+ *
+ * A library function that returns data that is directly controlled by a user.
+ */
+deprecated class LocalFlowFunction = LocalFlowSourceFunction;
 
 /** A library function that sends data over a network connection. */
 abstract class RemoteFlowSinkFunction extends Function {

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
@@ -1,9 +1,9 @@
 /**
- * Provides a class for modeling functions that return data from potentially untrusted sources. To use
- * this QL library, create a QL class extending `DataFlowFunction` with a
+ * Provides classes for modeling functions that return data from (or send data to) potentially untrusted
+ * sources. To use this QL library, create a QL class extending `DataFlowFunction` with a
  * characteristic predicate that selects the function or set of functions you
  * are modeling. Within that class, override the predicates provided by
- * `RemoteFlowFunction` to match the flow within that function.
+ * `RemoteFlowSourceFunction` or `RemoteFlowSinkFunction` to match the flow within that function.
  */
 
 import cpp
@@ -13,7 +13,7 @@ import semmle.code.cpp.models.Models
 /**
  * A library function that returns data that may be read from a network connection.
  */
-abstract class RemoteFlowFunction extends Function {
+abstract class RemoteFlowSourceFunction extends Function {
   /**
    * Holds if remote data described by `description` flows from `output` of a call to this function.
    */
@@ -23,7 +23,7 @@ abstract class RemoteFlowFunction extends Function {
 /**
  * A library function that returns data that is directly controlled by a user.
  */
-abstract class LocalFlowFunction extends Function {
+abstract class LocalFlowSourceFunction extends Function {
   /**
    * Holds if data described by `description` flows from `output` of a call to this function.
    */
@@ -31,7 +31,7 @@ abstract class LocalFlowFunction extends Function {
 }
 
 /** A library function that sends data over a network connection. */
-abstract class RemoteFlowFunctionSink extends Function {
+abstract class RemoteFlowSinkFunction extends Function {
   /**
    * Holds if data described by `description` flows into `input` to a call to this function, and is then
    * send over a network connection.

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
@@ -29,3 +29,12 @@ abstract class LocalFlowFunction extends Function {
    */
   abstract predicate hasLocalFlowSource(FunctionOutput output, string description);
 }
+
+/** A library function that sends data over a network connection. */
+abstract class RemoteFlowFunctionSink extends Function {
+  /**
+   * Holds if data described by `description` flows into `input` to a call to this function, and is then
+   * send over a network connection.
+   */
+  abstract predicate hasRemoteFlowSink(FunctionInput input, string description);
+}

--- a/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
@@ -23,7 +23,7 @@ private class RemoteReturnSource extends RemoteFlowSource {
   string sourceType;
 
   RemoteReturnSource() {
-    exists(RemoteFlowFunction func, CallInstruction instr, FunctionOutput output |
+    exists(RemoteFlowSourceFunction func, CallInstruction instr, FunctionOutput output |
       asInstruction() = instr and
       instr.getStaticCallTarget() = func and
       func.hasRemoteFlowSource(output, sourceType) and
@@ -42,7 +42,7 @@ private class RemoteParameterSource extends RemoteFlowSource {
   string sourceType;
 
   RemoteParameterSource() {
-    exists(RemoteFlowFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
+    exists(RemoteFlowSourceFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
       asInstruction() = instr and
       instr.getPrimaryInstruction().(CallInstruction).getStaticCallTarget() = func and
       func.hasRemoteFlowSource(output, sourceType) and
@@ -57,7 +57,7 @@ private class LocalReturnSource extends LocalFlowSource {
   string sourceType;
 
   LocalReturnSource() {
-    exists(LocalFlowFunction func, CallInstruction instr, FunctionOutput output |
+    exists(LocalFlowSourceFunction func, CallInstruction instr, FunctionOutput output |
       asInstruction() = instr and
       instr.getStaticCallTarget() = func and
       func.hasLocalFlowSource(output, sourceType) and
@@ -76,7 +76,7 @@ private class LocalParameterSource extends LocalFlowSource {
   string sourceType;
 
   LocalParameterSource() {
-    exists(LocalFlowFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
+    exists(LocalFlowSourceFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
       asInstruction() = instr and
       instr.getPrimaryInstruction().(CallInstruction).getStaticCallTarget() = func and
       func.hasLocalFlowSource(output, sourceType) and
@@ -109,7 +109,7 @@ private class RemoteParameterSink extends RemoteFlowSink {
   string sourceType;
 
   RemoteParameterSink() {
-    exists(RemoteFlowFunctionSink func, FunctionInput input, CallInstruction call, int index |
+    exists(RemoteFlowSinkFunction func, FunctionInput input, CallInstruction call, int index |
       func.hasRemoteFlowSink(input, sourceType) and call.getStaticCallTarget() = func
     |
       exists(ReadSideEffectInstruction read |

--- a/cpp/ql/src/semmle/code/cpp/security/Security.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/Security.qll
@@ -60,17 +60,11 @@ class SecurityOptions extends string {
       or
       functionCall.getTarget().hasGlobalName(fname) and
       exists(functionCall.getArgument(arg)) and
-      (
-        fname = "recvmsg" and arg = 1
-        or
-        fname = "getaddrinfo" and arg = 3
-        or
-        fname = "recvfrom" and
-        (arg = 1 or arg = 4 or arg = 5)
-      )
+      fname = "getaddrinfo" and
+      arg = 3
     )
     or
-    exists(RemoteFlowFunction remote, FunctionOutput output |
+    exists(RemoteFlowSourceFunction remote, FunctionOutput output |
       functionCall.getTarget() = remote and
       output.isParameterDerefOrQualifierObject(arg) and
       remote.hasRemoteFlowSource(output, _)
@@ -89,7 +83,7 @@ class SecurityOptions extends string {
       )
     )
     or
-    exists(RemoteFlowFunction remote, FunctionOutput output |
+    exists(RemoteFlowSourceFunction remote, FunctionOutput output |
       functionCall.getTarget() = remote and
       (output.isReturnValue() or output.isReturnValueDeref()) and
       remote.hasRemoteFlowSource(output, _)

--- a/cpp/ql/src/semmle/code/cpp/security/Security.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/Security.qll
@@ -6,6 +6,7 @@
 import semmle.code.cpp.exprs.Expr
 import semmle.code.cpp.commons.Environment
 import semmle.code.cpp.security.SecurityOptions
+import semmle.code.cpp.models.interfaces.FlowSource
 
 /**
  * Extend this class to customize the security queries for
@@ -60,13 +61,19 @@ class SecurityOptions extends string {
       functionCall.getTarget().hasGlobalName(fname) and
       exists(functionCall.getArgument(arg)) and
       (
-        fname = ["read", "recv", "recvmsg"] and arg = 1
+        fname = "recvmsg" and arg = 1
         or
         fname = "getaddrinfo" and arg = 3
         or
         fname = "recvfrom" and
         (arg = 1 or arg = 4 or arg = 5)
       )
+    )
+    or
+    exists(RemoteFlowFunction remote, FunctionOutput output |
+      functionCall.getTarget() = remote and
+      output.isParameterDerefOrQualifierObject(arg) and
+      remote.hasRemoteFlowSource(output, _)
     )
   }
 
@@ -80,6 +87,12 @@ class SecurityOptions extends string {
         fname = ["fgets", "gets"] or
         userInputReturn(fname)
       )
+    )
+    or
+    exists(RemoteFlowFunction remote, FunctionOutput output |
+      functionCall.getTarget() = remote and
+      (output.isReturnValue() or output.isReturnValueDeref()) and
+      remote.hasRemoteFlowSource(output, _)
     )
   }
 

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/annotate_sinks_only/defaulttainttracking.cpp
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/annotate_sinks_only/defaulttainttracking.cpp
@@ -216,3 +216,22 @@ void test_pointers2()
 	sink(ptr4); // clean
 	sink(*ptr4); // $ MISSING: ast,ir
 }
+
+// --- recv ---
+
+int recv(int s, char* buf, int len, int flags);
+
+void test_recv() {
+	char buffer[1024];
+	recv(0, buffer, sizeof(buffer), 0);
+	sink(buffer); // $ ast,ir
+	sink(*buffer); // $ ast,ir
+}
+
+// --- send ---
+
+int send(int, const void*, int, int);
+
+void test_send(char* buffer, int length) {
+  send(0, buffer, length, 0); // $ remote
+}

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/annotate_sinks_only/remote-flow-sink.ql
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/annotate_sinks_only/remote-flow-sink.ql
@@ -1,0 +1,20 @@
+/** This tests that we are able to detect remote flow sinks. */
+
+import cpp
+import TestUtilities.InlineExpectationsTest
+import semmle.code.cpp.security.FlowSources
+
+class RemoteFlowSinkTest extends InlineExpectationsTest {
+  RemoteFlowSinkTest() { this = "RemoteFlowSinkTest" }
+
+  override string getARelevantTag() { result = "remote" }
+
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    tag = "remote" and
+    value = "" and
+    exists(RemoteFlowSink node |
+      location = node.getLocation() and
+      element = node.toString()
+    )
+  }
+}


### PR DESCRIPTION
Part of https://github.com/github/codeql-c-analysis-team/issues/209.

I think the most important parts for @rdmarsh2 to look at are the additions to:
- cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
- cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
- cpp/ql/src/semmle/code/cpp/security/Security.qll

the rest should be fairly standard modeling.