### PR TITLE
Java: Add VarAccess.accessSameVarOfSameOwner

### DIFF
--- a/java/ql/src/Likely Bugs/Likely Typos/SelfAssignment.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/SelfAssignment.ql
@@ -12,38 +12,8 @@
 
 import java
 
-predicate toCompare(VarAccess left, VarAccess right) {
-  exists(AssignExpr assign | assign.getDest() = left and assign.getSource() = right)
-  or
-  exists(VarAccess outerleft, VarAccess outerright |
-    toCompare(outerleft, outerright) and
-    left = outerleft.getQualifier() and
-    right = outerright.getQualifier()
-  )
-}
-
-predicate local(RefType enclosingType, VarAccess v) {
-  enclosingType = v.getQualifier().(ThisAccess).getType()
-  or
-  not exists(v.getQualifier()) and enclosingType = v.getEnclosingCallable().getDeclaringType()
-}
-
-predicate sameVariable(VarAccess left, VarAccess right) {
-  toCompare(left, right) and
-  left.getVariable() = right.getVariable() and
-  (
-    exists(Expr q1, Expr q2 |
-      q1 = left.getQualifier() and
-      sameVariable(q1, q2) and
-      q2 = right.getQualifier()
-    )
-    or
-    exists(RefType enclosingType | local(enclosingType, left) and local(enclosingType, right))
-  )
-}
-
 from AssignExpr assign
-where sameVariable(assign.getDest(), assign.getSource())
+where assign.getDest().(VarAccess).accessSameVarOfSameOwner(assign.getSource())
 select assign,
   "This assigns the variable " + assign.getDest().(VarAccess).getVariable().getName() +
     " to itself and has no effect."

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1526,6 +1526,44 @@ class VarAccess extends Expr, @varaccess {
     getQualifier().(InstanceAccess).isOwnInstanceAccess()
   }
 
+  private predicate accessSameVarOfSameOwner(VarAccess a, VarAccess b) {
+    a.getVariable() = b.getVariable() and
+    (
+      a.getVariable().isStatic()
+      or
+      a.isLocal() and b.isLocal()
+      or
+      exists(RefType enclosing |
+        a.(FieldAccess).isEnclosingFieldAccess(enclosing) and
+        b.(FieldAccess).isEnclosingFieldAccess(enclosing)
+      )
+      or
+      accessSameOwner(a.getQualifier(), b.getQualifier())
+    )
+  }
+
+  private predicate accessSameOwner(Expr qualifierA, Expr qualifierB) {
+    accessSameVarOfSameOwner(qualifierA, qualifierB)
+    or
+    exists(ArrayAccess arrayA, ArrayAccess arrayB | arrayA = qualifierA and arrayB = qualifierB |
+      accessSameOwner(arrayA.getArray(), arrayB.getArray()) and
+      (
+        arrayA.getIndexExpr().(IntegerLiteral).getIntValue() =
+          arrayB.getIndexExpr().(IntegerLiteral).getIntValue()
+        or
+        accessSameVarOfSameOwner(arrayA.getIndexExpr(), arrayB.getIndexExpr())
+      )
+    )
+  }
+
+  /**
+   * Holds if this variable access refers to the same variable as the other access
+   * and the object (if any) whose variable is accessed is the same. The result of
+   * this predicate is only accurate when no assignments occur between this variable
+   * access and the other one.
+   */
+  predicate accessSameVarOfSameOwner(VarAccess other) { accessSameVarOfSameOwner(this, other) }
+
   override string getAPrimaryQlClass() { result = "VarAccess" }
 }
 

--- a/java/ql/test/library-tests/VarAccess/VarAccess.java
+++ b/java/ql/test/library-tests/VarAccess/VarAccess.java
@@ -1,0 +1,85 @@
+class VarAccess {
+    static Nested staticF;
+    Nested f;
+    Nested[] nesteds;
+    static Nested[] staticNesteds;
+
+    class Nested {
+        String fInner;
+        Nested nested;
+
+        void inner(VarAccess other) {
+            // Enclosing field access
+            checkSameVarAccess(nesteds, nesteds); // $sameVarAccess
+            checkSameVarAccess(VarAccess.this.nesteds, nesteds); // $sameVarAccess
+            // Should not match, access of field with other owner
+            checkSameVarAccess(other.nesteds, nesteds);
+            checkSameVarAccess(other.nesteds, VarAccess.this.nesteds);
+
+            checkSameVarAccess(other.nesteds, other.nesteds); // $sameVarAccess
+        }
+    }
+
+    // Inner class extending outer
+    class NestedExtending extends VarAccess {
+        void inner() {
+            checkSameVarAccess(f, f); // $sameVarAccess
+            checkSameVarAccess(this.f, f); // $sameVarAccess
+            checkSameVarAccess(super.f, f); // $sameVarAccess
+            checkSameVarAccess(NestedExtending.this.f, f); // $sameVarAccess
+            checkSameVarAccess(NestedExtending.super.f, f); // $sameVarAccess
+            // Not same; accesses `this.f` and enclosing `f`
+            checkSameVarAccess(NestedExtending.super.f, VarAccess.this.f);
+            checkSameVarAccess(VarAccess.this.f, f);
+        }
+
+        class NestedNested {
+            void inner() {
+                checkSameVarAccess(NestedExtending.super.f, NestedExtending.this.f); // $sameVarAccess
+                checkSameVarAccess(NestedExtending.super.f, NestedExtending.super.f); // $sameVarAccess
+
+                // Not same; access enclosing `VarAccess.f` and `NestedExtending.f`
+                checkSameVarAccess(VarAccess.this.f, NestedExtending.this.f);
+                checkSameVarAccess(VarAccess.this.f, NestedExtending.super.f);
+            }
+        }
+    }
+
+    void test(VarAccess other) {
+        checkSameVarAccess(f, f); // $sameVarAccess
+        checkSameVarAccess(f.fInner, f.fInner); // $sameVarAccess
+        checkSameVarAccess(f.fInner, f.nested);
+        checkSameVarAccess(f.fInner, other.f.fInner);
+        checkSameVarAccess(f.nested.nested, f.nested.nested); // $sameVarAccess
+
+        checkSameVarAccess(staticF, staticF); // $sameVarAccess
+
+        // Qualifier should be ignored when accessing static field
+        checkSameVarAccess(this.staticF, other.staticF); // $sameVarAccess
+        checkSameVarAccess(this.staticF.nested, other.staticF.nested); // $sameVarAccess
+        checkSameVarAccess(this.staticNesteds[0].nested, other.staticNesteds[0].nested); // $sameVarAccess
+
+        checkSameVarAccess(other, other); // $sameVarAccess
+        checkSameVarAccess(this.nesteds, other.nesteds);
+        checkSameVarAccess(VarAccess.this.nesteds, nesteds); // $sameVarAccess
+    }
+
+    void testArray(int i) {
+        checkSameVarAccess(nesteds[0].nested, nesteds[0].nested); // $sameVarAccess
+        checkSameVarAccess(this.nesteds[0].nested, nesteds[0].nested); // $sameVarAccess
+        checkSameVarAccess(VarAccess.this.nesteds[0].nested, nesteds[0].nested); // $sameVarAccess
+
+        final int i1 = 0;
+        final int i2 = 0;
+        // No match when same compile time constants are used
+        checkSameVarAccess(nesteds[i1].nested, nesteds[i2].nested);
+        checkSameVarAccess(nesteds[1 + 1].nested, nesteds[2].nested);
+
+        checkSameVarAccess(nesteds[i].nested, nesteds[i].nested); // $sameVarAccess
+        checkSameVarAccess(nesteds[i].nested, nesteds[0].nested);
+        checkSameVarAccess(nesteds[i].nested, nesteds[i + 1].nested);
+    }
+
+    // Used in QL test to check var access
+    static void checkSameVarAccess(Object a, Object b) {}
+}

--- a/java/ql/test/library-tests/VarAccess/VarAccess.ql
+++ b/java/ql/test/library-tests/VarAccess/VarAccess.ql
@@ -1,0 +1,25 @@
+import java
+import TestUtilities.InlineExpectationsTest
+
+class SameVarAccessTest extends InlineExpectationsTest {
+  SameVarAccessTest() { this = "SameVarAccessTest" }
+
+  override string getARelevantTag() { result = "sameVarAccess" }
+
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    tag = "sameVarAccess" and
+    exists(MethodAccess call |
+      call.getMethod().hasStringSignature("checkSameVarAccess(Object, Object)") and
+      (
+        // Verify that predicate is symmetric
+        call.getArgument(0).(VarAccess).accessSameVarOfSameOwner(call.getArgument(1)) and
+        call.getArgument(1).(VarAccess).accessSameVarOfSameOwner(call.getArgument(0))
+      ) and
+      // No value because only have to verify whether arguments are the same (InlineExpectationsTest comment
+      // is present) or not (no comment is present)
+      value = "" and
+      location = call.getLocation() and
+      element = call.toString()
+    )
+  }
+}


### PR DESCRIPTION
Adds the predicate `VarAccess.accessSameVarOfSameOwner`.

There are multiple types of queries where such a predicate is useful, e.g.:
- `equals(Object)` comparing same fields
- Unit test assertion methods comparing same fields
- Simplifiable assignments
- Assignments of variable to itself (query `java/redundant-assignment`)

I have marked this pull request as draft for now because the query test might have to be organized a little bit better, and I am not sure whether it is good style to have a predicate on `VarAccess` check for the subclass `FieldAccess`.