### PR TITLE
JS: Even more performance improvements.

### DIFF
--- a/javascript/ql/src/semmle/javascript/AMD.qll
+++ b/javascript/ql/src/semmle/javascript/AMD.qll
@@ -158,7 +158,7 @@ class AmdModuleDefinition extends CallExpr {
     result = [getAnImplicitExportsValue(), getAnExplicitExportsValue()]
   }
 
-  pragma[noinline]
+  pragma[noinline, nomagic]
   private AbstractValue getAnImplicitExportsValue() {
     // implicit exports: anything that is returned from the factory function
     result = getModuleExpr().analyze().getAValue()

--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -344,7 +344,7 @@ module DOM {
         or
         exists(JQuery::MethodCall call | this = call and call.getMethodName() = "get" |
           call.getNumArgument() = 1 and
-          forex(InferredType t | t = call.getArgument(0).analyze().getAType() | t = TTNumber())
+          unique(InferredType t | t = call.getArgument(0).analyze().getAType()) = TTNumber()
         )
         or
         // A `this` node from a callback given to a `$().each(callback)` call.

--- a/javascript/ql/src/semmle/javascript/MembershipCandidates.qll
+++ b/javascript/ql/src/semmle/javascript/MembershipCandidates.qll
@@ -222,27 +222,27 @@ module MembershipCandidate {
    */
   class ObjectPropertyNameMembershipCandidate extends MembershipCandidate::Range,
     DataFlow::ValueNode {
-    DataFlow::ValueNode test;
-    DataFlow::ValueNode membersNode;
+    Expr test;
+    Expr membersNode;
 
     ObjectPropertyNameMembershipCandidate() {
       exists(InExpr inExpr |
         this = inExpr.getLeftOperand().flow() and
-        test = inExpr.flow() and
-        membersNode = inExpr.getRightOperand().flow()
+        test = inExpr and
+        membersNode = inExpr.getRightOperand()
       )
       or
-      exists(DataFlow::MethodCallNode hasOwn |
-        this = hasOwn.getArgument(0) and
+      exists(MethodCallExpr hasOwn |
+        this = hasOwn.getArgument(0).flow() and
         test = hasOwn and
         hasOwn.calls(membersNode, "hasOwnProperty")
       )
     }
 
-    override DataFlow::Node getTest() { result = test }
+    override DataFlow::Node getTest() { result = test.flow() }
 
     override string getAMemberString() {
-      exists(membersNode.getALocalSource().getAPropertyWrite(result))
+      exists(membersNode.flow().getALocalSource().getAPropertyWrite(result))
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Modules.qll
+++ b/javascript/ql/src/semmle/javascript/Modules.qll
@@ -107,6 +107,7 @@ abstract class Module extends TopLevel {
    * Symbols defined in another module that are re-exported by
    * this module are only sometimes considered.
    */
+  cached
   abstract DataFlow::Node getAnExportedValue(string name);
 
   /**

--- a/javascript/ql/src/semmle/javascript/SSA.qll
+++ b/javascript/ql/src/semmle/javascript/SSA.qll
@@ -660,14 +660,6 @@ class SsaPhiNode extends SsaPseudoDefinition, TPhi {
 
   override string prettyPrintDef() { result = getSourceVariable() + " = phi(" + ppInputs() + ")" }
 
-  override predicate hasLocationInfo(
-    string filepath, int startline, int startcolumn, int endline, int endcolumn
-  ) {
-    endline = startline and
-    endcolumn = startcolumn and
-    getBasicBlock().getLocation().hasLocationInfo(filepath, startline, startcolumn, _, _)
-  }
-
   /**
    * If all inputs to this phi node are (transitive) refinements of the same variable,
    * gets that variable.

--- a/javascript/ql/src/semmle/javascript/SSA.qll
+++ b/javascript/ql/src/semmle/javascript/SSA.qll
@@ -520,7 +520,10 @@ class SsaExplicitDefinition extends SsaDefinition, TExplicitDef {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    getDef().getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    exists(Location loc |
+      pragma[only_bind_into](loc) = pragma[only_bind_into](getDef()).getLocation() and
+      loc.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    )
   }
 
   /**
@@ -552,7 +555,10 @@ abstract class SsaImplicitDefinition extends SsaDefinition {
   ) {
     endline = startline and
     endcolumn = startcolumn and
-    getBasicBlock().getLocation().hasLocationInfo(filepath, startline, startcolumn, _, _)
+    exists(Location loc |
+      pragma[only_bind_into](loc) = pragma[only_bind_into](getBasicBlock()).getLocation() and
+      loc.hasLocationInfo(filepath, startline, startcolumn, _, _)
+    )
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
@@ -590,10 +590,6 @@ module JQuery {
         read.getBase().getALocalSource() = [dollar(), objectRef()] and
         read.mayHavePropertyName(name)
       )
-      or
-      // Handle contributed JQuery objects that aren't source nodes (usually parameter uses)
-      getReceiver() = legacyObjectSource() and
-      this.(DataFlow::MethodCallNode).getMethodName() = name
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
@@ -544,17 +544,17 @@ module JQuery {
   }
 
   /** A source of jQuery objects from the AST-based `JQueryObject` class. */
-  private DataFlow::Node legacyObjectSource() { result = any(JQueryObjectInternal e).flow() }
+  private DataFlow::SourceNode legacyObjectSource() {
+    result = any(JQueryObjectInternal e).flow().getALocalSource()
+  }
 
   /** Gets a source of jQuery objects. */
   private DataFlow::SourceNode objectSource(DataFlow::TypeTracker t) {
     t.start() and
     result instanceof ObjectSource::Range
     or
-    exists(DataFlow::TypeTracker init |
-      init.start() and
-      t = init.smallstep(legacyObjectSource(), result)
-    )
+    t.start() and
+    result = legacyObjectSource()
   }
 
   /** Gets a data flow node referring to a jQuery object. */

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
@@ -229,6 +229,7 @@ private class PostMessageEventParameter extends RemoteFlowSource {
  * even if the window is opened from a foreign domain.
  */
 private class WindowNameAccess extends RemoteFlowSource {
+  pragma[nomagic, noinline]
   WindowNameAccess() {
     this = DataFlow::globalObjectRef().getAPropertyRead("name")
     or


### PR DESCRIPTION
The biggest impact is adding `cache` to `Module::getAnExportedValue`. 

[Evaluation looks very good](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/nextperf-test-default-security-bcqs-run/reports).  

About 4% across the security suite. 

I found these by trying to find out what causes #5183 to be slow.  
But the improvements I found can be landed in a separate PR (this one). 

Ready for review, but should not be merged yet due to the use of `pragma[only_bind_into]`. 