### PR TITLE
Python: Use `LocalSourceNode` in type tracker tests

### DIFF
--- a/python/ql/test/experimental/dataflow/typetracking/moduleattr.expected
+++ b/python/ql/test/experimental/dataflow/typetracking/moduleattr.expected
@@ -1,7 +1,6 @@
 module_tracker
 | import_as_attr.py:1:6:1:11 | ControlFlowNode for ImportExpr |
 module_attr_tracker
-| import_as_attr.py:0:0:0:0 | ModuleVariableNode for Global Variable attr_ref in Module import_as_attr |
 | import_as_attr.py:1:20:1:35 | ControlFlowNode for ImportMember |
 | import_as_attr.py:1:28:1:35 | GSSA Variable attr_ref |
 | import_as_attr.py:3:1:3:1 | GSSA Variable x |

--- a/python/ql/test/experimental/dataflow/typetracking/moduleattr.ql
+++ b/python/ql/test/experimental/dataflow/typetracking/moduleattr.ql
@@ -2,16 +2,18 @@ import python
 import semmle.python.dataflow.new.DataFlow
 import semmle.python.dataflow.new.TypeTracker
 
-DataFlow::Node module_tracker(TypeTracker t) {
+DataFlow::LocalSourceNode module_tracker(TypeTracker t) {
   t.start() and
   result = DataFlow::importNode("module")
   or
   exists(TypeTracker t2 | result = module_tracker(t2).track(t2, t))
 }
 
-query DataFlow::Node module_tracker() { result = module_tracker(DataFlow::TypeTracker::end()) }
+query DataFlow::Node module_tracker() {
+  module_tracker(DataFlow::TypeTracker::end()).flowsTo(result)
+}
 
-DataFlow::Node module_attr_tracker(TypeTracker t) {
+DataFlow::LocalSourceNode module_attr_tracker(TypeTracker t) {
   t.startInAttr("attr") and
   result = module_tracker()
   or
@@ -19,5 +21,5 @@ DataFlow::Node module_attr_tracker(TypeTracker t) {
 }
 
 query DataFlow::Node module_attr_tracker() {
-  result = module_attr_tracker(DataFlow::TypeTracker::end())
+  module_attr_tracker(DataFlow::TypeTracker::end()).flowsTo(result)
 }

--- a/python/ql/test/experimental/dataflow/typetracking/tracked.ql
+++ b/python/ql/test/experimental/dataflow/typetracking/tracked.ql
@@ -6,7 +6,7 @@ import TestUtilities.InlineExpectationsTest
 // -----------------------------------------------------------------------------
 // tracked
 // -----------------------------------------------------------------------------
-DataFlow::Node tracked(TypeTracker t) {
+DataFlow::LocalSourceNode tracked(TypeTracker t) {
   t.start() and
   result.asCfgNode() = any(NameNode n | n.getId() = "tracked")
   or
@@ -20,7 +20,7 @@ class TrackedTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(DataFlow::Node e, TypeTracker t |
-      e = tracked(t) and
+      tracked(t).flowsTo(e) and
       // Module variables have no sensible location, and hence can't be annotated.
       not e instanceof DataFlow::ModuleVariableNode and
       tag = "tracked" and
@@ -34,14 +34,14 @@ class TrackedTest extends InlineExpectationsTest {
 // -----------------------------------------------------------------------------
 // int + str
 // -----------------------------------------------------------------------------
-DataFlow::Node int_type(TypeTracker t) {
+DataFlow::LocalSourceNode int_type(TypeTracker t) {
   t.start() and
   result.asCfgNode() = any(CallNode c | c.getFunction().(NameNode).getId() = "int")
   or
   exists(TypeTracker t2 | result = int_type(t2).track(t2, t))
 }
 
-DataFlow::Node string_type(TypeTracker t) {
+DataFlow::LocalSourceNode string_type(TypeTracker t) {
   t.start() and
   result.asCfgNode() = any(CallNode c | c.getFunction().(NameNode).getId() = "str")
   or
@@ -55,7 +55,7 @@ class TrackedIntTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(DataFlow::Node e, TypeTracker t |
-      e = int_type(t) and
+      int_type(t).flowsTo(e) and
       tag = "int" and
       location = e.getLocation() and
       value = t.getAttr() and
@@ -71,7 +71,7 @@ class TrackedStringTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(DataFlow::Node e, TypeTracker t |
-      e = string_type(t) and
+      string_type(t).flowsTo(e) and
       tag = "str" and
       location = e.getLocation() and
       value = t.getAttr() and
@@ -83,7 +83,7 @@ class TrackedStringTest extends InlineExpectationsTest {
 // -----------------------------------------------------------------------------
 // tracked_self
 // -----------------------------------------------------------------------------
-DataFlow::Node tracked_self(TypeTracker t) {
+DataFlow::LocalSourceNode tracked_self(TypeTracker t) {
   t.start() and
   exists(Function f |
     f.isMethod() and
@@ -101,7 +101,7 @@ class TrackedSelfTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(DataFlow::Node e, TypeTracker t |
-      e = tracked_self(t) and
+      tracked_self(t).flowsTo(e) and
       // Module variables have no sensible location, and hence can't be annotated.
       not e instanceof DataFlow::ModuleVariableNode and
       tag = "tracked_self" and
@@ -117,7 +117,7 @@ class TrackedSelfTest extends InlineExpectationsTest {
 // -----------------------------------------------------------------------------
 // This modeling follows the same pattern that we currently use in our real library modeling.
 /** Gets a reference to `foo` (fictive module). */
-private DataFlow::Node foo(DataFlow::TypeTracker t) {
+private DataFlow::LocalSourceNode foo(DataFlow::TypeTracker t) {
   t.start() and
   result = DataFlow::importNode("foo")
   or
@@ -125,10 +125,10 @@ private DataFlow::Node foo(DataFlow::TypeTracker t) {
 }
 
 /** Gets a reference to `foo` (fictive module). */
-DataFlow::Node foo() { result = foo(DataFlow::TypeTracker::end()) }
+DataFlow::Node foo() { foo(DataFlow::TypeTracker::end()).flowsTo(result) }
 
 /** Gets a reference to `foo.bar` (fictive module). */
-private DataFlow::Node foo_bar(DataFlow::TypeTracker t) {
+private DataFlow::LocalSourceNode foo_bar(DataFlow::TypeTracker t) {
   t.start() and
   result = DataFlow::importNode("foo.bar")
   or
@@ -139,10 +139,10 @@ private DataFlow::Node foo_bar(DataFlow::TypeTracker t) {
 }
 
 /** Gets a reference to `foo.bar` (fictive module). */
-DataFlow::Node foo_bar() { result = foo_bar(DataFlow::TypeTracker::end()) }
+DataFlow::Node foo_bar() { foo_bar(DataFlow::TypeTracker::end()).flowsTo(result) }
 
 /** Gets a reference to `foo.bar.baz` (fictive attribute on `foo.bar` module). */
-private DataFlow::Node foo_bar_baz(DataFlow::TypeTracker t) {
+private DataFlow::LocalSourceNode foo_bar_baz(DataFlow::TypeTracker t) {
   t.start() and
   result = DataFlow::importNode("foo.bar.baz")
   or
@@ -153,7 +153,7 @@ private DataFlow::Node foo_bar_baz(DataFlow::TypeTracker t) {
 }
 
 /** Gets a reference to `foo.bar.baz` (fictive attribute on `foo.bar` module). */
-DataFlow::Node foo_bar_baz() { result = foo_bar_baz(DataFlow::TypeTracker::end()) }
+DataFlow::Node foo_bar_baz() { foo_bar_baz(DataFlow::TypeTracker::end()).flowsTo(result) }
 
 class TrackedFooBarBaz extends InlineExpectationsTest {
   TrackedFooBarBaz() { this = "TrackedFooBarBaz" }


### PR DESCRIPTION
One minor change to the tests results needed: there is no longer local
flow going into the `ModuleVariableNode` for `attr_ref` in the
`moduleattr.ql` test, but I think this is reasonable.