### PR TITLE
Dataflow: Content-aware simple steps

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -469,6 +469,11 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+
+  cached
+  newtype TContentOption =
+    TContentNone() or
+    TContentSome(Content c) { simpleLocalFlowContentStep(c, _, _) }
 }
 
 /**
@@ -839,3 +844,27 @@ class AccessPathFrontOption extends TAccessPathFrontOption {
     this = TAccessPathFrontSome(any(AccessPathFront apf | result = apf.toString()))
   }
 }
+
+abstract class ContentOption extends TContentOption {
+  abstract string toString();
+
+  Content getContent() { none() }
+}
+
+class ContentNone extends ContentOption, TContentNone {
+  override string toString() { result = "<nones>" }
+}
+
+ContentOption contentNone() { result instanceof ContentNone }
+
+class ContentSome extends ContentOption, TContentSome {
+  private Content c;
+
+  ContentSome() { this = TContentSome(c) }
+
+  override string toString() { result = c.toString() }
+
+  override Content getContent() { result = c }
+}
+
+ContentOption contentSome(Content c) { result.getContent() = c }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -7,6 +7,7 @@ private import semmle.code.cpp.dataflow.internal.FlowVar
 private import semmle.code.cpp.models.interfaces.DataFlow
 private import semmle.code.cpp.controlflow.Guards
 private import semmle.code.cpp.dataflow.internal.AddressFlow
+private import DataFlowPrivate
 
 cached
 private newtype TNode =
@@ -698,6 +699,14 @@ private predicate exprToExprStep_nocfg(Expr fromExpr, Expr toExpr) {
       )
     )
 }
+
+/**
+ * INTERNAL: do not use.
+ *
+ * Holds if data can flow from `nodeFrom` to `nodeTo` in exactly one local (intra-procedural) step
+ * when the head of the access path is `c`.
+ */
+predicate simpleLocalFlowContentStep(Content c, Node nodeFrom, Node nodeTo) { none() }
 
 private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
   exists(DataFlowFunction f, Call call, FunctionOutput outModel, int argOutIndex |

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -469,6 +469,11 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+
+  cached
+  newtype TContentOption =
+    TContentNone() or
+    TContentSome(Content c) { simpleLocalFlowContentStep(c, _, _) }
 }
 
 /**
@@ -839,3 +844,27 @@ class AccessPathFrontOption extends TAccessPathFrontOption {
     this = TAccessPathFrontSome(any(AccessPathFront apf | result = apf.toString()))
   }
 }
+
+abstract class ContentOption extends TContentOption {
+  abstract string toString();
+
+  Content getContent() { none() }
+}
+
+class ContentNone extends ContentOption, TContentNone {
+  override string toString() { result = "<nones>" }
+}
+
+ContentOption contentNone() { result instanceof ContentNone }
+
+class ContentSome extends ContentOption, TContentSome {
+  private Content c;
+
+  ContentSome() { this = TContentSome(c) }
+
+  override string toString() { result = c.toString() }
+
+  override Content getContent() { result = c }
+}
+
+ContentOption contentSome(Content c) { result.getContent() = c }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -478,7 +478,7 @@ private predicate suppressUnusedNode(Node n) { any() }
 // Java QL library compatibility wrappers
 //////////////////////////////////////////////////////////////////////////////
 /** A node that performs a type cast. */
-class CastNode extends InstructionNode {
+class CastNode extends Node {
   CastNode() { none() } // stub implementation
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -10,6 +10,7 @@ private import semmle.code.cpp.ir.ValueNumbering
 private import semmle.code.cpp.ir.IR
 private import semmle.code.cpp.controlflow.IRGuards
 private import semmle.code.cpp.models.interfaces.DataFlow
+private import DataFlowPrivate
 
 cached
 private newtype TIRDataFlowNode =
@@ -599,6 +600,14 @@ predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
   // Instruction -> Operand flow
   simpleOperandLocalFlowStep(nodeFrom.asInstruction(), nodeTo.asOperand())
 }
+
+/**
+ * INTERNAL: do not use.
+ *
+ * Holds if data can flow from `nodeFrom` to `nodeTo` in exactly one local (intra-procedural) step
+ * when the head of the access path is `c`.
+ */
+predicate simpleLocalFlowContentStep(Content c, Node nodeFrom, Node nodeTo) { none() }
 
 pragma[noinline]
 private predicate getFieldSizeOfClass(Class c, Type type, int size) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -469,6 +469,11 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+
+  cached
+  newtype TContentOption =
+    TContentNone() or
+    TContentSome(Content c) { simpleLocalFlowContentStep(c, _, _) }
 }
 
 /**
@@ -839,3 +844,27 @@ class AccessPathFrontOption extends TAccessPathFrontOption {
     this = TAccessPathFrontSome(any(AccessPathFront apf | result = apf.toString()))
   }
 }
+
+abstract class ContentOption extends TContentOption {
+  abstract string toString();
+
+  Content getContent() { none() }
+}
+
+class ContentNone extends ContentOption, TContentNone {
+  override string toString() { result = "<nones>" }
+}
+
+ContentOption contentNone() { result instanceof ContentNone }
+
+class ContentSome extends ContentOption, TContentSome {
+  private Content c;
+
+  ContentSome() { this = TContentSome(c) }
+
+  override string toString() { result = c.toString() }
+
+  override Content getContent() { result = c }
+}
+
+ContentOption contentSome(Content c) { result.getContent() = c }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -888,6 +888,14 @@ private module Cached {
   }
 }
 
+/**
+ * INTERNAL: Do not use.
+ *
+ * Holds if data can flow from `nodeFrom` to `nodeTo` in exactly one local (intra-procedural) step
+ * when the head of the access path is `c`.
+ */
+predicate simpleLocalFlowContentStep(Content c, Node nodeFrom, Node nodeTo) { none() }
+
 import Cached
 
 /** An SSA definition, viewed as a node in a data flow graph. */

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -469,6 +469,11 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+
+  cached
+  newtype TContentOption =
+    TContentNone() or
+    TContentSome(Content c) { simpleLocalFlowContentStep(c, _, _) }
 }
 
 /**
@@ -839,3 +844,27 @@ class AccessPathFrontOption extends TAccessPathFrontOption {
     this = TAccessPathFrontSome(any(AccessPathFront apf | result = apf.toString()))
   }
 }
+
+abstract class ContentOption extends TContentOption {
+  abstract string toString();
+
+  Content getContent() { none() }
+}
+
+class ContentNone extends ContentOption, TContentNone {
+  override string toString() { result = "<nones>" }
+}
+
+ContentOption contentNone() { result instanceof ContentNone }
+
+class ContentSome extends ContentOption, TContentSome {
+  private Content c;
+
+  ContentSome() { this = TContentSome(c) }
+
+  override string toString() { result = c.toString() }
+
+  override Content getContent() { result = c }
+}
+
+ContentOption contentSome(Content c) { result.getContent() = c }

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -431,6 +431,14 @@ predicate simpleLocalFlowStep(Node node1, Node node2) {
 }
 
 /**
+ * INTERNAL: do not use.
+ *
+ * Holds if data can flow from `nodeFrom` to `nodeTo` in exactly one local (intra-procedural) step
+ * when the head of the access path is `c`.
+ */
+predicate simpleLocalFlowContentStep(Content c, Node nodeFrom, Node nodeTo) { none() }
+
+/**
  * Gets the node that occurs as the qualifier of `fa`.
  */
 Node getFieldQualifier(FieldAccess fa) {

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -469,6 +469,11 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+
+  cached
+  newtype TContentOption =
+    TContentNone() or
+    TContentSome(Content c) { simpleLocalFlowContentStep(c, _, _) }
 }
 
 /**
@@ -839,3 +844,27 @@ class AccessPathFrontOption extends TAccessPathFrontOption {
     this = TAccessPathFrontSome(any(AccessPathFront apf | result = apf.toString()))
   }
 }
+
+abstract class ContentOption extends TContentOption {
+  abstract string toString();
+
+  Content getContent() { none() }
+}
+
+class ContentNone extends ContentOption, TContentNone {
+  override string toString() { result = "<nones>" }
+}
+
+ContentOption contentNone() { result instanceof ContentNone }
+
+class ContentSome extends ContentOption, TContentSome {
+  private Content c;
+
+  ContentSome() { this = TContentSome(c) }
+
+  override string toString() { result = c.toString() }
+
+  override Content getContent() { result = c }
+}
+
+ContentOption contentSome(Content c) { result.getContent() = c }

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -244,6 +244,14 @@ predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
 }
 
 /**
+ * INTERNAL: Do not use.
+ *
+ * Holds if data can flow from `nodeFrom` to `nodeTo` in exactly one local (intra-procedural) step
+ * when the head of the access path is `c`.
+ */
+predicate simpleLocalFlowContentStep(Content c, Node nodeFrom, Node nodeTo) { none() }
+
+/**
  * Holds if there is an Essa flow step from `nodeFrom` to `nodeTo` that does not switch between
  * local and global SSA variables.
  */


### PR DESCRIPTION
For C++ we often have a tainted indirection  (i.e., `*p`) that requires a dereference to be reached. We want to model this using field flow, where the node for `p` is tainted with `ArrayContent` on the access path if `*p` is tainted.

However, when `p` is tainted and the access path is `[ArrayContent]` we don't get to use non-value preserving steps, which means that we don't get flow in cases such as: `int* q = p + 1; sink(*q)` since the step from `p` to `p + 1` isn't value preserving.

This PR implements a new feature in the shared dataflow library, where each language can define a step relation that is parameterized by a `Content`, and this relation is included in the value-preserving step-relation. The `Content` column of the relation represents the content that must be at the head of the access path in order to perform this flow step.

Currently this is implemented as `none()` in all languages (including the C++ IR where I want to use this). Eventually, the implementation in the C++ IR's `DataFlowUtil.qll` will be something along the lines of:

```codeql
predicate simpleLocalFlowContentStep(Content c, Node nodeFrom, Node nodeTo) {
  c instanceof ArrayContent and
  nodeFrom.asOperand() = nodeTo.asInstruction().(PointerArithmeticInstruction).getAnOperand()
}
```

meaning that, when the head of the access path is an `ArrayContent`, we will have flow from `p` to `p + 1`.

I'm curious to hear if this is something that would be feasible to include in the shared library, and if anyone else would find this useful.

[This CPP-difference](https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1744/) compares https://github.com/github/codeql/pull/5127 to https://github.com/github/codeql/pull/5127 + this PR (with the above implementation of `simpleLocalFlowContentStep`). The slowdown looks like noise: The query with the most slowdown is one that doesn't use dataflow.