### PR TITLE
Python: Add FP test for unknown argument in string format

### DIFF
--- a/python/ql/test/query-tests/Expressions/Formatting/UnusedNamedArgumentIn3101Format.expected
+++ b/python/ql/test/query-tests/Expressions/Formatting/UnusedNamedArgumentIn3101Format.expected
@@ -6,3 +6,6 @@
 | test.py:45:1:45:35 | format() | Surplus named argument for string format. An argument named 'z' is provided, but it is not required by $@. | test.py:39:14:39:18 | Str | any format used. |
 | test.py:46:1:46:34 | Attribute() | Surplus named argument for string format. An argument named 'z' is provided, but it is not required by $@. | test.py:37:14:37:18 | Str | any format used. |
 | test.py:46:1:46:34 | Attribute() | Surplus named argument for string format. An argument named 'z' is provided, but it is not required by $@. | test.py:39:14:39:18 | Str | any format used. |
+| unknown_format_string.py:9:12:9:30 | Attribute() | Surplus named argument for string format. An argument named 'b' is provided, but it is not required by $@. | unknown_format_string.py:8:15:8:19 | Str | format "{a}" |
+| unknown_format_string.py:17:12:17:30 | Attribute() | Surplus named argument for string format. An argument named 'b' is provided, but it is not required by $@. | unknown_format_string.py:16:15:16:19 | Str | format "{a}" |
+| unknown_format_string.py:25:12:25:30 | Attribute() | Surplus named argument for string format. An argument named 'b' is provided, but it is not required by $@. | unknown_format_string.py:24:15:24:19 | Str | format "{a}" |

--- a/python/ql/test/query-tests/Expressions/Formatting/unknown_format_string.py
+++ b/python/ql/test/query-tests/Expressions/Formatting/unknown_format_string.py
@@ -1,0 +1,25 @@
+# FP Reported in https://github.com/github/codeql/issues/2650
+
+def possibly_unknown_format_string1(x):
+    user_specified = unknown_function()
+    if user_specified:
+        fmt = user_specified
+    else:
+        fmt = "{a}"
+    return fmt.format(a=1,b=2)
+
+def possibly_unknown_format_string2(x):
+    user_specified = input()
+    if user_specified:
+        fmt = user_specified
+    else:
+        fmt = "{a}"
+    return fmt.format(a=1,b=2)
+
+
+def possibly_unknown_format_string3(x):
+    if unknown_function():
+        fmt = input()
+    else:
+        fmt = "{a}"
+    return fmt.format(a=1,b=2)


### PR DESCRIPTION
Reported in #2650

I found this during a bit of spring cleaning in my working
directory. As this doesn't have any immediate security implications, I
don't know when we'll get round to fixing it, but it can't hurt to
have the test case checked in.