### PR TITLE
JS: Various small performance improvements

### DIFF
--- a/javascript/ql/src/semmle/javascript/AST.qll
+++ b/javascript/ql/src/semmle/javascript/AST.qll
@@ -118,6 +118,7 @@ class ASTNode extends @ast_node, NodeInStmtContainer {
   int getNumChildStmt() { result = count(getAChildStmt()) }
 
   /** Gets the parent node of this node, if any. */
+  cached
   ASTNode getParent() { this = result.getAChild() }
 
   /** Gets the first control flow node belonging to this syntactic entity. */

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -156,9 +156,8 @@ private module ArrayDataFlow {
 
     ArrayIndexingStep() {
       read = this and
-      forex(InferredType type | type = read.getPropertyNameExpr().flow().analyze().getAType() |
-        type = TTNumber()
-      ) and
+      TTNumber() =
+        unique(InferredType type | type = read.getPropertyNameExpr().flow().analyze().getAType()) and
       exists(VarAccess i, ExprOrVarDecl init |
         i = read.getPropertyNameExpr() and init = any(ForStmt f).getInit()
       |

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -1296,12 +1296,9 @@ private predicate summarizedHigherOrderCall(
     Function f, DataFlow::InvokeNode outer, DataFlow::InvokeNode inner, int j,
     DataFlow::Node innerArg, DataFlow::SourceNode cbParm, PathSummary oldSummary
   |
-    reachableFromInput(f, outer, arg, innerArg, cfg, oldSummary) and
-    // Only track actual parameter flow.
     // Captured flow does not need to be summarized - it is handled by the local case in `higherOrderCall`.
     not arg = DataFlow::capturedVariableNode(_) and
-    argumentPassing(outer, cb, f, cbParm) and
-    innerArg = inner.getArgument(j)
+    summarizedHigherOrderCallAux(f, outer, arg, innerArg, cfg, oldSummary, cbParm, inner, j, cb)
   |
     // direct higher-order call
     cbParm.flowsTo(inner.getCalleeNode()) and
@@ -1315,6 +1312,21 @@ private predicate summarizedHigherOrderCall(
       summary = oldSummary.append(PathSummary::call()).append(newSummary)
     )
   )
+}
+
+/**
+ * @see `summarizedHigherOrderCall`.
+ */
+pragma[noinline]
+private predicate summarizedHigherOrderCallAux(
+  Function f, DataFlow::InvokeNode outer, DataFlow::Node arg, DataFlow::Node innerArg,
+  DataFlow::Configuration cfg, PathSummary oldSummary, DataFlow::SourceNode cbParm,
+  DataFlow::InvokeNode inner, int j, DataFlow::Node cb
+) {
+  reachableFromInput(f, outer, arg, innerArg, cfg, oldSummary) and
+  // Only track actual parameter flow.
+  argumentPassing(outer, cb, f, cbParm) and
+  innerArg = inner.getArgument(j)
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Refinements.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Refinements.qll
@@ -324,6 +324,7 @@ class VarRefinementContext extends RefinementContext, TVarRefinementContext {
 }
 
 /** Holds if `e` is nested inside a guard node. */
+pragma[nomagic]
 private predicate inGuard(Expr e) {
   e = any(GuardControlFlowNode g).getTest()
   or

--- a/javascript/ql/src/semmle/javascript/frameworks/PropertyProjection.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/PropertyProjection.qll
@@ -66,6 +66,53 @@ module PropertyProjection {
 deprecated class CustomPropertyProjection = PropertyProjection::Range;
 
 /**
+ * Gets a callee of a simple property projection call.
+ * This predicate is used exclusively in `SimplePropertyProjection`.
+ */
+pragma[noinline]
+private DataFlow::SourceNode getASimplePropertyProjectionCallee(
+  boolean singleton, int selectorIndex, int objectIndex
+) {
+  singleton = false and
+  (
+    result = LodashUnderscore::member("pick") and
+    objectIndex = 0 and
+    selectorIndex = [1 .. max(result.getACall().getNumArgument())]
+    or
+    result = LodashUnderscore::member("pickBy") and
+    objectIndex = 0 and
+    selectorIndex = 1
+    or
+    result = DataFlow::moduleMember("ramda", ["pick", "pickAll", "pickBy"]) and
+    objectIndex = 1 and
+    selectorIndex = 0
+    or
+    result = DataFlow::moduleMember("dotty", "search") and
+    objectIndex = 0 and
+    selectorIndex = 1
+  )
+  or
+  singleton = true and
+  (
+    result = LodashUnderscore::member("get") and
+    objectIndex = 0 and
+    selectorIndex = 1
+    or
+    result = DataFlow::moduleMember("ramda", "path") and
+    objectIndex = 1 and
+    selectorIndex = 0
+    or
+    result = DataFlow::moduleMember("dottie", "get") and
+    objectIndex = 0 and
+    selectorIndex = 1
+    or
+    result = DataFlow::moduleMember("dotty", "get") and
+    objectIndex = 0 and
+    selectorIndex = 1
+  )
+}
+
+/**
  * A simple model of common property projection functions.
  */
 private class SimplePropertyProjection extends PropertyProjection::Range {
@@ -74,51 +121,7 @@ private class SimplePropertyProjection extends PropertyProjection::Range {
   boolean singleton;
 
   SimplePropertyProjection() {
-    exists(DataFlow::SourceNode callee | this = callee.getACall() |
-      singleton = false and
-      (
-        callee = LodashUnderscore::member("pick") and
-        objectIndex = 0 and
-        selectorIndex = [1 .. getNumArgument()]
-        or
-        callee = LodashUnderscore::member("pickBy") and
-        objectIndex = 0 and
-        selectorIndex = 1
-        or
-        exists(string name |
-          name = "pick" or
-          name = "pickAll" or
-          name = "pickBy"
-        |
-          callee = DataFlow::moduleMember("ramda", name) and
-          objectIndex = 1 and
-          selectorIndex = 0
-        )
-        or
-        callee = DataFlow::moduleMember("dotty", "search") and
-        objectIndex = 0 and
-        selectorIndex = 1
-      )
-      or
-      singleton = true and
-      (
-        callee = LodashUnderscore::member("get") and
-        objectIndex = 0 and
-        selectorIndex = 1
-        or
-        callee = DataFlow::moduleMember("ramda", "path") and
-        objectIndex = 1 and
-        selectorIndex = 0
-        or
-        callee = DataFlow::moduleMember("dottie", "get") and
-        objectIndex = 0 and
-        selectorIndex = 1
-        or
-        callee = DataFlow::moduleMember("dotty", "get") and
-        objectIndex = 0 and
-        selectorIndex = 1
-      )
-    )
+    this = getASimplePropertyProjectionCallee(singleton, selectorIndex, objectIndex).getACall()
   }
 
   override DataFlow::Node getObject() { result = getArgument(objectIndex) }

--- a/javascript/ql/src/semmle/javascript/frameworks/SystemCommandExecutors.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SystemCommandExecutors.qll
@@ -5,33 +5,29 @@
 
 import javascript
 
-private predicate execApi(string mod, string fn, int cmdArg, int optionsArg, boolean shell) {
-  mod = "cross-spawn" and
-  fn = "sync" and
-  cmdArg = 0 and
-  shell = false and
-  optionsArg = -1
-  or
-  mod = "execa" and
-  optionsArg = -1 and
+pragma[noinline]
+private predicate execApi(
+  string mod, string fn, int cmdArg, int optionsArg, boolean shell, boolean sync
+) {
+  sync = getSync(fn) and
   (
+    mod = "cross-spawn" and
+    fn = "sync" and
+    cmdArg = 0 and
     shell = false and
-    (
-      fn = "node" or
-      fn = "stdout" or
-      fn = "stderr" or
-      fn = "sync"
-    )
+    optionsArg = -1
     or
-    shell = true and
+    mod = "execa" and
+    optionsArg = -1 and
     (
-      fn = "command" or
-      fn = "commandSync" or
-      fn = "shell" or
-      fn = "shellSync"
-    )
-  ) and
-  cmdArg = 0
+      shell = false and
+      fn = ["node", "stdout", "stderr", "sync"]
+      or
+      shell = true and
+      fn = ["command", "commandSync", "shell", "shellSync"]
+    ) and
+    cmdArg = 0
+  )
 }
 
 private predicate execApi(string mod, int cmdArg, int optionsArg, boolean shell) {
@@ -61,17 +57,16 @@ private class SystemCommandExecutors extends SystemCommandExecution, DataFlow::I
   SystemCommandExecutors() {
     exists(string mod |
       exists(string fn |
-        execApi(mod, fn, cmdArg, optionsArg, shell) and
-        sync = getSync(fn) and
-        this = API::moduleImport(mod).getMember(fn).getReturn().getAUse()
+        execApi(mod, fn, cmdArg, optionsArg, shell, sync) and
+        this = API::moduleImport(mod).getMember(fn).getAnInvocation()
       )
       or
       execApi(mod, cmdArg, optionsArg, shell) and
       sync = false and
-      this = API::moduleImport(mod).getReturn().getAUse()
+      this = API::moduleImport(mod).getAnInvocation()
     )
     or
-    this = API::moduleImport("foreground-child").getReturn().getAUse() and
+    this = API::moduleImport("foreground-child").getACall() and
     cmdArg = 0 and
     optionsArg = 1 and
     shell = false and
@@ -115,19 +110,19 @@ private class RemoteCommandExecutor extends SystemCommandExecution, DataFlow::In
   int cmdArg;
 
   RemoteCommandExecutor() {
-    this = API::moduleImport("remote-exec").getReturn().getAUse() and
+    this = API::moduleImport("remote-exec").getACall() and
     cmdArg = 1
     or
     exists(API::Node ssh2, API::Node client |
       ssh2 = API::moduleImport("ssh2") and
       client in [ssh2, ssh2.getMember("Client")] and
-      this = client.getInstance().getMember("exec").getReturn().getAUse() and
+      this = client.getInstance().getMember("exec").getACall() and
       cmdArg = 0
     )
     or
     exists(API::Node ssh2stream |
       ssh2stream = API::moduleImport("ssh2-streams").getMember("SSH2Stream") and
-      this = ssh2stream.getInstance().getMember("exec").getReturn().getAUse() and
+      this = ssh2stream.getInstance().getMember("exec").getACall() and
       cmdArg = 1
     )
   }
@@ -142,7 +137,7 @@ private class RemoteCommandExecutor extends SystemCommandExecution, DataFlow::In
 }
 
 private class Opener extends SystemCommandExecution, DataFlow::InvokeNode {
-  Opener() { this = API::moduleImport("opener").getReturn().getAUse() }
+  Opener() { this = API::moduleImport("opener").getACall() }
 
   override DataFlow::Node getACommandArgument() { result = getOptionArgument(1, "command") }
 

--- a/javascript/ql/test/library-tests/Nodes/globalObjectRef.expected
+++ b/javascript/ql/test/library-tests/Nodes/globalObjectRef.expected
@@ -9,6 +9,5 @@
 | tst.js:1:1:1:6 | window |
 | tst.js:3:1:3:6 | window |
 | tst.js:4:1:4:6 | window |
-| tst.js:4:1:4:13 | window.window |
 | tst.js:5:1:5:4 | self |
 | tst.js:6:1:6:10 | globalThis |

--- a/javascript/ql/test/library-tests/Nodes/globalVarRef.expected
+++ b/javascript/ql/test/library-tests/Nodes/globalVarRef.expected
@@ -2,7 +2,6 @@
 | String | tst2.js:9:1:9:11 | this.String |
 | document | tst2.js:2:1:2:26 | require ... ument") |
 | document | tst.js:3:1:3:15 | window.document |
-| document | tst.js:4:1:4:22 | window. ... ocument |
 | document | tst.js:5:1:5:13 | self.document |
 | document | tst.js:6:1:6:19 | globalThis.document |
 | foo | tst3.js:4:1:4:5 | w.foo |


### PR DESCRIPTION
[Evaluation on default/TaintedPath.ql](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/vsPerf-2/reports). 

Makes various predicates run faster by changing the join order.   
I found them by running `TaintedPath.ql` on `vscode`, and then looking through the clause timing reports and tuple counts. 

It also makes the `globalVarRef` predicate non-recursive. 
So we no longer treat e.g. `window.globalThis.global.window` as being a reference to the global object.  
(The performance benefit of that change is minor, so let me know if you want it reverted). 

Summary of how how time is saved by each commit (`TaintedPath.ql` running on VSCode). 

- `rearange ArrayIndexingStep to avoid #shared predicate` - saves about 5s
- `cache AstNode::getParent` - saves a few seconds
- `make globalVarRef non recursive` - saves about 200ms
- `remove magic from inGuard` - saves about 1-2 seconds
- `outline callee computation - to avoid many joins on getACall` - saves about 300ms
- `change join order for summarizedHigherOrderCall` - saves about 11s 
- `change join order for SystemCommandExecutors - and use ApiGraphs::getACall` - saves about 5s