### PR TITLE
JS: Improve TypeInference related join-orderings

### DIFF
--- a/javascript/ql/src/semmle/javascript/AMD.qll
+++ b/javascript/ql/src/semmle/javascript/AMD.qll
@@ -155,9 +155,17 @@ class AmdModuleDefinition extends CallExpr {
    * into this module's `module.exports` property.
    */
   DefiniteAbstractValue getAModuleExportsValue() {
+    result = [getAnImplicitExportsValue(), getAnExplicitExportsValue()]
+  }
+
+  pragma[noinline]
+  private AbstractValue getAnImplicitExportsValue() {
     // implicit exports: anything that is returned from the factory function
     result = getModuleExpr().analyze().getAValue()
-    or
+  }
+
+  pragma[noinline]
+  private AbstractValue getAnExplicitExportsValue() {
     // explicit exports: anything assigned to `module.exports`
     exists(AbstractProperty moduleExports, AmdModule m |
       this = m.getDefine() and

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
@@ -85,7 +85,7 @@ class AnalyzedNode extends DataFlow::Node {
   }
 
   /** Gets a type inferred for this node. */
-  pragma[nomagic]
+  cached
   InferredType getAType() { result = getAValue().getType() }
 
   /**


### PR DESCRIPTION
And cache `getAType()`.   

These improvements will hopefully unblock https://github.com/github/codeql/pull/5183 

I've confirmed that both changes independently improved performance (on a single query when running on `azure-sdk-for-node`). 

[Here is nightly/smoke evaluation](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/inf-test-5/reports) showing about 2.5% improvement.   
A [`nightly/security` evaluation](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/inf-test-7/reports) shows a lesser improvement when running many queries (as expected).   
I also did [an evaluation just for the `cache getType`](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/inf-test-just-cache-gettype/reports) change, and it seems OK. 