### PR TITLE
C++: Support BSL in Allocation.qll, Deallocation.qll.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -15,7 +15,7 @@ private class MallocAllocationFunction extends AllocationFunction {
 
   MallocAllocationFunction() {
     // --- C library allocation
-    hasGlobalOrStdName("malloc") and // malloc(size)
+    hasGlobalOrStdOrBslName("malloc") and // malloc(size)
     sizeArg = 0
     or
     hasGlobalName([
@@ -104,7 +104,7 @@ private class CallocAllocationFunction extends AllocationFunction {
 
   CallocAllocationFunction() {
     // --- C library allocation
-    hasGlobalOrStdName("calloc") and // calloc(num, size)
+    hasGlobalOrStdOrBslName("calloc") and // calloc(num, size)
     sizeArg = 1 and
     multArg = 0
   }
@@ -124,7 +124,7 @@ private class ReallocAllocationFunction extends AllocationFunction {
 
   ReallocAllocationFunction() {
     // --- C library allocation
-    hasGlobalOrStdName("realloc") and // realloc(ptr, size)
+    hasGlobalOrStdOrBslName("realloc") and // realloc(ptr, size)
     sizeArg = 1 and
     reallocArg = 0
     or

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
@@ -13,9 +13,13 @@ private class StandardDeallocationFunction extends DeallocationFunction {
   int freedArg;
 
   StandardDeallocationFunction() {
-    hasGlobalName([
+    hasGlobalOrStdOrBslName([
         // --- C library allocation
-        "free", "realloc",
+        "free", "realloc"
+      ]) and
+    freedArg = 0
+    or
+    hasGlobalName([
         // --- OpenSSL memory allocation
         "CRYPTO_free", "CRYPTO_secure_free"
       ]) and


### PR DESCRIPTION
 - `malloc`, `calloc`, `realloc` and `free` are defined from native versions so must behave the same in BSL  (https://github.com/bloomberg/bde/blob/81e73ce7156bcffff46703ee08b478c774684423/groups/bsl/bsl%2Bbslhdrs/bsl_cstdlib.h#L42)
 - `alloca`,`LocalFree` and `VirtualFree` are occasionally used (on some platforms) but not defined in BSL
 - the functions beginning `MMAllocate`, `MmFree`, `CoTaskMem`, `kmem_`, `CRYPTO_`, `ExAllocate`, `ExDelete`, `ExFree`, `IoAllocate`, `IoFree`, `Local[Re]Alloc`, `Global[Re]Alloc`, `GlobalFree`, `VirutalAlloc`, `VirtualFree`, `Heap[Re]Alloc`, `HeapFree`, `SysFree`, `__builtin_alloc`, `_alloca`, `_malloca`, `MmMapLocked` and `pool_` do not appear to be defined or otherwise referenced in BSL (and I would strongly not expect them to be defined).
 
@criemen 