### PR TITLE
Actions: Add workflow to request docs review

### DIFF
--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -1,0 +1,29 @@
+# When a PR is labelled with 'ready-for-docs-review',
+# this workflow comments on the PR to notify the GitHub CodeQL docs team.
+name: Request docs review
+on:
+  # Runs in the context of the base repo.
+  # This gives the workflow write access to comment on PRs.
+  # The workflow should not check out or build the given ref,
+  # or use untrusted data from the event payload in a command line.
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  request-docs-review:
+    name: Request docs review
+    # Run only on labelled PRs to the main repository.
+    # Do not run on PRs to forks.
+    if:
+      github.event.label.name == 'ready-for-docs-review'
+      && github.event.pull_request.draft == false
+      && github.event.pull_request.base.repo.full_name == 'github/codeql'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment to request docs review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "github/codeql" \
+            --body "Hello @github/docs-content-codeql: this PR is ready for docs review."


### PR DESCRIPTION
When a PR is labelled with `docs-review-required`, this workflow comments on the PR to notify the GitHub CodeQL docs team.
Runs on `pull_request_target` events so it can write comments to the PR.
Since this runs in the context of the base repo, it must not check out the PR or use untrusted data from the event payload.

Only runs when the PR base is `github/codeql`, to prevent notifications from forks.

@github/docs-content-codeql does this work for your needs?