### PR TITLE
Java: Simplify tests using InlineExpectationsTest

### DIFF
--- a/java/ql/test/library-tests/dataflow/fluent-methods/Test.java
+++ b/java/ql/test/library-tests/dataflow/fluent-methods/Test.java
@@ -42,19 +42,19 @@ public class Test {
   public static void test1() {
     Test t = new Test();
     t.fluentNoop().fluentSet(source()).fluentNoop();
-    sink(t.get()); // $hasTaintFlow=y
+    sink(t.get()); // $hasTaintFlow
   }
 
   public static void test2() {
     Test t = new Test();
     Test.identity(t).fluentNoop().fluentSet(source()).fluentNoop();
-    sink(t.get()); // $hasTaintFlow=y
+    sink(t.get()); // $hasTaintFlow
   }
 
   public static void test3() {
     Test t = new Test();
     t.indirectlyFluentNoop().fluentSet(source()).fluentNoop();
-    sink(t.get()); // $hasTaintFlow=y
+    sink(t.get()); // $hasTaintFlow
   }
 
   public static void testModel1() {

--- a/java/ql/test/library-tests/dataflow/fluent-methods/Test.java
+++ b/java/ql/test/library-tests/dataflow/fluent-methods/Test.java
@@ -60,13 +60,13 @@ public class Test {
   public static void testModel1() {
     Test t = new Test();
     t.indirectlyFluentNoop().modelledFluentMethod().fluentSet(source()).fluentNoop();
-    sink(t.get()); // $hasTaintFlow=y
+    sink(t.get()); // $hasTaintFlow
   }
 
   public static void testModel2() {
     Test t = new Test();
     Test.modelledIdentity(t).indirectlyFluentNoop().modelledFluentMethod().fluentSet(source()).fluentNoop();
-    sink(t.get()); // $hasTaintFlow=y
+    sink(t.get()); // $hasTaintFlow
   }
 
 }

--- a/java/ql/test/library-tests/dataflow/fluent-methods/flow.ql
+++ b/java/ql/test/library-tests/dataflow/fluent-methods/flow.ql
@@ -35,7 +35,7 @@ class HasFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node src, DataFlow::Node sink, Conf conf | conf.hasFlow(src, sink) |
       sink.getLocation() = location and
       element = sink.toString() and
-      value = "y"
+      value = ""
     )
   }
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTest.java
@@ -14,120 +14,120 @@ class StrBuilderTest {
 
     void test() throws Exception {
 
-        StrBuilder cons1 = new StrBuilder(taint()); sink(cons1.toString()); // $hasTaintFlow=y
+        StrBuilder cons1 = new StrBuilder(taint()); sink(cons1.toString()); // $hasTaintFlow
 
-        StrBuilder sb1 = new StrBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
-        StrBuilder sb2 = new StrBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
-        StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // $ MISSING: hasTaintFlow=y
-        StrBuilder sb4 = new StrBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // $ MISSING: hasTaintFlow=y
-        StrBuilder sb5 = new StrBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow=y
-        StrBuilder sb6 = new StrBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow=y
-        StrBuilder sb7 = new StrBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow=y
+        StrBuilder sb1 = new StrBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow
+        StrBuilder sb2 = new StrBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow
+        StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // $ MISSING: hasTaintFlow
+        StrBuilder sb4 = new StrBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // $ MISSING: hasTaintFlow
+        StrBuilder sb5 = new StrBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow
+        StrBuilder sb6 = new StrBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow
+        StrBuilder sb7 = new StrBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow
         {
             StrBuilder auxsb = new StrBuilder(); auxsb.append(taint());
-            StrBuilder sb8 = new StrBuilder(); sb8.append(auxsb); sink(sb8.toString()); // $hasTaintFlow=y
+            StrBuilder sb8 = new StrBuilder(); sb8.append(auxsb); sink(sb8.toString()); // $hasTaintFlow
         }
-        StrBuilder sb9 = new StrBuilder(); sb9.append(new StringBuffer(taint())); sink(sb9.toString()); // $hasTaintFlow=y
-        StrBuilder sb10 = new StrBuilder(); sb10.append(new StringBuffer(taint()), 0, 0); sink(sb10.toString()); // $hasTaintFlow=y
-        StrBuilder sb11 = new StrBuilder(); sb11.append(new StringBuilder(taint())); sink(sb11.toString()); // $hasTaintFlow=y
-        StrBuilder sb12 = new StrBuilder(); sb12.append(new StringBuilder(taint()), 0, 0); sink(sb12.toString()); // $hasTaintFlow=y
-        StrBuilder sb13 = new StrBuilder(); sb13.append(taint()); sink(sb13.toString()); // $hasTaintFlow=y
-        StrBuilder sb14 = new StrBuilder(); sb14.append(taint(), 0, 0); sink(sb14.toString()); // $hasTaintFlow=y
-        StrBuilder sb15 = new StrBuilder(); sb15.append(taint(), "format", "args"); sink(sb15.toString()); // $hasTaintFlow=y
-        StrBuilder sb16 = new StrBuilder(); sb16.append("Format string", taint(), "args"); sink(sb16.toString()); // $hasTaintFlow=y
+        StrBuilder sb9 = new StrBuilder(); sb9.append(new StringBuffer(taint())); sink(sb9.toString()); // $hasTaintFlow
+        StrBuilder sb10 = new StrBuilder(); sb10.append(new StringBuffer(taint()), 0, 0); sink(sb10.toString()); // $hasTaintFlow
+        StrBuilder sb11 = new StrBuilder(); sb11.append(new StringBuilder(taint())); sink(sb11.toString()); // $hasTaintFlow
+        StrBuilder sb12 = new StrBuilder(); sb12.append(new StringBuilder(taint()), 0, 0); sink(sb12.toString()); // $hasTaintFlow
+        StrBuilder sb13 = new StrBuilder(); sb13.append(taint()); sink(sb13.toString()); // $hasTaintFlow
+        StrBuilder sb14 = new StrBuilder(); sb14.append(taint(), 0, 0); sink(sb14.toString()); // $hasTaintFlow
+        StrBuilder sb15 = new StrBuilder(); sb15.append(taint(), "format", "args"); sink(sb15.toString()); // $hasTaintFlow
+        StrBuilder sb16 = new StrBuilder(); sb16.append("Format string", taint(), "args"); sink(sb16.toString()); // $hasTaintFlow
         {
             List<String> taintedList = new ArrayList<>();
             taintedList.add(taint());
-            StrBuilder sb17 = new StrBuilder(); sb17.appendAll(taintedList); sink(sb17.toString()); // $hasTaintFlow=y
-            StrBuilder sb18 = new StrBuilder(); sb18.appendAll(taintedList.iterator()); sink(sb18.toString()); // $hasTaintFlow=y
+            StrBuilder sb17 = new StrBuilder(); sb17.appendAll(taintedList); sink(sb17.toString()); // $hasTaintFlow
+            StrBuilder sb18 = new StrBuilder(); sb18.appendAll(taintedList.iterator()); sink(sb18.toString()); // $hasTaintFlow
         }
-        StrBuilder sb19 = new StrBuilder(); sb19.appendAll("clean", taint()); sink(sb19.toString()); // $hasTaintFlow=y
-        StrBuilder sb20 = new StrBuilder(); sb20.appendAll(taint(), "clean"); sink(sb20.toString()); // $hasTaintFlow=y
-        StrBuilder sb21 = new StrBuilder(); sb21.appendFixedWidthPadLeft(taint(), 0, ' '); sink(sb21.toString()); // $hasTaintFlow=y
-        StrBuilder sb22 = new StrBuilder(); sb22.appendFixedWidthPadRight(taint(), 0, ' '); sink(sb22.toString()); // $hasTaintFlow=y
-        StrBuilder sb23 = new StrBuilder(); sb23.appendln(taint().toCharArray()); sink(sb23.toString()); // $hasTaintFlow=y
-        StrBuilder sb24 = new StrBuilder(); sb24.appendln(taint().toCharArray(), 0, 0); sink(sb24.toString()); // $hasTaintFlow=y
-        StrBuilder sb25 = new StrBuilder(); sb25.appendln((Object)taint()); sink(sb25.toString()); // $hasTaintFlow=y
+        StrBuilder sb19 = new StrBuilder(); sb19.appendAll("clean", taint()); sink(sb19.toString()); // $hasTaintFlow
+        StrBuilder sb20 = new StrBuilder(); sb20.appendAll(taint(), "clean"); sink(sb20.toString()); // $hasTaintFlow
+        StrBuilder sb21 = new StrBuilder(); sb21.appendFixedWidthPadLeft(taint(), 0, ' '); sink(sb21.toString()); // $hasTaintFlow
+        StrBuilder sb22 = new StrBuilder(); sb22.appendFixedWidthPadRight(taint(), 0, ' '); sink(sb22.toString()); // $hasTaintFlow
+        StrBuilder sb23 = new StrBuilder(); sb23.appendln(taint().toCharArray()); sink(sb23.toString()); // $hasTaintFlow
+        StrBuilder sb24 = new StrBuilder(); sb24.appendln(taint().toCharArray(), 0, 0); sink(sb24.toString()); // $hasTaintFlow
+        StrBuilder sb25 = new StrBuilder(); sb25.appendln((Object)taint()); sink(sb25.toString()); // $hasTaintFlow
         {
             StrBuilder auxsb = new StrBuilder(); auxsb.appendln(taint());
-            StrBuilder sb26 = new StrBuilder(); sb26.appendln(auxsb); sink(sb26.toString()); // $hasTaintFlow=y
+            StrBuilder sb26 = new StrBuilder(); sb26.appendln(auxsb); sink(sb26.toString()); // $hasTaintFlow
         }
-        StrBuilder sb27 = new StrBuilder(); sb27.appendln(new StringBuffer(taint())); sink(sb27.toString()); // $hasTaintFlow=y
-        StrBuilder sb28 = new StrBuilder(); sb28.appendln(new StringBuffer(taint()), 0, 0); sink(sb28.toString()); // $hasTaintFlow=y
-        StrBuilder sb29 = new StrBuilder(); sb29.appendln(new StringBuilder(taint())); sink(sb29.toString()); // $hasTaintFlow=y
-        StrBuilder sb30 = new StrBuilder(); sb30.appendln(new StringBuilder(taint()), 0, 0); sink(sb30.toString()); // $hasTaintFlow=y
-        StrBuilder sb31 = new StrBuilder(); sb31.appendln(taint()); sink(sb31.toString()); // $hasTaintFlow=y
-        StrBuilder sb32 = new StrBuilder(); sb32.appendln(taint(), 0, 0); sink(sb32.toString()); // $hasTaintFlow=y
-        StrBuilder sb33 = new StrBuilder(); sb33.appendln(taint(), "format", "args"); sink(sb33.toString()); // $hasTaintFlow=y
-        StrBuilder sb34 = new StrBuilder(); sb34.appendln("Format string", taint(), "args"); sink(sb34.toString()); // $hasTaintFlow=y
-        StrBuilder sb35 = new StrBuilder(); sb35.appendSeparator(taint()); sink(sb35.toString()); // $hasTaintFlow=y
-        StrBuilder sb36 = new StrBuilder(); sb36.appendSeparator(taint(), 0); sink(sb36.toString()); // $hasTaintFlow=y
-        StrBuilder sb37 = new StrBuilder(); sb37.appendSeparator(taint(), "default"); sink(sb37.toString()); // $hasTaintFlow=y
-        StrBuilder sb38 = new StrBuilder(); sb38.appendSeparator("", taint()); sink(sb38.toString()); // $hasTaintFlow=y
+        StrBuilder sb27 = new StrBuilder(); sb27.appendln(new StringBuffer(taint())); sink(sb27.toString()); // $hasTaintFlow
+        StrBuilder sb28 = new StrBuilder(); sb28.appendln(new StringBuffer(taint()), 0, 0); sink(sb28.toString()); // $hasTaintFlow
+        StrBuilder sb29 = new StrBuilder(); sb29.appendln(new StringBuilder(taint())); sink(sb29.toString()); // $hasTaintFlow
+        StrBuilder sb30 = new StrBuilder(); sb30.appendln(new StringBuilder(taint()), 0, 0); sink(sb30.toString()); // $hasTaintFlow
+        StrBuilder sb31 = new StrBuilder(); sb31.appendln(taint()); sink(sb31.toString()); // $hasTaintFlow
+        StrBuilder sb32 = new StrBuilder(); sb32.appendln(taint(), 0, 0); sink(sb32.toString()); // $hasTaintFlow
+        StrBuilder sb33 = new StrBuilder(); sb33.appendln(taint(), "format", "args"); sink(sb33.toString()); // $hasTaintFlow
+        StrBuilder sb34 = new StrBuilder(); sb34.appendln("Format string", taint(), "args"); sink(sb34.toString()); // $hasTaintFlow
+        StrBuilder sb35 = new StrBuilder(); sb35.appendSeparator(taint()); sink(sb35.toString()); // $hasTaintFlow
+        StrBuilder sb36 = new StrBuilder(); sb36.appendSeparator(taint(), 0); sink(sb36.toString()); // $hasTaintFlow
+        StrBuilder sb37 = new StrBuilder(); sb37.appendSeparator(taint(), "default"); sink(sb37.toString()); // $hasTaintFlow
+        StrBuilder sb38 = new StrBuilder(); sb38.appendSeparator("", taint()); sink(sb38.toString()); // $hasTaintFlow
         {
             StrBuilder auxsb = new StrBuilder(); auxsb.appendln(taint());
-            StrBuilder sb39 = new StrBuilder(); auxsb.appendTo(sb39); sink(sb39.toString()); // $hasTaintFlow=y
+            StrBuilder sb39 = new StrBuilder(); auxsb.appendTo(sb39); sink(sb39.toString()); // $hasTaintFlow
         }
         {
             List<String> taintedList = new ArrayList<>();
             taintedList.add(taint());
-            StrBuilder sb40 = new StrBuilder(); sb40.appendWithSeparators(taintedList, ", "); sink(sb40.toString()); // $hasTaintFlow=y
-            StrBuilder sb41 = new StrBuilder(); sb41.appendWithSeparators(taintedList.iterator(), ", "); sink(sb41.toString()); // $hasTaintFlow=y
+            StrBuilder sb40 = new StrBuilder(); sb40.appendWithSeparators(taintedList, ", "); sink(sb40.toString()); // $hasTaintFlow
+            StrBuilder sb41 = new StrBuilder(); sb41.appendWithSeparators(taintedList.iterator(), ", "); sink(sb41.toString()); // $hasTaintFlow
             List<String> untaintedList = new ArrayList<>();
-            StrBuilder sb42 = new StrBuilder(); sb42.appendWithSeparators(untaintedList, taint()); sink(sb42.toString()); // $hasTaintFlow=y
-            StrBuilder sb43 = new StrBuilder(); sb43.appendWithSeparators(untaintedList.iterator(), taint()); sink(sb43.toString()); // $hasTaintFlow=y
+            StrBuilder sb42 = new StrBuilder(); sb42.appendWithSeparators(untaintedList, taint()); sink(sb42.toString()); // $hasTaintFlow
+            StrBuilder sb43 = new StrBuilder(); sb43.appendWithSeparators(untaintedList.iterator(), taint()); sink(sb43.toString()); // $hasTaintFlow
             String[] taintedArray = new String[] { taint() };
             String[] untaintedArray = new String[] {};
-            StrBuilder sb44 = new StrBuilder(); sb44.appendWithSeparators(taintedArray, ", "); sink(sb44.toString()); // $hasTaintFlow=y
-            StrBuilder sb45 = new StrBuilder(); sb45.appendWithSeparators(untaintedArray, taint()); sink(sb45.toString()); // $hasTaintFlow=y
+            StrBuilder sb44 = new StrBuilder(); sb44.appendWithSeparators(taintedArray, ", "); sink(sb44.toString()); // $hasTaintFlow
+            StrBuilder sb45 = new StrBuilder(); sb45.appendWithSeparators(untaintedArray, taint()); sink(sb45.toString()); // $hasTaintFlow
         }
         {
             StrBuilder sb46 = new StrBuilder(); sb46.append(taint());
             char[] target = new char[100];
             sb46.asReader().read(target);
-            sink(target); // $hasTaintFlow=y
+            sink(target); // $hasTaintFlow
         }
-        StrBuilder sb47 = new StrBuilder(); sb47.append(taint()); sink(sb47.asTokenizer().next()); // $hasTaintFlow=y
-        StrBuilder sb48 = new StrBuilder(); sb48.append(taint()); sink(sb48.build()); // $hasTaintFlow=y
-        StrBuilder sb49 = new StrBuilder(); sb49.append(taint()); sink(sb49.getChars(null)); // $hasTaintFlow=y
+        StrBuilder sb47 = new StrBuilder(); sb47.append(taint()); sink(sb47.asTokenizer().next()); // $hasTaintFlow
+        StrBuilder sb48 = new StrBuilder(); sb48.append(taint()); sink(sb48.build()); // $hasTaintFlow
+        StrBuilder sb49 = new StrBuilder(); sb49.append(taint()); sink(sb49.getChars(null)); // $hasTaintFlow
         {
             StrBuilder sb50 = new StrBuilder(); sb50.append(taint());
             char[] target = new char[100];
             sb50.getChars(target);
-            sink(target); // $hasTaintFlow=y
+            sink(target); // $hasTaintFlow
         }
         {
             StrBuilder sb51 = new StrBuilder(); sb51.append(taint());
             char[] target = new char[100];
             sb51.getChars(0, 0, target, 0);
-            sink(target); // $hasTaintFlow=y
+            sink(target); // $hasTaintFlow
         }
-        StrBuilder sb52 = new StrBuilder(); sb52.insert(0, taint().toCharArray()); sink(sb52.toString()); // $hasTaintFlow=y
-        StrBuilder sb53 = new StrBuilder(); sb53.insert(0, taint().toCharArray(), 0, 0); sink(sb53.toString()); // $hasTaintFlow=y
-        StrBuilder sb54 = new StrBuilder(); sb54.insert(0, taint()); sink(sb54.toString()); // $hasTaintFlow=y
-        StrBuilder sb55 = new StrBuilder(); sb55.insert(0, (Object)taint()); sink(sb55.toString()); // $hasTaintFlow=y
-        StrBuilder sb56 = new StrBuilder(); sb56.append(taint()); sink(sb56.leftString(0)); // $hasTaintFlow=y
-        StrBuilder sb57 = new StrBuilder(); sb57.append(taint()); sink(sb57.midString(0, 0)); // $hasTaintFlow=y
+        StrBuilder sb52 = new StrBuilder(); sb52.insert(0, taint().toCharArray()); sink(sb52.toString()); // $hasTaintFlow
+        StrBuilder sb53 = new StrBuilder(); sb53.insert(0, taint().toCharArray(), 0, 0); sink(sb53.toString()); // $hasTaintFlow
+        StrBuilder sb54 = new StrBuilder(); sb54.insert(0, taint()); sink(sb54.toString()); // $hasTaintFlow
+        StrBuilder sb55 = new StrBuilder(); sb55.insert(0, (Object)taint()); sink(sb55.toString()); // $hasTaintFlow
+        StrBuilder sb56 = new StrBuilder(); sb56.append(taint()); sink(sb56.leftString(0)); // $hasTaintFlow
+        StrBuilder sb57 = new StrBuilder(); sb57.append(taint()); sink(sb57.midString(0, 0)); // $hasTaintFlow
         {
             StringReader reader = new StringReader(taint());
-            StrBuilder sb58 = new StrBuilder(); sb58.readFrom(reader); sink(sb58.toString()); // $hasTaintFlow=y
+            StrBuilder sb58 = new StrBuilder(); sb58.readFrom(reader); sink(sb58.toString()); // $hasTaintFlow
         }
-        StrBuilder sb59 = new StrBuilder(); sb59.replace(0, 0, taint()); sink(sb59.toString()); // $hasTaintFlow=y
-        StrBuilder sb60 = new StrBuilder(); sb60.replace(null, taint(), 0, 0, 0); sink(sb60.toString()); // $hasTaintFlow=y
-        StrBuilder sb61 = new StrBuilder(); sb61.replaceAll((StrMatcher)null, taint()); sink(sb61.toString()); // $hasTaintFlow=y
-        StrBuilder sb62 = new StrBuilder(); sb62.replaceAll("search", taint()); sink(sb62.toString()); // $hasTaintFlow=y
+        StrBuilder sb59 = new StrBuilder(); sb59.replace(0, 0, taint()); sink(sb59.toString()); // $hasTaintFlow
+        StrBuilder sb60 = new StrBuilder(); sb60.replace(null, taint(), 0, 0, 0); sink(sb60.toString()); // $hasTaintFlow
+        StrBuilder sb61 = new StrBuilder(); sb61.replaceAll((StrMatcher)null, taint()); sink(sb61.toString()); // $hasTaintFlow
+        StrBuilder sb62 = new StrBuilder(); sb62.replaceAll("search", taint()); sink(sb62.toString()); // $hasTaintFlow
         StrBuilder sb63 = new StrBuilder(); sb63.replaceAll(taint(), "replace"); sink(sb63.toString()); // GOOD (search string doesn't convey taint)
-        StrBuilder sb64 = new StrBuilder(); sb64.replaceFirst((StrMatcher)null, taint()); sink(sb64.toString()); // $hasTaintFlow=y
-        StrBuilder sb65 = new StrBuilder(); sb65.replaceFirst("search", taint()); sink(sb65.toString()); // $hasTaintFlow=y
+        StrBuilder sb64 = new StrBuilder(); sb64.replaceFirst((StrMatcher)null, taint()); sink(sb64.toString()); // $hasTaintFlow
+        StrBuilder sb65 = new StrBuilder(); sb65.replaceFirst("search", taint()); sink(sb65.toString()); // $hasTaintFlow
         StrBuilder sb66 = new StrBuilder(); sb66.replaceFirst(taint(), "replace"); sink(sb66.toString()); // GOOD (search string doesn't convey taint)
-        StrBuilder sb67 = new StrBuilder(); sb67.append(taint()); sink(sb67.rightString(0)); // $hasTaintFlow=y
-        StrBuilder sb68 = new StrBuilder(); sb68.append(taint()); sink(sb68.subSequence(0, 0)); // $hasTaintFlow=y
-        StrBuilder sb69 = new StrBuilder(); sb69.append(taint()); sink(sb69.substring(0)); // $hasTaintFlow=y
-        StrBuilder sb70 = new StrBuilder(); sb70.append(taint()); sink(sb70.substring(0, 0)); // $hasTaintFlow=y
-        StrBuilder sb71 = new StrBuilder(); sb71.append(taint()); sink(sb71.toCharArray()); // $hasTaintFlow=y
-        StrBuilder sb72 = new StrBuilder(); sb72.append(taint()); sink(sb72.toCharArray(0, 0)); // $hasTaintFlow=y
-        StrBuilder sb73 = new StrBuilder(); sb73.append(taint()); sink(sb73.toStringBuffer()); // $hasTaintFlow=y
-        StrBuilder sb74 = new StrBuilder(); sb74.append(taint()); sink(sb74.toStringBuilder()); // $hasTaintFlow=y
+        StrBuilder sb67 = new StrBuilder(); sb67.append(taint()); sink(sb67.rightString(0)); // $hasTaintFlow
+        StrBuilder sb68 = new StrBuilder(); sb68.append(taint()); sink(sb68.subSequence(0, 0)); // $hasTaintFlow
+        StrBuilder sb69 = new StrBuilder(); sb69.append(taint()); sink(sb69.substring(0)); // $hasTaintFlow
+        StrBuilder sb70 = new StrBuilder(); sb70.append(taint()); sink(sb70.substring(0, 0)); // $hasTaintFlow
+        StrBuilder sb71 = new StrBuilder(); sb71.append(taint()); sink(sb71.toCharArray()); // $hasTaintFlow
+        StrBuilder sb72 = new StrBuilder(); sb72.append(taint()); sink(sb72.toCharArray(0, 0)); // $hasTaintFlow
+        StrBuilder sb73 = new StrBuilder(); sb73.append(taint()); sink(sb73.toStringBuffer()); // $hasTaintFlow
+        StrBuilder sb74 = new StrBuilder(); sb74.append(taint()); sink(sb74.toStringBuilder()); // $hasTaintFlow
     }
 
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTextTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrBuilderTextTest.java
@@ -14,120 +14,120 @@ class StrBuilderTextTest {
 
     void test() throws Exception {
 
-        StrBuilder cons1 = new StrBuilder(taint()); sink(cons1.toString()); // $hasTaintFlow=y
+        StrBuilder cons1 = new StrBuilder(taint()); sink(cons1.toString()); // $hasTaintFlow
 
-        StrBuilder sb1 = new StrBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
-        StrBuilder sb2 = new StrBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
-        StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // $ MISSING: hasTaintFlow=y
-        StrBuilder sb4 = new StrBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // $ MISSING: hasTaintFlow=y
-        StrBuilder sb5 = new StrBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow=y
-        StrBuilder sb6 = new StrBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow=y
-        StrBuilder sb7 = new StrBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow=y
+        StrBuilder sb1 = new StrBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow
+        StrBuilder sb2 = new StrBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow
+        StrBuilder sb3 = new StrBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // $ MISSING: hasTaintFlow
+        StrBuilder sb4 = new StrBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // $ MISSING: hasTaintFlow
+        StrBuilder sb5 = new StrBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow
+        StrBuilder sb6 = new StrBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow
+        StrBuilder sb7 = new StrBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow
         {
             StrBuilder auxsb = new StrBuilder(); auxsb.append(taint());
-            StrBuilder sb8 = new StrBuilder(); sb8.append(auxsb); sink(sb8.toString()); // $hasTaintFlow=y
+            StrBuilder sb8 = new StrBuilder(); sb8.append(auxsb); sink(sb8.toString()); // $hasTaintFlow
         }
-        StrBuilder sb9 = new StrBuilder(); sb9.append(new StringBuffer(taint())); sink(sb9.toString()); // $hasTaintFlow=y
-        StrBuilder sb10 = new StrBuilder(); sb10.append(new StringBuffer(taint()), 0, 0); sink(sb10.toString()); // $hasTaintFlow=y
-        StrBuilder sb11 = new StrBuilder(); sb11.append(new StringBuilder(taint())); sink(sb11.toString()); // $hasTaintFlow=y
-        StrBuilder sb12 = new StrBuilder(); sb12.append(new StringBuilder(taint()), 0, 0); sink(sb12.toString()); // $hasTaintFlow=y
-        StrBuilder sb13 = new StrBuilder(); sb13.append(taint()); sink(sb13.toString()); // $hasTaintFlow=y
-        StrBuilder sb14 = new StrBuilder(); sb14.append(taint(), 0, 0); sink(sb14.toString()); // $hasTaintFlow=y
-        StrBuilder sb15 = new StrBuilder(); sb15.append(taint(), "format", "args"); sink(sb15.toString()); // $hasTaintFlow=y
-        StrBuilder sb16 = new StrBuilder(); sb16.append("Format string", taint(), "args"); sink(sb16.toString()); // $hasTaintFlow=y
+        StrBuilder sb9 = new StrBuilder(); sb9.append(new StringBuffer(taint())); sink(sb9.toString()); // $hasTaintFlow
+        StrBuilder sb10 = new StrBuilder(); sb10.append(new StringBuffer(taint()), 0, 0); sink(sb10.toString()); // $hasTaintFlow
+        StrBuilder sb11 = new StrBuilder(); sb11.append(new StringBuilder(taint())); sink(sb11.toString()); // $hasTaintFlow
+        StrBuilder sb12 = new StrBuilder(); sb12.append(new StringBuilder(taint()), 0, 0); sink(sb12.toString()); // $hasTaintFlow
+        StrBuilder sb13 = new StrBuilder(); sb13.append(taint()); sink(sb13.toString()); // $hasTaintFlow
+        StrBuilder sb14 = new StrBuilder(); sb14.append(taint(), 0, 0); sink(sb14.toString()); // $hasTaintFlow
+        StrBuilder sb15 = new StrBuilder(); sb15.append(taint(), "format", "args"); sink(sb15.toString()); // $hasTaintFlow
+        StrBuilder sb16 = new StrBuilder(); sb16.append("Format string", taint(), "args"); sink(sb16.toString()); // $hasTaintFlow
         {
             List<String> taintedList = new ArrayList<>();
             taintedList.add(taint());
-            StrBuilder sb17 = new StrBuilder(); sb17.appendAll(taintedList); sink(sb17.toString()); // $hasTaintFlow=y
-            StrBuilder sb18 = new StrBuilder(); sb18.appendAll(taintedList.iterator()); sink(sb18.toString()); // $hasTaintFlow=y
+            StrBuilder sb17 = new StrBuilder(); sb17.appendAll(taintedList); sink(sb17.toString()); // $hasTaintFlow
+            StrBuilder sb18 = new StrBuilder(); sb18.appendAll(taintedList.iterator()); sink(sb18.toString()); // $hasTaintFlow
         }
-        StrBuilder sb19 = new StrBuilder(); sb19.appendAll("clean", taint()); sink(sb19.toString()); // $hasTaintFlow=y
-        StrBuilder sb20 = new StrBuilder(); sb20.appendAll(taint(), "clean"); sink(sb20.toString()); // $hasTaintFlow=y
-        StrBuilder sb21 = new StrBuilder(); sb21.appendFixedWidthPadLeft(taint(), 0, ' '); sink(sb21.toString()); // $hasTaintFlow=y
-        StrBuilder sb22 = new StrBuilder(); sb22.appendFixedWidthPadRight(taint(), 0, ' '); sink(sb22.toString()); // $hasTaintFlow=y
-        StrBuilder sb23 = new StrBuilder(); sb23.appendln(taint().toCharArray()); sink(sb23.toString()); // $hasTaintFlow=y
-        StrBuilder sb24 = new StrBuilder(); sb24.appendln(taint().toCharArray(), 0, 0); sink(sb24.toString()); // $hasTaintFlow=y
-        StrBuilder sb25 = new StrBuilder(); sb25.appendln((Object)taint()); sink(sb25.toString()); // $hasTaintFlow=y
+        StrBuilder sb19 = new StrBuilder(); sb19.appendAll("clean", taint()); sink(sb19.toString()); // $hasTaintFlow
+        StrBuilder sb20 = new StrBuilder(); sb20.appendAll(taint(), "clean"); sink(sb20.toString()); // $hasTaintFlow
+        StrBuilder sb21 = new StrBuilder(); sb21.appendFixedWidthPadLeft(taint(), 0, ' '); sink(sb21.toString()); // $hasTaintFlow
+        StrBuilder sb22 = new StrBuilder(); sb22.appendFixedWidthPadRight(taint(), 0, ' '); sink(sb22.toString()); // $hasTaintFlow
+        StrBuilder sb23 = new StrBuilder(); sb23.appendln(taint().toCharArray()); sink(sb23.toString()); // $hasTaintFlow
+        StrBuilder sb24 = new StrBuilder(); sb24.appendln(taint().toCharArray(), 0, 0); sink(sb24.toString()); // $hasTaintFlow
+        StrBuilder sb25 = new StrBuilder(); sb25.appendln((Object)taint()); sink(sb25.toString()); // $hasTaintFlow
         {
             StrBuilder auxsb = new StrBuilder(); auxsb.appendln(taint());
-            StrBuilder sb26 = new StrBuilder(); sb26.appendln(auxsb); sink(sb26.toString()); // $hasTaintFlow=y
+            StrBuilder sb26 = new StrBuilder(); sb26.appendln(auxsb); sink(sb26.toString()); // $hasTaintFlow
         }
-        StrBuilder sb27 = new StrBuilder(); sb27.appendln(new StringBuffer(taint())); sink(sb27.toString()); // $hasTaintFlow=y
-        StrBuilder sb28 = new StrBuilder(); sb28.appendln(new StringBuffer(taint()), 0, 0); sink(sb28.toString()); // $hasTaintFlow=y
-        StrBuilder sb29 = new StrBuilder(); sb29.appendln(new StringBuilder(taint())); sink(sb29.toString()); // $hasTaintFlow=y
-        StrBuilder sb30 = new StrBuilder(); sb30.appendln(new StringBuilder(taint()), 0, 0); sink(sb30.toString()); // $hasTaintFlow=y
-        StrBuilder sb31 = new StrBuilder(); sb31.appendln(taint()); sink(sb31.toString()); // $hasTaintFlow=y
-        StrBuilder sb32 = new StrBuilder(); sb32.appendln(taint(), 0, 0); sink(sb32.toString()); // $hasTaintFlow=y
-        StrBuilder sb33 = new StrBuilder(); sb33.appendln(taint(), "format", "args"); sink(sb33.toString()); // $hasTaintFlow=y
-        StrBuilder sb34 = new StrBuilder(); sb34.appendln("Format string", taint(), "args"); sink(sb34.toString()); // $hasTaintFlow=y
-        StrBuilder sb35 = new StrBuilder(); sb35.appendSeparator(taint()); sink(sb35.toString()); // $hasTaintFlow=y
-        StrBuilder sb36 = new StrBuilder(); sb36.appendSeparator(taint(), 0); sink(sb36.toString()); // $hasTaintFlow=y
-        StrBuilder sb37 = new StrBuilder(); sb37.appendSeparator(taint(), "default"); sink(sb37.toString()); // $hasTaintFlow=y
-        StrBuilder sb38 = new StrBuilder(); sb38.appendSeparator("", taint()); sink(sb38.toString()); // $hasTaintFlow=y
+        StrBuilder sb27 = new StrBuilder(); sb27.appendln(new StringBuffer(taint())); sink(sb27.toString()); // $hasTaintFlow
+        StrBuilder sb28 = new StrBuilder(); sb28.appendln(new StringBuffer(taint()), 0, 0); sink(sb28.toString()); // $hasTaintFlow
+        StrBuilder sb29 = new StrBuilder(); sb29.appendln(new StringBuilder(taint())); sink(sb29.toString()); // $hasTaintFlow
+        StrBuilder sb30 = new StrBuilder(); sb30.appendln(new StringBuilder(taint()), 0, 0); sink(sb30.toString()); // $hasTaintFlow
+        StrBuilder sb31 = new StrBuilder(); sb31.appendln(taint()); sink(sb31.toString()); // $hasTaintFlow
+        StrBuilder sb32 = new StrBuilder(); sb32.appendln(taint(), 0, 0); sink(sb32.toString()); // $hasTaintFlow
+        StrBuilder sb33 = new StrBuilder(); sb33.appendln(taint(), "format", "args"); sink(sb33.toString()); // $hasTaintFlow
+        StrBuilder sb34 = new StrBuilder(); sb34.appendln("Format string", taint(), "args"); sink(sb34.toString()); // $hasTaintFlow
+        StrBuilder sb35 = new StrBuilder(); sb35.appendSeparator(taint()); sink(sb35.toString()); // $hasTaintFlow
+        StrBuilder sb36 = new StrBuilder(); sb36.appendSeparator(taint(), 0); sink(sb36.toString()); // $hasTaintFlow
+        StrBuilder sb37 = new StrBuilder(); sb37.appendSeparator(taint(), "default"); sink(sb37.toString()); // $hasTaintFlow
+        StrBuilder sb38 = new StrBuilder(); sb38.appendSeparator("", taint()); sink(sb38.toString()); // $hasTaintFlow
         {
             StrBuilder auxsb = new StrBuilder(); auxsb.appendln(taint());
-            StrBuilder sb39 = new StrBuilder(); auxsb.appendTo(sb39); sink(sb39.toString()); // $hasTaintFlow=y
+            StrBuilder sb39 = new StrBuilder(); auxsb.appendTo(sb39); sink(sb39.toString()); // $hasTaintFlow
         }
         {
             List<String> taintedList = new ArrayList<>();
             taintedList.add(taint());
-            StrBuilder sb40 = new StrBuilder(); sb40.appendWithSeparators(taintedList, ", "); sink(sb40.toString()); // $hasTaintFlow=y
-            StrBuilder sb41 = new StrBuilder(); sb41.appendWithSeparators(taintedList.iterator(), ", "); sink(sb41.toString()); // $hasTaintFlow=y
+            StrBuilder sb40 = new StrBuilder(); sb40.appendWithSeparators(taintedList, ", "); sink(sb40.toString()); // $hasTaintFlow
+            StrBuilder sb41 = new StrBuilder(); sb41.appendWithSeparators(taintedList.iterator(), ", "); sink(sb41.toString()); // $hasTaintFlow
             List<String> untaintedList = new ArrayList<>();
-            StrBuilder sb42 = new StrBuilder(); sb42.appendWithSeparators(untaintedList, taint()); sink(sb42.toString()); // $hasTaintFlow=y
-            StrBuilder sb43 = new StrBuilder(); sb43.appendWithSeparators(untaintedList.iterator(), taint()); sink(sb43.toString()); // $hasTaintFlow=y
+            StrBuilder sb42 = new StrBuilder(); sb42.appendWithSeparators(untaintedList, taint()); sink(sb42.toString()); // $hasTaintFlow
+            StrBuilder sb43 = new StrBuilder(); sb43.appendWithSeparators(untaintedList.iterator(), taint()); sink(sb43.toString()); // $hasTaintFlow
             String[] taintedArray = new String[] { taint() };
             String[] untaintedArray = new String[] {};
-            StrBuilder sb44 = new StrBuilder(); sb44.appendWithSeparators(taintedArray, ", "); sink(sb44.toString()); // $hasTaintFlow=y
-            StrBuilder sb45 = new StrBuilder(); sb45.appendWithSeparators(untaintedArray, taint()); sink(sb45.toString()); // $hasTaintFlow=y
+            StrBuilder sb44 = new StrBuilder(); sb44.appendWithSeparators(taintedArray, ", "); sink(sb44.toString()); // $hasTaintFlow
+            StrBuilder sb45 = new StrBuilder(); sb45.appendWithSeparators(untaintedArray, taint()); sink(sb45.toString()); // $hasTaintFlow
         }
         {
             StrBuilder sb46 = new StrBuilder(); sb46.append(taint());
             char[] target = new char[100];
             sb46.asReader().read(target);
-            sink(target); // $hasTaintFlow=y
+            sink(target); // $hasTaintFlow
         }
-        StrBuilder sb47 = new StrBuilder(); sb47.append(taint()); sink(sb47.asTokenizer().next()); // $hasTaintFlow=y
-        StrBuilder sb48 = new StrBuilder(); sb48.append(taint()); sink(sb48.build()); // $hasTaintFlow=y
-        StrBuilder sb49 = new StrBuilder(); sb49.append(taint()); sink(sb49.getChars(null)); // $hasTaintFlow=y
+        StrBuilder sb47 = new StrBuilder(); sb47.append(taint()); sink(sb47.asTokenizer().next()); // $hasTaintFlow
+        StrBuilder sb48 = new StrBuilder(); sb48.append(taint()); sink(sb48.build()); // $hasTaintFlow
+        StrBuilder sb49 = new StrBuilder(); sb49.append(taint()); sink(sb49.getChars(null)); // $hasTaintFlow
         {
             StrBuilder sb50 = new StrBuilder(); sb50.append(taint());
             char[] target = new char[100];
             sb50.getChars(target);
-            sink(target); // $hasTaintFlow=y
+            sink(target); // $hasTaintFlow
         }
         {
             StrBuilder sb51 = new StrBuilder(); sb51.append(taint());
             char[] target = new char[100];
             sb51.getChars(0, 0, target, 0);
-            sink(target); // $hasTaintFlow=y
+            sink(target); // $hasTaintFlow
         }
-        StrBuilder sb52 = new StrBuilder(); sb52.insert(0, taint().toCharArray()); sink(sb52.toString()); // $hasTaintFlow=y
-        StrBuilder sb53 = new StrBuilder(); sb53.insert(0, taint().toCharArray(), 0, 0); sink(sb53.toString()); // $hasTaintFlow=y
-        StrBuilder sb54 = new StrBuilder(); sb54.insert(0, taint()); sink(sb54.toString()); // $hasTaintFlow=y
-        StrBuilder sb55 = new StrBuilder(); sb55.insert(0, (Object)taint()); sink(sb55.toString()); // $hasTaintFlow=y
-        StrBuilder sb56 = new StrBuilder(); sb56.append(taint()); sink(sb56.leftString(0)); // $hasTaintFlow=y
-        StrBuilder sb57 = new StrBuilder(); sb57.append(taint()); sink(sb57.midString(0, 0)); // $hasTaintFlow=y
+        StrBuilder sb52 = new StrBuilder(); sb52.insert(0, taint().toCharArray()); sink(sb52.toString()); // $hasTaintFlow
+        StrBuilder sb53 = new StrBuilder(); sb53.insert(0, taint().toCharArray(), 0, 0); sink(sb53.toString()); // $hasTaintFlow
+        StrBuilder sb54 = new StrBuilder(); sb54.insert(0, taint()); sink(sb54.toString()); // $hasTaintFlow
+        StrBuilder sb55 = new StrBuilder(); sb55.insert(0, (Object)taint()); sink(sb55.toString()); // $hasTaintFlow
+        StrBuilder sb56 = new StrBuilder(); sb56.append(taint()); sink(sb56.leftString(0)); // $hasTaintFlow
+        StrBuilder sb57 = new StrBuilder(); sb57.append(taint()); sink(sb57.midString(0, 0)); // $hasTaintFlow
         {
             StringReader reader = new StringReader(taint());
-            StrBuilder sb58 = new StrBuilder(); sb58.readFrom(reader); sink(sb58.toString()); // $hasTaintFlow=y
+            StrBuilder sb58 = new StrBuilder(); sb58.readFrom(reader); sink(sb58.toString()); // $hasTaintFlow
         }
-        StrBuilder sb59 = new StrBuilder(); sb59.replace(0, 0, taint()); sink(sb59.toString()); // $hasTaintFlow=y
-        StrBuilder sb60 = new StrBuilder(); sb60.replace(null, taint(), 0, 0, 0); sink(sb60.toString()); // $hasTaintFlow=y
-        StrBuilder sb61 = new StrBuilder(); sb61.replaceAll((StrMatcher)null, taint()); sink(sb61.toString()); // $hasTaintFlow=y
-        StrBuilder sb62 = new StrBuilder(); sb62.replaceAll("search", taint()); sink(sb62.toString()); // $hasTaintFlow=y
+        StrBuilder sb59 = new StrBuilder(); sb59.replace(0, 0, taint()); sink(sb59.toString()); // $hasTaintFlow
+        StrBuilder sb60 = new StrBuilder(); sb60.replace(null, taint(), 0, 0, 0); sink(sb60.toString()); // $hasTaintFlow
+        StrBuilder sb61 = new StrBuilder(); sb61.replaceAll((StrMatcher)null, taint()); sink(sb61.toString()); // $hasTaintFlow
+        StrBuilder sb62 = new StrBuilder(); sb62.replaceAll("search", taint()); sink(sb62.toString()); // $hasTaintFlow
         StrBuilder sb63 = new StrBuilder(); sb63.replaceAll(taint(), "replace"); sink(sb63.toString()); // GOOD (search string doesn't convey taint)
-        StrBuilder sb64 = new StrBuilder(); sb64.replaceFirst((StrMatcher)null, taint()); sink(sb64.toString()); // $hasTaintFlow=y
-        StrBuilder sb65 = new StrBuilder(); sb65.replaceFirst("search", taint()); sink(sb65.toString()); // $hasTaintFlow=y
+        StrBuilder sb64 = new StrBuilder(); sb64.replaceFirst((StrMatcher)null, taint()); sink(sb64.toString()); // $hasTaintFlow
+        StrBuilder sb65 = new StrBuilder(); sb65.replaceFirst("search", taint()); sink(sb65.toString()); // $hasTaintFlow
         StrBuilder sb66 = new StrBuilder(); sb66.replaceFirst(taint(), "replace"); sink(sb66.toString()); // GOOD (search string doesn't convey taint)
-        StrBuilder sb67 = new StrBuilder(); sb67.append(taint()); sink(sb67.rightString(0)); // $hasTaintFlow=y
-        StrBuilder sb68 = new StrBuilder(); sb68.append(taint()); sink(sb68.subSequence(0, 0)); // $hasTaintFlow=y
-        StrBuilder sb69 = new StrBuilder(); sb69.append(taint()); sink(sb69.substring(0)); // $hasTaintFlow=y
-        StrBuilder sb70 = new StrBuilder(); sb70.append(taint()); sink(sb70.substring(0, 0)); // $hasTaintFlow=y
-        StrBuilder sb71 = new StrBuilder(); sb71.append(taint()); sink(sb71.toCharArray()); // $hasTaintFlow=y
-        StrBuilder sb72 = new StrBuilder(); sb72.append(taint()); sink(sb72.toCharArray(0, 0)); // $hasTaintFlow=y
-        StrBuilder sb73 = new StrBuilder(); sb73.append(taint()); sink(sb73.toStringBuffer()); // $hasTaintFlow=y
-        StrBuilder sb74 = new StrBuilder(); sb74.append(taint()); sink(sb74.toStringBuilder()); // $hasTaintFlow=y
+        StrBuilder sb67 = new StrBuilder(); sb67.append(taint()); sink(sb67.rightString(0)); // $hasTaintFlow
+        StrBuilder sb68 = new StrBuilder(); sb68.append(taint()); sink(sb68.subSequence(0, 0)); // $hasTaintFlow
+        StrBuilder sb69 = new StrBuilder(); sb69.append(taint()); sink(sb69.substring(0)); // $hasTaintFlow
+        StrBuilder sb70 = new StrBuilder(); sb70.append(taint()); sink(sb70.substring(0, 0)); // $hasTaintFlow
+        StrBuilder sb71 = new StrBuilder(); sb71.append(taint()); sink(sb71.toCharArray()); // $hasTaintFlow
+        StrBuilder sb72 = new StrBuilder(); sb72.append(taint()); sink(sb72.toCharArray(0, 0)); // $hasTaintFlow
+        StrBuilder sb73 = new StrBuilder(); sb73.append(taint()); sink(sb73.toStringBuffer()); // $hasTaintFlow
+        StrBuilder sb74 = new StrBuilder(); sb74.append(taint()); sink(sb74.toStringBuilder()); // $hasTaintFlow
     }
 
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrLookupTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrLookupTest.java
@@ -11,7 +11,7 @@ class StrLookupTest {
       Map<String, String> map = new HashMap<String, String>();
       map.put("key", taint());
       StrLookup<String> lookup = StrLookup.mapLookup(map);
-      sink(lookup.lookup("key")); // $hasTaintFlow=y
+      sink(lookup.lookup("key")); // $hasTaintFlow
     }
 
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrSubstitutorTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrSubstitutorTest.java
@@ -17,66 +17,66 @@ class StrSubstitutorTest {
       StrLookup<String> taintedLookup = StrLookup.mapLookup(taintedMap);
 
       // Test constructors:
-      StrSubstitutor ss1 = new StrSubstitutor(); ss1.setVariableResolver(taintedLookup); sink(ss1.replace("input")); // $hasTaintFlow=y
-      StrSubstitutor ss2 = new StrSubstitutor(taintedMap); sink(ss2.replace("input")); // $hasTaintFlow=y
-      StrSubstitutor ss3 = new StrSubstitutor(taintedMap, "{", "}"); sink(ss3.replace("input")); // $hasTaintFlow=y
-      StrSubstitutor ss4 = new StrSubstitutor(taintedMap, "{", "}", ' '); sink(ss4.replace("input")); // $hasTaintFlow=y
-      StrSubstitutor ss5 = new StrSubstitutor(taintedMap, "{", "}", ' ', ","); sink(ss5.replace("input")); // $hasTaintFlow=y
-      StrSubstitutor ss6 = new StrSubstitutor(taintedLookup); sink(ss6.replace("input")); // $hasTaintFlow=y
-      StrSubstitutor ss7 = new StrSubstitutor(taintedLookup, "{", "}", ' '); sink(ss7.replace("input")); // $hasTaintFlow=y
-      StrSubstitutor ss8 = new StrSubstitutor(taintedLookup, "{", "}", ' ', ","); sink(ss8.replace("input")); // $hasTaintFlow=y
-      StrSubstitutor ss9 = new StrSubstitutor(taintedLookup, (StrMatcher)null, null, ' '); sink(ss9.replace("input")); // $hasTaintFlow=y
-      StrSubstitutor ss10 = new StrSubstitutor(taintedLookup, (StrMatcher)null, null, ' ', null); sink(ss10.replace("input")); // $hasTaintFlow=y
+      StrSubstitutor ss1 = new StrSubstitutor(); ss1.setVariableResolver(taintedLookup); sink(ss1.replace("input")); // $hasTaintFlow
+      StrSubstitutor ss2 = new StrSubstitutor(taintedMap); sink(ss2.replace("input")); // $hasTaintFlow
+      StrSubstitutor ss3 = new StrSubstitutor(taintedMap, "{", "}"); sink(ss3.replace("input")); // $hasTaintFlow
+      StrSubstitutor ss4 = new StrSubstitutor(taintedMap, "{", "}", ' '); sink(ss4.replace("input")); // $hasTaintFlow
+      StrSubstitutor ss5 = new StrSubstitutor(taintedMap, "{", "}", ' ', ","); sink(ss5.replace("input")); // $hasTaintFlow
+      StrSubstitutor ss6 = new StrSubstitutor(taintedLookup); sink(ss6.replace("input")); // $hasTaintFlow
+      StrSubstitutor ss7 = new StrSubstitutor(taintedLookup, "{", "}", ' '); sink(ss7.replace("input")); // $hasTaintFlow
+      StrSubstitutor ss8 = new StrSubstitutor(taintedLookup, "{", "}", ' ', ","); sink(ss8.replace("input")); // $hasTaintFlow
+      StrSubstitutor ss9 = new StrSubstitutor(taintedLookup, (StrMatcher)null, null, ' '); sink(ss9.replace("input")); // $hasTaintFlow
+      StrSubstitutor ss10 = new StrSubstitutor(taintedLookup, (StrMatcher)null, null, ' ', null); sink(ss10.replace("input")); // $hasTaintFlow
 
       // Test replace overloads (tainted substitution map):
       StrSubstitutor taintedSubst = ss2;
-      sink(taintedSubst.replace((Object)"input")); // $hasTaintFlow=y
-      sink(taintedSubst.replace("input")); // $hasTaintFlow=y
-      sink(taintedSubst.replace("input", 0, 0)); // $hasTaintFlow=y
-      sink(taintedSubst.replace("input".toCharArray())); // $hasTaintFlow=y
-      sink(taintedSubst.replace("input".toCharArray(), 0, 0)); // $hasTaintFlow=y
-      sink(taintedSubst.replace((CharSequence)"input")); // $hasTaintFlow=y
-      sink(taintedSubst.replace((CharSequence)"input", 0, 0)); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new StrBuilder("input"))); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new StrBuilder("input"), 0, 0)); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new StringBuilder("input"))); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new StringBuilder("input"), 0, 0)); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new StringBuffer("input"))); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new StringBuffer("input"), 0, 0)); // $hasTaintFlow=y
+      sink(taintedSubst.replace((Object)"input")); // $hasTaintFlow
+      sink(taintedSubst.replace("input")); // $hasTaintFlow
+      sink(taintedSubst.replace("input", 0, 0)); // $hasTaintFlow
+      sink(taintedSubst.replace("input".toCharArray())); // $hasTaintFlow
+      sink(taintedSubst.replace("input".toCharArray(), 0, 0)); // $hasTaintFlow
+      sink(taintedSubst.replace((CharSequence)"input")); // $hasTaintFlow
+      sink(taintedSubst.replace((CharSequence)"input", 0, 0)); // $hasTaintFlow
+      sink(taintedSubst.replace(new StrBuilder("input"))); // $hasTaintFlow
+      sink(taintedSubst.replace(new StrBuilder("input"), 0, 0)); // $hasTaintFlow
+      sink(taintedSubst.replace(new StringBuilder("input"))); // $hasTaintFlow
+      sink(taintedSubst.replace(new StringBuilder("input"), 0, 0)); // $hasTaintFlow
+      sink(taintedSubst.replace(new StringBuffer("input"))); // $hasTaintFlow
+      sink(taintedSubst.replace(new StringBuffer("input"), 0, 0)); // $hasTaintFlow
 
       // Test replace overloads (tainted input):
       StrSubstitutor untaintedSubst = ss1;
-      sink(untaintedSubst.replace((Object)taint())); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(taint())); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(taint(), 0, 0)); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(taint().toCharArray())); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(taint().toCharArray(), 0, 0)); // $hasTaintFlow=y
-      sink(untaintedSubst.replace((CharSequence)taint())); // $hasTaintFlow=y
-      sink(untaintedSubst.replace((CharSequence)taint(), 0, 0)); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new StrBuilder(taint()))); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new StrBuilder(taint()), 0, 0)); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new StringBuilder(taint()))); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new StringBuilder(taint()), 0, 0)); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new StringBuffer(taint()))); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new StringBuffer(taint()), 0, 0)); // $hasTaintFlow=y
+      sink(untaintedSubst.replace((Object)taint())); // $hasTaintFlow
+      sink(untaintedSubst.replace(taint())); // $hasTaintFlow
+      sink(untaintedSubst.replace(taint(), 0, 0)); // $hasTaintFlow
+      sink(untaintedSubst.replace(taint().toCharArray())); // $hasTaintFlow
+      sink(untaintedSubst.replace(taint().toCharArray(), 0, 0)); // $hasTaintFlow
+      sink(untaintedSubst.replace((CharSequence)taint())); // $hasTaintFlow
+      sink(untaintedSubst.replace((CharSequence)taint(), 0, 0)); // $hasTaintFlow
+      sink(untaintedSubst.replace(new StrBuilder(taint()))); // $hasTaintFlow
+      sink(untaintedSubst.replace(new StrBuilder(taint()), 0, 0)); // $hasTaintFlow
+      sink(untaintedSubst.replace(new StringBuilder(taint()))); // $hasTaintFlow
+      sink(untaintedSubst.replace(new StringBuilder(taint()), 0, 0)); // $hasTaintFlow
+      sink(untaintedSubst.replace(new StringBuffer(taint()))); // $hasTaintFlow
+      sink(untaintedSubst.replace(new StringBuffer(taint()), 0, 0)); // $hasTaintFlow
 
       // Test static replace methods:
-      sink(StrSubstitutor.replace(taint(), new HashMap<String, String>())); // $hasTaintFlow=y
-      sink(StrSubstitutor.replace(taint(), new HashMap<String, String>(), "{", "}")); // $hasTaintFlow=y
-      sink(StrSubstitutor.replace("input", taintedMap)); // $hasTaintFlow=y
-      sink(StrSubstitutor.replace("input", taintedMap, "{", "}")); // $hasTaintFlow=y
+      sink(StrSubstitutor.replace(taint(), new HashMap<String, String>())); // $hasTaintFlow
+      sink(StrSubstitutor.replace(taint(), new HashMap<String, String>(), "{", "}")); // $hasTaintFlow
+      sink(StrSubstitutor.replace("input", taintedMap)); // $hasTaintFlow
+      sink(StrSubstitutor.replace("input", taintedMap, "{", "}")); // $hasTaintFlow
       Properties taintedProps = new Properties();
       taintedProps.put("key", taint());
-      sink(StrSubstitutor.replace(taint(), new Properties())); // $hasTaintFlow=y
-      sink(StrSubstitutor.replace("input", taintedProps)); // $hasTaintFlow=y
+      sink(StrSubstitutor.replace(taint(), new Properties())); // $hasTaintFlow
+      sink(StrSubstitutor.replace("input", taintedProps)); // $hasTaintFlow
 
       // Test replaceIn methods:
-      StrBuilder strBuilder1 = new StrBuilder(); taintedSubst.replaceIn(strBuilder1); sink(strBuilder1.toString()); // $hasTaintFlow=y
-      StrBuilder strBuilder2 = new StrBuilder(); taintedSubst.replaceIn(strBuilder2, 0, 0); sink(strBuilder2.toString()); // $hasTaintFlow=y
-      StringBuilder stringBuilder1 = new StringBuilder(); taintedSubst.replaceIn(stringBuilder1); sink(stringBuilder1.toString()); // $hasTaintFlow=y
-      StringBuilder stringBuilder2 = new StringBuilder(); taintedSubst.replaceIn(stringBuilder2, 0, 0); sink(stringBuilder2.toString()); // $hasTaintFlow=y
-      StringBuffer stringBuffer1 = new StringBuffer(); taintedSubst.replaceIn(stringBuffer1); sink(stringBuffer1.toString()); // $hasTaintFlow=y
-      StringBuffer stringBuffer2 = new StringBuffer(); taintedSubst.replaceIn(stringBuffer2, 0, 0); sink(stringBuffer2.toString()); // $hasTaintFlow=y
+      StrBuilder strBuilder1 = new StrBuilder(); taintedSubst.replaceIn(strBuilder1); sink(strBuilder1.toString()); // $hasTaintFlow
+      StrBuilder strBuilder2 = new StrBuilder(); taintedSubst.replaceIn(strBuilder2, 0, 0); sink(strBuilder2.toString()); // $hasTaintFlow
+      StringBuilder stringBuilder1 = new StringBuilder(); taintedSubst.replaceIn(stringBuilder1); sink(stringBuilder1.toString()); // $hasTaintFlow
+      StringBuilder stringBuilder2 = new StringBuilder(); taintedSubst.replaceIn(stringBuilder2, 0, 0); sink(stringBuilder2.toString()); // $hasTaintFlow
+      StringBuffer stringBuffer1 = new StringBuffer(); taintedSubst.replaceIn(stringBuffer1); sink(stringBuffer1.toString()); // $hasTaintFlow
+      StringBuffer stringBuffer2 = new StringBuffer(); taintedSubst.replaceIn(stringBuffer2, 0, 0); sink(stringBuffer2.toString()); // $hasTaintFlow
     }
 
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrTokenizerTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrTokenizerTest.java
@@ -9,38 +9,38 @@ public class StrTokenizerTest {
   void test() throws Exception {
 
     // Test constructors:
-    sink((new StrTokenizer(taint().toCharArray())).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint().toCharArray(), ',')).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint().toCharArray(), ',', '"')).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint().toCharArray(), ",")).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint().toCharArray(), (StrMatcher)null)).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint().toCharArray(), (StrMatcher)null, (StrMatcher)null)).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint(), ',')).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint(), ',', '"')).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint(), ",")).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint(), (StrMatcher)null)).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint(), (StrMatcher)null, (StrMatcher)null)).toString()); // $hasTaintFlow=y
+    sink((new StrTokenizer(taint().toCharArray())).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint().toCharArray(), ',')).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint().toCharArray(), ',', '"')).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint().toCharArray(), ",")).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint().toCharArray(), (StrMatcher)null)).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint().toCharArray(), (StrMatcher)null, (StrMatcher)null)).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint(), ',')).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint(), ',', '"')).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint(), ",")).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint(), (StrMatcher)null)).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint(), (StrMatcher)null, (StrMatcher)null)).toString()); // $hasTaintFlow
 
     // Test constructing static methods:
-    sink(StrTokenizer.getCSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow=y
-    sink(StrTokenizer.getCSVInstance(taint()).toString()); // $hasTaintFlow=y
-    sink(StrTokenizer.getTSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow=y
-    sink(StrTokenizer.getTSVInstance(taint()).toString()); // $hasTaintFlow=y
+    sink(StrTokenizer.getCSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow
+    sink(StrTokenizer.getCSVInstance(taint()).toString()); // $hasTaintFlow
+    sink(StrTokenizer.getTSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow
+    sink(StrTokenizer.getTSVInstance(taint()).toString()); // $hasTaintFlow
 
     // Test accessors:
-    sink((new StrTokenizer(taint())).clone()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).getContent()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).getTokenArray()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).getTokenList()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).next()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).nextToken()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).previous()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).previousToken()); // $hasTaintFlow=y
+    sink((new StrTokenizer(taint())).clone()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).getContent()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).getTokenArray()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).getTokenList()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).next()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).nextToken()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).previous()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).previousToken()); // $hasTaintFlow
 
     // Test mutators:
-    sink((new StrTokenizer()).reset(taint().toCharArray()).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer()).reset(taint()).toString()); // $hasTaintFlow=y
+    sink((new StrTokenizer()).reset(taint().toCharArray()).toString()); // $hasTaintFlow
+    sink((new StrTokenizer()).reset(taint()).toString()); // $hasTaintFlow
 
   }
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrTokenizerTextTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StrTokenizerTextTest.java
@@ -9,38 +9,38 @@ public class StrTokenizerTextTest {
   void test() throws Exception {
 
     // Test constructors:
-    sink((new StrTokenizer(taint().toCharArray())).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint().toCharArray(), ',')).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint().toCharArray(), ',', '"')).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint().toCharArray(), ",")).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint().toCharArray(), (StrMatcher)null)).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint().toCharArray(), (StrMatcher)null, (StrMatcher)null)).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint(), ',')).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint(), ',', '"')).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint(), ",")).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint(), (StrMatcher)null)).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint(), (StrMatcher)null, (StrMatcher)null)).toString()); // $hasTaintFlow=y
+    sink((new StrTokenizer(taint().toCharArray())).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint().toCharArray(), ',')).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint().toCharArray(), ',', '"')).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint().toCharArray(), ",")).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint().toCharArray(), (StrMatcher)null)).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint().toCharArray(), (StrMatcher)null, (StrMatcher)null)).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint(), ',')).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint(), ',', '"')).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint(), ",")).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint(), (StrMatcher)null)).toString()); // $hasTaintFlow
+    sink((new StrTokenizer(taint(), (StrMatcher)null, (StrMatcher)null)).toString()); // $hasTaintFlow
 
     // Test constructing static methods:
-    sink(StrTokenizer.getCSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow=y
-    sink(StrTokenizer.getCSVInstance(taint()).toString()); // $hasTaintFlow=y
-    sink(StrTokenizer.getTSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow=y
-    sink(StrTokenizer.getTSVInstance(taint()).toString()); // $hasTaintFlow=y
+    sink(StrTokenizer.getCSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow
+    sink(StrTokenizer.getCSVInstance(taint()).toString()); // $hasTaintFlow
+    sink(StrTokenizer.getTSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow
+    sink(StrTokenizer.getTSVInstance(taint()).toString()); // $hasTaintFlow
 
     // Test accessors:
-    sink((new StrTokenizer(taint())).clone()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).getContent()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).getTokenArray()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).getTokenList()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).next()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).nextToken()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).previous()); // $hasTaintFlow=y
-    sink((new StrTokenizer(taint())).previousToken()); // $hasTaintFlow=y
+    sink((new StrTokenizer(taint())).clone()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).getContent()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).getTokenArray()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).getTokenList()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).next()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).nextToken()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).previous()); // $hasTaintFlow
+    sink((new StrTokenizer(taint())).previousToken()); // $hasTaintFlow
 
     // Test mutators:
-    sink((new StrTokenizer()).reset(taint().toCharArray()).toString()); // $hasTaintFlow=y
-    sink((new StrTokenizer()).reset(taint()).toString()); // $hasTaintFlow=y
+    sink((new StrTokenizer()).reset(taint().toCharArray()).toString()); // $hasTaintFlow
+    sink((new StrTokenizer()).reset(taint()).toString()); // $hasTaintFlow
 
   }
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StringLookupTextTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StringLookupTextTest.java
@@ -12,7 +12,7 @@ class StringLookupTextTest {
       Map<String, String> map = new HashMap<String, String>();
       map.put("key", taint());
       StringLookup lookup = StringLookupFactory.INSTANCE.mapStringLookup(map);
-      sink(lookup.lookup("key")); // $hasTaintFlow=y
+      sink(lookup.lookup("key")); // $hasTaintFlow
     }
 
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StringSubstitutorTextTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StringSubstitutorTextTest.java
@@ -18,66 +18,66 @@ class StringSubstitutorTextTest {
       StringLookup taintedLookup = StringLookupFactory.INSTANCE.mapStringLookup(taintedMap);
 
       // Test constructors:
-      StringSubstitutor ss1 = new StringSubstitutor(); ss1.setVariableResolver(taintedLookup); sink(ss1.replace("input")); // $hasTaintFlow=y
-      StringSubstitutor ss2 = new StringSubstitutor(taintedMap); sink(ss2.replace("input")); // $hasTaintFlow=y
-      StringSubstitutor ss3 = new StringSubstitutor(taintedMap, "{", "}"); sink(ss3.replace("input")); // $hasTaintFlow=y
-      StringSubstitutor ss4 = new StringSubstitutor(taintedMap, "{", "}", ' '); sink(ss4.replace("input")); // $hasTaintFlow=y
-      StringSubstitutor ss5 = new StringSubstitutor(taintedMap, "{", "}", ' ', ","); sink(ss5.replace("input")); // $hasTaintFlow=y
-      StringSubstitutor ss6 = new StringSubstitutor(taintedLookup); sink(ss6.replace("input")); // $hasTaintFlow=y
-      StringSubstitutor ss7 = new StringSubstitutor(taintedLookup, "{", "}", ' '); sink(ss7.replace("input")); // $hasTaintFlow=y
-      StringSubstitutor ss8 = new StringSubstitutor(taintedLookup, "{", "}", ' ', ","); sink(ss8.replace("input")); // $hasTaintFlow=y
-      StringSubstitutor ss9 = new StringSubstitutor(taintedLookup, (StringMatcher)null, null, ' '); sink(ss9.replace("input")); // $hasTaintFlow=y
-      StringSubstitutor ss10 = new StringSubstitutor(taintedLookup, (StringMatcher)null, null, ' ', null); sink(ss10.replace("input")); // $hasTaintFlow=y
+      StringSubstitutor ss1 = new StringSubstitutor(); ss1.setVariableResolver(taintedLookup); sink(ss1.replace("input")); // $hasTaintFlow
+      StringSubstitutor ss2 = new StringSubstitutor(taintedMap); sink(ss2.replace("input")); // $hasTaintFlow
+      StringSubstitutor ss3 = new StringSubstitutor(taintedMap, "{", "}"); sink(ss3.replace("input")); // $hasTaintFlow
+      StringSubstitutor ss4 = new StringSubstitutor(taintedMap, "{", "}", ' '); sink(ss4.replace("input")); // $hasTaintFlow
+      StringSubstitutor ss5 = new StringSubstitutor(taintedMap, "{", "}", ' ', ","); sink(ss5.replace("input")); // $hasTaintFlow
+      StringSubstitutor ss6 = new StringSubstitutor(taintedLookup); sink(ss6.replace("input")); // $hasTaintFlow
+      StringSubstitutor ss7 = new StringSubstitutor(taintedLookup, "{", "}", ' '); sink(ss7.replace("input")); // $hasTaintFlow
+      StringSubstitutor ss8 = new StringSubstitutor(taintedLookup, "{", "}", ' ', ","); sink(ss8.replace("input")); // $hasTaintFlow
+      StringSubstitutor ss9 = new StringSubstitutor(taintedLookup, (StringMatcher)null, null, ' '); sink(ss9.replace("input")); // $hasTaintFlow
+      StringSubstitutor ss10 = new StringSubstitutor(taintedLookup, (StringMatcher)null, null, ' ', null); sink(ss10.replace("input")); // $hasTaintFlow
 
       // Test replace overloads (tainted substitution map):
       StringSubstitutor taintedSubst = ss2;
-      sink(taintedSubst.replace((Object)"input")); // $hasTaintFlow=y
-      sink(taintedSubst.replace("input")); // $hasTaintFlow=y
-      sink(taintedSubst.replace("input", 0, 0)); // $hasTaintFlow=y
-      sink(taintedSubst.replace("input".toCharArray())); // $hasTaintFlow=y
-      sink(taintedSubst.replace("input".toCharArray(), 0, 0)); // $hasTaintFlow=y
-      sink(taintedSubst.replace((CharSequence)"input")); // $hasTaintFlow=y
-      sink(taintedSubst.replace((CharSequence)"input", 0, 0)); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new TextStringBuilder("input"))); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new TextStringBuilder("input"), 0, 0)); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new StringBuilder("input"))); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new StringBuilder("input"), 0, 0)); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new StringBuffer("input"))); // $hasTaintFlow=y
-      sink(taintedSubst.replace(new StringBuffer("input"), 0, 0)); // $hasTaintFlow=y
+      sink(taintedSubst.replace((Object)"input")); // $hasTaintFlow
+      sink(taintedSubst.replace("input")); // $hasTaintFlow
+      sink(taintedSubst.replace("input", 0, 0)); // $hasTaintFlow
+      sink(taintedSubst.replace("input".toCharArray())); // $hasTaintFlow
+      sink(taintedSubst.replace("input".toCharArray(), 0, 0)); // $hasTaintFlow
+      sink(taintedSubst.replace((CharSequence)"input")); // $hasTaintFlow
+      sink(taintedSubst.replace((CharSequence)"input", 0, 0)); // $hasTaintFlow
+      sink(taintedSubst.replace(new TextStringBuilder("input"))); // $hasTaintFlow
+      sink(taintedSubst.replace(new TextStringBuilder("input"), 0, 0)); // $hasTaintFlow
+      sink(taintedSubst.replace(new StringBuilder("input"))); // $hasTaintFlow
+      sink(taintedSubst.replace(new StringBuilder("input"), 0, 0)); // $hasTaintFlow
+      sink(taintedSubst.replace(new StringBuffer("input"))); // $hasTaintFlow
+      sink(taintedSubst.replace(new StringBuffer("input"), 0, 0)); // $hasTaintFlow
 
       // Test replace overloads (tainted input):
       StringSubstitutor untaintedSubst = ss1;
-      sink(untaintedSubst.replace((Object)taint())); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(taint())); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(taint(), 0, 0)); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(taint().toCharArray())); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(taint().toCharArray(), 0, 0)); // $hasTaintFlow=y
-      sink(untaintedSubst.replace((CharSequence)taint())); // $hasTaintFlow=y
-      sink(untaintedSubst.replace((CharSequence)taint(), 0, 0)); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new TextStringBuilder(taint()))); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new TextStringBuilder(taint()), 0, 0)); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new StringBuilder(taint()))); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new StringBuilder(taint()), 0, 0)); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new StringBuffer(taint()))); // $hasTaintFlow=y
-      sink(untaintedSubst.replace(new StringBuffer(taint()), 0, 0)); // $hasTaintFlow=y
+      sink(untaintedSubst.replace((Object)taint())); // $hasTaintFlow
+      sink(untaintedSubst.replace(taint())); // $hasTaintFlow
+      sink(untaintedSubst.replace(taint(), 0, 0)); // $hasTaintFlow
+      sink(untaintedSubst.replace(taint().toCharArray())); // $hasTaintFlow
+      sink(untaintedSubst.replace(taint().toCharArray(), 0, 0)); // $hasTaintFlow
+      sink(untaintedSubst.replace((CharSequence)taint())); // $hasTaintFlow
+      sink(untaintedSubst.replace((CharSequence)taint(), 0, 0)); // $hasTaintFlow
+      sink(untaintedSubst.replace(new TextStringBuilder(taint()))); // $hasTaintFlow
+      sink(untaintedSubst.replace(new TextStringBuilder(taint()), 0, 0)); // $hasTaintFlow
+      sink(untaintedSubst.replace(new StringBuilder(taint()))); // $hasTaintFlow
+      sink(untaintedSubst.replace(new StringBuilder(taint()), 0, 0)); // $hasTaintFlow
+      sink(untaintedSubst.replace(new StringBuffer(taint()))); // $hasTaintFlow
+      sink(untaintedSubst.replace(new StringBuffer(taint()), 0, 0)); // $hasTaintFlow
 
       // Test static replace methods:
-      sink(StringSubstitutor.replace(taint(), new HashMap<String, String>())); // $hasTaintFlow=y
-      sink(StringSubstitutor.replace(taint(), new HashMap<String, String>(), "{", "}")); // $hasTaintFlow=y
-      sink(StringSubstitutor.replace("input", taintedMap)); // $hasTaintFlow=y
-      sink(StringSubstitutor.replace("input", taintedMap, "{", "}")); // $hasTaintFlow=y
+      sink(StringSubstitutor.replace(taint(), new HashMap<String, String>())); // $hasTaintFlow
+      sink(StringSubstitutor.replace(taint(), new HashMap<String, String>(), "{", "}")); // $hasTaintFlow
+      sink(StringSubstitutor.replace("input", taintedMap)); // $hasTaintFlow
+      sink(StringSubstitutor.replace("input", taintedMap, "{", "}")); // $hasTaintFlow
       Properties taintedProps = new Properties();
       taintedProps.put("key", taint());
-      sink(StringSubstitutor.replace(taint(), new Properties())); // $hasTaintFlow=y
-      sink(StringSubstitutor.replace("input", taintedProps)); // $hasTaintFlow=y
+      sink(StringSubstitutor.replace(taint(), new Properties())); // $hasTaintFlow
+      sink(StringSubstitutor.replace("input", taintedProps)); // $hasTaintFlow
 
       // Test replaceIn methods:
-      TextStringBuilder strBuilder1 = new TextStringBuilder(); taintedSubst.replaceIn(strBuilder1); sink(strBuilder1.toString()); // $hasTaintFlow=y
-      TextStringBuilder strBuilder2 = new TextStringBuilder(); taintedSubst.replaceIn(strBuilder2, 0, 0); sink(strBuilder2.toString()); // $hasTaintFlow=y
-      StringBuilder stringBuilder1 = new StringBuilder(); taintedSubst.replaceIn(stringBuilder1); sink(stringBuilder1.toString()); // $hasTaintFlow=y
-      StringBuilder stringBuilder2 = new StringBuilder(); taintedSubst.replaceIn(stringBuilder2, 0, 0); sink(stringBuilder2.toString()); // $hasTaintFlow=y
-      StringBuffer stringBuffer1 = new StringBuffer(); taintedSubst.replaceIn(stringBuffer1); sink(stringBuffer1.toString()); // $hasTaintFlow=y
-      StringBuffer stringBuffer2 = new StringBuffer(); taintedSubst.replaceIn(stringBuffer2, 0, 0); sink(stringBuffer2.toString()); // $hasTaintFlow=y
+      TextStringBuilder strBuilder1 = new TextStringBuilder(); taintedSubst.replaceIn(strBuilder1); sink(strBuilder1.toString()); // $hasTaintFlow
+      TextStringBuilder strBuilder2 = new TextStringBuilder(); taintedSubst.replaceIn(strBuilder2, 0, 0); sink(strBuilder2.toString()); // $hasTaintFlow
+      StringBuilder stringBuilder1 = new StringBuilder(); taintedSubst.replaceIn(stringBuilder1); sink(stringBuilder1.toString()); // $hasTaintFlow
+      StringBuilder stringBuilder2 = new StringBuilder(); taintedSubst.replaceIn(stringBuilder2, 0, 0); sink(stringBuilder2.toString()); // $hasTaintFlow
+      StringBuffer stringBuffer1 = new StringBuffer(); taintedSubst.replaceIn(stringBuffer1); sink(stringBuffer1.toString()); // $hasTaintFlow
+      StringBuffer stringBuffer2 = new StringBuffer(); taintedSubst.replaceIn(stringBuffer2, 0, 0); sink(stringBuffer2.toString()); // $hasTaintFlow
     }
 
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StringTokenizerTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StringTokenizerTest.java
@@ -9,38 +9,38 @@ public class StringTokenizerTest {
   void test() throws Exception {
 
     // Test constructors:
-    sink((new StringTokenizer(taint().toCharArray())).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint().toCharArray(), ',')).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint().toCharArray(), ',', '"')).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint().toCharArray(), ",")).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint().toCharArray(), (StringMatcher)null)).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint().toCharArray(), (StringMatcher)null, (StringMatcher)null)).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint())).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint(), ',')).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint(), ',', '"')).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint(), ",")).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint(), (StringMatcher)null)).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint(), (StringMatcher)null, (StringMatcher)null)).toString()); // $hasTaintFlow=y
+    sink((new StringTokenizer(taint().toCharArray())).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint().toCharArray(), ',')).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint().toCharArray(), ',', '"')).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint().toCharArray(), ",")).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint().toCharArray(), (StringMatcher)null)).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint().toCharArray(), (StringMatcher)null, (StringMatcher)null)).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint())).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint(), ',')).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint(), ',', '"')).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint(), ",")).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint(), (StringMatcher)null)).toString()); // $hasTaintFlow
+    sink((new StringTokenizer(taint(), (StringMatcher)null, (StringMatcher)null)).toString()); // $hasTaintFlow
 
     // Test constructing static methods:
-    sink(StringTokenizer.getCSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow=y
-    sink(StringTokenizer.getCSVInstance(taint()).toString()); // $hasTaintFlow=y
-    sink(StringTokenizer.getTSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow=y
-    sink(StringTokenizer.getTSVInstance(taint()).toString()); // $hasTaintFlow=y
+    sink(StringTokenizer.getCSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow
+    sink(StringTokenizer.getCSVInstance(taint()).toString()); // $hasTaintFlow
+    sink(StringTokenizer.getTSVInstance(taint().toCharArray()).toString()); // $hasTaintFlow
+    sink(StringTokenizer.getTSVInstance(taint()).toString()); // $hasTaintFlow
 
     // Test accessors:
-    sink((new StringTokenizer(taint())).clone()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint())).getContent()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint())).getTokenArray()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint())).getTokenList()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint())).next()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint())).nextToken()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint())).previous()); // $hasTaintFlow=y
-    sink((new StringTokenizer(taint())).previousToken()); // $hasTaintFlow=y
+    sink((new StringTokenizer(taint())).clone()); // $hasTaintFlow
+    sink((new StringTokenizer(taint())).getContent()); // $hasTaintFlow
+    sink((new StringTokenizer(taint())).getTokenArray()); // $hasTaintFlow
+    sink((new StringTokenizer(taint())).getTokenList()); // $hasTaintFlow
+    sink((new StringTokenizer(taint())).next()); // $hasTaintFlow
+    sink((new StringTokenizer(taint())).nextToken()); // $hasTaintFlow
+    sink((new StringTokenizer(taint())).previous()); // $hasTaintFlow
+    sink((new StringTokenizer(taint())).previousToken()); // $hasTaintFlow
 
     // Test mutators:
-    sink((new StringTokenizer()).reset(taint().toCharArray()).toString()); // $hasTaintFlow=y
-    sink((new StringTokenizer()).reset(taint()).toString()); // $hasTaintFlow=y
+    sink((new StringTokenizer()).reset(taint().toCharArray()).toString()); // $hasTaintFlow
+    sink((new StringTokenizer()).reset(taint()).toString()); // $hasTaintFlow
 
   }
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/Test.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/Test.java
@@ -12,57 +12,57 @@ class Test {
     void test() throws Exception {
 
         // All these calls should convey taint to `sink` except as noted.
-        sink(StringUtils.abbreviate(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.abbreviate(taint(), 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.abbreviate(taint(), "...", 0)); // $hasTaintFlow=y
-        sink(StringUtils.abbreviate("Untainted", taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.abbreviate(taint(), "...", 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.abbreviate("Untainted", taint(), 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.abbreviateMiddle(taint(), "...", 0)); // $hasTaintFlow=y
-        sink(StringUtils.abbreviateMiddle("Untainted", taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.appendIfMissing(taint(), "suffix", "candsuffix1", "candsuffix2")); // $hasTaintFlow=y
-        sink(StringUtils.appendIfMissing("prefix", taint(), "candsuffix1", "candsuffix2")); // $hasTaintFlow=y
+        sink(StringUtils.abbreviate(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.abbreviate(taint(), 0, 0)); // $hasTaintFlow
+        sink(StringUtils.abbreviate(taint(), "...", 0)); // $hasTaintFlow
+        sink(StringUtils.abbreviate("Untainted", taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.abbreviate(taint(), "...", 0, 0)); // $hasTaintFlow
+        sink(StringUtils.abbreviate("Untainted", taint(), 0, 0)); // $hasTaintFlow
+        sink(StringUtils.abbreviateMiddle(taint(), "...", 0)); // $hasTaintFlow
+        sink(StringUtils.abbreviateMiddle("Untainted", taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.appendIfMissing(taint(), "suffix", "candsuffix1", "candsuffix2")); // $hasTaintFlow
+        sink(StringUtils.appendIfMissing("prefix", taint(), "candsuffix1", "candsuffix2")); // $hasTaintFlow
         // (next 2 calls) GOOD: candidate suffixes do not flow to the return value.
         sink(StringUtils.appendIfMissing("prefix", "suffix", taint(), "candsuffix2"));
         sink(StringUtils.appendIfMissing("prefix", "suffix", "candsuffix1", taint()));
-        sink(StringUtils.appendIfMissingIgnoreCase(taint(), "suffix", "candsuffix1", "candsuffix2")); // $hasTaintFlow=y
-        sink(StringUtils.appendIfMissingIgnoreCase("prefix", taint(), "candsuffix1", "candsuffix2")); // $hasTaintFlow=y
+        sink(StringUtils.appendIfMissingIgnoreCase(taint(), "suffix", "candsuffix1", "candsuffix2")); // $hasTaintFlow
+        sink(StringUtils.appendIfMissingIgnoreCase("prefix", taint(), "candsuffix1", "candsuffix2")); // $hasTaintFlow
         // (next 2 calls) GOOD: candidate suffixes do not flow to the return value.
         sink(StringUtils.appendIfMissingIgnoreCase("prefix", "suffix", taint(), "candsuffix2"));
         sink(StringUtils.appendIfMissingIgnoreCase("prefix", "suffix", "candsuffix1", taint()));
-        sink(StringUtils.capitalize(taint())); // $hasTaintFlow=y
-        sink(StringUtils.center(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.center(taint(), 0, 'x')); // $hasTaintFlow=y
-        sink(StringUtils.center(taint(), 0, "padding string")); // $hasTaintFlow=y
-        sink(StringUtils.center("Center me", 0, taint())); // $hasTaintFlow=y
-        sink(StringUtils.chomp(taint())); // $hasTaintFlow=y
-        sink(StringUtils.chomp(taint(), "separator")); // $hasTaintFlow=y
+        sink(StringUtils.capitalize(taint())); // $hasTaintFlow
+        sink(StringUtils.center(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.center(taint(), 0, 'x')); // $hasTaintFlow
+        sink(StringUtils.center(taint(), 0, "padding string")); // $hasTaintFlow
+        sink(StringUtils.center("Center me", 0, taint())); // $hasTaintFlow
+        sink(StringUtils.chomp(taint())); // $hasTaintFlow
+        sink(StringUtils.chomp(taint(), "separator")); // $hasTaintFlow
         // GOOD: separator does not flow to the return value.
         sink(StringUtils.chomp("Chomp me", taint()));
-        sink(StringUtils.chop(taint())); // $hasTaintFlow=y
-        sink(StringUtils.defaultIfBlank(taint(), "default")); // $hasTaintFlow=y
-        sink(StringUtils.defaultIfBlank("Perhaps blank", taint())); // $hasTaintFlow=y
-        sink(StringUtils.defaultIfEmpty(taint(), "default")); // $hasTaintFlow=y
-        sink(StringUtils.defaultIfEmpty("Perhaps empty", taint())); // $hasTaintFlow=y
-        sink(StringUtils.defaultString(taint())); // $hasTaintFlow=y
-        sink(StringUtils.defaultString(taint(), "default string")); // $hasTaintFlow=y
-        sink(StringUtils.defaultString("perhaps null", taint())); // $hasTaintFlow=y
-        sink(StringUtils.deleteWhitespace(taint())); // $hasTaintFlow=y
-        sink(StringUtils.difference(taint(), "rhs")); // $hasTaintFlow=y
-        sink(StringUtils.difference("lhs", taint())); // $hasTaintFlow=y
-        sink(StringUtils.firstNonBlank(taint(), "second string")); // $hasTaintFlow=y
-        sink(StringUtils.firstNonBlank("first string", taint())); // $hasTaintFlow=y
-        sink(StringUtils.firstNonEmpty(taint(), "second string")); // $hasTaintFlow=y
-        sink(StringUtils.firstNonEmpty("first string", taint())); // $hasTaintFlow=y
-        sink(StringUtils.getBytes(taint(), (Charset)null)); // $hasTaintFlow=y
-        sink(StringUtils.getBytes(taint(), "some charset")); // $hasTaintFlow=y
+        sink(StringUtils.chop(taint())); // $hasTaintFlow
+        sink(StringUtils.defaultIfBlank(taint(), "default")); // $hasTaintFlow
+        sink(StringUtils.defaultIfBlank("Perhaps blank", taint())); // $hasTaintFlow
+        sink(StringUtils.defaultIfEmpty(taint(), "default")); // $hasTaintFlow
+        sink(StringUtils.defaultIfEmpty("Perhaps empty", taint())); // $hasTaintFlow
+        sink(StringUtils.defaultString(taint())); // $hasTaintFlow
+        sink(StringUtils.defaultString(taint(), "default string")); // $hasTaintFlow
+        sink(StringUtils.defaultString("perhaps null", taint())); // $hasTaintFlow
+        sink(StringUtils.deleteWhitespace(taint())); // $hasTaintFlow
+        sink(StringUtils.difference(taint(), "rhs")); // $hasTaintFlow
+        sink(StringUtils.difference("lhs", taint())); // $hasTaintFlow
+        sink(StringUtils.firstNonBlank(taint(), "second string")); // $hasTaintFlow
+        sink(StringUtils.firstNonBlank("first string", taint())); // $hasTaintFlow
+        sink(StringUtils.firstNonEmpty(taint(), "second string")); // $hasTaintFlow
+        sink(StringUtils.firstNonEmpty("first string", taint())); // $hasTaintFlow
+        sink(StringUtils.getBytes(taint(), (Charset)null)); // $hasTaintFlow
+        sink(StringUtils.getBytes(taint(), "some charset")); // $hasTaintFlow
         // GOOD: charset names are not a source of taint
         sink(StringUtils.getBytes("some string", taint()));
-        sink(StringUtils.getCommonPrefix(taint(), "second string")); // $hasTaintFlow=y
-        sink(StringUtils.getCommonPrefix("first string", taint())); // $hasTaintFlow=y
-        sink(StringUtils.getDigits(taint())); // $hasTaintFlow=y
-        sink(StringUtils.getIfBlank(taint(), () -> "default")); // $hasTaintFlow=y
-        sink(StringUtils.getIfEmpty(taint(), () -> "default")); // $hasTaintFlow=y
+        sink(StringUtils.getCommonPrefix(taint(), "second string")); // $hasTaintFlow
+        sink(StringUtils.getCommonPrefix("first string", taint())); // $hasTaintFlow
+        sink(StringUtils.getDigits(taint())); // $hasTaintFlow
+        sink(StringUtils.getIfBlank(taint(), () -> "default")); // $hasTaintFlow
+        sink(StringUtils.getIfEmpty(taint(), () -> "default")); // $hasTaintFlow
         // BAD (but not detected yet): latent taint in lambdas
         sink(StringUtils.getIfBlank("maybe blank", () -> taint()));
         sink(StringUtils.getIfEmpty("maybe blank", () -> taint()));
@@ -70,70 +70,70 @@ class Test {
         // of tainted data.
         sink(StringUtils.join(StringUtils.getBytes(taint(), "UTF-8"), ' '));
         sink(StringUtils.join(StringUtils.getBytes(taint(), "UTF-8"), ' ', 0, 0));
-        sink(StringUtils.join(taint().toCharArray(), ' ')); // $hasTaintFlow=y
-        sink(StringUtils.join(taint().toCharArray(), ' ', 0, 0)); // $hasTaintFlow=y
+        sink(StringUtils.join(taint().toCharArray(), ' ')); // $hasTaintFlow
+        sink(StringUtils.join(taint().toCharArray(), ' ', 0, 0)); // $hasTaintFlow
         // Testing the Iterable<?> overloads of `join`
         List<String> taintedList = new ArrayList<>();
         taintedList.add(taint());
-        sink(StringUtils.join(taintedList, ' ')); // $hasTaintFlow=y
-        sink(StringUtils.join(taintedList, "sep")); // $hasTaintFlow=y
+        sink(StringUtils.join(taintedList, ' ')); // $hasTaintFlow
+        sink(StringUtils.join(taintedList, "sep")); // $hasTaintFlow
         List<String> untaintedList = new ArrayList<>();
-        sink(StringUtils.join(untaintedList, taint())); // $hasTaintFlow=y
+        sink(StringUtils.join(untaintedList, taint())); // $hasTaintFlow
         // Testing the Iterator<?> overloads of `join`
-        sink(StringUtils.join(taintedList.iterator(), ' ')); // $hasTaintFlow=y
-        sink(StringUtils.join(taintedList.iterator(), "sep")); // $hasTaintFlow=y
-        sink(StringUtils.join(untaintedList.iterator(), taint())); // $hasTaintFlow=y
+        sink(StringUtils.join(taintedList.iterator(), ' ')); // $hasTaintFlow
+        sink(StringUtils.join(taintedList.iterator(), "sep")); // $hasTaintFlow
+        sink(StringUtils.join(untaintedList.iterator(), taint())); // $hasTaintFlow
         // Testing the List<?> overloads of `join`, which have start/end indices
-        sink(StringUtils.join(taintedList, ' ', 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.join(taintedList, "sep", 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.join(untaintedList, taint(), 0, 0)); // $hasTaintFlow=y
+        sink(StringUtils.join(taintedList, ' ', 0, 0)); // $hasTaintFlow
+        sink(StringUtils.join(taintedList, "sep", 0, 0)); // $hasTaintFlow
+        sink(StringUtils.join(untaintedList, taint(), 0, 0)); // $hasTaintFlow
         // Testing the Object[] overloads of `join`, which may have start/end indices
         Object[] taintedArray = new Object[] { taint() };
-        sink(StringUtils.join(taintedArray, ' ')); // $hasTaintFlow=y
-        sink(StringUtils.join(taintedArray, "sep")); // $hasTaintFlow=y
-        sink(StringUtils.join(taintedArray, ' ', 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.join(taintedArray, "sep", 0, 0)); // $hasTaintFlow=y
+        sink(StringUtils.join(taintedArray, ' ')); // $hasTaintFlow
+        sink(StringUtils.join(taintedArray, "sep")); // $hasTaintFlow
+        sink(StringUtils.join(taintedArray, ' ', 0, 0)); // $hasTaintFlow
+        sink(StringUtils.join(taintedArray, "sep", 0, 0)); // $hasTaintFlow
         Object[] untaintedArray = new Object[] { "safe" };
-        sink(StringUtils.join(untaintedArray, taint())); // $hasTaintFlow=y
-        sink(StringUtils.join(untaintedArray, taint(), 0, 0)); // $hasTaintFlow=y
+        sink(StringUtils.join(untaintedArray, taint())); // $hasTaintFlow
+        sink(StringUtils.join(untaintedArray, taint(), 0, 0)); // $hasTaintFlow
         // Testing the variadic overload of `join` and `joinWith`
-        sink(StringUtils.join(taint(), "other string")); // $hasTaintFlow=y
-        sink(StringUtils.join("other string before", taint())); // $hasTaintFlow=y
-        sink(StringUtils.joinWith("separator", taint(), "other string")); // $hasTaintFlow=y
-        sink(StringUtils.joinWith("separator", "other string before", taint())); // $hasTaintFlow=y
-        sink(StringUtils.joinWith(taint(), "other string before", "other string after")); // $hasTaintFlow=y
+        sink(StringUtils.join(taint(), "other string")); // $hasTaintFlow
+        sink(StringUtils.join("other string before", taint())); // $hasTaintFlow
+        sink(StringUtils.joinWith("separator", taint(), "other string")); // $hasTaintFlow
+        sink(StringUtils.joinWith("separator", "other string before", taint())); // $hasTaintFlow
+        sink(StringUtils.joinWith(taint(), "other string before", "other string after")); // $hasTaintFlow
         // End of `join` tests
-        sink(StringUtils.left(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.leftPad(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.leftPad(taint(), 0, ' ')); // $hasTaintFlow=y
-        sink(StringUtils.leftPad(taint(), 0, "padding")); // $hasTaintFlow=y
-        sink(StringUtils.leftPad("to pad", 0, taint())); // $hasTaintFlow=y
-        sink(StringUtils.lowerCase(taint())); // $hasTaintFlow=y
-        sink(StringUtils.lowerCase(taint(), Locale.UK)); // $hasTaintFlow=y
-        sink(StringUtils.mid(taint(), 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.normalizeSpace(taint())); // $hasTaintFlow=y
-        sink(StringUtils.overlay(taint(), "overlay", 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.overlay("underlay", taint(), 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.prependIfMissing(taint(), "append prefix", "check prefix 1", "check prefix 2")); // $hasTaintFlow=y
-        sink(StringUtils.prependIfMissing("original string", taint(), "check prefix 1", "check prefix 2")); // $hasTaintFlow=y
+        sink(StringUtils.left(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.leftPad(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.leftPad(taint(), 0, ' ')); // $hasTaintFlow
+        sink(StringUtils.leftPad(taint(), 0, "padding")); // $hasTaintFlow
+        sink(StringUtils.leftPad("to pad", 0, taint())); // $hasTaintFlow
+        sink(StringUtils.lowerCase(taint())); // $hasTaintFlow
+        sink(StringUtils.lowerCase(taint(), Locale.UK)); // $hasTaintFlow
+        sink(StringUtils.mid(taint(), 0, 0)); // $hasTaintFlow
+        sink(StringUtils.normalizeSpace(taint())); // $hasTaintFlow
+        sink(StringUtils.overlay(taint(), "overlay", 0, 0)); // $hasTaintFlow
+        sink(StringUtils.overlay("underlay", taint(), 0, 0)); // $hasTaintFlow
+        sink(StringUtils.prependIfMissing(taint(), "append prefix", "check prefix 1", "check prefix 2")); // $hasTaintFlow
+        sink(StringUtils.prependIfMissing("original string", taint(), "check prefix 1", "check prefix 2")); // $hasTaintFlow
         // (next 2 calls) GOOD: args 3+ are checked against but do not propagate to the return value
         sink(StringUtils.prependIfMissing("original string", "append prefix", taint(), "check prefix 2"));
         sink(StringUtils.prependIfMissing("original string", "append prefix", "check prefix 1", taint()));
-        sink(StringUtils.prependIfMissingIgnoreCase(taint(), "append prefix", "check prefix 1", "check prefix 2")); // $hasTaintFlow=y
-        sink(StringUtils.prependIfMissingIgnoreCase("original string", taint(), "check prefix 1", "check prefix 2")); // $hasTaintFlow=y
+        sink(StringUtils.prependIfMissingIgnoreCase(taint(), "append prefix", "check prefix 1", "check prefix 2")); // $hasTaintFlow
+        sink(StringUtils.prependIfMissingIgnoreCase("original string", taint(), "check prefix 1", "check prefix 2")); // $hasTaintFlow
         // (next 2 calls) GOOD: args 3+ are checked against but do not propagate to the return value
         sink(StringUtils.prependIfMissingIgnoreCase("original string", "append prefix", taint(), "check prefix 2"));
         sink(StringUtils.prependIfMissingIgnoreCase("original string", "append prefix", "check prefix 1", taint()));
-        sink(StringUtils.remove(taint(), ' ')); // $hasTaintFlow=y
-        sink(StringUtils.remove(taint(), "delete me")); // $hasTaintFlow=y
-        sink(StringUtils.removeAll(taint(), "delete me")); // $hasTaintFlow=y
-        sink(StringUtils.removeEnd(taint(), "delete me")); // $hasTaintFlow=y
-        sink(StringUtils.removeEndIgnoreCase(taint(), "delete me")); // $hasTaintFlow=y
-        sink(StringUtils.removeFirst(taint(), "delete me")); // $hasTaintFlow=y
-        sink(StringUtils.removeIgnoreCase(taint(), "delete me")); // $hasTaintFlow=y
-        sink(StringUtils.removePattern(taint(), "delete me")); // $hasTaintFlow=y
-        sink(StringUtils.removeStart(taint(), "delete me")); // $hasTaintFlow=y
-        sink(StringUtils.removeStartIgnoreCase(taint(), "delete me")); // $hasTaintFlow=y
+        sink(StringUtils.remove(taint(), ' ')); // $hasTaintFlow
+        sink(StringUtils.remove(taint(), "delete me")); // $hasTaintFlow
+        sink(StringUtils.removeAll(taint(), "delete me")); // $hasTaintFlow
+        sink(StringUtils.removeEnd(taint(), "delete me")); // $hasTaintFlow
+        sink(StringUtils.removeEndIgnoreCase(taint(), "delete me")); // $hasTaintFlow
+        sink(StringUtils.removeFirst(taint(), "delete me")); // $hasTaintFlow
+        sink(StringUtils.removeIgnoreCase(taint(), "delete me")); // $hasTaintFlow
+        sink(StringUtils.removePattern(taint(), "delete me")); // $hasTaintFlow
+        sink(StringUtils.removeStart(taint(), "delete me")); // $hasTaintFlow
+        sink(StringUtils.removeStartIgnoreCase(taint(), "delete me")); // $hasTaintFlow
         // GOOD (next 9 calls): the removed string doesn't propagate to the return value
         sink(StringUtils.remove("remove from", taint()));
         sink(StringUtils.removeAll("remove from", taint()));
@@ -144,32 +144,32 @@ class Test {
         sink(StringUtils.removePattern("remove from", taint()));
         sink(StringUtils.removeStart("remove from", taint()));
         sink(StringUtils.removeStartIgnoreCase("remove from", taint()));
-        sink(StringUtils.repeat(taint(), 1)); // $hasTaintFlow=y
-        sink(StringUtils.repeat(taint(), "separator", 1)); // $hasTaintFlow=y
-        sink(StringUtils.repeat("repeat me", taint(), 1)); // $hasTaintFlow=y
-        sink(StringUtils.replace(taint(), "search", "replacement")); // $hasTaintFlow=y
-        sink(StringUtils.replace("haystack", "search", taint())); // $hasTaintFlow=y
-        sink(StringUtils.replace(taint(), "search", "replacement", 0)); // $hasTaintFlow=y
-        sink(StringUtils.replace("haystack", "search", taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.replaceAll(taint(), "search", "replacement")); // $hasTaintFlow=y
-        sink(StringUtils.replaceAll("haystack", "search", taint())); // $hasTaintFlow=y
-        sink(StringUtils.replaceChars(taint(), 'a', 'b')); // $hasTaintFlow=y
-        sink(StringUtils.replaceChars(taint(), "abc", "xyz")); // $hasTaintFlow=y
-        sink(StringUtils.replaceChars("haystack", "abc", taint())); // $hasTaintFlow=y
-        sink(StringUtils.replaceEach(taint(), new String[] { "search" }, new String[] { "replacement" })); // $hasTaintFlow=y
-        sink(StringUtils.replaceEach("haystack", new String[] { "search" }, new String[] { taint() })); // $hasTaintFlow=y
-        sink(StringUtils.replaceEachRepeatedly(taint(), new String[] { "search" }, new String[] { "replacement" })); // $hasTaintFlow=y
-        sink(StringUtils.replaceEachRepeatedly("haystack", new String[] { "search" }, new String[] { taint() })); // $hasTaintFlow=y
-        sink(StringUtils.replaceFirst(taint(), "search", "replacement")); // $hasTaintFlow=y
-        sink(StringUtils.replaceFirst("haystack", "search", taint())); // $hasTaintFlow=y
-        sink(StringUtils.replaceIgnoreCase(taint(), "search", "replacement")); // $hasTaintFlow=y
-        sink(StringUtils.replaceIgnoreCase("haystack", "search", taint())); // $hasTaintFlow=y
-        sink(StringUtils.replaceOnce(taint(), "search", "replacement")); // $hasTaintFlow=y
-        sink(StringUtils.replaceOnce("haystack", "search", taint())); // $hasTaintFlow=y
-        sink(StringUtils.replaceOnceIgnoreCase(taint(), "search", "replacement")); // $hasTaintFlow=y
-        sink(StringUtils.replaceOnceIgnoreCase("haystack", "search", taint())); // $hasTaintFlow=y
-        sink(StringUtils.replacePattern(taint(), "search", "replacement")); // $hasTaintFlow=y
-        sink(StringUtils.replacePattern("haystack", "search", taint())); // $hasTaintFlow=y
+        sink(StringUtils.repeat(taint(), 1)); // $hasTaintFlow
+        sink(StringUtils.repeat(taint(), "separator", 1)); // $hasTaintFlow
+        sink(StringUtils.repeat("repeat me", taint(), 1)); // $hasTaintFlow
+        sink(StringUtils.replace(taint(), "search", "replacement")); // $hasTaintFlow
+        sink(StringUtils.replace("haystack", "search", taint())); // $hasTaintFlow
+        sink(StringUtils.replace(taint(), "search", "replacement", 0)); // $hasTaintFlow
+        sink(StringUtils.replace("haystack", "search", taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.replaceAll(taint(), "search", "replacement")); // $hasTaintFlow
+        sink(StringUtils.replaceAll("haystack", "search", taint())); // $hasTaintFlow
+        sink(StringUtils.replaceChars(taint(), 'a', 'b')); // $hasTaintFlow
+        sink(StringUtils.replaceChars(taint(), "abc", "xyz")); // $hasTaintFlow
+        sink(StringUtils.replaceChars("haystack", "abc", taint())); // $hasTaintFlow
+        sink(StringUtils.replaceEach(taint(), new String[] { "search" }, new String[] { "replacement" })); // $hasTaintFlow
+        sink(StringUtils.replaceEach("haystack", new String[] { "search" }, new String[] { taint() })); // $hasTaintFlow
+        sink(StringUtils.replaceEachRepeatedly(taint(), new String[] { "search" }, new String[] { "replacement" })); // $hasTaintFlow
+        sink(StringUtils.replaceEachRepeatedly("haystack", new String[] { "search" }, new String[] { taint() })); // $hasTaintFlow
+        sink(StringUtils.replaceFirst(taint(), "search", "replacement")); // $hasTaintFlow
+        sink(StringUtils.replaceFirst("haystack", "search", taint())); // $hasTaintFlow
+        sink(StringUtils.replaceIgnoreCase(taint(), "search", "replacement")); // $hasTaintFlow
+        sink(StringUtils.replaceIgnoreCase("haystack", "search", taint())); // $hasTaintFlow
+        sink(StringUtils.replaceOnce(taint(), "search", "replacement")); // $hasTaintFlow
+        sink(StringUtils.replaceOnce("haystack", "search", taint())); // $hasTaintFlow
+        sink(StringUtils.replaceOnceIgnoreCase(taint(), "search", "replacement")); // $hasTaintFlow
+        sink(StringUtils.replaceOnceIgnoreCase("haystack", "search", taint())); // $hasTaintFlow
+        sink(StringUtils.replacePattern(taint(), "search", "replacement")); // $hasTaintFlow
+        sink(StringUtils.replacePattern("haystack", "search", taint())); // $hasTaintFlow
         // GOOD (next 11 calls): searched string in replace methods does not flow to the return value.
         sink(StringUtils.replace("haystack", taint(), "replacement"));
         sink(StringUtils.replace("haystack", taint(), "replacement", 0));
@@ -182,28 +182,28 @@ class Test {
         sink(StringUtils.replaceOnce("haystack", taint(), "replacement"));
         sink(StringUtils.replaceOnceIgnoreCase("haystack", taint(), "replacement"));
         sink(StringUtils.replacePattern("haystack", taint(), "replacement"));
-        sink(StringUtils.reverse(taint())); // $hasTaintFlow=y
-        sink(StringUtils.reverseDelimited(taint(), ',')); // $hasTaintFlow=y
-        sink(StringUtils.right(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.rightPad(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.rightPad(taint(), 0, ' ')); // $hasTaintFlow=y
-        sink(StringUtils.rightPad(taint(), 0, "padding")); // $hasTaintFlow=y
-        sink(StringUtils.rightPad("to pad", 0, taint())); // $hasTaintFlow=y
-        sink(StringUtils.rotate(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.split(taint())); // $hasTaintFlow=y
-        sink(StringUtils.split(taint(), ' ')); // $hasTaintFlow=y
-        sink(StringUtils.split(taint(), " ,; // $hasTaintFlow=y")); // $hasTaintFlow=y
-        sink(StringUtils.split(taint(), " ,; // $hasTaintFlow=y", 0)); // $hasTaintFlow=y
-        sink(StringUtils.splitByCharacterType(taint())); // $hasTaintFlow=y
-        sink(StringUtils.splitByCharacterTypeCamelCase(taint())); // $hasTaintFlow=y
-        sink(StringUtils.splitByWholeSeparator(taint(), "separator")); // $hasTaintFlow=y
-        sink(StringUtils.splitByWholeSeparator(taint(), "separator", 0)); // $hasTaintFlow=y
-        sink(StringUtils.splitByWholeSeparatorPreserveAllTokens(taint(), "separator")); // $hasTaintFlow=y
-        sink(StringUtils.splitByWholeSeparatorPreserveAllTokens(taint(), "separator", 0)); // $hasTaintFlow=y
-        sink(StringUtils.splitPreserveAllTokens(taint())); // $hasTaintFlow=y
-        sink(StringUtils.splitPreserveAllTokens(taint(), ' ')); // $hasTaintFlow=y
-        sink(StringUtils.splitPreserveAllTokens(taint(), " ,;")); // $hasTaintFlow=y
-        sink(StringUtils.splitPreserveAllTokens(taint(), " ,;", 0)); // $hasTaintFlow=y
+        sink(StringUtils.reverse(taint())); // $hasTaintFlow
+        sink(StringUtils.reverseDelimited(taint(), ',')); // $hasTaintFlow
+        sink(StringUtils.right(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.rightPad(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.rightPad(taint(), 0, ' ')); // $hasTaintFlow
+        sink(StringUtils.rightPad(taint(), 0, "padding")); // $hasTaintFlow
+        sink(StringUtils.rightPad("to pad", 0, taint())); // $hasTaintFlow
+        sink(StringUtils.rotate(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.split(taint())); // $hasTaintFlow
+        sink(StringUtils.split(taint(), ' ')); // $hasTaintFlow
+        sink(StringUtils.split(taint(), " ,; // $hasTaintFlow")); // $hasTaintFlow
+        sink(StringUtils.split(taint(), " ,; // $hasTaintFlow", 0)); // $hasTaintFlow
+        sink(StringUtils.splitByCharacterType(taint())); // $hasTaintFlow
+        sink(StringUtils.splitByCharacterTypeCamelCase(taint())); // $hasTaintFlow
+        sink(StringUtils.splitByWholeSeparator(taint(), "separator")); // $hasTaintFlow
+        sink(StringUtils.splitByWholeSeparator(taint(), "separator", 0)); // $hasTaintFlow
+        sink(StringUtils.splitByWholeSeparatorPreserveAllTokens(taint(), "separator")); // $hasTaintFlow
+        sink(StringUtils.splitByWholeSeparatorPreserveAllTokens(taint(), "separator", 0)); // $hasTaintFlow
+        sink(StringUtils.splitPreserveAllTokens(taint())); // $hasTaintFlow
+        sink(StringUtils.splitPreserveAllTokens(taint(), ' ')); // $hasTaintFlow
+        sink(StringUtils.splitPreserveAllTokens(taint(), " ,;")); // $hasTaintFlow
+        sink(StringUtils.splitPreserveAllTokens(taint(), " ,;", 0)); // $hasTaintFlow
         // GOOD (next 8 calls): separators don't propagate to the return value
         sink(StringUtils.split("to split", taint()));
         sink(StringUtils.split("to split", taint(), 0));
@@ -213,30 +213,30 @@ class Test {
         sink(StringUtils.splitByWholeSeparatorPreserveAllTokens("to split", taint()));
         sink(StringUtils.splitByWholeSeparatorPreserveAllTokens("to split", taint(), 0));
         sink(StringUtils.splitPreserveAllTokens("to split", taint()));
-        sink(StringUtils.strip(taint())); // $hasTaintFlow=y
-        sink(StringUtils.strip(taint(), "charstoremove")); // $hasTaintFlow=y
-        sink(StringUtils.stripAccents(taint())); // $hasTaintFlow=y
-        sink(StringUtils.stripAll(new String[] { taint() }, "charstoremove")); // $hasTaintFlow=y
-        sink(StringUtils.stripEnd(taint(), "charstoremove")); // $hasTaintFlow=y
-        sink(StringUtils.stripStart(taint(), "charstoremove")); // $hasTaintFlow=y
+        sink(StringUtils.strip(taint())); // $hasTaintFlow
+        sink(StringUtils.strip(taint(), "charstoremove")); // $hasTaintFlow
+        sink(StringUtils.stripAccents(taint())); // $hasTaintFlow
+        sink(StringUtils.stripAll(new String[] { taint() }, "charstoremove")); // $hasTaintFlow
+        sink(StringUtils.stripEnd(taint(), "charstoremove")); // $hasTaintFlow
+        sink(StringUtils.stripStart(taint(), "charstoremove")); // $hasTaintFlow
         // GOOD (next 4 calls): stripped chars do not flow to the return value.
         sink(StringUtils.strip("original text", taint()));
         sink(StringUtils.stripAll(new String[] { "original text" }, taint()));
         sink(StringUtils.stripEnd("original text", taint()));
         sink(StringUtils.stripStart("original text", taint()));
-        sink(StringUtils.stripToEmpty(taint())); // $hasTaintFlow=y
-        sink(StringUtils.stripToNull(taint())); // $hasTaintFlow=y
-        sink(StringUtils.substring(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.substring(taint(), 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.substringAfter(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.substringAfter(taint(), "separator")); // $hasTaintFlow=y
-        sink(StringUtils.substringAfterLast(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.substringAfterLast(taint(), "separator")); // $hasTaintFlow=y
-        sink(StringUtils.substringBefore(taint(), "separator")); // $hasTaintFlow=y
-        sink(StringUtils.substringBeforeLast(taint(), "separator")); // $hasTaintFlow=y
-        sink(StringUtils.substringBetween(taint(), "separator")); // $hasTaintFlow=y
-        sink(StringUtils.substringBetween(taint(), "start-tag", "end-tag")); // $hasTaintFlow=y
-        sink(StringUtils.substringsBetween(taint(), "start-tag", "end-tag")[0]); // $hasTaintFlow=y
+        sink(StringUtils.stripToEmpty(taint())); // $hasTaintFlow
+        sink(StringUtils.stripToNull(taint())); // $hasTaintFlow
+        sink(StringUtils.substring(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.substring(taint(), 0, 0)); // $hasTaintFlow
+        sink(StringUtils.substringAfter(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.substringAfter(taint(), "separator")); // $hasTaintFlow
+        sink(StringUtils.substringAfterLast(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.substringAfterLast(taint(), "separator")); // $hasTaintFlow
+        sink(StringUtils.substringBefore(taint(), "separator")); // $hasTaintFlow
+        sink(StringUtils.substringBeforeLast(taint(), "separator")); // $hasTaintFlow
+        sink(StringUtils.substringBetween(taint(), "separator")); // $hasTaintFlow
+        sink(StringUtils.substringBetween(taint(), "start-tag", "end-tag")); // $hasTaintFlow
+        sink(StringUtils.substringsBetween(taint(), "start-tag", "end-tag")[0]); // $hasTaintFlow
         // GOOD (next 9 calls): separators and bounding tags do not flow to the return value.
         sink(StringUtils.substringAfter("original text", taint()));
         sink(StringUtils.substringAfterLast("original text", taint()));
@@ -247,31 +247,31 @@ class Test {
         sink(StringUtils.substringBetween("original text", "start-tag", taint()));
         sink(StringUtils.substringsBetween("original text", taint(), "end-tag")[0]);
         sink(StringUtils.substringsBetween("original text", "start-tag", taint())[0]);
-        sink(StringUtils.swapCase(taint())); // $hasTaintFlow=y
-        sink(StringUtils.toCodePoints(taint())); // $hasTaintFlow=y
-        sink(StringUtils.toEncodedString(StringUtils.getBytes(taint(), "charset"), null)); // $hasTaintFlow=y
-        sink(StringUtils.toRootLowerCase(taint())); // $hasTaintFlow=y
-        sink(StringUtils.toRootUpperCase(taint())); // $hasTaintFlow=y
-        sink(StringUtils.toString(StringUtils.getBytes(taint(), "charset"), "charset")); // $hasTaintFlow=y
-        sink(StringUtils.trim(taint())); // $hasTaintFlow=y
-        sink(StringUtils.trimToEmpty(taint())); // $hasTaintFlow=y
-        sink(StringUtils.trimToNull(taint())); // $hasTaintFlow=y
-        sink(StringUtils.truncate(taint(), 0)); // $hasTaintFlow=y
-        sink(StringUtils.truncate(taint(), 0, 0)); // $hasTaintFlow=y
-        sink(StringUtils.uncapitalize(taint())); // $hasTaintFlow=y
-        sink(StringUtils.unwrap(taint(), '"')); // $hasTaintFlow=y
-        sink(StringUtils.unwrap(taint(), "separator")); // $hasTaintFlow=y
+        sink(StringUtils.swapCase(taint())); // $hasTaintFlow
+        sink(StringUtils.toCodePoints(taint())); // $hasTaintFlow
+        sink(StringUtils.toEncodedString(StringUtils.getBytes(taint(), "charset"), null)); // $hasTaintFlow
+        sink(StringUtils.toRootLowerCase(taint())); // $hasTaintFlow
+        sink(StringUtils.toRootUpperCase(taint())); // $hasTaintFlow
+        sink(StringUtils.toString(StringUtils.getBytes(taint(), "charset"), "charset")); // $hasTaintFlow
+        sink(StringUtils.trim(taint())); // $hasTaintFlow
+        sink(StringUtils.trimToEmpty(taint())); // $hasTaintFlow
+        sink(StringUtils.trimToNull(taint())); // $hasTaintFlow
+        sink(StringUtils.truncate(taint(), 0)); // $hasTaintFlow
+        sink(StringUtils.truncate(taint(), 0, 0)); // $hasTaintFlow
+        sink(StringUtils.uncapitalize(taint())); // $hasTaintFlow
+        sink(StringUtils.unwrap(taint(), '"')); // $hasTaintFlow
+        sink(StringUtils.unwrap(taint(), "separator")); // $hasTaintFlow
         // GOOD: the wrapper string does not flow to the return value.
         sink(StringUtils.unwrap("original string", taint()));
-        sink(StringUtils.upperCase(taint())); // $hasTaintFlow=y
-        sink(StringUtils.upperCase(taint(), null)); // $hasTaintFlow=y
-        sink(StringUtils.valueOf(taint().toCharArray())); // $hasTaintFlow=y
-        sink(StringUtils.wrap(taint(), '"')); // $hasTaintFlow=y
-        sink(StringUtils.wrap(taint(), "wrapper token")); // $hasTaintFlow=y
-        sink(StringUtils.wrap("wrap me", taint())); // $hasTaintFlow=y
-        sink(StringUtils.wrapIfMissing(taint(), '"')); // $hasTaintFlow=y
-        sink(StringUtils.wrapIfMissing(taint(), "wrapper token")); // $hasTaintFlow=y
-        sink(StringUtils.wrapIfMissing("wrap me", taint())); // $hasTaintFlow=y
+        sink(StringUtils.upperCase(taint())); // $hasTaintFlow
+        sink(StringUtils.upperCase(taint(), null)); // $hasTaintFlow
+        sink(StringUtils.valueOf(taint().toCharArray())); // $hasTaintFlow
+        sink(StringUtils.wrap(taint(), '"')); // $hasTaintFlow
+        sink(StringUtils.wrap(taint(), "wrapper token")); // $hasTaintFlow
+        sink(StringUtils.wrap("wrap me", taint())); // $hasTaintFlow
+        sink(StringUtils.wrapIfMissing(taint(), '"')); // $hasTaintFlow
+        sink(StringUtils.wrapIfMissing(taint(), "wrapper token")); // $hasTaintFlow
+        sink(StringUtils.wrapIfMissing("wrap me", taint())); // $hasTaintFlow
 
     }
 

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/TextStringBuilderTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/TextStringBuilderTest.java
@@ -14,121 +14,121 @@ class TextStringBuilderTest {
 
     void test() throws Exception {
 
-        TextStringBuilder cons1 = new TextStringBuilder(taint()); sink(cons1.toString()); // $hasTaintFlow=y
-        TextStringBuilder cons2 = new TextStringBuilder((CharSequence)taint()); sink(cons2.toString()); // $hasTaintFlow=y
+        TextStringBuilder cons1 = new TextStringBuilder(taint()); sink(cons1.toString()); // $hasTaintFlow
+        TextStringBuilder cons2 = new TextStringBuilder((CharSequence)taint()); sink(cons2.toString()); // $hasTaintFlow
 
-        TextStringBuilder sb1 = new TextStringBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb2 = new TextStringBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb3 = new TextStringBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // $ MISSING: hasTaintFlow=y
-        TextStringBuilder sb4 = new TextStringBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // $ MISSING: hasTaintFlow=y
-        TextStringBuilder sb5 = new TextStringBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb6 = new TextStringBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb7 = new TextStringBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb1 = new TextStringBuilder(); sb1.append(taint().toCharArray()); sink(sb1.toString()); // $hasTaintFlow
+        TextStringBuilder sb2 = new TextStringBuilder(); sb2.append(taint().toCharArray(), 0, 0); sink(sb2.toString()); // $hasTaintFlow
+        TextStringBuilder sb3 = new TextStringBuilder(); sb3.append(CharBuffer.wrap(taint().toCharArray())); sink(sb3.toString()); // $ MISSING: hasTaintFlow
+        TextStringBuilder sb4 = new TextStringBuilder(); sb4.append(CharBuffer.wrap(taint().toCharArray()), 0, 0); sink(sb4.toString()); // $ MISSING: hasTaintFlow
+        TextStringBuilder sb5 = new TextStringBuilder(); sb5.append((CharSequence)taint()); sink(sb5.toString()); // $hasTaintFlow
+        TextStringBuilder sb6 = new TextStringBuilder(); sb6.append((CharSequence)taint(), 0, 0); sink(sb6.toString()); // $hasTaintFlow
+        TextStringBuilder sb7 = new TextStringBuilder(); sb7.append((Object)taint()); sink(sb7.toString()); // $hasTaintFlow
         {
             TextStringBuilder auxsb = new TextStringBuilder(); auxsb.append(taint());
-            TextStringBuilder sb8 = new TextStringBuilder(); sb8.append(auxsb); sink(sb8.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb8 = new TextStringBuilder(); sb8.append(auxsb); sink(sb8.toString()); // $hasTaintFlow
         }
-        TextStringBuilder sb9 = new TextStringBuilder(); sb9.append(new StringBuffer(taint())); sink(sb9.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb10 = new TextStringBuilder(); sb10.append(new StringBuffer(taint()), 0, 0); sink(sb10.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb11 = new TextStringBuilder(); sb11.append(new StringBuilder(taint())); sink(sb11.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb12 = new TextStringBuilder(); sb12.append(new StringBuilder(taint()), 0, 0); sink(sb12.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb13 = new TextStringBuilder(); sb13.append(taint()); sink(sb13.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb14 = new TextStringBuilder(); sb14.append(taint(), 0, 0); sink(sb14.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb15 = new TextStringBuilder(); sb15.append(taint(), "format", "args"); sink(sb15.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb16 = new TextStringBuilder(); sb16.append("Format string", taint(), "args"); sink(sb16.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb9 = new TextStringBuilder(); sb9.append(new StringBuffer(taint())); sink(sb9.toString()); // $hasTaintFlow
+        TextStringBuilder sb10 = new TextStringBuilder(); sb10.append(new StringBuffer(taint()), 0, 0); sink(sb10.toString()); // $hasTaintFlow
+        TextStringBuilder sb11 = new TextStringBuilder(); sb11.append(new StringBuilder(taint())); sink(sb11.toString()); // $hasTaintFlow
+        TextStringBuilder sb12 = new TextStringBuilder(); sb12.append(new StringBuilder(taint()), 0, 0); sink(sb12.toString()); // $hasTaintFlow
+        TextStringBuilder sb13 = new TextStringBuilder(); sb13.append(taint()); sink(sb13.toString()); // $hasTaintFlow
+        TextStringBuilder sb14 = new TextStringBuilder(); sb14.append(taint(), 0, 0); sink(sb14.toString()); // $hasTaintFlow
+        TextStringBuilder sb15 = new TextStringBuilder(); sb15.append(taint(), "format", "args"); sink(sb15.toString()); // $hasTaintFlow
+        TextStringBuilder sb16 = new TextStringBuilder(); sb16.append("Format string", taint(), "args"); sink(sb16.toString()); // $hasTaintFlow
         {
             List<String> taintedList = new ArrayList<>();
             taintedList.add(taint());
-            TextStringBuilder sb17 = new TextStringBuilder(); sb17.appendAll(taintedList); sink(sb17.toString()); // $hasTaintFlow=y
-            TextStringBuilder sb18 = new TextStringBuilder(); sb18.appendAll(taintedList.iterator()); sink(sb18.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb17 = new TextStringBuilder(); sb17.appendAll(taintedList); sink(sb17.toString()); // $hasTaintFlow
+            TextStringBuilder sb18 = new TextStringBuilder(); sb18.appendAll(taintedList.iterator()); sink(sb18.toString()); // $hasTaintFlow
         }
-        TextStringBuilder sb19 = new TextStringBuilder(); sb19.appendAll("clean", taint()); sink(sb19.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb20 = new TextStringBuilder(); sb20.appendAll(taint(), "clean"); sink(sb20.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb21 = new TextStringBuilder(); sb21.appendFixedWidthPadLeft(taint(), 0, ' '); sink(sb21.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb22 = new TextStringBuilder(); sb22.appendFixedWidthPadRight(taint(), 0, ' '); sink(sb22.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb23 = new TextStringBuilder(); sb23.appendln(taint().toCharArray()); sink(sb23.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb24 = new TextStringBuilder(); sb24.appendln(taint().toCharArray(), 0, 0); sink(sb24.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb25 = new TextStringBuilder(); sb25.appendln((Object)taint()); sink(sb25.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb19 = new TextStringBuilder(); sb19.appendAll("clean", taint()); sink(sb19.toString()); // $hasTaintFlow
+        TextStringBuilder sb20 = new TextStringBuilder(); sb20.appendAll(taint(), "clean"); sink(sb20.toString()); // $hasTaintFlow
+        TextStringBuilder sb21 = new TextStringBuilder(); sb21.appendFixedWidthPadLeft(taint(), 0, ' '); sink(sb21.toString()); // $hasTaintFlow
+        TextStringBuilder sb22 = new TextStringBuilder(); sb22.appendFixedWidthPadRight(taint(), 0, ' '); sink(sb22.toString()); // $hasTaintFlow
+        TextStringBuilder sb23 = new TextStringBuilder(); sb23.appendln(taint().toCharArray()); sink(sb23.toString()); // $hasTaintFlow
+        TextStringBuilder sb24 = new TextStringBuilder(); sb24.appendln(taint().toCharArray(), 0, 0); sink(sb24.toString()); // $hasTaintFlow
+        TextStringBuilder sb25 = new TextStringBuilder(); sb25.appendln((Object)taint()); sink(sb25.toString()); // $hasTaintFlow
         {
             TextStringBuilder auxsb = new TextStringBuilder(); auxsb.appendln(taint());
-            TextStringBuilder sb26 = new TextStringBuilder(); sb26.appendln(auxsb); sink(sb26.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb26 = new TextStringBuilder(); sb26.appendln(auxsb); sink(sb26.toString()); // $hasTaintFlow
         }
-        TextStringBuilder sb27 = new TextStringBuilder(); sb27.appendln(new StringBuffer(taint())); sink(sb27.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb28 = new TextStringBuilder(); sb28.appendln(new StringBuffer(taint()), 0, 0); sink(sb28.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb29 = new TextStringBuilder(); sb29.appendln(new StringBuilder(taint())); sink(sb29.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb30 = new TextStringBuilder(); sb30.appendln(new StringBuilder(taint()), 0, 0); sink(sb30.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb31 = new TextStringBuilder(); sb31.appendln(taint()); sink(sb31.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb32 = new TextStringBuilder(); sb32.appendln(taint(), 0, 0); sink(sb32.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb33 = new TextStringBuilder(); sb33.appendln(taint(), "format", "args"); sink(sb33.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb34 = new TextStringBuilder(); sb34.appendln("Format string", taint(), "args"); sink(sb34.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb35 = new TextStringBuilder(); sb35.appendSeparator(taint()); sink(sb35.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb36 = new TextStringBuilder(); sb36.appendSeparator(taint(), 0); sink(sb36.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb37 = new TextStringBuilder(); sb37.appendSeparator(taint(), "default"); sink(sb37.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb38 = new TextStringBuilder(); sb38.appendSeparator("", taint()); sink(sb38.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb27 = new TextStringBuilder(); sb27.appendln(new StringBuffer(taint())); sink(sb27.toString()); // $hasTaintFlow
+        TextStringBuilder sb28 = new TextStringBuilder(); sb28.appendln(new StringBuffer(taint()), 0, 0); sink(sb28.toString()); // $hasTaintFlow
+        TextStringBuilder sb29 = new TextStringBuilder(); sb29.appendln(new StringBuilder(taint())); sink(sb29.toString()); // $hasTaintFlow
+        TextStringBuilder sb30 = new TextStringBuilder(); sb30.appendln(new StringBuilder(taint()), 0, 0); sink(sb30.toString()); // $hasTaintFlow
+        TextStringBuilder sb31 = new TextStringBuilder(); sb31.appendln(taint()); sink(sb31.toString()); // $hasTaintFlow
+        TextStringBuilder sb32 = new TextStringBuilder(); sb32.appendln(taint(), 0, 0); sink(sb32.toString()); // $hasTaintFlow
+        TextStringBuilder sb33 = new TextStringBuilder(); sb33.appendln(taint(), "format", "args"); sink(sb33.toString()); // $hasTaintFlow
+        TextStringBuilder sb34 = new TextStringBuilder(); sb34.appendln("Format string", taint(), "args"); sink(sb34.toString()); // $hasTaintFlow
+        TextStringBuilder sb35 = new TextStringBuilder(); sb35.appendSeparator(taint()); sink(sb35.toString()); // $hasTaintFlow
+        TextStringBuilder sb36 = new TextStringBuilder(); sb36.appendSeparator(taint(), 0); sink(sb36.toString()); // $hasTaintFlow
+        TextStringBuilder sb37 = new TextStringBuilder(); sb37.appendSeparator(taint(), "default"); sink(sb37.toString()); // $hasTaintFlow
+        TextStringBuilder sb38 = new TextStringBuilder(); sb38.appendSeparator("", taint()); sink(sb38.toString()); // $hasTaintFlow
         {
             TextStringBuilder auxsb = new TextStringBuilder(); auxsb.appendln(taint());
-            TextStringBuilder sb39 = new TextStringBuilder(); auxsb.appendTo(sb39); sink(sb39.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb39 = new TextStringBuilder(); auxsb.appendTo(sb39); sink(sb39.toString()); // $hasTaintFlow
         }
         {
             List<String> taintedList = new ArrayList<>();
             taintedList.add(taint());
-            TextStringBuilder sb40 = new TextStringBuilder(); sb40.appendWithSeparators(taintedList, ", "); sink(sb40.toString()); // $hasTaintFlow=y
-            TextStringBuilder sb41 = new TextStringBuilder(); sb41.appendWithSeparators(taintedList.iterator(), ", "); sink(sb41.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb40 = new TextStringBuilder(); sb40.appendWithSeparators(taintedList, ", "); sink(sb40.toString()); // $hasTaintFlow
+            TextStringBuilder sb41 = new TextStringBuilder(); sb41.appendWithSeparators(taintedList.iterator(), ", "); sink(sb41.toString()); // $hasTaintFlow
             List<String> untaintedList = new ArrayList<>();
-            TextStringBuilder sb42 = new TextStringBuilder(); sb42.appendWithSeparators(untaintedList, taint()); sink(sb42.toString()); // $hasTaintFlow=y
-            TextStringBuilder sb43 = new TextStringBuilder(); sb43.appendWithSeparators(untaintedList.iterator(), taint()); sink(sb43.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb42 = new TextStringBuilder(); sb42.appendWithSeparators(untaintedList, taint()); sink(sb42.toString()); // $hasTaintFlow
+            TextStringBuilder sb43 = new TextStringBuilder(); sb43.appendWithSeparators(untaintedList.iterator(), taint()); sink(sb43.toString()); // $hasTaintFlow
             String[] taintedArray = new String[] { taint() };
             String[] untaintedArray = new String[] {};
-            TextStringBuilder sb44 = new TextStringBuilder(); sb44.appendWithSeparators(taintedArray, ", "); sink(sb44.toString()); // $hasTaintFlow=y
-            TextStringBuilder sb45 = new TextStringBuilder(); sb45.appendWithSeparators(untaintedArray, taint()); sink(sb45.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb44 = new TextStringBuilder(); sb44.appendWithSeparators(taintedArray, ", "); sink(sb44.toString()); // $hasTaintFlow
+            TextStringBuilder sb45 = new TextStringBuilder(); sb45.appendWithSeparators(untaintedArray, taint()); sink(sb45.toString()); // $hasTaintFlow
         }
         {
             TextStringBuilder sb46 = new TextStringBuilder(); sb46.append(taint());
             char[] target = new char[100];
             sb46.asReader().read(target);
-            sink(target); // $hasTaintFlow=y
+            sink(target); // $hasTaintFlow
         }
-        TextStringBuilder sb47 = new TextStringBuilder(); sb47.append(taint()); sink(sb47.asTokenizer().next()); // $hasTaintFlow=y
-        TextStringBuilder sb48 = new TextStringBuilder(); sb48.append(taint()); sink(sb48.build()); // $hasTaintFlow=y
-        TextStringBuilder sb49 = new TextStringBuilder(); sb49.append(taint()); sink(sb49.getChars(null)); // $hasTaintFlow=y
+        TextStringBuilder sb47 = new TextStringBuilder(); sb47.append(taint()); sink(sb47.asTokenizer().next()); // $hasTaintFlow
+        TextStringBuilder sb48 = new TextStringBuilder(); sb48.append(taint()); sink(sb48.build()); // $hasTaintFlow
+        TextStringBuilder sb49 = new TextStringBuilder(); sb49.append(taint()); sink(sb49.getChars(null)); // $hasTaintFlow
         {
             TextStringBuilder sb50 = new TextStringBuilder(); sb50.append(taint());
             char[] target = new char[100];
             sb50.getChars(target);
-            sink(target); // $hasTaintFlow=y
+            sink(target); // $hasTaintFlow
         }
         {
             TextStringBuilder sb51 = new TextStringBuilder(); sb51.append(taint());
             char[] target = new char[100];
             sb51.getChars(0, 0, target, 0);
-            sink(target); // $hasTaintFlow=y
+            sink(target); // $hasTaintFlow
         }
-        TextStringBuilder sb52 = new TextStringBuilder(); sb52.insert(0, taint().toCharArray()); sink(sb52.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb53 = new TextStringBuilder(); sb53.insert(0, taint().toCharArray(), 0, 0); sink(sb53.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb54 = new TextStringBuilder(); sb54.insert(0, taint()); sink(sb54.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb55 = new TextStringBuilder(); sb55.insert(0, (Object)taint()); sink(sb55.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb56 = new TextStringBuilder(); sb56.append(taint()); sink(sb56.leftString(0)); // $hasTaintFlow=y
-        TextStringBuilder sb57 = new TextStringBuilder(); sb57.append(taint()); sink(sb57.midString(0, 0)); // $hasTaintFlow=y
+        TextStringBuilder sb52 = new TextStringBuilder(); sb52.insert(0, taint().toCharArray()); sink(sb52.toString()); // $hasTaintFlow
+        TextStringBuilder sb53 = new TextStringBuilder(); sb53.insert(0, taint().toCharArray(), 0, 0); sink(sb53.toString()); // $hasTaintFlow
+        TextStringBuilder sb54 = new TextStringBuilder(); sb54.insert(0, taint()); sink(sb54.toString()); // $hasTaintFlow
+        TextStringBuilder sb55 = new TextStringBuilder(); sb55.insert(0, (Object)taint()); sink(sb55.toString()); // $hasTaintFlow
+        TextStringBuilder sb56 = new TextStringBuilder(); sb56.append(taint()); sink(sb56.leftString(0)); // $hasTaintFlow
+        TextStringBuilder sb57 = new TextStringBuilder(); sb57.append(taint()); sink(sb57.midString(0, 0)); // $hasTaintFlow
         {
             StringReader reader = new StringReader(taint());
-            TextStringBuilder sb58 = new TextStringBuilder(); sb58.readFrom(reader); sink(sb58.toString()); // $hasTaintFlow=y
+            TextStringBuilder sb58 = new TextStringBuilder(); sb58.readFrom(reader); sink(sb58.toString()); // $hasTaintFlow
         }
-        TextStringBuilder sb59 = new TextStringBuilder(); sb59.replace(0, 0, taint()); sink(sb59.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb60 = new TextStringBuilder(); sb60.replace(null, taint(), 0, 0, 0); sink(sb60.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb61 = new TextStringBuilder(); sb61.replaceAll((StringMatcher)null, taint()); sink(sb61.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb62 = new TextStringBuilder(); sb62.replaceAll("search", taint()); sink(sb62.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb59 = new TextStringBuilder(); sb59.replace(0, 0, taint()); sink(sb59.toString()); // $hasTaintFlow
+        TextStringBuilder sb60 = new TextStringBuilder(); sb60.replace(null, taint(), 0, 0, 0); sink(sb60.toString()); // $hasTaintFlow
+        TextStringBuilder sb61 = new TextStringBuilder(); sb61.replaceAll((StringMatcher)null, taint()); sink(sb61.toString()); // $hasTaintFlow
+        TextStringBuilder sb62 = new TextStringBuilder(); sb62.replaceAll("search", taint()); sink(sb62.toString()); // $hasTaintFlow
         TextStringBuilder sb63 = new TextStringBuilder(); sb63.replaceAll(taint(), "replace"); sink(sb63.toString()); // GOOD (search string doesn't convey taint)
-        TextStringBuilder sb64 = new TextStringBuilder(); sb64.replaceFirst((StringMatcher)null, taint()); sink(sb64.toString()); // $hasTaintFlow=y
-        TextStringBuilder sb65 = new TextStringBuilder(); sb65.replaceFirst("search", taint()); sink(sb65.toString()); // $hasTaintFlow=y
+        TextStringBuilder sb64 = new TextStringBuilder(); sb64.replaceFirst((StringMatcher)null, taint()); sink(sb64.toString()); // $hasTaintFlow
+        TextStringBuilder sb65 = new TextStringBuilder(); sb65.replaceFirst("search", taint()); sink(sb65.toString()); // $hasTaintFlow
         TextStringBuilder sb66 = new TextStringBuilder(); sb66.replaceFirst(taint(), "replace"); sink(sb66.toString()); // GOOD (search string doesn't convey taint)
-        TextStringBuilder sb67 = new TextStringBuilder(); sb67.append(taint()); sink(sb67.rightString(0)); // $hasTaintFlow=y
-        TextStringBuilder sb68 = new TextStringBuilder(); sb68.append(taint()); sink(sb68.subSequence(0, 0)); // $hasTaintFlow=y
-        TextStringBuilder sb69 = new TextStringBuilder(); sb69.append(taint()); sink(sb69.substring(0)); // $hasTaintFlow=y
-        TextStringBuilder sb70 = new TextStringBuilder(); sb70.append(taint()); sink(sb70.substring(0, 0)); // $hasTaintFlow=y
-        TextStringBuilder sb71 = new TextStringBuilder(); sb71.append(taint()); sink(sb71.toCharArray()); // $hasTaintFlow=y
-        TextStringBuilder sb72 = new TextStringBuilder(); sb72.append(taint()); sink(sb72.toCharArray(0, 0)); // $hasTaintFlow=y
-        TextStringBuilder sb73 = new TextStringBuilder(); sb73.append(taint()); sink(sb73.toStringBuffer()); // $hasTaintFlow=y
-        TextStringBuilder sb74 = new TextStringBuilder(); sb74.append(taint()); sink(sb74.toStringBuilder()); // $hasTaintFlow=y
+        TextStringBuilder sb67 = new TextStringBuilder(); sb67.append(taint()); sink(sb67.rightString(0)); // $hasTaintFlow
+        TextStringBuilder sb68 = new TextStringBuilder(); sb68.append(taint()); sink(sb68.subSequence(0, 0)); // $hasTaintFlow
+        TextStringBuilder sb69 = new TextStringBuilder(); sb69.append(taint()); sink(sb69.substring(0)); // $hasTaintFlow
+        TextStringBuilder sb70 = new TextStringBuilder(); sb70.append(taint()); sink(sb70.substring(0, 0)); // $hasTaintFlow
+        TextStringBuilder sb71 = new TextStringBuilder(); sb71.append(taint()); sink(sb71.toCharArray()); // $hasTaintFlow
+        TextStringBuilder sb72 = new TextStringBuilder(); sb72.append(taint()); sink(sb72.toCharArray(0, 0)); // $hasTaintFlow
+        TextStringBuilder sb73 = new TextStringBuilder(); sb73.append(taint()); sink(sb73.toStringBuffer()); // $hasTaintFlow
+        TextStringBuilder sb74 = new TextStringBuilder(); sb74.append(taint()); sink(sb74.toStringBuilder()); // $hasTaintFlow
     }
 
 }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/WordUtilsTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/WordUtilsTest.java
@@ -6,20 +6,20 @@ public class WordUtilsTest {
   void sink(Object o) {}
 
   void test() throws Exception {
-    sink(WordUtils.capitalize(taint())); // $hasTaintFlow=y
-    sink(WordUtils.capitalize(taint(), ' ', ',')); // $hasTaintFlow=y
-    sink(WordUtils.capitalizeFully(taint())); // $hasTaintFlow=y
-    sink(WordUtils.capitalizeFully(taint(), ' ', ',')); // $hasTaintFlow=y
-    sink(WordUtils.initials(taint())); // $hasTaintFlow=y
-    sink(WordUtils.initials(taint(), ' ', ',')); // $hasTaintFlow=y
-    sink(WordUtils.swapCase(taint())); // $hasTaintFlow=y
-    sink(WordUtils.uncapitalize(taint())); // $hasTaintFlow=y
-    sink(WordUtils.uncapitalize(taint(), ' ', ',')); // $hasTaintFlow=y
-    sink(WordUtils.wrap(taint(), 0)); // $hasTaintFlow=y
-    sink(WordUtils.wrap(taint(), 0, "\n", false)); // $hasTaintFlow=y
-    sink(WordUtils.wrap("wrap me", 0, taint(), false)); // $hasTaintFlow=y
-    sink(WordUtils.wrap(taint(), 0, "\n", false, "\n")); // $hasTaintFlow=y
-    sink(WordUtils.wrap("wrap me", 0, taint(), false, "\n")); // $hasTaintFlow=y
+    sink(WordUtils.capitalize(taint())); // $hasTaintFlow
+    sink(WordUtils.capitalize(taint(), ' ', ',')); // $hasTaintFlow
+    sink(WordUtils.capitalizeFully(taint())); // $hasTaintFlow
+    sink(WordUtils.capitalizeFully(taint(), ' ', ',')); // $hasTaintFlow
+    sink(WordUtils.initials(taint())); // $hasTaintFlow
+    sink(WordUtils.initials(taint(), ' ', ',')); // $hasTaintFlow
+    sink(WordUtils.swapCase(taint())); // $hasTaintFlow
+    sink(WordUtils.uncapitalize(taint())); // $hasTaintFlow
+    sink(WordUtils.uncapitalize(taint(), ' ', ',')); // $hasTaintFlow
+    sink(WordUtils.wrap(taint(), 0)); // $hasTaintFlow
+    sink(WordUtils.wrap(taint(), 0, "\n", false)); // $hasTaintFlow
+    sink(WordUtils.wrap("wrap me", 0, taint(), false)); // $hasTaintFlow
+    sink(WordUtils.wrap(taint(), 0, "\n", false, "\n")); // $hasTaintFlow
+    sink(WordUtils.wrap("wrap me", 0, taint(), false, "\n")); // $hasTaintFlow
     // GOOD: the wrap-on line terminator does not propagate to the return value
     sink(WordUtils.wrap("wrap me", 0, "\n", false, taint()));
   }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/WordUtilsTextTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/WordUtilsTextTest.java
@@ -6,22 +6,22 @@ public class WordUtilsTextTest {
   void sink(Object o) {}
 
   void test() throws Exception {
-    sink(WordUtils.abbreviate(taint(), 0, 0, "append me")); // $hasTaintFlow=y
-    sink(WordUtils.abbreviate("abbreviate me", 0, 0, taint())); // $hasTaintFlow=y
-    sink(WordUtils.capitalize(taint())); // $hasTaintFlow=y
-    sink(WordUtils.capitalize(taint(), ' ', ',')); // $hasTaintFlow=y
-    sink(WordUtils.capitalizeFully(taint())); // $hasTaintFlow=y
-    sink(WordUtils.capitalizeFully(taint(), ' ', ',')); // $hasTaintFlow=y
-    sink(WordUtils.initials(taint())); // $hasTaintFlow=y
-    sink(WordUtils.initials(taint(), ' ', ',')); // $hasTaintFlow=y
-    sink(WordUtils.swapCase(taint())); // $hasTaintFlow=y
-    sink(WordUtils.uncapitalize(taint())); // $hasTaintFlow=y
-    sink(WordUtils.uncapitalize(taint(), ' ', ',')); // $hasTaintFlow=y
-    sink(WordUtils.wrap(taint(), 0)); // $hasTaintFlow=y
-    sink(WordUtils.wrap(taint(), 0, "\n", false)); // $hasTaintFlow=y
-    sink(WordUtils.wrap("wrap me", 0, taint(), false)); // $hasTaintFlow=y
-    sink(WordUtils.wrap(taint(), 0, "\n", false, "\n")); // $hasTaintFlow=y
-    sink(WordUtils.wrap("wrap me", 0, taint(), false, "\n")); // $hasTaintFlow=y
+    sink(WordUtils.abbreviate(taint(), 0, 0, "append me")); // $hasTaintFlow
+    sink(WordUtils.abbreviate("abbreviate me", 0, 0, taint())); // $hasTaintFlow
+    sink(WordUtils.capitalize(taint())); // $hasTaintFlow
+    sink(WordUtils.capitalize(taint(), ' ', ',')); // $hasTaintFlow
+    sink(WordUtils.capitalizeFully(taint())); // $hasTaintFlow
+    sink(WordUtils.capitalizeFully(taint(), ' ', ',')); // $hasTaintFlow
+    sink(WordUtils.initials(taint())); // $hasTaintFlow
+    sink(WordUtils.initials(taint(), ' ', ',')); // $hasTaintFlow
+    sink(WordUtils.swapCase(taint())); // $hasTaintFlow
+    sink(WordUtils.uncapitalize(taint())); // $hasTaintFlow
+    sink(WordUtils.uncapitalize(taint(), ' ', ',')); // $hasTaintFlow
+    sink(WordUtils.wrap(taint(), 0)); // $hasTaintFlow
+    sink(WordUtils.wrap(taint(), 0, "\n", false)); // $hasTaintFlow
+    sink(WordUtils.wrap("wrap me", 0, taint(), false)); // $hasTaintFlow
+    sink(WordUtils.wrap(taint(), 0, "\n", false, "\n")); // $hasTaintFlow
+    sink(WordUtils.wrap("wrap me", 0, taint(), false, "\n")); // $hasTaintFlow
     // GOOD: the wrap-on line terminator does not propagate to the return value
     sink(WordUtils.wrap("wrap me", 0, "\n", false, taint()));
   }

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/flow.ql
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/flow.ql
@@ -24,7 +24,7 @@ class HasFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node src, DataFlow::Node sink, Conf conf | conf.hasFlow(src, sink) |
       sink.getLocation() = location and
       element = sink.toString() and
-      value = "y"
+      value = ""
     )
   }
 }

--- a/java/ql/test/library-tests/frameworks/apache-http/A.java
+++ b/java/ql/test/library-tests/frameworks/apache-http/A.java
@@ -12,54 +12,54 @@ class A {
 
     class Test1 implements HttpRequestHandler {
         public void handle(HttpRequest req, HttpResponse res, HttpContext ctx) throws IOException {
-            A.sink(req.getRequestLine()); //$hasTaintFlow=y
-            A.sink(req.getRequestLine().getUri()); //$hasTaintFlow=y
-            A.sink(req.getRequestLine().getMethod()); //$hasTaintFlow=y
-            A.sink(req.getAllHeaders()); //$hasTaintFlow=y
+            A.sink(req.getRequestLine()); //$hasTaintFlow
+            A.sink(req.getRequestLine().getUri()); //$hasTaintFlow
+            A.sink(req.getRequestLine().getMethod()); //$hasTaintFlow
+            A.sink(req.getAllHeaders()); //$hasTaintFlow
             HeaderIterator it = req.headerIterator();
-            A.sink(it.next()); //$hasTaintFlow=y
-            A.sink(it.nextHeader()); //$hasTaintFlow=y
+            A.sink(it.next()); //$hasTaintFlow
+            A.sink(it.nextHeader()); //$hasTaintFlow
             Header h = req.getHeaders("abc")[3];
-            A.sink(h.getName()); //$hasTaintFlow=y
-            A.sink(h.getValue()); //$hasTaintFlow=y
+            A.sink(h.getName()); //$hasTaintFlow
+            A.sink(h.getValue()); //$hasTaintFlow
             HeaderElement el = h.getElements()[0];
-            A.sink(el.getName()); //$hasTaintFlow=y
-            A.sink(el.getValue()); //$hasTaintFlow=y
-            A.sink(el.getParameters()); //$hasTaintFlow=y
-            A.sink(el.getParameterByName("abc").getValue()); //$hasTaintFlow=y
-            A.sink(el.getParameter(0).getName()); //$hasTaintFlow=y
+            A.sink(el.getName()); //$hasTaintFlow
+            A.sink(el.getValue()); //$hasTaintFlow
+            A.sink(el.getParameters()); //$hasTaintFlow
+            A.sink(el.getParameterByName("abc").getValue()); //$hasTaintFlow
+            A.sink(el.getParameter(0).getName()); //$hasTaintFlow
             HttpEntity ent = ((HttpEntityEnclosingRequest)req).getEntity();
-            A.sink(ent.getContent()); //$hasTaintFlow=y
-            A.sink(ent.getContentEncoding()); //$hasTaintFlow=y
-            A.sink(ent.getContentType()); //$hasTaintFlow=y
-            A.sink(EntityUtils.toString(ent)); //$hasTaintFlow=y
-            A.sink(EntityUtils.toByteArray(ent)); //$hasTaintFlow=y
-            A.sink(EntityUtils.getContentCharSet(ent)); //$hasTaintFlow=y
-            A.sink(EntityUtils.getContentMimeType(ent)); //$hasTaintFlow=y
-            res.setEntity(new StringEntity("<a href='" + req.getRequestLine().getUri() + "'>a</a>")); //$hasTaintFlow=y
-            EntityUtils.updateEntity(res, new ByteArrayEntity(EntityUtils.toByteArray(ent))); //$hasTaintFlow=y
-            res.setHeader("Location", req.getRequestLine().getUri()); //$hasTaintFlow=y
-            res.setHeader(new BasicHeader("Location", req.getRequestLine().getUri())); //$hasTaintFlow=y
+            A.sink(ent.getContent()); //$hasTaintFlow
+            A.sink(ent.getContentEncoding()); //$hasTaintFlow
+            A.sink(ent.getContentType()); //$hasTaintFlow
+            A.sink(EntityUtils.toString(ent)); //$hasTaintFlow
+            A.sink(EntityUtils.toByteArray(ent)); //$hasTaintFlow
+            A.sink(EntityUtils.getContentCharSet(ent)); //$hasTaintFlow
+            A.sink(EntityUtils.getContentMimeType(ent)); //$hasTaintFlow
+            res.setEntity(new StringEntity("<a href='" + req.getRequestLine().getUri() + "'>a</a>")); //$hasTaintFlow
+            EntityUtils.updateEntity(res, new ByteArrayEntity(EntityUtils.toByteArray(ent))); //$hasTaintFlow
+            res.setHeader("Location", req.getRequestLine().getUri()); //$hasTaintFlow
+            res.setHeader(new BasicHeader("Location", req.getRequestLine().getUri())); //$hasTaintFlow
         }
     }
 
     void test2() {
         ByteArrayBuffer bbuf = new ByteArrayBuffer(42);
         bbuf.append((byte[]) taint(), 0, 3);
-        sink(bbuf.buffer()); //$hasTaintFlow=y
-        sink(bbuf.toByteArray()); //$hasTaintFlow=y
+        sink(bbuf.buffer()); //$hasTaintFlow
+        sink(bbuf.toByteArray()); //$hasTaintFlow
 
         CharArrayBuffer cbuf = new CharArrayBuffer(42);
         cbuf.append(bbuf.toByteArray(), 0, 3);
-        sink(cbuf.toCharArray()); //$hasTaintFlow=y
-        sink(cbuf.toString()); //$hasTaintFlow=y
-        sink(cbuf.subSequence(0, 3)); //$hasTaintFlow=y
-        sink(cbuf.substring(0, 3)); //$hasTaintFlow=y
-        sink(cbuf.substringTrimmed(0, 3)); //$hasTaintFlow=y
+        sink(cbuf.toCharArray()); //$hasTaintFlow
+        sink(cbuf.toString()); //$hasTaintFlow
+        sink(cbuf.subSequence(0, 3)); //$hasTaintFlow
+        sink(cbuf.substring(0, 3)); //$hasTaintFlow
+        sink(cbuf.substringTrimmed(0, 3)); //$hasTaintFlow
 
-        sink(Args.notNull(taint(), "x")); //$hasTaintFlow=y
-        sink(Args.notEmpty((String) taint(), "x")); //$hasTaintFlow=y
-        sink(Args.notBlank((String) taint(), "x")); //$hasTaintFlow=y
+        sink(Args.notNull(taint(), "x")); //$hasTaintFlow
+        sink(Args.notEmpty((String) taint(), "x")); //$hasTaintFlow
+        sink(Args.notBlank((String) taint(), "x")); //$hasTaintFlow
         sink(Args.notNull("x", (String) taint())); // Good
     }
 }

--- a/java/ql/test/library-tests/frameworks/apache-http/B.java
+++ b/java/ql/test/library-tests/frameworks/apache-http/B.java
@@ -14,63 +14,63 @@ class B {
 
     class Test1 implements HttpRequestHandler {
         public void handle(ClassicHttpRequest req, ClassicHttpResponse res, HttpContext ctx) throws IOException, ParseException {
-            B.sink(req.getAuthority().getHostName()); //$hasTaintFlow=y
-            B.sink(req.getAuthority().toString()); //$hasTaintFlow=y
-            B.sink(req.getMethod()); //$hasTaintFlow=y
-            B.sink(req.getPath()); //$hasTaintFlow=y
+            B.sink(req.getAuthority().getHostName()); //$hasTaintFlow
+            B.sink(req.getAuthority().toString()); //$hasTaintFlow
+            B.sink(req.getMethod()); //$hasTaintFlow
+            B.sink(req.getPath()); //$hasTaintFlow
             B.sink(req.getScheme()); 
-            B.sink(req.getRequestUri()); //$hasTaintFlow=y
+            B.sink(req.getRequestUri()); //$hasTaintFlow
             RequestLine line = new RequestLine(req);
-            B.sink(line.getUri()); //$hasTaintFlow=y
-            B.sink(line.getMethod()); //$hasTaintFlow=y
-            B.sink(req.getHeaders()); //$hasTaintFlow=y
-            B.sink(req.headerIterator()); //$hasTaintFlow=y
+            B.sink(line.getUri()); //$hasTaintFlow
+            B.sink(line.getMethod()); //$hasTaintFlow
+            B.sink(req.getHeaders()); //$hasTaintFlow
+            B.sink(req.headerIterator()); //$hasTaintFlow
             Header h = req.getHeaders("abc")[3];
-            B.sink(h.getName()); //$hasTaintFlow=y
-            B.sink(h.getValue()); //$hasTaintFlow=y
-            B.sink(req.getFirstHeader("abc")); //$hasTaintFlow=y
-            B.sink(req.getLastHeader("abc")); //$hasTaintFlow=y
+            B.sink(h.getName()); //$hasTaintFlow
+            B.sink(h.getValue()); //$hasTaintFlow
+            B.sink(req.getFirstHeader("abc")); //$hasTaintFlow
+            B.sink(req.getLastHeader("abc")); //$hasTaintFlow
             HttpEntity ent = req.getEntity();
-            B.sink(ent.getContent()); //$hasTaintFlow=y
-            B.sink(ent.getContentEncoding()); //$hasTaintFlow=y
-            B.sink(ent.getContentType()); //$hasTaintFlow=y
-            B.sink(ent.getTrailerNames()); //$hasTaintFlow=y
-            B.sink(ent.getTrailers().get()); //$hasTaintFlow=y
-            B.sink(EntityUtils.toString(ent)); //$hasTaintFlow=y
-            B.sink(EntityUtils.toByteArray(ent)); //$hasTaintFlow=y
-            B.sink(EntityUtils.parse(ent)); //$hasTaintFlow=y
-            res.setEntity(new StringEntity("<a href='" + req.getRequestUri() + "'>a</a>")); //$hasTaintFlow=y
-            res.setEntity(new ByteArrayEntity(EntityUtils.toByteArray(ent), ContentType.TEXT_HTML)); //$hasTaintFlow=y
-            res.setEntity(HttpEntities.create("<a href='" + req.getRequestUri() + "'>a</a>")); //$hasTaintFlow=y
-            res.setHeader("Location", req.getRequestUri()); //$hasTaintFlow=y
-            res.setHeader(new BasicHeader("Location", req.getRequestUri())); //$hasTaintFlow=y
+            B.sink(ent.getContent()); //$hasTaintFlow
+            B.sink(ent.getContentEncoding()); //$hasTaintFlow
+            B.sink(ent.getContentType()); //$hasTaintFlow
+            B.sink(ent.getTrailerNames()); //$hasTaintFlow
+            B.sink(ent.getTrailers().get()); //$hasTaintFlow
+            B.sink(EntityUtils.toString(ent)); //$hasTaintFlow
+            B.sink(EntityUtils.toByteArray(ent)); //$hasTaintFlow
+            B.sink(EntityUtils.parse(ent)); //$hasTaintFlow
+            res.setEntity(new StringEntity("<a href='" + req.getRequestUri() + "'>a</a>")); //$hasTaintFlow
+            res.setEntity(new ByteArrayEntity(EntityUtils.toByteArray(ent), ContentType.TEXT_HTML)); //$hasTaintFlow
+            res.setEntity(HttpEntities.create("<a href='" + req.getRequestUri() + "'>a</a>")); //$hasTaintFlow
+            res.setHeader("Location", req.getRequestUri()); //$hasTaintFlow
+            res.setHeader(new BasicHeader("Location", req.getRequestUri())); //$hasTaintFlow
         }
     }
 
     void test2() {
         ByteArrayBuffer bbuf = new ByteArrayBuffer(42);
         bbuf.append((byte[]) taint(), 0, 3); 
-        sink(bbuf.array()); //$hasTaintFlow=y
-        sink(bbuf.toByteArray()); //$hasTaintFlow=y
+        sink(bbuf.array()); //$hasTaintFlow
+        sink(bbuf.toByteArray()); //$hasTaintFlow
         sink(bbuf.toString()); 
 
         CharArrayBuffer cbuf = new CharArrayBuffer(42);
         cbuf.append(bbuf.toByteArray(), 0, 3); 
-        sink(cbuf.toCharArray()); //$hasTaintFlow=y
-        sink(cbuf.toString()); //$hasTaintFlow=y
-        sink(cbuf.subSequence(0, 3)); //$hasTaintFlow=y
-        sink(cbuf.substring(0, 3)); //$hasTaintFlow=y
-        sink(cbuf.substringTrimmed(0, 3)); //$hasTaintFlow=y
+        sink(cbuf.toCharArray()); //$hasTaintFlow
+        sink(cbuf.toString()); //$hasTaintFlow
+        sink(cbuf.subSequence(0, 3)); //$hasTaintFlow
+        sink(cbuf.substring(0, 3)); //$hasTaintFlow
+        sink(cbuf.substringTrimmed(0, 3)); //$hasTaintFlow
 
-        sink(Args.notNull(taint(), "x")); //$hasTaintFlow=y
-        sink(Args.notEmpty((String) taint(), "x")); //$hasTaintFlow=y
-        sink(Args.notBlank((String) taint(), "x")); //$hasTaintFlow=y
+        sink(Args.notNull(taint(), "x")); //$hasTaintFlow
+        sink(Args.notEmpty((String) taint(), "x")); //$hasTaintFlow
+        sink(Args.notBlank((String) taint(), "x")); //$hasTaintFlow
         sink(Args.notNull("x", (String) taint())); 
     }
 
     class Test3 implements HttpServerRequestHandler {
         public void handle(ClassicHttpRequest req, HttpServerRequestHandler.ResponseTrigger restr, HttpContext ctx) throws HttpException, IOException {
-            B.sink(req.getEntity()); //$hasTaintFlow=y
+            B.sink(req.getEntity()); //$hasTaintFlow
         }
     }
 }

--- a/java/ql/test/library-tests/frameworks/apache-http/flow.ql
+++ b/java/ql/test/library-tests/frameworks/apache-http/flow.ql
@@ -33,7 +33,7 @@ class HasFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node src, DataFlow::Node sink, Conf conf | conf.hasFlow(src, sink) |
       sink.getLocation() = location and
       element = sink.toString() and
-      value = "y"
+      value = ""
     )
   }
 }


### PR DESCRIPTION
Instead of using `value = "y"` just use `value = ""` to not require including the value in the Java test classes