### PR TITLE
C++: Model vector versions of BSD-style reads and writes.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Recv.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Recv.qll
@@ -18,7 +18,10 @@ private class Recv extends AliasFunction, ArrayFunction, SideEffectFunction,
         "recvfrom", // recvfrom(socket, dest, len, flags, from, fromlen)
         "recvmsg", // recvmsg(socket, msg, flags)
         "read", // read(socket, dest, len)
-        "pread" // pread(socket, dest, len, offset)
+        "pread", // pread(socket, dest, len, offset)
+        "readv", // readv(socket, dest, len)
+        "preadv", // readv(socket, dest, len, offset)
+        "preadv2" // readv2(socket, dest, len, offset, flags)
       ])
   }
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Send.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Send.qll
@@ -16,7 +16,10 @@ private class Send extends AliasFunction, ArrayFunction, SideEffectFunction, Rem
         "send", // send(socket, buf, len, flags)
         "sendto", // sendto(socket, buf, len, flags, to, tolen)
         "sendmsg", // sendmsg(socket, msg, flags)
-        "write" // write(socket, buf, len);
+        "write", // write(socket, buf, len)
+        "writev", // writev(socket, buf, len)
+        "pwritev", // pwritev(socket, buf, len, offset)
+        "pwritev2" // pwritev2(socket, buf, len, offset, flags)
       ])
   }
 

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/annotate_sinks_only/defaulttainttracking.cpp
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/annotate_sinks_only/defaulttainttracking.cpp
@@ -228,10 +228,34 @@ void test_recv() {
 	sink(*buffer); // $ ast,ir
 }
 
-// --- send ---
+// --- send and related functions ---
 
 int send(int, const void*, int, int);
 
 void test_send(char* buffer, int length) {
   send(0, buffer, length, 0); // $ remote
+}
+
+struct iovec {
+  void  *iov_base;
+  unsigned iov_len;
+};
+
+int readv(int, const struct iovec*, int);
+int writev(int, const struct iovec*, int);
+
+void sink(const iovec* iovs);
+void sink(iovec);
+
+int test_readv_and_writev(iovec* iovs) {
+  readv(0, iovs, 16);
+  sink(iovs); // $ast,ir
+  sink(iovs[0]); // $ast MISSING: ir
+  sink(*iovs); // $ast MISSING: ir
+
+  char* p = (char*)iovs[1].iov_base;
+  sink(p); // $ MISSING: ast,ir
+  sink(*p); // $ MISSING: ast,ir
+
+  writev(0, iovs, 16); // $ remote
 }


### PR DESCRIPTION
Part of https://github.com/github/codeql-c-analysis-team/issues/209. I was planning on including `getsockopt` and `setsockopt`, but they have some interesting flow that I would like to discuss on the issue before making a PR with those changes.

(cc @rdmarsh2)