### PR TITLE
JS: Improve performance in API-graphs.

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -746,7 +746,7 @@ module API {
     /**
      * Holds if `nd`, which is a use of an API-graph node, flows in zero or more potentially
      * inter-procedural steps to some intermediate node, and then from that intermediate node to
-     * `res` in one step described by the resulting TypeTracker.
+     * `res` in one step. The entire flow is described by the resulting `TypeTracker`.
      *
      * This predicate exists solely to enforce a better join order in `trackUseNode` above.
      */
@@ -794,9 +794,9 @@ module API {
     }
 
     /**
-     * Holds if `nd`, which is a def of an API-graph node, flows in zero or more potentially
-     * inter-procedural steps from some intermediate node, and then to that intermediate node from
-     * `prev` in one step described by the resulting TypeTracker.
+     * Holds if `nd`, which is a def of an API-graph node, can be reached in zero or more potentially
+     * inter-procedural steps from some intermediate node, and `prev` flows into that intermediate node
+     * in one step. The entire flow is described by the resulting `TypeTracker`.
      *
      * This predicate exists solely to enforce a better join order in `trackDefNode` above.
      */
@@ -937,7 +937,7 @@ module API {
     }
 
     /**
-     * Gets an API node where a RHS of the node if the `i`th argument to this call.
+     * Gets an API node where a RHS of the node is the `i`th argument to this call.
      */
     private Node getAParameterCandidate(int i) { result.getARhs() = getArgument(i) }
 

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -914,10 +914,16 @@ module API {
     }
 
     /** Gets the API node for the `i`th parameter of this invocation. */
+    pragma[nomagic]
     Node getParameter(int i) {
       result = callee.getParameter(i) and
-      result.getARhs() = getArgument(i)
+      result = getAParameterCandidate(i)
     }
+
+    /**
+     * Gets an API node where a RHS of the node if the `i`th argument to this call.
+     */
+    private Node getAParameterCandidate(int i) { result.getARhs() = getArgument(i) }
 
     /** Gets the API node for a parameter of this invocation. */
     Node getAParameter() { result = getParameter(_) }

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -790,7 +790,23 @@ module API {
         )
       )
       or
-      exists(DataFlow::TypeBackTracker t2 | result = trackDefNode(nd, t2).backtrack(t2, t))
+      t = defStep(nd, result)
+    }
+
+    /**
+     * Holds if `nd`, which is a def of an API-graph node, flows in zero or more potentially
+     * inter-procedural steps from some intermediate node, and then to that intermediate node from
+     * `prev` in one step described by the resulting TypeTracker.
+     *
+     * This predicate exists solely to enforce a better join order in `trackDefNode` above.
+     */
+    pragma[noopt]
+    private DataFlow::TypeBackTracker defStep(DataFlow::Node nd, DataFlow::SourceNode prev) {
+      exists(DataFlow::TypeBackTracker t, StepSummary summary, DataFlow::Node next |
+        next = trackDefNode(nd, t) and
+        StepSummary::step(prev, next, summary) and
+        result = t.prepend(summary)
+      )
     }
 
     /**


### PR DESCRIPTION
Inspired by a performance regression in `openlayers/ol2`. 

[Evaluation looks great](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/api-use-3/reports). (I only evaluated on `TaintedPath.ql`). 

/cc @tausbn, @max-schaefer (I added you guys to my evaluation-repo above). 

~~**TODO**: I also did an evaluation on each commit on it's own. And I might revert the `API::InvokeNode::getParameter` change.~~ 
I can't see from an evaluation if the `API::InvokeNode::getParameter` change helps. 
But it saved 7.5s for `TaintedPath.ql` on `ol2` on my machine, so I'm keeping it. 
 