### PR TITLE
Java: Fix NashornScriptEngine detection in ScriptEngine query

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-094/NashornScriptEngine.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/NashornScriptEngine.java
@@ -1,0 +1,4 @@
+// Bad: Execute externally controlled input in Nashorn Script Engine
+NashornScriptEngineFactory factory = new NashornScriptEngineFactory();
+NashornScriptEngine engine = (NashornScriptEngine) factory.getScriptEngine(new String[] { "-scripting"});
+Object result = engine.eval(input);

--- a/java/ql/src/experimental/Security/CWE/CWE-094/ScriptEngine.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/ScriptEngine.qhelp
@@ -15,6 +15,7 @@ It allows applications to interact with scripts written in languages such as Jav
 <example>
 <p>The following code could execute random JavaScript code</p>
 <sample src="ScriptEngine.java" />
+<sample src="NashornScriptEngine.java" />
 </example>
 
 <references>

--- a/java/ql/src/experimental/Security/CWE/CWE-094/ScriptEngine.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/ScriptEngine.ql
@@ -15,7 +15,7 @@ import DataFlow::PathGraph
 
 class ScriptEngineMethod extends Method {
   ScriptEngineMethod() {
-    this.getDeclaringType().hasQualifiedName("javax.script", "ScriptEngine") and
+    this.getDeclaringType().getASupertype*().hasQualifiedName("javax.script", "ScriptEngine") and
     this.hasName("eval")
   }
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-094/ScriptEngine.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/ScriptEngine.expected
@@ -1,0 +1,32 @@
+edges
+| ScriptEngineTest.java:8:44:8:55 | input : String | ScriptEngineTest.java:12:37:12:41 | input |
+| ScriptEngineTest.java:15:51:15:62 | input : String | ScriptEngineTest.java:19:31:19:35 | input |
+| ScriptEngineTest.java:23:58:23:69 | input : String | ScriptEngineTest.java:27:31:27:35 | input |
+| ScriptEngineTest.java:30:46:30:57 | input : String | ScriptEngineTest.java:34:31:34:35 | input |
+| ScriptEngineTest.java:37:26:37:38 | args : String[] | ScriptEngineTest.java:38:56:38:62 | ...[...] : String |
+| ScriptEngineTest.java:37:26:37:38 | args : String[] | ScriptEngineTest.java:39:63:39:69 | ...[...] : String |
+| ScriptEngineTest.java:37:26:37:38 | args : String[] | ScriptEngineTest.java:40:70:40:76 | ...[...] : String |
+| ScriptEngineTest.java:37:26:37:38 | args : String[] | ScriptEngineTest.java:41:58:41:64 | ...[...] : String |
+| ScriptEngineTest.java:38:56:38:62 | ...[...] : String | ScriptEngineTest.java:8:44:8:55 | input : String |
+| ScriptEngineTest.java:39:63:39:69 | ...[...] : String | ScriptEngineTest.java:15:51:15:62 | input : String |
+| ScriptEngineTest.java:40:70:40:76 | ...[...] : String | ScriptEngineTest.java:23:58:23:69 | input : String |
+| ScriptEngineTest.java:41:58:41:64 | ...[...] : String | ScriptEngineTest.java:30:46:30:57 | input : String |
+nodes
+| ScriptEngineTest.java:8:44:8:55 | input : String | semmle.label | input : String |
+| ScriptEngineTest.java:12:37:12:41 | input | semmle.label | input |
+| ScriptEngineTest.java:15:51:15:62 | input : String | semmle.label | input : String |
+| ScriptEngineTest.java:19:31:19:35 | input | semmle.label | input |
+| ScriptEngineTest.java:23:58:23:69 | input : String | semmle.label | input : String |
+| ScriptEngineTest.java:27:31:27:35 | input | semmle.label | input |
+| ScriptEngineTest.java:30:46:30:57 | input : String | semmle.label | input : String |
+| ScriptEngineTest.java:34:31:34:35 | input | semmle.label | input |
+| ScriptEngineTest.java:37:26:37:38 | args : String[] | semmle.label | args : String[] |
+| ScriptEngineTest.java:38:56:38:62 | ...[...] : String | semmle.label | ...[...] : String |
+| ScriptEngineTest.java:39:63:39:69 | ...[...] : String | semmle.label | ...[...] : String |
+| ScriptEngineTest.java:40:70:40:76 | ...[...] : String | semmle.label | ...[...] : String |
+| ScriptEngineTest.java:41:58:41:64 | ...[...] : String | semmle.label | ...[...] : String |
+#select
+| ScriptEngineTest.java:12:19:12:42 | eval(...) | ScriptEngineTest.java:37:26:37:38 | args : String[] | ScriptEngineTest.java:12:37:12:41 | input | ScriptEngine eval $@. | ScriptEngineTest.java:37:26:37:38 | args | user input |
+| ScriptEngineTest.java:19:19:19:36 | eval(...) | ScriptEngineTest.java:37:26:37:38 | args : String[] | ScriptEngineTest.java:19:31:19:35 | input | ScriptEngine eval $@. | ScriptEngineTest.java:37:26:37:38 | args | user input |
+| ScriptEngineTest.java:27:19:27:36 | eval(...) | ScriptEngineTest.java:37:26:37:38 | args : String[] | ScriptEngineTest.java:27:31:27:35 | input | ScriptEngine eval $@. | ScriptEngineTest.java:37:26:37:38 | args | user input |
+| ScriptEngineTest.java:34:19:34:36 | eval(...) | ScriptEngineTest.java:37:26:37:38 | args : String[] | ScriptEngineTest.java:34:31:34:35 | input | ScriptEngine eval $@. | ScriptEngineTest.java:37:26:37:38 | args | user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-094/ScriptEngine.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/ScriptEngine.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-094/ScriptEngine.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-094/ScriptEngineTest.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/ScriptEngineTest.java
@@ -1,0 +1,58 @@
+import jdk.nashorn.api.scripting.NashornScriptEngine;
+import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
+import javax.script.*;
+
+
+public class ScriptEngineTest {
+
+	public void testWithScriptEngineReference(String input) throws ScriptException {
+		ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
+		// Create with ScriptEngine reference
+		ScriptEngine scriptEngine = scriptEngineManager.getEngineByExtension("js");
+		Object result = scriptEngine.eval(input);
+	}
+	
+	public void testNashornWithScriptEngineReference(String input) throws ScriptException {
+		NashornScriptEngineFactory factory = new NashornScriptEngineFactory();
+		// Create Nashorn with ScriptEngine reference
+		ScriptEngine engine = (NashornScriptEngine) factory.getScriptEngine(new String[] { "-scripting" });
+		Object result = engine.eval(input);
+	}
+
+	
+	public void testNashornWithNashornScriptEngineReference(String input) throws ScriptException {
+		NashornScriptEngineFactory factory = new NashornScriptEngineFactory();
+		// Create Nashorn with NashornScriptEngine reference
+		NashornScriptEngine engine = (NashornScriptEngine) factory.getScriptEngine(new String[] { "-scripting" });
+		Object result = engine.eval(input);
+	}
+	
+	public void testCustomScriptEngineReference(String input) throws ScriptException {
+		MyCustomFactory factory = new MyCustomFactory();
+		//Create with Custom Script Engine reference
+		MyCustomScriptEngine engine = (MyCustomScriptEngine) factory.getScriptEngine(new String[] { "-scripting" });
+		Object result = engine.eval(input);
+	}
+	
+	public static void main(String[] args) throws ScriptException {
+		new ScriptEngineTest().testWithScriptEngineReference(args[0]);
+		new ScriptEngineTest().testNashornWithScriptEngineReference(args[0]);
+		new ScriptEngineTest().testNashornWithNashornScriptEngineReference(args[0]);
+		new ScriptEngineTest().testCustomScriptEngineReference(args[0]);
+	}
+	
+	private static class MyCustomScriptEngine extends AbstractScriptEngine {
+		public Object eval(String var1) throws ScriptException {
+			return null;
+		}
+	}
+	
+	private static class MyCustomFactory implements ScriptEngineFactory {
+		public MyCustomFactory() {
+    		}
+    		
+    		public ScriptEngine getScriptEngine() { return null; }
+
+		public ScriptEngine getScriptEngine(String... args) { return null; }
+	}
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-094/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/options
@@ -1,1 +1,2 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/springframework-5.2.3:${testdir}/../../../../stubs/mvel2-2.4.7:${testdir}/../../../../stubs/jsr223-api:${testdir}/../../../../stubs/apache-commons-jexl-2.1.1:${testdir}/../../../../stubs/apache-commons-jexl-3.1
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/springframework-5.2.3:${testdir}/../../../../stubs/mvel2-2.4.7:${testdir}/../../../../stubs/jsr223-api:${testdir}/../../../../stubs/apache-commons-jexl-2.1.1:${testdir}/../../../../stubs/apache-commons-jexl-3.1:${testdir}/../../../../stubs/scriptengine
+

--- a/java/ql/test/stubs/scriptengine/javax/script/AbstractScriptEngine.java
+++ b/java/ql/test/stubs/scriptengine/javax/script/AbstractScriptEngine.java
@@ -1,0 +1,8 @@
+package javax.script;
+
+public abstract class AbstractScriptEngine implements ScriptEngine {
+	public Object eval(String var1) throws ScriptException {
+		return null;
+	}
+}
+

--- a/java/ql/test/stubs/scriptengine/javax/script/ScriptEngine.java
+++ b/java/ql/test/stubs/scriptengine/javax/script/ScriptEngine.java
@@ -1,0 +1,6 @@
+package javax.script;
+
+public interface ScriptEngine {
+    Object eval(String var1) throws ScriptException;
+}
+

--- a/java/ql/test/stubs/scriptengine/javax/script/ScriptEngineFactory.java
+++ b/java/ql/test/stubs/scriptengine/javax/script/ScriptEngineFactory.java
@@ -1,0 +1,6 @@
+package javax.script;
+
+public interface ScriptEngineFactory {
+    ScriptEngine getScriptEngine();
+}
+

--- a/java/ql/test/stubs/scriptengine/javax/script/ScriptEngineManager.java
+++ b/java/ql/test/stubs/scriptengine/javax/script/ScriptEngineManager.java
@@ -1,0 +1,22 @@
+package javax.script;
+
+public class ScriptEngineManager {
+
+
+    public ScriptEngineManager() {
+
+    }
+
+    public ScriptEngine getEngineByName(String shortName) {
+	return null;
+    }
+
+    public ScriptEngine getEngineByExtension(String extension) {
+        return null;
+    }
+
+    public ScriptEngine getEngineByMimeType(String mimeType) {
+	return null;
+    }
+}
+

--- a/java/ql/test/stubs/scriptengine/javax/script/ScriptException.java
+++ b/java/ql/test/stubs/scriptengine/javax/script/ScriptException.java
@@ -1,0 +1,7 @@
+package javax.script;
+
+public class ScriptException extends Exception {
+    public ScriptException(String s) {
+    }
+}
+

--- a/java/ql/test/stubs/scriptengine/jdk/nashorn/api/scripting/NashornScriptEngine.java
+++ b/java/ql/test/stubs/scriptengine/jdk/nashorn/api/scripting/NashornScriptEngine.java
@@ -1,0 +1,10 @@
+package jdk.nashorn.api.scripting;
+
+import javax.script.*;
+
+public final class NashornScriptEngine extends AbstractScriptEngine {
+	public Object eval(String var1) throws ScriptException {
+		return null;
+	}
+}
+

--- a/java/ql/test/stubs/scriptengine/jdk/nashorn/api/scripting/NashornScriptEngineFactory.java
+++ b/java/ql/test/stubs/scriptengine/jdk/nashorn/api/scripting/NashornScriptEngineFactory.java
@@ -1,0 +1,22 @@
+package jdk.nashorn.api.scripting;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+
+
+public final class NashornScriptEngineFactory implements ScriptEngineFactory {
+
+    public NashornScriptEngineFactory() {
+    }
+
+
+    public ScriptEngine getScriptEngine() {
+        return null;
+    }
+
+
+    public ScriptEngine getScriptEngine(String... args) {
+        return null;
+    }
+}
+


### PR DESCRIPTION
In case of creating ScriptEngine by this way:
NashornScriptEngine engine = (NashornScriptEngine) factory.getScriptEngine(...);
engine.eval(input);
ScriptEngine.ql cannot detect this sink.