### PR TITLE
Python: Fix taint-propagation to methods

### DIFF
--- a/python/ql/src/semmle/python/frameworks/Flask.qll
+++ b/python/ql/src/semmle/python/frameworks/Flask.qll
@@ -351,7 +351,8 @@ module Flask {
       exists(string method_name | method_name in ["get_data", "get_json"] |
         // Method access
         nodeFrom = request().getAUse() and
-        nodeTo = request().getMember(method_name).getAnImmediateUse()
+        nodeTo.(DataFlow::AttrRead).getObject() = nodeFrom and
+        nodeTo.(DataFlow::AttrRead).getAttributeName() = method_name
         or
         // Method call
         nodeFrom = request().getMember(method_name).getAUse() and


### PR DESCRIPTION
Before we would add a step from _any_ request instance to _any_ method (CP).