### PR TITLE
C++: Improve StdSet and StdPair models

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
@@ -7,9 +7,15 @@ import semmle.code.cpp.models.interfaces.Taint
 /**
  * An instantiation of `std::pair<T1, T2>`.
  */
-class StdPair extends ClassTemplateInstantiation {
+private class StdPair extends ClassTemplateInstantiation {
   StdPair() { this.hasQualifiedName(["std", "bsl"], "pair") }
 }
+
+/**
+ * DEPRECATED: This is now called `StdPair` and is a private part of the
+ * library implementation.
+ */
+deprecated class StdPairClass = StdPair;
 
 /**
  * Any of the single-parameter constructors of `std::pair` that takes a reference to an

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
@@ -44,7 +44,7 @@ class StdPairCopyishConstructor extends Constructor, TaintFunction {
  * Additional model for `std::pair` constructors.
  */
 private class StdPairConstructor extends Constructor, TaintFunction {
-  StdPairConstructor() { this.hasQualifiedName("std", "pair", "pair") }
+  StdPairConstructor() { this.getDeclaringType() instanceof StdPair }
 
   /**
    * Gets the index of a parameter to this function that is a reference to

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
@@ -7,8 +7,8 @@ import semmle.code.cpp.models.interfaces.Taint
 /**
  * An instantiation of `std::pair<T1, T2>`.
  */
-class StdPairClass extends ClassTemplateInstantiation {
-  StdPairClass() { getTemplate().hasQualifiedName("std", "pair") }
+class StdPair extends ClassTemplateInstantiation {
+  StdPair() { this.hasQualifiedName("std", "pair") }
 }
 
 /**
@@ -18,9 +18,9 @@ class StdPairClass extends ClassTemplateInstantiation {
  */
 class StdPairCopyishConstructor extends Constructor, TaintFunction {
   StdPairCopyishConstructor() {
-    this.getDeclaringType() instanceof StdPairClass and
+    this.getDeclaringType() instanceof StdPair and
     this.getNumberOfParameters() = 1 and
-    this.getParameter(0).getUnspecifiedType().(ReferenceType).getBaseType() instanceof StdPairClass
+    this.getParameter(0).getUnspecifiedType().(ReferenceType).getBaseType() instanceof StdPair
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
@@ -8,7 +8,7 @@ import semmle.code.cpp.models.interfaces.Taint
  * An instantiation of `std::pair<T1, T2>`.
  */
 class StdPair extends ClassTemplateInstantiation {
-  StdPair() { this.hasQualifiedName("std", "pair") }
+  StdPair() { this.hasQualifiedName(["std", "bsl"], "pair") }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
@@ -8,7 +8,7 @@ import semmle.code.cpp.models.interfaces.Iterator
 /**
  * An instantiation of `std::set` or `std::unordered_set`.
  */
-class StdSet extends ClassTemplateInstantiation {
+private class StdSet extends ClassTemplateInstantiation {
   StdSet() { this.hasQualifiedName(["std", "bsl"], ["set", "unordered_set"]) }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
@@ -9,7 +9,7 @@ import semmle.code.cpp.models.interfaces.Iterator
  * An instantiation of `std::set` or `std::unordered_set`.
  */
 class StdSet extends ClassTemplateInstantiation {
-  StdSet() { this.hasQualifiedName("std", ["set", "unordered_set"]) }
+  StdSet() { this.hasQualifiedName(["std", "bsl"], ["set", "unordered_set"]) }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
@@ -6,13 +6,17 @@ import semmle.code.cpp.models.interfaces.Taint
 import semmle.code.cpp.models.interfaces.Iterator
 
 /**
+ * An instantiation of `std::set` or `std::unordered_set`.
+ */
+class StdSet extends ClassTemplateInstantiation {
+  StdSet() { this.hasQualifiedName("std", ["set", "unordered_set"]) }
+}
+
+/**
  * Additional model for set constructors using iterator inputs.
  */
 private class StdSetConstructor extends Constructor, TaintFunction {
-  StdSetConstructor() {
-    this.hasQualifiedName("std", "set", "set") or
-    this.hasQualifiedName("std", "unordered_set", "unordered_set")
-  }
+  StdSetConstructor() { this.getDeclaringType() instanceof StdSet }
 
   /**
    * Gets the index of a parameter to this function that is an iterator.
@@ -36,7 +40,7 @@ private class StdSetConstructor extends Constructor, TaintFunction {
  * The standard set `insert` and `insert_or_assign` functions.
  */
 private class StdSetInsert extends TaintFunction {
-  StdSetInsert() { this.hasQualifiedName("std", ["set", "unordered_set"], "insert") }
+  StdSetInsert() { this.getClassAndName("insert") instanceof StdSet }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from last parameter to qualifier and return value
@@ -53,9 +57,7 @@ private class StdSetInsert extends TaintFunction {
  * The standard set `emplace` and `emplace_hint` functions.
  */
 private class StdSetEmplace extends TaintFunction {
-  StdSetEmplace() {
-    this.hasQualifiedName("std", ["set", "unordered_set"], ["emplace", "emplace_hint"])
-  }
+  StdSetEmplace() { this.getClassAndName(["emplace", "emplace_hint"]) instanceof StdSet }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from any parameter to qualifier and return value
@@ -76,7 +78,7 @@ private class StdSetEmplace extends TaintFunction {
  * The standard set `merge` function.
  */
 private class StdSetMerge extends TaintFunction {
-  StdSetMerge() { this.hasQualifiedName("std", ["set", "unordered_set"], "merge") }
+  StdSetMerge() { this.getClassAndName("merge") instanceof StdSet }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // container1.merge(container2)
@@ -89,7 +91,7 @@ private class StdSetMerge extends TaintFunction {
  * The standard set `find` function.
  */
 private class StdSetFind extends TaintFunction {
-  StdSetFind() { this.hasQualifiedName("std", ["set", "unordered_set"], "find") }
+  StdSetFind() { this.getClassAndName("find") instanceof StdSet }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     input.isQualifierObject() and
@@ -101,7 +103,7 @@ private class StdSetFind extends TaintFunction {
  * The standard set `erase` function.
  */
 private class StdSetErase extends TaintFunction {
-  StdSetErase() { this.hasQualifiedName("std", ["set", "unordered_set"], "erase") }
+  StdSetErase() { this.getClassAndName("erase") instanceof StdSet }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from qualifier to iterator return value
@@ -116,8 +118,7 @@ private class StdSetErase extends TaintFunction {
  */
 private class StdSetEqualRange extends TaintFunction {
   StdSetEqualRange() {
-    this.hasQualifiedName("std", ["set", "unordered_set"],
-      ["lower_bound", "upper_bound", "equal_range"])
+    this.getClassAndName(["lower_bound", "upper_bound", "equal_range"]) instanceof StdSet
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {


### PR DESCRIPTION
Improve `StdSet.qll` and `StdPair.qll` models:
 - modelling the class instantiations as well as class member functions (this has been found to be a little bit cleaner, easier to work with and more efficient)
 - `StdSet.qll` now includes bsl compatibility (bsl is missing `insert_or_assign` and `merge` but that should be harmless)
 - `StdPair.qll` now includes bsl compatibility (though the bsl has some extra stuff, such as the base classes for pair, that we don't model; this could be improved but should be harmless)
