### PR TITLE
Java: Add support for commons-lang's StrBuilder class

### DIFF
--- a/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
+++ b/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
@@ -123,8 +123,8 @@ private class ApacheStringUtilsTaintPreservingMethod extends TaintPreservingCall
  * A method declared on Apache Commons Lang's `StrBuilder`, or the same class or its
  * renamed version `TextStringBuilder` in Commons Text.
  */
-class ApacheStrBuilderMethod extends Method {
-  ApacheStrBuilderMethod() {
+class ApacheStrBuilderCallable extends Callable {
+  ApacheStrBuilderCallable() {
     this.getDeclaringType().hasQualifiedName("org.apache.commons.lang3.text", "StrBuilder") or
     this.getDeclaringType()
         .hasQualifiedName("org.apache.commons.text", ["StrBuilder", "TextStringBuilder"])
@@ -134,8 +134,11 @@ class ApacheStrBuilderMethod extends Method {
 /**
  * An Apache Commons Lang StrBuilder method that adds taint to the StrBuilder.
  */
-private class ApacheStrBuilderTaintingMethod extends ApacheStrBuilderMethod, TaintPreservingCallable {
+private class ApacheStrBuilderTaintingMethod extends ApacheStrBuilderCallable,
+  TaintPreservingCallable {
   ApacheStrBuilderTaintingMethod() {
+    this instanceof Constructor
+    or
     this.hasName([
         "append", "appendAll", "appendFixedWidthPadLeft", "appendFixedWidthPadRight", "appendln",
         "appendSeparator", "appendWithSeparators", "insert", "readFrom", "replace", "replaceAll",
@@ -170,12 +173,14 @@ private class ApacheStrBuilderTaintingMethod extends ApacheStrBuilderMethod, Tai
       this.consumesTaintFromAllArgs() and fromArg in [0 .. this.getNumberOfParameters() - 1]
     )
   }
+
+  override predicate returnsTaintFrom(int arg) { this instanceof Constructor and arg = 0 }
 }
 
 /**
  * An Apache Commons Lang StrBuilder method that returns taint from the StrBuilder.
  */
-private class ApacheStrBuilderTaintGetter extends ApacheStrBuilderMethod, TaintPreservingCallable {
+private class ApacheStrBuilderTaintGetter extends ApacheStrBuilderCallable, TaintPreservingCallable {
   ApacheStrBuilderTaintGetter() {
     // Taint getters:
     this.hasName([
@@ -193,7 +198,7 @@ private class ApacheStrBuilderTaintGetter extends ApacheStrBuilderMethod, TaintP
 /**
  * An Apache Commons Lang StrBuilder method that writes taint from the StrBuilder to some parameter.
  */
-private class ApacheStrBuilderTaintWriter extends ApacheStrBuilderMethod, TaintPreservingCallable {
+private class ApacheStrBuilderTaintWriter extends ApacheStrBuilderCallable, TaintPreservingCallable {
   ApacheStrBuilderTaintWriter() { this.hasName(["appendTo", "getChars"]) }
 
   override predicate transfersTaint(int fromArg, int toArg) {

--- a/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
+++ b/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
@@ -132,7 +132,7 @@ class ApacheStrBuilderCallable extends Callable {
 }
 
 /**
- * An Apache Commons Lang StrBuilder method that adds taint to the StrBuilder.
+ * An Apache Commons Lang `StrBuilder` method that adds taint to the `StrBuilder`.
  */
 private class ApacheStrBuilderTaintingMethod extends ApacheStrBuilderCallable,
   TaintPreservingCallable {
@@ -178,7 +178,7 @@ private class ApacheStrBuilderTaintingMethod extends ApacheStrBuilderCallable,
 }
 
 /**
- * An Apache Commons Lang StrBuilder method that returns taint from the StrBuilder.
+ * An Apache Commons Lang `StrBuilder` method that returns taint from the `StrBuilder`.
  */
 private class ApacheStrBuilderTaintGetter extends ApacheStrBuilderCallable, TaintPreservingCallable {
   ApacheStrBuilderTaintGetter() {
@@ -196,20 +196,18 @@ private class ApacheStrBuilderTaintGetter extends ApacheStrBuilderCallable, Tain
 }
 
 /**
- * An Apache Commons Lang StrBuilder method that writes taint from the StrBuilder to some parameter.
+ * An Apache Commons Lang `StrBuilder` method that writes taint from the `StrBuilder` to some parameter.
  */
 private class ApacheStrBuilderTaintWriter extends ApacheStrBuilderCallable, TaintPreservingCallable {
   ApacheStrBuilderTaintWriter() { this.hasName(["appendTo", "getChars"]) }
 
   override predicate transfersTaint(int fromArg, int toArg) {
     fromArg = -1 and
-    (
-      // appendTo(Readable) and getChars(char[])
-      if this.getNumberOfParameters() = 1
-      then toArg = 0
-      else
-        // getChars(int, int, char[], int)
-        toArg = 2
-    )
+    // appendTo(Readable) and getChars(char[])
+    if this.getNumberOfParameters() = 1
+    then toArg = 0
+    else
+      // getChars(int, int, char[], int)
+      toArg = 2
   }
 }

--- a/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
+++ b/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
@@ -144,7 +144,7 @@ private class ApacheStrBuilderTaintingMethod extends ApacheStrBuilderMethod, Tai
   }
 
   private predicate consumesTaintFromAllArgs() {
-    // Specifically the append[ln](String, Object...) overloads also consume taint from its other arguments:
+    // Specifically the append[ln](String, Object...) overloads also consume taint from their other arguments:
     this.getName() in ["appendAll", "appendWithSeparators"]
     or
     this.getName() = ["append", "appendln"] and this.getAParameter().isVarargs()
@@ -167,7 +167,7 @@ private class ApacheStrBuilderTaintingMethod extends ApacheStrBuilderMethod, Tai
         else fromArg = 1
       )
       or
-      consumesTaintFromAllArgs() and fromArg in [0 .. this.getNumberOfParameters() - 1]
+      this.consumesTaintFromAllArgs() and fromArg in [0 .. this.getNumberOfParameters() - 1]
     )
   }
 }

--- a/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
+++ b/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
@@ -122,14 +122,14 @@ private class ApacheStringUtilsTaintPreservingMethod extends TaintPreservingCall
 /**
  * A method declared on `org.apache.commons.lang3.text.StrBuilder`.
  */
-abstract class ApacheStrBuilderMethod extends Callable {
+class ApacheStrBuilderMethod extends Method {
   ApacheStrBuilderMethod() {
     this.getDeclaringType().hasQualifiedName("org.apache.commons.lang3.text", "StrBuilder")
   }
 }
 
 /**
- * An Apache Commons-Lang StrBuilder methods that add taint to the StrBuilder.
+ * An Apache Commons Lang StrBuilder method that adds taint to the StrBuilder.
  */
 private class ApacheStrBuilderTaintingMethod extends ApacheStrBuilderMethod, TaintPreservingCallable {
   ApacheStrBuilderTaintingMethod() {
@@ -170,7 +170,7 @@ private class ApacheStrBuilderTaintingMethod extends ApacheStrBuilderMethod, Tai
 }
 
 /**
- * An Apache Commons-Lang StrBuilder methods that return taint from the StrBuilder.
+ * An Apache Commons Lang StrBuilder method that returns taint from the StrBuilder.
  */
 private class ApacheStrBuilderTaintGetter extends ApacheStrBuilderMethod, TaintPreservingCallable {
   ApacheStrBuilderTaintGetter() {
@@ -188,7 +188,7 @@ private class ApacheStrBuilderTaintGetter extends ApacheStrBuilderMethod, TaintP
 }
 
 /**
- * An Apache Commons-Lang StrBuilder methods that write taint from the StrBuilder to some parameter.
+ * An Apache Commons Lang StrBuilder method that writes taint from the StrBuilder to some parameter.
  */
 private class ApacheStrBuilderTaintWriter extends ApacheStrBuilderMethod, TaintPreservingCallable {
   ApacheStrBuilderTaintWriter() { this.hasName(["appendTo", "getChars"]) }

--- a/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
+++ b/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
@@ -120,11 +120,14 @@ private class ApacheStringUtilsTaintPreservingMethod extends TaintPreservingCall
 }
 
 /**
- * A method declared on `org.apache.commons.lang3.text.StrBuilder`.
+ * A method declared on Apache Commons Lang's `StrBuilder`, or the same class or its
+ * renamed version `TextStringBuilder` in Commons Text.
  */
 class ApacheStrBuilderMethod extends Method {
   ApacheStrBuilderMethod() {
-    this.getDeclaringType().hasQualifiedName("org.apache.commons.lang3.text", "StrBuilder")
+    this.getDeclaringType().hasQualifiedName("org.apache.commons.lang3.text", "StrBuilder") or
+    this.getDeclaringType()
+        .hasQualifiedName("org.apache.commons.text", ["StrBuilder", "TextStringBuilder"])
   }
 }
 

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTest.java
@@ -1,0 +1,132 @@
+import org.apache.commons.lang3.builder.Builder;
+import org.apache.commons.lang3.text.StrBuilder;
+import org.apache.commons.lang3.text.StrMatcher;
+import org.apache.commons.lang3.text.StrTokenizer;
+import java.io.StringReader;
+import java.nio.CharBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+class StrBuilderTest {
+    String taint() { return "tainted"; }
+
+    void sink(Object o) {}
+
+    void test() throws Exception {
+
+        StrBuilder sb1 = new StrBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
+        StrBuilder sb2 = new StrBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
+        StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // BAD (but not detected because we don't model CharBuffer yet)
+        StrBuilder sb4 = new StrBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // BAD (but not detected because we don't model CharBuffer yet)
+        StrBuilder sb5 = new StrBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow=y
+        StrBuilder sb6 = new StrBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow=y
+        StrBuilder sb7 = new StrBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow=y
+        {
+            StrBuilder auxsb = new StrBuilder(); auxsb.append(taint());
+            StrBuilder sb8 = new StrBuilder(); sb8.append(auxsb); sink(sb8.toString()); // $hasTaintFlow=y
+        }
+        StrBuilder sb9 = new StrBuilder(); sb9.append(new StringBuffer(taint())); sink(sb9.toString()); // $hasTaintFlow=y
+        StrBuilder sb10 = new StrBuilder(); sb10.append(new StringBuffer(taint()), 0, 0); sink(sb10.toString()); // $hasTaintFlow=y
+        StrBuilder sb11 = new StrBuilder(); sb11.append(new StringBuilder(taint())); sink(sb11.toString()); // $hasTaintFlow=y
+        StrBuilder sb12 = new StrBuilder(); sb12.append(new StringBuilder(taint()), 0, 0); sink(sb12.toString()); // $hasTaintFlow=y
+        StrBuilder sb13 = new StrBuilder(); sb13.append(taint()); sink(sb13.toString()); // $hasTaintFlow=y
+        StrBuilder sb14 = new StrBuilder(); sb14.append(taint(), 0, 0); sink(sb14.toString()); // $hasTaintFlow=y
+        StrBuilder sb15 = new StrBuilder(); sb15.append(taint(), "format", "args"); sink(sb15.toString()); // $hasTaintFlow=y
+        StrBuilder sb16 = new StrBuilder(); sb16.append("Format string", taint(), "args"); sink(sb16.toString()); // $hasTaintFlow=y
+        {
+            List<String> taintedList = new ArrayList<>();
+            taintedList.add(taint());
+            StrBuilder sb17 = new StrBuilder(); sb17.appendAll(taintedList); sink(sb17.toString()); // $hasTaintFlow=y
+            StrBuilder sb18 = new StrBuilder(); sb18.appendAll(taintedList.iterator()); sink(sb18.toString()); // $hasTaintFlow=y
+        }
+        StrBuilder sb19 = new StrBuilder(); sb19.appendAll("clean", taint()); sink(sb19.toString()); // $hasTaintFlow=y
+        StrBuilder sb20 = new StrBuilder(); sb20.appendAll(taint(), "clean"); sink(sb20.toString()); // $hasTaintFlow=y
+        StrBuilder sb21 = new StrBuilder(); sb21.appendFixedWidthPadLeft(taint(), 0, ' '); sink(sb21.toString()); // $hasTaintFlow=y
+        StrBuilder sb22 = new StrBuilder(); sb22.appendFixedWidthPadRight(taint(), 0, ' '); sink(sb22.toString()); // $hasTaintFlow=y
+        StrBuilder sb23 = new StrBuilder(); sb23.appendln(taint().toCharArray()); sink(sb23.toString()); // $hasTaintFlow=y
+        StrBuilder sb24 = new StrBuilder(); sb24.appendln(taint().toCharArray(), 0, 0); sink(sb24.toString()); // $hasTaintFlow=y
+        StrBuilder sb25 = new StrBuilder(); sb25.appendln((Object)taint()); sink(sb25.toString()); // $hasTaintFlow=y
+        {
+            StrBuilder auxsb = new StrBuilder(); auxsb.appendln(taint());
+            StrBuilder sb26 = new StrBuilder(); sb26.appendln(auxsb); sink(sb26.toString()); // $hasTaintFlow=y
+        }
+        StrBuilder sb27 = new StrBuilder(); sb27.appendln(new StringBuffer(taint())); sink(sb27.toString()); // $hasTaintFlow=y
+        StrBuilder sb28 = new StrBuilder(); sb28.appendln(new StringBuffer(taint()), 0, 0); sink(sb28.toString()); // $hasTaintFlow=y
+        StrBuilder sb29 = new StrBuilder(); sb29.appendln(new StringBuilder(taint())); sink(sb29.toString()); // $hasTaintFlow=y
+        StrBuilder sb30 = new StrBuilder(); sb30.appendln(new StringBuilder(taint()), 0, 0); sink(sb30.toString()); // $hasTaintFlow=y
+        StrBuilder sb31 = new StrBuilder(); sb31.appendln(taint()); sink(sb31.toString()); // $hasTaintFlow=y
+        StrBuilder sb32 = new StrBuilder(); sb32.appendln(taint(), 0, 0); sink(sb32.toString()); // $hasTaintFlow=y
+        StrBuilder sb33 = new StrBuilder(); sb33.appendln(taint(), "format", "args"); sink(sb33.toString()); // $hasTaintFlow=y
+        StrBuilder sb34 = new StrBuilder(); sb34.appendln("Format string", taint(), "args"); sink(sb34.toString()); // $hasTaintFlow=y
+        StrBuilder sb35 = new StrBuilder(); sb35.appendSeparator(taint()); sink(sb35.toString()); // $hasTaintFlow=y
+        StrBuilder sb36 = new StrBuilder(); sb36.appendSeparator(taint(), 0); sink(sb36.toString()); // $hasTaintFlow=y
+        StrBuilder sb37 = new StrBuilder(); sb37.appendSeparator(taint(), "default"); sink(sb37.toString()); // $hasTaintFlow=y
+        StrBuilder sb38 = new StrBuilder(); sb38.appendSeparator("", taint()); sink(sb38.toString()); // $hasTaintFlow=y
+        {
+            StrBuilder auxsb = new StrBuilder(); auxsb.appendln(taint());
+            StrBuilder sb39 = new StrBuilder(); auxsb.appendTo(sb39); sink(sb39.toString()); // $hasTaintFlow=y
+        }
+        {
+            List<String> taintedList = new ArrayList<>();
+            taintedList.add(taint());
+            StrBuilder sb40 = new StrBuilder(); sb40.appendWithSeparators(taintedList, ", "); sink(sb40.toString()); // $hasTaintFlow=y
+            StrBuilder sb41 = new StrBuilder(); sb41.appendWithSeparators(taintedList.iterator(), ", "); sink(sb41.toString()); // $hasTaintFlow=y
+            List<String> untaintedList = new ArrayList<>();
+            StrBuilder sb42 = new StrBuilder(); sb42.appendWithSeparators(untaintedList, taint()); sink(sb42.toString()); // $hasTaintFlow=y
+            StrBuilder sb43 = new StrBuilder(); sb43.appendWithSeparators(untaintedList.iterator(), taint()); sink(sb43.toString()); // $hasTaintFlow=y
+            String[] taintedArray = new String[] { taint() };
+            String[] untaintedArray = new String[] {};
+            StrBuilder sb44 = new StrBuilder(); sb44.appendWithSeparators(taintedArray, ", "); sink(sb44.toString()); // $hasTaintFlow=y
+            StrBuilder sb45 = new StrBuilder(); sb45.appendWithSeparators(untaintedArray, taint()); sink(sb45.toString()); // $hasTaintFlow=y
+        }
+        {
+            StrBuilder sb46 = new StrBuilder(); sb46.append(taint());
+            char[] target = new char[100];
+            sb46.asReader().read(target);
+            sink(target); // $hasTaintFlow=y
+        }
+        StrBuilder sb47 = new StrBuilder(); sb47.append(taint()); sink(sb47.asTokenizer().next()); // $hasTaintFlow=y
+        StrBuilder sb48 = new StrBuilder(); sb48.append(taint()); sink(sb48.build()); // $hasTaintFlow=y
+        StrBuilder sb49 = new StrBuilder(); sb49.append(taint()); sink(sb49.getChars(null)); // $hasTaintFlow=y
+        {
+            StrBuilder sb50 = new StrBuilder(); sb50.append(taint());
+            char[] target = new char[100];
+            sb50.getChars(target);
+            sink(target); // $hasTaintFlow=y
+        }
+        {
+            StrBuilder sb51 = new StrBuilder(); sb51.append(taint());
+            char[] target = new char[100];
+            sb51.getChars(0, 0, target, 0);
+            sink(target); // $hasTaintFlow=y
+        }
+        StrBuilder sb52 = new StrBuilder(); sb52.insert(0, taint().toCharArray()); sink(sb52.toString()); // $hasTaintFlow=y
+        StrBuilder sb53 = new StrBuilder(); sb53.insert(0, taint().toCharArray(), 0, 0); sink(sb53.toString()); // $hasTaintFlow=y
+        StrBuilder sb54 = new StrBuilder(); sb54.insert(0, taint()); sink(sb54.toString()); // $hasTaintFlow=y
+        StrBuilder sb55 = new StrBuilder(); sb55.insert(0, (Object)taint()); sink(sb55.toString()); // $hasTaintFlow=y
+        StrBuilder sb56 = new StrBuilder(); sb56.append(taint()); sink(sb56.leftString(0)); // $hasTaintFlow=y
+        StrBuilder sb57 = new StrBuilder(); sb57.append(taint()); sink(sb57.midString(0, 0)); // $hasTaintFlow=y
+        {
+            StringReader reader = new StringReader(taint());
+            StrBuilder sb58 = new StrBuilder(); sb58.readFrom(reader); sink(sb58.toString()); // $hasTaintFlow=y
+        }
+        StrBuilder sb59 = new StrBuilder(); sb59.replace(0, 0, taint()); sink(sb59.toString()); // $hasTaintFlow=y
+        StrBuilder sb60 = new StrBuilder(); sb60.replace(null, taint(), 0, 0, 0); sink(sb60.toString()); // $hasTaintFlow=y
+        StrBuilder sb61 = new StrBuilder(); sb61.replaceAll((StrMatcher)null, taint()); sink(sb61.toString()); // $hasTaintFlow=y
+        StrBuilder sb62 = new StrBuilder(); sb62.replaceAll("search", taint()); sink(sb62.toString()); // $hasTaintFlow=y
+        StrBuilder sb63 = new StrBuilder(); sb63.replaceAll(taint(), "replace"); sink(sb63.toString()); // GOOD (search string doesn't convey taint)
+        StrBuilder sb64 = new StrBuilder(); sb64.replaceFirst((StrMatcher)null, taint()); sink(sb64.toString()); // $hasTaintFlow=y
+        StrBuilder sb65 = new StrBuilder(); sb65.replaceFirst("search", taint()); sink(sb65.toString()); // $hasTaintFlow=y
+        StrBuilder sb66 = new StrBuilder(); sb66.replaceFirst(taint(), "replace"); sink(sb66.toString()); // GOOD (search string doesn't convey taint)
+        StrBuilder sb67 = new StrBuilder(); sb67.append(taint()); sink(sb67.rightString(0)); // $hasTaintFlow=y
+        StrBuilder sb68 = new StrBuilder(); sb68.append(taint()); sink(sb68.subSequence(0, 0)); // $hasTaintFlow=y
+        StrBuilder sb69 = new StrBuilder(); sb69.append(taint()); sink(sb69.substring(0)); // $hasTaintFlow=y
+        StrBuilder sb70 = new StrBuilder(); sb70.append(taint()); sink(sb70.substring(0, 0)); // $hasTaintFlow=y
+        StrBuilder sb71 = new StrBuilder(); sb71.append(taint()); sink(sb71.toCharArray()); // $hasTaintFlow=y
+        StrBuilder sb72 = new StrBuilder(); sb72.append(taint()); sink(sb72.toCharArray(0, 0)); // $hasTaintFlow=y
+        StrBuilder sb73 = new StrBuilder(); sb73.append(taint()); sink(sb73.toStringBuffer()); // $hasTaintFlow=y
+        StrBuilder sb74 = new StrBuilder(); sb74.append(taint()); sink(sb74.toStringBuilder()); // $hasTaintFlow=y
+    }
+
+}

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTest.java
@@ -14,6 +14,8 @@ class StrBuilderTest {
 
     void test() throws Exception {
 
+        StrBuilder cons1 = new StrBuilder(taint()); sink(cons1.toString()); // $hasTaintFlow=y
+
         StrBuilder sb1 = new StrBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
         StrBuilder sb2 = new StrBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
         StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // BAD (but not detected because we don't model CharBuffer yet)

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTest.java
@@ -18,8 +18,8 @@ class StrBuilderTest {
 
         StrBuilder sb1 = new StrBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
         StrBuilder sb2 = new StrBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
-        StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // BAD (but not detected because we don't model CharBuffer yet)
-        StrBuilder sb4 = new StrBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // BAD (but not detected because we don't model CharBuffer yet)
+        StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // $ MISSING: hasTaintFlow=y
+        StrBuilder sb4 = new StrBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // $ MISSING: hasTaintFlow=y
         StrBuilder sb5 = new StrBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow=y
         StrBuilder sb6 = new StrBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow=y
         StrBuilder sb7 = new StrBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow=y

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTextTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTextTest.java
@@ -18,8 +18,8 @@ class StrBuilderTextTest {
 
         StrBuilder sb1 = new StrBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
         StrBuilder sb2 = new StrBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
-        StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // BAD (but not detected because we don't model CharBuffer yet)
-        StrBuilder sb4 = new StrBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // BAD (but not detected because we don't model CharBuffer yet)
+        StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // $ MISSING: hasTaintFlow=y
+        StrBuilder sb4 = new StrBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // $ MISSING: hasTaintFlow=y
         StrBuilder sb5 = new StrBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow=y
         StrBuilder sb6 = new StrBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow=y
         StrBuilder sb7 = new StrBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow=y

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTextTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTextTest.java
@@ -1,13 +1,13 @@
-import org.apache.commons.lang3.text.StrBuilder;
-import org.apache.commons.lang3.text.StrMatcher;
-import org.apache.commons.lang3.text.StrTokenizer;
+import org.apache.commons.text.StrBuilder;
+import org.apache.commons.text.StrMatcher;
+import org.apache.commons.text.StrTokenizer;
 import java.io.StringReader;
 import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-class StrBuilderTest {
+class StrBuilderTextTest {
     String taint() { return "tainted"; }
 
     void sink(Object o) {}

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTextTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTextTest.java
@@ -14,6 +14,8 @@ class StrBuilderTextTest {
 
     void test() throws Exception {
 
+        StrBuilder cons1 = new StrBuilder(taint()); sink(cons1.toString()); // $hasTaintFlow=y
+
         StrBuilder sb1 = new StrBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
         StrBuilder sb2 = new StrBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
         StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // BAD (but not detected because we don't model CharBuffer yet)

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/TextStringBuilderTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/TextStringBuilderTest.java
@@ -19,8 +19,8 @@ class TextStringBuilderTest {
 
         TextStringBuilder sb1 = new TextStringBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
         TextStringBuilder sb2 = new TextStringBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb3 = new TextStringBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // BAD (but not detected because we don't model CharBuffer yet)
-        TextStringBuilder sb4 = new TextStringBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // BAD (but not detected because we don't model CharBuffer yet)
+        TextStringBuilder sb3 = new TextStringBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // $ MISSING: hasTaintFlow=y
+        TextStringBuilder sb4 = new TextStringBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // $ MISSING: hasTaintFlow=y
         TextStringBuilder sb5 = new TextStringBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow=y
         TextStringBuilder sb6 = new TextStringBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow=y
         TextStringBuilder sb7 = new TextStringBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow=y

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/TextStringBuilderTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/TextStringBuilderTest.java
@@ -1,0 +1,131 @@
+import org.apache.commons.text.TextStringBuilder;
+import org.apache.commons.text.matcher.StringMatcher;
+import org.apache.commons.text.StringTokenizer;
+import java.io.StringReader;
+import java.nio.CharBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+class TextStringBuilderTest {
+    String taint() { return "tainted"; }
+
+    void sink(Object o) {}
+
+    void test() throws Exception {
+
+        TextStringBuilder sb1 = new TextStringBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb2 = new TextStringBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb3 = new TextStringBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // BAD (but not detected because we don't model CharBuffer yet)
+        TextStringBuilder sb4 = new TextStringBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // BAD (but not detected because we don't model CharBuffer yet)
+        TextStringBuilder sb5 = new TextStringBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb6 = new TextStringBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb7 = new TextStringBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow=y
+        {
+            TextStringBuilder auxsb = new TextStringBuilder(); auxsb.append(taint());
+            TextStringBuilder sb8 = new TextStringBuilder(); sb8.append(auxsb); sink(sb8.toString()); // $hasTaintFlow=y
+        }
+        TextStringBuilder sb9 = new TextStringBuilder(); sb9.append(new StringBuffer(taint())); sink(sb9.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb10 = new TextStringBuilder(); sb10.append(new StringBuffer(taint()), 0, 0); sink(sb10.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb11 = new TextStringBuilder(); sb11.append(new StringBuilder(taint())); sink(sb11.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb12 = new TextStringBuilder(); sb12.append(new StringBuilder(taint()), 0, 0); sink(sb12.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb13 = new TextStringBuilder(); sb13.append(taint()); sink(sb13.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb14 = new TextStringBuilder(); sb14.append(taint(), 0, 0); sink(sb14.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb15 = new TextStringBuilder(); sb15.append(taint(), "format", "args"); sink(sb15.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb16 = new TextStringBuilder(); sb16.append("Format string", taint(), "args"); sink(sb16.toString()); // $hasTaintFlow=y
+        {
+            List<String> taintedList = new ArrayList<>();
+            taintedList.add(taint());
+            TextStringBuilder sb17 = new TextStringBuilder(); sb17.appendAll(taintedList); sink(sb17.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb18 = new TextStringBuilder(); sb18.appendAll(taintedList.iterator()); sink(sb18.toString()); // $hasTaintFlow=y
+        }
+        TextStringBuilder sb19 = new TextStringBuilder(); sb19.appendAll("clean", taint()); sink(sb19.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb20 = new TextStringBuilder(); sb20.appendAll(taint(), "clean"); sink(sb20.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb21 = new TextStringBuilder(); sb21.appendFixedWidthPadLeft(taint(), 0, ' '); sink(sb21.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb22 = new TextStringBuilder(); sb22.appendFixedWidthPadRight(taint(), 0, ' '); sink(sb22.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb23 = new TextStringBuilder(); sb23.appendln(taint().toCharArray()); sink(sb23.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb24 = new TextStringBuilder(); sb24.appendln(taint().toCharArray(), 0, 0); sink(sb24.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb25 = new TextStringBuilder(); sb25.appendln((Object)taint()); sink(sb25.toString()); // $hasTaintFlow=y
+        {
+            TextStringBuilder auxsb = new TextStringBuilder(); auxsb.appendln(taint());
+            TextStringBuilder sb26 = new TextStringBuilder(); sb26.appendln(auxsb); sink(sb26.toString()); // $hasTaintFlow=y
+        }
+        TextStringBuilder sb27 = new TextStringBuilder(); sb27.appendln(new StringBuffer(taint())); sink(sb27.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb28 = new TextStringBuilder(); sb28.appendln(new StringBuffer(taint()), 0, 0); sink(sb28.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb29 = new TextStringBuilder(); sb29.appendln(new StringBuilder(taint())); sink(sb29.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb30 = new TextStringBuilder(); sb30.appendln(new StringBuilder(taint()), 0, 0); sink(sb30.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb31 = new TextStringBuilder(); sb31.appendln(taint()); sink(sb31.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb32 = new TextStringBuilder(); sb32.appendln(taint(), 0, 0); sink(sb32.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb33 = new TextStringBuilder(); sb33.appendln(taint(), "format", "args"); sink(sb33.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb34 = new TextStringBuilder(); sb34.appendln("Format string", taint(), "args"); sink(sb34.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb35 = new TextStringBuilder(); sb35.appendSeparator(taint()); sink(sb35.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb36 = new TextStringBuilder(); sb36.appendSeparator(taint(), 0); sink(sb36.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb37 = new TextStringBuilder(); sb37.appendSeparator(taint(), "default"); sink(sb37.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb38 = new TextStringBuilder(); sb38.appendSeparator("", taint()); sink(sb38.toString()); // $hasTaintFlow=y
+        {
+            TextStringBuilder auxsb = new TextStringBuilder(); auxsb.appendln(taint());
+            TextStringBuilder sb39 = new TextStringBuilder(); auxsb.appendTo(sb39); sink(sb39.toString()); // $hasTaintFlow=y
+        }
+        {
+            List<String> taintedList = new ArrayList<>();
+            taintedList.add(taint());
+            TextStringBuilder sb40 = new TextStringBuilder(); sb40.appendWithSeparators(taintedList, ", "); sink(sb40.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb41 = new TextStringBuilder(); sb41.appendWithSeparators(taintedList.iterator(), ", "); sink(sb41.toString()); // $hasTaintFlow=y
+            List<String> untaintedList = new ArrayList<>();
+            TextStringBuilder sb42 = new TextStringBuilder(); sb42.appendWithSeparators(untaintedList, taint()); sink(sb42.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb43 = new TextStringBuilder(); sb43.appendWithSeparators(untaintedList.iterator(), taint()); sink(sb43.toString()); // $hasTaintFlow=y
+            String[] taintedArray = new String[] { taint() };
+            String[] untaintedArray = new String[] {};
+            TextStringBuilder sb44 = new TextStringBuilder(); sb44.appendWithSeparators(taintedArray, ", "); sink(sb44.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb45 = new TextStringBuilder(); sb45.appendWithSeparators(untaintedArray, taint()); sink(sb45.toString()); // $hasTaintFlow=y
+        }
+        {
+            TextStringBuilder sb46 = new TextStringBuilder(); sb46.append(taint());
+            char[] target = new char[100];
+            sb46.asReader().read(target);
+            sink(target); // $hasTaintFlow=y
+        }
+        TextStringBuilder sb47 = new TextStringBuilder(); sb47.append(taint()); sink(sb47.asTokenizer().next()); // $hasTaintFlow=y
+        TextStringBuilder sb48 = new TextStringBuilder(); sb48.append(taint()); sink(sb48.build()); // $hasTaintFlow=y
+        TextStringBuilder sb49 = new TextStringBuilder(); sb49.append(taint()); sink(sb49.getChars(null)); // $hasTaintFlow=y
+        {
+            TextStringBuilder sb50 = new TextStringBuilder(); sb50.append(taint());
+            char[] target = new char[100];
+            sb50.getChars(target);
+            sink(target); // $hasTaintFlow=y
+        }
+        {
+            TextStringBuilder sb51 = new TextStringBuilder(); sb51.append(taint());
+            char[] target = new char[100];
+            sb51.getChars(0, 0, target, 0);
+            sink(target); // $hasTaintFlow=y
+        }
+        TextStringBuilder sb52 = new TextStringBuilder(); sb52.insert(0, taint().toCharArray()); sink(sb52.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb53 = new TextStringBuilder(); sb53.insert(0, taint().toCharArray(), 0, 0); sink(sb53.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb54 = new TextStringBuilder(); sb54.insert(0, taint()); sink(sb54.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb55 = new TextStringBuilder(); sb55.insert(0, (Object)taint()); sink(sb55.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb56 = new TextStringBuilder(); sb56.append(taint()); sink(sb56.leftString(0)); // $hasTaintFlow=y
+        TextStringBuilder sb57 = new TextStringBuilder(); sb57.append(taint()); sink(sb57.midString(0, 0)); // $hasTaintFlow=y
+        {
+            StringReader reader = new StringReader(taint());
+            TextStringBuilder sb58 = new TextStringBuilder(); sb58.readFrom(reader); sink(sb58.toString()); // $hasTaintFlow=y
+        }
+        TextStringBuilder sb59 = new TextStringBuilder(); sb59.replace(0, 0, taint()); sink(sb59.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb60 = new TextStringBuilder(); sb60.replace(null, taint(), 0, 0, 0); sink(sb60.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb61 = new TextStringBuilder(); sb61.replaceAll((StringMatcher)null, taint()); sink(sb61.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb62 = new TextStringBuilder(); sb62.replaceAll("search", taint()); sink(sb62.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb63 = new TextStringBuilder(); sb63.replaceAll(taint(), "replace"); sink(sb63.toString()); // GOOD (search string doesn't convey taint)
+        TextStringBuilder sb64 = new TextStringBuilder(); sb64.replaceFirst((StringMatcher)null, taint()); sink(sb64.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb65 = new TextStringBuilder(); sb65.replaceFirst("search", taint()); sink(sb65.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb66 = new TextStringBuilder(); sb66.replaceFirst(taint(), "replace"); sink(sb66.toString()); // GOOD (search string doesn't convey taint)
+        TextStringBuilder sb67 = new TextStringBuilder(); sb67.append(taint()); sink(sb67.rightString(0)); // $hasTaintFlow=y
+        TextStringBuilder sb68 = new TextStringBuilder(); sb68.append(taint()); sink(sb68.subSequence(0, 0)); // $hasTaintFlow=y
+        TextStringBuilder sb69 = new TextStringBuilder(); sb69.append(taint()); sink(sb69.substring(0)); // $hasTaintFlow=y
+        TextStringBuilder sb70 = new TextStringBuilder(); sb70.append(taint()); sink(sb70.substring(0, 0)); // $hasTaintFlow=y
+        TextStringBuilder sb71 = new TextStringBuilder(); sb71.append(taint()); sink(sb71.toCharArray()); // $hasTaintFlow=y
+        TextStringBuilder sb72 = new TextStringBuilder(); sb72.append(taint()); sink(sb72.toCharArray(0, 0)); // $hasTaintFlow=y
+        TextStringBuilder sb73 = new TextStringBuilder(); sb73.append(taint()); sink(sb73.toStringBuffer()); // $hasTaintFlow=y
+        TextStringBuilder sb74 = new TextStringBuilder(); sb74.append(taint()); sink(sb74.toStringBuilder()); // $hasTaintFlow=y
+    }
+
+}

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/TextStringBuilderTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/TextStringBuilderTest.java
@@ -14,6 +14,9 @@ class TextStringBuilderTest {
 
     void test() throws Exception {
 
+        TextStringBuilder cons1 = new TextStringBuilder(taint()); sink(cons1.toString()); // $hasTaintFlow=y
+        TextStringBuilder cons2 = new TextStringBuilder((CharSequence)taint()); sink(cons2.toString()); // $hasTaintFlow=y
+
         TextStringBuilder sb1 = new TextStringBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
         TextStringBuilder sb2 = new TextStringBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
         TextStringBuilder sb3 = new TextStringBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // BAD (but not detected because we don't model CharBuffer yet)

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/options
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/options
@@ -1,1 +1,1 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/apache-commons-lang3-3.7
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/apache-commons-lang3-3.7:${testdir}/../../../stubs/apache-commons-text-1.9

--- a/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/builder/Builder.java
+++ b/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/builder/Builder.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.builder;
+
+/**
+ * <p>
+ * The Builder interface is designed to designate a class as a <em>builder</em> 
+ * object in the Builder design pattern. Builders are capable of creating and 
+ * configuring objects or results that normally take multiple steps to construct 
+ * or are very complex to derive. 
+ * </p>
+ * 
+ * <p>
+ * The builder interface defines a single method, {@link #build()}, that 
+ * classes must implement. The result of this method should be the final 
+ * configured object or result after all building operations are performed.
+ * </p>
+ * 
+ * <p>
+ * It is a recommended practice that the methods supplied to configure the 
+ * object or result being built return a reference to {@code this} so that
+ * method calls can be chained together.
+ * </p>
+ * 
+ * <p>
+ * Example Builder:
+ * <pre><code>
+ * class FontBuilder implements Builder&lt;Font&gt; {
+ *     private Font font;
+ *     
+ *     public FontBuilder(String fontName) {
+ *         this.font = new Font(fontName, Font.PLAIN, 12);
+ *     }
+ * 
+ *     public FontBuilder bold() {
+ *         this.font = this.font.deriveFont(Font.BOLD);
+ *         return this; // Reference returned so calls can be chained
+ *     }
+ *     
+ *     public FontBuilder size(float pointSize) {
+ *         this.font = this.font.deriveFont(pointSize);
+ *         return this; // Reference returned so calls can be chained
+ *     }
+ * 
+ *     // Other Font construction methods
+ * 
+ *     public Font build() {
+ *         return this.font;
+ *     }
+ * }
+ * </code></pre>
+ * 
+ * Example Builder Usage:
+ * <pre><code>
+ * Font bold14ptSansSerifFont = new FontBuilder(Font.SANS_SERIF).bold()
+ *                                                              .size(14.0f)
+ *                                                              .build();
+ * </code></pre>
+ *
+ * 
+ * @param <T> the type of object that the builder will construct or compute.
+ * 
+ * @since 3.0
+ */
+public interface Builder<T> {
+    T build();
+
+}

--- a/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/text/StrBuilder.java
+++ b/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/text/StrBuilder.java
@@ -1,0 +1,614 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.text;
+
+import org.apache.commons.lang3.builder.Builder;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Serializable;
+import java.io.Writer;
+import java.nio.CharBuffer;
+import java.util.Iterator;
+import java.util.List;
+
+
+public class StrBuilder implements CharSequence, Appendable, Serializable, Builder<String> {
+    public StrBuilder() {
+    }
+
+    public StrBuilder(int initialCapacity) {
+    }
+
+    public StrBuilder(final String str) {
+    }
+
+    public String getNewLineText() {
+      return null;
+    }
+
+    public StrBuilder setNewLineText(final String newLine) {
+      return null;
+    }
+
+    public String getNullText() {
+      return null;
+    }
+
+    public StrBuilder setNullText(String nullText) {
+      return null;
+    }
+
+    @Override
+    public int length() {
+      return 0;
+    }
+
+    public StrBuilder setLength(final int length) {
+      return null;
+    }
+
+    public int capacity() {
+      return 0;
+    }
+
+    public StrBuilder ensureCapacity(final int capacity) {
+      return null;
+    }
+
+    public StrBuilder minimizeCapacity() {
+      return null;
+    }
+
+    public int size() {
+      return 0;
+    }
+
+    public boolean isEmpty() {
+      return false;
+    }
+
+    public StrBuilder clear() {
+      return null;
+    }
+
+    @Override
+    public char charAt(final int index) {
+      return 0;
+    }
+
+    public StrBuilder setCharAt(final int index, final char ch) {
+      return null;
+    }
+
+    public StrBuilder deleteCharAt(final int index) {
+      return null;
+    }
+
+    public char[] toCharArray() {
+      return null;
+    }
+
+    public char[] toCharArray(final int startIndex, int endIndex) {
+      return null;
+    }
+
+    public char[] getChars(char[] destination) {
+      return null;
+    }
+
+    public void getChars(final int startIndex, final int endIndex, final char destination[], final int destinationIndex) {
+    }
+
+    public int readFrom(final Readable readable) throws IOException {
+      return 0;
+    }
+
+    public StrBuilder appendNewLine() {
+      return null;
+    }
+
+    public StrBuilder appendNull() {
+      return null;
+    }
+
+    public StrBuilder append(final Object obj) {
+      return null;
+    }
+
+    @Override
+    public StrBuilder append(final CharSequence seq) {
+      return null;
+    }
+
+    @Override
+    public StrBuilder append(final CharSequence seq, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final String str) {
+      return null;
+    }
+
+    public StrBuilder append(final String str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final String format, final Object... objs) {
+      return null;
+    }
+
+    public StrBuilder append(final CharBuffer buf) {
+      return null;
+    }
+
+    public StrBuilder append(final CharBuffer buf, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final StringBuffer str) {
+      return null;
+    }
+
+    public StrBuilder append(final StringBuffer str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final StringBuilder str) {
+      return null;
+    }
+
+    public StrBuilder append(final StringBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final StrBuilder str) {
+      return null;
+    }
+
+    public StrBuilder append(final StrBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final char[] chars) {
+      return null;
+    }
+
+    public StrBuilder append(final char[] chars, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final boolean value) {
+      return null;
+    }
+
+    @Override
+    public StrBuilder append(final char ch) {
+      return null;
+    }
+
+    public StrBuilder append(final int value) {
+      return null;
+    }
+
+    public StrBuilder append(final long value) {
+      return null;
+    }
+
+    public StrBuilder append(final float value) {
+      return null;
+    }
+
+    public StrBuilder append(final double value) {
+      return null;
+    }
+
+    public StrBuilder appendln(final Object obj) {
+      return null;
+    }
+
+    public StrBuilder appendln(final String str) {
+      return null;
+    }
+
+    public StrBuilder appendln(final String str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendln(final String format, final Object... objs) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StringBuffer str) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StringBuilder str) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StringBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StringBuffer str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StrBuilder str) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StrBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendln(final char[] chars) {
+      return null;
+    }
+
+    public StrBuilder appendln(final char[] chars, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendln(final boolean value) {
+      return null;
+    }
+
+    public StrBuilder appendln(final char ch) {
+      return null;
+    }
+
+    public StrBuilder appendln(final int value) {
+      return null;
+    }
+
+    public StrBuilder appendln(final long value) {
+      return null;
+    }
+
+    public StrBuilder appendln(final float value) {
+      return null;
+    }
+
+    public StrBuilder appendln(final double value) {
+      return null;
+    }
+
+    public <T> StrBuilder appendAll(final T... array) {
+      return null;
+    }
+
+    public StrBuilder appendAll(final Iterable<?> iterable) {
+      return null;
+    }
+
+    public StrBuilder appendAll(final Iterator<?> it) {
+      return null;
+    }
+
+    public StrBuilder appendWithSeparators(final Object[] array, final String separator) {
+      return null;
+    }
+
+    public StrBuilder appendWithSeparators(final Iterable<?> iterable, final String separator) {
+      return null;
+    }
+
+    public StrBuilder appendWithSeparators(final Iterator<?> it, final String separator) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final String separator) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final String standard, final String defaultIfEmpty) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final char separator) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final char standard, final char defaultIfEmpty) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final String separator, final int loopIndex) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final char separator, final int loopIndex) {
+      return null;
+    }
+
+    public StrBuilder appendPadding(final int length, final char padChar) {
+      return null;
+    }
+
+    public StrBuilder appendFixedWidthPadLeft(final Object obj, final int width, final char padChar) {
+      return null;
+    }
+
+    public StrBuilder appendFixedWidthPadLeft(final int value, final int width, final char padChar) {
+      return null;
+    }
+
+    public StrBuilder appendFixedWidthPadRight(final Object obj, final int width, final char padChar) {
+      return null;
+    }
+
+    public StrBuilder appendFixedWidthPadRight(final int value, final int width, final char padChar) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final Object obj) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, String str) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final char chars[]) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final char chars[], final int offset, final int length) {
+      return null;
+    }
+
+    public StrBuilder insert(int index, final boolean value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final char value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final int value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final long value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final float value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final double value) {
+      return null;
+    }
+
+    public StrBuilder delete(final int startIndex, int endIndex) {
+      return null;
+    }
+
+    public StrBuilder deleteAll(final char ch) {
+      return null;
+    }
+
+    public StrBuilder deleteFirst(final char ch) {
+      return null;
+    }
+
+    public StrBuilder deleteAll(final String str) {
+      return null;
+    }
+
+    public StrBuilder deleteFirst(final String str) {
+      return null;
+    }
+
+    public StrBuilder deleteAll(final StrMatcher matcher) {
+      return null;
+    }
+
+    public StrBuilder deleteFirst(final StrMatcher matcher) {
+      return null;
+    }
+
+    public StrBuilder replace(final int startIndex, int endIndex, final String replaceStr) {
+      return null;
+    }
+
+    public StrBuilder replaceAll(final char search, final char replace) {
+      return null;
+    }
+
+    public StrBuilder replaceFirst(final char search, final char replace) {
+      return null;
+    }
+
+    public StrBuilder replaceAll(final String searchStr, final String replaceStr) {
+      return null;
+    }
+
+    public StrBuilder replaceFirst(final String searchStr, final String replaceStr) {
+      return null;
+    }
+
+    public StrBuilder replaceAll(final StrMatcher matcher, final String replaceStr) {
+      return null;
+    }
+
+    public StrBuilder replaceFirst(final StrMatcher matcher, final String replaceStr) {
+      return null;
+    }
+
+    public StrBuilder replace(
+            final StrMatcher matcher, final String replaceStr,
+            final int startIndex, int endIndex, final int replaceCount) {
+      return null;
+    }
+
+    public StrBuilder reverse() {
+      return null;
+    }
+
+    public StrBuilder trim() {
+      return null;
+    }
+
+    public boolean startsWith(final String str) {
+      return false;
+    }
+
+    public boolean endsWith(final String str) {
+      return false;
+    }
+
+    @Override
+    public CharSequence subSequence(final int startIndex, final int endIndex) {
+      return null;
+    }
+
+    public String substring(final int start) {
+      return null;
+    }
+
+    public String substring(final int startIndex, int endIndex) {
+      return null;
+    }
+
+    public String leftString(final int length) {
+      return null;
+    }
+
+    public String rightString(final int length) {
+      return null;
+    }
+
+    public String midString(int index, final int length) {
+      return null;
+    }
+
+    public boolean contains(final char ch) {
+      return false;
+    }
+
+    public boolean contains(final String str) {
+      return false;
+    }
+
+    public boolean contains(final StrMatcher matcher) {
+      return false;
+    }
+
+    public int indexOf(final char ch) {
+      return 0;
+    }
+
+    public int indexOf(final char ch, int startIndex) {
+      return 0;
+    }
+
+    public int indexOf(final String str) {
+      return 0;
+    }
+
+    public int indexOf(final String str, int startIndex) {
+      return 0;
+    }
+
+    public int indexOf(final StrMatcher matcher) {
+      return 0;
+    }
+
+    public int indexOf(final StrMatcher matcher, int startIndex) {
+      return 0;
+    }
+
+    public int lastIndexOf(final char ch) {
+      return 0;
+    }
+
+    public int lastIndexOf(final char ch, int startIndex) {
+      return 0;
+    }
+
+    public int lastIndexOf(final String str) {
+      return 0;
+    }
+
+    public int lastIndexOf(final String str, int startIndex) {
+      return 0;
+    }
+
+    public int lastIndexOf(final StrMatcher matcher) {
+      return 0;
+    }
+
+    public int lastIndexOf(final StrMatcher matcher, int startIndex) {
+      return 0;
+    }
+
+    public StrTokenizer asTokenizer() {
+      return null;
+    }
+
+    public Reader asReader() {
+      return null;
+    }
+
+    public Writer asWriter() {
+      return null;
+    }
+
+    public void appendTo(final Appendable appendable) throws IOException {
+    }
+
+    public boolean equalsIgnoreCase(final StrBuilder other) {
+      return false;
+    }
+
+    public boolean equals(final StrBuilder other) {
+      return false;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    @Override
+    public String toString() {
+      return null;
+    }
+
+    public StringBuffer toStringBuffer() {
+      return null;
+    }
+
+    public StringBuilder toStringBuilder() {
+      return null;
+    }
+
+    @Override
+    public String build() {
+      return null;
+    }
+
+}

--- a/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/text/StrMatcher.java
+++ b/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/text/StrMatcher.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.text;
+
+import java.util.Arrays;
+
+
+public abstract class StrMatcher {
+    public static StrMatcher commaMatcher() {
+      return null;
+    }
+
+    public static StrMatcher tabMatcher() {
+      return null;
+    }
+
+    public static StrMatcher spaceMatcher() {
+      return null;
+    }
+
+    public static StrMatcher splitMatcher() {
+      return null;
+    }
+
+    public static StrMatcher trimMatcher() {
+      return null;
+    }
+
+    public static StrMatcher singleQuoteMatcher() {
+      return null;
+    }
+
+    public static StrMatcher doubleQuoteMatcher() {
+      return null;
+    }
+
+    public static StrMatcher quoteMatcher() {
+      return null;
+    }
+
+    public static StrMatcher noneMatcher() {
+      return null;
+    }
+
+    public static StrMatcher charMatcher(final char ch) {
+      return null;
+    }
+
+    public static StrMatcher charSetMatcher(final char... chars) {
+      return null;
+    }
+
+    public static StrMatcher charSetMatcher(final String chars) {
+      return null;
+    }
+
+    public static StrMatcher stringMatcher(final String str) {
+      return null;
+    }
+
+    public abstract int isMatch(char[] buffer, int pos, int bufferStart, int bufferEnd);
+
+    public int isMatch(final char[] buffer, final int pos) {
+      return 0;
+    }
+
+}

--- a/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/text/StrTokenizer.java
+++ b/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/text/StrTokenizer.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.text;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
+
+
+public class StrTokenizer implements ListIterator<String>, Cloneable {
+    public static StrTokenizer getCSVInstance() {
+      return null;
+    }
+
+    public static StrTokenizer getCSVInstance(final String input) {
+      return null;
+    }
+
+    public static StrTokenizer getCSVInstance(final char[] input) {
+      return null;
+    }
+
+    public static StrTokenizer getTSVInstance() {
+      return null;
+    }
+
+    public static StrTokenizer getTSVInstance(final String input) {
+      return null;
+    }
+
+    public static StrTokenizer getTSVInstance(final char[] input) {
+      return null;
+    }
+
+    public StrTokenizer() {
+    }
+
+    public StrTokenizer(final String input) {
+    }
+
+    public StrTokenizer(final String input, final char delim) {
+    }
+
+    public StrTokenizer(final String input, final String delim) {
+    }
+
+    public StrTokenizer(final String input, final StrMatcher delim) {
+    }
+
+    public StrTokenizer(final String input, final char delim, final char quote) {
+    }
+
+    public StrTokenizer(final String input, final StrMatcher delim, final StrMatcher quote) {
+    }
+
+    public StrTokenizer(final char[] input) {
+    }
+
+    public StrTokenizer(final char[] input, final char delim) {
+    }
+
+    public StrTokenizer(final char[] input, final String delim) {
+    }
+
+    public StrTokenizer(final char[] input, final StrMatcher delim) {
+    }
+
+    public StrTokenizer(final char[] input, final char delim, final char quote) {
+    }
+
+    public StrTokenizer(final char[] input, final StrMatcher delim, final StrMatcher quote) {
+    }
+
+    public int size() {
+      return 0;
+    }
+
+    public String nextToken() {
+      return null;
+    }
+
+    public String previousToken() {
+      return null;
+    }
+
+    public String[] getTokenArray() {
+      return null;
+    }
+
+    public List<String> getTokenList() {
+      return null;
+    }
+
+    public StrTokenizer reset() {
+      return null;
+    }
+
+    public StrTokenizer reset(final String input) {
+      return null;
+    }
+
+    public StrTokenizer reset(final char[] input) {
+      return null;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return false;
+    }
+
+    @Override
+    public String next() {
+      return null;
+    }
+
+    @Override
+    public int nextIndex() {
+      return 0;
+    }
+
+    @Override
+    public boolean hasPrevious() {
+      return false;
+    }
+
+    @Override
+    public String previous() {
+      return null;
+    }
+
+    @Override
+    public int previousIndex() {
+      return 0;
+    }
+
+    @Override
+    public void remove() {
+    }
+
+    @Override
+    public void set(final String obj) {
+    }
+
+    @Override
+    public void add(final String obj) {
+    }
+
+    public StrMatcher getDelimiterMatcher() {
+      return null;
+    }
+
+    public StrTokenizer setDelimiterMatcher(final StrMatcher delim) {
+      return null;
+    }
+
+    public StrTokenizer setDelimiterChar(final char delim) {
+      return null;
+    }
+
+    public StrTokenizer setDelimiterString(final String delim) {
+      return null;
+    }
+
+    public StrMatcher getQuoteMatcher() {
+      return null;
+    }
+
+    public StrTokenizer setQuoteMatcher(final StrMatcher quote) {
+      return null;
+    }
+
+    public StrTokenizer setQuoteChar(final char quote) {
+      return null;
+    }
+
+    public StrMatcher getIgnoredMatcher() {
+      return null;
+    }
+
+    public StrTokenizer setIgnoredMatcher(final StrMatcher ignored) {
+      return null;
+    }
+
+    public StrTokenizer setIgnoredChar(final char ignored) {
+      return null;
+    }
+
+    public StrMatcher getTrimmerMatcher() {
+      return null;
+    }
+
+    public StrTokenizer setTrimmerMatcher(final StrMatcher trimmer) {
+      return null;
+    }
+
+    public boolean isEmptyTokenAsNull() {
+      return false;
+    }
+
+    public StrTokenizer setEmptyTokenAsNull(final boolean emptyAsNull) {
+      return null;
+    }
+
+    public boolean isIgnoreEmptyTokens() {
+      return false;
+    }
+
+    public StrTokenizer setIgnoreEmptyTokens(final boolean ignoreEmptyTokens) {
+      return null;
+    }
+
+    public String getContent() {
+      return null;
+    }
+
+    @Override
+    public Object clone() {
+      return null;
+    }
+
+    @Override
+    public String toString() {
+      return null;
+    }
+
+}

--- a/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/Builder.java
+++ b/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/Builder.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text;
+
+/**
+ * <p>
+ * The Builder interface is designed to designate a class as a <em>builder</em>
+ * object in the Builder design pattern. Builders are capable of creating and
+ * configuring objects or results that normally take multiple steps to construct
+ * or are very complex to derive.
+ * </p>
+ *
+ * <p>
+ * The builder interface defines a single method, {@link #build()}, that
+ * classes must implement. The result of this method should be the final
+ * configured object or result after all building operations are performed.
+ * </p>
+ *
+ * <p>
+ * It is a recommended practice that the methods supplied to configure the
+ * object or result being built return a reference to {@code this} so that
+ * method calls can be chained together.
+ * </p>
+ *
+ * <p>
+ * Example Builder:
+ * </p>
+ * <pre><code>
+ * class FontBuilder implements Builder&lt;Font&gt; {
+ *     private Font font;
+ *
+ *     public FontBuilder(String fontName) {
+ *         this.font = new Font(fontName, Font.PLAIN, 12);
+ *     }
+ *
+ *     public FontBuilder bold() {
+ *         this.font = this.font.deriveFont(Font.BOLD);
+ *         return this; // Reference returned so calls can be chained
+ *     }
+ *
+ *     public FontBuilder size(float pointSize) {
+ *         this.font = this.font.deriveFont(pointSize);
+ *         return this; // Reference returned so calls can be chained
+ *     }
+ *
+ *     // Other Font construction methods
+ *
+ *     public Font build() {
+ *         return this.font;
+ *     }
+ * }
+ * </code></pre>
+ *
+ * Example Builder Usage:
+ * <pre><code>
+ * Font bold14ptSansSerifFont = new FontBuilder(Font.SANS_SERIF).bold()
+ *                                                              .size(14.0f)
+ *                                                              .build();
+ * </code></pre>
+ *
+ *
+ * @param <T> the type of object that the builder will construct or compute.
+ * @since 1.0
+ *
+ */
+public interface Builder<T> {
+    T build();
+
+}

--- a/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/StrBuilder.java
+++ b/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/StrBuilder.java
@@ -1,0 +1,619 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Serializable;
+import java.io.Writer;
+import java.nio.CharBuffer;
+import java.util.Iterator;
+import java.util.List;
+
+
+public class StrBuilder implements CharSequence, Appendable, Serializable, Builder<String> {
+    public StrBuilder() {
+    }
+
+    public StrBuilder(int initialCapacity) {
+    }
+
+    public StrBuilder(final String str) {
+    }
+
+    public StrBuilder append(final boolean value) {
+      return null;
+    }
+
+    @Override
+    public StrBuilder append(final char ch) {
+      return null;
+    }
+
+    public StrBuilder append(final char[] chars) {
+      return null;
+    }
+
+    public StrBuilder append(final char[] chars, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final CharBuffer buf) {
+      return null;
+    }
+
+    public StrBuilder append(final CharBuffer buf, final int startIndex, final int length) {
+      return null;
+    }
+
+    @Override
+    public StrBuilder append(final CharSequence seq) {
+      return null;
+    }
+
+    @Override
+    public StrBuilder append(final CharSequence seq, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final double value) {
+      return null;
+    }
+
+    public StrBuilder append(final float value) {
+      return null;
+    }
+
+    public StrBuilder append(final int value) {
+      return null;
+    }
+
+    public StrBuilder append(final long value) {
+      return null;
+    }
+
+    public StrBuilder append(final Object obj) {
+      return null;
+    }
+
+    public StrBuilder append(final StrBuilder str) {
+      return null;
+    }
+
+    public StrBuilder append(final StrBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final String str) {
+      return null;
+    }
+
+    public StrBuilder append(final String str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final String format, final Object... objs) {
+      return null;
+    }
+
+    public StrBuilder append(final StringBuffer str) {
+      return null;
+    }
+
+    public StrBuilder append(final StringBuffer str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder append(final StringBuilder str) {
+      return null;
+    }
+
+    public StrBuilder append(final StringBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendAll(final Iterable<?> iterable) {
+      return null;
+    }
+
+    public StrBuilder appendAll(final Iterator<?> it) {
+      return null;
+    }
+
+    public <T> StrBuilder appendAll(@SuppressWarnings("unchecked") final T... array) {
+      return null;
+    }
+
+    public StrBuilder appendFixedWidthPadLeft(final int value, final int width, final char padChar) {
+      return null;
+    }
+
+    public StrBuilder appendFixedWidthPadLeft(final Object obj, final int width, final char padChar) {
+      return null;
+    }
+
+    public StrBuilder appendFixedWidthPadRight(final int value, final int width, final char padChar) {
+      return null;
+    }
+
+    public StrBuilder appendFixedWidthPadRight(final Object obj, final int width, final char padChar) {
+      return null;
+    }
+
+    public StrBuilder appendln(final boolean value) {
+      return null;
+    }
+
+    public StrBuilder appendln(final char ch) {
+      return null;
+    }
+
+    public StrBuilder appendln(final char[] chars) {
+      return null;
+    }
+
+    public StrBuilder appendln(final char[] chars, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendln(final double value) {
+      return null;
+    }
+
+    public StrBuilder appendln(final float value) {
+      return null;
+    }
+
+    public StrBuilder appendln(final int value) {
+      return null;
+    }
+
+    public StrBuilder appendln(final long value) {
+      return null;
+    }
+
+    public StrBuilder appendln(final Object obj) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StrBuilder str) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StrBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendln(final String str) {
+      return null;
+    }
+
+    public StrBuilder appendln(final String str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendln(final String format, final Object... objs) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StringBuffer str) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StringBuffer str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StringBuilder str) {
+      return null;
+    }
+
+    public StrBuilder appendln(final StringBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public StrBuilder appendNewLine() {
+      return null;
+    }
+
+    public StrBuilder appendNull() {
+      return null;
+    }
+
+    public StrBuilder appendPadding(final int length, final char padChar) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final char separator) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final char standard, final char defaultIfEmpty) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final char separator, final int loopIndex) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final String separator) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final String separator, final int loopIndex) {
+      return null;
+    }
+
+    public StrBuilder appendSeparator(final String standard, final String defaultIfEmpty) {
+      return null;
+    }
+
+    public void appendTo(final Appendable appendable) throws IOException {
+    }
+
+    public StrBuilder appendWithSeparators(final Iterable<?> iterable, final String separator) {
+      return null;
+    }
+
+    public StrBuilder appendWithSeparators(final Iterator<?> it, final String separator) {
+      return null;
+    }
+
+    public StrBuilder appendWithSeparators(final Object[] array, final String separator) {
+      return null;
+    }
+
+    public Reader asReader() {
+      return null;
+    }
+
+    public StrTokenizer asTokenizer() {
+      return null;
+    }
+
+    public Writer asWriter() {
+      return null;
+    }
+
+    @Override
+    public String build() {
+      return null;
+    }
+
+    public int capacity() {
+      return 0;
+    }
+
+    @Override
+    public char charAt(final int index) {
+      return 0;
+    }
+
+    public StrBuilder clear() {
+      return null;
+    }
+
+    public boolean contains(final char ch) {
+      return false;
+    }
+
+    public boolean contains(final String str) {
+      return false;
+    }
+
+    public boolean contains(final StrMatcher matcher) {
+      return false;
+    }
+
+    public StrBuilder delete(final int startIndex, int endIndex) {
+      return null;
+    }
+
+    public StrBuilder deleteAll(final char ch) {
+      return null;
+    }
+
+    public StrBuilder deleteAll(final String str) {
+      return null;
+    }
+
+    public StrBuilder deleteAll(final StrMatcher matcher) {
+      return null;
+    }
+
+    public StrBuilder deleteCharAt(final int index) {
+      return null;
+    }
+
+    public StrBuilder deleteFirst(final char ch) {
+      return null;
+    }
+
+    public StrBuilder deleteFirst(final String str) {
+      return null;
+    }
+
+    public StrBuilder deleteFirst(final StrMatcher matcher) {
+      return null;
+    }
+
+    public boolean endsWith(final String str) {
+      return false;
+    }
+
+    public StrBuilder ensureCapacity(final int capacity) {
+      return null;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      return false;
+    }
+
+    public boolean equals(final StrBuilder other) {
+      return false;
+    }
+
+    public boolean equalsIgnoreCase(final StrBuilder other) {
+      return false;
+    }
+
+    public char[] getChars(char[] destination) {
+      return null;
+    }
+
+    public void getChars(final int startIndex,
+                         final int endIndex,
+                         final char[] destination,
+                         final int destinationIndex) {
+    }
+
+    public String getNewLineText() {
+      return null;
+    }
+
+    public String getNullText() {
+      return null;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    public int indexOf(final char ch) {
+      return 0;
+    }
+
+    public int indexOf(final char ch, int startIndex) {
+      return 0;
+    }
+
+    public int indexOf(final String str) {
+      return 0;
+    }
+
+    public int indexOf(final String str, int startIndex) {
+      return 0;
+    }
+
+    public int indexOf(final StrMatcher matcher) {
+      return 0;
+    }
+
+    public int indexOf(final StrMatcher matcher, int startIndex) {
+      return 0;
+    }
+
+    public StrBuilder insert(int index, final boolean value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final char value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final char[] chars) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final char[] chars, final int offset, final int length) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final double value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final float value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final int value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final long value) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, final Object obj) {
+      return null;
+    }
+
+    public StrBuilder insert(final int index, String str) {
+      return null;
+    }
+
+    public boolean isEmpty() {
+      return false;
+    }
+
+    public boolean isNotEmpty() {
+      return false;
+    }
+
+    public int lastIndexOf(final char ch) {
+      return 0;
+    }
+
+    public int lastIndexOf(final char ch, int startIndex) {
+      return 0;
+    }
+
+    public int lastIndexOf(final String str) {
+      return 0;
+    }
+
+    public int lastIndexOf(final String str, int startIndex) {
+      return 0;
+    }
+
+    public int lastIndexOf(final StrMatcher matcher) {
+      return 0;
+    }
+
+    public int lastIndexOf(final StrMatcher matcher, int startIndex) {
+      return 0;
+    }
+
+    public String leftString(final int length) {
+      return null;
+    }
+
+    @Override
+    public int length() {
+      return 0;
+    }
+
+    public String midString(int index, final int length) {
+      return null;
+    }
+
+    public StrBuilder minimizeCapacity() {
+      return null;
+    }
+
+    public int readFrom(final Readable readable) throws IOException {
+      return 0;
+    }
+
+    public StrBuilder replace(final int startIndex, int endIndex, final String replaceStr) {
+      return null;
+    }
+
+    public StrBuilder replace(
+            final StrMatcher matcher, final String replaceStr,
+            final int startIndex, int endIndex, final int replaceCount) {
+      return null;
+    }
+
+    public StrBuilder replaceAll(final char search, final char replace) {
+      return null;
+    }
+
+    public StrBuilder replaceAll(final String searchStr, final String replaceStr) {
+      return null;
+    }
+
+    public StrBuilder replaceAll(final StrMatcher matcher, final String replaceStr) {
+      return null;
+    }
+
+    public StrBuilder replaceFirst(final char search, final char replace) {
+      return null;
+    }
+
+    public StrBuilder replaceFirst(final String searchStr, final String replaceStr) {
+      return null;
+    }
+
+    public StrBuilder replaceFirst(final StrMatcher matcher, final String replaceStr) {
+      return null;
+    }
+
+    public StrBuilder reverse() {
+      return null;
+    }
+
+    public String rightString(final int length) {
+      return null;
+    }
+
+    public StrBuilder setCharAt(final int index, final char ch) {
+      return null;
+    }
+
+    public StrBuilder setLength(final int length) {
+      return null;
+    }
+
+    public StrBuilder setNewLineText(final String newLine) {
+      return null;
+    }
+
+    public StrBuilder setNullText(String nullText) {
+      return null;
+    }
+
+    public int size() {
+      return 0;
+    }
+
+    public boolean startsWith(final String str) {
+      return false;
+    }
+
+    @Override
+    public CharSequence subSequence(final int startIndex, final int endIndex) {
+      return null;
+    }
+
+    public String substring(final int start) {
+      return null;
+    }
+
+    public String substring(final int startIndex, int endIndex) {
+      return null;
+    }
+
+    public char[] toCharArray() {
+      return null;
+    }
+
+    public char[] toCharArray(final int startIndex, int endIndex) {
+      return null;
+    }
+
+    @Override
+    public String toString() {
+      return null;
+    }
+
+    public StringBuffer toStringBuffer() {
+      return null;
+    }
+
+    public StringBuilder toStringBuilder() {
+      return null;
+    }
+
+    public StrBuilder trim() {
+      return null;
+    }
+
+}

--- a/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/StrMatcher.java
+++ b/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/StrMatcher.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text;
+
+public abstract class StrMatcher {
+    public static StrMatcher commaMatcher() {
+      return null;
+    }
+
+    public static StrMatcher tabMatcher() {
+      return null;
+    }
+
+    public static StrMatcher spaceMatcher() {
+      return null;
+    }
+
+    public static StrMatcher splitMatcher() {
+      return null;
+    }
+
+    public static StrMatcher trimMatcher() {
+      return null;
+    }
+
+    public static StrMatcher singleQuoteMatcher() {
+      return null;
+    }
+
+    public static StrMatcher doubleQuoteMatcher() {
+      return null;
+    }
+
+    public static StrMatcher quoteMatcher() {
+      return null;
+    }
+
+    public static StrMatcher noneMatcher() {
+      return null;
+    }
+
+    public static StrMatcher charMatcher(final char ch) {
+      return null;
+    }
+
+    public static StrMatcher charSetMatcher(final char... chars) {
+      return null;
+    }
+
+    public static StrMatcher charSetMatcher(final String chars) {
+      return null;
+    }
+
+    public static StrMatcher stringMatcher(final String str) {
+      return null;
+    }
+
+    public abstract int isMatch(char[] buffer, int pos, int bufferStart, int bufferEnd);
+
+    public int isMatch(final char[] buffer, final int pos) {
+      return 0;
+    }
+
+}

--- a/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/StrTokenizer.java
+++ b/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/StrTokenizer.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text;
+
+import java.util.List;
+import java.util.ListIterator;
+
+public class StrTokenizer implements ListIterator<String>, Cloneable {
+    public static StrTokenizer getCSVInstance() {
+      return null;
+    }
+
+    public static StrTokenizer getCSVInstance(final char[] input) {
+      return null;
+    }
+
+    public static StrTokenizer getCSVInstance(final String input) {
+      return null;
+    }
+
+    public static StrTokenizer getTSVInstance() {
+      return null;
+    }
+
+    public static StrTokenizer getTSVInstance(final char[] input) {
+      return null;
+    }
+
+    public static StrTokenizer getTSVInstance(final String input) {
+      return null;
+    }
+
+    public StrTokenizer() {
+    }
+
+    public StrTokenizer(final char[] input) {
+    }
+
+    public StrTokenizer(final char[] input, final char delim) {
+    }
+
+    public StrTokenizer(final char[] input, final char delim, final char quote) {
+    }
+
+    public StrTokenizer(final char[] input, final String delim) {
+    }
+
+    public StrTokenizer(final char[] input, final StrMatcher delim) {
+    }
+
+    public StrTokenizer(final char[] input, final StrMatcher delim, final StrMatcher quote) {
+    }
+
+    public StrTokenizer(final String input) {
+    }
+
+    public StrTokenizer(final String input, final char delim) {
+    }
+
+    public StrTokenizer(final String input, final char delim, final char quote) {
+    }
+
+    public StrTokenizer(final String input, final String delim) {
+    }
+
+    public StrTokenizer(final String input, final StrMatcher delim) {
+    }
+
+    public StrTokenizer(final String input, final StrMatcher delim, final StrMatcher quote) {
+    }
+
+    @Override
+    public void add(final String obj) {
+    }
+
+    @Override
+    public Object clone() {
+      return null;
+    }
+
+    public String getContent() {
+      return null;
+    }
+
+    public StrMatcher getDelimiterMatcher() {
+      return null;
+    }
+
+    public StrMatcher getIgnoredMatcher() {
+      return null;
+    }
+
+    public StrMatcher getQuoteMatcher() {
+      return null;
+    }
+
+    public String[] getTokenArray() {
+      return null;
+    }
+
+    public List<String> getTokenList() {
+      return null;
+    }
+
+    public StrMatcher getTrimmerMatcher() {
+      return null;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return false;
+    }
+
+    @Override
+    public boolean hasPrevious() {
+      return false;
+    }
+
+    public boolean isEmptyTokenAsNull() {
+      return false;
+    }
+
+    public boolean isIgnoreEmptyTokens() {
+      return false;
+    }
+
+    @Override
+    public String next() {
+      return null;
+    }
+
+    @Override
+    public int nextIndex() {
+      return 0;
+    }
+
+    public String nextToken() {
+      return null;
+    }
+
+    @Override
+    public String previous() {
+      return null;
+    }
+
+    @Override
+    public int previousIndex() {
+      return 0;
+    }
+
+    public String previousToken() {
+      return null;
+    }
+
+    @Override
+    public void remove() {
+    }
+
+    public StrTokenizer reset() {
+      return null;
+    }
+
+    public StrTokenizer reset(final char[] input) {
+      return null;
+    }
+
+    public StrTokenizer reset(final String input) {
+      return null;
+    }
+
+    @Override
+    public void set(final String obj) {
+    }
+
+    public StrTokenizer setDelimiterChar(final char delim) {
+      return null;
+    }
+
+    public StrTokenizer setDelimiterMatcher(final StrMatcher delim) {
+      return null;
+    }
+
+    public StrTokenizer setDelimiterString(final String delim) {
+      return null;
+    }
+
+    public StrTokenizer setEmptyTokenAsNull(final boolean emptyAsNull) {
+      return null;
+    }
+
+    public StrTokenizer setIgnoredChar(final char ignored) {
+      return null;
+    }
+
+    public StrTokenizer setIgnoredMatcher(final StrMatcher ignored) {
+      return null;
+    }
+
+    public StrTokenizer setIgnoreEmptyTokens(final boolean ignoreEmptyTokens) {
+      return null;
+    }
+
+    public StrTokenizer setQuoteChar(final char quote) {
+      return null;
+    }
+
+    public StrTokenizer setQuoteMatcher(final StrMatcher quote) {
+      return null;
+    }
+
+    public StrTokenizer setTrimmerMatcher(final StrMatcher trimmer) {
+      return null;
+    }
+
+    public int size() {
+      return 0;
+    }
+
+    @Override
+    public String toString() {
+      return null;
+    }
+
+}

--- a/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/StringTokenizer.java
+++ b/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/StringTokenizer.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text;
+
+import java.util.List;
+import java.util.ListIterator;
+
+import org.apache.commons.text.matcher.StringMatcher;
+
+public class StringTokenizer implements ListIterator<String>, Cloneable {
+    public static StringTokenizer getCSVInstance() {
+      return null;
+    }
+
+    public static StringTokenizer getCSVInstance(final char[] input) {
+      return null;
+    }
+
+    public static StringTokenizer getCSVInstance(final String input) {
+      return null;
+    }
+
+    public static StringTokenizer getTSVInstance() {
+      return null;
+    }
+
+    public static StringTokenizer getTSVInstance(final char[] input) {
+      return null;
+    }
+
+    public static StringTokenizer getTSVInstance(final String input) {
+      return null;
+    }
+
+    public StringTokenizer() {
+    }
+
+    public StringTokenizer(final char[] input) {
+    }
+
+    public StringTokenizer(final char[] input, final char delim) {
+    }
+
+    public StringTokenizer(final char[] input, final char delim, final char quote) {
+    }
+
+    public StringTokenizer(final char[] input, final String delim) {
+    }
+
+    public StringTokenizer(final char[] input, final StringMatcher delim) {
+    }
+
+    public StringTokenizer(final char[] input, final StringMatcher delim, final StringMatcher quote) {
+    }
+
+    public StringTokenizer(final String input) {
+    }
+
+    public StringTokenizer(final String input, final char delim) {
+    }
+
+    public StringTokenizer(final String input, final char delim, final char quote) {
+    }
+
+    public StringTokenizer(final String input, final String delim) {
+    }
+
+    public StringTokenizer(final String input, final StringMatcher delim) {
+    }
+
+    public StringTokenizer(final String input, final StringMatcher delim, final StringMatcher quote) {
+    }
+
+    @Override
+    public void add(final String obj) {
+    }
+
+    @Override
+    public Object clone() {
+      return null;
+    }
+
+    public String getContent() {
+      return null;
+    }
+
+    public StringMatcher getDelimiterMatcher() {
+      return null;
+    }
+
+    public StringMatcher getIgnoredMatcher() {
+      return null;
+    }
+
+    public StringMatcher getQuoteMatcher() {
+      return null;
+    }
+
+    public String[] getTokenArray() {
+      return null;
+    }
+
+    public List<String> getTokenList() {
+      return null;
+    }
+
+    public StringMatcher getTrimmerMatcher() {
+      return null;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return false;
+    }
+
+    @Override
+    public boolean hasPrevious() {
+      return false;
+    }
+
+    public boolean isEmptyTokenAsNull() {
+      return false;
+    }
+
+    public boolean isIgnoreEmptyTokens() {
+      return false;
+    }
+
+    @Override
+    public String next() {
+      return null;
+    }
+
+    @Override
+    public int nextIndex() {
+      return 0;
+    }
+
+    public String nextToken() {
+      return null;
+    }
+
+    @Override
+    public String previous() {
+      return null;
+    }
+
+    @Override
+    public int previousIndex() {
+      return 0;
+    }
+
+    public String previousToken() {
+      return null;
+    }
+
+    @Override
+    public void remove() {
+    }
+
+    public StringTokenizer reset() {
+      return null;
+    }
+
+    public StringTokenizer reset(final char[] input) {
+      return null;
+    }
+
+    public StringTokenizer reset(final String input) {
+      return null;
+    }
+
+    @Override
+    public void set(final String obj) {
+    }
+
+    public StringTokenizer setDelimiterChar(final char delim) {
+      return null;
+    }
+
+    public StringTokenizer setDelimiterMatcher(final StringMatcher delim) {
+      return null;
+    }
+
+    public StringTokenizer setDelimiterString(final String delim) {
+      return null;
+    }
+
+    public StringTokenizer setEmptyTokenAsNull(final boolean emptyAsNull) {
+      return null;
+    }
+
+    public StringTokenizer setIgnoredChar(final char ignored) {
+      return null;
+    }
+
+    public StringTokenizer setIgnoredMatcher(final StringMatcher ignored) {
+      return null;
+    }
+
+    public StringTokenizer setIgnoreEmptyTokens(final boolean ignoreEmptyTokens) {
+      return null;
+    }
+
+    public StringTokenizer setQuoteChar(final char quote) {
+      return null;
+    }
+
+    public StringTokenizer setQuoteMatcher(final StringMatcher quote) {
+      return null;
+    }
+
+    public StringTokenizer setTrimmerMatcher(final StringMatcher trimmer) {
+      return null;
+    }
+
+    public int size() {
+      return 0;
+    }
+
+    @Override
+    public String toString() {
+      return null;
+    }
+
+}

--- a/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/TextStringBuilder.java
+++ b/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/TextStringBuilder.java
@@ -1,0 +1,655 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Serializable;
+import java.io.Writer;
+import java.nio.CharBuffer;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.text.matcher.StringMatcher;
+
+public class TextStringBuilder implements CharSequence, Appendable, Serializable, Builder<String> {
+    public static TextStringBuilder wrap(final char[] initialBuffer) {
+      return null;
+    }
+
+    public static TextStringBuilder wrap(final char[] initialBuffer, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder() {
+    }
+
+    public TextStringBuilder(final CharSequence seq) {
+    }
+
+    public TextStringBuilder(final int initialCapacity) {
+    }
+
+    public TextStringBuilder(final String str) {
+    }
+
+    public TextStringBuilder append(final boolean value) {
+      return null;
+    }
+
+    @Override
+    public TextStringBuilder append(final char ch) {
+      return null;
+    }
+
+    public TextStringBuilder append(final char[] chars) {
+      return null;
+    }
+
+    public TextStringBuilder append(final char[] chars, final int startIndex, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder append(final CharBuffer str) {
+      return null;
+    }
+
+    public TextStringBuilder append(final CharBuffer buf, final int startIndex, final int length) {
+      return null;
+    }
+
+    @Override
+    public TextStringBuilder append(final CharSequence seq) {
+      return null;
+    }
+
+    @Override
+    public TextStringBuilder append(final CharSequence seq, final int startIndex, final int endIndex) {
+      return null;
+    }
+
+    public TextStringBuilder append(final double value) {
+      return null;
+    }
+
+    public TextStringBuilder append(final float value) {
+      return null;
+    }
+
+    public TextStringBuilder append(final int value) {
+      return null;
+    }
+
+    public TextStringBuilder append(final long value) {
+      return null;
+    }
+
+    public TextStringBuilder append(final Object obj) {
+      return null;
+    }
+
+    public TextStringBuilder append(final String str) {
+      return null;
+    }
+
+    public TextStringBuilder append(final String str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder append(final String format, final Object... objs) {
+      return null;
+    }
+
+    public TextStringBuilder append(final StringBuffer str) {
+      return null;
+    }
+
+    public TextStringBuilder append(final StringBuffer str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder append(final StringBuilder str) {
+      return null;
+    }
+
+    public TextStringBuilder append(final StringBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder append(final TextStringBuilder str) {
+      return null;
+    }
+
+    public TextStringBuilder append(final TextStringBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder appendAll(final Iterable<?> iterable) {
+      return null;
+    }
+
+    public TextStringBuilder appendAll(final Iterator<?> it) {
+      return null;
+    }
+
+    public <T> TextStringBuilder appendAll(@SuppressWarnings("unchecked") final T... array) {
+      return null;
+    }
+
+    public TextStringBuilder appendFixedWidthPadLeft(final int value, final int width, final char padChar) {
+      return null;
+    }
+
+    public TextStringBuilder appendFixedWidthPadLeft(final Object obj, final int width, final char padChar) {
+      return null;
+    }
+
+    public TextStringBuilder appendFixedWidthPadRight(final int value, final int width, final char padChar) {
+      return null;
+    }
+
+    public TextStringBuilder appendFixedWidthPadRight(final Object obj, final int width, final char padChar) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final boolean value) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final char ch) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final char[] chars) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final char[] chars, final int startIndex, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final double value) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final float value) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final int value) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final long value) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final Object obj) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final String str) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final String str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final String format, final Object... objs) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final StringBuffer str) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final StringBuffer str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final StringBuilder str) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final StringBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final TextStringBuilder str) {
+      return null;
+    }
+
+    public TextStringBuilder appendln(final TextStringBuilder str, final int startIndex, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder appendNewLine() {
+      return null;
+    }
+
+    public TextStringBuilder appendNull() {
+      return null;
+    }
+
+    public TextStringBuilder appendPadding(final int length, final char padChar) {
+      return null;
+    }
+
+    public TextStringBuilder appendSeparator(final char separator) {
+      return null;
+    }
+
+    public TextStringBuilder appendSeparator(final char standard, final char defaultIfEmpty) {
+      return null;
+    }
+
+    public TextStringBuilder appendSeparator(final char separator, final int loopIndex) {
+      return null;
+    }
+
+    public TextStringBuilder appendSeparator(final String separator) {
+      return null;
+    }
+
+    public TextStringBuilder appendSeparator(final String separator, final int loopIndex) {
+      return null;
+    }
+
+    public TextStringBuilder appendSeparator(final String standard, final String defaultIfEmpty) {
+      return null;
+    }
+
+    public void appendTo(final Appendable appendable) throws IOException {
+    }
+
+    public TextStringBuilder appendWithSeparators(final Iterable<?> iterable, final String separator) {
+      return null;
+    }
+
+    public TextStringBuilder appendWithSeparators(final Iterator<?> it, final String separator) {
+      return null;
+    }
+
+    public TextStringBuilder appendWithSeparators(final Object[] array, final String separator) {
+      return null;
+    }
+
+    public Reader asReader() {
+      return null;
+    }
+
+    public StringTokenizer asTokenizer() {
+      return null;
+    }
+
+    public Writer asWriter() {
+      return null;
+    }
+
+    @Override
+    public String build() {
+      return null;
+    }
+
+    public int capacity() {
+      return 0;
+    }
+
+    @Override
+    public char charAt(final int index) {
+      return 0;
+    }
+
+    public TextStringBuilder clear() {
+      return null;
+    }
+
+    public boolean contains(final char ch) {
+      return false;
+    }
+
+    public boolean contains(final String str) {
+      return false;
+    }
+
+    public boolean contains(final StringMatcher matcher) {
+      return false;
+    }
+
+    public TextStringBuilder delete(final int startIndex, final int endIndex) {
+      return null;
+    }
+
+    public TextStringBuilder deleteAll(final char ch) {
+      return null;
+    }
+
+    public TextStringBuilder deleteAll(final String str) {
+      return null;
+    }
+
+    public TextStringBuilder deleteAll(final StringMatcher matcher) {
+      return null;
+    }
+
+    public TextStringBuilder deleteCharAt(final int index) {
+      return null;
+    }
+
+    public TextStringBuilder deleteFirst(final char ch) {
+      return null;
+    }
+
+    public TextStringBuilder deleteFirst(final String str) {
+      return null;
+    }
+
+    public TextStringBuilder deleteFirst(final StringMatcher matcher) {
+      return null;
+    }
+
+    public char drainChar(final int index) {
+      return 0;
+    }
+
+    public int drainChars(final int startIndex, final int endIndex, final char[] target, final int targetIndex) {
+      return 0;
+    }
+
+    public boolean endsWith(final String str) {
+      return false;
+    }
+
+    public TextStringBuilder ensureCapacity(final int capacity) {
+      return null;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      return false;
+    }
+
+    public boolean equals(final TextStringBuilder other) {
+      return false;
+    }
+
+    public boolean equalsIgnoreCase(final TextStringBuilder other) {
+      return false;
+    }
+
+    public char[] getChars(char[] target) {
+      return null;
+    }
+
+    public void getChars(final int startIndex, final int endIndex, final char[] target, final int targetIndex) {
+    }
+
+    public String getNewLineText() {
+      return null;
+    }
+
+    public String getNullText() {
+      return null;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    public int indexOf(final char ch) {
+      return 0;
+    }
+
+    public int indexOf(final char ch, int startIndex) {
+      return 0;
+    }
+
+    public int indexOf(final String str) {
+      return 0;
+    }
+
+    public int indexOf(final String str, int startIndex) {
+      return 0;
+    }
+
+    public int indexOf(final StringMatcher matcher) {
+      return 0;
+    }
+
+    public int indexOf(final StringMatcher matcher, int startIndex) {
+      return 0;
+    }
+
+    public TextStringBuilder insert(final int index, final boolean value) {
+      return null;
+    }
+
+    public TextStringBuilder insert(final int index, final char value) {
+      return null;
+    }
+
+    public TextStringBuilder insert(final int index, final char[] chars) {
+      return null;
+    }
+
+    public TextStringBuilder insert(final int index, final char[] chars, final int offset, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder insert(final int index, final double value) {
+      return null;
+    }
+
+    public TextStringBuilder insert(final int index, final float value) {
+      return null;
+    }
+
+    public TextStringBuilder insert(final int index, final int value) {
+      return null;
+    }
+
+    public TextStringBuilder insert(final int index, final long value) {
+      return null;
+    }
+
+    public TextStringBuilder insert(final int index, final Object obj) {
+      return null;
+    }
+
+    public TextStringBuilder insert(final int index, String str) {
+      return null;
+    }
+
+    public boolean isEmpty() {
+      return false;
+    }
+
+    public boolean isNotEmpty() {
+      return false;
+    }
+
+    public boolean isReallocated() {
+      return false;
+    }
+
+    public int lastIndexOf(final char ch) {
+      return 0;
+    }
+
+    public int lastIndexOf(final char ch, int startIndex) {
+      return 0;
+    }
+
+    public int lastIndexOf(final String str) {
+      return 0;
+    }
+
+    public int lastIndexOf(final String str, int startIndex) {
+      return 0;
+    }
+
+    public int lastIndexOf(final StringMatcher matcher) {
+      return 0;
+    }
+
+    public int lastIndexOf(final StringMatcher matcher, int startIndex) {
+      return 0;
+    }
+
+    public String leftString(final int length) {
+      return null;
+    }
+
+    @Override
+    public int length() {
+      return 0;
+    }
+
+    public String midString(int index, final int length) {
+      return null;
+    }
+
+    public TextStringBuilder minimizeCapacity() {
+      return null;
+    }
+
+    public int readFrom(final CharBuffer charBuffer) throws IOException {
+      return 0;
+    }
+
+    public int readFrom(final Readable readable) throws IOException {
+      return 0;
+    }
+
+    public int readFrom(final Reader reader) throws IOException {
+      return 0;
+    }
+
+    public int readFrom(final Reader reader, final int count) throws IOException {
+      return 0;
+    }
+
+    public TextStringBuilder replace(final int startIndex, int endIndex, final String replaceStr) {
+      return null;
+    }
+
+    public TextStringBuilder replace(final StringMatcher matcher, final String replaceStr, final int startIndex,
+        int endIndex, final int replaceCount) {
+      return null;
+    }
+
+    public TextStringBuilder replaceAll(final char search, final char replace) {
+      return null;
+    }
+
+    public TextStringBuilder replaceAll(final String searchStr, final String replaceStr) {
+      return null;
+    }
+
+    public TextStringBuilder replaceAll(final StringMatcher matcher, final String replaceStr) {
+      return null;
+    }
+
+    public TextStringBuilder replaceFirst(final char search, final char replace) {
+      return null;
+    }
+
+    public TextStringBuilder replaceFirst(final String searchStr, final String replaceStr) {
+      return null;
+    }
+
+    public TextStringBuilder replaceFirst(final StringMatcher matcher, final String replaceStr) {
+      return null;
+    }
+
+    public TextStringBuilder reverse() {
+      return null;
+    }
+
+    public String rightString(final int length) {
+      return null;
+    }
+
+    public TextStringBuilder set(final CharSequence str) {
+      return null;
+    }
+
+    public TextStringBuilder setCharAt(final int index, final char ch) {
+      return null;
+    }
+
+    public TextStringBuilder setLength(final int length) {
+      return null;
+    }
+
+    public TextStringBuilder setNewLineText(final String newLine) {
+      return null;
+    }
+
+    public TextStringBuilder setNullText(String nullText) {
+      return null;
+    }
+
+    public int size() {
+      return 0;
+    }
+
+    public boolean startsWith(final String str) {
+      return false;
+    }
+
+    @Override
+    public CharSequence subSequence(final int startIndex, final int endIndex) {
+      return null;
+    }
+
+    public String substring(final int start) {
+      return null;
+    }
+
+    public String substring(final int startIndex, int endIndex) {
+      return null;
+    }
+
+    public char[] toCharArray() {
+      return null;
+    }
+
+    public char[] toCharArray(final int startIndex, int endIndex) {
+      return null;
+    }
+
+    @Override
+    public String toString() {
+      return null;
+    }
+
+    public StringBuffer toStringBuffer() {
+      return null;
+    }
+
+    public StringBuilder toStringBuilder() {
+      return null;
+    }
+
+    public TextStringBuilder trim() {
+      return null;
+    }
+
+}

--- a/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/matcher/StringMatcher.java
+++ b/java/ql/test/stubs/apache-commons-text-1.9/org/apache/commons/text/matcher/StringMatcher.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.text.matcher;
+
+
+public interface StringMatcher {
+    default StringMatcher andThen(final StringMatcher stringMatcher) {
+      return null;
+    }
+
+    default int isMatch(final char[] buffer, final int pos) {
+      return 0;
+    }
+
+    int isMatch(char[] buffer, int start, int bufferStart, int bufferEnd);
+
+    default int isMatch(final CharSequence buffer, final int pos) {
+      return 0;
+    }
+
+    default int isMatch(final CharSequence buffer, final int start, final int bufferStart, final int bufferEnd) {
+      return 0;
+    }
+
+    default int size() {
+      return 0;
+    }
+
+}


### PR DESCRIPTION
This excludes its fluent methods for the time being, which will be added in an upcoming PR.

Based on https://github.com/github/codeql/pull/5126, review only latest commit.