### PR TITLE
Actions: Add change note checker

### DIFF
--- a/.github/workflows/check-change-note.yml
+++ b/.github/workflows/check-change-note.yml
@@ -10,7 +10,6 @@ jobs:
   check-change-note:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Fail if no change note found. To fix, either add one, or add the `no-change-note-required` label.
         if: |
           github.event.pull_request.draft == false &&
@@ -19,5 +18,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api 'repos/${{github.repository}}/pulls/${{github.event.number}}/files' --paginate |
-          jq '.[].filename' --raw-output |
-          grep '/change-notes/.*\.md$'
+          jq 'any(.[].filename ; test("/change-notes/.*[.]md$"))' --exit-status

--- a/.github/workflows/check-change-note.yml
+++ b/.github/workflows/check-change-note.yml
@@ -1,9 +1,10 @@
 on:
   pull_request_target:
+    types: [labeled, unlabeled, opened, synchronize, reopened, ready_for_review]
     paths:
-      - '**/*.ql'
-      - '**/*.qll'
-      - '!**/experimental/**'
+      - "*/ql/src/**/*.ql"
+      - "*/ql/src/**/*.qll"
+      - "!**/experimental/**"
 
 jobs:
   check-change-note:
@@ -19,17 +20,14 @@ jobs:
       - name: Get PR labels
         id: pr-labels
         uses: joerick/pr-labels-action@v1.0.6
-      - name: Inform the PR author
+      - name: Fail if change note is missing
         uses: actions/github-script@v3
         if: |
-          steps.paths_filter.outputs.change_note == 'false' && 
-          !contains(steps.pr-labels.outputs.labels, ' minor-change ')
+          github.event.pull_request.draft == false &&
+          steps.paths_filter.outputs.change_note == 'false' &&
+          !contains(steps.pr-labels.outputs.labels, ' no-change-note-required ')
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['Needs change note']
-            })
+            core.setFailed('No change note found.' +
+            ' Either add one, or add the `no-change-note-required` label.')

--- a/.github/workflows/check-change-note.yml
+++ b/.github/workflows/check-change-note.yml
@@ -1,0 +1,35 @@
+on:
+  pull_request_target:
+    paths:
+      - '**/*.ql'
+      - '**/*.qll'
+      - '!**/experimental/**'
+
+jobs:
+  check-change-note:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if change note file is present
+        uses: dorny/paths-filter@v2
+        id: paths_filter
+        with:
+          filters: |
+            change_note:
+              - '**/change-notes/*.md'
+      - name: Get PR labels
+        id: pr-labels
+        uses: joerick/pr-labels-action@v1.0.6
+      - name: Inform the PR author
+        uses: actions/github-script@v3
+        if: |
+          steps.paths_filter.outputs.change_note == 'false' && 
+          !contains(steps.pr-labels.outputs.labels, ' minor-change ')
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Needs change note']
+            })

--- a/.github/workflows/check-change-note.yml
+++ b/.github/workflows/check-change-note.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if change note file is present
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@7c0f15b688b020e95e00f15c61299b022f08ca95 # v2.8.0
         id: paths_filter
         with:
           filters: |
@@ -19,7 +19,7 @@ jobs:
               - '**/change-notes/*.md'
       - name: Get PR labels
         id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.6
+        uses: joerick/pr-labels-action@0a4cc4ee0ab557ec0b1ae1157fa6fa7f9f4c494b # v1.0.6
       - name: Fail if change note is missing
         uses: actions/github-script@v3
         if: |

--- a/.github/workflows/check-change-note.yml
+++ b/.github/workflows/check-change-note.yml
@@ -10,24 +10,14 @@ jobs:
   check-change-note:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if change note file is present
-        uses: dorny/paths-filter@7c0f15b688b020e95e00f15c61299b022f08ca95 # v2.8.0
-        id: paths_filter
-        with:
-          filters: |
-            change_note:
-              - '**/change-notes/*.md'
-      - name: Get PR labels
-        id: pr-labels
-        uses: joerick/pr-labels-action@0a4cc4ee0ab557ec0b1ae1157fa6fa7f9f4c494b # v1.0.6
-      - name: Fail if change note is missing
-        uses: actions/github-script@v3
+      - uses: actions/checkout@v2
+      - name: Fail if no change note found. To fix, either add one, or add the `no-change-note-required` label.
         if: |
           github.event.pull_request.draft == false &&
-          steps.paths_filter.outputs.change_note == 'false' &&
-          !contains(steps.pr-labels.outputs.labels, ' no-change-note-required ')
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            core.setFailed('No change note found.' +
-            ' Either add one, or add the `no-change-note-required` label.')
+          !contains(github.event.pull_request.labels.*.name, 'no-change-note-required')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api 'repos/${{github.repository}}/pulls/${{github.event.number}}/files' --paginate |
+          jq '.[].filename' --raw-output |
+          grep '/change-notes/.*\.md$'


### PR DESCRIPTION
Checks whether a change note is present on a PR (assuming it should be) and adds a label to indicate when its not.

Considers all `.ql` and `.qll` files relevant, unless:
- the files are in a subdirectory of `experimental`, or
- the PR has been labelled with the label "Minor change"

If any relevant files are found, and there is no corresponding change note, the label "Needs change note" is applied to the PR.

I'm thinking we may want to roll this out to just the Python team at first. I have tested it manually, but I can't guarantee that it works perfectly.

Open questions:
- Should this add a comment instead of a label?
- Should this fail the action and block merging?

cc: @RasmusWL @calumgrant @adityasharad 