### PR TITLE
Python: Remove getAnArg from DataFlow::CallCfgNode

### DIFF
--- a/python/ql/src/Security/CWE-295/MissingHostKeyValidation.ql
+++ b/python/ql/src/Security/CWE-295/MissingHostKeyValidation.ql
@@ -24,8 +24,9 @@ private API::Node paramikoSSHClientInstance() {
 
 from DataFlow::CallCfgNode call, DataFlow::Node arg, string name
 where
+  // see http://docs.paramiko.org/en/stable/api/client.html#paramiko.client.SSHClient.set_missing_host_key_policy
   call = paramikoSSHClientInstance().getMember("set_missing_host_key_policy").getACall() and
-  arg = call.getAnArg() and
+  arg in [call.getArg(0), call.getArgByName("policy")] and
   (
     arg = unsafe_paramiko_policy(name).getAUse() or
     arg = unsafe_paramiko_policy(name).getReturn().getAUse()

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -193,13 +193,6 @@ class CallCfgNode extends CfgNode {
 
   /** Gets the data-flow node corresponding to the named argument of the call corresponding to this data-flow node */
   Node getArgByName(string name) { result.asCfgNode() = node.getArgByName(name) }
-
-  /** Gets the data-flow node corresponding to an argument of the call corresponding to this data-flow node */
-  Node getAnArg() {
-    exists(int n | result = this.getArg(n))
-    or
-    exists(string name | result = this.getArgByName(name))
-  }
 }
 
 /**


### PR DESCRIPTION
As discussed internally before, the getAnArg name clashes with the functionality in `Function`: github/codeql-python-team#95 (and our normal pattern of when providing `getFoo(index i)`, then also providing `getAFoo() { result = this.getFoo(_) }`)

Follow up to https://github.com/github/codeql/pull/5251