### PR TITLE
Java: CWE-1004 Query to check sensitive cookies without the HttpOnly flag set

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.java
@@ -1,0 +1,44 @@
+class SensitiveCookieNotHttpOnly {
+    // GOOD - Create a sensitive cookie with the `HttpOnly` flag set.
+    public void addCookie(String jwt_token, HttpServletRequest request, HttpServletResponse response) {
+        Cookie jwtCookie =new Cookie("jwt_token", jwt_token);
+        jwtCookie.setPath("/");
+        jwtCookie.setMaxAge(3600*24*7);
+        jwtCookie.setHttpOnly(true);
+        response.addCookie(jwtCookie);
+    }
+
+    // BAD - Create a sensitive cookie without the `HttpOnly` flag set.
+    public void addCookie2(String jwt_token, String userId, HttpServletRequest request, HttpServletResponse response) {
+        Cookie jwtCookie =new Cookie("jwt_token", jwt_token);
+        jwtCookie.setPath("/");
+        jwtCookie.setMaxAge(3600*24*7);
+        response.addCookie(jwtCookie);
+    }
+
+    // GOOD - Set a sensitive cookie header with the `HttpOnly` flag set.
+    public void addCookie3(String authId, HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("Set-Cookie", "token=" +authId + ";HttpOnly;Secure");
+    }
+
+    // BAD - Set a sensitive cookie header without the `HttpOnly` flag set.
+    public void addCookie4(String authId, HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("Set-Cookie", "token=" +authId + ";Secure");
+    }
+    
+    // GOOD - Set a sensitive cookie header using the class `javax.ws.rs.core.Cookie` with the `HttpOnly` flag set through string concatenation.
+    public void addCookie5(String accessKey, HttpServletRequest request, HttpServletResponse response) {
+        response.setHeader("Set-Cookie", new NewCookie("session-access-key", accessKey, "/", null, null, 0, true) + ";HttpOnly");
+    }
+
+    // BAD - Set a sensitive cookie header using the class `javax.ws.rs.core.Cookie` without the `HttpOnly` flag set.
+    public void addCookie6(String accessKey, HttpServletRequest request, HttpServletResponse response) {
+        response.setHeader("Set-Cookie", new NewCookie("session-access-key", accessKey, "/", null, null, 0, true).toString());
+    }
+
+    // GOOD - Set a sensitive cookie header using the class `javax.ws.rs.core.Cookie` with the `HttpOnly` flag set through the constructor.
+    public void addCookie7(String accessKey, HttpServletRequest request, HttpServletResponse response) {
+        NewCookie accessKeyCookie = new NewCookie("session-access-key", accessKey, "/", null, null, 0, true, true);
+        response.setHeader("Set-Cookie", accessKeyCookie.toString());
+    }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.qhelp
@@ -1,0 +1,27 @@
+<!DOCTYPE qhelp SYSTEM "qhelp.dtd">
+<qhelp>
+
+  <overview>
+    <p>Cross-Site Scripting (XSS) is categorized as one of the OWASP Top 10 Security Vulnerabilities. The <code>HttpOnly</code> flag directs compatible browsers to prevent client-side script from accessing cookies. Including the HttpOnly flag in the Set-Cookie HTTP response header for a sensitive cookie helps mitigate the risk associated with XSS where an attacker's script code attempts to read the contents of a cookie and exfiltrate information obtained.</p>
+  </overview>
+
+  <recommendation>
+    <p>Use the <code>HttpOnly</code> flag when generating a cookie containing sensitive information to help mitigate the risk of client side script accessing the protected cookie.</p>
+  </recommendation>
+
+  <example>
+    <p>The following example shows two ways of generating sensitive cookies. In the 'BAD' cases, the <code>HttpOnly</code> flag is not set. In the 'GOOD' cases, the <code>HttpOnly</code> flag is set.</p>
+    <sample src="SensitiveCookieNotHttpOnly.java" />
+  </example>
+
+  <references>
+    <li>
+      PortSwigger:
+      <a href="https://portswigger.net/kb/issues/00500600_cookie-without-httponly-flag-set">Cookie without HttpOnly flag set</a>
+    </li>
+    <li>
+      OWASP:
+      <a href="https://owasp.org/www-community/HttpOnly">HttpOnly</a>
+    </li>
+  </references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.qhelp
@@ -2,7 +2,7 @@
 <qhelp>
 
   <overview>
-    <p>Cross-Site Scripting (XSS) is categorized as one of the OWASP Top 10 Security Vulnerabilities. The <code>HttpOnly</code> flag directs compatible browsers to prevent client-side script from accessing cookies. Including the HttpOnly flag in the Set-Cookie HTTP response header for a sensitive cookie helps mitigate the risk associated with XSS where an attacker's script code attempts to read the contents of a cookie and exfiltrate information obtained.</p>
+    <p>Cross-Site Scripting (XSS) is categorized as one of the OWASP Top 10 Security Vulnerabilities. The <code>HttpOnly</code> flag directs compatible browsers to prevent client-side script from accessing cookies. Including the <code>HttpOnly</code> flag in the Set-Cookie HTTP response header for a sensitive cookie helps mitigate the risk associated with XSS where an attacker's script code attempts to read the contents of a cookie and exfiltrate information obtained.</p>
   </overview>
 
   <recommendation>

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -82,8 +82,8 @@ class CookieClass extends RefType {
   }
 }
 
-/** Holds if the `expr` is `true` or a variable that is ever assigned `true`. */
-// This could be a very large result set if computed out of context
+/** Holds if `expr` is any boolean-typed expression other than literal `false`. */
+// Inlined because this could be a very large result set if computed out of context
 pragma[inline]
 predicate mayBeBooleanTrue(Expr expr) {
   expr.getType() instanceof BooleanType and
@@ -123,11 +123,11 @@ predicate isTestMethod(MethodAccess ma) {
 }
 
 /**
- * A taint configuration tracking flow of a method or a wrapper method that sets the `HttpOnly`
- * flag, or one that removes a cookie, to a `ServletResponse.addCookie` call.
+ * A taint configuration tracking flow of a method that sets the `HttpOnly` flag,
+ * or one that removes a cookie, to a `ServletResponse.addCookie` call.
  */
-class SetHttpOnlyInCookieConfiguration extends TaintTracking2::Configuration {
-  SetHttpOnlyInCookieConfiguration() { this = "SetHttpOnlyInCookieConfiguration" }
+class SetHttpOnlyOrRemovesCookieConfiguration extends TaintTracking2::Configuration {
+  SetHttpOnlyOrRemovesCookieConfiguration() { this = "SetHttpOnlyOrRemovesCookieConfiguration" }
 
   override predicate isSource(DataFlow::Node source) {
     source.asExpr() =
@@ -150,7 +150,7 @@ class CookieResponseSink extends DataFlow::ExprNode {
       (
         ma.getMethod() instanceof ResponseAddCookieMethod and
         this.getExpr() = ma.getArgument(0) and
-        not exists(SetHttpOnlyInCookieConfiguration cc | cc.hasFlowTo(this))
+        not exists(SetHttpOnlyOrRemovesCookieConfiguration cc | cc.hasFlowTo(this))
         or
         ma instanceof SetCookieMethodAccess and
         this.getExpr() = ma.getArgument(1) and

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -79,7 +79,10 @@ class CookieResponseSink extends DataFlow::ExprNode {
   }
 }
 
-/** Holds if `cie` is an invocation of a JAX-RS `NewCookie` constructor that sets `HttpOnly` to true. */
+/**
+ * Holds if `ClassInstanceExpr` cie is an invocation of a JAX-RS `NewCookie` constructor
+ * that sets `HttpOnly` to true.
+ */
 predicate setHttpOnlyInNewCookie(ClassInstanceExpr cie) {
   cie.getConstructedType().hasQualifiedName(["javax.ws.rs.core", "jakarta.ws.rs.core"], "NewCookie") and
   (
@@ -111,7 +114,7 @@ class CookieInstanceExpr extends TaintPreservingCallable {
 }
 
 /**
- * Holds if the node is a test method indicated by:
+ * Holds if the MethodAccess `ma` is a test method call indicated by:
  *    a) in a test directory such as `src/test/java`
  *    b) in a test package whose name has the word `test`
  *    c) in a test class whose name has the word `test`

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -9,7 +9,6 @@
 
 import java
 import semmle.code.java.frameworks.Servlets
-import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.TaintTracking
 import DataFlow::PathGraph
 
@@ -18,8 +17,8 @@ string getSensitiveCookieNameRegex() { result = "(?i).*(auth|session|token|key|c
 
 /** Holds if a string is concatenated with the name of a sensitive cookie. */
 predicate isSensitiveCookieNameExpr(Expr expr) {
-  expr.(StringLiteral)
-      .getRepresentedString()
+  expr.(CompileTimeConstantExpr)
+      .getStringValue()
       .toLowerCase()
       .regexpMatch(getSensitiveCookieNameRegex()) or
   isSensitiveCookieNameExpr(expr.(AddExpr).getAnOperand())
@@ -27,7 +26,7 @@ predicate isSensitiveCookieNameExpr(Expr expr) {
 
 /** Holds if a string is concatenated with the `HttpOnly` flag. */
 predicate hasHttpOnlyExpr(Expr expr) {
-  expr.(StringLiteral).getRepresentedString().toLowerCase().matches("%httponly%") or
+  expr.(CompileTimeConstantExpr).getStringValue().toLowerCase().matches("%httponly%") or
   hasHttpOnlyExpr(expr.(AddExpr).getAnOperand())
 }
 
@@ -38,37 +37,34 @@ class SetCookieMethodAccess extends MethodAccess {
       this.getMethod() instanceof ResponseAddHeaderMethod or
       this.getMethod() instanceof ResponseSetHeaderMethod
     ) and
-    this.getArgument(0).(StringLiteral).getRepresentedString().toLowerCase() = "set-cookie"
+    this.getArgument(0).(CompileTimeConstantExpr).getStringValue().toLowerCase() = "set-cookie"
   }
 }
 
 /** Sensitive cookie name used in a `Cookie` constructor or a `Set-Cookie` call. */
 class SensitiveCookieNameExpr extends Expr {
   SensitiveCookieNameExpr() {
-    isSensitiveCookieNameExpr(this) and
-    (
-      exists(
-        ClassInstanceExpr cie // new Cookie("jwt_token", token)
-      |
-        (
-          cie.getConstructor().getDeclaringType().hasQualifiedName("javax.servlet.http", "Cookie") or
-          cie.getConstructor()
-              .getDeclaringType()
-              .getASupertype*()
-              .hasQualifiedName("javax.ws.rs.core", "Cookie") or
-          cie.getConstructor()
-              .getDeclaringType()
-              .getASupertype*()
-              .hasQualifiedName("jakarta.ws.rs.core", "Cookie")
-        ) and
-        DataFlow::localExprFlow(this, cie.getArgument(0))
-      )
-      or
-      exists(
-        SetCookieMethodAccess ma // response.addHeader("Set-Cookie: token=" +authId + ";HttpOnly;Secure")
-      |
-        DataFlow::localExprFlow(this, ma.getArgument(1))
-      )
+    exists(
+      ClassInstanceExpr cie, Expr e // new Cookie("jwt_token", token)
+    |
+      (
+        cie.getConstructor().getDeclaringType().hasQualifiedName("javax.servlet.http", "Cookie") or
+        cie.getConstructor()
+            .getDeclaringType()
+            .getASupertype*()
+            .hasQualifiedName(["javax.ws.rs.core", "jakarta.ws.rs.core"], "Cookie")
+      ) and
+      this = cie and
+      isSensitiveCookieNameExpr(e) and
+      DataFlow::localExprFlow(e, cie.getArgument(0))
+    )
+    or
+    exists(
+      SetCookieMethodAccess ma, Expr e // response.addHeader("Set-Cookie: token=" +authId + ";HttpOnly;Secure")
+    |
+      this = ma.getArgument(1) and
+      isSensitiveCookieNameExpr(e) and
+      DataFlow::localExprFlow(e, ma.getArgument(1))
     )
   }
 }
@@ -78,15 +74,20 @@ class CookieResponseSink extends DataFlow::ExprNode {
   CookieResponseSink() {
     exists(MethodAccess ma |
       (
-        ma.getMethod() instanceof ResponseAddCookieMethod or
-        ma instanceof SetCookieMethodAccess
-      ) and
-      ma.getAnArgument() = this.getExpr()
+        ma.getMethod() instanceof ResponseAddCookieMethod and
+        this.getExpr() = ma.getArgument(0)
+        or
+        ma instanceof SetCookieMethodAccess and
+        this.getExpr() = ma.getArgument(1)
+      )
     )
   }
 }
 
-/** Holds if the `node` is a method call of `setHttpOnly(true)` on a cookie. */
+/**
+ * Holds if `node` is an access to a variable which has `setHttpOnly(true)` called on it and is also
+ * the first argument to a call to the method `addCookie` of `javax.servlet.http.HttpServletResponse`.
+ */
 predicate setHttpOnlyMethodAccess(DataFlow::Node node) {
   exists(
     MethodAccess addCookie, Variable cookie, MethodAccess m // jwtCookie.setHttpOnly(true)
@@ -100,7 +101,10 @@ predicate setHttpOnlyMethodAccess(DataFlow::Node node) {
   )
 }
 
-/** Holds if the `node` is a method call of `Set-Cookie` header with the `HttpOnly` flag whose cookie name is sensitive. */
+/**
+ * Holds if `node` is a string that contains `httponly` and which flows to the second argument
+ * of a method to set a cookie.
+ */
 predicate setHttpOnlyInSetCookie(DataFlow::Node node) {
   exists(SetCookieMethodAccess sa |
     hasHttpOnlyExpr(node.asExpr()) and
@@ -108,20 +112,17 @@ predicate setHttpOnlyInSetCookie(DataFlow::Node node) {
   )
 }
 
-/** Holds if the `node` is an invocation of a JAX-RS `NewCookie` constructor that sets `HttpOnly` to true. */
-predicate setHttpOnlyInNewCookie(DataFlow::Node node) {
-  exists(ClassInstanceExpr cie |
-    cie.getConstructor().getDeclaringType().hasName("NewCookie") and
-    DataFlow::localExprFlow(node.asExpr(), cie.getArgument(0)) and
-    (
-      cie.getNumArgument() = 6 and cie.getArgument(5).(BooleanLiteral).getBooleanValue() = true // NewCookie(Cookie cookie, String comment, int maxAge, Date expiry, boolean secure, boolean httpOnly)
-      or
-      cie.getNumArgument() = 8 and
-      cie.getArgument(6).getType() instanceof BooleanType and
-      cie.getArgument(7).(BooleanLiteral).getBooleanValue() = true // NewCookie(String name, String value, String path, String domain, String comment, int maxAge, boolean secure, boolean httpOnly)
-      or
-      cie.getNumArgument() = 10 and cie.getArgument(9).(BooleanLiteral).getBooleanValue() = true // NewCookie(String name, String value, String path, String domain, int version, String comment, int maxAge, Date expiry, boolean secure, boolean httpOnly)
-    )
+/** Holds if `cie` is an invocation of a JAX-RS `NewCookie` constructor that sets `HttpOnly` to true. */
+predicate setHttpOnlyInNewCookie(ClassInstanceExpr cie) {
+  cie.getConstructedType().hasQualifiedName(["javax.ws.rs.core", "jakarta.ws.rs.core"], "NewCookie") and
+  (
+    cie.getNumArgument() = 6 and cie.getArgument(5).(BooleanLiteral).getBooleanValue() = true // NewCookie(Cookie cookie, String comment, int maxAge, Date expiry, boolean secure, boolean httpOnly)
+    or
+    cie.getNumArgument() = 8 and
+    cie.getArgument(6).getType() instanceof BooleanType and
+    cie.getArgument(7).(BooleanLiteral).getBooleanValue() = true // NewCookie(String name, String value, String path, String domain, String comment, int maxAge, boolean secure, boolean httpOnly)
+    or
+    cie.getNumArgument() = 10 and cie.getArgument(9).(BooleanLiteral).getBooleanValue() = true // NewCookie(String name, String value, String path, String domain, int version, String comment, int maxAge, Date expiry, boolean secure, boolean httpOnly)
   )
 }
 
@@ -145,7 +146,10 @@ predicate isTestMethod(DataFlow::Node node) {
   )
 }
 
-/** A taint configuration tracking flow from a sensitive cookie without HttpOnly flag set to its HTTP response. */
+/**
+ * A taint configuration tracking flow from a sensitive cookie without the `HttpOnly` flag
+ * set to its HTTP response.
+ */
 class MissingHttpOnlyConfiguration extends TaintTracking::Configuration {
   MissingHttpOnlyConfiguration() { this = "MissingHttpOnlyConfiguration" }
 
@@ -159,25 +163,17 @@ class MissingHttpOnlyConfiguration extends TaintTracking::Configuration {
     // cookie.setHttpOnly(true)
     setHttpOnlyMethodAccess(node)
     or
-    // response.addHeader("Set-Cookie: token=" +authId + ";HttpOnly;Secure")
+    // response.addHeader("Set-Cookie", "token=" +authId + ";HttpOnly;Secure")
     setHttpOnlyInSetCookie(node)
     or
     // new NewCookie("session-access-key", accessKey, "/", null, null, 0, true, true)
-    setHttpOnlyInNewCookie(node)
+    setHttpOnlyInNewCookie(node.asExpr())
     or
     // Test class or method
     isTestMethod(node)
   }
 
   override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(
-      ClassInstanceExpr cie // `NewCookie` constructor
-    |
-      cie.getAnArgument() = pred.asExpr() and
-      cie = succ.asExpr() and
-      cie.getConstructor().getDeclaringType().hasName("NewCookie")
-    )
-    or
     exists(
       MethodAccess ma // `toString` call on a cookie object
     |

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -45,7 +45,7 @@ class SetCookieMethodAccess extends MethodAccess {
 class SensitiveCookieNameExpr extends Expr {
   SensitiveCookieNameExpr() {
     exists(
-      ClassInstanceExpr cie, Expr e // new Cookie("jwt_token", token)
+      ClassInstanceExpr cie // new Cookie("jwt_token", token)
     |
       (
         cie.getConstructor().getDeclaringType().hasQualifiedName("javax.servlet.http", "Cookie") or
@@ -55,16 +55,14 @@ class SensitiveCookieNameExpr extends Expr {
             .hasQualifiedName(["javax.ws.rs.core", "jakarta.ws.rs.core"], "Cookie")
       ) and
       this = cie and
-      isSensitiveCookieNameExpr(e) and
-      DataFlow::localExprFlow(e, cie.getArgument(0))
+      isSensitiveCookieNameExpr(cie.getArgument(0))
     )
     or
     exists(
-      SetCookieMethodAccess ma, Expr e // response.addHeader("Set-Cookie: token=" +authId + ";HttpOnly;Secure")
+      SetCookieMethodAccess ma // response.addHeader("Set-Cookie: token=" +authId + ";HttpOnly;Secure")
     |
       this = ma.getArgument(1) and
-      isSensitiveCookieNameExpr(e) and
-      DataFlow::localExprFlow(e, ma.getArgument(1))
+      isSensitiveCookieNameExpr(this)
     )
   }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -16,12 +16,18 @@ import DataFlow::PathGraph
 /** Gets a regular expression for matching common names of sensitive cookies. */
 string getSensitiveCookieNameRegex() { result = "(?i).*(auth|session|token|key|credential).*" }
 
-/** Holds if a string is concatenated with the name of a sensitive cookie. */
+/** Gets a regular expression for matching CSRF cookies. */
+string getCsrfCookieNameRegex() { result = "(?i).*(csrf).*" }
+
+/**
+ * Holds if a string is concatenated with the name of a sensitive cookie. Excludes CSRF cookies since
+ * they are special cookies implementing the Synchronizer Token Pattern that can be used in JavaScript.
+ */
 predicate isSensitiveCookieNameExpr(Expr expr) {
-  expr.(CompileTimeConstantExpr)
-      .getStringValue()
-      .toLowerCase()
-      .regexpMatch(getSensitiveCookieNameRegex()) or
+  exists(string s | s = expr.(CompileTimeConstantExpr).getStringValue().toLowerCase() |
+    s.regexpMatch(getSensitiveCookieNameRegex()) and not s.regexpMatch(getCsrfCookieNameRegex())
+  )
+  or
   isSensitiveCookieNameExpr(expr.(AddExpr).getAnOperand())
 }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -48,9 +48,8 @@ class SensitiveCookieNameExpr extends Expr {
       ClassInstanceExpr cie // new Cookie("jwt_token", token)
     |
       (
-        cie.getConstructor().getDeclaringType().hasQualifiedName("javax.servlet.http", "Cookie") or
-        cie.getConstructor()
-            .getDeclaringType()
+        cie.getConstructedType().hasQualifiedName("javax.servlet.http", "Cookie") or
+        cie.getConstructedType()
             .getASupertype*()
             .hasQualifiedName(["javax.ws.rs.core", "jakarta.ws.rs.core"], "Cookie")
       ) and

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -1,0 +1,194 @@
+/**
+ * @name Sensitive cookies without the HttpOnly response header set
+ * @description Sensitive cookies without 'HttpOnly' leaves session cookies vulnerable to an XSS attack.
+ * @kind path-problem
+ * @id java/sensitive-cookie-not-httponly
+ * @tags security
+ *       external/cwe/cwe-1004
+ */
+
+import java
+import semmle.code.java.frameworks.Servlets
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.dataflow.TaintTracking
+import DataFlow::PathGraph
+
+/** Gets a regular expression for matching common names of sensitive cookies. */
+string getSensitiveCookieNameRegex() { result = "(?i).*(auth|session|token|key|credential).*" }
+
+/** Holds if a string is concatenated with the name of a sensitive cookie. */
+predicate isSensitiveCookieNameExpr(Expr expr) {
+  expr.(StringLiteral)
+      .getRepresentedString()
+      .toLowerCase()
+      .regexpMatch(getSensitiveCookieNameRegex()) or
+  isSensitiveCookieNameExpr(expr.(AddExpr).getAnOperand())
+}
+
+/** Holds if a string is concatenated with the `HttpOnly` flag. */
+predicate hasHttpOnlyExpr(Expr expr) {
+  expr.(StringLiteral).getRepresentedString().toLowerCase().matches("%httponly%") or
+  hasHttpOnlyExpr(expr.(AddExpr).getAnOperand())
+}
+
+/** The method call `Set-Cookie` of `addHeader` or `setHeader`. */
+class SetCookieMethodAccess extends MethodAccess {
+  SetCookieMethodAccess() {
+    (
+      this.getMethod() instanceof ResponseAddHeaderMethod or
+      this.getMethod() instanceof ResponseSetHeaderMethod
+    ) and
+    this.getArgument(0).(StringLiteral).getRepresentedString().toLowerCase() = "set-cookie"
+  }
+}
+
+/** Sensitive cookie name used in a `Cookie` constructor or a `Set-Cookie` call. */
+class SensitiveCookieNameExpr extends Expr {
+  SensitiveCookieNameExpr() {
+    isSensitiveCookieNameExpr(this) and
+    (
+      exists(
+        ClassInstanceExpr cie // new Cookie("jwt_token", token)
+      |
+        (
+          cie.getConstructor().getDeclaringType().hasQualifiedName("javax.servlet.http", "Cookie") or
+          cie.getConstructor()
+              .getDeclaringType()
+              .getASupertype*()
+              .hasQualifiedName("javax.ws.rs.core", "Cookie") or
+          cie.getConstructor()
+              .getDeclaringType()
+              .getASupertype*()
+              .hasQualifiedName("jakarta.ws.rs.core", "Cookie")
+        ) and
+        DataFlow::localExprFlow(this, cie.getArgument(0))
+      )
+      or
+      exists(
+        SetCookieMethodAccess ma // response.addHeader("Set-Cookie: token=" +authId + ";HttpOnly;Secure")
+      |
+        DataFlow::localExprFlow(this, ma.getArgument(1))
+      )
+    )
+  }
+}
+
+/** Sink of adding a cookie to the HTTP response. */
+class CookieResponseSink extends DataFlow::ExprNode {
+  CookieResponseSink() {
+    exists(MethodAccess ma |
+      (
+        ma.getMethod() instanceof ResponseAddCookieMethod or
+        ma instanceof SetCookieMethodAccess
+      ) and
+      ma.getAnArgument() = this.getExpr()
+    )
+  }
+}
+
+/** Holds if the `node` is a method call of `setHttpOnly(true)` on a cookie. */
+predicate setHttpOnlyMethodAccess(DataFlow::Node node) {
+  exists(
+    MethodAccess addCookie, Variable cookie, MethodAccess m // jwtCookie.setHttpOnly(true)
+  |
+    addCookie.getMethod() instanceof ResponseAddCookieMethod and
+    addCookie.getArgument(0) = cookie.getAnAccess() and
+    m.getMethod().getName() = "setHttpOnly" and
+    m.getArgument(0).(BooleanLiteral).getBooleanValue() = true and
+    m.getQualifier() = cookie.getAnAccess() and
+    node.asExpr() = cookie.getAnAccess()
+  )
+}
+
+/** Holds if the `node` is a method call of `Set-Cookie` header with the `HttpOnly` flag whose cookie name is sensitive. */
+predicate setHttpOnlyInSetCookie(DataFlow::Node node) {
+  exists(SetCookieMethodAccess sa |
+    hasHttpOnlyExpr(node.asExpr()) and
+    DataFlow::localExprFlow(node.asExpr(), sa.getArgument(1))
+  )
+}
+
+/** Holds if the `node` is an invocation of a JAX-RS `NewCookie` constructor that sets `HttpOnly` to true. */
+predicate setHttpOnlyInNewCookie(DataFlow::Node node) {
+  exists(ClassInstanceExpr cie |
+    cie.getConstructor().getDeclaringType().hasName("NewCookie") and
+    DataFlow::localExprFlow(node.asExpr(), cie.getArgument(0)) and
+    (
+      cie.getNumArgument() = 6 and cie.getArgument(5).(BooleanLiteral).getBooleanValue() = true // NewCookie(Cookie cookie, String comment, int maxAge, Date expiry, boolean secure, boolean httpOnly)
+      or
+      cie.getNumArgument() = 8 and
+      cie.getArgument(6).getType() instanceof BooleanType and
+      cie.getArgument(7).(BooleanLiteral).getBooleanValue() = true // NewCookie(String name, String value, String path, String domain, String comment, int maxAge, boolean secure, boolean httpOnly)
+      or
+      cie.getNumArgument() = 10 and cie.getArgument(9).(BooleanLiteral).getBooleanValue() = true // NewCookie(String name, String value, String path, String domain, int version, String comment, int maxAge, Date expiry, boolean secure, boolean httpOnly)
+    )
+  )
+}
+
+/**
+ * Holds if the node is a test method indicated by:
+ *    a) in a test directory such as `src/test/java`
+ *    b) in a test package whose name has the word `test`
+ *    c) in a test class whose name has the word `test`
+ *    d) in a test class implementing a test framework such as JUnit or TestNG
+ */
+predicate isTestMethod(DataFlow::Node node) {
+  exists(MethodAccess ma, Method m |
+    node.asExpr() = ma.getAnArgument() and
+    m = ma.getEnclosingCallable() and
+    (
+      m.getDeclaringType().getName().toLowerCase().matches("%test%") or // Simple check to exclude test classes to reduce FPs
+      m.getDeclaringType().getPackage().getName().toLowerCase().matches("%test%") or // Simple check to exclude classes in test packages to reduce FPs
+      exists(m.getLocation().getFile().getAbsolutePath().indexOf("/src/test/java")) or //  Match test directory structure of build tools like maven
+      m instanceof TestMethod // Test method of a test case implementing a test framework such as JUnit or TestNG
+    )
+  )
+}
+
+/** A taint configuration tracking flow from a sensitive cookie without HttpOnly flag set to its HTTP response. */
+class MissingHttpOnlyConfiguration extends TaintTracking::Configuration {
+  MissingHttpOnlyConfiguration() { this = "MissingHttpOnlyConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source.asExpr() instanceof SensitiveCookieNameExpr
+  }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof CookieResponseSink }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    // cookie.setHttpOnly(true)
+    setHttpOnlyMethodAccess(node)
+    or
+    // response.addHeader("Set-Cookie: token=" +authId + ";HttpOnly;Secure")
+    setHttpOnlyInSetCookie(node)
+    or
+    // new NewCookie("session-access-key", accessKey, "/", null, null, 0, true, true)
+    setHttpOnlyInNewCookie(node)
+    or
+    // Test class or method
+    isTestMethod(node)
+  }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(
+      ClassInstanceExpr cie // `NewCookie` constructor
+    |
+      cie.getAnArgument() = pred.asExpr() and
+      cie = succ.asExpr() and
+      cie.getConstructor().getDeclaringType().hasName("NewCookie")
+    )
+    or
+    exists(
+      MethodAccess ma // `toString` call on a cookie object
+    |
+      ma.getQualifier() = pred.asExpr() and
+      ma.getMethod().hasName("toString") and
+      ma = succ.asExpr()
+    )
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, MissingHttpOnlyConfiguration c
+where c.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "$@ doesn't have the HttpOnly flag set.", source.getNode(),
+  "This sensitive cookie"

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -104,8 +104,8 @@ class CookieTaintPreservingConstructor extends Constructor, TaintPreservingCalla
 }
 
 /** The method call `toString` to get a stringified cookie representation. */
-class CookieInstanceExpr extends TaintPreservingCallable {
-  CookieInstanceExpr() {
+class CookieToString extends TaintPreservingCallable {
+  CookieToString() {
     this.getDeclaringType() instanceof CookieClass and
     this.hasName("toString")
   }

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -60,24 +60,16 @@ class CookieInstanceExpr extends TaintPreservingCallable {
   override predicate returnsTaintFrom(int arg) { arg = -1 }
 }
 
+/** The cookie constructor. */
+class CookieTaintPreservingConstructor extends Constructor, TaintPreservingCallable {
+  CookieTaintPreservingConstructor() { this.getDeclaringType() instanceof CookieClass }
+
+  override predicate returnsTaintFrom(int arg) { arg = 0 }
+}
+
 /** Sensitive cookie name used in a `Cookie` constructor or a `Set-Cookie` call. */
 class SensitiveCookieNameExpr extends Expr {
-  SensitiveCookieNameExpr() {
-    exists(
-      ClassInstanceExpr cie // new Cookie("jwt_token", token)
-    |
-      cie.getConstructedType() instanceof CookieClass and
-      this = cie and
-      isSensitiveCookieNameExpr(cie.getArgument(0))
-    )
-    or
-    exists(
-      SetCookieMethodAccess ma // response.addHeader("Set-Cookie: token=" +authId + ";HttpOnly;Secure")
-    |
-      this = ma.getArgument(1) and
-      isSensitiveCookieNameExpr(this)
-    )
-  }
+  SensitiveCookieNameExpr() { isSensitiveCookieNameExpr(this) }
 }
 
 /** Sink of adding a cookie to the HTTP response. */

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
@@ -1,0 +1,13 @@
+edges
+| SensitiveCookieNotHttpOnly.java:22:38:22:48 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie |
+| SensitiveCookieNotHttpOnly.java:49:56:49:75 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) |
+nodes
+| SensitiveCookieNotHttpOnly.java:22:38:22:48 | "jwt_token" : String | semmle.label | "jwt_token" : String |
+| SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | semmle.label | jwtCookie |
+| SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | semmle.label | ... + ... |
+| SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | semmle.label | toString(...) |
+| SensitiveCookieNotHttpOnly.java:49:56:49:75 | "session-access-key" : String | semmle.label | "session-access-key" : String |
+#select
+| SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:22:38:22:48 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:22:38:22:48 | "jwt_token" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | SensitiveCookieNotHttpOnly.java:49:56:49:75 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:49:56:49:75 | "session-access-key" | This sensitive cookie |

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
@@ -1,13 +1,13 @@
 edges
-| SensitiveCookieNotHttpOnly.java:22:38:22:48 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie |
-| SensitiveCookieNotHttpOnly.java:49:56:49:75 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) |
+| SensitiveCookieNotHttpOnly.java:22:27:22:60 | new Cookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie |
+| SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) : NewCookie | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) |
 nodes
-| SensitiveCookieNotHttpOnly.java:22:38:22:48 | "jwt_token" : String | semmle.label | "jwt_token" : String |
+| SensitiveCookieNotHttpOnly.java:22:27:22:60 | new Cookie(...) : Cookie | semmle.label | new Cookie(...) : Cookie |
 | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | semmle.label | jwtCookie |
 | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | semmle.label | ... + ... |
+| SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) : NewCookie | semmle.label | new NewCookie(...) : NewCookie |
 | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | semmle.label | toString(...) |
-| SensitiveCookieNotHttpOnly.java:49:56:49:75 | "session-access-key" : String | semmle.label | "session-access-key" : String |
 #select
-| SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:22:38:22:48 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:22:38:22:48 | "jwt_token" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:22:27:22:60 | new Cookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:22:27:22:60 | new Cookie(...) | This sensitive cookie |
 | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | SensitiveCookieNotHttpOnly.java:49:56:49:75 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:49:56:49:75 | "session-access-key" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) : NewCookie | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) | This sensitive cookie |

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
@@ -7,6 +7,9 @@ edges
 | SensitiveCookieNotHttpOnly.java:70:28:70:35 | "token=" : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString |
 | SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString |
 | SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString |
+| SensitiveCookieNotHttpOnly.java:88:35:88:51 | "Presto-UI-Token" : String | SensitiveCookieNotHttpOnly.java:91:16:91:21 | cookie : Cookie |
+| SensitiveCookieNotHttpOnly.java:91:16:91:21 | cookie : Cookie | SensitiveCookieNotHttpOnly.java:102:25:102:64 | createAuthenticationCookie(...) : Cookie |
+| SensitiveCookieNotHttpOnly.java:102:25:102:64 | createAuthenticationCookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:103:28:103:33 | cookie |
 nodes
 | SensitiveCookieNotHttpOnly.java:24:33:24:43 | "jwt_token" : String | semmle.label | "jwt_token" : String |
 | SensitiveCookieNotHttpOnly.java:31:28:31:36 | jwtCookie | semmle.label | jwtCookie |
@@ -21,6 +24,10 @@ nodes
 | SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... : String | semmle.label | ... + ... : String |
 | SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... : String | semmle.label | ... + ... : String |
 | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | semmle.label | secString |
+| SensitiveCookieNotHttpOnly.java:88:35:88:51 | "Presto-UI-Token" : String | semmle.label | "Presto-UI-Token" : String |
+| SensitiveCookieNotHttpOnly.java:91:16:91:21 | cookie : Cookie | semmle.label | cookie : Cookie |
+| SensitiveCookieNotHttpOnly.java:102:25:102:64 | createAuthenticationCookie(...) : Cookie | semmle.label | createAuthenticationCookie(...) : Cookie |
+| SensitiveCookieNotHttpOnly.java:103:28:103:33 | cookie | semmle.label | cookie |
 #select
 | SensitiveCookieNotHttpOnly.java:31:28:31:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:24:33:24:43 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:31:28:31:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:24:33:24:43 | "jwt_token" | This sensitive cookie |
 | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | SensitiveCookieNotHttpOnly.java:42:42:42:49 | "token=" : String | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:42:42:42:49 | "token=" | This sensitive cookie |
@@ -31,3 +38,4 @@ nodes
 | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | SensitiveCookieNotHttpOnly.java:70:28:70:35 | "token=" : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:70:28:70:35 | "token=" | This sensitive cookie |
 | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... | This sensitive cookie |
 | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:103:28:103:33 | cookie | SensitiveCookieNotHttpOnly.java:88:35:88:51 | "Presto-UI-Token" : String | SensitiveCookieNotHttpOnly.java:103:28:103:33 | cookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:88:35:88:51 | "Presto-UI-Token" | This sensitive cookie |

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
@@ -1,17 +1,33 @@
 edges
-| SensitiveCookieNotHttpOnly.java:22:28:22:61 | new Cookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie |
-| SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) : NewCookie | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) |
-| SensitiveCookieNotHttpOnly.java:60:37:60:115 | new NewCookie(...) : NewCookie | SensitiveCookieNotHttpOnly.java:62:42:62:47 | keyStr |
+| SensitiveCookieNotHttpOnly.java:22:33:22:43 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:29:28:29:36 | jwtCookie |
+| SensitiveCookieNotHttpOnly.java:40:42:40:49 | "token=" : String | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... |
+| SensitiveCookieNotHttpOnly.java:40:42:40:57 | ... + ... : String | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... |
+| SensitiveCookieNotHttpOnly.java:50:56:50:75 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:50:42:50:124 | toString(...) |
+| SensitiveCookieNotHttpOnly.java:61:51:61:70 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:63:42:63:47 | keyStr |
+| SensitiveCookieNotHttpOnly.java:68:28:68:35 | "token=" : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString |
+| SensitiveCookieNotHttpOnly.java:68:28:68:43 | ... + ... : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString |
+| SensitiveCookieNotHttpOnly.java:68:28:68:55 | ... + ... : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString |
 nodes
-| SensitiveCookieNotHttpOnly.java:22:28:22:61 | new Cookie(...) : Cookie | semmle.label | new Cookie(...) : Cookie |
-| SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | semmle.label | jwtCookie |
-| SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | semmle.label | ... + ... |
-| SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) : NewCookie | semmle.label | new NewCookie(...) : NewCookie |
-| SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | semmle.label | toString(...) |
-| SensitiveCookieNotHttpOnly.java:60:37:60:115 | new NewCookie(...) : NewCookie | semmle.label | new NewCookie(...) : NewCookie |
-| SensitiveCookieNotHttpOnly.java:62:42:62:47 | keyStr | semmle.label | keyStr |
+| SensitiveCookieNotHttpOnly.java:22:33:22:43 | "jwt_token" : String | semmle.label | "jwt_token" : String |
+| SensitiveCookieNotHttpOnly.java:29:28:29:36 | jwtCookie | semmle.label | jwtCookie |
+| SensitiveCookieNotHttpOnly.java:40:42:40:49 | "token=" : String | semmle.label | "token=" : String |
+| SensitiveCookieNotHttpOnly.java:40:42:40:57 | ... + ... : String | semmle.label | ... + ... : String |
+| SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | semmle.label | ... + ... |
+| SensitiveCookieNotHttpOnly.java:50:42:50:124 | toString(...) | semmle.label | toString(...) |
+| SensitiveCookieNotHttpOnly.java:50:56:50:75 | "session-access-key" : String | semmle.label | "session-access-key" : String |
+| SensitiveCookieNotHttpOnly.java:61:51:61:70 | "session-access-key" : String | semmle.label | "session-access-key" : String |
+| SensitiveCookieNotHttpOnly.java:63:42:63:47 | keyStr | semmle.label | keyStr |
+| SensitiveCookieNotHttpOnly.java:68:28:68:35 | "token=" : String | semmle.label | "token=" : String |
+| SensitiveCookieNotHttpOnly.java:68:28:68:43 | ... + ... : String | semmle.label | ... + ... : String |
+| SensitiveCookieNotHttpOnly.java:68:28:68:55 | ... + ... : String | semmle.label | ... + ... : String |
+| SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | semmle.label | secString |
 #select
-| SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:22:28:22:61 | new Cookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:22:28:22:61 | new Cookie(...) | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) : NewCookie | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:62:42:62:47 | keyStr | SensitiveCookieNotHttpOnly.java:60:37:60:115 | new NewCookie(...) : NewCookie | SensitiveCookieNotHttpOnly.java:62:42:62:47 | keyStr | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:60:37:60:115 | new NewCookie(...) | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:29:28:29:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:22:33:22:43 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:29:28:29:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:22:33:22:43 | "jwt_token" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | SensitiveCookieNotHttpOnly.java:40:42:40:49 | "token=" : String | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:40:42:40:49 | "token=" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | SensitiveCookieNotHttpOnly.java:40:42:40:57 | ... + ... : String | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:40:42:40:57 | ... + ... | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:50:42:50:124 | toString(...) | SensitiveCookieNotHttpOnly.java:50:56:50:75 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:50:42:50:124 | toString(...) | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:50:56:50:75 | "session-access-key" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:63:42:63:47 | keyStr | SensitiveCookieNotHttpOnly.java:61:51:61:70 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:63:42:63:47 | keyStr | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:61:51:61:70 | "session-access-key" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | SensitiveCookieNotHttpOnly.java:68:28:68:35 | "token=" : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:68:28:68:35 | "token=" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | SensitiveCookieNotHttpOnly.java:68:28:68:43 | ... + ... : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:68:28:68:43 | ... + ... | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | SensitiveCookieNotHttpOnly.java:68:28:68:55 | ... + ... : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:68:28:68:55 | ... + ... | This sensitive cookie |

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
@@ -8,8 +8,8 @@ edges
 | SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString |
 | SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString |
 | SensitiveCookieNotHttpOnly.java:88:35:88:51 | "Presto-UI-Token" : String | SensitiveCookieNotHttpOnly.java:91:16:91:21 | cookie : Cookie |
-| SensitiveCookieNotHttpOnly.java:91:16:91:21 | cookie : Cookie | SensitiveCookieNotHttpOnly.java:102:25:102:64 | createAuthenticationCookie(...) : Cookie |
-| SensitiveCookieNotHttpOnly.java:102:25:102:64 | createAuthenticationCookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:103:28:103:33 | cookie |
+| SensitiveCookieNotHttpOnly.java:91:16:91:21 | cookie : Cookie | SensitiveCookieNotHttpOnly.java:110:25:110:64 | createAuthenticationCookie(...) : Cookie |
+| SensitiveCookieNotHttpOnly.java:110:25:110:64 | createAuthenticationCookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:111:28:111:33 | cookie |
 nodes
 | SensitiveCookieNotHttpOnly.java:24:33:24:43 | "jwt_token" : String | semmle.label | "jwt_token" : String |
 | SensitiveCookieNotHttpOnly.java:31:28:31:36 | jwtCookie | semmle.label | jwtCookie |
@@ -26,8 +26,8 @@ nodes
 | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | semmle.label | secString |
 | SensitiveCookieNotHttpOnly.java:88:35:88:51 | "Presto-UI-Token" : String | semmle.label | "Presto-UI-Token" : String |
 | SensitiveCookieNotHttpOnly.java:91:16:91:21 | cookie : Cookie | semmle.label | cookie : Cookie |
-| SensitiveCookieNotHttpOnly.java:102:25:102:64 | createAuthenticationCookie(...) : Cookie | semmle.label | createAuthenticationCookie(...) : Cookie |
-| SensitiveCookieNotHttpOnly.java:103:28:103:33 | cookie | semmle.label | cookie |
+| SensitiveCookieNotHttpOnly.java:110:25:110:64 | createAuthenticationCookie(...) : Cookie | semmle.label | createAuthenticationCookie(...) : Cookie |
+| SensitiveCookieNotHttpOnly.java:111:28:111:33 | cookie | semmle.label | cookie |
 #select
 | SensitiveCookieNotHttpOnly.java:31:28:31:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:24:33:24:43 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:31:28:31:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:24:33:24:43 | "jwt_token" | This sensitive cookie |
 | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | SensitiveCookieNotHttpOnly.java:42:42:42:49 | "token=" : String | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:42:42:42:49 | "token=" | This sensitive cookie |
@@ -38,4 +38,4 @@ nodes
 | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | SensitiveCookieNotHttpOnly.java:70:28:70:35 | "token=" : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:70:28:70:35 | "token=" | This sensitive cookie |
 | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... | This sensitive cookie |
 | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:103:28:103:33 | cookie | SensitiveCookieNotHttpOnly.java:88:35:88:51 | "Presto-UI-Token" : String | SensitiveCookieNotHttpOnly.java:103:28:103:33 | cookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:88:35:88:51 | "Presto-UI-Token" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:111:28:111:33 | cookie | SensitiveCookieNotHttpOnly.java:88:35:88:51 | "Presto-UI-Token" : String | SensitiveCookieNotHttpOnly.java:111:28:111:33 | cookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:88:35:88:51 | "Presto-UI-Token" | This sensitive cookie |

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
@@ -1,33 +1,33 @@
 edges
-| SensitiveCookieNotHttpOnly.java:22:33:22:43 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:29:28:29:36 | jwtCookie |
-| SensitiveCookieNotHttpOnly.java:40:42:40:49 | "token=" : String | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... |
-| SensitiveCookieNotHttpOnly.java:40:42:40:57 | ... + ... : String | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... |
-| SensitiveCookieNotHttpOnly.java:50:56:50:75 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:50:42:50:124 | toString(...) |
-| SensitiveCookieNotHttpOnly.java:61:51:61:70 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:63:42:63:47 | keyStr |
-| SensitiveCookieNotHttpOnly.java:68:28:68:35 | "token=" : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString |
-| SensitiveCookieNotHttpOnly.java:68:28:68:43 | ... + ... : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString |
-| SensitiveCookieNotHttpOnly.java:68:28:68:55 | ... + ... : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString |
+| SensitiveCookieNotHttpOnly.java:24:33:24:43 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:31:28:31:36 | jwtCookie |
+| SensitiveCookieNotHttpOnly.java:42:42:42:49 | "token=" : String | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... |
+| SensitiveCookieNotHttpOnly.java:42:42:42:57 | ... + ... : String | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... |
+| SensitiveCookieNotHttpOnly.java:52:56:52:75 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:52:42:52:124 | toString(...) |
+| SensitiveCookieNotHttpOnly.java:63:51:63:70 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:65:42:65:47 | keyStr |
+| SensitiveCookieNotHttpOnly.java:70:28:70:35 | "token=" : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString |
+| SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString |
+| SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString |
 nodes
-| SensitiveCookieNotHttpOnly.java:22:33:22:43 | "jwt_token" : String | semmle.label | "jwt_token" : String |
-| SensitiveCookieNotHttpOnly.java:29:28:29:36 | jwtCookie | semmle.label | jwtCookie |
-| SensitiveCookieNotHttpOnly.java:40:42:40:49 | "token=" : String | semmle.label | "token=" : String |
-| SensitiveCookieNotHttpOnly.java:40:42:40:57 | ... + ... : String | semmle.label | ... + ... : String |
-| SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | semmle.label | ... + ... |
-| SensitiveCookieNotHttpOnly.java:50:42:50:124 | toString(...) | semmle.label | toString(...) |
-| SensitiveCookieNotHttpOnly.java:50:56:50:75 | "session-access-key" : String | semmle.label | "session-access-key" : String |
-| SensitiveCookieNotHttpOnly.java:61:51:61:70 | "session-access-key" : String | semmle.label | "session-access-key" : String |
-| SensitiveCookieNotHttpOnly.java:63:42:63:47 | keyStr | semmle.label | keyStr |
-| SensitiveCookieNotHttpOnly.java:68:28:68:35 | "token=" : String | semmle.label | "token=" : String |
-| SensitiveCookieNotHttpOnly.java:68:28:68:43 | ... + ... : String | semmle.label | ... + ... : String |
-| SensitiveCookieNotHttpOnly.java:68:28:68:55 | ... + ... : String | semmle.label | ... + ... : String |
-| SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | semmle.label | secString |
+| SensitiveCookieNotHttpOnly.java:24:33:24:43 | "jwt_token" : String | semmle.label | "jwt_token" : String |
+| SensitiveCookieNotHttpOnly.java:31:28:31:36 | jwtCookie | semmle.label | jwtCookie |
+| SensitiveCookieNotHttpOnly.java:42:42:42:49 | "token=" : String | semmle.label | "token=" : String |
+| SensitiveCookieNotHttpOnly.java:42:42:42:57 | ... + ... : String | semmle.label | ... + ... : String |
+| SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | semmle.label | ... + ... |
+| SensitiveCookieNotHttpOnly.java:52:42:52:124 | toString(...) | semmle.label | toString(...) |
+| SensitiveCookieNotHttpOnly.java:52:56:52:75 | "session-access-key" : String | semmle.label | "session-access-key" : String |
+| SensitiveCookieNotHttpOnly.java:63:51:63:70 | "session-access-key" : String | semmle.label | "session-access-key" : String |
+| SensitiveCookieNotHttpOnly.java:65:42:65:47 | keyStr | semmle.label | keyStr |
+| SensitiveCookieNotHttpOnly.java:70:28:70:35 | "token=" : String | semmle.label | "token=" : String |
+| SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... : String | semmle.label | ... + ... : String |
+| SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... : String | semmle.label | ... + ... : String |
+| SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | semmle.label | secString |
 #select
-| SensitiveCookieNotHttpOnly.java:29:28:29:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:22:33:22:43 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:29:28:29:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:22:33:22:43 | "jwt_token" | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | SensitiveCookieNotHttpOnly.java:40:42:40:49 | "token=" : String | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:40:42:40:49 | "token=" | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | SensitiveCookieNotHttpOnly.java:40:42:40:57 | ... + ... : String | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:40:42:40:57 | ... + ... | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:40:42:40:69 | ... + ... | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:50:42:50:124 | toString(...) | SensitiveCookieNotHttpOnly.java:50:56:50:75 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:50:42:50:124 | toString(...) | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:50:56:50:75 | "session-access-key" | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:63:42:63:47 | keyStr | SensitiveCookieNotHttpOnly.java:61:51:61:70 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:63:42:63:47 | keyStr | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:61:51:61:70 | "session-access-key" | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | SensitiveCookieNotHttpOnly.java:68:28:68:35 | "token=" : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:68:28:68:35 | "token=" | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | SensitiveCookieNotHttpOnly.java:68:28:68:43 | ... + ... : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:68:28:68:43 | ... + ... | This sensitive cookie |
-| SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | SensitiveCookieNotHttpOnly.java:68:28:68:55 | ... + ... : String | SensitiveCookieNotHttpOnly.java:69:42:69:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:68:28:68:55 | ... + ... | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:31:28:31:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:24:33:24:43 | "jwt_token" : String | SensitiveCookieNotHttpOnly.java:31:28:31:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:24:33:24:43 | "jwt_token" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | SensitiveCookieNotHttpOnly.java:42:42:42:49 | "token=" : String | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:42:42:42:49 | "token=" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | SensitiveCookieNotHttpOnly.java:42:42:42:57 | ... + ... : String | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:42:42:42:57 | ... + ... | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:42:42:42:69 | ... + ... | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:52:42:52:124 | toString(...) | SensitiveCookieNotHttpOnly.java:52:56:52:75 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:52:42:52:124 | toString(...) | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:52:56:52:75 | "session-access-key" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:65:42:65:47 | keyStr | SensitiveCookieNotHttpOnly.java:63:51:63:70 | "session-access-key" : String | SensitiveCookieNotHttpOnly.java:65:42:65:47 | keyStr | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:63:51:63:70 | "session-access-key" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | SensitiveCookieNotHttpOnly.java:70:28:70:35 | "token=" : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:70:28:70:35 | "token=" | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:70:28:70:43 | ... + ... | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... : String | SensitiveCookieNotHttpOnly.java:71:42:71:50 | secString | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:70:28:70:55 | ... + ... | This sensitive cookie |

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.expected
@@ -1,13 +1,17 @@
 edges
-| SensitiveCookieNotHttpOnly.java:22:27:22:60 | new Cookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie |
+| SensitiveCookieNotHttpOnly.java:22:28:22:61 | new Cookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie |
 | SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) : NewCookie | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) |
+| SensitiveCookieNotHttpOnly.java:60:37:60:115 | new NewCookie(...) : NewCookie | SensitiveCookieNotHttpOnly.java:62:42:62:47 | keyStr |
 nodes
-| SensitiveCookieNotHttpOnly.java:22:27:22:60 | new Cookie(...) : Cookie | semmle.label | new Cookie(...) : Cookie |
+| SensitiveCookieNotHttpOnly.java:22:28:22:61 | new Cookie(...) : Cookie | semmle.label | new Cookie(...) : Cookie |
 | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | semmle.label | jwtCookie |
 | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | semmle.label | ... + ... |
 | SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) : NewCookie | semmle.label | new NewCookie(...) : NewCookie |
 | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | semmle.label | toString(...) |
+| SensitiveCookieNotHttpOnly.java:60:37:60:115 | new NewCookie(...) : NewCookie | semmle.label | new NewCookie(...) : NewCookie |
+| SensitiveCookieNotHttpOnly.java:62:42:62:47 | keyStr | semmle.label | keyStr |
 #select
-| SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:22:27:22:60 | new Cookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:22:27:22:60 | new Cookie(...) | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | SensitiveCookieNotHttpOnly.java:22:28:22:61 | new Cookie(...) : Cookie | SensitiveCookieNotHttpOnly.java:28:28:28:36 | jwtCookie | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:22:28:22:61 | new Cookie(...) | This sensitive cookie |
 | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:39:42:39:69 | ... + ... | This sensitive cookie |
 | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) : NewCookie | SensitiveCookieNotHttpOnly.java:49:42:49:124 | toString(...) | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:49:42:49:113 | new NewCookie(...) | This sensitive cookie |
+| SensitiveCookieNotHttpOnly.java:62:42:62:47 | keyStr | SensitiveCookieNotHttpOnly.java:60:37:60:115 | new NewCookie(...) : NewCookie | SensitiveCookieNotHttpOnly.java:62:42:62:47 | keyStr | $@ doesn't have the HttpOnly flag set. | SensitiveCookieNotHttpOnly.java:60:37:60:115 | new NewCookie(...) | This sensitive cookie |

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
@@ -91,6 +91,14 @@ class SensitiveCookieNotHttpOnly {
         return cookie;
     }
 
+    public Cookie removeAuthenticationCookie(HttpServletRequest request, String jwt) {
+        String PRESTO_UI_COOKIE = "Presto-UI-Token";
+        Cookie cookie = new Cookie(PRESTO_UI_COOKIE, jwt);
+        cookie.setPath("/ui");
+        cookie.setMaxAge(0);
+        return cookie;
+    }
+
     // GOOD - Tests set a sensitive cookie header with the `HttpOnly` flag set using a wrapper method.
     public void addCookie11(HttpServletRequest request, HttpServletResponse response, String jwt) {
         Cookie cookie = createHttpOnlyAuthenticationCookie(request, jwt);
@@ -100,6 +108,12 @@ class SensitiveCookieNotHttpOnly {
     // BAD - Tests set a sensitive cookie header without the `HttpOnly` flag set using a wrapper method.
     public void addCookie12(HttpServletRequest request, HttpServletResponse response, String jwt) {
         Cookie cookie = createAuthenticationCookie(request, jwt);
+        response.addCookie(cookie);
+    }
+
+    // GOOD - Tests remove a sensitive cookie header without the `HttpOnly` flag set using a wrapper method.
+    public void addCookie13(HttpServletRequest request, HttpServletResponse response, String jwt) {
+        Cookie cookie = removeAuthenticationCookie(request, jwt);
         response.addCookie(cookie);
     }
 
@@ -119,12 +133,12 @@ class SensitiveCookieNotHttpOnly {
     }
 
     // GOOD - Tests set a sensitive cookie header with the `HttpOnly` flag set through a boolean variable using a wrapper method.
-    public void addCookie13(HttpServletRequest request, HttpServletResponse response, String refreshToken) {
+    public void addCookie14(HttpServletRequest request, HttpServletResponse response, String refreshToken) {
         response.addCookie(createCookie("refresh_token", refreshToken, true));
     }
 
     // BAD - Tests set a sensitive cookie header with the `HttpOnly` flag not set through a boolean variable using a wrapper method.
-    public void addCookie14(HttpServletRequest request, HttpServletResponse response, String refreshToken) {
+    public void addCookie15(HttpServletRequest request, HttpServletResponse response, String refreshToken) {
         response.addCookie(createCookie("refresh_token", refreshToken, false));
     }
 

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
@@ -19,7 +19,8 @@ class SensitiveCookieNotHttpOnly {
 
     // BAD - Tests adding a sensitive cookie without the `HttpOnly` flag set.
     public void addCookie2(String jwt_token, String userId, HttpServletRequest request, HttpServletResponse response) {
-        Cookie jwtCookie = new Cookie("jwt_token", jwt_token);
+        String tokenCookieStr = "jwt_token";
+        Cookie jwtCookie = new Cookie(tokenCookieStr, jwt_token);
         Cookie userIdCookie = new Cookie("user_id", userId);
         jwtCookie.setPath("/");
         userIdCookie.setPath("/");
@@ -61,4 +62,10 @@ class SensitiveCookieNotHttpOnly {
         String keyStr = accessKeyCookie.toString();
         response.setHeader("Set-Cookie", keyStr);
     }
+
+    // BAD - Tests set a sensitive cookie header using a variable without the `HttpOnly` flag set.
+    public void addCookie9(String authId, HttpServletRequest request, HttpServletResponse response) {
+        String secString = "token=" +authId + ";Secure";
+        response.addHeader("Set-Cookie", secString);
+    }    
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
@@ -71,6 +71,63 @@ class SensitiveCookieNotHttpOnly {
         response.addHeader("Set-Cookie", secString);
     }
 
+    // GOOD - Tests set a sensitive cookie header with the `HttpOnly` flag set using `String.format(...)`.
+    public void addCookie10(HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly", "sessionkey", request.getSession().getAttribute("sessionkey")));
+    }
+
+    public Cookie createHttpOnlyAuthenticationCookie(HttpServletRequest request, String jwt) {
+        String PRESTO_UI_COOKIE = "Presto-UI-Token";
+        Cookie cookie = new Cookie(PRESTO_UI_COOKIE, jwt);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/ui");
+        return cookie;
+    }
+
+    public Cookie createAuthenticationCookie(HttpServletRequest request, String jwt) {
+        String PRESTO_UI_COOKIE = "Presto-UI-Token";
+        Cookie cookie = new Cookie(PRESTO_UI_COOKIE, jwt);
+        cookie.setPath("/ui");
+        return cookie;
+    }
+
+    // GOOD - Tests set a sensitive cookie header with the `HttpOnly` flag set using a wrapper method.
+    public void addCookie11(HttpServletRequest request, HttpServletResponse response, String jwt) {
+        Cookie cookie = createHttpOnlyAuthenticationCookie(request, jwt);
+        response.addCookie(cookie);
+    }
+
+    // BAD - Tests set a sensitive cookie header without the `HttpOnly` flag set using a wrapper method.
+    public void addCookie12(HttpServletRequest request, HttpServletResponse response, String jwt) {
+        Cookie cookie = createAuthenticationCookie(request, jwt);
+        response.addCookie(cookie);
+    }
+
+    private Cookie createCookie(String name, String value, Boolean httpOnly){
+        Cookie cookie = null;
+        cookie = new Cookie(name, value);
+        cookie.setDomain("/");
+        cookie.setHttpOnly(httpOnly);
+
+        //for production https
+        cookie.setSecure(true);
+
+        cookie.setMaxAge(60*60*24*30);
+        cookie.setPath("/");
+
+        return cookie;
+    }
+
+    // GOOD - Tests set a sensitive cookie header with the `HttpOnly` flag set through a boolean variable using a wrapper method.
+    public void addCookie13(HttpServletRequest request, HttpServletResponse response, String refreshToken) {
+        response.addCookie(createCookie("refresh_token", refreshToken, true));
+    }
+
+    // BAD - Tests set a sensitive cookie header with the `HttpOnly` flag not set through a boolean variable using a wrapper method.
+    public void addCookie14(HttpServletRequest request, HttpServletResponse response, String refreshToken) {
+        response.addCookie(createCookie("refresh_token", refreshToken, false));
+    }
+
     // GOOD - CSRF token doesn't need to have the `HttpOnly` flag set.
     public void addCsrfCookie(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         // Spring put the CSRF token in session attribute "_csrf"

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
@@ -1,0 +1,57 @@
+import java.io.IOException;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+
+import javax.ws.rs.core.NewCookie;
+
+class SensitiveCookieNotHttpOnly {
+    // GOOD - Tests adding a sensitive cookie with the `HttpOnly` flag set.
+    public void addCookie(String jwt_token, HttpServletRequest request, HttpServletResponse response) {
+        Cookie jwtCookie =new Cookie("jwt_token", jwt_token);
+        jwtCookie.setPath("/");
+        jwtCookie.setMaxAge(3600*24*7);
+        jwtCookie.setHttpOnly(true);
+        response.addCookie(jwtCookie);
+    }
+
+    // BAD - Tests adding a sensitive cookie without the `HttpOnly` flag set.
+    public void addCookie2(String jwt_token, String userId, HttpServletRequest request, HttpServletResponse response) {
+        Cookie jwtCookie =new Cookie("jwt_token", jwt_token);
+        Cookie userIdCookie =new Cookie("user_id", userId.toString());
+        jwtCookie.setPath("/");
+        userIdCookie.setPath("/");
+        jwtCookie.setMaxAge(3600*24*7);
+        userIdCookie.setMaxAge(3600*24*7);
+        response.addCookie(jwtCookie);
+        response.addCookie(userIdCookie);
+    }
+
+    // GOOD - Tests set a sensitive cookie header with the `HttpOnly` flag set.
+    public void addCookie3(String authId, HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("Set-Cookie", "token=" +authId + ";HttpOnly;Secure");
+    }
+
+    // BAD - Tests set a sensitive cookie header without the `HttpOnly` flag set.
+    public void addCookie4(String authId, HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("Set-Cookie", "token=" +authId + ";Secure");
+    }
+    
+    // GOOD - Tests set a sensitive cookie header using the class `javax.ws.rs.core.Cookie` with the `HttpOnly` flag set through string concatenation.
+    public void addCookie5(String accessKey, HttpServletRequest request, HttpServletResponse response) {
+        response.setHeader("Set-Cookie", new NewCookie("session-access-key", accessKey, "/", null, null, 0, true) + ";HttpOnly");
+    }
+
+    // BAD - Tests set a sensitive cookie header using the class `javax.ws.rs.core.Cookie` without the `HttpOnly` flag set.
+    public void addCookie6(String accessKey, HttpServletRequest request, HttpServletResponse response) {
+        response.setHeader("Set-Cookie", new NewCookie("session-access-key", accessKey, "/", null, null, 0, true).toString());
+    }
+
+    // GOOD - Tests set a sensitive cookie header using the class `javax.ws.rs.core.Cookie` with the `HttpOnly` flag set through the constructor.
+    public void addCookie7(String accessKey, HttpServletRequest request, HttpServletResponse response) {
+        NewCookie accessKeyCookie = new NewCookie("session-access-key", accessKey, "/", null, null, 0, true, true);
+        response.setHeader("Set-Cookie", accessKeyCookie.toString());
+    }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
@@ -10,7 +10,7 @@ import javax.ws.rs.core.NewCookie;
 class SensitiveCookieNotHttpOnly {
     // GOOD - Tests adding a sensitive cookie with the `HttpOnly` flag set.
     public void addCookie(String jwt_token, HttpServletRequest request, HttpServletResponse response) {
-        Cookie jwtCookie =new Cookie("jwt_token", jwt_token);
+        Cookie jwtCookie = new Cookie("jwt_token", jwt_token);
         jwtCookie.setPath("/");
         jwtCookie.setMaxAge(3600*24*7);
         jwtCookie.setHttpOnly(true);
@@ -19,8 +19,8 @@ class SensitiveCookieNotHttpOnly {
 
     // BAD - Tests adding a sensitive cookie without the `HttpOnly` flag set.
     public void addCookie2(String jwt_token, String userId, HttpServletRequest request, HttpServletResponse response) {
-        Cookie jwtCookie =new Cookie("jwt_token", jwt_token);
-        Cookie userIdCookie =new Cookie("user_id", userId.toString());
+        Cookie jwtCookie = new Cookie("jwt_token", jwt_token);
+        Cookie userIdCookie = new Cookie("user_id", userId);
         jwtCookie.setPath("/");
         userIdCookie.setPath("/");
         jwtCookie.setMaxAge(3600*24*7);
@@ -53,5 +53,12 @@ class SensitiveCookieNotHttpOnly {
     public void addCookie7(String accessKey, HttpServletRequest request, HttpServletResponse response) {
         NewCookie accessKeyCookie = new NewCookie("session-access-key", accessKey, "/", null, null, 0, true, true);
         response.setHeader("Set-Cookie", accessKeyCookie.toString());
+    }
+
+    // BAD - Tests set a sensitive cookie header using the class `javax.ws.rs.core.Cookie` without the `HttpOnly` flag set.
+    public void addCookie8(String accessKey, HttpServletRequest request, HttpServletResponse response) {
+        NewCookie accessKeyCookie = new NewCookie("session-access-key", accessKey, "/", null, 0, null, 86400, true);
+        String keyStr = accessKeyCookie.toString();
+        response.setHeader("Set-Cookie", keyStr);
     }
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.java
@@ -137,7 +137,7 @@ class SensitiveCookieNotHttpOnly {
         response.addCookie(createCookie("refresh_token", refreshToken, true));
     }
 
-    // BAD - Tests set a sensitive cookie header with the `HttpOnly` flag not set through a boolean variable using a wrapper method.
+    // GOOD - Tests set a sensitive cookie header with the `HttpOnly` flag not set through a boolean variable using a wrapper method.
     public void addCookie15(HttpServletRequest request, HttpServletResponse response, String refreshToken) {
         response.addCookie(createCookie("refresh_token", refreshToken, false));
     }

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/SensitiveCookieNotHttpOnly.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/options
@@ -1,0 +1,1 @@
+// semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/servlet-api-2.4:${testdir}/../../../../stubs/jsr311-api-1.1.1

--- a/java/ql/test/experimental/query-tests/security/CWE-1004/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-1004/options
@@ -1,1 +1,1 @@
-// semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/servlet-api-2.4:${testdir}/../../../../stubs/jsr311-api-1.1.1
+// semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/servlet-api-2.4:${testdir}/../../../../stubs/jsr311-api-1.1.1:${testdir}/../../../../stubs/springframework-5.2.3

--- a/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/Cookie.java
+++ b/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/Cookie.java
@@ -51,10 +51,16 @@ package javax.ws.rs.core;
  * @since 1.0
  */
 public class Cookie {
+
     /**
      * Cookies using the default version correspond to RFC 2109.
      */
     public static final int DEFAULT_VERSION = 1;
+    private final String name;
+    private final String value;
+    private final int version;
+    private final String path;
+    private final String domain;
 
     /**
      * Create a new instance.
@@ -68,6 +74,11 @@ public class Cookie {
      */
     public Cookie(final String name, final String value, final String path, final String domain, final int version)
             throws IllegalArgumentException {
+        this.name = name;
+        this.value = value;
+        this.version = version;
+        this.domain = domain;
+        this.path = path;
     }
 
     /**
@@ -81,6 +92,7 @@ public class Cookie {
      */
     public Cookie(final String name, final String value, final String path, final String domain)
             throws IllegalArgumentException {
+        this(name, value, path, domain, DEFAULT_VERSION);
     }
 
     /**
@@ -92,6 +104,7 @@ public class Cookie {
      */
     public Cookie(final String name, final String value)
             throws IllegalArgumentException {
+        this(name, value, null, null);
     }
 
     /**
@@ -112,7 +125,7 @@ public class Cookie {
      * @return the cookie name.
      */
     public String getName() {
-        return null;
+        return name;
     }
 
     /**
@@ -121,7 +134,7 @@ public class Cookie {
      * @return the cookie value.
      */
     public String getValue() {
-        return null;
+        return value;
     }
 
     /**
@@ -130,7 +143,7 @@ public class Cookie {
      * @return the cookie version.
      */
     public int getVersion() {
-        return -1;
+        return version;
     }
 
     /**
@@ -139,7 +152,7 @@ public class Cookie {
      * @return the cookie domain.
      */
     public String getDomain() {
-        return null;
+        return domain;
     }
 
     /**
@@ -148,40 +161,6 @@ public class Cookie {
      * @return the cookie path.
      */
     public String getPath() {
-        return null;
-    }
-
-    /**
-     * Convert the cookie to a string suitable for use as the value of the
-     * corresponding HTTP header.
-     *
-     * @return a stringified cookie.
-     */
-    @Override
-    public String toString() {
-        return null;
-    }
-
-    /**
-     * Generate a hash code by hashing all of the cookies properties.
-     *
-     * @return the cookie hash code.
-     */
-    @Override
-    public int hashCode() {
-        return -1;
-    }
-
-    /**
-     * Compare for equality.
-     *
-     * @param obj the object to compare to.
-     * @return {@code true}, if the object is a {@code Cookie} with the same
-     *         value for all properties, {@code false} otherwise.
-     */
-    @SuppressWarnings({"StringEquality", "RedundantIfStatement"})
-    @Override
-    public boolean equals(final Object obj) {
-        return true;
+        return path;
     }
 }

--- a/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/Cookie.java
+++ b/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/Cookie.java
@@ -125,7 +125,7 @@ public class Cookie {
      * @return the cookie name.
      */
     public String getName() {
-        return name;
+        return null;
     }
 
     /**
@@ -134,7 +134,7 @@ public class Cookie {
      * @return the cookie value.
      */
     public String getValue() {
-        return value;
+        return null;
     }
 
     /**
@@ -143,7 +143,7 @@ public class Cookie {
      * @return the cookie version.
      */
     public int getVersion() {
-        return version;
+        return -1;
     }
 
     /**
@@ -152,7 +152,7 @@ public class Cookie {
      * @return the cookie domain.
      */
     public String getDomain() {
-        return domain;
+        return null;
     }
 
     /**
@@ -161,6 +161,6 @@ public class Cookie {
      * @return the cookie path.
      */
     public String getPath() {
-        return path;
+        return null;
     }
 }

--- a/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/Cookie.java
+++ b/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/Cookie.java
@@ -1,0 +1,187 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package javax.ws.rs.core;
+
+/**
+ * Represents the value of a HTTP cookie, transferred in a request.
+ * RFC 2109 specifies the legal characters for name,
+ * value, path and domain. The default version of 1 corresponds to RFC 2109.
+ *
+ * @author Paul Sandoz
+ * @author Marc Hadley
+ * @see <a href="http://www.ietf.org/rfc/rfc2109.txt">IETF RFC 2109</a>
+ * @since 1.0
+ */
+public class Cookie {
+    /**
+     * Cookies using the default version correspond to RFC 2109.
+     */
+    public static final int DEFAULT_VERSION = 1;
+
+    /**
+     * Create a new instance.
+     *
+     * @param name    the name of the cookie.
+     * @param value   the value of the cookie.
+     * @param path    the URI path for which the cookie is valid.
+     * @param domain  the host domain for which the cookie is valid.
+     * @param version the version of the specification to which the cookie complies.
+     * @throws IllegalArgumentException if name is {@code null}.
+     */
+    public Cookie(final String name, final String value, final String path, final String domain, final int version)
+            throws IllegalArgumentException {
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param name   the name of the cookie.
+     * @param value  the value of the cookie.
+     * @param path   the URI path for which the cookie is valid.
+     * @param domain the host domain for which the cookie is valid.
+     * @throws IllegalArgumentException if name is {@code null}.
+     */
+    public Cookie(final String name, final String value, final String path, final String domain)
+            throws IllegalArgumentException {
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param name  the name of the cookie.
+     * @param value the value of the cookie.
+     * @throws IllegalArgumentException if name is {@code null}.
+     */
+    public Cookie(final String name, final String value)
+            throws IllegalArgumentException {
+    }
+
+    /**
+     * Creates a new instance of {@code Cookie} by parsing the supplied string.
+     *
+     * @param value the cookie string.
+     * @return the newly created {@code Cookie}.
+     * @throws IllegalArgumentException if the supplied string cannot be parsed
+     *                                  or is {@code null}.
+     */
+    public static Cookie valueOf(final String value) {
+        return null;
+    }
+
+    /**
+     * Get the name of the cookie.
+     *
+     * @return the cookie name.
+     */
+    public String getName() {
+        return null;
+    }
+
+    /**
+     * Get the value of the cookie.
+     *
+     * @return the cookie value.
+     */
+    public String getValue() {
+        return null;
+    }
+
+    /**
+     * Get the version of the cookie.
+     *
+     * @return the cookie version.
+     */
+    public int getVersion() {
+        return -1;
+    }
+
+    /**
+     * Get the domain of the cookie.
+     *
+     * @return the cookie domain.
+     */
+    public String getDomain() {
+        return null;
+    }
+
+    /**
+     * Get the path of the cookie.
+     *
+     * @return the cookie path.
+     */
+    public String getPath() {
+        return null;
+    }
+
+    /**
+     * Convert the cookie to a string suitable for use as the value of the
+     * corresponding HTTP header.
+     *
+     * @return a stringified cookie.
+     */
+    @Override
+    public String toString() {
+        return null;
+    }
+
+    /**
+     * Generate a hash code by hashing all of the cookies properties.
+     *
+     * @return the cookie hash code.
+     */
+    @Override
+    public int hashCode() {
+        return -1;
+    }
+
+    /**
+     * Compare for equality.
+     *
+     * @param obj the object to compare to.
+     * @return {@code true}, if the object is a {@code Cookie} with the same
+     *         value for all properties, {@code false} otherwise.
+     */
+    @SuppressWarnings({"StringEquality", "RedundantIfStatement"})
+    @Override
+    public boolean equals(final Object obj) {
+        return true;
+    }
+}

--- a/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/NewCookie.java
+++ b/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/NewCookie.java
@@ -1,0 +1,359 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package javax.ws.rs.core;
+
+import java.util.Date;
+
+/**
+ * Used to create a new HTTP cookie, transferred in a response.
+ *
+ * @author Paul Sandoz
+ * @author Marc Hadley
+ * @see <a href="http://www.ietf.org/rfc/rfc2109.txt">IETF RFC 2109</a>
+ * @since 1.0
+ */
+public class NewCookie extends Cookie {
+
+    /**
+     * Specifies that the cookie expires with the current application/browser session.
+     */
+    public static final int DEFAULT_MAX_AGE = -1;
+
+    private final String comment;
+    private final int maxAge;
+    private final Date expiry;
+    private final boolean secure;
+    private final boolean httpOnly;
+
+    /**
+     * Create a new instance.
+     *
+     * @param name  the name of the cookie.
+     * @param value the value of the cookie.
+     * @throws IllegalArgumentException if name is {@code null}.
+     */
+    public NewCookie(String name, String value) {
+        this(name, value, null, null, DEFAULT_VERSION, null, DEFAULT_MAX_AGE, null, false, false);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param name    the name of the cookie.
+     * @param value   the value of the cookie.
+     * @param path    the URI path for which the cookie is valid.
+     * @param domain  the host domain for which the cookie is valid.
+     * @param comment the comment.
+     * @param maxAge  the maximum age of the cookie in seconds.
+     * @param secure  specifies whether the cookie will only be sent over a secure connection.
+     * @throws IllegalArgumentException if name is {@code null}.
+     */
+    public NewCookie(String name,
+                     String value,
+                     String path,
+                     String domain,
+                     String comment,
+                     int maxAge,
+                     boolean secure) {
+        this(name, value, path, domain, DEFAULT_VERSION, comment, maxAge, null, secure, false);                  
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param name     the name of the cookie.
+     * @param value    the value of the cookie.
+     * @param path     the URI path for which the cookie is valid.
+     * @param domain   the host domain for which the cookie is valid.
+     * @param comment  the comment.
+     * @param maxAge   the maximum age of the cookie in seconds.
+     * @param secure   specifies whether the cookie will only be sent over a secure connection.
+     * @param httpOnly if {@code true} make the cookie HTTP only, i.e. only visible as part of an HTTP request.
+     * @throws IllegalArgumentException if name is {@code null}.
+     * @since 2.0
+     */
+    public NewCookie(String name,
+                     String value,
+                     String path,
+                     String domain,
+                     String comment,
+                     int maxAge,
+                     boolean secure,
+                     boolean httpOnly) {
+        this(name, value, path, domain, DEFAULT_VERSION, comment, maxAge, null, secure, httpOnly);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param name    the name of the cookie
+     * @param value   the value of the cookie
+     * @param path    the URI path for which the cookie is valid
+     * @param domain  the host domain for which the cookie is valid
+     * @param version the version of the specification to which the cookie complies
+     * @param comment the comment
+     * @param maxAge  the maximum age of the cookie in seconds
+     * @param secure  specifies whether the cookie will only be sent over a secure connection
+     * @throws IllegalArgumentException if name is {@code null}.
+     */
+    public NewCookie(String name,
+                     String value,
+                     String path,
+                     String domain,
+                     int version,
+                     String comment,
+                     int maxAge,
+                     boolean secure) {
+        this(name, value, path, domain, version, comment, maxAge, null, secure, false);                 
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param name     the name of the cookie
+     * @param value    the value of the cookie
+     * @param path     the URI path for which the cookie is valid
+     * @param domain   the host domain for which the cookie is valid
+     * @param version  the version of the specification to which the cookie complies
+     * @param comment  the comment
+     * @param maxAge   the maximum age of the cookie in seconds
+     * @param expiry   the cookie expiry date.
+     * @param secure   specifies whether the cookie will only be sent over a secure connection
+     * @param httpOnly if {@code true} make the cookie HTTP only, i.e. only visible as part of an HTTP request.
+     * @throws IllegalArgumentException if name is {@code null}.
+     * @since 2.0
+     */
+    public NewCookie(String name,
+                     String value,
+                     String path,
+                     String domain,
+                     int version,
+                     String comment,
+                     int maxAge,
+                     Date expiry,
+                     boolean secure,
+                     boolean httpOnly) {
+            super(name, value, path, domain, version);
+            this.comment = comment;
+            this.maxAge = maxAge;
+            this.expiry = expiry;
+            this.secure = secure;
+            this.httpOnly = httpOnly;
+    }
+
+    /**
+     * Create a new instance copying the information in the supplied cookie.
+     *
+     * @param cookie the cookie to clone.
+     * @throws IllegalArgumentException if cookie is {@code null}.
+     */
+    public NewCookie(Cookie cookie) {
+        this(cookie, null, DEFAULT_MAX_AGE, null, false, false);
+    }
+
+    /**
+     * Create a new instance supplementing the information in the supplied cookie.
+     *
+     * @param cookie  the cookie to clone.
+     * @param comment the comment.
+     * @param maxAge  the maximum age of the cookie in seconds.
+     * @param secure  specifies whether the cookie will only be sent over a secure connection.
+     * @throws IllegalArgumentException if cookie is {@code null}.
+     */
+    public NewCookie(Cookie cookie, String comment, int maxAge, boolean secure) {
+        this(cookie, comment, maxAge, null, secure, false);
+    }
+
+    /**
+     * Create a new instance supplementing the information in the supplied cookie.
+     *
+     * @param cookie   the cookie to clone.
+     * @param comment  the comment.
+     * @param maxAge   the maximum age of the cookie in seconds.
+     * @param expiry   the cookie expiry date.
+     * @param secure   specifies whether the cookie will only be sent over a secure connection.
+     * @param httpOnly if {@code true} make the cookie HTTP only, i.e. only visible as part of an HTTP request.
+     * @throws IllegalArgumentException if cookie is {@code null}.
+     * @since 2.0
+     */
+    public NewCookie(Cookie cookie, String comment, int maxAge, Date expiry, boolean secure, boolean httpOnly) {
+        super(cookie == null ? null : cookie.getName(),
+        cookie == null ? null : cookie.getValue(),
+        cookie == null ? null : cookie.getPath(),
+        cookie == null ? null : cookie.getDomain(),
+        cookie == null ? Cookie.DEFAULT_VERSION : cookie.getVersion());
+        this.comment = comment;
+        this.maxAge = maxAge;
+        this.expiry = expiry;
+        this.secure = secure;
+        this.httpOnly = httpOnly;        
+    }
+
+    /**
+     * Creates a new instance of NewCookie by parsing the supplied string.
+     *
+     * @param value the cookie string.
+     * @return the newly created {@code NewCookie}.
+     * @throws IllegalArgumentException if the supplied string cannot be parsed
+     *                                  or is {@code null}.
+     */
+    public static NewCookie valueOf(String value) {
+        return null;
+    }
+
+    /**
+     * Get the comment associated with the cookie.
+     *
+     * @return the comment or null if none set
+     */
+    public String getComment() {
+        return null;
+    }
+
+    /**
+     * Get the maximum age of the the cookie in seconds. Cookies older than
+     * the maximum age are discarded. A cookie can be unset by sending a new
+     * cookie with maximum age of 0 since it will overwrite any existing cookie
+     * and then be immediately discarded. The default value of {@code -1} indicates
+     * that the cookie will be discarded at the end of the browser/application session.
+     * <p>
+     * Note that it is recommended to use {@code Max-Age} to control cookie
+     * expiration, however some browsers do not understand {@code Max-Age}, in which case
+     * setting {@link #getExpiry()} Expires} parameter may be necessary.
+     * </p>
+     *
+     * @return the maximum age in seconds.
+     * @see #getExpiry()
+     */
+    public int getMaxAge() {
+        return -1;
+    }
+
+    /**
+     * Get the cookie expiry date. Cookies whose expiry date has passed are discarded.
+     * A cookie can be unset by setting a new cookie with an expiry date in the past,
+     * typically the lowest possible date that can be set.
+     * <p>
+     * Note that it is recommended to use {@link #getMaxAge() Max-Age} to control cookie
+     * expiration, however some browsers do not understand {@code Max-Age}, in which case
+     * setting {@code Expires} parameter may be necessary.
+     * </p>
+     *
+     * @return cookie expiry date or {@code null} if no expiry date was set.
+     * @see #getMaxAge()
+     * @since 2.0
+     */
+    public Date getExpiry() {
+        return null;
+    }
+
+    /**
+     * Whether the cookie will only be sent over a secure connection. Defaults
+     * to {@code false}.
+     *
+     * @return {@code true} if the cookie will only be sent over a secure connection,
+     *         {@code false} otherwise.
+     */
+    public boolean isSecure() {
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if this cookie contains the {@code HttpOnly} attribute.
+     * This means that the cookie should not be accessible to scripting engines,
+     * like javascript.
+     *
+     * @return {@code true} if this cookie should be considered http only, {@code false}
+     *         otherwise.
+     * @since 2.0
+     */
+    public boolean isHttpOnly() {
+        return false;
+    }
+
+    /**
+     * Obtain a new instance of a {@link Cookie} with the same name, value, path,
+     * domain and version as this {@code NewCookie}. This method can be used to
+     * obtain an object that can be compared for equality with another {@code Cookie};
+     * since a {@code Cookie} will never compare equal to a {@code NewCookie}.
+     *
+     * @return a {@link Cookie}
+     */
+    public Cookie toCookie() {
+        return null;
+    }
+
+    /**
+     * Convert the cookie to a string suitable for use as the value of the
+     * corresponding HTTP header.
+     *
+     * @return a stringified cookie.
+     */
+    @Override
+    public String toString() {
+        return null;
+    }
+
+    /**
+     * Generate a hash code by hashing all of the properties.
+     *
+     * @return the hash code.
+     */
+    @Override
+    public int hashCode() {
+        return -1;
+    }
+
+    /**
+     * Compare for equality. Use {@link #toCookie()} to compare a
+     * {@code NewCookie} to a {@code Cookie} considering only the common
+     * properties.
+     *
+     * @param obj the object to compare to
+     * @return true if the object is a {@code NewCookie} with the same value for
+     *         all properties, false otherwise.
+     */
+    @SuppressWarnings({"StringEquality", "RedundantIfStatement"})
+    @Override
+    public boolean equals(Object obj) {
+        return true;
+    }
+}

--- a/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/NewCookie.java
+++ b/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/NewCookie.java
@@ -320,4 +320,15 @@ public class NewCookie extends Cookie {
     public Cookie toCookie() {
         return null;
     }
+
+    /**
+     * Convert the cookie to a string suitable for use as the value of the
+     * corresponding HTTP header.
+     *
+     * @return a stringified cookie.
+     */
+    @Override
+    public String toString() {
+        return null;
+    }    
 }

--- a/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/NewCookie.java
+++ b/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/NewCookie.java
@@ -320,40 +320,4 @@ public class NewCookie extends Cookie {
     public Cookie toCookie() {
         return null;
     }
-
-    /**
-     * Convert the cookie to a string suitable for use as the value of the
-     * corresponding HTTP header.
-     *
-     * @return a stringified cookie.
-     */
-    @Override
-    public String toString() {
-        return null;
-    }
-
-    /**
-     * Generate a hash code by hashing all of the properties.
-     *
-     * @return the hash code.
-     */
-    @Override
-    public int hashCode() {
-        return -1;
-    }
-
-    /**
-     * Compare for equality. Use {@link #toCookie()} to compare a
-     * {@code NewCookie} to a {@code Cookie} considering only the common
-     * properties.
-     *
-     * @param obj the object to compare to
-     * @return true if the object is a {@code NewCookie} with the same value for
-     *         all properties, false otherwise.
-     */
-    @SuppressWarnings({"StringEquality", "RedundantIfStatement"})
-    @Override
-    public boolean equals(Object obj) {
-        return true;
-    }
 }

--- a/java/ql/test/stubs/servlet-api-2.4/javax/servlet/http/Cookie.java
+++ b/java/ql/test/stubs/servlet-api-2.4/javax/servlet/http/Cookie.java
@@ -24,95 +24,51 @@
 package javax.servlet.http;
 
 public class Cookie implements Cloneable {
-    private String name; // NAME= ... "$Name" style is reserved
-    private String value; // value of NAME
-    private String comment; // ;Comment=VALUE ... describes cookie's use
-    private String domain; // ;Domain=VALUE ... domain that sees cookie
-    private int maxAge = -1; // ;Max-Age=VALUE ... cookies auto-expire
-    private String path; // ;Path=VALUE ... URLs that see the cookie
-    private boolean secure; // ;Secure ... e.g. use SSL
-    private int version = 0; // ;Version=1 ... means RFC 2109++ style
-    private boolean isHttpOnly = false;
 
     public Cookie(String name, String value) {
-        this.name = name;
-        this.value = value;
     }
     public void setComment(String purpose) {
-        comment = purpose;
     }
     public String getComment() {
-        return comment;
+        return null;
     }
     public void setDomain(String pattern) {
-        domain = pattern.toLowerCase(); // IE allegedly needs this
     }
     public String getDomain() {
-        return domain;
+        return null;
     }
     public void setMaxAge(int expiry) {
-        maxAge = expiry;
     }
     public int getMaxAge() {
-        return maxAge;
+        return -1;
     }
     public void setPath(String uri) {
-        path = uri;
     }
     public String getPath() {
-        return path;
+        return null;
     }
     public void setSecure(boolean flag) {
-        secure = flag;
     }
     public boolean getSecure() {
-        return secure;
+        return false;
     }
     public String getName() {
-        return name;
+        return null;
     }
     public void setValue(String newValue) {
-        value = newValue;
     }
     public String getValue() {
-        return value;
+        return null;
     }
     public int getVersion() {
-        return version;
+        return -1;
     }
     public void setVersion(int v) {
     }
-
-    /**
-     * Marks or unmarks this Cookie as <i>HttpOnly</i>.
-     *
-     * <p>If <tt>isHttpOnly</tt> is set to <tt>true</tt>, this cookie is
-     * marked as <i>HttpOnly</i>, by adding the <tt>HttpOnly</tt> attribute
-     * to it.
-     *
-     * <p><i>HttpOnly</i> cookies are not supposed to be exposed to
-     * client-side scripting code, and may therefore help mitigate certain
-     * kinds of cross-site scripting attacks.
-     *
-     * @param isHttpOnly true if this cookie is to be marked as
-     * <i>HttpOnly</i>, false otherwise
-     *
-     * @since Servlet 3.0
-     */
     public void setHttpOnly(boolean isHttpOnly) {
-        this.isHttpOnly = isHttpOnly;
     }
- 
-    /**
-     * Checks whether this Cookie has been marked as <i>HttpOnly</i>.
-     *
-     * @return true if this Cookie has been marked as <i>HttpOnly</i>,
-     * false otherwise
-     *
-     * @since Servlet 3.0
-     */
     public boolean isHttpOnly() {
-        return isHttpOnly;
+        return false;
     }
 
     /**

--- a/java/ql/test/stubs/servlet-api-2.4/javax/servlet/http/Cookie.java
+++ b/java/ql/test/stubs/servlet-api-2.4/javax/servlet/http/Cookie.java
@@ -114,4 +114,15 @@ public class Cookie implements Cloneable {
     public boolean isHttpOnly() {
         return isHttpOnly;
     }
+
+    /**
+     * Convert the cookie to a string suitable for use as the value of the
+     * corresponding HTTP header.
+     *
+     * @return a stringified cookie.
+     */
+    @Override
+    public String toString() {
+        return null;
+    }    
 }

--- a/java/ql/test/stubs/servlet-api-2.4/javax/servlet/http/Cookie.java
+++ b/java/ql/test/stubs/servlet-api-2.4/javax/servlet/http/Cookie.java
@@ -32,6 +32,7 @@ public class Cookie implements Cloneable {
     private String path; // ;Path=VALUE ... URLs that see the cookie
     private boolean secure; // ;Secure ... e.g. use SSL
     private int version = 0; // ;Version=1 ... means RFC 2109++ style
+    private boolean isHttpOnly = false;
 
     public Cookie(String name, String value) {
         this.name = name;
@@ -80,5 +81,37 @@ public class Cookie implements Cloneable {
         return version;
     }
     public void setVersion(int v) {
+    }
+
+    /**
+     * Marks or unmarks this Cookie as <i>HttpOnly</i>.
+     *
+     * <p>If <tt>isHttpOnly</tt> is set to <tt>true</tt>, this cookie is
+     * marked as <i>HttpOnly</i>, by adding the <tt>HttpOnly</tt> attribute
+     * to it.
+     *
+     * <p><i>HttpOnly</i> cookies are not supposed to be exposed to
+     * client-side scripting code, and may therefore help mitigate certain
+     * kinds of cross-site scripting attacks.
+     *
+     * @param isHttpOnly true if this cookie is to be marked as
+     * <i>HttpOnly</i>, false otherwise
+     *
+     * @since Servlet 3.0
+     */
+    public void setHttpOnly(boolean isHttpOnly) {
+        this.isHttpOnly = isHttpOnly;
+    }
+ 
+    /**
+     * Checks whether this Cookie has been marked as <i>HttpOnly</i>.
+     *
+     * @return true if this Cookie has been marked as <i>HttpOnly</i>,
+     * false otherwise
+     *
+     * @since Servlet 3.0
+     */
+    public boolean isHttpOnly() {
+        return isHttpOnly;
     }
 }

--- a/java/ql/test/stubs/servlet-api-2.4/javax/servlet/http/HttpServletResponse.java
+++ b/java/ql/test/stubs/servlet-api-2.4/javax/servlet/http/HttpServletResponse.java
@@ -24,6 +24,7 @@
 package javax.servlet.http;
 
 import java.io.IOException;
+import java.util.Collection;
 import javax.servlet.ServletResponse;
 
 public interface HttpServletResponse extends ServletResponse {
@@ -44,6 +45,11 @@ public interface HttpServletResponse extends ServletResponse {
     public void addIntHeader(String name, int value);
     public void setStatus(int sc);
     public void setStatus(int sc, String sm);
+    public int getStatus();
+    public String getHeader(String name);
+    public Collection<String> getHeaders(String name);
+    public Collection<String> getHeaderNames();
+
 
     public static final int SC_CONTINUE = 100;
     public static final int SC_SWITCHING_PROTOCOLS = 101;

--- a/java/ql/test/stubs/springframework-5.2.3/org/springframework/security/web/csrf/CsrfToken.java
+++ b/java/ql/test/stubs/springframework-5.2.3/org/springframework/security/web/csrf/CsrfToken.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.csrf;
+
+import java.io.Serializable;
+
+/**
+ * Provides the information about an expected CSRF token.
+ *
+ * @author Rob Winch
+ * @since 3.2
+ * @see DefaultCsrfToken
+ */
+public interface CsrfToken extends Serializable {
+
+	/**
+	 * Gets the HTTP header that the CSRF is populated on the response and can be placed
+	 * on requests instead of the parameter. Cannot be null.
+	 * @return the HTTP header that the CSRF is populated on the response and can be
+	 * placed on requests instead of the parameter
+	 */
+	String getHeaderName();
+
+	/**
+	 * Gets the HTTP parameter name that should contain the token. Cannot be null.
+	 * @return the HTTP parameter name that should contain the token.
+	 */
+	String getParameterName();
+
+	/**
+	 * Gets the token value. Cannot be null.
+	 * @return the token value
+	 */
+	String getToken();
+
+}


### PR DESCRIPTION
Cross-Site Scripting (XSS) has been a popular attack for many years, which is ranked as one of the OWASP Top 10 Security Vulnerabilities 2020. Cookies holding sensitive information are vulnerable to XSS attacks if they don't have the <code>HttpOnly</code> flag set.

The <code>HttpOnly</code> flag directs compatible browsers to prevent client-side script from accessing cookies. Including the HttpOnly flag in the Set-Cookie HTTP response header for a sensitive cookie helps mitigate the risk associated with XSS where an attacker's script code attempts to read the contents of a cookie and exfiltrate information obtained.

The query detects all the following three scenarios of the Java EE framework:
- <code>HttpOnly</code> not set in <code>javax.servlet.http.Cookie</code>
- <code>HttpOnly</code> not set in <code>javax.ws.rs.core.Cookie</code> or <code>jakarta.ws.rs.core.Cookie</code>
- <code>HttpOnly</code> not directly set in <code>response.addHeader("Set-Cookie", ...)</code> or <code>response.setHeader("Set-Cookie", ...)</code>

Please consider to merge the PR. Thanks.