### PR TITLE
CPP: Add query for CWE-20 Improper Input Validation

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.c
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.c
@@ -1,0 +1,7 @@
+if(len<0) return 1;
+memset(dest, source, len); // GOOD: variable `len` checked before call
+
+...
+
+memset(dest, source, len); // BAD: variable `len` checked after call
+if(len<0) return 1;

--- a/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.qhelp
@@ -1,0 +1,28 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Checking the function argument after calling the function itself. This situation looks suspicious and requires the attention of the developer. It may be necessary to add validation before calling the function</p>
+
+
+</overview>
+<recommendation>
+
+<p>We recommend checking before calling the function.</p>
+
+</recommendation>
+<example>
+<p>The following example demonstrates an erroneous and fixed use of function argument validation.</p>
+<sample src="LateCheckOfFunctionArgument.c" />
+
+</example>
+<references>
+
+<li>
+  CWE Common Weakness Enumeration:
+  <a href="https://cwe.mitre.org/data/definitions/20.html"> CWE-20: Improper Input Validation</a>.
+</li>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
@@ -15,7 +15,7 @@
 import cpp
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 
-/ ** Pridekat allows you to get the number of the argument used for positioning in the buffer by the name of the function. * /
+/** Holds for a function `f` that has an argument at index `apos` used for positioning in a buffer. */
 predicate numberArgument(Function f, int apos) {
   f.hasGlobalOrStdName("write") and apos = 2
   or
@@ -54,7 +54,7 @@ class IfCompareWithZero extends IfStmt {
 
 from FunctionCall fc, IfCompareWithZero ifc, int na
 where
-  numberArgument(fc.getTarget(), na)
+  numberArgument(fc.getTarget(), na) and
   globalValueNumber(fc.getArgument(na)) = globalValueNumber(ifc.noZerroOperand()) and
   dominates(fc, ifc) and
   not exists(IfStmt ifc1 |

--- a/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
@@ -61,4 +61,6 @@ where
     dominates(ifc1, fc) and
     globalValueNumber(fc.getArgument(na)) = globalValueNumber(ifc1.getCondition().getAChild*())
   )
-select fc, "The value of argument '$@' appears to be checked after the call, rather than before it.", fc.getArgument(na), fc.getArgument(na).toString()
+select fc,
+  "The value of argument '$@' appears to be checked after the call, rather than before it.",
+  fc.getArgument(na), fc.getArgument(na).toString()

--- a/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
@@ -1,0 +1,66 @@
+/**
+ * @name Late Check Of Function Argument
+ * @description --Checking the function argument after calling the function itself.
+ *              --This situation looks suspicious and requires the attention of the developer.
+ *              --It may be necessary to add validation before calling the function.
+ * @kind problem
+ * @id cpp/late-check-of-function-argument
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ *       security
+ *       external/cwe/cwe-20
+ */
+
+import cpp
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
+
+predicate numberArgument(Function f, int size) {
+  f.hasGlobalOrStdName("write") and size = 2
+  or
+  f.hasGlobalOrStdName("read") and size = 2
+  or
+  f.hasGlobalOrStdName("lseek") and size = 1
+  or
+  f.hasGlobalOrStdName("memmove") and size = 2
+  or
+  f.hasGlobalOrStdName("memset") and size = 2
+  or
+  f.hasGlobalOrStdName("memcpy") and size = 2
+  or
+  f.hasGlobalOrStdName("memcmp") and size = 2
+  or
+  f.hasGlobalOrStdName("strncat") and size = 2
+  or
+  f.hasGlobalOrStdName("strncpy") and size = 2
+  or
+  f.hasGlobalOrStdName("strncmp") and size = 2
+  or
+  f.hasGlobalOrStdName("snprintf") and size = 1
+  or
+  f.hasGlobalOrStdName("strndup") and size = 2
+  or
+  f.hasGlobalOrStdName("read") and size = 2
+}
+
+class IfCompareWithZero extends IfStmt {
+  IfCompareWithZero() { this.getCondition().(RelationalOperation).getAChild().getValue() = "0" }
+
+  Expr noZerroOperand() {
+    if this.getCondition().(RelationalOperation).getGreaterOperand().getValue() = "0"
+    then result = this.getCondition().(RelationalOperation).getLesserOperand()
+    else result = this.getCondition().(RelationalOperation).getGreaterOperand()
+  }
+}
+
+from FunctionCall fc, IfCompareWithZero ifc, int na
+where
+  numberArgument(fc.getTarget(), na) and
+  na >= 0 and
+  globalValueNumber(fc.getArgument(na)) = globalValueNumber(ifc.noZerroOperand()) and
+  dominates(fc, ifc) and
+  not exists(IfStmt ifc1 |
+    dominates(ifc1, fc) and
+    globalValueNumber(fc.getArgument(na)) = globalValueNumber(ifc1.getCondition().getAChild*())
+  )
+select fc, "Argument '$@' will be checked later.", fc.getArgument(na), fc.getArgument(na).toString()

--- a/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
@@ -15,32 +15,31 @@
 import cpp
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 
-predicate numberArgument(Function f, int size) {
-  f.hasGlobalOrStdName("write") and size = 2
+/ ** Pridekat allows you to get the number of the argument used for positioning in the buffer by the name of the function. * /
+predicate numberArgument(Function f, int apos) {
+  f.hasGlobalOrStdName("write") and apos = 2
   or
-  f.hasGlobalOrStdName("read") and size = 2
+  f.hasGlobalOrStdName("read") and apos = 2
   or
-  f.hasGlobalOrStdName("lseek") and size = 1
+  f.hasGlobalOrStdName("lseek") and apos = 1
   or
-  f.hasGlobalOrStdName("memmove") and size = 2
+  f.hasGlobalOrStdName("memmove") and apos = 2
   or
-  f.hasGlobalOrStdName("memset") and size = 2
+  f.hasGlobalOrStdName("memset") and apos = 2
   or
-  f.hasGlobalOrStdName("memcpy") and size = 2
+  f.hasGlobalOrStdName("memcpy") and apos = 2
   or
-  f.hasGlobalOrStdName("memcmp") and size = 2
+  f.hasGlobalOrStdName("memcmp") and apos = 2
   or
-  f.hasGlobalOrStdName("strncat") and size = 2
+  f.hasGlobalOrStdName("strncat") and apos = 2
   or
-  f.hasGlobalOrStdName("strncpy") and size = 2
+  f.hasGlobalOrStdName("strncpy") and apos = 2
   or
-  f.hasGlobalOrStdName("strncmp") and size = 2
+  f.hasGlobalOrStdName("strncmp") and apos = 2
   or
-  f.hasGlobalOrStdName("snprintf") and size = 1
+  f.hasGlobalOrStdName("snprintf") and apos = 1
   or
-  f.hasGlobalOrStdName("strndup") and size = 2
-  or
-  f.hasGlobalOrStdName("read") and size = 2
+  f.hasGlobalOrStdName("strndup") and apos = 2
 }
 
 class IfCompareWithZero extends IfStmt {
@@ -55,12 +54,11 @@ class IfCompareWithZero extends IfStmt {
 
 from FunctionCall fc, IfCompareWithZero ifc, int na
 where
-  numberArgument(fc.getTarget(), na) and
-  na >= 0 and
+  numberArgument(fc.getTarget(), na)
   globalValueNumber(fc.getArgument(na)) = globalValueNumber(ifc.noZerroOperand()) and
   dominates(fc, ifc) and
   not exists(IfStmt ifc1 |
     dominates(ifc1, fc) and
     globalValueNumber(fc.getArgument(na)) = globalValueNumber(ifc1.getCondition().getAChild*())
   )
-select fc, "Argument '$@' will be checked later.", fc.getArgument(na), fc.getArgument(na).toString()
+select fc, "The value of argument '$@' appears to be checked after the call, rather than before it.", fc.getArgument(na), fc.getArgument(na).toString()

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-020/semmle/tests/LateCheckOfFunctionArgument.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-020/semmle/tests/LateCheckOfFunctionArgument.expected
@@ -1,0 +1,1 @@
+| test.c:6:3:6:8 | call to memset | Argument '$@' will be checked later. | test.c:6:17:6:20 | len1 | len1 |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-020/semmle/tests/LateCheckOfFunctionArgument.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-020/semmle/tests/LateCheckOfFunctionArgument.expected
@@ -1,1 +1,1 @@
-| test.c:6:3:6:8 | call to memset | Argument '$@' will be checked later. | test.c:6:17:6:20 | len1 | len1 |
+| test.c:6:3:6:8 | call to memset | The value of argument '$@' appears to be checked after the call, rather than before it. | test.c:6:17:6:20 | len1 | len1 |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-020/semmle/tests/LateCheckOfFunctionArgument.qlref
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-020/semmle/tests/LateCheckOfFunctionArgument.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-020/semmle/tests/test.c
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-020/semmle/tests/test.c
@@ -1,0 +1,8 @@
+void workFunction_0(char *s) {
+  int len = 5, len1;
+  char buf[80], buf1[8];
+  if(len<0) return;
+  memset(buf,0,len); //GOOD
+  memset(buf1,0,len1); //BAD
+  if(len1<0) return;
+}


### PR DESCRIPTION
Good day.
This error is pretty simple. Checking the value of the buffer length occurs after calling the function to work with it.
The error is quite common in projects and requires the attention of the developer.
It should be noted that most often an error occurs as a result of code refactoring.

Information about the found and accepted fix in the project: https://github.com/irssi/irssi/pull/1270
