### PR TITLE
JS: cache RemoteFlowSource

### DIFF
--- a/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
@@ -415,7 +415,7 @@ module AccessPath {
   pragma[inline]
   DataFlow::SourceNode getAnAliasedSourceNode(DataFlow::Node node) {
     exists(DataFlow::SourceNode root, string accessPath |
-      node = AccessPath::getAReferenceTo(root, accessPath) and
+      node = pragma[only_bind_into](AccessPath::getAReferenceTo(root, accessPath)) and
       result = AccessPath::getAReferenceTo(root, accessPath)
     )
     or

--- a/javascript/ql/src/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Hapi.qll
@@ -196,10 +196,13 @@ module Hapi {
 
     private DataFlow::SourceNode getARouteHandler(DataFlow::TypeBackTracker t) {
       t.start() and
-      result = handler.flow().getALocalSource()
+      result = getRouteHandler().getALocalSource()
       or
       exists(DataFlow::TypeBackTracker t2 | result = getARouteHandler(t2).backtrack(t2, t))
     }
+
+    pragma[noinline]
+    private DataFlow::Node getRouteHandler() { result = handler.flow() }
 
     Expr getRouteHandlerExpr() { result = handler }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
@@ -7,13 +7,16 @@ import semmle.javascript.frameworks.HTTP
 import semmle.javascript.security.dataflow.DOM
 
 /** A data flow source of remote user input. */
+cached
 abstract class RemoteFlowSource extends DataFlow::Node {
   /** Gets a string that describes the type of this remote flow source. */
+  cached
   abstract string getSourceType();
 
   /**
    * Holds if this can be a user-controlled object, such as a JSON object parsed from user-controlled data.
    */
+  cached
   predicate isUserControlledObject() { none() }
 }
 


### PR DESCRIPTION
The `RemoteFlowSource` constructor was inlined into `isSource` in every query that used it. 
If we `cache` it instead, we can save a lot of work. 

Also two other small performance improvements I found. 

[nightly/security evaluation](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/cache-remote-nightly-security/reports) shows 1.5% improvement. 

Ready for review, but should not be merged yet due to `pragma[only_bind_into]`. 