### PR TITLE
Java: Add backward dataflow edges through modelled function invocations

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
@@ -50,7 +50,7 @@ abstract class FluentMethod extends ValuePreservingCallable {
   override predicate returnsValue(int arg) { arg = -1 }
 }
 
-private class StandardLibraryValuePreservingCallable extends ValuePreservingCallable {
+private class StandardLibraryValuePreservingMethod extends ValuePreservingMethod {
   int returnsArgNo;
 
   StandardLibraryValuePreservingCallable() {

--- a/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
@@ -21,7 +21,7 @@ private module Frameworks {
 }
 
 /**
- * A method or constructor that returns the exact value of one of its parameters or the qualifier.
+ * A method that returns the exact value of one of its parameters or the qualifier.
  *
  * Extend this class and override `returnsValue` to add additional value-preserving steps through a
  * method that should be added to the basic local flow step relation.
@@ -29,16 +29,16 @@ private module Frameworks {
  * These steps will be visible for all global data-flow purposes, as well as via
  * `DataFlow::Node.getASuccessor` and other related functions exposing intraprocedural dataflow.
  */
-abstract class ValuePreservingCallable extends Callable {
+abstract class ValuePreservingMethod extends Method {
   /**
-   * Holds if this callable returns precisely the value passed into argument `arg`.
+   * Holds if this method returns precisely the value passed into argument `arg`.
    * `arg` is a parameter index, or is -1 to indicate the qualifier.
    */
   abstract predicate returnsValue(int arg);
 }
 
 /**
- * A method or constructor that returns the exact value of its qualifier (e.g., `return this;`)
+ * A method that returns the exact value of its qualifier (e.g., `return this;`)
  *
  * Extend this class and override `returnsValue` to add additional value-preserving steps through a
  * method that should be added to the basic local flow step relation.

--- a/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
@@ -21,6 +21,60 @@ private module Frameworks {
 }
 
 /**
+ * A method or constructor that returns the exact value of one of its parameters or the qualifier.
+ *
+ * Extend this class and override `returnsValue` to add additional value-preserving steps through a
+ * method that should be added to the basic local flow step relation.
+ *
+ * These steps will be visible for all global data-flow purposes, as well as via
+ * `DataFlow::Node.getASuccessor` and other related functions exposing intraprocedural dataflow.
+ */
+abstract class ValuePreservingCallable extends Callable {
+  /**
+   * Holds if this callable returns precisely the value passed into argument `arg`.
+   * `arg` is a parameter index, or is -1 to indicate the qualifier.
+   */
+  abstract predicate returnsValue(int arg);
+}
+
+/**
+ * A method or constructor that returns the exact value of its qualifier (e.g., `return this;`)
+ *
+ * Extend this class and override `returnsValue` to add additional value-preserving steps through a
+ * method that should be added to the basic local flow step relation.
+ *
+ * These steps will be visible for all global data-flow purposes, as well as via
+ * `DataFlow::Node.getASuccessor` and other related functions exposing intraprocedural dataflow.
+ */
+abstract class FluentMethod extends ValuePreservingCallable {
+  override predicate returnsValue(int arg) { arg = -1 }
+}
+
+private class StandardLibraryValuePreservingCallable extends ValuePreservingCallable {
+  int returnsArgNo;
+
+  StandardLibraryValuePreservingCallable() {
+    this.getDeclaringType().hasQualifiedName("java.util", "Objects") and
+    (
+      this.hasName(["requireNonNull", "requireNonNullElseGet"]) and returnsArgNo = 0
+      or
+      this.hasName("requireNonNullElse") and returnsArgNo = [0 .. this.getNumberOfParameters() - 1]
+      or
+      this.hasName("toString") and returnsArgNo = 1
+    )
+    or
+    this.getDeclaringType()
+        .getSourceDeclaration()
+        .getASourceSupertype*()
+        .hasQualifiedName("java.util", "Stack") and
+    this.hasName("push") and
+    returnsArgNo = 0
+  }
+
+  override predicate returnsValue(int argNo) { argNo = returnsArgNo }
+}
+
+/**
  * A unit class for adding additional taint steps.
  *
  * Extend this class to add additional taint steps that should apply to all

--- a/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
@@ -46,14 +46,14 @@ abstract class ValuePreservingMethod extends Method {
  * These steps will be visible for all global data-flow purposes, as well as via
  * `DataFlow::Node.getASuccessor` and other related functions exposing intraprocedural dataflow.
  */
-abstract class FluentMethod extends ValuePreservingCallable {
+abstract class FluentMethod extends ValuePreservingMethod {
   override predicate returnsValue(int arg) { arg = -1 }
 }
 
 private class StandardLibraryValuePreservingMethod extends ValuePreservingMethod {
   int returnsArgNo;
 
-  StandardLibraryValuePreservingCallable() {
+  StandardLibraryValuePreservingMethod() {
     this.getDeclaringType().hasQualifiedName("java.util", "Objects") and
     (
       this.hasName(["requireNonNull", "requireNonNullElseGet"]) and returnsArgNo = 0
@@ -63,9 +63,7 @@ private class StandardLibraryValuePreservingMethod extends ValuePreservingMethod
       this.hasName("toString") and returnsArgNo = 1
     )
     or
-    this.getDeclaringType()
-        .getASourceSupertype*()
-        .hasQualifiedName("java.util", "Stack") and
+    this.getDeclaringType().getASourceSupertype*().hasQualifiedName("java.util", "Stack") and
     this.hasName("push") and
     returnsArgNo = 0
   }

--- a/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
@@ -40,7 +40,7 @@ abstract class ValuePreservingMethod extends Method {
 /**
  * A method that returns the exact value of its qualifier (e.g., `return this;`)
  *
- * Extend this class and override `returnsValue` to add additional value-preserving steps through a
+ * Extend this class to add additional value-preserving steps from qualifier to return value through a
  * method that should be added to the basic local flow step relation.
  *
  * These steps will be visible for all global data-flow purposes, as well as via

--- a/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
@@ -64,7 +64,6 @@ private class StandardLibraryValuePreservingCallable extends ValuePreservingCall
     )
     or
     this.getDeclaringType()
-        .getSourceDeclaration()
         .getASourceSupertype*()
         .hasQualifiedName("java.util", "Stack") and
     this.hasName("push") and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -410,7 +410,7 @@ predicate simpleLocalFlowStep(Node node1, Node node2) {
   summaryStep(node1, node2, "value")
   or
   exists(MethodAccess ma, ValuePreservingCallable c, int argNo |
-    ma.getCallee() = c and c.returnsValue(argNo)
+    ma.getCallee().getSourceDeclaration() = c and c.returnsValue(argNo)
   |
     node2.asExpr() = ma and
     (

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -409,15 +409,11 @@ predicate simpleLocalFlowStep(Node node1, Node node2) {
   or
   summaryStep(node1, node2, "value")
   or
-  exists(MethodAccess ma, ValuePreservingCallable c, int argNo |
-    ma.getCallee().getSourceDeclaration() = c and c.returnsValue(argNo)
+  exists(MethodAccess ma, ValuePreservingMethod m, int argNo |
+    ma.getCallee().getSourceDeclaration() = m and m.returnsValue(argNo)
   |
     node2.asExpr() = ma and
-    (
-      node1.asExpr() = ma.getArgument(argNo)
-      or
-      argNo = -1 and node1.asExpr() = ma.getQualifier()
-    )
+    node1.(ArgumentNode).argumentOf(ma, argNo)
   )
 }
 

--- a/java/ql/test/library-tests/dataflow/fluent-methods/Test.java
+++ b/java/ql/test/library-tests/dataflow/fluent-methods/Test.java
@@ -6,6 +6,16 @@ public class Test {
     return this;
   }
 
+  public Test modelledFluentMethod() {
+    // A model in the accompanying .ql file will indicate that the qualifier flows to the return value.
+    return null;
+  }
+
+  public static Test modelledIdentity(Test t) {
+    // A model in the accompanying .ql file will indicate that the argument flows to the return value.
+    return null;
+  }
+
   public Test indirectlyFluentNoop() {
     return this.fluentNoop();
   }
@@ -44,6 +54,18 @@ public class Test {
   public static void test3() {
     Test t = new Test();
     t.indirectlyFluentNoop().fluentSet(source()).fluentNoop();
+    sink(t.get()); // $hasTaintFlow=y
+  }
+
+  public static void testModel1() {
+    Test t = new Test();
+    t.indirectlyFluentNoop().modelledFluentMethod().fluentSet(source()).fluentNoop();
+    sink(t.get()); // $hasTaintFlow=y
+  }
+
+  public static void testModel2() {
+    Test t = new Test();
+    Test.modelledIdentity(t).indirectlyFluentNoop().modelledFluentMethod().fluentSet(source()).fluentNoop();
     sink(t.get()); // $hasTaintFlow=y
   }
 

--- a/java/ql/test/library-tests/dataflow/fluent-methods/flow.ql
+++ b/java/ql/test/library-tests/dataflow/fluent-methods/flow.ql
@@ -19,7 +19,7 @@ class Model extends FluentMethod {
   Model() { this.getName() = "modelledFluentMethod" }
 }
 
-class IdentityModel extends ValuePreservingCallable {
+class IdentityModel extends ValuePreservingMethod {
   IdentityModel() { this.getName() = "modelledIdentity" }
 
   override predicate returnsValue(int arg) { arg = 0 }

--- a/java/ql/test/library-tests/dataflow/fluent-methods/flow.ql
+++ b/java/ql/test/library-tests/dataflow/fluent-methods/flow.ql
@@ -1,5 +1,6 @@
 import java
 import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.FlowSteps
 import TestUtilities.InlineExpectationsTest
 
 class Conf extends DataFlow::Configuration {
@@ -12,6 +13,16 @@ class Conf extends DataFlow::Configuration {
   override predicate isSink(DataFlow::Node n) {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
   }
+}
+
+class Model extends DataFlow::FluentMethod {
+  Model() { this.getName() = "modelledFluentMethod" }
+}
+
+class IdentityModel extends DataFlow::ValuePreservingCallable {
+  IdentityModel() { this.getName() = "modelledIdentity" }
+
+  override predicate returnsValue(int arg) { arg = 0 }
 }
 
 class HasFlowTest extends InlineExpectationsTest {

--- a/java/ql/test/library-tests/dataflow/fluent-methods/flow.ql
+++ b/java/ql/test/library-tests/dataflow/fluent-methods/flow.ql
@@ -15,11 +15,11 @@ class Conf extends DataFlow::Configuration {
   }
 }
 
-class Model extends DataFlow::FluentMethod {
+class Model extends FluentMethod {
   Model() { this.getName() = "modelledFluentMethod" }
 }
 
-class IdentityModel extends DataFlow::ValuePreservingCallable {
+class IdentityModel extends ValuePreservingCallable {
   IdentityModel() { this.getName() = "modelledIdentity" }
 
   override predicate returnsValue(int arg) { arg = 0 }


### PR DESCRIPTION
This extends https://github.com/github/codeql/pull/5219 to also consider modelled functions, and provides a simple abstract class to annotate new value-preserving functions.