### PR TITLE
Docs (CodeQL for VS Code): Move info about telemetry into codeql.github.com

### DIFF
--- a/docs/codeql/codeql-for-visual-studio-code/about-codeql-for-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/about-codeql-for-visual-studio-code.rst
@@ -26,6 +26,12 @@ features for query files (extension ``.ql``) and library files (extension ``.qll
 
 You can also use the VS Code **Format Document** command to format your code according to the `CodeQL style guide <https://github.com/github/codeql/blob/main/docs/ql-style-guide.md>`__.
 
+Data and telemetry
+-------------------
+
+If you specifically opt in to permit GitHub to do so, GitHub will collect usage data and metrics for the purposes of helping the core developers to improve the CodeQL extension for VS Code.
+For more information, see ":doc:`About telemetry in CodeQL for Visual Studio Code <about-telemetry-in-codeql-for-visual-studio-code>`."
+
 Further reading
 -------------------
 

--- a/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
@@ -1,0 +1,59 @@
+:tocdepth: 1
+
+.. _about-telemetry-in-codeql-for-visual-studio-code:
+
+About telemetry in CodeQL for Visual Studio Code
+=================================================
+
+If you specifically opt-in to permit GitHub to do so, GitHub will collect usage data and metrics for the purposes of helping the core developers to improve the CodeQL extension for VS Code. This data will not be shared with any parties outside of GitHub. IP addresses and installation IDs will be retained for a maximum of 30 days. Anonymous data will be retained for a maximum of 180 days.
+
+Why do you collect data?
+--------------------------------------
+
+GitHub collects aggregated, anonymous usage data and metrics to help us improve CodeQL for VS Code. IP addresses and installation IDs are collected only to ensure that anonymous data is not duplicated during aggregation.
+
+What data is collected
+--------------------------------------
+
+If you opt in, GitHub collects the following information related to the usage of the extension. The data collected are:
+
+- The identifiers of any CodeQL-related `VS Code commands <https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_command-palette>`__ that are run
+- For each command: the timestamp, time taken, and whether or not the command completed successfully
+- VS Code and extension version
+- Randomly generated GUID that uniquely identifies a CodeQL extension installation. (Discarded before aggregation.)
+- IP address of the client sending the telemetry data. (Discarded before aggregation.)
+- Whether or not the ``codeQL.canary`` setting is enabled and set to `true`
+
+How long will data be retained?
+--------------------------------------
+
+IP address and GUIDs will be retained for a maximum of 30 days. Anonymous, aggregated data that includes command identifiers, run times, and timestamps will be retained for a maximum of 180 days.
+
+Who will have access to this data?
+--------------------------------------
+
+IP address and GUIDs will only be available to the core developers of CodeQL. Aggregated data will be available to GitHub employees.
+
+What data is **NOT** collected?
+--------------------------------------
+
+We only collect the minimal amount of data we need to answer the questions about how our users are experiencing this product. To that end, we do not collect the following information:
+
+- No GitHub user ID
+- No CodeQL database names or contents
+- No contents of CodeQL queries
+- No filesystem paths.
+
+How do I disable telemetry reporting?
+---------------------------------------------------------
+
+When telemetry collection is disabled, no data will be sent to GitHub servers.
+
+You can disable telemetry collection by setting ``codeQL.telemetry.enableTelemetry`` to ``false`` in `your settings <https://code.visualstudio.com/docs/getstarted/settings#_settings-editor>`__. Telemetry collection is _disabled_ by default.
+
+Additionally, telemetry collection will be disabled if the global ``telemetry.enableTelemetry`` setting is set to ``false``. For more information on global telemetry collection, see `Microsoft’s documentation <https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting>`__.
+
+More information
+-------------------
+
+See GitHub's `Privacy Statement <https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-privacy-statement>`__ and `Terms of Service <https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-terms-of-service>`__ for more information.

--- a/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
@@ -5,9 +5,11 @@
 About telemetry in CodeQL for Visual Studio Code
 =================================================
 
-If you specifically opt-in to permit GitHub to do so, GitHub will collect usage data and metrics for the purposes of helping the core developers to improve the CodeQL extension for VS Code. This data will not be shared with any parties outside of GitHub. IP addresses and installation IDs will be retained for a maximum of 30 days. Anonymous data will be retained for a maximum of 180 days.
+If you specifically opt in to permit GitHub to do so, GitHub will collect usage data and metrics for the purposes of helping the core developers to improve the CodeQL extension for VS Code.
 
-Why do you collect data?
+This data will not be shared with any parties outside of GitHub. IP addresses and installation IDs will be retained for a maximum of 30 days. Anonymous data will be retained for a maximum of 180 days.
+
+Why we collect data
 --------------------------------------
 
 GitHub collects aggregated, anonymous usage data and metrics to help us improve CodeQL for VS Code. IP addresses and installation IDs are collected only to ensure that anonymous data is not duplicated during aggregation.
@@ -17,43 +19,44 @@ What data is collected
 
 If you opt in, GitHub collects the following information related to the usage of the extension. The data collected are:
 
-- The identifiers of any CodeQL-related `VS Code commands <https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_command-palette>`__ that are run
-- For each command: the timestamp, time taken, and whether or not the command completed successfully
-- VS Code and extension version
+- The identifiers of any CodeQL-related VS Code commands that are run.
+- For each command: the timestamp, time taken, and whether or not the command completed successfully.
+- VS Code and extension version.
 - Randomly generated GUID that uniquely identifies a CodeQL extension installation. (Discarded before aggregation.)
 - IP address of the client sending the telemetry data. (Discarded before aggregation.)
-- Whether or not the ``codeQL.canary`` setting is enabled and set to `true`
+- Whether or not the ``codeQL.canary`` setting is enabled and set to ``true``.
 
-How long will data be retained?
---------------------------------------
+How long data is retained
+--------------------------
 
 IP address and GUIDs will be retained for a maximum of 30 days. Anonymous, aggregated data that includes command identifiers, run times, and timestamps will be retained for a maximum of 180 days.
 
-Who will have access to this data?
---------------------------------------
+Access to the data
+-------------------
 
 IP address and GUIDs will only be available to the core developers of CodeQL. Aggregated data will be available to GitHub employees.
 
-What data is **NOT** collected?
---------------------------------------
+What data is **NOT** collected
+--------------------------------
 
 We only collect the minimal amount of data we need to answer the questions about how our users are experiencing this product. To that end, we do not collect the following information:
 
 - No GitHub user ID
 - No CodeQL database names or contents
 - No contents of CodeQL queries
-- No filesystem paths.
+- No filesystem paths
 
-How do I disable telemetry reporting?
----------------------------------------------------------
+Disabling telemetry reporting
+------------------------------
 
 When telemetry collection is disabled, no data will be sent to GitHub servers.
 
-You can disable telemetry collection by setting ``codeQL.telemetry.enableTelemetry`` to ``false`` in `your settings <https://code.visualstudio.com/docs/getstarted/settings#_settings-editor>`__. Telemetry collection is _disabled_ by default.
+You can disable telemetry collection by setting ``codeQL.telemetry.enableTelemetry`` to ``false`` in your settings. For more information about CodeQL settings, see ":doc:`Customizing settings <customizing-settings>`." 
+Telemetry collection is *disabled* by default.
 
-Additionally, telemetry collection will be disabled if the global ``telemetry.enableTelemetry`` setting is set to ``false``. For more information on global telemetry collection, see `Microsoft’s documentation <https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting>`__.
+Additionally, telemetry collection will be disabled if the global ``telemetry.enableTelemetry`` setting is set to ``false``. For more information about global telemetry collection, see "`Microsoft's documentation <https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting>`__."
 
-More information
--------------------
+Further reading
+----------------
 
-See GitHub's `Privacy Statement <https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-privacy-statement>`__ and `Terms of Service <https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-terms-of-service>`__ for more information.
+For more information, see GitHub's "`Privacy Statement <https://docs.github.com/github/site-policy/github-privacy-statement>`__" and "`Terms of Service <https://docs.github.com/github/site-policy/github-terms-of-service>`__."

--- a/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
@@ -49,10 +49,11 @@ We only collect the minimal amount of data we need to answer the questions about
 Disabling telemetry reporting
 ------------------------------
 
+Telemetry collection is *disabled* by default.
+
 When telemetry collection is disabled, no data will be sent to GitHub servers.
 
 You can disable telemetry collection by setting ``codeQL.telemetry.enableTelemetry`` to ``false`` in your settings. For more information about CodeQL settings, see ":doc:`Customizing settings <customizing-settings>`." 
-Telemetry collection is *disabled* by default.
 
 Additionally, telemetry collection will be disabled if the global ``telemetry.enableTelemetry`` setting is set to ``false``. For more information about global telemetry collection, see "`Microsoft's documentation <https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting>`__."
 

--- a/docs/codeql/codeql-for-visual-studio-code/index.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/index.rst
@@ -39,6 +39,8 @@ The CodeQL extension for Visual Studio Code adds rich language support for CodeQ
   <troubleshooting-codeql-for-visual-studio-code>`: You can use the detailed 
   information written to the extension's log files if you need to troubleshoot problems.
 
+- :doc:`About telemetry in CodeQL for Visual Studio Code <about-telemetry-in-codeql-for-visual-studio-code>`: If you specifically opt in to permit GitHub to do so, GitHub will collect usage data and metrics for the purposes of helping the core developers to improve the CodeQL extension for VS Code.
+
 .. toctree::
    :hidden:
    :titlesonly:
@@ -51,3 +53,4 @@ The CodeQL extension for Visual Studio Code adds rich language support for CodeQ
    testing-codeql-queries-in-visual-studio-code
    customizing-settings
    troubleshooting-codeql-for-visual-studio-code
+   about-telemetry-in-codeql-for-visual-studio-code


### PR DESCRIPTION
### Summary

We'd like to move the information from [TELEMETRY.md](https://github.com/github/vscode-codeql/blob/ab31d86a8d7e09926772e0b84744e8a45639be47/extensions/ql-vscode/TELEMETRY.md) into the main docs set on codeql.github.com. The telemetry content was originally discussed and added in https://github.com/github/vscode-codeql/pull/611. To avoid duplication, we'll now delete the TELEMETRY.md file from the vscode-codeql repo (see https://github.com/github/vscode-codeql/pull/758).

### Changes

https://github.com/github/codeql/commit/48ace064ccbc2596e69fcd2fd89338923b6d391b copies the original doc into the Sphinx project and https://github.com/github/codeql/commit/28848ecf32e011f8b914be4d7cd72ccc3f19ad84 adds links to this new article.


👇🏽 **This is the main commit to review** 👇🏽 

https://github.com/github/codeql/commit/4dd1be5ba158643c6710110bde6645003a7d2a28 contains editorial changes to the telemetry doc. I've kept most of the text as-is, since I didn't want to change the specific details around data collection etc.

I've provided a link to a preview in the internal (linked) issue.