### PR TITLE
Python: Ensure old dataflow queries are not used

### DIFF
--- a/python/ql/src/experimental/Security-old-dataflow/CWE-022/PathInjection.ql
+++ b/python/ql/src/experimental/Security-old-dataflow/CWE-022/PathInjection.ql
@@ -1,19 +1,7 @@
 /**
- * @name Uncontrolled data used in path expression
+ * @name OLD QUERY: Uncontrolled data used in path expression
  * @description Accessing paths influenced by users can allow an attacker to access unexpected resources.
  * @kind path-problem
- * @problem.severity error
- * @sub-severity high
- * @precision high
- * @id py/path-injection
- * @tags correctness
- *       security
- *       external/owasp/owasp-a1
- *       external/cwe/cwe-022
- *       external/cwe/cwe-023
- *       external/cwe/cwe-036
- *       external/cwe/cwe-073
- *       external/cwe/cwe-099
  */
 
 import python

--- a/python/ql/src/experimental/Security-old-dataflow/CWE-078/CommandInjection.ql
+++ b/python/ql/src/experimental/Security-old-dataflow/CWE-078/CommandInjection.ql
@@ -1,17 +1,8 @@
 /**
- * @name Uncontrolled command line
+ * @name OLD QUERY: Uncontrolled command line
  * @description Using externally controlled strings in a command line may allow a malicious
  *              user to change the meaning of the command.
  * @kind path-problem
- * @problem.severity error
- * @sub-severity high
- * @precision high
- * @id py/command-line-injection
- * @tags correctness
- *       security
- *       external/owasp/owasp-a1
- *       external/cwe/cwe-078
- *       external/cwe/cwe-088
  */
 
 import python

--- a/python/ql/src/experimental/Security-old-dataflow/CWE-079/ReflectedXss.ql
+++ b/python/ql/src/experimental/Security-old-dataflow/CWE-079/ReflectedXss.ql
@@ -1,15 +1,8 @@
 /**
- * @name Reflected server-side cross-site scripting
+ * @name OLD QUERY: Reflected server-side cross-site scripting
  * @description Writing user input directly to a web page
  *              allows for a cross-site scripting vulnerability.
  * @kind path-problem
- * @problem.severity error
- * @sub-severity high
- * @precision high
- * @id py/reflective-xss
- * @tags security
- *       external/cwe/cwe-079
- *       external/cwe/cwe-116
  */
 
 import python

--- a/python/ql/src/experimental/Security-old-dataflow/CWE-089/SqlInjection.ql
+++ b/python/ql/src/experimental/Security-old-dataflow/CWE-089/SqlInjection.ql
@@ -1,14 +1,8 @@
 /**
- * @name SQL query built from user-controlled sources
+ * @name OLD QUERY: SQL query built from user-controlled sources
  * @description Building a SQL query from user-controlled sources is vulnerable to insertion of
  *              malicious SQL code by the user.
  * @kind path-problem
- * @problem.severity error
- * @precision high
- * @id py/sql-injection
- * @tags security
- *       external/cwe/cwe-089
- *       external/owasp/owasp-a1
  */
 
 import python

--- a/python/ql/src/experimental/Security-old-dataflow/CWE-094/CodeInjection.ql
+++ b/python/ql/src/experimental/Security-old-dataflow/CWE-094/CodeInjection.ql
@@ -3,15 +3,6 @@
  * @description Interpreting unsanitized user input as code allows a malicious user arbitrary
  *              code execution.
  * @kind path-problem
- * @problem.severity error
- * @sub-severity high
- * @precision high
- * @id py/code-injection
- * @tags security
- *       external/owasp/owasp-a1
- *       external/cwe/cwe-094
- *       external/cwe/cwe-095
- *       external/cwe/cwe-116
  */
 
 import python

--- a/python/ql/src/experimental/Security-old-dataflow/CWE-502/UnsafeDeserialization.ql
+++ b/python/ql/src/experimental/Security-old-dataflow/CWE-502/UnsafeDeserialization.ql
@@ -1,14 +1,7 @@
 /**
- * @name Deserializing untrusted input
+ * @name OLD QUERY: Deserializing untrusted input
  * @description Deserializing user-controlled data may allow attackers to execute arbitrary code.
  * @kind path-problem
- * @id py/unsafe-deserialization
- * @problem.severity error
- * @sub-severity high
- * @precision high
- * @tags external/cwe/cwe-502
- *       security
- *       serialization
  */
 
 import python

--- a/python/ql/src/experimental/Security-old-dataflow/CWE-601/UrlRedirect.ql
+++ b/python/ql/src/experimental/Security-old-dataflow/CWE-601/UrlRedirect.ql
@@ -1,14 +1,8 @@
 /**
- * @name URL redirection from remote source
+ * @name OLD QUERY: URL redirection from remote source
  * @description URL redirection based on unvalidated user input
  *              may cause redirection to malicious web sites.
  * @kind path-problem
- * @problem.severity error
- * @sub-severity low
- * @id py/url-redirection
- * @tags security
- *       external/cwe/cwe-601
- * @precision high
  */
 
 import python


### PR DESCRIPTION
There seems to have been some cases where the old ones have been picked up instead of the new ones. At least I spotted _one_ case where this happened, in an internal actions run.

I'm not sure how to actual debug this, so I'm just removing all the tags that could make these queries to become picked up :|