### PR TITLE
JS: Restrict names of extracted HTML attributes

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/HTMLExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/HTMLExtractor.java
@@ -143,6 +143,18 @@ public class HTMLExtractor implements IExtractor {
           }
       }
     }
+
+    @Override
+    public boolean shouldExtractAttributes(Element element) {
+      Attributes attributes = element.getAttributes();
+      if (attributes == null) return false;
+      for (Attribute attr : attributes) {
+        if (!VALID_ATTRIBUTE_NAME.matcher(attr.getName()).matches()) {
+          return false;
+        }
+      }
+      return true;
+    }
   }
 
   private boolean isAngularTemplateAttributeName(String name) {
@@ -152,6 +164,8 @@ public class HTMLExtractor implements IExtractor {
   }
 
   private static final Pattern ANGULAR_FOR_LOOP_DECL = Pattern.compile("^ *let +(\\w+) +of(?: +|(?!\\w))(.*)");
+
+  private static final Pattern VALID_ATTRIBUTE_NAME = Pattern.compile("\\*?\\[?\\(?[\\w:_\\-]+\\]?\\)?");
 
   /** List of HTML attributes whose value is interpreted as JavaScript. */
   private static final Pattern JS_ATTRIBUTE =

--- a/javascript/ql/test/query-tests/DOM/HTML/DuplicateAttributes.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/DuplicateAttributes.html
@@ -1,1 +1,3 @@
 <a href="https://semmle.com" href="https://semmle.com">Semmle</a>
+
+<td {% foo %} {% bar %}></td>

--- a/javascript/ql/test/query-tests/DOM/HTML/DuplicateAttributes.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/DuplicateAttributes.html
@@ -1,3 +1,3 @@
 <a href="https://semmle.com" href="https://semmle.com">Semmle</a>
 
-<td {% foo %} {% bar %}></td>
+<td {% foo %} {% foo %}></td>


### PR DESCRIPTION
Depends on an internal PR which must be merged first.

For context: we configure the HTML parser to be tolerant of syntax errors in attribute names, in order to parse Angular templates (which contains attributes names like `[foo]`).

It turns out we got more than we asked for, and are now extracting attributes named `{%`, `if`, `rounds.isWinner`, and `%}` from the following:
```html
<td {% if round.isWinner %}>
```

We now suppress attribute extraction if any of the attribute names is invalid (according to our definition of valid, which includes Angular-specific attribute names).

So the above would simply be extracted as `<td>`. It is formulated on a per-element basis rather than a per-attribute basis so we don't get the spurious attribute `if` either.