### PR TITLE
C++: More models work

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Fread.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Fread.qll
@@ -2,7 +2,7 @@ import semmle.code.cpp.models.interfaces.Alias
 import semmle.code.cpp.models.interfaces.FlowSource
 
 private class Fread extends AliasFunction, RemoteFlowSourceFunction {
-  Fread() { this.hasGlobalName("fread") }
+  Fread() { this.hasGlobalOrStdOrBslName("fread") }
 
   override predicate parameterNeverEscapes(int n) {
     n = 0 or

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Getenv.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Getenv.qll
@@ -9,7 +9,7 @@ import semmle.code.cpp.models.interfaces.FlowSource
  * The POSIX function `getenv`.
  */
 class Getenv extends LocalFlowSourceFunction {
-  Getenv() { this.hasGlobalName("getenv") }
+  Getenv() { this.hasGlobalOrStdOrBslName("getenv") }
 
   override predicate hasLocalFlowSource(FunctionOutput output, string description) {
     (

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Gets.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Gets.qll
@@ -19,7 +19,7 @@ private class GetsFunction extends DataFlowFunction, TaintFunction, ArrayFunctio
     // gets(str)
     // fgets(str, num, stream)
     // fgetws(wstr, num, stream)
-    hasGlobalOrStdName(["gets", "fgets", "fgetws"])
+    hasGlobalOrStdOrBslName(["gets", "fgets", "fgetws"])
   }
 
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
@@ -54,13 +54,13 @@ private class GetsFunction extends DataFlowFunction, TaintFunction, ArrayFunctio
   }
 
   override predicate hasArrayWithVariableSize(int bufParam, int countParam) {
-    not hasGlobalOrStdName("gets") and
+    not hasName("gets") and
     bufParam = 0 and
     countParam = 1
   }
 
   override predicate hasArrayWithUnknownSize(int bufParam) {
-    hasGlobalOrStdName("gets") and
+    hasName("gets") and
     bufParam = 0
   }
 


### PR DESCRIPTION
BSL appears to use native:
 - `gets`, `fgets` , `fread` (https://github.com/bloomberg/bde/blob/81e73ce7156bcffff46703ee08b478c774684423/groups/bsl/bsl%2Bbslhdrs/bsl_cstdio.h#L84); the exact change I've made also permits `std::fread` now, which I'm not entirely sure ever exists (can't find in any snapshots, but then BSL's `using native_std::fread` appears to reference it; in any case it shouldn't do any harm to allow it).
 - `fgetws` (https://github.com/bloomberg/bde/blob/81e73ce7156bcffff46703ee08b478c774684423/groups/bsl/bsl%2Bbslhdrs/bsl_cwchar.h#L28)
 - `getenv` (https://github.com/bloomberg/bde/blob/81e73ce7156bcffff46703ee08b478c774684423/groups/bsl/bsl%2Bbslhdrs/bsl_cstdlib.h#L38); similarly to `fread` the exact change I've made also permits `std::getenv` now.

@criemen 