### PR TITLE
C++: Refactor IdentityFunction.qll.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/IdentityFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/IdentityFunction.qll
@@ -6,12 +6,9 @@ import semmle.code.cpp.models.interfaces.SideEffect
 /**
  * The standard function templates `std::move` and `std::forward`.
  */
-private class IdentityFunction extends DataFlowFunction, SideEffectFunction, AliasFunction {
-  IdentityFunction() {
-    this.getNamespace().getParentNamespace() instanceof GlobalNamespace and
-    this.getNamespace().getName() = "std" and
-    this.getName() = ["move", "forward"]
-  }
+private class IdentityFunction extends DataFlowFunction, SideEffectFunction, AliasFunction,
+  FunctionTemplateInstantiation {
+  IdentityFunction() { this.hasQualifiedName("std", ["move", "forward"]) }
 
   override predicate hasOnlySpecificReadSideEffects() { any() }
 


### PR DESCRIPTION
In my understanding, BSL doesn't contain the modelled functions.
I didn't create a separate private class, as we use the `hasQualifiedName` only once.