### PR TITLE
JS: use manual recursion in `Refinements::inGuard`

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Refinements.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Refinements.qll
@@ -324,7 +324,11 @@ class VarRefinementContext extends RefinementContext, TVarRefinementContext {
 }
 
 /** Holds if `e` is nested inside a guard node. */
-private predicate inGuard(Expr e) { e.getParentExpr*() = any(GuardControlFlowNode g).getTest() }
+private predicate inGuard(Expr e) {
+  e = any(GuardControlFlowNode g).getTest()
+  or
+  inGuard(e.getParentExpr())
+}
 
 /**
  * An abstract value of a refinement expression.


### PR DESCRIPTION
Saves about 14 seconds in `ol2` on my laptop. 

It seems like the full transitive closure of the `getParent()` relation was computed. But we don't need that. 