### PR TITLE
C++: Add CWE-676 tag.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-676/DangerousFunctionOverflow.ql
+++ b/cpp/ql/src/Security/CWE/CWE-676/DangerousFunctionOverflow.ql
@@ -8,6 +8,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-242
+ *       external/cwe/cwe-676
  */
 
 import cpp


### PR DESCRIPTION
I noticed that one of the queries in the `Security/CWE/CWE-676` directory doesn't actually have the `CWE-676` ("Use of Potentially Dangerous Function") tag corresponding to its directory.  This is a bit odd.  It does have the `CWE-242` ("Use of Inherently Dangerous Function`") tag, which is related but not the same.