### PR TITLE
C++/Java/Python: Allow Python string prefix in InlineExpectationsTest

### DIFF
--- a/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -233,7 +233,9 @@ private string expectationPattern() {
   exists(string tag, string tags, string value |
     tag = "[A-Za-z-_][A-Za-z-_0-9]*" and
     tags = "((?:" + tag + ")(?:\\s*,\\s*" + tag + ")*)" and
-    value = "((?:\"[^\"]*\"|'[^']*'|\\S+)*)" and
+    // In Python, we allow both `"` and `'` for strings, as well as the prefixes `bru`.
+    // For example, `b"foo"`.
+    value = "((?:[bru]*\"[^\"]*\"|[bru]*'[^']*'|\\S+)*)" and
     result = tags + "(?:=" + value + ")?"
   )
 }

--- a/java/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/java/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -233,7 +233,9 @@ private string expectationPattern() {
   exists(string tag, string tags, string value |
     tag = "[A-Za-z-_][A-Za-z-_0-9]*" and
     tags = "((?:" + tag + ")(?:\\s*,\\s*" + tag + ")*)" and
-    value = "((?:\"[^\"]*\"|'[^']*'|\\S+)*)" and
+    // In Python, we allow both `"` and `'` for strings, as well as the prefixes `bru`.
+    // For example, `b"foo"`.
+    value = "((?:[bru]*\"[^\"]*\"|[bru]*'[^']*'|\\S+)*)" and
     result = tags + "(?:=" + value + ")?"
   )
 }

--- a/python/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/python/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -233,7 +233,9 @@ private string expectationPattern() {
   exists(string tag, string tags, string value |
     tag = "[A-Za-z-_][A-Za-z-_0-9]*" and
     tags = "((?:" + tag + ")(?:\\s*,\\s*" + tag + ")*)" and
-    value = "((?:\"[^\"]*\"|'[^']*'|\\S+)*)" and
+    // In Python, we allow both `"` and `'` for strings, as well as the prefixes `bru`.
+    // For example, `b"foo"`.
+    value = "((?:[bru]*\"[^\"]*\"|[bru]*'[^']*'|\\S+)*)" and
     result = tags + "(?:=" + value + ")?"
   )
 }


### PR DESCRIPTION
I've been writing tests for crypto libraries in Python, and have wanted to write code along the lines of

```py
md5.hash(b"some message") # $ HashInput=b"some message"
```

which didn't work before this commit, forcing me to store my text in a variable like below. This turned out to be really annoying when dealing with more complex examples, so therefore I'm adding this new functionality to allow this behavior.

```py
msg = b"some message"
md5.hash(msg) # $ HashInput=msg
```

Requested review from @MathiasVP on the C++ side, since I know you know about the way we use these tests in Python (and probably cursed a bit at us for doing so), and @smowton on the Java side.