### PR TITLE
JS: Type-inference related changes.

### DIFF
--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -25,7 +25,7 @@ module ArrayTaintTracking {
     // `array.map(function (elt, i, ary) { ... })`: if `array` is tainted, then so are
     // `elt` and `ary`; similar for `forEach`
     exists(Function f |
-      call.getArgument(0).analyze().getAValue().(AbstractFunction).getFunction() = f and
+      call.getArgument(0).getAFunctionValue(0).getFunction() = f and
       call.(DataFlow::MethodCallNode).getMethodName() = ["map", "forEach"] and
       pred = call.getReceiver() and
       succ = DataFlow::parameterNode(f.getParameter([0, 2]))

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -106,7 +106,7 @@ module DataFlow {
 
     /** Holds if this node may evaluate to the Boolean value `b`. */
     predicate mayHaveBooleanValue(boolean b) {
-      getAPredecessor().mayHaveBooleanValue(b) // needed stage 31 + stage 26 + stage 22 (unfixable)
+      getAPredecessor().mayHaveBooleanValue(b)
       or
       b = true and asExpr().(BooleanLiteral).getValue() = "true"
       or

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -106,7 +106,11 @@ module DataFlow {
 
     /** Holds if this node may evaluate to the Boolean value `b`. */
     predicate mayHaveBooleanValue(boolean b) {
-      b = analyze().getAValue().(AbstractBoolean).getBooleanValue()
+      getAPredecessor().mayHaveBooleanValue(b) // needed stage 31 + stage 26 + stage 22 (unfixable)
+      or
+      b = true and asExpr().(BooleanLiteral).getValue() = "true"
+      or
+      b = false and asExpr().(BooleanLiteral).getValue() = "false"
     }
 
     /** Gets the integer value of this node, if it is an integer constant. */

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -168,7 +168,13 @@ class InvokeNode extends DataFlow::SourceNode {
   private ObjectLiteralNode getOptionsArgument(int i) { result.flowsTo(getArgument(i)) }
 
   /** Gets an abstract value representing possible callees of this call site. */
-  final AbstractValue getACalleeValue() { result = getCalleeNode().analyze().getAValue() }
+  final AbstractValue getACalleeValue() {
+    exists(DataFlow::Node callee, DataFlow::AnalyzedNode analyzed |
+      pragma[only_bind_into](callee) = getCalleeNode() and
+      pragma[only_bind_into](analyzed) = callee.analyze() and
+      pragma[only_bind_into](result) = analyzed.getAValue()
+    )
+  }
 
   /**
    * Gets a potential callee of this call site.

--- a/javascript/ql/src/semmle/javascript/frameworks/Testing.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Testing.qll
@@ -33,7 +33,7 @@ class BDDTest extends Test, @call_expr {
     exists(CallExpr call | call = this |
       call.getCallee().(VarAccess).getName() = "it" and
       exists(call.getArgument(0).getStringValue()) and
-      call.getArgument(1).analyze().getAValue() instanceof AbstractFunction
+      exists(call.getArgument(1).flow().getAFunctionValue(0))
     )
   }
 }
@@ -60,7 +60,7 @@ class JestTest extends Test, @call_expr {
     exists(CallExpr call | call = this |
       call.getCallee().(GlobalVarAccess).getName() = "test" and
       exists(call.getArgument(0).getStringValue()) and
-      call.getArgument(1).analyze().getAValue() instanceof AbstractFunction
+      exists(call.getArgument(1).flow().getAFunctionValue(0))
     ) and
     getFile() = getTestFile(any(File f), "test")
   }
@@ -94,7 +94,7 @@ class CucumberTest extends Test, @call_expr {
     exists(DataFlow::ModuleImportNode m, CallExpr call |
       m.getPath() = "cucumber" and
       call = m.getAnInvocation().asExpr() and
-      call.getArgument(0).analyze().getAValue() instanceof AbstractFunction and
+      exists(call.getArgument(0).flow().getAFunctionValue()) and
       this = call
     )
   }


### PR DESCRIPTION
[About 3% performance gain on average](https://github.com/dsp-testing/erik-krogh-dca/tree/run/moreinf-default-taintedPath/reports). 

There are two ways of improving performance: 
 1. Make slow predicates run faster. 
 2. Don't depend on slow predicates. 

This PR is of the second type.  
I noticed that `TypeInference::AnalyzedNode::getAValue_dispred#ff_10#join_rhs` was evaluated in 5 different stages in `TaintedPath.ql`, and it ran slow.   
I was able to remove 4 of those by changing the predicates that depend on `getAValue`. 

For some of the predicates I removed the use of type-inference, and used dataflow/callgraph instead. 