### PR TITLE
C++: Remove more field-to-object flow

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -694,9 +694,9 @@ private predicate simpleInstructionLocalFlowStep(Operand opFrom, Instruction iTo
     opFrom.getAnyDef() instanceof WriteSideEffectInstruction and
     chi.getPartialOperand() = opFrom and
     not chi.isResultConflated() and
-    // In a call such as `set_value(&x->val);`
-    // we don't want the memory that of `x` to receive dataflow. This is handled by field flow. If we
-    // add dataflow here we get field to object flow.
+    // In a call such as `set_value(&x->val);` we don't want the memory representing `x` to receive
+    // dataflow by a simple step. Instead, this is handled by field flow. If we add a simple step here
+    // we can get field-to-object flow.
     not chi.isPartialUpdate()
   )
   or

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -693,7 +693,11 @@ private predicate simpleInstructionLocalFlowStep(Operand opFrom, Instruction iTo
   exists(ChiInstruction chi | chi = iTo |
     opFrom.getAnyDef() instanceof WriteSideEffectInstruction and
     chi.getPartialOperand() = opFrom and
-    not chi.isResultConflated()
+    not chi.isResultConflated() and
+    // In a call such as `set_value(&x->val);`
+    // we don't want the memory that of `x` to receive dataflow. This is handled by field flow. If we
+    // add dataflow here we get field to object flow.
+    not chi.isPartialUpdate()
   )
   or
   // Flow through modeled functions

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -2055,6 +2055,13 @@ class ChiInstruction extends Instruction {
   final predicate getUpdatedInterval(int startBit, int endBit) {
     Construction::getIntervalUpdatedByChi(this, startBit, endBit)
   }
+
+  /**
+   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
+   * `ChiTotalOperand`.
+   */
+  final predicate isPartialUpdate() { Construction::chiOnlyPartiallyUpdatesLocation(this) }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -629,7 +629,11 @@ MemoryLocation getOperandMemoryLocation(MemoryOperand operand) {
 }
 
 /** Gets the start bit offset of a `MemoryLocation`, if any. */
-int getStartBitOffset(VariableMemoryLocation location) { result = location.getStartBitOffset() }
+int getStartBitOffset(VariableMemoryLocation location) {
+  result = location.getStartBitOffset() and Ints::hasValue(result)
+}
 
 /** Gets the end bit offset of a `MemoryLocation`, if any. */
-int getEndBitOffset(VariableMemoryLocation location) { result = location.getEndBitOffset() }
+int getEndBitOffset(VariableMemoryLocation location) {
+  result = location.getEndBitOffset() and Ints::hasValue(result)
+}

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -179,6 +179,22 @@ private module Cached {
   }
 
   /**
+   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
+   * `ChiTotalOperand`.
+   */
+  cached
+  predicate chiOnlyPartiallyUpdatesLocation(ChiInstruction chi) {
+    exists(Alias::MemoryLocation location, OldInstruction oldInstruction |
+      oldInstruction = getOldInstruction(chi.getPartial()) and
+      location = Alias::getResultMemoryLocation(oldInstruction)
+    |
+      Alias::getStartBitOffset(location) != 0 or
+      Alias::getEndBitOffset(location) != 8 * location.getType().getByteSize()
+    )
+  }
+
+  /**
    * Holds if `instr` is part of a cycle in the operand graph that doesn't go
    * through a phi instruction and therefore should be impossible.
    *

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -179,9 +179,9 @@ private module Cached {
   }
 
   /**
-   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
-   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
-   * `ChiTotalOperand`.
+   * Holds if the `ChiPartialOperand` only partially overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated
+   * with the `ChiTotalOperand`.
    */
   cached
   predicate chiOnlyPartiallyUpdatesLocation(ChiInstruction chi) {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -2055,6 +2055,13 @@ class ChiInstruction extends Instruction {
   final predicate getUpdatedInterval(int startBit, int endBit) {
     Construction::getIntervalUpdatedByChi(this, startBit, endBit)
   }
+
+  /**
+   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
+   * `ChiTotalOperand`.
+   */
+  final predicate isPartialUpdate() { Construction::chiOnlyPartiallyUpdatesLocation(this) }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -194,6 +194,8 @@ predicate getIntervalUpdatedByChi(ChiInstruction chi, int startBit, int endBit) 
  */
 predicate getUsedInterval(Operand operand, int startBit, int endBit) { none() }
 
+predicate chiOnlyPartiallyUpdatesLocation(ChiInstruction chi) { none() }
+
 /** Gets a non-phi instruction that defines an operand of `instr`. */
 private Instruction getNonPhiOperandDef(Instruction instr) {
   result = getRegisterOperandDefinition(instr, _)

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -2055,6 +2055,13 @@ class ChiInstruction extends Instruction {
   final predicate getUpdatedInterval(int startBit, int endBit) {
     Construction::getIntervalUpdatedByChi(this, startBit, endBit)
   }
+
+  /**
+   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
+   * `ChiTotalOperand`.
+   */
+  final predicate isPartialUpdate() { Construction::chiOnlyPartiallyUpdatesLocation(this) }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -178,6 +178,17 @@ private module Cached {
     )
   }
 
+  cached
+  predicate chiOnlyPartiallyUpdatesLocation(ChiInstruction chi) {
+    exists(Alias::MemoryLocation location, OldInstruction oldInstruction |
+      oldInstruction = getOldInstruction(chi.getPartial()) and
+      location = Alias::getResultMemoryLocation(oldInstruction)
+    |
+      Alias::getStartBitOffset(location) != 0 or
+      Alias::getEndBitOffset(location) != 8 * location.getType().getByteSize()
+    )
+  }
+
   /**
    * Holds if `instr` is part of a cycle in the operand graph that doesn't go
    * through a phi instruction and therefore should be impossible.

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -178,6 +178,11 @@ private module Cached {
     )
   }
 
+  /**
+   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
+   * `ChiTotalOperand`.
+   */
   cached
   predicate chiOnlyPartiallyUpdatesLocation(ChiInstruction chi) {
     exists(Alias::MemoryLocation location, OldInstruction oldInstruction |

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -179,9 +179,9 @@ private module Cached {
   }
 
   /**
-   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
-   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
-   * `ChiTotalOperand`.
+   * Holds if the `ChiPartialOperand` only partially overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated
+   * with the `ChiTotalOperand`.
    */
   cached
   predicate chiOnlyPartiallyUpdatesLocation(ChiInstruction chi) {

--- a/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
@@ -124,7 +124,7 @@ void pointer_deref(int* xs) {
 
 void pointer_deref_sub(int* xs) {
   taint_a_ptr(xs - 2);
-  sink(*(xs - 2)); // $ ir MISSING: ast
+  sink(*(xs - 2)); // $ MISSING: ast,ir
 }
 
 void pointer_many_addrof_and_deref(int* xs) {
@@ -156,13 +156,13 @@ struct S_with_array {
 void pointer_member_deref() {
   S_with_array s;
   taint_a_ptr(s.data);
-  sink(*s.data); // $ ir,ast
+  sink(*s.data); // $ ast MISSING: ir
 }
 
 void array_member_deref() {
   S_with_array s;
   taint_a_ptr(s.data);
-  sink(s.data[0]); // $ ir,ast
+  sink(s.data[0]); // $ ast MISSING: ir
 }
 
 struct S2 {

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -50,27 +50,18 @@ edges
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:98:3:98:21 | Chi [m1] |
 | aliasing.cpp:100:14:100:14 | Store [m1] | aliasing.cpp:102:8:102:10 | * ... |
 | aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument [array content] |
-| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:126:15:126:20 | taint_a_ptr output argument [array content] |
 | aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:131:15:131:16 | taint_a_ptr output argument [array content] |
 | aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:136:15:136:17 | taint_a_ptr output argument [array content] |
-| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:158:15:158:20 | taint_a_ptr output argument [array content] |
-| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:164:15:164:20 | taint_a_ptr output argument [array content] |
 | aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:175:15:175:22 | taint_a_ptr output argument [array content] |
 | aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:187:15:187:22 | taint_a_ptr output argument [array content] |
 | aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:200:15:200:24 | taint_a_ptr output argument [array content] |
 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:106:3:106:20 | Chi [array content] |
 | aliasing.cpp:121:15:121:16 | Chi [array content] | aliasing.cpp:122:8:122:12 | access to array |
 | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument [array content] | aliasing.cpp:121:15:121:16 | Chi [array content] |
-| aliasing.cpp:126:15:126:20 | Chi [array content] | aliasing.cpp:127:8:127:16 | * ... |
-| aliasing.cpp:126:15:126:20 | taint_a_ptr output argument [array content] | aliasing.cpp:126:15:126:20 | Chi [array content] |
 | aliasing.cpp:131:15:131:16 | Chi [array content] | aliasing.cpp:132:8:132:14 | * ... |
 | aliasing.cpp:131:15:131:16 | taint_a_ptr output argument [array content] | aliasing.cpp:131:15:131:16 | Chi [array content] |
 | aliasing.cpp:136:15:136:17 | Chi [array content] | aliasing.cpp:137:8:137:11 | * ... |
 | aliasing.cpp:136:15:136:17 | taint_a_ptr output argument [array content] | aliasing.cpp:136:15:136:17 | Chi [array content] |
-| aliasing.cpp:158:15:158:20 | Chi [array content] | aliasing.cpp:159:8:159:14 | * ... |
-| aliasing.cpp:158:15:158:20 | taint_a_ptr output argument [array content] | aliasing.cpp:158:15:158:20 | Chi [array content] |
-| aliasing.cpp:164:15:164:20 | Chi [array content] | aliasing.cpp:165:8:165:16 | access to array |
-| aliasing.cpp:164:15:164:20 | taint_a_ptr output argument [array content] | aliasing.cpp:164:15:164:20 | Chi [array content] |
 | aliasing.cpp:175:15:175:22 | Chi | aliasing.cpp:175:15:175:22 | Chi [m1] |
 | aliasing.cpp:175:15:175:22 | Chi [m1] | aliasing.cpp:176:13:176:14 | m1 |
 | aliasing.cpp:175:15:175:22 | taint_a_ptr output argument [array content] | aliasing.cpp:175:15:175:22 | Chi |
@@ -270,21 +261,12 @@ nodes
 | aliasing.cpp:121:15:121:16 | Chi [array content] | semmle.label | Chi [array content] |
 | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
 | aliasing.cpp:122:8:122:12 | access to array | semmle.label | access to array |
-| aliasing.cpp:126:15:126:20 | Chi [array content] | semmle.label | Chi [array content] |
-| aliasing.cpp:126:15:126:20 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
-| aliasing.cpp:127:8:127:16 | * ... | semmle.label | * ... |
 | aliasing.cpp:131:15:131:16 | Chi [array content] | semmle.label | Chi [array content] |
 | aliasing.cpp:131:15:131:16 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
 | aliasing.cpp:132:8:132:14 | * ... | semmle.label | * ... |
 | aliasing.cpp:136:15:136:17 | Chi [array content] | semmle.label | Chi [array content] |
 | aliasing.cpp:136:15:136:17 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
 | aliasing.cpp:137:8:137:11 | * ... | semmle.label | * ... |
-| aliasing.cpp:158:15:158:20 | Chi [array content] | semmle.label | Chi [array content] |
-| aliasing.cpp:158:15:158:20 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
-| aliasing.cpp:159:8:159:14 | * ... | semmle.label | * ... |
-| aliasing.cpp:164:15:164:20 | Chi [array content] | semmle.label | Chi [array content] |
-| aliasing.cpp:164:15:164:20 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
-| aliasing.cpp:165:8:165:16 | access to array | semmle.label | access to array |
 | aliasing.cpp:175:15:175:22 | Chi | semmle.label | Chi |
 | aliasing.cpp:175:15:175:22 | Chi [m1] | semmle.label | Chi [m1] |
 | aliasing.cpp:175:15:175:22 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
@@ -441,11 +423,8 @@ nodes
 | aliasing.cpp:93:12:93:13 | m1 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:93:12:93:13 | m1 | m1 flows from $@ | aliasing.cpp:92:12:92:21 | call to user_input | call to user_input |
 | aliasing.cpp:102:8:102:10 | * ... | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:102:8:102:10 | * ... | * ... flows from $@ | aliasing.cpp:98:10:98:19 | call to user_input | call to user_input |
 | aliasing.cpp:122:8:122:12 | access to array | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:122:8:122:12 | access to array | access to array flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:127:8:127:16 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:127:8:127:16 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | aliasing.cpp:132:8:132:14 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:132:8:132:14 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | aliasing.cpp:137:8:137:11 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:137:8:137:11 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:159:8:159:14 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:159:8:159:14 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:165:8:165:16 | access to array | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:165:8:165:16 | access to array | access to array flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | aliasing.cpp:176:13:176:14 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:176:13:176:14 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | aliasing.cpp:189:15:189:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:189:15:189:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | aliasing.cpp:201:15:201:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:201:15:201:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -6245,6 +6245,14 @@
 | taint.cpp:657:12:657:15 | call to data | taint.cpp:657:3:657:8 | call to memcpy |  |
 | taint.cpp:657:20:657:25 | source | taint.cpp:657:3:657:8 | call to memcpy | TAINT |
 | taint.cpp:657:20:657:25 | source | taint.cpp:657:12:657:15 | ref arg call to data | TAINT |
+| taint.cpp:668:14:668:14 | s | taint.cpp:669:18:669:18 | s |  |
+| taint.cpp:668:14:668:14 | s | taint.cpp:671:7:671:7 | s |  |
+| taint.cpp:668:14:668:14 | s | taint.cpp:672:7:672:7 | s |  |
+| taint.cpp:668:14:668:14 | s | taint.cpp:673:7:673:7 | s |  |
+| taint.cpp:669:18:669:18 | s [post update] | taint.cpp:671:7:671:7 | s |  |
+| taint.cpp:669:18:669:18 | s [post update] | taint.cpp:672:7:672:7 | s |  |
+| taint.cpp:669:18:669:18 | s [post update] | taint.cpp:673:7:673:7 | s |  |
+| taint.cpp:672:7:672:7 | s [post update] | taint.cpp:673:7:673:7 | s |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:17:26:17:32 | source1 |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:31:38:31:44 | source1 |  |
 | vector.cpp:17:21:17:33 | call to vector | vector.cpp:19:14:19:14 | v |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -657,3 +657,18 @@ void test_with_const_member(char* source) {
   memcpy(c.data(), source, 16);
   sink(c.data()); // $ ast MISSING: ir
 }
+
+void argument_source(void*);
+
+struct two_members {
+	char *x, *y;
+};
+
+void test_argument_source_field_to_obj() {
+	two_members s;
+	argument_source(s.x);
+
+	sink(s); // $ SPURIOUS: ast
+	sink(s.x); // $ ast MISSING: ir
+	sink(s.y); // clean
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
@@ -53,6 +53,11 @@ module ASTTest {
       or
       // Track uninitialized variables
       exists(source.asUninitialized())
+      or
+      exists(FunctionCall fc |
+        fc.getAnArgument() = source.asDefiningArgument() and
+        fc.getTarget().hasName("argument_source")
+      )
     }
 
     override predicate isSink(DataFlow::Node sink) {
@@ -80,6 +85,11 @@ module IRTest {
       source.(DataFlow::ExprNode).getConvertedExpr().(FunctionCall).getTarget().getName() = "source"
       or
       source.asParameter().getName().matches("source%")
+      or
+      exists(FunctionCall fc |
+        fc.getAnArgument() = source.asDefiningArgument() and
+        fc.getTarget().hasName("argument_source")
+      )
     }
 
     override predicate isSink(DataFlow::Node sink) {

--- a/csharp/ql/src/experimental/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/Instruction.qll
@@ -2055,6 +2055,13 @@ class ChiInstruction extends Instruction {
   final predicate getUpdatedInterval(int startBit, int endBit) {
     Construction::getIntervalUpdatedByChi(this, startBit, endBit)
   }
+
+  /**
+   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
+   * `ChiTotalOperand`.
+   */
+  final predicate isPartialUpdate() { Construction::chiOnlyPartiallyUpdatesLocation(this) }
 }
 
 /**

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/IRConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/IRConstruction.qll
@@ -228,6 +228,9 @@ private module Cached {
   cached
   predicate getUsedInterval(Operand operand, int startBit, int endBit) { none() }
 
+  cached
+  predicate chiOnlyPartiallyUpdatesLocation(ChiInstruction chi) { none() }
+
   /**
    * Holds if `instr` is part of a cycle in the operand graph that doesn't go
    * through a phi instruction and therefore should be impossible.

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/Instruction.qll
@@ -2055,6 +2055,13 @@ class ChiInstruction extends Instruction {
   final predicate getUpdatedInterval(int startBit, int endBit) {
     Construction::getIntervalUpdatedByChi(this, startBit, endBit)
   }
+
+  /**
+   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
+   * `ChiTotalOperand`.
+   */
+  final predicate isPartialUpdate() { Construction::chiOnlyPartiallyUpdatesLocation(this) }
 }
 
 /**

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -178,6 +178,17 @@ private module Cached {
     )
   }
 
+  cached
+  predicate chiOnlyPartiallyUpdatesLocation(ChiInstruction chi) {
+    exists(Alias::MemoryLocation location, OldInstruction oldInstruction |
+      oldInstruction = getOldInstruction(chi.getPartial()) and
+      location = Alias::getResultMemoryLocation(oldInstruction)
+    |
+      Alias::getStartBitOffset(location) != 0 or
+      Alias::getEndBitOffset(location) != 8 * location.getType().getByteSize()
+    )
+  }
+
   /**
    * Holds if `instr` is part of a cycle in the operand graph that doesn't go
    * through a phi instruction and therefore should be impossible.

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -178,6 +178,11 @@ private module Cached {
     )
   }
 
+  /**
+   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
+   * `ChiTotalOperand`.
+   */
   cached
   predicate chiOnlyPartiallyUpdatesLocation(ChiInstruction chi) {
     exists(Alias::MemoryLocation location, OldInstruction oldInstruction |

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -179,9 +179,9 @@ private module Cached {
   }
 
   /**
-   * Holds if the `ChiPartialOperand` totally, but not exactly, overlaps with the `ChiTotalOperand`.
-   * This means that the `ChiPartialOperand` will not override the entire memory associated with the
-   * `ChiTotalOperand`.
+   * Holds if the `ChiPartialOperand` only partially overlaps with the `ChiTotalOperand`.
+   * This means that the `ChiPartialOperand` will not override the entire memory associated
+   * with the `ChiTotalOperand`.
    */
   cached
   predicate chiOnlyPartiallyUpdatesLocation(ChiInstruction chi) {


### PR DESCRIPTION
Copy/paste from my comment [here](https://github.com/github/codeql-c-analysis-team/issues/103):

-----------
While looking through the CPP-differences changes for https://github.com/github/codeql/pull/3364 I found another source of field -> object taint in `simpleInstructionLocalFlowStep` in `DataFlowUtil`:

```codeql
private predicate simpleInstructionLocalFlowStep(Operand opFrom, Instruction iTo) {
  // ...
  exists(ChiInstruction chi | chi = iTo |
      opFrom.getAnyDef() instanceof WriteSideEffectInstruction and
      chi.getPartialOperand() = opFrom and
      not chi.isResultConflated()
    )
  // ..
}
```

This rule ensures that we get flow from the `WriteSideEffect` after calling `set_value` to the argument to `sink` in this example:
```cpp
void set_value(int*);

void test() {
  int n;
  set_value(&n);
  sink(n);
}
```
however, it also transfers flow from the `WriteSideEffect` to the `sink` argument in the following case:
```cpp
void test() {
  struct { int field1, field2; } obj;
  set_value(&obj->field1);
  sink(obj);
}
```
this pattern gave rise to some field conflation on `cpp/uncontrolled-allocation-size` on OpenJDK and on `cpp/unbounded-write` on vim.

The fix is to restrict the rule in `simpleInstructionLocalFlowStep` to only propagate flow from the `WriteSideEffect` to the `Chi` when we know that the `Chi` isn't only a partial update. <s>We should be able to use the `getUpdatedInterval` predicate on the `ChiInstruction` for this.</s>

-----------
I was right about everything except for the very last line. It's not so easy to use `getUpdatedInterval` to detect whether the entire memory location is updated since (AFAIK) it's not possible to get the type of the memory location without digging into SSA. So I added a new predicate on `ChiInstruction` that forwards to a new predicate in `SSAConstruction.qll` which then does the actual work.

Unfortunately, we lose a couple of results in dataflow. This is due to field flow not looking "deep enough" through the destination address on write side effects (i.e., we only look check whether the destination instruction is a `FieldAddress` or not, but we should traverse through the entire chain of instructions like in https://github.com/github/codeql/pull/5127). So `simpleInstructionLocalFlowStep` expects field flow to handle this case, but it currently doesn't.

@dbartol / @rdmarsh2  I'd appreciate your thoughts on the first commit (i.e. 200d94777adc5e3fa024cddd52042772819619cc).

(Part of https://github.com/github/codeql-c-analysis-team/issues/103.)