### PR TITLE
Java: Add Argument.getParameter()

### DIFF
--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1954,6 +1954,15 @@ class Argument extends Expr {
   int getPosition() { result = pos }
 
   /**
+   * Gets the parameter for which this argument is a value. If this argument is part
+   * of an implicit varargs array this predicate has no result.
+   */
+  Parameter getParameter() {
+    result = call.getCallee().getParameter(pos) and
+    not isVararg()
+  }
+
+  /**
    * Holds if this argument is an array of the appropriate type passed to a
    * varargs parameter.
    */
@@ -1975,6 +1984,12 @@ class Argument extends Expr {
 
   /** Holds if this argument is part of an implicit varargs array. */
   predicate isVararg() { isNthVararg(_) }
+
+  /**
+   * If this argument is part of an implicit varargs array gets the
+   * varargs parameter it is a value for. Otherwise has no result.
+   */
+  Parameter getVarargsParameter() { isVararg() and result = call.getCallee().getVarargsParameter() }
 
   /**
    * Holds if this argument is part of an implicit varargs array at the

--- a/java/ql/src/semmle/code/java/Member.qll
+++ b/java/ql/src/semmle/code/java/Member.qll
@@ -171,6 +171,9 @@ class Callable extends StmtParent, Member, @callable {
   /** Gets the formal parameter at the specified (zero-based) position. */
   Parameter getParameter(int n) { params(result, _, n, this, _) }
 
+  /** Gets the varargs (variable arity) parameter, if any. */
+  Parameter getVarargsParameter() { result = getAParameter() and result.isVarargs() }
+
   /** Gets the type of the formal parameter at the specified (zero-based) position. */
   Type getParameterType(int n) { params(_, result, n, this, _) }
 


### PR DESCRIPTION
Adds the following predicates:
- `Argument.getParameter()`
- `Argument.getVarargsParameter()`
- `Callable.getVarargsParameter()`

`Argument.getParameter()` is probably the most useful one of them, but I added the other ones for completeness.
However, I am not sure how useful they actually are which is why I have marked this pull request as Draft for now.