### PR TITLE
Data flow: Performance tweaks

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -447,7 +447,7 @@ private module Cached {
   predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
     or
-    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+    exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCall(n, call))
   }
 
   cached
@@ -592,7 +592,7 @@ class CallContextSomeCall extends CallContextCall, TSomeCall {
   override string toString() { result = "CcSomeCall" }
 
   override predicate relevantFor(DataFlowCallable callable) {
-    exists(ParameterNode p | p.getEnclosingCallable() = callable)
+    exists(ParameterNode p | getNodeEnclosingCallable(p) = callable)
   }
 
   override predicate matchesCall(DataFlowCall call) { any() }
@@ -637,7 +637,7 @@ class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall 
 }
 
 private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-  exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
+  exists(Node n | getNodeEnclosingCallable(n) = callable and isUnreachableInCall(n, call))
 }
 
 /**
@@ -746,9 +746,22 @@ class ReturnPosition extends TReturnPosition0 {
   string toString() { result = "[" + kind + "] " + c }
 }
 
+/**
+ * Gets the enclosing callable of `n`. Unlike `n.getEnclosingCallable()`, this
+ * predicate ensures that joins go from `n` to the result instead of the other
+ * way around.
+ */
+pragma[inline]
+DataFlowCallable getNodeEnclosingCallable(Node n) {
+  exists(Node n0 |
+    pragma[only_bind_into](n0) = n and
+    result = n0.getEnclosingCallable()
+  )
+}
+
 pragma[noinline]
 private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
-  result = ret.getEnclosingCallable()
+  result = getNodeEnclosingCallable(ret)
 }
 
 pragma[noinline]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -447,7 +447,7 @@ private module Cached {
   predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
     or
-    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+    exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCall(n, call))
   }
 
   cached
@@ -592,7 +592,7 @@ class CallContextSomeCall extends CallContextCall, TSomeCall {
   override string toString() { result = "CcSomeCall" }
 
   override predicate relevantFor(DataFlowCallable callable) {
-    exists(ParameterNode p | p.getEnclosingCallable() = callable)
+    exists(ParameterNode p | getNodeEnclosingCallable(p) = callable)
   }
 
   override predicate matchesCall(DataFlowCall call) { any() }
@@ -637,7 +637,7 @@ class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall 
 }
 
 private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-  exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
+  exists(Node n | getNodeEnclosingCallable(n) = callable and isUnreachableInCall(n, call))
 }
 
 /**
@@ -746,9 +746,22 @@ class ReturnPosition extends TReturnPosition0 {
   string toString() { result = "[" + kind + "] " + c }
 }
 
+/**
+ * Gets the enclosing callable of `n`. Unlike `n.getEnclosingCallable()`, this
+ * predicate ensures that joins go from `n` to the result instead of the other
+ * way around.
+ */
+pragma[inline]
+DataFlowCallable getNodeEnclosingCallable(Node n) {
+  exists(Node n0 |
+    pragma[only_bind_into](n0) = n and
+    result = n0.getEnclosingCallable()
+  )
+}
+
 pragma[noinline]
 private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
-  result = ret.getEnclosingCallable()
+  result = getNodeEnclosingCallable(ret)
 }
 
 pragma[noinline]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -765,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -1384,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -2077,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -447,7 +447,7 @@ private module Cached {
   predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
     or
-    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+    exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCall(n, call))
   }
 
   cached
@@ -592,7 +592,7 @@ class CallContextSomeCall extends CallContextCall, TSomeCall {
   override string toString() { result = "CcSomeCall" }
 
   override predicate relevantFor(DataFlowCallable callable) {
-    exists(ParameterNode p | p.getEnclosingCallable() = callable)
+    exists(ParameterNode p | getNodeEnclosingCallable(p) = callable)
   }
 
   override predicate matchesCall(DataFlowCall call) { any() }
@@ -637,7 +637,7 @@ class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall 
 }
 
 private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-  exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
+  exists(Node n | getNodeEnclosingCallable(n) = callable and isUnreachableInCall(n, call))
 }
 
 /**
@@ -746,9 +746,22 @@ class ReturnPosition extends TReturnPosition0 {
   string toString() { result = "[" + kind + "] " + c }
 }
 
+/**
+ * Gets the enclosing callable of `n`. Unlike `n.getEnclosingCallable()`, this
+ * predicate ensures that joins go from `n` to the result instead of the other
+ * way around.
+ */
+pragma[inline]
+DataFlowCallable getNodeEnclosingCallable(Node n) {
+  exists(Node n0 |
+    pragma[only_bind_into](n0) = n and
+    result = n0.getEnclosingCallable()
+  )
+}
+
 pragma[noinline]
 private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
-  result = ret.getEnclosingCallable()
+  result = getNodeEnclosingCallable(ret)
 }
 
 pragma[noinline]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -447,7 +447,7 @@ private module Cached {
   predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
     or
-    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+    exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCall(n, call))
   }
 
   cached
@@ -592,7 +592,7 @@ class CallContextSomeCall extends CallContextCall, TSomeCall {
   override string toString() { result = "CcSomeCall" }
 
   override predicate relevantFor(DataFlowCallable callable) {
-    exists(ParameterNode p | p.getEnclosingCallable() = callable)
+    exists(ParameterNode p | getNodeEnclosingCallable(p) = callable)
   }
 
   override predicate matchesCall(DataFlowCall call) { any() }
@@ -637,7 +637,7 @@ class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall 
 }
 
 private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-  exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
+  exists(Node n | getNodeEnclosingCallable(n) = callable and isUnreachableInCall(n, call))
 }
 
 /**
@@ -746,9 +746,22 @@ class ReturnPosition extends TReturnPosition0 {
   string toString() { result = "[" + kind + "] " + c }
 }
 
+/**
+ * Gets the enclosing callable of `n`. Unlike `n.getEnclosingCallable()`, this
+ * predicate ensures that joins go from `n` to the result instead of the other
+ * way around.
+ */
+pragma[inline]
+DataFlowCallable getNodeEnclosingCallable(Node n) {
+  exists(Node n0 |
+    pragma[only_bind_into](n0) = n and
+    result = n0.getEnclosingCallable()
+  )
+}
+
 pragma[noinline]
 private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
-  result = ret.getEnclosingCallable()
+  result = getNodeEnclosingCallable(ret)
 }
 
 pragma[noinline]

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -207,18 +207,6 @@ private predicate fullBarrier(Node node, Configuration config) {
   )
 }
 
-private class AdditionalFlowStepSource extends Node {
-  AdditionalFlowStepSource() { any(Configuration c).isAdditionalFlowStep(this, _) }
-}
-
-pragma[noinline]
-private predicate isAdditionalFlowStep(
-  AdditionalFlowStepSource node1, Node node2, DataFlowCallable callable1, Configuration config
-) {
-  config.isAdditionalFlowStep(node1, node2) and
-  callable1 = node1.getEnclosingCallable()
-}
-
 /**
  * Holds if data can flow in one local step from `node1` to `node2`.
  */
@@ -237,7 +225,8 @@ private predicate localFlowStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` does not jump between callables.
  */
 private predicate additionalLocalFlowStep(Node node1, Node node2, Configuration config) {
-  isAdditionalFlowStep(node1, node2, node2.getEnclosingCallable(), config) and
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) = getNodeEnclosingCallable(node2) and
   not outBarrier(node1, config) and
   not inBarrier(node2, config) and
   not fullBarrier(node1, config) and
@@ -259,14 +248,12 @@ private predicate jumpStep(Node node1, Node node2, Configuration config) {
  * Holds if the additional step from `node1` to `node2` jumps between callables.
  */
 private predicate additionalJumpStep(Node node1, Node node2, Configuration config) {
-  exists(DataFlowCallable callable1 |
-    isAdditionalFlowStep(node1, node2, callable1, config) and
-    node2.getEnclosingCallable() != callable1 and
-    not outBarrier(node1, config) and
-    not inBarrier(node2, config) and
-    not fullBarrier(node1, config) and
-    not fullBarrier(node2, config)
-  )
+  config.isAdditionalFlowStep(node1, node2) and
+  getNodeEnclosingCallable(node1) != getNodeEnclosingCallable(node2) and
+  not outBarrier(node1, config) and
+  not inBarrier(node2, config) and
+  not fullBarrier(node1, config) and
+  not fullBarrier(node2, config)
 }
 
 /**
@@ -601,7 +588,7 @@ private module Stage1 {
   ) {
     exists(ReturnNodeExt ret |
       throughFlowNodeCand(ret, config) and
-      callable = ret.getEnclosingCallable() and
+      callable = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     )
   }
@@ -614,7 +601,7 @@ private module Stage1 {
     exists(ReturnKindExt kind |
       throughFlowNodeCand(p, config) and
       returnFlowCallableNodeCand(c, kind, config) and
-      p.getEnclosingCallable() = c and
+      getNodeEnclosingCallable(p) = c and
       exists(ap) and
       // we don't expect a parameter to return stored in itself
       not exists(int pos |
@@ -778,7 +765,7 @@ private module Stage2 {
   bindingset[result, ap]
   private ApApprox getApprox(Ap ap) { any() }
 
-  private ApNil getApNil(Node node) { any() }
+  private Ap getApNil(Node node) { PrevStage::revFlow(node, _) and result instanceof ApNil }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
@@ -966,7 +953,7 @@ private module Stage2 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -985,7 +972,7 @@ private module Stage2 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1216,13 +1203,13 @@ private module Stage2 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -1348,7 +1335,7 @@ private module LocalFlowBigStep {
         t = getNodeType(node2)
       ) and
       node1 != node2 and
-      cc.relevantFor(node1.getEnclosingCallable()) and
+      cc.relevantFor(getNodeEnclosingCallable(node1)) and
       not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
       Stage2::revFlow(node2, unbind(config))
       or
@@ -1397,7 +1384,9 @@ private module Stage3 {
 
   private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(Node node) { result = TFrontNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TFrontNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
@@ -1594,7 +1583,7 @@ private module Stage3 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1613,7 +1602,7 @@ private module Stage3 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -1844,13 +1833,13 @@ private module Stage3 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2090,7 +2079,9 @@ private module Stage4 {
 
   private ApApprox getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(Node node) { result = TNil(getNodeType(node)) }
+  private ApNil getApNil(Node node) {
+    PrevStage::revFlow(node, _) and result = TNil(getNodeType(node))
+  }
 
   bindingset[tc, tail]
   private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
@@ -2135,7 +2126,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(cc, node.getEnclosingCallable())
+    result = getLocalCallContext(cc, getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -2300,7 +2291,7 @@ private module Stage4 {
     exists(ArgumentNode arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
+      innercc = getCallContextCall(call, getNodeEnclosingCallable(p), outercc)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2319,7 +2310,7 @@ private module Stage4 {
     exists(ReturnNodeExt ret, boolean allowsFieldFlow, DataFlowCallable inner |
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
+      inner = getNodeEnclosingCallable(ret) and
       checkCallContextReturn(innercc, inner, call) and
       ccOut = getCallContextReturn(inner, call)
     |
@@ -2550,13 +2541,13 @@ private module Stage4 {
     ParameterNode p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
   ) {
     revFlow(p, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
+    c = getNodeEnclosingCallable(p)
   }
 
   predicate parameterMayFlowThrough(ParameterNode p, DataFlowCallable c, Ap ap, Configuration config) {
     exists(ReturnNodeExt ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
+      c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
       fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
@@ -2590,7 +2581,7 @@ private predicate nodeMayUseSummary(Node n, AccessPathApprox apa, Configuration 
     Stage4::parameterMayFlowThrough(_, c, apa, _) and
     Stage4::revFlow(n, true, _, apa0, config) and
     Stage4::fwdFlow(n, any(CallContextCall ccc), TAccessPathApproxSome(apa), apa0, config) and
-    n.getEnclosingCallable() = c
+    getNodeEnclosingCallable(n) = c
   )
 }
 
@@ -3119,7 +3110,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = getLocalCallContext(cc, getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
@@ -3405,14 +3396,14 @@ private module FlowExploration {
       // flow out of a callable
       viableReturnPosOut(_, getReturnPosition(node1), node2)
     |
-      c1 = node1.getEnclosingCallable() and
-      c2 = node2.getEnclosingCallable() and
+      c1 = getNodeEnclosingCallable(node1) and
+      c2 = getNodeEnclosingCallable(node2) and
       c1 != c2
     )
   }
 
   private predicate interestingCallableSrc(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSource(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSource(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSrc(mid, config) and callableStep(mid, c, config)
@@ -3420,7 +3411,7 @@ private module FlowExploration {
   }
 
   private predicate interestingCallableSink(DataFlowCallable c, Configuration config) {
-    exists(Node n | config.isSink(n) and c = n.getEnclosingCallable())
+    exists(Node n | config.isSink(n) and c = getNodeEnclosingCallable(n))
     or
     exists(DataFlowCallable mid |
       interestingCallableSink(mid, config) and callableStep(c, mid, config)
@@ -3449,13 +3440,13 @@ private module FlowExploration {
     exists(Node n, Configuration config |
       ce1 = TCallableSrc() and
       config.isSource(n) and
-      ce2 = TCallable(n.getEnclosingCallable(), config)
+      ce2 = TCallable(getNodeEnclosingCallable(n), config)
     )
     or
     exists(Node n, Configuration config |
       ce2 = TCallableSink() and
       config.isSink(n) and
-      ce1 = TCallable(n.getEnclosingCallable(), config)
+      ce1 = TCallable(getNodeEnclosingCallable(n), config)
     )
   }
 
@@ -3586,7 +3577,7 @@ private module FlowExploration {
       exists(config.explorationLimit())
       or
       partialPathNodeMk0(node, cc, sc1, sc2, ap, config) and
-      distSrc(node.getEnclosingCallable(), config) <= config.explorationLimit()
+      distSrc(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
     } or
     TPartialPathNodeRev(
       Node node, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2, RevPartialAccessPath ap,
@@ -3603,7 +3594,7 @@ private module FlowExploration {
         revPartialPathStep(mid, node, sc1, sc2, ap, config) and
         not clearsContent(node, ap.getHead()) and
         not fullBarrier(node, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
+        distSink(getNodeEnclosingCallable(node), config) <= config.explorationLimit()
       )
     }
 
@@ -3662,7 +3653,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSourceDistance() {
-      result = distSrc(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSrc(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     /**
@@ -3670,7 +3661,7 @@ private module FlowExploration {
      * of interprocedural steps.
      */
     int getSinkDistance() {
-      result = distSink(this.getNode().getEnclosingCallable(), this.getConfiguration())
+      result = distSink(getNodeEnclosingCallable(this.getNode()), this.getConfiguration())
     }
 
     private string ppAp() {

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -447,7 +447,7 @@ private module Cached {
   predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
     or
-    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+    exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCall(n, call))
   }
 
   cached
@@ -592,7 +592,7 @@ class CallContextSomeCall extends CallContextCall, TSomeCall {
   override string toString() { result = "CcSomeCall" }
 
   override predicate relevantFor(DataFlowCallable callable) {
-    exists(ParameterNode p | p.getEnclosingCallable() = callable)
+    exists(ParameterNode p | getNodeEnclosingCallable(p) = callable)
   }
 
   override predicate matchesCall(DataFlowCall call) { any() }
@@ -637,7 +637,7 @@ class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall 
 }
 
 private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-  exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
+  exists(Node n | getNodeEnclosingCallable(n) = callable and isUnreachableInCall(n, call))
 }
 
 /**
@@ -746,9 +746,22 @@ class ReturnPosition extends TReturnPosition0 {
   string toString() { result = "[" + kind + "] " + c }
 }
 
+/**
+ * Gets the enclosing callable of `n`. Unlike `n.getEnclosingCallable()`, this
+ * predicate ensures that joins go from `n` to the result instead of the other
+ * way around.
+ */
+pragma[inline]
+DataFlowCallable getNodeEnclosingCallable(Node n) {
+  exists(Node n0 |
+    pragma[only_bind_into](n0) = n and
+    result = n0.getEnclosingCallable()
+  )
+}
+
 pragma[noinline]
 private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
-  result = ret.getEnclosingCallable()
+  result = getNodeEnclosingCallable(ret)
 }
 
 pragma[noinline]


### PR DESCRIPTION
The first commit uses the newly introduced `pragma[only_bind_into]` to enforce the correct join-order for `Node::getEnclosingCallable()`. We have previously attempted to achieve this by using the `unique` aggregate, but that only works if the `unique` predicate is not `cached` (functionality information does not survive across stages), so one would have to compute the aggregate for all queries which is not ideal.

The second commit restricts `getApNil` to relevant nodes. An alternative would be to inline `getApNil`, not sure what is best.