### PR TITLE
Docs: Update list of support frameworks in Python

### DIFF
--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -122,19 +122,20 @@ JavaScript and TypeScript built-in support
 Python built-in support
 ====================================
 
-.. csv-table:: 
+.. csv-table::
    :header-rows: 1
    :class: fullWidthTable
    :widths: auto
 
    Name, Category
-   Bottle, Web framework
-   CherryPy, Web framework
-   Django, Web application framework
-   Falcon, Web API framework
-   Flask, Microframework
-   Pyramid, Web application framework
-   Tornado, Web application framework and asynchronous networking library
-   Turbogears, Web framework
-   Twisted, Networking engine
-   WebOb, WSGI request library
+   Django, Web framework
+   Flask, Web framework
+   Tornado, Web framework
+   PyYAML, Serialization
+   dill, Serialization
+   fabric, Utility library
+   invoke, Utility library
+   mysql-connector-python, Database
+   MySQLdb, Database
+   psycopg2, Database
+   sqlite3, Database


### PR DESCRIPTION
So it follows what is we actually support with https://github.com/github/codeql/blob/6eafa9d3968a9f4752ef07e7d5159699591079c3/python/ql/src/semmle/python/Frameworks.qll