### PR TITLE
JS: Add ClientRequest models for `apollo-client` libraries

### DIFF
--- a/javascript/change-notes/2021-02-11-apollo-client.md
+++ b/javascript/change-notes/2021-02-11-apollo-client.md
@@ -1,0 +1,8 @@
+lgtm,codescanning
+* URIs used in the Apollo-link libraries are now recognized as sinks for `js/request-forgery`.
+  Affected packages are
+    [apollo-link-http](https://www.npmjs.com/package/apollo-link-http), 
+    [apollo-client](https://www.npmjs.com/package/apollo-client), 
+    [apollo-boost](https://www.npmjs.com/package/apollo-boost), 
+    [apollo-client-preset](https://www.npmjs.com/package/apollo-client-preset), and
+    [apollo-link-ws](https://www.npmjs.com/package/apollo-link-ws)

--- a/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
@@ -844,8 +844,8 @@ module ClientRequest {
     /**
      * A model of a URL request made using apollo-client.
      */
-    class ApolloClientRequeist extends ClientRequest::Range, API::InvokeNode {
-      ApolloClientRequeist() { this = apolloUriCallee().getAnInvocation() }
+    class ApolloClientRequest extends ClientRequest::Range, API::InvokeNode {
+      ApolloClientRequest() { this = apolloUriCallee().getAnInvocation() }
 
       override DataFlow::Node getUrl() { result = getParameter(0).getMember("uri").getARhs() }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
@@ -823,4 +823,35 @@ module ClientRequest {
 
     override DataFlow::Node getADataNode() { none() }
   }
+
+  /**
+   * Classes and predicates modelling the `apollo-client` library.
+   */
+  private module ApolloClient {
+    /**
+     * A function from `apollo-client` that accepts an options object that may contain a `uri` property.
+     */
+    API::Node apolloUriCallee() {
+      result = API::moduleImport("apollo-link-http").getMember(["HttpLink", "createHttpLink"])
+      or
+      result =
+        API::moduleImport(["apollo-boost", "apollo-client", "apollo-client-preset"])
+            .getMember(["ApolloClient", "HttpLink", "createNetworkInterface"])
+      or
+      result = API::moduleImport("apollo-link-ws").getMember("WebSocketLink")
+    }
+
+    /**
+     * A model of a URL request made using apollo-client.
+     */
+    class ApolloClientRequeist extends ClientRequest::Range, API::InvokeNode {
+      ApolloClientRequeist() { this = apolloUriCallee().getAnInvocation() }
+
+      override DataFlow::Node getUrl() { result = getParameter(0).getMember("uri").getARhs() }
+
+      override DataFlow::Node getHost() { none() }
+
+      override DataFlow::Node getADataNode() { none() }
+    }
+  }
 }

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -1,4 +1,10 @@
 test_ClientRequest
+| apollo.js:5:18:5:78 | new cre ... hql' }) |
+| apollo.js:10:1:10:54 | new Htt ... hql' }) |
+| apollo.js:14:16:14:69 | new Apo ... .com'}) |
+| apollo.js:17:1:17:34 | new Pre ... yurl"}) |
+| apollo.js:20:1:20:77 | createN ... phql'}) |
+| apollo.js:23:1:23:31 | new Web ... wsUri}) |
 | tst.js:11:5:11:16 | request(url) |
 | tst.js:13:5:13:20 | request.get(url) |
 | tst.js:15:5:15:23 | request.delete(url) |
@@ -111,6 +117,12 @@ test_getHost
 | tst.js:93:5:93:35 | net.req ... host }) | tst.js:93:29:93:32 | host |
 | tst.js:219:5:219:41 | data.so ... Host"}) | tst.js:219:32:219:39 | "myHost" |
 test_getUrl
+| apollo.js:5:18:5:78 | new cre ... hql' }) | apollo.js:5:44:5:75 | 'https: ... raphql' |
+| apollo.js:10:1:10:54 | new Htt ... hql' }) | apollo.js:10:21:10:51 | 'http:/ ... raphql' |
+| apollo.js:14:16:14:69 | new Apo ... .com'}) | apollo.js:14:39:14:67 | 'https: ... le.com' |
+| apollo.js:17:1:17:34 | new Pre ... yurl"}) | apollo.js:17:26:17:32 | "myurl" |
+| apollo.js:20:1:20:77 | createN ... phql'}) | apollo.js:20:30:20:75 | 'https: ... raphql' |
+| apollo.js:23:1:23:31 | new Web ... wsUri}) | apollo.js:23:25:23:29 | wsUri |
 | tst.js:11:5:11:16 | request(url) | tst.js:11:13:11:15 | url |
 | tst.js:13:5:13:20 | request.get(url) | tst.js:13:17:13:19 | url |
 | tst.js:15:5:15:23 | request.delete(url) | tst.js:15:20:15:22 | url |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/apollo.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/apollo.js
@@ -1,0 +1,23 @@
+import { ApolloClient } from 'apollo-client'
+import { HttpLink } from 'apollo-link-http'
+import { createHttpLink } from 'apollo-link-http'
+
+const httpLink = new createHttpLink({ uri: 'https://api.github.com/graphql' }) // url 1
+
+const ApolloClient = require('apollo-client-preset').ApolloClient;
+const HttpLink = require('apollo-link-http').HttpLink;
+
+new HttpLink({ uri: 'http://localhost:8080/graphql' }); // url 2
+
+import ApolloClient from 'apollo-boost'; // / 'apollo-client'
+ 
+const client = new ApolloClient({uri: 'https://graphql.example.com'}); // url 3
+
+let PresetHttpLink = require('apollo-client-preset').HttpLink;
+new PresetHttpLink({uri: "myurl"}); // url 4
+
+import { createNetworkInterface } from 'apollo-client';
+createNetworkInterface({uri: 'https://web-go-demo.herokuapp.com/__/graphql'}) // url 5
+
+const { WebSocketLink } = require('apollo-link-ws')
+new WebSocketLink({uri: wsUri}) // url 6


### PR DESCRIPTION
[An evaluation looks OK](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/apollo-eval-1/reports).  
There is a slight hint of a performance regression.   
The evaluation ran on `CommandInjection.ql`, `FileAccessToHttp.ql`, `InsecureDownload.ql`, `HttpToFileAccess.ql`, and `RequestForgery.ql`. 