### PR TITLE
JS: Add model for http-proxy

### DIFF
--- a/javascript/change-notes/2021-02-25-http-proxy.md
+++ b/javascript/change-notes/2021-02-25-http-proxy.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* Sources of user input and sinks for `js/request-forgery` in the http-proxy are now recognized. 
+  Affected packages are
+    [http-proxy](https://www.npmjs.com/package/http-proxy)

--- a/javascript/ql/src/javascript.qll
+++ b/javascript/ql/src/javascript.qll
@@ -94,6 +94,7 @@ import semmle.javascript.frameworks.LazyCache
 import semmle.javascript.frameworks.LodashUnderscore
 import semmle.javascript.frameworks.Logging
 import semmle.javascript.frameworks.HttpFrameworks
+import semmle.javascript.frameworks.HttpProxy
 import semmle.javascript.frameworks.Markdown
 import semmle.javascript.frameworks.NoSQL
 import semmle.javascript.frameworks.PkgCloud

--- a/javascript/ql/src/semmle/javascript/frameworks/HttpProxy.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HttpProxy.qll
@@ -1,0 +1,54 @@
+/**
+ * Provides classes and predicates for working with the [http-proxy](https://www.npmjs.com/package/http-proxy) library.
+ */
+
+import javascript
+
+/**
+ * Provides classes and predicates modelling the [http-proxy](https://www.npmjs.com/package/http-proxy) library.
+ */
+private module HttpProxy {
+  /**
+   * A call that creates a http proxy.
+   */
+  class CreateServerCall extends API::CallNode, ClientRequest::Range {
+    CreateServerCall() {
+      this =
+        API::moduleImport("http-proxy")
+            .getMember(["createServer", "createProxyServer", "createProxy"])
+            .getACall()
+    }
+
+    override DataFlow::Node getUrl() { result = getParameter(0).getMember("target").getARhs() }
+
+    override DataFlow::Node getHost() { none() }
+
+    override DataFlow::Node getADataNode() { none() }
+  }
+
+  /**
+   * A call that proxies a request to some target.
+   */
+  class ProxyCall extends API::CallNode, ClientRequest::Range {
+    string method;
+
+    ProxyCall() {
+      method = ["ws", "web"] and
+      this = any(CreateServerCall server).getReturn().getMember(method).getACall()
+    }
+
+    override DataFlow::Node getUrl() {
+      exists(int optionsIndex |
+        method = "web" and optionsIndex = 2
+        or
+        method = "ws" and optionsIndex = 3
+      |
+        result = getParameter(optionsIndex).getMember("target").getARhs()
+      )
+    }
+
+    override DataFlow::Node getHost() { none() }
+
+    override DataFlow::Node getADataNode() { none() }
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/HttpProxy.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HttpProxy.qll
@@ -21,7 +21,9 @@ private module HttpProxy {
 
     override DataFlow::Node getUrl() { result = getParameter(0).getMember("target").getARhs() }
 
-    override DataFlow::Node getHost() { none() }
+    override DataFlow::Node getHost() {
+      result = getParameter(0).getMember("target").getMember("host").getARhs()
+    }
 
     override DataFlow::Node getADataNode() { none() }
   }
@@ -37,17 +39,21 @@ private module HttpProxy {
       this = any(CreateServerCall server).getReturn().getMember(method).getACall()
     }
 
-    override DataFlow::Node getUrl() {
+    private API::Node getOptionsObject() {
       exists(int optionsIndex |
         method = "web" and optionsIndex = 2
         or
         method = "ws" and optionsIndex = 3
       |
-        result = getParameter(optionsIndex).getMember("target").getARhs()
+        result = getParameter(optionsIndex)
       )
     }
 
-    override DataFlow::Node getHost() { none() }
+    override DataFlow::Node getUrl() { result = getOptionsObject().getMember("target").getARhs() }
+
+    override DataFlow::Node getHost() {
+      result = getOptionsObject().getMember("target").getMember("host").getARhs()
+    }
 
     override DataFlow::Node getADataNode() { none() }
   }

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -79,6 +79,9 @@ test_ClientRequest
 | tst.js:247:24:247:68 | request ... o.png') |
 | tst.js:249:1:251:2 | form.su ... e();\\n}) |
 | tst.js:257:1:262:2 | form.su ... rs()\\n}) |
+| tst.js:267:1:267:61 | httpPro ... 9000'}) |
+| tst.js:269:13:269:48 | httpPro ... ptions) |
+| tst.js:271:3:271:61 | proxy.w ... 080' }) |
 test_getADataNode
 | tst.js:53:5:53:23 | axios({data: data}) | tst.js:53:18:53:21 | data |
 | tst.js:57:5:57:39 | axios.p ... data2}) | tst.js:57:19:57:23 | data1 |
@@ -210,6 +213,8 @@ test_getUrl
 | tst.js:247:24:247:68 | request ... o.png') | tst.js:247:32:247:67 | 'http:/ ... go.png' |
 | tst.js:249:1:251:2 | form.su ... e();\\n}) | tst.js:249:13:249:33 | 'http:/ ... e.org/' |
 | tst.js:257:1:262:2 | form.su ... rs()\\n}) | tst.js:257:13:262:1 | {\\n    m ... ers()\\n} |
+| tst.js:267:1:267:61 | httpPro ... 9000'}) | tst.js:267:37:267:59 | 'http:/ ... t:9000' |
+| tst.js:271:3:271:61 | proxy.w ... 080' }) | tst.js:271:33:271:58 | 'http:/ ... m:8080' |
 test_getAResponseDataNode
 | tst.js:19:5:19:23 | requestPromise(url) | tst.js:19:5:19:23 | requestPromise(url) | text | true |
 | tst.js:21:5:21:23 | superagent.get(url) | tst.js:21:5:21:23 | superagent.get(url) | stream | true |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -82,6 +82,7 @@ test_ClientRequest
 | tst.js:267:1:267:61 | httpPro ... 9000'}) |
 | tst.js:269:13:269:48 | httpPro ... ptions) |
 | tst.js:271:3:271:61 | proxy.w ... 080' }) |
+| tst.js:274:1:283:2 | httpPro ... true\\n}) |
 test_getADataNode
 | tst.js:53:5:53:23 | axios({data: data}) | tst.js:53:18:53:21 | data |
 | tst.js:57:5:57:39 | axios.p ... data2}) | tst.js:57:19:57:23 | data1 |
@@ -127,6 +128,7 @@ test_getHost
 | tst.js:93:5:93:35 | net.req ... host }) | tst.js:93:29:93:32 | host |
 | tst.js:219:5:219:41 | data.so ... Host"}) | tst.js:219:32:219:39 | "myHost" |
 | tst.js:257:1:262:2 | form.su ... rs()\\n}) | tst.js:259:11:259:23 | 'example.org' |
+| tst.js:274:1:283:2 | httpPro ... true\\n}) | tst.js:277:15:277:30 | 'my-domain-name' |
 test_getUrl
 | apollo.js:5:18:5:78 | new cre ... hql' }) | apollo.js:5:44:5:75 | 'https: ... raphql' |
 | apollo.js:10:1:10:54 | new Htt ... hql' }) | apollo.js:10:21:10:51 | 'http:/ ... raphql' |
@@ -215,6 +217,7 @@ test_getUrl
 | tst.js:257:1:262:2 | form.su ... rs()\\n}) | tst.js:257:13:262:1 | {\\n    m ... ers()\\n} |
 | tst.js:267:1:267:61 | httpPro ... 9000'}) | tst.js:267:37:267:59 | 'http:/ ... t:9000' |
 | tst.js:271:3:271:61 | proxy.w ... 080' }) | tst.js:271:33:271:58 | 'http:/ ... m:8080' |
+| tst.js:274:1:283:2 | httpPro ... true\\n}) | tst.js:275:13:281:5 | {\\n      ... ,\\n    } |
 test_getAResponseDataNode
 | tst.js:19:5:19:23 | requestPromise(url) | tst.js:19:5:19:23 | requestPromise(url) | text | true |
 | tst.js:21:5:21:23 | superagent.get(url) | tst.js:21:5:21:23 | superagent.get(url) | stream | true |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -260,3 +260,13 @@ form.submit({
     path: '/upload',
     headers: form.getHeaders()
 });
+
+var httpProxy = require('http-proxy');
+var http = require("http");
+
+httpProxy.createProxyServer({target:'http://localhost:9000'}).listen(8000); 
+
+var proxy = httpProxy.createProxyServer(options);
+http.createServer(function(req, res) {
+  proxy.web(req, res, { target: 'http://mytarget.com:8080' });
+});

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -270,3 +270,14 @@ var proxy = httpProxy.createProxyServer(options);
 http.createServer(function(req, res) {
   proxy.web(req, res, { target: 'http://mytarget.com:8080' });
 });
+
+httpProxy.createProxyServer({
+    target: {
+        protocol: 'https:',
+        host: 'my-domain-name',
+        port: 443,
+        pfx: fs.readFileSync('path/to/certificate.p12'),
+        passphrase: 'password',
+    },
+    changeOrigin: true
+}).listen(8000);

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/src/http.js
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/src/http.js
@@ -74,3 +74,13 @@ http.createServer(function (req, res) {
     res.send(chunk); 
   })
 });
+
+var httpProxy = require('http-proxy');
+var proxy = httpProxy.createProxyServer({});
+ 
+proxy.on('proxyReq', function(proxyReq, req, res, options) {
+  req.on("data", chunk => { // RemoteFlowSource
+    res.send(chunk); 
+  });
+  res.end("bla");
+});

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -56,6 +56,9 @@ test_ResponseExpr
 | src/http.js:68:17:68:19 | res | src/http.js:68:12:68:27 | (req,res) => f() |
 | src/http.js:72:34:72:36 | res | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
 | src/http.js:74:5:74:7 | res | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
+| src/http.js:81:46:81:48 | res | src/http.js:81:22:86:1 | functio ... la");\\n} |
+| src/http.js:83:5:83:7 | res | src/http.js:81:22:86:1 | functio ... la");\\n} |
+| src/http.js:85:3:85:5 | res | src/http.js:81:22:86:1 | functio ... la");\\n} |
 | src/https.js:4:47:4:49 | res | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:7:3:7:5 | res | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:34:12:36 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
@@ -150,6 +153,9 @@ test_RouteHandler_getAResponseExpr
 | src/http.js:68:12:68:27 | (req,res) => f() | src/http.js:68:17:68:19 | res |
 | src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:72:34:72:36 | res |
 | src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:74:5:74:7 | res |
+| src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:81:46:81:48 | res |
+| src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:83:5:83:7 | res |
+| src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:85:3:85:5 | res |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:47:4:49 | res |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:7:3:7:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:34:12:36 | res |
@@ -189,6 +195,7 @@ test_ResponseSendArgument
 | src/http.js:14:13:14:17 | "foo" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:15:11:15:15 | "bar" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:64:11:64:16 | "bar2" | src/http.js:62:19:65:1 | functio ... r2");\\n} |
+| src/http.js:85:11:85:15 | "bla" | src/http.js:81:22:86:1 | functio ... la");\\n} |
 | src/https.js:14:13:14:17 | "foo" | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:15:11:15:15 | "bar" | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/indirect.js:26:13:26:17 | "foo" | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
@@ -235,6 +242,7 @@ test_RemoteFlowSources
 | src/http.js:40:23:40:30 | authInfo |
 | src/http.js:45:23:45:27 | error |
 | src/http.js:73:18:73:22 | chunk |
+| src/http.js:82:18:82:22 | chunk |
 | src/https.js:6:26:6:32 | req.url |
 | src/https.js:8:3:8:20 | req.headers.cookie |
 | src/https.js:9:3:9:17 | req.headers.foo |
@@ -273,6 +281,8 @@ test_RequestExpr
 | src/http.js:68:13:68:15 | req | src/http.js:68:12:68:27 | (req,res) => f() |
 | src/http.js:72:29:72:31 | req | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
 | src/http.js:73:3:73:5 | req | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
+| src/http.js:81:41:81:43 | req | src/http.js:81:22:86:1 | functio ... la");\\n} |
+| src/http.js:82:3:82:5 | req | src/http.js:81:22:86:1 | functio ... la");\\n} |
 | src/https.js:4:42:4:44 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:6:26:6:28 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:8:3:8:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
@@ -312,6 +322,8 @@ test_RouteHandler_getARequestExpr
 | src/http.js:68:12:68:27 | (req,res) => f() | src/http.js:68:13:68:15 | req |
 | src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:72:29:72:31 | req |
 | src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:73:3:73:5 | req |
+| src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:81:41:81:43 | req |
+| src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:82:3:82:5 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:42:4:44 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:6:26:6:28 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:8:3:8:5 | req |


### PR DESCRIPTION
[http-proxy](https://www.npmjs.com/package/http-proxy), is a simple proxy server, that forwards requests to some other server. 

A quick [smoke-test/security evaluation](https://github.com/dsp-testing/erik-krogh-BCQS/tree/auto/data/workflow/httpProxy-smoke-security/reports) looks fine. 