### PR TITLE
C++: Improve Iterator models

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
@@ -157,11 +157,9 @@ private class IteratorSubOperator extends Operator, TaintFunction {
  * A non-member `operator+=` or `operator-=` function for an iterator type.
  */
 private class IteratorAssignArithmeticOperator extends Operator, DataFlowFunction, TaintFunction {
-  FunctionInput iteratorInput;
-
   IteratorAssignArithmeticOperator() {
     this.hasName(["operator+=", "operator-="]) and
-    iteratorInput = getIteratorArgumentInput(this, 0)
+    exists(getIteratorArgumentInput(this, 0))
   }
 
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
@@ -167,11 +167,15 @@ private class IteratorAssignArithmeticOperator extends Operator, DataFlowFunctio
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
     input.isParameter(0) and
     output.isReturnValue()
-    or
-    input.isParameterDeref(0) and output.isReturnValueDeref()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    input.isParameterDeref(0) and output.isReturnValueDeref()
+    or
+    // reverse flow from returned reference to the object referenced by the first parameter
+    input.isReturnValueDeref() and
+    output.isParameterDeref(0)
+    or
     input.isParameterDeref(1) and
     output.isParameterDeref(0)
   }
@@ -224,9 +228,7 @@ private class IteratorCrementMemberOperator extends MemberFunction, DataFlowFunc
  * A member `operator->` function for an iterator type.
  */
 private class IteratorFieldMemberOperator extends Operator, TaintFunction {
-  IteratorFieldMemberOperator() {
-    this.getClassAndName("operator->") instanceof Iterator
-  }
+  IteratorFieldMemberOperator() { this.getClassAndName("operator->") instanceof Iterator }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     input.isQualifierObject() and
@@ -260,14 +262,18 @@ private class IteratorAssignArithmeticMemberOperator extends MemberFunction, Dat
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
     input.isQualifierAddress() and
     output.isReturnValue()
-    or
-    input.isReturnValueDeref() and
-    output.isQualifierObject()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     input.isQualifierObject() and
     output.isReturnValueDeref()
+    or
+    // reverse flow from returned reference to the qualifier
+    input.isReturnValueDeref() and
+    output.isQualifierObject()
+    or
+    input.isParameterDeref(0) and
+    output.isQualifierObject()
   }
 }
 
@@ -276,9 +282,7 @@ private class IteratorAssignArithmeticMemberOperator extends MemberFunction, Dat
  */
 private class IteratorArrayMemberOperator extends MemberFunction, TaintFunction,
   IteratorReferenceFunction {
-  IteratorArrayMemberOperator() {
-    this.getClassAndName("operator[]") instanceof Iterator
-  }
+  IteratorArrayMemberOperator() { this.getClassAndName("operator[]") instanceof Iterator }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     input.isQualifierObject() and

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
@@ -177,8 +177,7 @@ private class IteratorAssignArithmeticOperator extends Operator, DataFlowFunctio
 class IteratorPointerDereferenceMemberOperator extends MemberFunction, TaintFunction,
   IteratorReferenceFunction {
   IteratorPointerDereferenceMemberOperator() {
-    this.hasName("operator*") and
-    this.getDeclaringType() instanceof Iterator
+    this.getClassAndName("operator*") instanceof Iterator
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -195,8 +194,7 @@ class IteratorPointerDereferenceMemberOperator extends MemberFunction, TaintFunc
  */
 private class IteratorCrementMemberOperator extends MemberFunction, DataFlowFunction, TaintFunction {
   IteratorCrementMemberOperator() {
-    this.hasName(["operator++", "operator--"]) and
-    this.getDeclaringType() instanceof Iterator
+    this.getClassAndName(["operator++", "operator--"]) instanceof Iterator
   }
 
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
@@ -221,8 +219,7 @@ private class IteratorCrementMemberOperator extends MemberFunction, DataFlowFunc
  */
 private class IteratorFieldMemberOperator extends Operator, TaintFunction {
   IteratorFieldMemberOperator() {
-    this.hasName("operator->") and
-    this.getDeclaringType() instanceof Iterator
+    this.getClassAndName("operator->") instanceof Iterator
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -236,8 +233,7 @@ private class IteratorFieldMemberOperator extends Operator, TaintFunction {
  */
 private class IteratorBinaryArithmeticMemberOperator extends MemberFunction, TaintFunction {
   IteratorBinaryArithmeticMemberOperator() {
-    this.hasName(["operator+", "operator-"]) and
-    this.getDeclaringType() instanceof Iterator
+    this.getClassAndName(["operator+", "operator-"]) instanceof Iterator
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -252,8 +248,7 @@ private class IteratorBinaryArithmeticMemberOperator extends MemberFunction, Tai
 private class IteratorAssignArithmeticMemberOperator extends MemberFunction, DataFlowFunction,
   TaintFunction {
   IteratorAssignArithmeticMemberOperator() {
-    this.hasName(["operator+=", "operator-="]) and
-    this.getDeclaringType() instanceof Iterator
+    this.getClassAndName(["operator+=", "operator-="]) instanceof Iterator
   }
 
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
@@ -276,8 +271,7 @@ private class IteratorAssignArithmeticMemberOperator extends MemberFunction, Dat
 private class IteratorArrayMemberOperator extends MemberFunction, TaintFunction,
   IteratorReferenceFunction {
   IteratorArrayMemberOperator() {
-    this.hasName("operator[]") and
-    this.getDeclaringType() instanceof Iterator
+    this.getClassAndName("operator[]") instanceof Iterator
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
@@ -295,8 +289,7 @@ private class IteratorArrayMemberOperator extends MemberFunction, TaintFunction,
  */
 private class IteratorAssignmentMemberOperator extends MemberFunction, TaintFunction {
   IteratorAssignmentMemberOperator() {
-    this.hasName("operator=") and
-    this.getDeclaringType() instanceof Iterator and
+    this.getClassAndName("operator=") instanceof Iterator and
     not this instanceof CopyAssignmentOperator and
     not this instanceof MoveAssignmentOperator
   }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
@@ -15,7 +15,7 @@ import semmle.code.cpp.models.interfaces.Iterator
  */
 private class IteratorTraits extends Class {
   IteratorTraits() {
-    this.hasQualifiedName("std", "iterator_traits") and
+    this.hasQualifiedName(["std", "bsl"], "iterator_traits") and
     not this instanceof TemplateClass and
     exists(TypedefType t |
       this.getAMember() = t and
@@ -44,7 +44,7 @@ private class IteratorByTypedefs extends Iterator, Class {
     this.getAMember().(TypedefType).hasName("pointer") and
     this.getAMember().(TypedefType).hasName("reference") and
     this.getAMember().(TypedefType).hasName("iterator_category") and
-    not this.hasQualifiedName("std", "iterator_traits")
+    not this.hasQualifiedName(["std", "bsl"], "iterator_traits")
   }
 }
 
@@ -52,7 +52,7 @@ private class IteratorByTypedefs extends Iterator, Class {
  * The `std::iterator` class.
  */
 private class StdIterator extends Iterator, Class {
-  StdIterator() { this.hasQualifiedName("std", "iterator") }
+  StdIterator() { this.hasQualifiedName(["std", "bsl"], "iterator") }
 }
 
 /**
@@ -340,7 +340,7 @@ private class BeginOrEndFunction extends MemberFunction, TaintFunction, GetItera
  */
 private class InserterIteratorFunction extends GetIteratorFunction {
   InserterIteratorFunction() {
-    this.hasQualifiedName("std", ["front_inserter", "inserter", "back_inserter"])
+    this.hasQualifiedName(["std", "bsl"], ["front_inserter", "inserter", "back_inserter"])
   }
 
   override predicate getsIterator(FunctionInput input, FunctionOutput output) {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
@@ -27,6 +27,14 @@ private class IteratorTraits extends Class {
 }
 
 /**
+ * A type that is deduced to be an iterator because there is a corresponding
+ * `std::iterator_traits` instantiation for it.
+ */
+private class IteratorByTraits extends Iterator {
+  IteratorByTraits() { exists(IteratorTraits it | it.getIteratorType() = this) }
+}
+
+/**
  * A type which has the typedefs expected for an iterator.
  */
 private class IteratorByTypedefs extends Iterator, Class {
@@ -48,13 +56,9 @@ private class StdIterator extends Iterator, Class {
 }
 
 /**
- * A type that is deduced to be an iterator because there is a corresponding
- * `std::iterator_traits` instantiation for it.
+ * Gets the `FunctionInput` corresponding to an iterator parameter to
+ * user-defined operator `op`, at `index`.
  */
-private class IteratorByTraits extends Iterator {
-  IteratorByTraits() { exists(IteratorTraits it | it.getIteratorType() = this) }
-}
-
 private FunctionInput getIteratorArgumentInput(Operator op, int index) {
   exists(Type t |
     t =

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
@@ -157,9 +157,11 @@ private class IteratorSubOperator extends Operator, TaintFunction {
  * A non-member `operator+=` or `operator-=` function for an iterator type.
  */
 private class IteratorAssignArithmeticOperator extends Operator, DataFlowFunction, TaintFunction {
+  FunctionInput iteratorInput;
+
   IteratorAssignArithmeticOperator() {
     this.hasName(["operator+=", "operator-="]) and
-    this.getDeclaringType() instanceof Iterator
+    iteratorInput = getIteratorArgumentInput(this, 0)
   }
 
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -3197,6 +3197,52 @@
 | standalone_iterators.cpp:90:8:90:8 | call to operator-- | standalone_iterators.cpp:90:5:90:5 | call to operator* | TAINT |
 | standalone_iterators.cpp:90:8:90:8 | ref arg call to operator-- | standalone_iterators.cpp:90:6:90:7 | ref arg i2 |  |
 | standalone_iterators.cpp:90:13:90:13 | 0 | standalone_iterators.cpp:90:5:90:5 | ref arg call to operator* | TAINT |
+| standalone_iterators.cpp:98:15:98:16 | call to container | standalone_iterators.cpp:101:6:101:7 | c1 |  |
+| standalone_iterators.cpp:98:15:98:16 | call to container | standalone_iterators.cpp:102:6:102:7 | c1 |  |
+| standalone_iterators.cpp:98:15:98:16 | call to container | standalone_iterators.cpp:106:6:106:7 | c1 |  |
+| standalone_iterators.cpp:98:15:98:16 | call to container | standalone_iterators.cpp:109:7:109:8 | c1 |  |
+| standalone_iterators.cpp:101:6:101:7 | c1 | standalone_iterators.cpp:101:9:101:13 | call to begin | TAINT |
+| standalone_iterators.cpp:101:6:101:7 | ref arg c1 | standalone_iterators.cpp:102:6:102:7 | c1 |  |
+| standalone_iterators.cpp:101:6:101:7 | ref arg c1 | standalone_iterators.cpp:106:6:106:7 | c1 |  |
+| standalone_iterators.cpp:101:6:101:7 | ref arg c1 | standalone_iterators.cpp:109:7:109:8 | c1 |  |
+| standalone_iterators.cpp:101:9:101:13 | call to begin | standalone_iterators.cpp:101:2:101:15 | ... = ... |  |
+| standalone_iterators.cpp:101:9:101:13 | call to begin | standalone_iterators.cpp:103:3:103:3 | a |  |
+| standalone_iterators.cpp:101:9:101:13 | call to begin | standalone_iterators.cpp:104:7:104:7 | a |  |
+| standalone_iterators.cpp:102:6:102:7 | c1 | standalone_iterators.cpp:102:9:102:13 | call to begin | TAINT |
+| standalone_iterators.cpp:102:6:102:7 | ref arg c1 | standalone_iterators.cpp:106:6:106:7 | c1 |  |
+| standalone_iterators.cpp:102:6:102:7 | ref arg c1 | standalone_iterators.cpp:109:7:109:8 | c1 |  |
+| standalone_iterators.cpp:102:9:102:13 | call to begin | standalone_iterators.cpp:102:2:102:15 | ... = ... |  |
+| standalone_iterators.cpp:102:9:102:13 | call to begin | standalone_iterators.cpp:107:7:107:7 | b |  |
+| standalone_iterators.cpp:103:2:103:2 | ref arg call to operator* | standalone_iterators.cpp:103:3:103:3 | ref arg a | TAINT |
+| standalone_iterators.cpp:103:2:103:2 | ref arg call to operator* | standalone_iterators.cpp:106:6:106:7 | c1 |  |
+| standalone_iterators.cpp:103:2:103:2 | ref arg call to operator* | standalone_iterators.cpp:109:7:109:8 | c1 |  |
+| standalone_iterators.cpp:103:3:103:3 | a | standalone_iterators.cpp:103:2:103:2 | call to operator* | TAINT |
+| standalone_iterators.cpp:103:3:103:3 | ref arg a | standalone_iterators.cpp:104:7:104:7 | a |  |
+| standalone_iterators.cpp:103:7:103:12 | call to source | standalone_iterators.cpp:103:2:103:2 | ref arg call to operator* | TAINT |
+| standalone_iterators.cpp:104:7:104:7 | a [post update] | standalone_iterators.cpp:106:6:106:7 | c1 |  |
+| standalone_iterators.cpp:104:7:104:7 | a [post update] | standalone_iterators.cpp:109:7:109:8 | c1 |  |
+| standalone_iterators.cpp:106:6:106:7 | c1 | standalone_iterators.cpp:106:9:106:13 | call to begin | TAINT |
+| standalone_iterators.cpp:106:6:106:7 | ref arg c1 | standalone_iterators.cpp:109:7:109:8 | c1 |  |
+| standalone_iterators.cpp:106:9:106:13 | call to begin | standalone_iterators.cpp:106:2:106:15 | ... = ... |  |
+| standalone_iterators.cpp:106:9:106:13 | call to begin | standalone_iterators.cpp:108:7:108:7 | c |  |
+| standalone_iterators.cpp:107:7:107:7 | b [post update] | standalone_iterators.cpp:109:7:109:8 | c1 |  |
+| standalone_iterators.cpp:108:7:108:7 | c [post update] | standalone_iterators.cpp:109:7:109:8 | c1 |  |
+| standalone_iterators.cpp:113:15:113:16 | call to container | standalone_iterators.cpp:116:7:116:8 | c1 |  |
+| standalone_iterators.cpp:113:15:113:16 | call to container | standalone_iterators.cpp:122:7:122:8 | c1 |  |
+| standalone_iterators.cpp:116:7:116:8 | c1 | standalone_iterators.cpp:116:10:116:14 | call to begin | TAINT |
+| standalone_iterators.cpp:116:7:116:8 | ref arg c1 | standalone_iterators.cpp:122:7:122:8 | c1 |  |
+| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:116:2:116:16 | ... = ... |  |
+| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:117:7:117:8 | it |  |
+| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:118:2:118:3 | it |  |
+| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:119:7:119:8 | it |  |
+| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:120:2:120:3 | it |  |
+| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:121:7:121:8 | it |  |
+| standalone_iterators.cpp:117:7:117:8 | it [post update] | standalone_iterators.cpp:122:7:122:8 | c1 |  |
+| standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:119:7:119:8 | it |  |
+| standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:120:2:120:3 | it |  |
+| standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:121:7:121:8 | it |  |
+| standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:122:7:122:8 | c1 |  |
+| standalone_iterators.cpp:120:2:120:3 | ref arg it | standalone_iterators.cpp:121:7:121:8 | it |  |
 | stl.h:75:8:75:8 | Unknown literal | stl.h:75:8:75:8 | constructor init of field container | TAINT |
 | stl.h:75:8:75:8 | Unknown literal | stl.h:75:8:75:8 | constructor init of field container | TAINT |
 | stl.h:75:8:75:8 | this | stl.h:75:8:75:8 | constructor init of field container [pre-this] |  |
@@ -7481,3 +7527,64 @@
 | vector.cpp:496:25:496:30 | call to source | vector.cpp:496:2:496:3 | ref arg v2 | TAINT |
 | vector.cpp:496:25:496:30 | call to source | vector.cpp:496:5:496:11 | call to emplace | TAINT |
 | vector.cpp:497:7:497:8 | ref arg v2 | vector.cpp:498:1:498:1 | v2 |  |
+| vector.cpp:503:18:503:21 | {...} | vector.cpp:506:8:506:9 | as |  |
+| vector.cpp:503:18:503:21 | {...} | vector.cpp:507:8:507:9 | as |  |
+| vector.cpp:503:18:503:21 | {...} | vector.cpp:509:9:509:10 | as |  |
+| vector.cpp:503:18:503:21 | {...} | vector.cpp:515:8:515:9 | as |  |
+| vector.cpp:503:20:503:20 | 0 | vector.cpp:503:18:503:21 | {...} | TAINT |
+| vector.cpp:506:8:506:9 | as | vector.cpp:506:8:506:12 | access to array |  |
+| vector.cpp:506:11:506:11 | 1 | vector.cpp:506:8:506:12 | access to array | TAINT |
+| vector.cpp:507:8:507:9 | as | vector.cpp:507:8:507:19 | access to array |  |
+| vector.cpp:507:11:507:16 | call to source | vector.cpp:507:8:507:19 | access to array | TAINT |
+| vector.cpp:509:9:509:10 | as | vector.cpp:509:3:509:10 | ... = ... |  |
+| vector.cpp:509:9:509:10 | as | vector.cpp:510:9:510:11 | ptr |  |
+| vector.cpp:509:9:509:10 | as | vector.cpp:511:3:511:5 | ptr |  |
+| vector.cpp:510:9:510:11 | ptr | vector.cpp:510:8:510:11 | * ... | TAINT |
+| vector.cpp:511:3:511:5 | ptr | vector.cpp:511:3:511:10 | ... += ... | TAINT |
+| vector.cpp:511:3:511:10 | ... += ... | vector.cpp:512:9:512:11 | ptr |  |
+| vector.cpp:511:3:511:10 | ... += ... | vector.cpp:513:3:513:5 | ptr |  |
+| vector.cpp:511:10:511:10 | 1 | vector.cpp:511:3:511:10 | ... += ... | TAINT |
+| vector.cpp:512:9:512:11 | ptr | vector.cpp:512:8:512:11 | * ... | TAINT |
+| vector.cpp:513:3:513:5 | ptr | vector.cpp:513:3:513:17 | ... += ... | TAINT |
+| vector.cpp:513:3:513:17 | ... += ... | vector.cpp:514:9:514:11 | ptr |  |
+| vector.cpp:513:10:513:15 | call to source | vector.cpp:513:3:513:17 | ... += ... | TAINT |
+| vector.cpp:514:9:514:11 | ptr | vector.cpp:514:8:514:11 | * ... | TAINT |
+| vector.cpp:515:8:515:9 | as | vector.cpp:515:8:515:12 | access to array |  |
+| vector.cpp:515:11:515:11 | 1 | vector.cpp:515:8:515:12 | access to array | TAINT |
+| vector.cpp:520:25:520:31 | call to vector | vector.cpp:523:8:523:9 | vs |  |
+| vector.cpp:520:25:520:31 | call to vector | vector.cpp:524:8:524:9 | vs |  |
+| vector.cpp:520:25:520:31 | call to vector | vector.cpp:526:8:526:9 | vs |  |
+| vector.cpp:520:25:520:31 | call to vector | vector.cpp:532:8:532:9 | vs |  |
+| vector.cpp:520:25:520:31 | call to vector | vector.cpp:533:2:533:2 | vs |  |
+| vector.cpp:520:30:520:30 | 0 | vector.cpp:520:25:520:31 | call to vector | TAINT |
+| vector.cpp:523:8:523:9 | ref arg vs | vector.cpp:524:8:524:9 | vs |  |
+| vector.cpp:523:8:523:9 | ref arg vs | vector.cpp:526:8:526:9 | vs |  |
+| vector.cpp:523:8:523:9 | ref arg vs | vector.cpp:532:8:532:9 | vs |  |
+| vector.cpp:523:8:523:9 | ref arg vs | vector.cpp:533:2:533:2 | vs |  |
+| vector.cpp:523:8:523:9 | vs | vector.cpp:523:10:523:10 | call to operator[] | TAINT |
+| vector.cpp:524:8:524:9 | ref arg vs | vector.cpp:526:8:526:9 | vs |  |
+| vector.cpp:524:8:524:9 | ref arg vs | vector.cpp:532:8:532:9 | vs |  |
+| vector.cpp:524:8:524:9 | ref arg vs | vector.cpp:533:2:533:2 | vs |  |
+| vector.cpp:524:8:524:9 | vs | vector.cpp:524:10:524:10 | call to operator[] | TAINT |
+| vector.cpp:526:8:526:9 | ref arg vs | vector.cpp:532:8:532:9 | vs |  |
+| vector.cpp:526:8:526:9 | ref arg vs | vector.cpp:533:2:533:2 | vs |  |
+| vector.cpp:526:8:526:9 | vs | vector.cpp:526:11:526:15 | call to begin | TAINT |
+| vector.cpp:526:11:526:15 | call to begin | vector.cpp:526:3:526:17 | ... = ... |  |
+| vector.cpp:526:11:526:15 | call to begin | vector.cpp:527:9:527:10 | it |  |
+| vector.cpp:526:11:526:15 | call to begin | vector.cpp:528:3:528:4 | it |  |
+| vector.cpp:526:11:526:15 | call to begin | vector.cpp:529:9:529:10 | it |  |
+| vector.cpp:526:11:526:15 | call to begin | vector.cpp:530:3:530:4 | it |  |
+| vector.cpp:526:11:526:15 | call to begin | vector.cpp:531:9:531:10 | it |  |
+| vector.cpp:527:9:527:10 | it | vector.cpp:527:8:527:8 | call to operator* | TAINT |
+| vector.cpp:528:3:528:4 | it | vector.cpp:528:6:528:6 | call to operator+= |  |
+| vector.cpp:528:3:528:4 | ref arg it | vector.cpp:529:9:529:10 | it |  |
+| vector.cpp:528:3:528:4 | ref arg it | vector.cpp:530:3:530:4 | it |  |
+| vector.cpp:528:3:528:4 | ref arg it | vector.cpp:531:9:531:10 | it |  |
+| vector.cpp:528:9:528:9 | 1 | vector.cpp:528:6:528:6 | call to operator+= |  |
+| vector.cpp:529:9:529:10 | it | vector.cpp:529:8:529:8 | call to operator* | TAINT |
+| vector.cpp:530:3:530:4 | it | vector.cpp:530:6:530:6 | call to operator+= |  |
+| vector.cpp:530:3:530:4 | ref arg it | vector.cpp:531:9:531:10 | it |  |
+| vector.cpp:530:9:530:14 | call to source | vector.cpp:530:6:530:6 | call to operator+= |  |
+| vector.cpp:531:9:531:10 | it | vector.cpp:531:8:531:8 | call to operator* | TAINT |
+| vector.cpp:532:8:532:9 | ref arg vs | vector.cpp:533:2:533:2 | vs |  |
+| vector.cpp:532:8:532:9 | vs | vector.cpp:532:10:532:10 | call to operator[] | TAINT |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -3238,11 +3238,15 @@
 | standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:120:2:120:3 | it |  |
 | standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:121:7:121:8 | it |  |
 | standalone_iterators.cpp:117:7:117:8 | it [post update] | standalone_iterators.cpp:122:7:122:8 | c1 |  |
+| standalone_iterators.cpp:118:2:118:3 | it | standalone_iterators.cpp:118:5:118:5 | call to operator+= |  |
 | standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:119:7:119:8 | it |  |
 | standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:120:2:120:3 | it |  |
 | standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:121:7:121:8 | it |  |
 | standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:122:7:122:8 | c1 |  |
+| standalone_iterators.cpp:118:8:118:8 | 1 | standalone_iterators.cpp:118:2:118:3 | ref arg it | TAINT |
+| standalone_iterators.cpp:120:2:120:3 | it | standalone_iterators.cpp:120:5:120:5 | call to operator+= |  |
 | standalone_iterators.cpp:120:2:120:3 | ref arg it | standalone_iterators.cpp:121:7:121:8 | it |  |
+| standalone_iterators.cpp:120:8:120:13 | call to source | standalone_iterators.cpp:120:2:120:3 | ref arg it | TAINT |
 | stl.h:75:8:75:8 | Unknown literal | stl.h:75:8:75:8 | constructor init of field container | TAINT |
 | stl.h:75:8:75:8 | Unknown literal | stl.h:75:8:75:8 | constructor init of field container | TAINT |
 | stl.h:75:8:75:8 | this | stl.h:75:8:75:8 | constructor init of field container [pre-this] |  |
@@ -3922,12 +3926,10 @@
 | string.cpp:408:8:408:9 | i2 | string.cpp:409:10:409:11 | i7 |  |
 | string.cpp:409:10:409:11 | i7 | string.cpp:409:12:409:12 | call to operator+= |  |
 | string.cpp:409:12:409:12 | call to operator+= | string.cpp:409:8:409:8 | call to operator* | TAINT |
-| string.cpp:409:14:409:14 | 1 | string.cpp:409:12:409:12 | call to operator+= |  |
 | string.cpp:410:8:410:9 | i2 | string.cpp:410:3:410:9 | ... = ... |  |
 | string.cpp:410:8:410:9 | i2 | string.cpp:411:10:411:11 | i8 |  |
 | string.cpp:411:10:411:11 | i8 | string.cpp:411:12:411:12 | call to operator-= |  |
 | string.cpp:411:12:411:12 | call to operator-= | string.cpp:411:8:411:8 | call to operator* | TAINT |
-| string.cpp:411:14:411:14 | 1 | string.cpp:411:12:411:12 | call to operator-= |  |
 | string.cpp:413:8:413:9 | s2 | string.cpp:413:11:413:13 | call to end | TAINT |
 | string.cpp:413:11:413:13 | call to end | string.cpp:413:3:413:15 | ... = ... |  |
 | string.cpp:413:11:413:13 | call to end | string.cpp:414:5:414:6 | i9 |  |
@@ -7580,11 +7582,9 @@
 | vector.cpp:528:3:528:4 | ref arg it | vector.cpp:529:9:529:10 | it |  |
 | vector.cpp:528:3:528:4 | ref arg it | vector.cpp:530:3:530:4 | it |  |
 | vector.cpp:528:3:528:4 | ref arg it | vector.cpp:531:9:531:10 | it |  |
-| vector.cpp:528:9:528:9 | 1 | vector.cpp:528:6:528:6 | call to operator+= |  |
 | vector.cpp:529:9:529:10 | it | vector.cpp:529:8:529:8 | call to operator* | TAINT |
 | vector.cpp:530:3:530:4 | it | vector.cpp:530:6:530:6 | call to operator+= |  |
 | vector.cpp:530:3:530:4 | ref arg it | vector.cpp:531:9:531:10 | it |  |
-| vector.cpp:530:9:530:14 | call to source | vector.cpp:530:6:530:6 | call to operator+= |  |
 | vector.cpp:531:9:531:10 | it | vector.cpp:531:8:531:8 | call to operator* | TAINT |
 | vector.cpp:532:8:532:9 | ref arg vs | vector.cpp:533:2:533:2 | vs |  |
 | vector.cpp:532:8:532:9 | vs | vector.cpp:532:10:532:10 | call to operator[] | TAINT |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -3926,10 +3926,12 @@
 | string.cpp:408:8:408:9 | i2 | string.cpp:409:10:409:11 | i7 |  |
 | string.cpp:409:10:409:11 | i7 | string.cpp:409:12:409:12 | call to operator+= |  |
 | string.cpp:409:12:409:12 | call to operator+= | string.cpp:409:8:409:8 | call to operator* | TAINT |
+| string.cpp:409:14:409:14 | 1 | string.cpp:409:10:409:11 | ref arg i7 | TAINT |
 | string.cpp:410:8:410:9 | i2 | string.cpp:410:3:410:9 | ... = ... |  |
 | string.cpp:410:8:410:9 | i2 | string.cpp:411:10:411:11 | i8 |  |
 | string.cpp:411:10:411:11 | i8 | string.cpp:411:12:411:12 | call to operator-= |  |
 | string.cpp:411:12:411:12 | call to operator-= | string.cpp:411:8:411:8 | call to operator* | TAINT |
+| string.cpp:411:14:411:14 | 1 | string.cpp:411:10:411:11 | ref arg i8 | TAINT |
 | string.cpp:413:8:413:9 | s2 | string.cpp:413:11:413:13 | call to end | TAINT |
 | string.cpp:413:11:413:13 | call to end | string.cpp:413:3:413:15 | ... = ... |  |
 | string.cpp:413:11:413:13 | call to end | string.cpp:414:5:414:6 | i9 |  |
@@ -7582,9 +7584,11 @@
 | vector.cpp:528:3:528:4 | ref arg it | vector.cpp:529:9:529:10 | it |  |
 | vector.cpp:528:3:528:4 | ref arg it | vector.cpp:530:3:530:4 | it |  |
 | vector.cpp:528:3:528:4 | ref arg it | vector.cpp:531:9:531:10 | it |  |
+| vector.cpp:528:9:528:9 | 1 | vector.cpp:528:3:528:4 | ref arg it | TAINT |
 | vector.cpp:529:9:529:10 | it | vector.cpp:529:8:529:8 | call to operator* | TAINT |
 | vector.cpp:530:3:530:4 | it | vector.cpp:530:6:530:6 | call to operator+= |  |
 | vector.cpp:530:3:530:4 | ref arg it | vector.cpp:531:9:531:10 | it |  |
+| vector.cpp:530:9:530:14 | call to source | vector.cpp:530:3:530:4 | ref arg it | TAINT |
 | vector.cpp:531:9:531:10 | it | vector.cpp:531:8:531:8 | call to operator* | TAINT |
 | vector.cpp:532:8:532:9 | ref arg vs | vector.cpp:533:2:533:2 | vs |  |
 | vector.cpp:532:8:532:9 | vs | vector.cpp:532:10:532:10 | call to operator[] | TAINT |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/standalone_iterators.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/standalone_iterators.cpp
@@ -90,3 +90,34 @@ void test_insert_iterator() {
     *i2-- = 0;
     sink(c2); // clean
 }
+
+void sink(insert_iterator_by_trait);
+insert_iterator_by_trait &operator+=(insert_iterator_by_trait &it, int amount);
+
+void test_assign_through_iterator() {
+    container c1;
+    insert_iterator_by_trait a, b, c;
+
+	a = c1.begin();
+	b = c1.begin();
+	*a = source();
+	sink(a); // $ ast MISSING: ir
+
+	c = c1.begin();
+	sink(b); // MISSING: ast,ir
+	sink(c); // $ ast MISSING: ir
+	sink(c1); // $ ast MISSING: ir
+}
+
+void test_nonmember_iterator() {
+    container c1;
+    insert_iterator_by_trait it;
+
+	it = c1.begin();
+	sink(it);
+	it += 1;
+	sink(it);
+	it += source();
+	sink(it); // $ MISSING: ast,ir
+	sink(c1);
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/standalone_iterators.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/standalone_iterators.cpp
@@ -118,6 +118,6 @@ void test_nonmember_iterator() {
 	it += 1;
 	sink(it);
 	it += source();
-	sink(it); // $ MISSING: ast,ir
+	sink(it); // $ ast,ir
 	sink(c1);
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -496,3 +496,39 @@ void test_vector_emplace() {
 	v2.emplace(v2.begin(), source());
 	sink(v2); // $ ast,ir
 }
+
+void test_vector_iterator() {
+	{
+		// array behaviour, for comparison
+		short as[100] = {0};
+		short *ptr;
+
+		sink(as[1]);
+		sink(as[source()]); // $ ast,ir
+
+		ptr = as;
+		sink(*ptr);
+		ptr += 1;
+		sink(*ptr);
+		ptr += source();
+		sink(*ptr); // $ ast,ir
+		sink(as[1]);
+	}
+
+	{
+		// iterator behaviour
+		std::vector<short> vs(100, 0);
+		std::vector<short>::iterator it;
+
+		sink(vs[1]);
+		sink(vs[source()]); // $ MISSING: ast,ir
+
+		it = vs.begin();
+		sink(*it);
+		it += 1;
+		sink(*it);
+		it += source();
+		sink(*it); // $ MISSING: ast,ir
+		sink(vs[1]);
+	}
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -528,7 +528,7 @@ void test_vector_iterator() {
 		it += 1;
 		sink(*it);
 		it += source();
-		sink(*it); // $ MISSING: ast,ir
+		sink(*it); // $ ast,ir
 		sink(vs[1]);
 	}
 }


### PR DESCRIPTION
Improve Iterator.qll models:
 - for the most part `Iterator.qll` already models its classes, and uses a special predicate `getIteratorArgumentInput` to connect classes to non-member function models.  But there were a few opportunities to clean things up for member function models using `getClassAndName`.
 - there were some issues with the `operator+=` models, particularly with the non-member version and consistency between the member and non-member versions; I've added some more test cases and attempted to improve matters.  But please do say if you think I may have made a mistake!

Regarding BSL:
 - the `bsl` classes appear to have iterators, `begin` methods etc with the normal behaviour.
 - The `bsl::iterator`, `bsl::front_inserter`, `bsl::inserter`, and `bsl::back_inserter` functions don't appear to be documented but are [implemented as references](https://github.com/bloomberg/bde/blob/81e73ce7156bcffff46703ee08b478c774684423/groups/bsl/bslstl/bslstl_iterator.h#L195) (via `using` declarations) to the `std` versions.
 - depending on macros there is a [`bsl:iterator_traits`](https://github.com/bloomberg/bde/blob/81e73ce7156bcffff46703ee08b478c774684423/groups/bsl/bslstl/bslstl_iterator.h#L231) corresponding to `std::iterator_traits`, or a `using`.  I couldn't find documentation for it but it's clearly intended to be the same thing.
 - there are also a handful of special iterators (I think), such as `bsl::List_Iterator`.  This example should be caught by `IteratorByTypedefs` and modelled correctly.

TL;DR: `bsl` iterators work the same as `std` iterators, so I've changed the model to include them, and also fixed a few things.