### PR TITLE
JS: avoid cartesian product in isFilteredPropertyName

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
@@ -221,20 +221,16 @@ module CleartextLogging {
   /**
    * Holds if `name` is filtered by e.g. a regular-expression test or a filter call.
    */
-  private predicate isFilteredPropertyName(DataFlow::Node name) {
+  private predicate isFilteredPropertyName(DataFlow::SourceNode name) {
     exists(DataFlow::MethodCallNode reduceCall |
-      reduceCall.getABoundCallbackParameter(0, 1).flowsTo(name) and
-      reduceCall.getMethodName() = "reduce"
+      reduceCall.getMethodName() = "reduce" and
+      reduceCall.getABoundCallbackParameter(0, 1) = name
     |
       reduceCall.getReceiver+().(DataFlow::MethodCallNode).getMethodName() = "filter"
     )
     or
-    exists(StringOps::RegExpTest test |
-      test.getStringOperand().getALocalSource() = name.getALocalSource()
-    )
+    exists(StringOps::RegExpTest test | test.getStringOperand().getALocalSource() = name)
     or
-    exists(MembershipCandidate test |
-      test.getAMemberNode().getALocalSource() = name.getALocalSource()
-    )
+    exists(MembershipCandidate test | test.getAMemberNode().getALocalSource() = name)
   }
 }


### PR DESCRIPTION
The predicate went from taking 4 minutes to 50 ms when running on `ace`. 

The predicate was only ever used on `SourceNode`s, so changing `name.getALocalSource()` to `name` preserves behavior. 

I've not planned an evaluation. Let me know if you want one. 