### PR TITLE
Remove personal assignment to writers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,18 +3,3 @@
 /java/ @github/codeql-java
 /javascript/ @github/codeql-javascript
 /python/ @github/codeql-python
-
-# Assign query help for docs review
-/cpp/**/*.qhelp @hubwriter
-/csharp/**/*.qhelp @jf205
-/java/**/*.qhelp @felicitymay
-/javascript/**/*.qhelp @mchammer01
-/python/**/*.qhelp @felicitymay
-/docs/language/ @shati-patel @jf205
-
-# Exclude help for experimental queries from docs review
-/cpp/**/experimental/**/*.qhelp @github/codeql-c-analysis
-/csharp/**/experimental/**/*.qhelp @github/codeql-csharp
-/java/**/experimental/**/*.qhelp @github/codeql-java
-/javascript/**/experimental/**/*.qhelp @github/codeql-javascript
-/python/**/experimental/**/*.qhelp @github/codeql-python


### PR DESCRIPTION
This is part of the work to revise the process for requesting docs content team reviews on pull requests.

It should not be merged until the related internal pull requests are approved and merged.