### PR TITLE
Fix method name resolution issue with nullable suppression

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Name.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Name.cs
@@ -13,6 +13,13 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
             var target = symbolInfo.Symbol;
 
+            if (target == null &&
+                symbolInfo.CandidateReason == CandidateReason.OverloadResolutionFailure &&
+                info.Node.Parent.IsKind(SyntaxKind.SuppressNullableWarningExpression))
+            {
+                target = symbolInfo.CandidateSymbols.FirstOrDefault();
+            }
+
             if (target == null && symbolInfo.CandidateReason == CandidateReason.OverloadResolutionFailure)
             {
                 // The expression is probably a cast

--- a/csharp/ql/test/library-tests/csharp8/NameResolutionSuppressNullable.cs
+++ b/csharp/ql/test/library-tests/csharp8/NameResolutionSuppressNullable.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+class MyClass2
+{
+    private static WaitCallback? s_signalMethod;
+    private static WaitCallback SignalMethod => EnsureInitialized(ref s_signalMethod, () => new WaitCallback(M1!));
+
+    public static T EnsureInitialized<T>(ref T target, System.Func<T> valueFactory) where T : class { return target = valueFactory(); }
+
+    static void M1(object state)
+    {
+    }
+}

--- a/csharp/ql/test/library-tests/csharp8/NullableRefTypes.expected
+++ b/csharp/ql/test/library-tests/csharp8/NullableRefTypes.expected
@@ -1,4 +1,5 @@
 suppressNullableWarnings
+| NameResolutionSuppressNullable.cs:8:110:8:112 | ...! | NameResolutionSuppressNullable.cs:8:110:8:111 | access to method M1 |
 | NullableRefTypes.cs:85:20:85:21 | ...! | NullableRefTypes.cs:85:20:85:20 | access to local variable x |
 | NullableRefTypes.cs:86:13:86:14 | ...! | NullableRefTypes.cs:86:13:86:13 | access to local variable x |
 | NullableRefTypes.cs:88:13:88:14 | ...! | NullableRefTypes.cs:88:13:88:13 | access to local variable x |
@@ -206,6 +207,7 @@ returnTypes
 | NullableRefTypes.cs:215:10:215:20 | ElementTest | Void! |
 | NullableRefTypes.cs:223:48:223:54 | GetSelf | TestNullableFlowStates? |
 methodTypeArguments
+| NameResolutionSuppressNullable.cs:10:21:10:40 | EnsureInitialized | 0 | WaitCallback? |
 | NullableRefTypes.cs:51:12:51:15 | Q | 0 | MyClass! |
 | NullableRefTypes.cs:51:12:51:15 | Q | 0 | MyClass? |
 | NullableRefTypes.cs:67:10:67:21 | GenericFn | 0 | MyClass! |

--- a/csharp/ql/test/library-tests/csharp8/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp8/PrintAst.expected
@@ -121,6 +121,42 @@ DefaultInterfaceMethods.cs:
 #   26|   7: [Method] Greet
 #   26|     -1: [TypeMention] Void
 #   26|     4: [BlockStmt] {...}
+NameResolutionSuppressNullable.cs:
+#    5| [Class] MyClass2
+#    7|   5: [Field] s_signalMethod
+#    7|     -1: [TypeMention] WaitCallback
+#    8|   6: [Property] SignalMethod
+#    8|     -1: [TypeMention] WaitCallback
+#    8|     3: [Getter] get_SignalMethod
+#    8|       4: [MethodCall] call to method EnsureInitialized
+#    8|         0: [FieldAccess] access to field s_signalMethod
+#    8|         1: [LambdaExpr] (...) => ...
+#    8|           4: [ExplicitDelegateCreation] delegate creation of type WaitCallback
+#    8|             -1: [TypeMention] WaitCallback
+#    8|             0: [SuppressNullableWarningExpr] ...!
+#    8|               0: [MethodAccess] access to method M1
+#   10|   7: [Method] EnsureInitialized
+#   10|     -1: [TypeMention] T
+#-----|     1: (Type parameters)
+#   10|       0: [TypeParameter] T
+#-----|     2: (Parameters)
+#   10|       0: [Parameter] target
+#   10|         -1: [TypeMention] T
+#   10|       1: [Parameter] valueFactory
+#   10|         -1: [TypeMention] Func<T>
+#   10|           1: [TypeMention] T
+#   10|     4: [BlockStmt] {...}
+#   10|       0: [ReturnStmt] return ...;
+#   10|         0: [AssignExpr] ... = ...
+#   10|           0: [ParameterAccess] access to parameter target
+#   10|           1: [DelegateCall] delegate call
+#   10|             -1: [ParameterAccess] access to parameter valueFactory
+#   12|   9: [Method] M1
+#   12|     -1: [TypeMention] Void
+#-----|     2: (Parameters)
+#   12|       0: [Parameter] state
+#   12|         -1: [TypeMention] object
+#   13|     4: [BlockStmt] {...}
 NullCoalescingAssignment.cs:
 #    3| [Class] NullCoalescingAssignment
 #    5|   5: [Method] NullCoalescing


### PR DESCRIPTION
This PR fixes a name resolution issue that I found in the extraction logs of `dotnet/runtime`.

[Differences job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/897/)