### PR TITLE
InlineExpectationTest: clarify the need for an empty `.expected` file

### DIFF
--- a/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -1,6 +1,7 @@
 /**
  * Provides a library for writing QL tests whose success or failure is based on expected results
- * embedded in the test source code as comments, rather than a `.expected` file.
+ * embedded in the test source code as comments, rather than the contents of an `.expected` file
+ * (in that the `.expected` file should always be empty).
  *
  * To add this framework to a new language:
  * - Add a file `InlineExpectationsTestPrivate.qll` that defines a `LineComment` class. This class

--- a/java/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/java/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -1,6 +1,7 @@
 /**
  * Provides a library for writing QL tests whose success or failure is based on expected results
- * embedded in the test source code as comments, rather than a `.expected` file.
+ * embedded in the test source code as comments, rather than the contents of an `.expected` file
+ * (in that the `.expected` file should always be empty).
  *
  * To add this framework to a new language:
  * - Add a file `InlineExpectationsTestPrivate.qll` that defines a `LineComment` class. This class

--- a/python/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/python/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -1,6 +1,7 @@
 /**
  * Provides a library for writing QL tests whose success or failure is based on expected results
- * embedded in the test source code as comments, rather than a `.expected` file.
+ * embedded in the test source code as comments, rather than the contents of an `.expected` file
+ * (in that the `.expected` file should always be empty).
  *
  * To add this framework to a new language:
  * - Add a file `InlineExpectationsTestPrivate.qll` that defines a `LineComment` class. This class


### PR DESCRIPTION
To express the concern raised in #5343.