### PR TITLE
C#: Add more well-known enum underlying types

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/CustomAttributeDecoder.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/CustomAttributeDecoder.cs
@@ -56,7 +56,8 @@ namespace Semmle.Extraction.CIL.Entities
         private static readonly Dictionary<string, PrimitiveTypeCode> wellKnownEnums = new Dictionary<string, PrimitiveTypeCode>
         {
             { "System.AttributeTargets", PrimitiveTypeCode.Int32 },
-            { "System.ComponentModel.EditorBrowsableState", PrimitiveTypeCode.Int32 }
+            { "System.ComponentModel.EditorBrowsableState", PrimitiveTypeCode.Int32 },
+            { "System.Diagnostics.DebuggerBrowsableState", PrimitiveTypeCode.Int32 }
         };
     }
 }


### PR DESCRIPTION
Failing to get the underlying integer type of `DebuggerBrowsableState` results in 3000+ issues being logged during the extraction of `dotnet/runtime`.

[Differences job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/894/)