### PR TITLE
Python: Expose framework identifier for route-setup and request handler

### DIFF
--- a/python/ql/src/semmle/python/Concepts.qll
+++ b/python/ql/src/semmle/python/Concepts.qll
@@ -325,6 +325,9 @@ module HTTP {
        * requests for this route, if any. These automatically become a `RemoteFlowSource`.
        */
       Parameter getARoutedParameter() { result = range.getARoutedParameter() }
+
+      /** Gets a string that identifies the framework used for this route setup. */
+      string getFramework() { result = range.getFramework() }
     }
 
     /** Provides a class for modeling new HTTP routing APIs. */
@@ -359,6 +362,9 @@ module HTTP {
          * requests for this route, if any. These automatically become a `RemoteFlowSource`.
          */
         abstract Parameter getARoutedParameter();
+
+        /** Gets a string that identifies the framework used for this route setup. */
+        abstract string getFramework();
       }
     }
 
@@ -378,6 +384,9 @@ module HTTP {
        * requests, if any. These automatically become a `RemoteFlowSource`.
        */
       Parameter getARoutedParameter() { result = range.getARoutedParameter() }
+
+      /** Gets a string that identifies the framework used for this route setup. */
+      string getFramework() { result = range.getFramework() }
     }
 
     /** Provides a class for modeling new HTTP request handlers. */
@@ -396,6 +405,9 @@ module HTTP {
          * requests, if any. These automatically become a `RemoteFlowSource`.
          */
         abstract Parameter getARoutedParameter();
+
+        /** Gets a string that identifies the framework used for this request handler. */
+        abstract string getFramework();
       }
     }
 
@@ -408,13 +420,17 @@ module HTTP {
         result = rs.getARoutedParameter() and
         result in [this.getArg(_), this.getArgByName(_)]
       }
+
+      override string getFramework() { result = rs.getFramework() }
     }
 
     /** A parameter that will receive parts of the url when handling an incoming request. */
     private class RoutedParameter extends RemoteFlowSource::Range, DataFlow::ParameterNode {
-      RoutedParameter() { this.getParameter() = any(RequestHandler handler).getARoutedParameter() }
+      RequestHandler handler;
 
-      override string getSourceType() { result = "RoutedParameter" }
+      RoutedParameter() { this.getParameter() = handler.getARoutedParameter() }
+
+      override string getSourceType() { result = handler.getFramework() + " RoutedParameter" }
     }
 
     /**

--- a/python/ql/src/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/semmle/python/frameworks/Django.qll
@@ -2158,6 +2158,8 @@ private module Django {
         result = vc.getARequestHandler()
       )
     }
+
+    override string getFramework() { result = "Django" }
   }
 
   /** A request handler defined in a django view class, that has no known route. */
@@ -2175,6 +2177,8 @@ private module Django {
       result in [this.getArg(_), this.getArgByName(_)] and
       not result = any(int i | i <= this.getRequestParamIndex() | this.getArg(i))
     }
+
+    override string getFramework() { result = "Django" }
   }
 
   /**

--- a/python/ql/src/semmle/python/frameworks/Flask.qll
+++ b/python/ql/src/semmle/python/frameworks/Flask.qll
@@ -219,6 +219,8 @@ private module FlaskModel {
         )
       )
     }
+
+    override string getFramework() { result = "Flask" }
   }
 
   /**
@@ -277,6 +279,8 @@ private module FlaskModel {
       result in [this.getArg(_), this.getArgByName(_)] and
       not result = this.getArg(0)
     }
+
+    override string getFramework() { result = "Flask" }
   }
 
   // ---------------------------------------------------------------------------

--- a/python/ql/src/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/src/semmle/python/frameworks/Stdlib.qll
@@ -1629,6 +1629,8 @@ private module Stdlib {
       }
 
       override Parameter getARoutedParameter() { none() }
+
+      override string getFramework() { result = "Stdlib" }
     }
   }
 

--- a/python/ql/src/semmle/python/frameworks/Tornado.qll
+++ b/python/ql/src/semmle/python/frameworks/Tornado.qll
@@ -486,7 +486,9 @@ private module Tornado {
   }
 
   /** A tornado route setup. */
-  abstract class TornadoRouteSetup extends HTTP::Server::RouteSetup::Range { }
+  abstract class TornadoRouteSetup extends HTTP::Server::RouteSetup::Range {
+    override string getFramework() { result = "Tornado" }
+  }
 
   /**
    * A regex that is used to set up a route.
@@ -561,6 +563,8 @@ private module Tornado {
       result in [this.getArg(_), this.getArgByName(_)] and
       not result = this.getArg(0)
     }
+
+    override string getFramework() { result = "Tornado" }
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
This makes collecting metrics on framework coverage a bit simpler (specifically giving the RoutedParameter class a more descriptive result for getSourceType).

I guess it can also help a bit when trying to get an overview of a new DB, but making metrics collection easier is my main motivation for this.