### PR TITLE
Python: Highlight missing flow from default value in functions

### DIFF
--- a/python/ql/test/experimental/dataflow/coverage/test.py
+++ b/python/ql/test/experimental/dataflow/coverage/test.py
@@ -781,3 +781,9 @@ def test_reverse_read_subscript_cls():
     l = [withA]
     l[0].setA(SOURCE)
     SINK(withA.a) #$ MISSING:flow="SOURCE, l:-1 -> self.a"
+
+@expects(3)
+def test_with_default_param_value(x=SOURCE, /, y=SOURCE, *, z=SOURCE):
+    SINK(x) #$ MISSING:flow="SOURCE, l:-1 -> x"
+    SINK(y) #$ MISSING:flow="SOURCE, l:-2 -> y"
+    SINK(z) #$ MISSING:flow="SOURCE, l:-3 -> z"


### PR DESCRIPTION
Although it is becoming non-trivial to get an overview of what tests we have and don't have, I didn't find any that highlighted this one.

I used all 3 variants of parameters, just to be sure :)