### PR TITLE
Update supported go frameworks

### DIFF
--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -27,41 +27,47 @@ Go built-in support
    :widths: auto
 
    Name, Category
-   Chi, Web framework
-   Echo, Web framework
-   Gin, Web framework
-   glog, Logging library
-   go-restful, Web application framework
-   go-sh, Utility library
-   GoKit, Microservice toolkit
-   Gokogiri, XPath library
-   golang.org/x/crypto/ssh, Network communicator
-   golang.org/x/net/websocket, Network communicator
-   Gorilla websocket, Network communicator
-   GORM, Database
-   GoWebsocket, Network communicator
-   goxpath, XPath library
-   https://github.com/antchfx/htmlquery, XPath library
-   https://github.com/antchfx/jsonquery, XPath library
-   https://github.com/antchfx/xmlquery, XPath library
-   https://github.com/antchfx/xpath, XPath library
-   https://github.com/go-xmlpath/xmlpath, XPath library
-   json-iterator, Serialization
-   klog, Logging library
-   Logrus, Logging library
-   Macaron, Web framework
-   mongo, Database
-   mux, HTTP request router and dispatcher
-   nhooyr.io/websocket, Network communicator
-   pg, Database
-   proto, Serialization
-   Revel, Web framework
-   Spew, Logging library
-   sqlx, Database
-   SendGrid, Email library
-   Squirrel, Database
-   ws, Network communicator
-   xpathparser, XPath library
+   `beego <https://beego.me/>`_, Web/logging/database framework
+   `Chi <https://github.com/go-chi/chi>`_, Web framework
+   Couchbase (`gocb <https://github.com/couchbase/gocb>`_ and `go-couchbase <http://www.github.com/couchbase/go-couchbase>`_), Database
+   `Echo <https://echo.labstack.com/>`_, Web framework
+   `Gin <https://github.com/gin-gonic/gin>`_, Web framework
+   `glog <https://github.com/golang/glog>`_, Logging library
+   `go-pg <https://pg.uptrace.dev/>`_, Database
+   `go-restful <https://github.com/emicklei/go-restful>`_, Web application framework
+   `go-sh <https://github.com/codeskyblue/go-sh>`_, Utility library
+   `go-spew <https://github.com/davecgh/go-spew>`_, Logging library
+   `GoKit <https://github.com/go-kit/kit>`_, Microservice toolkit
+   `Gokogiri <https://github.com/jbowtie/gokogiri>`_, XPath library
+   `golang.org/x/crypto/ssh <https://pkg.go.dev/golang.org/x/crypto/ssh>`_, Network communicator
+   `golang.org/x/net/websocket <https://pkg.go.dev/golang.org/x/net/websocket>`_, Network communicator
+   `goproxy <https://github.com/elazarl/goproxy>`_, HTTP proxy library
+   `Gorilla mux <http://www.gorillatoolkit.org/pkg/mux>`_, HTTP request router and dispatcher
+   `Gorilla websocket <https://github.com/gorilla/websocket>`_, Network communicator
+   `GORM <https://gorm.io/>`_, Database
+   `GoWebsocket <https://github.com/sacOO7/gowebsocket>`_, Network communicator
+   `goxpath <https://github.com/ChrisTrenkamp/goxpath>`_, XPath library
+   `htmlquery <https://github.com/antchfx/htmlquery>`_, XPath library
+   `json-iterator <https://github.com/json-iterator/go>`_, Serialization
+   `jsonpatch <https://github.com/evanphx/json-patch>`_, Serialization
+   `jsonquery <https://github.com/antchfx/jsonquery>`_, XPath library
+   `klog <https://github.com/kubernetes/klog>`_, Logging library
+   `Logrus <https://github.com/sirupsen/logrus>`_, Logging library
+   `Macaron <https://gopkg.in/macaron.v1>`_, Web framework
+   `mongo <https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo>`_, Database
+   `nhooyr.io/websocket <http://nhooyr.io/websocket>`_, Network communicator
+   `protobuf <https://pkg.go.dev/google.golang.org/protobuf>`_, Serialization
+   `Revel <http://revel.github.io/>`_, Web framework
+   `sqlx <http://jmoiron.github.io/sqlx/>`_, Database
+   `SendGrid <https://github.com/sendgrid/sendgrid-go>`_, Email library
+   `Squirrel <https://github.com/Masterminds/squirrel>`_, Database
+   `ws <https://github.com/gobwas/ws>`_, Network communicator
+   `xmlpath <https://gopkg.in/xmlpath.v2>`_, XPath library
+   `xmlquery <https://github.com/antchfx/xmlquery>`_, XPath library
+   `xpath <https://github.com/antchfx/xpath>`_, XPath library
+   `xpathparser <https://github.com/santhosh-tekuri/xpathparser>`_, XPath library
+   `yaml <https://gopkg.in/yaml.v3>`_, Serialization
+   `zap <https://go.uber.org/zap>`_, Logging library
 
 Java built-in support
 ==================================


### PR DESCRIPTION
As a side note, it would be useful (for go at least) if we could have two columns rather than three. The new column would have some kind of unique identifier for the library, as there are several names which are used by competing libraries (e.g. goproxy). For go this unique identifier is normally a short URL, or in some cases just the suffix of a github URL would do (for example, `goproxy/goproxy` vs `elazarl/goproxy`).