### PR TITLE
Java: Add ConditionalExpr.getBranchExpr(boolean)

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/ModulusAnalysis.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/ModulusAnalysis.qll
@@ -268,9 +268,7 @@ predicate exprModulus(Expr e, Bound b, int val, int mod) {
 private predicate condExprBranchModulus(
   ConditionalExpr cond, boolean branch, Bound b, int val, int mod
 ) {
-  exprModulus(cond.getTrueExpr(), b, val, mod) and branch = true
-  or
-  exprModulus(cond.getFalseExpr(), b, val, mod) and branch = false
+  exprModulus(cond.getBranchExpr(branch), b, val, mod)
 }
 
 private predicate addModulus(Expr add, boolean isLeft, Bound b, int val, int mod) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/RangeUtils.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/RangeUtils.qll
@@ -415,5 +415,15 @@ module ExprNode {
 
     /** Gets the "else" expression of this conditional expression. */
     ExprNode getFalseExpr() { hasChild(e, e.getElse(), this, result) }
+
+    /**
+     * If `branch` is `true` gets the "then" expression, if `false` gets the
+     * "else" expression of this conditional expression.
+     */
+    ExprNode getBranchExpr(boolean branch) {
+      branch = true and result = getTrueExpr()
+      or
+      branch = false and result = getFalseExpr()
+    }
   }
 }

--- a/java/ql/src/Language Abuse/MissedTernaryOpportunity.ql
+++ b/java/ql/src/Language Abuse/MissedTernaryOpportunity.ql
@@ -14,7 +14,7 @@
 import java
 
 predicate complicatedBranch(Stmt branch) {
-  exists(ConditionalExpr ce | ce.getParent*() = branch) or
+  any(ConditionalExpr ce).getParent*() = branch or
   count(MethodAccess a | a.getParent*() = branch) > 1
 }
 

--- a/java/ql/src/Language Abuse/UselessUpcast.ql
+++ b/java/ql/src/Language Abuse/UselessUpcast.ql
@@ -36,7 +36,7 @@ predicate usefulUpcast(CastExpr e) {
   )
   or
   // Upcasts that are performed on an operand of a ternary expression.
-  exists(ConditionalExpr ce | e = ce.getBranchExpr(_))
+  e = any(ConditionalExpr ce).getABranchExpr()
   or
   // Upcasts to raw types.
   e.getType() instanceof RawType

--- a/java/ql/src/Language Abuse/UselessUpcast.ql
+++ b/java/ql/src/Language Abuse/UselessUpcast.ql
@@ -36,7 +36,7 @@ predicate usefulUpcast(CastExpr e) {
   )
   or
   // Upcasts that are performed on an operand of a ternary expression.
-  exists(ConditionalExpr ce | e = ce.getTrueExpr() or e = ce.getFalseExpr())
+  exists(ConditionalExpr ce | e = ce.getBranchExpr(_))
   or
   // Upcasts to raw types.
   e.getType() instanceof RawType

--- a/java/ql/src/Likely Bugs/Arithmetic/CondExprTypes.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/CondExprTypes.ql
@@ -16,10 +16,7 @@ class CharType extends PrimitiveType {
   CharType() { this.hasName("char") }
 }
 
-private Type getABranchType(ConditionalExpr ce) {
-  result = ce.getTrueExpr().getType() or
-  result = ce.getFalseExpr().getType()
-}
+private Type getABranchType(ConditionalExpr ce) { result = ce.getBranchExpr(_).getType() }
 
 from ConditionalExpr ce
 where

--- a/java/ql/src/Likely Bugs/Arithmetic/CondExprTypes.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/CondExprTypes.ql
@@ -16,7 +16,7 @@ class CharType extends PrimitiveType {
   CharType() { this.hasName("char") }
 }
 
-private Type getABranchType(ConditionalExpr ce) { result = ce.getBranchExpr(_).getType() }
+private Type getABranchType(ConditionalExpr ce) { result = ce.getABranchExpr().getType() }
 
 from ConditionalExpr ce
 where

--- a/java/ql/src/Likely Bugs/Comparison/NoAssignInBooleanExprs.ql
+++ b/java/ql/src/Likely Bugs/Comparison/NoAssignInBooleanExprs.ql
@@ -17,8 +17,8 @@ import semmle.code.java.Statement
 /** An expression that is used as a condition. */
 class BooleanExpr extends Expr {
   BooleanExpr() {
-    exists(ConditionalStmt s | s.getCondition() = this) or
-    exists(ConditionalExpr s | s.getCondition() = this)
+    this = any(ConditionalStmt s).getCondition() or
+    this = any(ConditionalExpr s).getCondition()
   }
 }
 

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseType.qll
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseType.qll
@@ -11,7 +11,7 @@ private predicate flowsInto(Expr e, Variable v) {
   or
   exists(CastExpr c | flowsInto(c, v) | e = c.getExpr())
   or
-  exists(ConditionalExpr c | flowsInto(c, v) | e = c.getTrueExpr() or e = c.getFalseExpr())
+  exists(ConditionalExpr c | flowsInto(c, v) | e = c.getBranchExpr(_))
 }
 
 /**

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseType.qll
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseType.qll
@@ -11,7 +11,7 @@ private predicate flowsInto(Expr e, Variable v) {
   or
   exists(CastExpr c | flowsInto(c, v) | e = c.getExpr())
   or
-  exists(ConditionalExpr c | flowsInto(c, v) | e = c.getBranchExpr(_))
+  exists(ConditionalExpr c | flowsInto(c, v) | e = c.getABranchExpr())
 }
 
 /**

--- a/java/ql/src/Security/CWE/CWE-190/ArithmeticCommon.qll
+++ b/java/ql/src/Security/CWE/CWE-190/ArithmeticCommon.qll
@@ -148,7 +148,7 @@ predicate upcastToWiderType(Expr e) {
     or
     exists(Parameter p | p.getAnArgument() = e and t2 = p.getType())
     or
-    exists(ConditionalExpr cond | cond.getBranchExpr(_) | t2 = cond.getType())
+    exists(ConditionalExpr cond | cond.getABranchExpr() = e | t2 = cond.getType())
   )
 }
 

--- a/java/ql/src/Security/CWE/CWE-190/ArithmeticCommon.qll
+++ b/java/ql/src/Security/CWE/CWE-190/ArithmeticCommon.qll
@@ -148,9 +148,7 @@ predicate upcastToWiderType(Expr e) {
     or
     exists(Parameter p | p.getAnArgument() = e and t2 = p.getType())
     or
-    exists(ConditionalExpr cond | cond.getTrueExpr() = e or cond.getFalseExpr() = e |
-      t2 = cond.getType()
-    )
+    exists(ConditionalExpr cond | cond.getBranchExpr(_) | t2 = cond.getType())
   )
 }
 

--- a/java/ql/src/Violations of Best Practice/legacy/AutoBoxing.ql
+++ b/java/ql/src/Violations of Best Practice/legacy/AutoBoxing.ql
@@ -45,9 +45,7 @@ predicate unboxed(BoxedExpr e) {
   or
   flowTarget(e).getType() instanceof PrimitiveType
   or
-  exists(ConditionalExpr cond | cond instanceof PrimitiveExpr |
-    cond.getTrueExpr() = e or cond.getFalseExpr() = e
-  )
+  exists(ConditionalExpr cond | cond instanceof PrimitiveExpr | cond.getBranchExpr(_) = e)
 }
 
 /**

--- a/java/ql/src/Violations of Best Practice/legacy/AutoBoxing.ql
+++ b/java/ql/src/Violations of Best Practice/legacy/AutoBoxing.ql
@@ -45,7 +45,7 @@ predicate unboxed(BoxedExpr e) {
   or
   flowTarget(e).getType() instanceof PrimitiveType
   or
-  exists(ConditionalExpr cond | cond instanceof PrimitiveExpr | cond.getBranchExpr(_) = e)
+  exists(ConditionalExpr cond | cond instanceof PrimitiveExpr | cond.getABranchExpr() = e)
 }
 
 /**

--- a/java/ql/src/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/src/semmle/code/java/ControlFlowGraph.qll
@@ -293,7 +293,7 @@ private module ControlFlowGraphImpl {
     exists(ConditionalExpr condexpr |
       condexpr.getCondition() = b
       or
-      condexpr.getBranchExpr(_) = b and
+      condexpr.getABranchExpr() = b and
       inBooleanContext(condexpr)
     )
     or
@@ -706,7 +706,7 @@ private module ControlFlowGraphImpl {
     or
     // The last node of a `ConditionalExpr` is in either of its branches.
     exists(ConditionalExpr condexpr | condexpr = n |
-      last(condexpr.getBranchExpr(_), last, completion)
+      last(condexpr.getABranchExpr(), last, completion)
     )
     or
     exists(InstanceOfExpr ioe | ioe.isPattern() and ioe = n |

--- a/java/ql/src/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/src/semmle/code/java/ControlFlowGraph.qll
@@ -293,7 +293,7 @@ private module ControlFlowGraphImpl {
     exists(ConditionalExpr condexpr |
       condexpr.getCondition() = b
       or
-      (condexpr.getTrueExpr() = b or condexpr.getFalseExpr() = b) and
+      condexpr.getBranchExpr(_) = b and
       inBooleanContext(condexpr)
     )
     or
@@ -706,8 +706,7 @@ private module ControlFlowGraphImpl {
     or
     // The last node of a `ConditionalExpr` is in either of its branches.
     exists(ConditionalExpr condexpr | condexpr = n |
-      last(condexpr.getFalseExpr(), last, completion) or
-      last(condexpr.getTrueExpr(), last, completion)
+      last(condexpr.getBranchExpr(_), last, completion)
     )
     or
     exists(InstanceOfExpr ioe | ioe.isPattern() and ioe = n |
@@ -915,14 +914,10 @@ private module ControlFlowGraphImpl {
     )
     or
     // Control flows to the corresponding branch depending on the boolean completion of the condition.
-    exists(ConditionalExpr e |
+    exists(ConditionalExpr e, boolean branch |
       last(e.getCondition(), n, completion) and
-      completion = BooleanCompletion(true, _) and
-      result = first(e.getTrueExpr())
-      or
-      last(e.getCondition(), n, completion) and
-      completion = BooleanCompletion(false, _) and
-      result = first(e.getFalseExpr())
+      completion = BooleanCompletion(branch, _) and
+      result = first(e.getBranchExpr(branch))
     )
     or
     exists(InstanceOfExpr ioe | ioe.isPattern() |

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -184,8 +184,7 @@ class CompileTimeConstantExpr extends Expr {
     // Ternary conditional, with compile-time constant condition.
     exists(ConditionalExpr ce, boolean condition |
       ce = this and
-      condition = ce.getCondition().(CompileTimeConstantExpr).getBooleanValue()
-    |
+      condition = ce.getCondition().(CompileTimeConstantExpr).getBooleanValue() and
       result = ce.getBranchExpr(condition).(CompileTimeConstantExpr).getStringValue()
     )
     or
@@ -293,9 +292,8 @@ class CompileTimeConstantExpr extends Expr {
     // Ternary expressions, where the `true` and `false` expressions are boolean compile-time constants.
     exists(ConditionalExpr ce, boolean condition |
       ce = this and
-      condition = ce.getCondition().(CompileTimeConstantExpr).getBooleanValue()
-    |
-      ce.getBranchExpr(condition).(CompileTimeConstantExpr).getBooleanValue()
+      condition = ce.getCondition().(CompileTimeConstantExpr).getBooleanValue() and
+      result = ce.getBranchExpr(condition).(CompileTimeConstantExpr).getBooleanValue()
     )
     or
     // Simple or qualified names where the variable is final and the initializer is a constant.
@@ -376,8 +374,7 @@ class CompileTimeConstantExpr extends Expr {
       // Ternary conditional, with compile-time constant condition.
       exists(ConditionalExpr ce, boolean condition |
         ce = this and
-        condition = ce.getCondition().(CompileTimeConstantExpr).getBooleanValue()
-      |
+        condition = ce.getCondition().(CompileTimeConstantExpr).getBooleanValue() and
         result = ce.getBranchExpr(condition).(CompileTimeConstantExpr).getIntValue()
       )
       or
@@ -1180,7 +1177,7 @@ class ChooseExpr extends Expr {
 
   /** Gets a result expression of this `switch` or conditional expression. */
   Expr getAResultExpr() {
-    result = this.(ConditionalExpr).getBranchExpr(_) or
+    result = this.(ConditionalExpr).getABranchExpr() or
     result = this.(SwitchExpr).getAResult()
   }
 }
@@ -1212,8 +1209,16 @@ class ConditionalExpr extends Expr, @conditionalexpr {
    * it is `getFalseExpr()`.
    */
   Expr getBranchExpr(boolean branch) {
-    if branch = true then result = getTrueExpr() else result = getFalseExpr()
+    branch = true and result = getTrueExpr()
+    or
+    branch = false and result = getFalseExpr()
   }
+
+  /**
+   * Gets the expressions that is evaluated by one of the branches (`true`
+   * or `false` branch) of this conditional expression.
+   */
+  Expr getABranchExpr() { result = getBranchExpr(_) }
 
   /** Gets a printable representation of this expression. */
   override string toString() { result = "...?...:..." }

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -186,9 +186,7 @@ class CompileTimeConstantExpr extends Expr {
       ce = this and
       condition = ce.getCondition().(CompileTimeConstantExpr).getBooleanValue()
     |
-      if condition = true
-      then result = ce.getTrueExpr().(CompileTimeConstantExpr).getStringValue()
-      else result = ce.getFalseExpr().(CompileTimeConstantExpr).getStringValue()
+      result = ce.getBranchExpr(condition).(CompileTimeConstantExpr).getStringValue()
     )
     or
     exists(Variable v | this = v.getAnAccess() |
@@ -297,9 +295,7 @@ class CompileTimeConstantExpr extends Expr {
       ce = this and
       condition = ce.getCondition().(CompileTimeConstantExpr).getBooleanValue()
     |
-      if condition = true
-      then result = ce.getTrueExpr().(CompileTimeConstantExpr).getBooleanValue()
-      else result = ce.getFalseExpr().(CompileTimeConstantExpr).getBooleanValue()
+      ce.getBranchExpr(condition).(CompileTimeConstantExpr).getBooleanValue()
     )
     or
     // Simple or qualified names where the variable is final and the initializer is a constant.
@@ -382,9 +378,7 @@ class CompileTimeConstantExpr extends Expr {
         ce = this and
         condition = ce.getCondition().(CompileTimeConstantExpr).getBooleanValue()
       |
-        if condition = true
-        then result = ce.getTrueExpr().(CompileTimeConstantExpr).getIntValue()
-        else result = ce.getFalseExpr().(CompileTimeConstantExpr).getIntValue()
+        result = ce.getBranchExpr(condition).(CompileTimeConstantExpr).getIntValue()
       )
       or
       // If a `Variable` is a `CompileTimeConstantExpr`, its value is its initializer.
@@ -1186,8 +1180,7 @@ class ChooseExpr extends Expr {
 
   /** Gets a result expression of this `switch` or conditional expression. */
   Expr getAResultExpr() {
-    result = this.(ConditionalExpr).getTrueExpr() or
-    result = this.(ConditionalExpr).getFalseExpr() or
+    result = this.(ConditionalExpr).getBranchExpr(_) or
     result = this.(SwitchExpr).getAResult()
   }
 }
@@ -1212,6 +1205,15 @@ class ConditionalExpr extends Expr, @conditionalexpr {
    * conditional expression evaluates to `false`.
    */
   Expr getFalseExpr() { result.isNthChildOf(this, 2) }
+
+  /**
+   * Gets the expression that is evaluated by the specific branch of this
+   * conditional expression. If `true` that is `getTrueExpr()`, if `false`
+   * it is `getFalseExpr()`.
+   */
+  Expr getBranchExpr(boolean branch) {
+    if branch = true then result = getTrueExpr() else result = getFalseExpr()
+  }
 
   /** Gets a printable representation of this expression. */
   override string toString() { result = "...?...:..." }

--- a/java/ql/src/semmle/code/java/controlflow/internal/GuardsLogic.qll
+++ b/java/ql/src/semmle/code/java/controlflow/internal/GuardsLogic.qll
@@ -40,9 +40,7 @@ predicate implies_v1(Guard g1, boolean b1, Guard g2, boolean b2) {
   )
   or
   exists(ConditionalExpr cond, boolean branch, BooleanLiteral boollit, boolean boolval |
-    cond.getTrueExpr() = boollit and branch = true
-    or
-    cond.getFalseExpr() = boollit and branch = false
+    cond.getBranchExpr(branch) = boollit
   |
     cond = g1 and
     boolval = boollit.getBooleanValue() and
@@ -50,9 +48,7 @@ predicate implies_v1(Guard g1, boolean b1, Guard g2, boolean b2) {
     (
       g2 = cond.getCondition() and b2 = branch.booleanNot()
       or
-      g2 = cond.getTrueExpr() and b2 = b1
-      or
-      g2 = cond.getFalseExpr() and b2 = b1
+      g2 = cond.getBranchExpr(_) and b2 = b1
     )
   )
   or
@@ -216,9 +212,7 @@ private predicate hasPossibleUnknownValue(SsaVariable v) {
  * `ConditionalExpr`s.
  */
 private Expr possibleValue(Expr e) {
-  result = possibleValue(e.(ConditionalExpr).getTrueExpr())
-  or
-  result = possibleValue(e.(ConditionalExpr).getFalseExpr())
+  result = possibleValue(e.(ConditionalExpr).getBranchExpr(_))
   or
   result = e and not e instanceof ConditionalExpr
 }
@@ -316,9 +310,7 @@ private predicate conditionalAssign(SsaVariable v, Guard guard, boolean branch, 
     v.(SsaExplicitUpdate).getDefiningExpr().(VariableAssign).getSource() = c and
     guard = c.getCondition()
   |
-    branch = true and e = c.getTrueExpr()
-    or
-    branch = false and e = c.getFalseExpr()
+    e = c.getBranchExpr(branch)
   )
   or
   exists(SsaExplicitUpdate upd, SsaPhiNode phi |

--- a/java/ql/src/semmle/code/java/controlflow/internal/GuardsLogic.qll
+++ b/java/ql/src/semmle/code/java/controlflow/internal/GuardsLogic.qll
@@ -40,15 +40,14 @@ predicate implies_v1(Guard g1, boolean b1, Guard g2, boolean b2) {
   )
   or
   exists(ConditionalExpr cond, boolean branch, BooleanLiteral boollit, boolean boolval |
-    cond.getBranchExpr(branch) = boollit
-  |
+    cond.getBranchExpr(branch) = boollit and
     cond = g1 and
     boolval = boollit.getBooleanValue() and
     b1 = boolval.booleanNot() and
     (
       g2 = cond.getCondition() and b2 = branch.booleanNot()
       or
-      g2 = cond.getBranchExpr(_) and b2 = b1
+      g2 = cond.getABranchExpr() and b2 = b1
     )
   )
   or
@@ -212,7 +211,7 @@ private predicate hasPossibleUnknownValue(SsaVariable v) {
  * `ConditionalExpr`s.
  */
 private Expr possibleValue(Expr e) {
-  result = possibleValue(e.(ConditionalExpr).getBranchExpr(_))
+  result = possibleValue(e.(ConditionalExpr).getABranchExpr())
   or
   result = e and not e instanceof ConditionalExpr
 }

--- a/java/ql/src/semmle/code/java/dataflow/ModulusAnalysis.qll
+++ b/java/ql/src/semmle/code/java/dataflow/ModulusAnalysis.qll
@@ -268,9 +268,7 @@ predicate exprModulus(Expr e, Bound b, int val, int mod) {
 private predicate condExprBranchModulus(
   ConditionalExpr cond, boolean branch, Bound b, int val, int mod
 ) {
-  exprModulus(cond.getTrueExpr(), b, val, mod) and branch = true
-  or
-  exprModulus(cond.getFalseExpr(), b, val, mod) and branch = false
+  exprModulus(cond.getBranchExpr(branch), b, val, mod)
 }
 
 private predicate addModulus(Expr add, boolean isLeft, Bound b, int val, int mod) {

--- a/java/ql/src/semmle/code/java/dataflow/Nullness.qll
+++ b/java/ql/src/semmle/code/java/dataflow/Nullness.qll
@@ -191,7 +191,7 @@ private predicate varMaybeNull(SsaVariable v, string msg, Expr reason) {
     // Comparisons in finally blocks are excluded since missing exception edges in the CFG could otherwise yield FPs.
     not exists(TryStmt try | try.getFinally() = e.getEnclosingStmt().getEnclosingStmt*()) and
     (
-      exists(ConditionalExpr c | c.getCondition().getAChildExpr*() = e) or
+      e = any(ConditionalExpr c).getCondition().getAChildExpr*() or
       not exists(MethodAccess ma | ma.getAnArgument().getAChildExpr*() = e)
     ) and
     // Don't use a guard as reason if there is a null assignment.
@@ -439,7 +439,6 @@ private predicate varConditionallyNull(SsaExplicitUpdate v, ConditionBlock cond,
     condexpr.getCondition() = cond.getCondition()
   |
     condexpr.getBranchExpr(branch) = nullExpr() and
-    branch = true and
     not condexpr.getBranchExpr(branch.booleanNot()) = nullExpr()
   )
   or

--- a/java/ql/src/semmle/code/java/dataflow/Nullness.qll
+++ b/java/ql/src/semmle/code/java/dataflow/Nullness.qll
@@ -438,13 +438,9 @@ private predicate varConditionallyNull(SsaExplicitUpdate v, ConditionBlock cond,
     v.getDefiningExpr().(VariableAssign).getSource() = condexpr and
     condexpr.getCondition() = cond.getCondition()
   |
-    condexpr.getTrueExpr() = nullExpr() and
+    condexpr.getBranchExpr(branch) = nullExpr() and
     branch = true and
-    not condexpr.getFalseExpr() = nullExpr()
-    or
-    condexpr.getFalseExpr() = nullExpr() and
-    branch = false and
-    not condexpr.getTrueExpr() = nullExpr()
+    not condexpr.getBranchExpr(branch.booleanNot()) = nullExpr()
   )
   or
   v.getDefiningExpr().(VariableAssign).getSource() = nullExpr() and

--- a/java/ql/src/semmle/code/java/dataflow/RangeAnalysis.qll
+++ b/java/ql/src/semmle/code/java/dataflow/RangeAnalysis.qll
@@ -874,7 +874,5 @@ private predicate boundedConditionalExpr(
   ConditionalExpr cond, Bound b, boolean upper, boolean branch, int delta, boolean fromBackEdge,
   int origdelta, Reason reason
 ) {
-  branch = true and bounded(cond.getTrueExpr(), b, delta, upper, fromBackEdge, origdelta, reason)
-  or
-  branch = false and bounded(cond.getFalseExpr(), b, delta, upper, fromBackEdge, origdelta, reason)
+  bounded(cond.getBranchExpr(branch), b, delta, upper, fromBackEdge, origdelta, reason)
 }

--- a/java/ql/src/semmle/code/java/dataflow/RangeUtils.qll
+++ b/java/ql/src/semmle/code/java/dataflow/RangeUtils.qll
@@ -27,10 +27,9 @@ private predicate nonNullSsaFwdStep(SsaVariable v, SsaVariable phi) {
 }
 
 private predicate nonNullDefStep(Expr e1, Expr e2) {
-  exists(ConditionalExpr cond | cond = e2 |
-    cond.getTrueExpr() = e1 and cond.getFalseExpr() instanceof NullLiteral
-    or
-    cond.getFalseExpr() = e1 and cond.getTrueExpr() instanceof NullLiteral
+  exists(ConditionalExpr cond, boolean branch | cond = e2 |
+    cond.getBranchExpr(branch) = e1 and
+    cond.getBranchExpr(branch.booleanNot()) instanceof NullLiteral
   )
 }
 

--- a/java/ql/src/semmle/code/java/deadcode/DeadEnumConstant.qll
+++ b/java/ql/src/semmle/code/java/deadcode/DeadEnumConstant.qll
@@ -7,10 +7,7 @@ import semmle.code.java.JDKAnnotations
 Expr valueFlow(Expr src) {
   result = src
   or
-  exists(ConditionalExpr c | result = c |
-    src = c.getTrueExpr() or
-    src = c.getFalseExpr()
-  )
+  exists(ConditionalExpr c | result = c | src = c.getBranchExpr(_))
 }
 
 /**

--- a/java/ql/src/semmle/code/java/deadcode/DeadEnumConstant.qll
+++ b/java/ql/src/semmle/code/java/deadcode/DeadEnumConstant.qll
@@ -7,7 +7,7 @@ import semmle.code.java.JDKAnnotations
 Expr valueFlow(Expr src) {
   result = src
   or
-  exists(ConditionalExpr c | result = c | src = c.getBranchExpr(_))
+  result.(ConditionalExpr).getABranchExpr() = src
 }
 
 /**


### PR DESCRIPTION
Adds the predicate `ConditionalExpr.getBranchExpr(boolean)` (similar to [`ConditionNode.getABranchSuccessor(boolean)`](https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/ControlFlowGraph.qll/predicate.ControlFlowGraph$ConditionNode$getABranchSuccessor.1.html) and updates current usage of `ConditionalExpr` predicates.