### PR TITLE
Java: CWE-297 Query to detect insecure LDAP endpoint configuration

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.java
@@ -1,0 +1,23 @@
+public class InsecureLdapEndpoint {
+    public Hashtable<String, String> createConnectionEnv() {
+        Hashtable<String, String> env = new Hashtable<String, String>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.PROVIDER_URL, "ldaps://ad.your-server.com:636");
+
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        env.put(Context.SECURITY_PRINCIPAL, "username");
+        env.put(Context.SECURITY_CREDENTIALS, "secpassword");
+
+		// BAD - Test configuration with disabled SSL endpoint check.
+		{
+        	System.setProperty("com.sun.jndi.ldap.object.disableEndpointIdentification", "true");
+		}
+
+		// GOOD - No configuration to disable SSL endpoint check since it is enabled by default.
+		{
+		}
+
+        return env;
+    }
+
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.qhelp
@@ -4,20 +4,27 @@
 <qhelp>
 
 <overview>
-<p>Java versions 8u181 or greater have enabled LDAPS endpoint identification by default. Nowadays infrastructure services like LDAP are commonly deployed behind load balancers therefore the LDAP server name can be different from the FQDN of the LDAPS endpoint. If a service certificate does not properly contain a matching DNS name as part of the certificate, Java will reject it by default.</p>
-<p>Instead of addressing the issue properly by having a compliant certificate deployed, frequently developers simply disable the LDAPS endpoint check.</p>
-<p>Failing to validate the certificate makes the SSL session susceptible to a man-in-the-middle attack. This query checks whether the LDAPS endpoint check is disabled in system properties.</p>
+<p>Java versions 8u181 or greater have enabled LDAPS endpoint identification by default. Nowadays 
+  infrastructure services like LDAP are commonly deployed behind load balancers therefore the LDAP 
+  server name can be different from the FQDN of the LDAPS endpoint. If a service certificate does not 
+  properly contain a matching DNS name as part of the certificate, Java will reject it by default.</p>
+<p>Instead of addressing the issue properly by having a compliant certificate deployed, frequently 
+  developers simply disable the LDAPS endpoint check.</p>
+<p>Failing to validate the certificate makes the SSL session susceptible to a man-in-the-middle attack. 
+  This query checks whether the LDAPS endpoint check is disabled in system properties.</p>
 </overview>
 
 <recommendation>
-<p>Replace any non-conforming LDAP server certificates to include a DNS name in the subjectAltName field of the certificate that matches the FQDN of the service.</p>
+<p>Replace any non-conforming LDAP server certificates to include a DNS name in the subjectAltName field 
+  of the certificate that matches the FQDN of the service.</p>
 </recommendation>
 
 <example>
-<p>The following two examples show two ways of configuring LDAPS endpoint. In the 'BAD' case,
-endpoint check is disabled. In the 'GOOD' case, endpoint check is left enabled through the default Java configuration.</p>
+<p>The following two examples show two ways of configuring LDAPS endpoint. In the 'BAD' case, 
+  endpoint check is disabled. In the 'GOOD' case, endpoint check is left enabled through the 
+  default Java configuration.</p>
 <sample src="InsecureLdapEndpoint.java" />
-<sample src="InsecureLdapEndpoint2.java" />>
+<sample src="InsecureLdapEndpoint2.java" />
 </example>
 
 <references>

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.qhelp
@@ -1,0 +1,32 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>Java versions 8u181 or greater have enabled LDAPS endpoint identification by default. Nowadays infrastructure services like LDAP are commonly deployed behind load balancers therefore the LDAP server name can be different from the FQDN of the LDAPS endpoint. If a service certificate does not properly contain a matching DNS name as part of the certificate, Java will reject it by default.</p>
+<p>Instead of addressing the issue properly by having a compliant certificate deployed, frequently developers simply disable SSL endpoint check.</p>
+<p>This query checks whether LDAPS endpoint check is disabled in system properties.</p>
+</overview>
+
+<recommendation>
+<p>Replace any non-conforming LDAP server certificates to include a DNS name in the subjectAltName field of the certificate that matches the FQDN of the service.</p>
+</recommendation>
+
+<example>
+<p>The following two examples show two ways of configuring SSL endpoint. In the 'BAD' case,
+endpoint check is disabled. In the 'GOOD' case, endpoint check is left enabled through the default Java configuration.</p>
+<sample src="InsecureSSLEndpoint.java" />
+</example>
+
+<references>
+<li>
+  Oracle Java 8 Update 181 (8u181):
+  <a href="https://www.java.com/en/download/help/release_changes.html">Endpoint identification enabled on LDAPS connections</a>
+</li>
+<li>
+  IBM:
+  <a href="https://www.ibm.com/support/pages/how-do-i-fix-ldap-ssl-error-%E2%80%9Cjavasecuritycertcertificateexception-no-subject-alternative-names-present%E2%80%9D-websphere-application-server">Fix this LDAP SSL error</a>
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.qhelp
@@ -5,8 +5,8 @@
 
 <overview>
 <p>Java versions 8u181 or greater have enabled LDAPS endpoint identification by default. Nowadays infrastructure services like LDAP are commonly deployed behind load balancers therefore the LDAP server name can be different from the FQDN of the LDAPS endpoint. If a service certificate does not properly contain a matching DNS name as part of the certificate, Java will reject it by default.</p>
-<p>Instead of addressing the issue properly by having a compliant certificate deployed, frequently developers simply disable LDAPS endpoint check.</p>
-<p>Failing to validate the certificate makes the SSL session susceptible to a man-in-the-middle attack. This query checks whether LDAPS endpoint check is disabled in system properties.</p>
+<p>Instead of addressing the issue properly by having a compliant certificate deployed, frequently developers simply disable the LDAPS endpoint check.</p>
+<p>Failing to validate the certificate makes the SSL session susceptible to a man-in-the-middle attack. This query checks whether the LDAPS endpoint check is disabled in system properties.</p>
 </overview>
 
 <recommendation>

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.qhelp
@@ -5,8 +5,8 @@
 
 <overview>
 <p>Java versions 8u181 or greater have enabled LDAPS endpoint identification by default. Nowadays infrastructure services like LDAP are commonly deployed behind load balancers therefore the LDAP server name can be different from the FQDN of the LDAPS endpoint. If a service certificate does not properly contain a matching DNS name as part of the certificate, Java will reject it by default.</p>
-<p>Instead of addressing the issue properly by having a compliant certificate deployed, frequently developers simply disable SSL endpoint check.</p>
-<p>This query checks whether LDAPS endpoint check is disabled in system properties.</p>
+<p>Instead of addressing the issue properly by having a compliant certificate deployed, frequently developers simply disable LDAPS endpoint check.</p>
+<p>Failing to validate the certificate makes the SSL session susceptible to a man-in-the-middle attack. This query checks whether LDAPS endpoint check is disabled in system properties.</p>
 </overview>
 
 <recommendation>
@@ -14,9 +14,10 @@
 </recommendation>
 
 <example>
-<p>The following two examples show two ways of configuring SSL endpoint. In the 'BAD' case,
+<p>The following two examples show two ways of configuring LDAPS endpoint. In the 'BAD' case,
 endpoint check is disabled. In the 'GOOD' case, endpoint check is left enabled through the default Java configuration.</p>
-<sample src="InsecureSSLEndpoint.java" />
+<sample src="InsecureLdapEndpoint.java" />
+<sample src="InsecureLdapEndpoint2.java" />>
 </example>
 
 <references>

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql
@@ -1,6 +1,7 @@
 /**
  * @name Insecure LDAPS Endpoint Configuration
- * @description Java application configured to disable LDAPS endpoint identification does not validate the SSL certificate to properly ensure that it is actually associated with that host.
+ * @description Java application configured to disable LDAPS endpoint identification does not validate
+ *              the SSL certificate to properly ensure that it is actually associated with that host.
  * @kind problem
  * @id java/insecure-ldaps-endpoint
  * @tags security
@@ -23,7 +24,8 @@ class TypeHashtable extends Class {
 }
 
 /**
- * The method to set Java properties either through `setProperty` declared in the class `Properties` or `put` declared in its parent class `HashTable`.
+ * The method to set Java properties either through `setProperty` declared in the class `Properties`
+ * or `put` declared in its parent class `HashTable`.
  */
 class SetPropertyMethod extends Method {
   SetPropertyMethod() {
@@ -40,7 +42,10 @@ class SetSystemPropertiesMethod extends Method {
   }
 }
 
-/** Holds if `expr` is evaluated to the string literal `com.sun.jndi.ldap.object.disableEndpointIdentification`. */
+/**
+ * Holds if `Expr` expr is evaluated to the string literal
+ * `com.sun.jndi.ldap.object.disableEndpointIdentification`.
+ */
 predicate isPropertyDisableLdapEndpointId(Expr expr) {
   expr.(CompileTimeConstantExpr).getStringValue() =
     "com.sun.jndi.ldap.object.disableEndpointIdentification"

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql
@@ -1,0 +1,65 @@
+/**
+ * @name Insecure LDAP Endpoint Configuration
+ * @description Java application configured to disable LDAP endpoint identification does not validate the SSL certificate to properly ensure that it is actually associated with that host.
+ * @kind problem
+ * @id java/insecure-ldap-endpoint
+ * @tags security
+ *       external/cwe-297
+ */
+
+import java
+
+/**
+ * The method to set a system property.
+ */
+class SetSystemPropertyMethod extends Method {
+  SetSystemPropertyMethod() {
+    this.hasName("setProperty") and
+    this.getDeclaringType().hasQualifiedName("java.lang", "System")
+  }
+}
+
+/**
+ * The method to set Java properties.
+ */
+class SetPropertyMethod extends Method {
+  SetPropertyMethod() {
+    this.hasName("setProperty") and
+    this.getDeclaringType().hasQualifiedName("java.util", "Properties")
+  }
+}
+
+/**
+ * The method to set system properties.
+ */
+class SetSystemPropertiesMethod extends Method {
+  SetSystemPropertiesMethod() {
+    this.hasName("setProperties") and
+    this.getDeclaringType().hasQualifiedName("java.lang", "System")
+  }
+}
+
+/** Holds if `MethodAccess` ma disables SSL endpoint check. */
+predicate isInsecureSSLEndpoint(MethodAccess ma) {
+  (
+    ma.getMethod() instanceof SetSystemPropertyMethod and
+    (
+      ma.getArgument(0).(CompileTimeConstantExpr).getStringValue() =
+        "com.sun.jndi.ldap.object.disableEndpointIdentification" and
+      ma.getArgument(1).(CompileTimeConstantExpr).getStringValue() = "true" //com.sun.jndi.ldap.object.disableEndpointIdentification=true
+    )
+    or
+    ma.getMethod() instanceof SetSystemPropertiesMethod and
+    exists(MethodAccess ma2 |
+      ma2.getMethod() instanceof SetPropertyMethod and
+      ma2.getArgument(0).(CompileTimeConstantExpr).getStringValue() =
+        "com.sun.jndi.ldap.object.disableEndpointIdentification" and
+      ma2.getArgument(1).(CompileTimeConstantExpr).getStringValue() = "true" and //com.sun.jndi.ldap.object.disableEndpointIdentification=true
+      ma2.getQualifier().(VarAccess).getVariable().getAnAccess() = ma.getArgument(0) // systemProps.setProperties(properties)
+    )
+  )
+}
+
+from MethodAccess ma
+where isInsecureSSLEndpoint(ma)
+select ma, "SSL configuration allows insecure endpoint configuration"

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql
@@ -32,7 +32,7 @@ class SetPropertyMethod extends Method {
   }
 }
 
-/** The method to set system properties. */
+/** The `setProperties` method declared in `java.lang.System`. */
 class SetSystemPropertiesMethod extends Method {
   SetSystemPropertiesMethod() {
     this.hasName("setProperties") and
@@ -40,7 +40,7 @@ class SetSystemPropertiesMethod extends Method {
   }
 }
 
-/** Holds if an expression is evaluated to the string literal `com.sun.jndi.ldap.object.disableEndpointIdentification`. */
+/** Holds if `expr` is evaluated to the string literal `com.sun.jndi.ldap.object.disableEndpointIdentification`. */
 predicate isPropertyDisableLdapEndpointId(Expr expr) {
   expr.(CompileTimeConstantExpr).getStringValue() =
     "com.sun.jndi.ldap.object.disableEndpointIdentification"
@@ -72,7 +72,8 @@ predicate isBooleanTrue(Expr expr) {
 
 /** Holds if `ma` is in a test class or method. */
 predicate isTestMethod(MethodAccess ma) {
-  ma.getMethod() instanceof TestMethod or
+  ma.getEnclosingCallable() instanceof TestMethod or
+  ma.getEnclosingCallable().getDeclaringType() instanceof TestClass or
   ma.getEnclosingCallable().getDeclaringType().getPackage().getName().matches("%test%") or
   ma.getEnclosingCallable().getDeclaringType().getName().toLowerCase().matches("%test%")
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint2.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint2.java
@@ -1,4 +1,4 @@
-public class InsecureLdapEndpoint {
+public class InsecureLdapEndpoint2 {
     public Hashtable<String, String> createConnectionEnv() {
         Hashtable<String, String> env = new Hashtable<String, String>();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
@@ -8,9 +8,8 @@ public class InsecureLdapEndpoint {
         env.put(Context.SECURITY_PRINCIPAL, "username");
         env.put(Context.SECURITY_CREDENTIALS, "secpassword");
 
-        // BAD - Test configuration with disabled SSL endpoint check.
+        // GOOD - No configuration to disable SSL endpoint check since it is enabled by default.
         {
-            System.setProperty("com.sun.jndi.ldap.object.disableEndpointIdentification", "true");
         }
 
         return env;

--- a/java/ql/test/experimental/query-tests/security/CWE-297/InsecureLdapEndpoint.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/InsecureLdapEndpoint.expected
@@ -1,2 +1,5 @@
-| InsecureLdapEndpoint.java:17:9:17:92 | setProperty(...) | SSL configuration allows insecure endpoint configuration |
-| InsecureLdapEndpoint.java:48:3:48:34 | setProperties(...) | SSL configuration allows insecure endpoint configuration |
+| InsecureLdapEndpoint.java:19:9:19:92 | setProperty(...) | LDAPS configuration allows insecure endpoint identification |
+| InsecureLdapEndpoint.java:50:9:50:40 | setProperties(...) | LDAPS configuration allows insecure endpoint identification |
+| InsecureLdapEndpoint.java:68:9:68:40 | setProperties(...) | LDAPS configuration allows insecure endpoint identification |
+| InsecureLdapEndpoint.java:84:9:84:94 | setProperty(...) | LDAPS configuration allows insecure endpoint identification |
+| InsecureLdapEndpoint.java:102:9:102:40 | setProperties(...) | LDAPS configuration allows insecure endpoint identification |

--- a/java/ql/test/experimental/query-tests/security/CWE-297/InsecureLdapEndpoint.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/InsecureLdapEndpoint.expected
@@ -1,0 +1,2 @@
+| InsecureLdapEndpoint.java:17:9:17:92 | setProperty(...) | SSL configuration allows insecure endpoint configuration |
+| InsecureLdapEndpoint.java:48:3:48:34 | setProperties(...) | SSL configuration allows insecure endpoint configuration |

--- a/java/ql/test/experimental/query-tests/security/CWE-297/InsecureLdapEndpoint.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/InsecureLdapEndpoint.java
@@ -3,7 +3,9 @@ import java.util.Properties;
 import javax.naming.Context;
 
 public class InsecureLdapEndpoint {
-    // BAD - Test configuration with disabled SSL endpoint check.
+    private static String PROP_DISABLE_LDAP_ENDPOINT_IDENTIFICATION = "com.sun.jndi.ldap.object.disableEndpointIdentification";
+
+    // BAD - Test configuration with disabled LDAPS endpoint check using `System.setProperty()`.
     public Hashtable<String, String> createConnectionEnv() {
         Hashtable<String, String> env = new Hashtable<String, String>();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
@@ -19,7 +21,7 @@ public class InsecureLdapEndpoint {
         return env;
     }
 
-    // GOOD - Test configuration without disabling SSL endpoint check.
+    // GOOD - Test configuration without disabling LDAPS endpoint check.
     public Hashtable<String, String> createConnectionEnv2() {
         Hashtable<String, String> env = new Hashtable<String, String>();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
@@ -32,7 +34,7 @@ public class InsecureLdapEndpoint {
         return env;
     }
 
-    // BAD - Test configuration with disabled SSL endpoint check.
+    // BAD - Test configuration with disabled LDAPS endpoint check using `System.setProperties()`.
     public Hashtable<String, String> createConnectionEnv3() {
         Hashtable<String, String> env = new Hashtable<String, String>();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
@@ -45,6 +47,58 @@ public class InsecureLdapEndpoint {
         // Disable SSL endpoint check
         Properties properties = new Properties();
         properties.setProperty("com.sun.jndi.ldap.object.disableEndpointIdentification", "true");
+        System.setProperties(properties);
+
+        return env;
+    }
+
+    // BAD - Test configuration with disabled LDAPS endpoint check using `HashTable.put()`.
+    public Hashtable<String, String> createConnectionEnv4() {
+        Hashtable<String, String> env = new Hashtable<String, String>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.PROVIDER_URL, "ldaps://ad.your-server.com:636");
+
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        env.put(Context.SECURITY_PRINCIPAL, "username");
+        env.put(Context.SECURITY_CREDENTIALS, "secpassword");
+
+        // Disable SSL endpoint check
+        Properties properties = new Properties();
+        properties.put("com.sun.jndi.ldap.object.disableEndpointIdentification", "true");
+        System.setProperties(properties);
+
+        return env;
+    }
+
+    // BAD - Test configuration with disabled LDAPS endpoint check using the `TRUE` boolean field.
+    public Hashtable<String, String> createConnectionEnv5() {
+        Hashtable<String, String> env = new Hashtable<String, String>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.PROVIDER_URL, "ldaps://ad.your-server.com:636");
+
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        env.put(Context.SECURITY_PRINCIPAL, "username");
+        env.put(Context.SECURITY_CREDENTIALS, "secpassword");
+
+        // Disable SSL endpoint check
+        System.setProperty(PROP_DISABLE_LDAP_ENDPOINT_IDENTIFICATION, Boolean.TRUE.toString());
+
+        return env;
+    }
+
+    // BAD - Test configuration with disabled LDAPS endpoint check using a boolean value.
+    public Hashtable<String, String> createConnectionEnv6() {
+        Hashtable<String, String> env = new Hashtable<String, String>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.PROVIDER_URL, "ldaps://ad.your-server.com:636");
+
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        env.put(Context.SECURITY_PRINCIPAL, "username");
+        env.put(Context.SECURITY_CREDENTIALS, "secpassword");
+
+        // Disable SSL endpoint check
+        Properties properties = new Properties();
+        properties.put("com.sun.jndi.ldap.object.disableEndpointIdentification", true);
         System.setProperties(properties);
 
         return env;

--- a/java/ql/test/experimental/query-tests/security/CWE-297/InsecureLdapEndpoint.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/InsecureLdapEndpoint.java
@@ -1,0 +1,52 @@
+import java.util.Hashtable;
+import java.util.Properties;
+import javax.naming.Context;
+
+public class InsecureLdapEndpoint {
+    // BAD - Test configuration with disabled SSL endpoint check.
+    public Hashtable<String, String> createConnectionEnv() {
+        Hashtable<String, String> env = new Hashtable<String, String>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.PROVIDER_URL, "ldaps://ad.your-server.com:636");
+
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        env.put(Context.SECURITY_PRINCIPAL, "username");
+        env.put(Context.SECURITY_CREDENTIALS, "secpassword");
+
+        // Disable SSL endpoint check
+        System.setProperty("com.sun.jndi.ldap.object.disableEndpointIdentification", "true");
+
+        return env;
+    }
+
+    // GOOD - Test configuration without disabling SSL endpoint check.
+    public Hashtable<String, String> createConnectionEnv2() {
+        Hashtable<String, String> env = new Hashtable<String, String>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.PROVIDER_URL, "ldaps://ad.your-server.com:636");
+
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        env.put(Context.SECURITY_PRINCIPAL, "username");
+        env.put(Context.SECURITY_CREDENTIALS, "secpassword");
+
+        return env;
+    }
+
+    // BAD - Test configuration with disabled SSL endpoint check.
+    public Hashtable<String, String> createConnectionEnv3() {
+        Hashtable<String, String> env = new Hashtable<String, String>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.PROVIDER_URL, "ldaps://ad.your-server.com:636");
+
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        env.put(Context.SECURITY_PRINCIPAL, "username");
+        env.put(Context.SECURITY_CREDENTIALS, "secpassword");
+
+        // Disable SSL endpoint check
+        Properties properties = new Properties();
+        properties.setProperty("com.sun.jndi.ldap.object.disableEndpointIdentification", "true");
+        System.setProperties(properties);
+
+        return env;
+    }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-297/InsecureLdapEndpoint.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/InsecureLdapEndpoint.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql


### PR DESCRIPTION
Java versions 8u181 or greater have enabled LDAPS endpoint identification by default to improve the security. Nowadays infrastructure services like LDAP are commonly deployed behind load balancers therefore the LDAP server name can be different from the FQDN of the LDAPS endpoint. If a service certificate does not properly contain a matching DNS name as part of the certificate, Java will reject it by default.

Instead of addressing the issue properly by having a compliant certificate deployed, frequently developers simply disable SSL endpoint check.

Failing to validate the certificate makes the SSL session susceptible to a man-in-the-middle attack. This query checks whether LDAPS endpoint check is disabled in system properties.

Please consider to merge the PR. Thanks.
