### PR TITLE
Python: Port `py/insecure-temporary-file`

### DIFF
--- a/python/ql/src/Security/CWE-377/InsecureTemporaryFile.ql
+++ b/python/ql/src/Security/CWE-377/InsecureTemporaryFile.ql
@@ -11,8 +11,9 @@
  */
 
 import python
+import semmle.python.ApiGraphs
 
-FunctionValue temporary_name_function(string mod, string function) {
+API::Node temporary_name_function(string mod, string function) {
   (
     mod = "tempfile" and function = "mktemp"
     or
@@ -23,9 +24,9 @@ FunctionValue temporary_name_function(string mod, string function) {
       function = "tempnam"
     )
   ) and
-  result = Module::named(mod).attr(function)
+  result = API::moduleImport(mod).getMember(function)
 }
 
 from Call c, string mod, string function
-where temporary_name_function(mod, function).getACall().getNode() = c
+where temporary_name_function(mod, function).getACall().asExpr() = c
 select c, "Call to deprecated function " + mod + "." + function + " may be insecure."


### PR DESCRIPTION
Straightforward. Since this should preserve behaviour, I don't think it needs a separate change note.

Still needs validation that no results were lost in this port.