### PR TITLE
Dataflow: Fix getLocalCc join order

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -2129,10 +2129,18 @@ private module Stage4 {
     innercc.(CallContextCall).matchesCall(call)
   }
 
+  pragma[noinline]
+  private predicate getLocalCc0(DataFlowCallable callable, Node node, Configuration config) {
+    localFlowEntry(node, config) and
+    callable = node.getEnclosingCallable()
+  }
+
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
-    localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    exists(DataFlowCallable callable |
+      getLocalCc0(callable, node, config) and
+      result = getLocalCallContext(cc, callable)
+    )
   }
 
   private predicate localStep(

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -3114,17 +3114,27 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   override predicate isSource() { config.isSource(node) }
 }
 
+pragma[noinline]
+private predicate localPathStep0(DataFlowCallable callable, Node midnode, Configuration conf) {
+  localFlowBigStep(midnode, _, _, _, conf, _) and
+  callable = midnode.getEnclosingCallable()
+}
+
 /**
  * Holds if data may flow from `mid` to `node`. The last step in or out of
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+  exists(
+    AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC,
+    DataFlowCallable callable
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localPathStep0(callable, midnode, conf) and
+    localCC = getLocalCallContext(cc, callable) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and


### PR DESCRIPTION
On the C++ IR we would get this join order: `getLocalContext -> getEnclosingCallable -> localFlowEntry`, while Java got a different (and much better!) join order: `localFlowEntry -> getEnclosingCallable -> getLocalContext`.

Before (on Wireshark):
```
Tuple counts for DataFlowImpl3::Stage4::fwdFlow0#fffff#join_rhs#1/2@ae700a:
371826   ~3%     {2} r1 = SCAN DataFlowImplCommon::getLocalCallContext#cpe#12#ff AS I OUTPUT I.<1>, I.<0> 'arg1'
80607395 ~0%     {2} r2 = JOIN r1 WITH DataFlowUtil::Node::getEnclosingCallable_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1> 'arg0', r1.<1> 'arg1'
                  return r2
...
Tuple counts for DataFlowImpl3::Stage4::fwdFlow0#fffff#join_rhs#2/3@b18565:
282      ~0%     {3} r1 = JOIN DataFlowImpl3::LocalFlowBigStep::localFlowEntry#ff AS L WITH DataFlowImpl3::Stage4::fwdFlow0#fffff#join_rhs#1 AS R ON FIRST 1 OUTPUT R.<0>, R.<1> 'arg1', L.<1> 'arg2'
                  return r1
```

After:
```
Tuple counts for DataFlowImpl3::Stage4::getLocalCc0#fff/3@2d9f53:
  143      ~0%     {3} r1 = JOIN DataFlowImpl3::LocalFlowBigStep::localFlowEntry#ff AS L WITH DataFlowUtil::Node::getEnclosingCallable_dispred#ff AS R ON FIRST 1 OUTPUT R.<1> 'callable', R.<0>, L.<1> 'config'
                    return r1
...
Tuple counts for DataFlowImpl3::Stage4::fwdFlow0#fffff#join_rhs#1/3@5e88d7:
  371826 ~3%     {2} r1 = SCAN DataFlowImplCommon::getLocalCallContext#cpe#12#ff AS I OUTPUT I.<1>, I.<0> 'arg1'
  282    ~1%     {3} r2 = JOIN r1 WITH DataFlowImpl3::Stage4::getLocalCc0#fff AS R ON FIRST 1 OUTPUT R.<1> 'arg0', r1.<1> 'arg1', R.<2> 'arg2'
                  return r2
```

Differences:
C++: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1712/
Java: https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/1176/
C#: https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/862/
Python: https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/408/