### PR TITLE
C++: Show arguments in path explanations

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -526,4 +526,4 @@ predicate isImmutableOrUnobservable(Node n) {
 }
 
 /** Holds if `n` should be hidden from path explanations. */
-predicate nodeIsHidden(Node n) { n instanceof OperandNode }
+predicate nodeIsHidden(Node n) { n instanceof OperandNode and not n instanceof ArgumentNode }

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -1,28 +1,37 @@
 edges
-| A.cpp:55:5:55:5 | set output argument [c] | A.cpp:56:13:56:15 | call to get |
-| A.cpp:55:12:55:19 | (C *)... | A.cpp:55:5:55:5 | set output argument [c] |
-| A.cpp:55:12:55:19 | new | A.cpp:55:5:55:5 | set output argument [c] |
-| A.cpp:57:11:57:24 | B output argument [c] | A.cpp:57:28:57:30 | call to get |
-| A.cpp:57:17:57:23 | new | A.cpp:57:11:57:24 | B output argument [c] |
+| A.cpp:55:5:55:5 | set output argument [c] | A.cpp:56:10:56:10 | Argument -1 indirection [c] |
+| A.cpp:55:8:55:10 | Argument 0 | A.cpp:55:5:55:5 | set output argument [c] |
+| A.cpp:55:12:55:19 | (C *)... | A.cpp:55:8:55:10 | Argument 0 |
+| A.cpp:55:12:55:19 | new | A.cpp:55:8:55:10 | Argument 0 |
+| A.cpp:56:10:56:10 | Argument -1 indirection [c] | A.cpp:56:13:56:15 | call to get |
+| A.cpp:57:10:57:25 | Argument -1 indirection [c] | A.cpp:57:28:57:30 | call to get |
+| A.cpp:57:11:57:24 | Argument 0 | A.cpp:57:11:57:24 | B output argument [c] |
+| A.cpp:57:11:57:24 | B output argument [c] | A.cpp:57:10:57:25 | Argument -1 indirection [c] |
+| A.cpp:57:17:57:23 | new | A.cpp:57:11:57:24 | Argument 0 |
 | A.cpp:98:12:98:18 | new | A.cpp:100:5:100:13 | Chi [a] |
-| A.cpp:100:5:100:13 | Chi [a] | A.cpp:103:14:103:14 | *c [a] |
+| A.cpp:100:5:100:13 | Chi [a] | A.cpp:101:8:101:9 | Argument 0 indirection [a] |
+| A.cpp:101:8:101:9 | Argument 0 indirection [a] | A.cpp:103:14:103:14 | *c [a] |
 | A.cpp:103:14:103:14 | *c [a] | A.cpp:107:16:107:16 | a |
 | A.cpp:126:5:126:5 | Chi [c] | A.cpp:131:8:131:8 | f7 output argument [c] |
 | A.cpp:126:5:126:5 | set output argument [c] | A.cpp:126:5:126:5 | Chi [c] |
-| A.cpp:126:12:126:18 | new | A.cpp:126:5:126:5 | set output argument [c] |
+| A.cpp:126:8:126:10 | Argument 0 | A.cpp:126:5:126:5 | set output argument [c] |
+| A.cpp:126:12:126:18 | new | A.cpp:126:8:126:10 | Argument 0 |
 | A.cpp:131:8:131:8 | Chi [c] | A.cpp:132:13:132:13 | c |
 | A.cpp:131:8:131:8 | f7 output argument [c] | A.cpp:131:8:131:8 | Chi [c] |
 | A.cpp:142:7:142:20 | Chi [c] | A.cpp:151:18:151:18 | D output argument [c] |
 | A.cpp:142:14:142:20 | new | A.cpp:142:7:142:20 | Chi [c] |
 | A.cpp:143:7:143:31 | Chi [b] | A.cpp:151:12:151:24 | D output argument [b] |
 | A.cpp:143:25:143:31 | new | A.cpp:143:7:143:31 | Chi [b] |
-| A.cpp:150:12:150:18 | new | A.cpp:151:12:151:24 | D output argument [b] |
+| A.cpp:150:12:150:18 | new | A.cpp:151:12:151:24 | Argument 0 |
+| A.cpp:151:12:151:24 | Argument 0 | A.cpp:151:12:151:24 | D output argument [b] |
 | A.cpp:151:12:151:24 | Chi [b] | A.cpp:152:13:152:13 | b |
 | A.cpp:151:12:151:24 | D output argument [b] | A.cpp:151:12:151:24 | Chi [b] |
 | A.cpp:151:18:151:18 | Chi [c] | A.cpp:154:13:154:13 | c |
 | A.cpp:151:18:151:18 | D output argument [c] | A.cpp:151:18:151:18 | Chi [c] |
-| C.cpp:18:12:18:18 | C output argument [s1] | C.cpp:27:8:27:11 | *#this [s1] |
-| C.cpp:18:12:18:18 | C output argument [s3] | C.cpp:27:8:27:11 | *#this [s3] |
+| C.cpp:18:12:18:18 | C output argument [s1] | C.cpp:19:5:19:5 | Argument -1 indirection [s1] |
+| C.cpp:18:12:18:18 | C output argument [s3] | C.cpp:19:5:19:5 | Argument -1 indirection [s3] |
+| C.cpp:19:5:19:5 | Argument -1 indirection [s1] | C.cpp:27:8:27:11 | *#this [s1] |
+| C.cpp:19:5:19:5 | Argument -1 indirection [s3] | C.cpp:27:8:27:11 | *#this [s3] |
 | C.cpp:22:12:22:21 | Chi [s1] | C.cpp:24:5:24:25 | Chi [s1] |
 | C.cpp:22:12:22:21 | new | C.cpp:22:12:22:21 | Chi [s1] |
 | C.cpp:24:5:24:25 | Chi [s1] | C.cpp:18:12:18:18 | C output argument [s1] |
@@ -77,14 +86,22 @@ edges
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... |
 | arrays.cpp:15:14:15:23 | call to user_input | arrays.cpp:16:8:16:13 | access to array |
 | arrays.cpp:36:26:36:35 | call to user_input | arrays.cpp:37:24:37:27 | data |
-| by_reference.cpp:50:3:50:3 | setDirectly output argument [a] | by_reference.cpp:51:10:51:20 | call to getDirectly |
-| by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] |
-| by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] | by_reference.cpp:57:10:57:22 | call to getIndirectly |
-| by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] |
-| by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
-| by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] |
-| by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
-| by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] |
+| by_reference.cpp:50:3:50:3 | setDirectly output argument [a] | by_reference.cpp:51:8:51:8 | Argument -1 indirection [a] |
+| by_reference.cpp:50:5:50:15 | Argument 0 | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] |
+| by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:50:5:50:15 | Argument 0 |
+| by_reference.cpp:51:8:51:8 | Argument -1 indirection [a] | by_reference.cpp:51:10:51:20 | call to getDirectly |
+| by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] | by_reference.cpp:57:8:57:8 | Argument -1 indirection [a] |
+| by_reference.cpp:56:5:56:17 | Argument 0 | by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] |
+| by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:56:5:56:17 | Argument 0 |
+| by_reference.cpp:57:8:57:8 | Argument -1 indirection [a] | by_reference.cpp:57:10:57:22 | call to getIndirectly |
+| by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] | by_reference.cpp:63:8:63:8 | Argument -1 indirection [a] |
+| by_reference.cpp:62:5:62:23 | Argument 0 | by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] |
+| by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:62:5:62:23 | Argument 0 |
+| by_reference.cpp:63:8:63:8 | Argument -1 indirection [a] | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
+| by_reference.cpp:68:3:68:15 | Argument 1 | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] |
+| by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] | by_reference.cpp:69:22:69:23 | Argument 0 indirection [a] |
+| by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:68:3:68:15 | Argument 1 |
+| by_reference.cpp:69:22:69:23 | Argument 0 indirection [a] | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
 | by_reference.cpp:84:3:84:25 | Chi [a] | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] |
 | by_reference.cpp:84:3:84:25 | Chi [a] | by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] |
 | by_reference.cpp:84:14:84:23 | call to user_input | by_reference.cpp:84:3:84:25 | Chi [a] |
@@ -117,91 +134,135 @@ edges
 | by_reference.cpp:128:15:128:23 | Chi | by_reference.cpp:128:15:128:23 | Chi [a] |
 | by_reference.cpp:128:15:128:23 | Chi [a] | by_reference.cpp:136:16:136:16 | a |
 | by_reference.cpp:128:15:128:23 | taint_a_ref output argument [array content] | by_reference.cpp:128:15:128:23 | Chi |
-| complex.cpp:40:17:40:17 | *b [a_] | complex.cpp:42:18:42:18 | call to a |
+| complex.cpp:40:17:40:17 | *b [a_] | complex.cpp:42:16:42:16 | Argument -1 indirection [a_] |
+| complex.cpp:40:17:40:17 | *b [b_] | complex.cpp:42:16:42:16 | Argument -1 indirection [b_] |
 | complex.cpp:40:17:40:17 | *b [b_] | complex.cpp:42:16:42:16 | Chi [b_] |
-| complex.cpp:40:17:40:17 | *b [b_] | complex.cpp:42:16:42:16 | a output argument [b_] |
-| complex.cpp:40:17:40:17 | *b [b_] | complex.cpp:43:18:43:18 | call to b |
-| complex.cpp:42:16:42:16 | Chi [b_] | complex.cpp:43:18:43:18 | call to b |
+| complex.cpp:40:17:40:17 | *b [b_] | complex.cpp:43:16:43:16 | Argument -1 indirection [b_] |
+| complex.cpp:42:16:42:16 | Argument -1 indirection [a_] | complex.cpp:42:18:42:18 | call to a |
+| complex.cpp:42:16:42:16 | Argument -1 indirection [b_] | complex.cpp:42:16:42:16 | a output argument [b_] |
+| complex.cpp:42:16:42:16 | Chi [b_] | complex.cpp:43:16:43:16 | Argument -1 indirection [b_] |
 | complex.cpp:42:16:42:16 | a output argument [b_] | complex.cpp:42:16:42:16 | Chi [b_] |
-| complex.cpp:42:16:42:16 | a output argument [b_] | complex.cpp:43:18:43:18 | call to b |
-| complex.cpp:53:12:53:12 | Chi [a_] | complex.cpp:40:17:40:17 | *b [a_] |
-| complex.cpp:53:12:53:12 | setA output argument [a_] | complex.cpp:40:17:40:17 | *b [a_] |
+| complex.cpp:42:16:42:16 | a output argument [b_] | complex.cpp:43:16:43:16 | Argument -1 indirection [b_] |
+| complex.cpp:43:16:43:16 | Argument -1 indirection [b_] | complex.cpp:43:18:43:18 | call to b |
+| complex.cpp:53:12:53:12 | Chi [a_] | complex.cpp:59:7:59:8 | Argument 0 indirection [a_] |
 | complex.cpp:53:12:53:12 | setA output argument [a_] | complex.cpp:53:12:53:12 | Chi [a_] |
-| complex.cpp:53:19:53:28 | call to user_input | complex.cpp:53:12:53:12 | setA output argument [a_] |
-| complex.cpp:54:12:54:12 | Chi [b_] | complex.cpp:40:17:40:17 | *b [b_] |
-| complex.cpp:54:12:54:12 | setB output argument [b_] | complex.cpp:40:17:40:17 | *b [b_] |
+| complex.cpp:53:12:53:12 | setA output argument [a_] | complex.cpp:59:7:59:8 | Argument 0 indirection [a_] |
+| complex.cpp:53:14:53:17 | Argument 0 | complex.cpp:53:12:53:12 | setA output argument [a_] |
+| complex.cpp:53:19:53:28 | call to user_input | complex.cpp:53:14:53:17 | Argument 0 |
+| complex.cpp:54:12:54:12 | Chi [b_] | complex.cpp:62:7:62:8 | Argument 0 indirection [b_] |
 | complex.cpp:54:12:54:12 | setB output argument [b_] | complex.cpp:54:12:54:12 | Chi [b_] |
-| complex.cpp:54:19:54:28 | call to user_input | complex.cpp:54:12:54:12 | setB output argument [b_] |
-| complex.cpp:55:12:55:12 | Chi [a_] | complex.cpp:40:17:40:17 | *b [a_] |
+| complex.cpp:54:12:54:12 | setB output argument [b_] | complex.cpp:62:7:62:8 | Argument 0 indirection [b_] |
+| complex.cpp:54:14:54:17 | Argument 0 | complex.cpp:54:12:54:12 | setB output argument [b_] |
+| complex.cpp:54:19:54:28 | call to user_input | complex.cpp:54:14:54:17 | Argument 0 |
+| complex.cpp:55:12:55:12 | Chi [a_] | complex.cpp:56:12:56:12 | Argument -1 indirection [a_] |
 | complex.cpp:55:12:55:12 | Chi [a_] | complex.cpp:56:12:56:12 | Chi [a_] |
-| complex.cpp:55:12:55:12 | Chi [a_] | complex.cpp:56:12:56:12 | setB output argument [a_] |
-| complex.cpp:55:12:55:12 | setA output argument [a_] | complex.cpp:40:17:40:17 | *b [a_] |
+| complex.cpp:55:12:55:12 | Chi [a_] | complex.cpp:65:7:65:8 | Argument 0 indirection [a_] |
 | complex.cpp:55:12:55:12 | setA output argument [a_] | complex.cpp:55:12:55:12 | Chi [a_] |
+| complex.cpp:55:12:55:12 | setA output argument [a_] | complex.cpp:56:12:56:12 | Argument -1 indirection [a_] |
 | complex.cpp:55:12:55:12 | setA output argument [a_] | complex.cpp:56:12:56:12 | Chi [a_] |
-| complex.cpp:55:12:55:12 | setA output argument [a_] | complex.cpp:56:12:56:12 | setB output argument [a_] |
-| complex.cpp:55:19:55:28 | call to user_input | complex.cpp:55:12:55:12 | setA output argument [a_] |
-| complex.cpp:56:12:56:12 | Chi [a_] | complex.cpp:40:17:40:17 | *b [a_] |
-| complex.cpp:56:12:56:12 | Chi [b_] | complex.cpp:40:17:40:17 | *b [b_] |
-| complex.cpp:56:12:56:12 | setB output argument [a_] | complex.cpp:40:17:40:17 | *b [a_] |
+| complex.cpp:55:12:55:12 | setA output argument [a_] | complex.cpp:65:7:65:8 | Argument 0 indirection [a_] |
+| complex.cpp:55:14:55:17 | Argument 0 | complex.cpp:55:12:55:12 | setA output argument [a_] |
+| complex.cpp:55:19:55:28 | call to user_input | complex.cpp:55:14:55:17 | Argument 0 |
+| complex.cpp:56:12:56:12 | Argument -1 indirection [a_] | complex.cpp:56:12:56:12 | setB output argument [a_] |
+| complex.cpp:56:12:56:12 | Chi [a_] | complex.cpp:65:7:65:8 | Argument 0 indirection [a_] |
+| complex.cpp:56:12:56:12 | Chi [b_] | complex.cpp:65:7:65:8 | Argument 0 indirection [b_] |
 | complex.cpp:56:12:56:12 | setB output argument [a_] | complex.cpp:56:12:56:12 | Chi [a_] |
-| complex.cpp:56:12:56:12 | setB output argument [b_] | complex.cpp:40:17:40:17 | *b [b_] |
+| complex.cpp:56:12:56:12 | setB output argument [a_] | complex.cpp:65:7:65:8 | Argument 0 indirection [a_] |
 | complex.cpp:56:12:56:12 | setB output argument [b_] | complex.cpp:56:12:56:12 | Chi [b_] |
-| complex.cpp:56:19:56:28 | call to user_input | complex.cpp:56:12:56:12 | setB output argument [b_] |
-| constructors.cpp:26:15:26:15 | *f [a_] | constructors.cpp:28:12:28:12 | call to a |
-| constructors.cpp:26:15:26:15 | *f [b_] | constructors.cpp:28:10:28:10 | a output argument [b_] |
-| constructors.cpp:26:15:26:15 | *f [b_] | constructors.cpp:29:12:29:12 | call to b |
-| constructors.cpp:28:10:28:10 | a output argument [b_] | constructors.cpp:29:12:29:12 | call to b |
-| constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:34:11:34:26 | Foo output argument [a_] |
-| constructors.cpp:34:11:34:26 | Foo output argument [a_] | constructors.cpp:26:15:26:15 | *f [a_] |
-| constructors.cpp:35:11:35:26 | Foo output argument [b_] | constructors.cpp:26:15:26:15 | *f [b_] |
-| constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:35:11:35:26 | Foo output argument [b_] |
-| constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:36:11:36:37 | Foo output argument [a_] |
-| constructors.cpp:36:11:36:37 | Foo output argument [a_] | constructors.cpp:26:15:26:15 | *f [a_] |
-| constructors.cpp:36:11:36:37 | Foo output argument [b_] | constructors.cpp:26:15:26:15 | *f [b_] |
-| constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:36:11:36:37 | Foo output argument [b_] |
-| simple.cpp:26:15:26:15 | *f [a_] | simple.cpp:28:12:28:12 | call to a |
-| simple.cpp:26:15:26:15 | *f [b_] | simple.cpp:28:10:28:10 | a output argument [b_] |
-| simple.cpp:26:15:26:15 | *f [b_] | simple.cpp:29:12:29:12 | call to b |
-| simple.cpp:28:10:28:10 | a output argument [b_] | simple.cpp:29:12:29:12 | call to b |
-| simple.cpp:39:5:39:5 | setA output argument [a_] | simple.cpp:26:15:26:15 | *f [a_] |
-| simple.cpp:39:12:39:21 | call to user_input | simple.cpp:39:5:39:5 | setA output argument [a_] |
-| simple.cpp:40:5:40:5 | setB output argument [b_] | simple.cpp:26:15:26:15 | *f [b_] |
-| simple.cpp:40:12:40:21 | call to user_input | simple.cpp:40:5:40:5 | setB output argument [b_] |
-| simple.cpp:41:5:41:5 | setA output argument [a_] | simple.cpp:26:15:26:15 | *f [a_] |
-| simple.cpp:41:5:41:5 | setA output argument [a_] | simple.cpp:42:5:42:5 | setB output argument [a_] |
-| simple.cpp:41:12:41:21 | call to user_input | simple.cpp:41:5:41:5 | setA output argument [a_] |
-| simple.cpp:42:5:42:5 | setB output argument [a_] | simple.cpp:26:15:26:15 | *f [a_] |
-| simple.cpp:42:5:42:5 | setB output argument [b_] | simple.cpp:26:15:26:15 | *f [b_] |
-| simple.cpp:42:12:42:21 | call to user_input | simple.cpp:42:5:42:5 | setB output argument [b_] |
+| complex.cpp:56:12:56:12 | setB output argument [b_] | complex.cpp:65:7:65:8 | Argument 0 indirection [b_] |
+| complex.cpp:56:14:56:17 | Argument 0 | complex.cpp:56:12:56:12 | setB output argument [b_] |
+| complex.cpp:56:19:56:28 | call to user_input | complex.cpp:56:14:56:17 | Argument 0 |
+| complex.cpp:59:7:59:8 | Argument 0 indirection [a_] | complex.cpp:40:17:40:17 | *b [a_] |
+| complex.cpp:62:7:62:8 | Argument 0 indirection [b_] | complex.cpp:40:17:40:17 | *b [b_] |
+| complex.cpp:65:7:65:8 | Argument 0 indirection [a_] | complex.cpp:40:17:40:17 | *b [a_] |
+| complex.cpp:65:7:65:8 | Argument 0 indirection [b_] | complex.cpp:40:17:40:17 | *b [b_] |
+| constructors.cpp:26:15:26:15 | *f [a_] | constructors.cpp:28:10:28:10 | Argument -1 indirection [a_] |
+| constructors.cpp:26:15:26:15 | *f [b_] | constructors.cpp:28:10:28:10 | Argument -1 indirection [b_] |
+| constructors.cpp:26:15:26:15 | *f [b_] | constructors.cpp:29:10:29:10 | Argument -1 indirection [b_] |
+| constructors.cpp:28:10:28:10 | Argument -1 indirection [a_] | constructors.cpp:28:12:28:12 | call to a |
+| constructors.cpp:28:10:28:10 | Argument -1 indirection [b_] | constructors.cpp:28:10:28:10 | a output argument [b_] |
+| constructors.cpp:28:10:28:10 | a output argument [b_] | constructors.cpp:29:10:29:10 | Argument -1 indirection [b_] |
+| constructors.cpp:29:10:29:10 | Argument -1 indirection [b_] | constructors.cpp:29:12:29:12 | call to b |
+| constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:34:11:34:26 | Argument 0 |
+| constructors.cpp:34:11:34:26 | Argument 0 | constructors.cpp:34:11:34:26 | Foo output argument [a_] |
+| constructors.cpp:34:11:34:26 | Foo output argument [a_] | constructors.cpp:40:9:40:9 | Argument 0 indirection [a_] |
+| constructors.cpp:35:11:35:26 | Argument 1 | constructors.cpp:35:11:35:26 | Foo output argument [b_] |
+| constructors.cpp:35:11:35:26 | Foo output argument [b_] | constructors.cpp:43:9:43:9 | Argument 0 indirection [b_] |
+| constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:35:11:35:26 | Argument 1 |
+| constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:36:11:36:37 | Argument 0 |
+| constructors.cpp:36:11:36:37 | Argument 0 | constructors.cpp:36:11:36:37 | Foo output argument [a_] |
+| constructors.cpp:36:11:36:37 | Argument 1 | constructors.cpp:36:11:36:37 | Foo output argument [b_] |
+| constructors.cpp:36:11:36:37 | Foo output argument [a_] | constructors.cpp:46:9:46:9 | Argument 0 indirection [a_] |
+| constructors.cpp:36:11:36:37 | Foo output argument [b_] | constructors.cpp:46:9:46:9 | Argument 0 indirection [b_] |
+| constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:36:11:36:37 | Argument 1 |
+| constructors.cpp:40:9:40:9 | Argument 0 indirection [a_] | constructors.cpp:26:15:26:15 | *f [a_] |
+| constructors.cpp:43:9:43:9 | Argument 0 indirection [b_] | constructors.cpp:26:15:26:15 | *f [b_] |
+| constructors.cpp:46:9:46:9 | Argument 0 indirection [a_] | constructors.cpp:26:15:26:15 | *f [a_] |
+| constructors.cpp:46:9:46:9 | Argument 0 indirection [b_] | constructors.cpp:26:15:26:15 | *f [b_] |
+| simple.cpp:26:15:26:15 | *f [a_] | simple.cpp:28:10:28:10 | Argument -1 indirection [a_] |
+| simple.cpp:26:15:26:15 | *f [b_] | simple.cpp:28:10:28:10 | Argument -1 indirection [b_] |
+| simple.cpp:26:15:26:15 | *f [b_] | simple.cpp:29:10:29:10 | Argument -1 indirection [b_] |
+| simple.cpp:28:10:28:10 | Argument -1 indirection [a_] | simple.cpp:28:12:28:12 | call to a |
+| simple.cpp:28:10:28:10 | Argument -1 indirection [b_] | simple.cpp:28:10:28:10 | a output argument [b_] |
+| simple.cpp:28:10:28:10 | a output argument [b_] | simple.cpp:29:10:29:10 | Argument -1 indirection [b_] |
+| simple.cpp:29:10:29:10 | Argument -1 indirection [b_] | simple.cpp:29:12:29:12 | call to b |
+| simple.cpp:39:5:39:5 | setA output argument [a_] | simple.cpp:45:9:45:9 | Argument 0 indirection [a_] |
+| simple.cpp:39:7:39:10 | Argument 0 | simple.cpp:39:5:39:5 | setA output argument [a_] |
+| simple.cpp:39:12:39:21 | call to user_input | simple.cpp:39:7:39:10 | Argument 0 |
+| simple.cpp:40:5:40:5 | setB output argument [b_] | simple.cpp:48:9:48:9 | Argument 0 indirection [b_] |
+| simple.cpp:40:7:40:10 | Argument 0 | simple.cpp:40:5:40:5 | setB output argument [b_] |
+| simple.cpp:40:12:40:21 | call to user_input | simple.cpp:40:7:40:10 | Argument 0 |
+| simple.cpp:41:5:41:5 | setA output argument [a_] | simple.cpp:42:5:42:5 | Argument -1 indirection [a_] |
+| simple.cpp:41:5:41:5 | setA output argument [a_] | simple.cpp:51:9:51:9 | Argument 0 indirection [a_] |
+| simple.cpp:41:7:41:10 | Argument 0 | simple.cpp:41:5:41:5 | setA output argument [a_] |
+| simple.cpp:41:12:41:21 | call to user_input | simple.cpp:41:7:41:10 | Argument 0 |
+| simple.cpp:42:5:42:5 | Argument -1 indirection [a_] | simple.cpp:42:5:42:5 | setB output argument [a_] |
+| simple.cpp:42:5:42:5 | setB output argument [a_] | simple.cpp:51:9:51:9 | Argument 0 indirection [a_] |
+| simple.cpp:42:5:42:5 | setB output argument [b_] | simple.cpp:51:9:51:9 | Argument 0 indirection [b_] |
+| simple.cpp:42:7:42:10 | Argument 0 | simple.cpp:42:5:42:5 | setB output argument [b_] |
+| simple.cpp:42:12:42:21 | call to user_input | simple.cpp:42:7:42:10 | Argument 0 |
+| simple.cpp:45:9:45:9 | Argument 0 indirection [a_] | simple.cpp:26:15:26:15 | *f [a_] |
+| simple.cpp:48:9:48:9 | Argument 0 indirection [b_] | simple.cpp:26:15:26:15 | *f [b_] |
+| simple.cpp:51:9:51:9 | Argument 0 indirection [a_] | simple.cpp:26:15:26:15 | *f [a_] |
+| simple.cpp:51:9:51:9 | Argument 0 indirection [b_] | simple.cpp:26:15:26:15 | *f [b_] |
 | simple.cpp:65:5:65:22 | Store [i] | simple.cpp:66:12:66:12 | Store [i] |
 | simple.cpp:65:11:65:20 | call to user_input | simple.cpp:65:5:65:22 | Store [i] |
 | simple.cpp:66:12:66:12 | Store [i] | simple.cpp:67:13:67:13 | i |
-| simple.cpp:83:9:83:28 | Chi [f1] | simple.cpp:84:14:84:20 | call to getf2f1 |
+| simple.cpp:83:9:83:28 | Chi [f1] | simple.cpp:84:14:84:20 | Argument -1 indirection [f1] |
 | simple.cpp:83:17:83:26 | call to user_input | simple.cpp:83:9:83:28 | Chi [f1] |
+| simple.cpp:84:14:84:20 | Argument -1 indirection [f1] | simple.cpp:84:14:84:20 | call to getf2f1 |
 | simple.cpp:92:5:92:22 | Store [i] | simple.cpp:93:20:93:20 | Store [i] |
 | simple.cpp:92:11:92:20 | call to user_input | simple.cpp:92:5:92:22 | Store [i] |
 | simple.cpp:93:20:93:20 | Store [i] | simple.cpp:94:13:94:13 | i |
 | struct_init.c:14:24:14:25 | *ab [a] | struct_init.c:15:12:15:12 | a |
-| struct_init.c:20:20:20:29 | Chi [a] | struct_init.c:14:24:14:25 | *ab [a] |
+| struct_init.c:20:20:20:29 | Chi [a] | struct_init.c:24:10:24:12 | Argument 0 indirection [a] |
 | struct_init.c:20:20:20:29 | call to user_input | struct_init.c:20:20:20:29 | Chi [a] |
 | struct_init.c:20:20:20:29 | call to user_input | struct_init.c:22:11:22:11 | a |
-| struct_init.c:27:7:27:16 | Chi [a] | struct_init.c:14:24:14:25 | *ab [a] |
+| struct_init.c:24:10:24:12 | Argument 0 indirection [a] | struct_init.c:14:24:14:25 | *ab [a] |
+| struct_init.c:27:7:27:16 | Chi [a] | struct_init.c:36:10:36:24 | Argument 0 indirection [a] |
 | struct_init.c:27:7:27:16 | call to user_input | struct_init.c:27:7:27:16 | Chi [a] |
 | struct_init.c:27:7:27:16 | call to user_input | struct_init.c:31:23:31:23 | a |
+| struct_init.c:36:10:36:24 | Argument 0 indirection [a] | struct_init.c:14:24:14:25 | *ab [a] |
 nodes
 | A.cpp:55:5:55:5 | set output argument [c] | semmle.label | set output argument [c] |
+| A.cpp:55:8:55:10 | Argument 0 | semmle.label | Argument 0 |
 | A.cpp:55:12:55:19 | (C *)... | semmle.label | (C *)... |
 | A.cpp:55:12:55:19 | new | semmle.label | new |
+| A.cpp:56:10:56:10 | Argument -1 indirection [c] | semmle.label | Argument -1 indirection [c] |
 | A.cpp:56:13:56:15 | call to get | semmle.label | call to get |
+| A.cpp:57:10:57:25 | Argument -1 indirection [c] | semmle.label | Argument -1 indirection [c] |
+| A.cpp:57:11:57:24 | Argument 0 | semmle.label | Argument 0 |
 | A.cpp:57:11:57:24 | B output argument [c] | semmle.label | B output argument [c] |
 | A.cpp:57:17:57:23 | new | semmle.label | new |
 | A.cpp:57:28:57:30 | call to get | semmle.label | call to get |
 | A.cpp:98:12:98:18 | new | semmle.label | new |
 | A.cpp:100:5:100:13 | Chi [a] | semmle.label | Chi [a] |
+| A.cpp:101:8:101:9 | Argument 0 indirection [a] | semmle.label | Argument 0 indirection [a] |
 | A.cpp:103:14:103:14 | *c [a] | semmle.label | *c [a] |
 | A.cpp:107:16:107:16 | a | semmle.label | a |
 | A.cpp:126:5:126:5 | Chi [c] | semmle.label | Chi [c] |
 | A.cpp:126:5:126:5 | set output argument [c] | semmle.label | set output argument [c] |
+| A.cpp:126:8:126:10 | Argument 0 | semmle.label | Argument 0 |
 | A.cpp:126:12:126:18 | new | semmle.label | new |
 | A.cpp:131:8:131:8 | Chi [c] | semmle.label | Chi [c] |
 | A.cpp:131:8:131:8 | f7 output argument [c] | semmle.label | f7 output argument [c] |
@@ -211,6 +272,7 @@ nodes
 | A.cpp:143:7:143:31 | Chi [b] | semmle.label | Chi [b] |
 | A.cpp:143:25:143:31 | new | semmle.label | new |
 | A.cpp:150:12:150:18 | new | semmle.label | new |
+| A.cpp:151:12:151:24 | Argument 0 | semmle.label | Argument 0 |
 | A.cpp:151:12:151:24 | Chi [b] | semmle.label | Chi [b] |
 | A.cpp:151:12:151:24 | D output argument [b] | semmle.label | D output argument [b] |
 | A.cpp:151:18:151:18 | Chi [c] | semmle.label | Chi [c] |
@@ -219,6 +281,8 @@ nodes
 | A.cpp:154:13:154:13 | c | semmle.label | c |
 | C.cpp:18:12:18:18 | C output argument [s1] | semmle.label | C output argument [s1] |
 | C.cpp:18:12:18:18 | C output argument [s3] | semmle.label | C output argument [s3] |
+| C.cpp:19:5:19:5 | Argument -1 indirection [s1] | semmle.label | Argument -1 indirection [s1] |
+| C.cpp:19:5:19:5 | Argument -1 indirection [s3] | semmle.label | Argument -1 indirection [s3] |
 | C.cpp:22:12:22:21 | Chi [s1] | semmle.label | Chi [s1] |
 | C.cpp:22:12:22:21 | new | semmle.label | new |
 | C.cpp:24:5:24:25 | Chi [s1] | semmle.label | Chi [s1] |
@@ -289,17 +353,25 @@ nodes
 | arrays.cpp:36:26:36:35 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:37:24:37:27 | data | semmle.label | data |
 | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] | semmle.label | setDirectly output argument [a] |
+| by_reference.cpp:50:5:50:15 | Argument 0 | semmle.label | Argument 0 |
 | by_reference.cpp:50:17:50:26 | call to user_input | semmle.label | call to user_input |
+| by_reference.cpp:51:8:51:8 | Argument -1 indirection [a] | semmle.label | Argument -1 indirection [a] |
 | by_reference.cpp:51:10:51:20 | call to getDirectly | semmle.label | call to getDirectly |
 | by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] | semmle.label | setIndirectly output argument [a] |
+| by_reference.cpp:56:5:56:17 | Argument 0 | semmle.label | Argument 0 |
 | by_reference.cpp:56:19:56:28 | call to user_input | semmle.label | call to user_input |
+| by_reference.cpp:57:8:57:8 | Argument -1 indirection [a] | semmle.label | Argument -1 indirection [a] |
 | by_reference.cpp:57:10:57:22 | call to getIndirectly | semmle.label | call to getIndirectly |
 | by_reference.cpp:62:3:62:3 | setThroughNonMember output argument [a] | semmle.label | setThroughNonMember output argument [a] |
+| by_reference.cpp:62:5:62:23 | Argument 0 | semmle.label | Argument 0 |
 | by_reference.cpp:62:25:62:34 | call to user_input | semmle.label | call to user_input |
+| by_reference.cpp:63:8:63:8 | Argument -1 indirection [a] | semmle.label | Argument -1 indirection [a] |
 | by_reference.cpp:63:10:63:28 | call to getThroughNonMember | semmle.label | call to getThroughNonMember |
+| by_reference.cpp:68:3:68:15 | Argument 1 | semmle.label | Argument 1 |
 | by_reference.cpp:68:17:68:18 | nonMemberSetA output argument [a] | semmle.label | nonMemberSetA output argument [a] |
 | by_reference.cpp:68:21:68:30 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:69:8:69:20 | call to nonMemberGetA | semmle.label | call to nonMemberGetA |
+| by_reference.cpp:69:22:69:23 | Argument 0 indirection [a] | semmle.label | Argument 0 indirection [a] |
 | by_reference.cpp:84:3:84:25 | Chi [a] | semmle.label | Chi [a] |
 | by_reference.cpp:84:14:84:23 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:88:3:88:24 | Chi [a] | semmle.label | Chi [a] |
@@ -338,57 +410,93 @@ nodes
 | by_reference.cpp:136:16:136:16 | a | semmle.label | a |
 | complex.cpp:40:17:40:17 | *b [a_] | semmle.label | *b [a_] |
 | complex.cpp:40:17:40:17 | *b [b_] | semmle.label | *b [b_] |
+| complex.cpp:42:16:42:16 | Argument -1 indirection [a_] | semmle.label | Argument -1 indirection [a_] |
+| complex.cpp:42:16:42:16 | Argument -1 indirection [b_] | semmle.label | Argument -1 indirection [b_] |
 | complex.cpp:42:16:42:16 | Chi [b_] | semmle.label | Chi [b_] |
 | complex.cpp:42:16:42:16 | a output argument [b_] | semmle.label | a output argument [b_] |
 | complex.cpp:42:18:42:18 | call to a | semmle.label | call to a |
+| complex.cpp:43:16:43:16 | Argument -1 indirection [b_] | semmle.label | Argument -1 indirection [b_] |
 | complex.cpp:43:18:43:18 | call to b | semmle.label | call to b |
 | complex.cpp:53:12:53:12 | Chi [a_] | semmle.label | Chi [a_] |
 | complex.cpp:53:12:53:12 | setA output argument [a_] | semmle.label | setA output argument [a_] |
+| complex.cpp:53:14:53:17 | Argument 0 | semmle.label | Argument 0 |
 | complex.cpp:53:19:53:28 | call to user_input | semmle.label | call to user_input |
 | complex.cpp:54:12:54:12 | Chi [b_] | semmle.label | Chi [b_] |
 | complex.cpp:54:12:54:12 | setB output argument [b_] | semmle.label | setB output argument [b_] |
+| complex.cpp:54:14:54:17 | Argument 0 | semmle.label | Argument 0 |
 | complex.cpp:54:19:54:28 | call to user_input | semmle.label | call to user_input |
 | complex.cpp:55:12:55:12 | Chi [a_] | semmle.label | Chi [a_] |
 | complex.cpp:55:12:55:12 | setA output argument [a_] | semmle.label | setA output argument [a_] |
+| complex.cpp:55:14:55:17 | Argument 0 | semmle.label | Argument 0 |
 | complex.cpp:55:19:55:28 | call to user_input | semmle.label | call to user_input |
+| complex.cpp:56:12:56:12 | Argument -1 indirection [a_] | semmle.label | Argument -1 indirection [a_] |
 | complex.cpp:56:12:56:12 | Chi [a_] | semmle.label | Chi [a_] |
 | complex.cpp:56:12:56:12 | Chi [b_] | semmle.label | Chi [b_] |
 | complex.cpp:56:12:56:12 | setB output argument [a_] | semmle.label | setB output argument [a_] |
 | complex.cpp:56:12:56:12 | setB output argument [b_] | semmle.label | setB output argument [b_] |
+| complex.cpp:56:14:56:17 | Argument 0 | semmle.label | Argument 0 |
 | complex.cpp:56:19:56:28 | call to user_input | semmle.label | call to user_input |
+| complex.cpp:59:7:59:8 | Argument 0 indirection [a_] | semmle.label | Argument 0 indirection [a_] |
+| complex.cpp:62:7:62:8 | Argument 0 indirection [b_] | semmle.label | Argument 0 indirection [b_] |
+| complex.cpp:65:7:65:8 | Argument 0 indirection [a_] | semmle.label | Argument 0 indirection [a_] |
+| complex.cpp:65:7:65:8 | Argument 0 indirection [b_] | semmle.label | Argument 0 indirection [b_] |
 | constructors.cpp:26:15:26:15 | *f [a_] | semmle.label | *f [a_] |
 | constructors.cpp:26:15:26:15 | *f [b_] | semmle.label | *f [b_] |
+| constructors.cpp:28:10:28:10 | Argument -1 indirection [a_] | semmle.label | Argument -1 indirection [a_] |
+| constructors.cpp:28:10:28:10 | Argument -1 indirection [b_] | semmle.label | Argument -1 indirection [b_] |
 | constructors.cpp:28:10:28:10 | a output argument [b_] | semmle.label | a output argument [b_] |
 | constructors.cpp:28:12:28:12 | call to a | semmle.label | call to a |
+| constructors.cpp:29:10:29:10 | Argument -1 indirection [b_] | semmle.label | Argument -1 indirection [b_] |
 | constructors.cpp:29:12:29:12 | call to b | semmle.label | call to b |
 | constructors.cpp:34:11:34:20 | call to user_input | semmle.label | call to user_input |
+| constructors.cpp:34:11:34:26 | Argument 0 | semmle.label | Argument 0 |
 | constructors.cpp:34:11:34:26 | Foo output argument [a_] | semmle.label | Foo output argument [a_] |
+| constructors.cpp:35:11:35:26 | Argument 1 | semmle.label | Argument 1 |
 | constructors.cpp:35:11:35:26 | Foo output argument [b_] | semmle.label | Foo output argument [b_] |
 | constructors.cpp:35:14:35:23 | call to user_input | semmle.label | call to user_input |
 | constructors.cpp:36:11:36:20 | call to user_input | semmle.label | call to user_input |
+| constructors.cpp:36:11:36:37 | Argument 0 | semmle.label | Argument 0 |
+| constructors.cpp:36:11:36:37 | Argument 1 | semmle.label | Argument 1 |
 | constructors.cpp:36:11:36:37 | Foo output argument [a_] | semmle.label | Foo output argument [a_] |
 | constructors.cpp:36:11:36:37 | Foo output argument [b_] | semmle.label | Foo output argument [b_] |
 | constructors.cpp:36:25:36:34 | call to user_input | semmle.label | call to user_input |
+| constructors.cpp:40:9:40:9 | Argument 0 indirection [a_] | semmle.label | Argument 0 indirection [a_] |
+| constructors.cpp:43:9:43:9 | Argument 0 indirection [b_] | semmle.label | Argument 0 indirection [b_] |
+| constructors.cpp:46:9:46:9 | Argument 0 indirection [a_] | semmle.label | Argument 0 indirection [a_] |
+| constructors.cpp:46:9:46:9 | Argument 0 indirection [b_] | semmle.label | Argument 0 indirection [b_] |
 | simple.cpp:26:15:26:15 | *f [a_] | semmle.label | *f [a_] |
 | simple.cpp:26:15:26:15 | *f [b_] | semmle.label | *f [b_] |
+| simple.cpp:28:10:28:10 | Argument -1 indirection [a_] | semmle.label | Argument -1 indirection [a_] |
+| simple.cpp:28:10:28:10 | Argument -1 indirection [b_] | semmle.label | Argument -1 indirection [b_] |
 | simple.cpp:28:10:28:10 | a output argument [b_] | semmle.label | a output argument [b_] |
 | simple.cpp:28:12:28:12 | call to a | semmle.label | call to a |
+| simple.cpp:29:10:29:10 | Argument -1 indirection [b_] | semmle.label | Argument -1 indirection [b_] |
 | simple.cpp:29:12:29:12 | call to b | semmle.label | call to b |
 | simple.cpp:39:5:39:5 | setA output argument [a_] | semmle.label | setA output argument [a_] |
+| simple.cpp:39:7:39:10 | Argument 0 | semmle.label | Argument 0 |
 | simple.cpp:39:12:39:21 | call to user_input | semmle.label | call to user_input |
 | simple.cpp:40:5:40:5 | setB output argument [b_] | semmle.label | setB output argument [b_] |
+| simple.cpp:40:7:40:10 | Argument 0 | semmle.label | Argument 0 |
 | simple.cpp:40:12:40:21 | call to user_input | semmle.label | call to user_input |
 | simple.cpp:41:5:41:5 | setA output argument [a_] | semmle.label | setA output argument [a_] |
+| simple.cpp:41:7:41:10 | Argument 0 | semmle.label | Argument 0 |
 | simple.cpp:41:12:41:21 | call to user_input | semmle.label | call to user_input |
+| simple.cpp:42:5:42:5 | Argument -1 indirection [a_] | semmle.label | Argument -1 indirection [a_] |
 | simple.cpp:42:5:42:5 | setB output argument [a_] | semmle.label | setB output argument [a_] |
 | simple.cpp:42:5:42:5 | setB output argument [b_] | semmle.label | setB output argument [b_] |
+| simple.cpp:42:7:42:10 | Argument 0 | semmle.label | Argument 0 |
 | simple.cpp:42:12:42:21 | call to user_input | semmle.label | call to user_input |
+| simple.cpp:45:9:45:9 | Argument 0 indirection [a_] | semmle.label | Argument 0 indirection [a_] |
+| simple.cpp:48:9:48:9 | Argument 0 indirection [b_] | semmle.label | Argument 0 indirection [b_] |
+| simple.cpp:51:9:51:9 | Argument 0 indirection [a_] | semmle.label | Argument 0 indirection [a_] |
+| simple.cpp:51:9:51:9 | Argument 0 indirection [b_] | semmle.label | Argument 0 indirection [b_] |
 | simple.cpp:65:5:65:22 | Store [i] | semmle.label | Store [i] |
 | simple.cpp:65:11:65:20 | call to user_input | semmle.label | call to user_input |
 | simple.cpp:66:12:66:12 | Store [i] | semmle.label | Store [i] |
 | simple.cpp:67:13:67:13 | i | semmle.label | i |
 | simple.cpp:83:9:83:28 | Chi [f1] | semmle.label | Chi [f1] |
 | simple.cpp:83:17:83:26 | call to user_input | semmle.label | call to user_input |
+| simple.cpp:84:14:84:20 | Argument -1 indirection [f1] | semmle.label | Argument -1 indirection [f1] |
 | simple.cpp:84:14:84:20 | call to getf2f1 | semmle.label | call to getf2f1 |
 | simple.cpp:92:5:92:22 | Store [i] | semmle.label | Store [i] |
 | simple.cpp:92:11:92:20 | call to user_input | semmle.label | call to user_input |
@@ -399,9 +507,11 @@ nodes
 | struct_init.c:20:20:20:29 | Chi [a] | semmle.label | Chi [a] |
 | struct_init.c:20:20:20:29 | call to user_input | semmle.label | call to user_input |
 | struct_init.c:22:11:22:11 | a | semmle.label | a |
+| struct_init.c:24:10:24:12 | Argument 0 indirection [a] | semmle.label | Argument 0 indirection [a] |
 | struct_init.c:27:7:27:16 | Chi [a] | semmle.label | Chi [a] |
 | struct_init.c:27:7:27:16 | call to user_input | semmle.label | call to user_input |
 | struct_init.c:31:23:31:23 | a | semmle.label | a |
+| struct_init.c:36:10:36:24 | Argument 0 indirection [a] | semmle.label | Argument 0 indirection [a] |
 #select
 | A.cpp:56:13:56:15 | call to get | A.cpp:55:12:55:19 | (C *)... | A.cpp:56:13:56:15 | call to get | call to get flows from $@ | A.cpp:55:12:55:19 | (C *)... | (C *)... |
 | A.cpp:56:13:56:15 | call to get | A.cpp:55:12:55:19 | new | A.cpp:56:13:56:15 | call to get | call to get flows from $@ | A.cpp:55:12:55:19 | new | new |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-079/semmle/CgiXss/CgiXss.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-079/semmle/CgiXss/CgiXss.expected
@@ -8,14 +8,18 @@ edges
 | search.c:22:24:22:28 | *query | search.c:23:39:23:43 | query |
 | search.c:22:24:22:28 | query | search.c:23:39:23:43 | query |
 | search.c:22:24:22:28 | query | search.c:23:39:23:43 | query |
-| search.c:51:21:51:26 | call to getenv | search.c:14:24:14:28 | *query |
-| search.c:51:21:51:26 | call to getenv | search.c:14:24:14:28 | *query |
-| search.c:51:21:51:26 | call to getenv | search.c:14:24:14:28 | query |
-| search.c:51:21:51:26 | call to getenv | search.c:14:24:14:28 | query |
-| search.c:51:21:51:26 | call to getenv | search.c:22:24:22:28 | *query |
-| search.c:51:21:51:26 | call to getenv | search.c:22:24:22:28 | *query |
-| search.c:51:21:51:26 | call to getenv | search.c:22:24:22:28 | query |
-| search.c:51:21:51:26 | call to getenv | search.c:22:24:22:28 | query |
+| search.c:51:21:51:26 | call to getenv | search.c:55:5:55:15 | Argument 0 |
+| search.c:51:21:51:26 | call to getenv | search.c:55:5:55:15 | Argument 0 |
+| search.c:51:21:51:26 | call to getenv | search.c:55:17:55:25 | Argument 0 indirection |
+| search.c:51:21:51:26 | call to getenv | search.c:55:17:55:25 | Argument 0 indirection |
+| search.c:51:21:51:26 | call to getenv | search.c:57:5:57:15 | Argument 0 |
+| search.c:51:21:51:26 | call to getenv | search.c:57:5:57:15 | Argument 0 |
+| search.c:51:21:51:26 | call to getenv | search.c:57:17:57:25 | Argument 0 indirection |
+| search.c:51:21:51:26 | call to getenv | search.c:57:17:57:25 | Argument 0 indirection |
+| search.c:55:5:55:15 | Argument 0 | search.c:14:24:14:28 | query |
+| search.c:55:17:55:25 | Argument 0 indirection | search.c:14:24:14:28 | *query |
+| search.c:57:5:57:15 | Argument 0 | search.c:22:24:22:28 | query |
+| search.c:57:17:57:25 | Argument 0 indirection | search.c:22:24:22:28 | *query |
 nodes
 | search.c:14:24:14:28 | *query | semmle.label | *query |
 | search.c:14:24:14:28 | query | semmle.label | query |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
@@ -7,14 +7,18 @@ edges
 | test.cpp:29:30:29:36 | *command | test.cpp:31:10:31:16 | command |
 | test.cpp:29:30:29:36 | command | test.cpp:31:10:31:16 | command |
 | test.cpp:29:30:29:36 | command | test.cpp:31:10:31:16 | command |
-| test.cpp:42:18:42:23 | call to getenv | test.cpp:24:30:24:36 | *command |
-| test.cpp:42:18:42:23 | call to getenv | test.cpp:24:30:24:36 | command |
-| test.cpp:42:18:42:34 | (const char *)... | test.cpp:24:30:24:36 | *command |
-| test.cpp:42:18:42:34 | (const char *)... | test.cpp:24:30:24:36 | command |
-| test.cpp:43:18:43:23 | call to getenv | test.cpp:29:30:29:36 | *command |
-| test.cpp:43:18:43:23 | call to getenv | test.cpp:29:30:29:36 | command |
-| test.cpp:43:18:43:34 | (const char *)... | test.cpp:29:30:29:36 | *command |
-| test.cpp:43:18:43:34 | (const char *)... | test.cpp:29:30:29:36 | command |
+| test.cpp:42:7:42:16 | Argument 0 | test.cpp:24:30:24:36 | command |
+| test.cpp:42:18:42:23 | call to getenv | test.cpp:42:7:42:16 | Argument 0 |
+| test.cpp:42:18:42:23 | call to getenv | test.cpp:42:18:42:34 | Argument 0 indirection |
+| test.cpp:42:18:42:34 | (const char *)... | test.cpp:42:7:42:16 | Argument 0 |
+| test.cpp:42:18:42:34 | (const char *)... | test.cpp:42:18:42:34 | Argument 0 indirection |
+| test.cpp:42:18:42:34 | Argument 0 indirection | test.cpp:24:30:24:36 | *command |
+| test.cpp:43:7:43:16 | Argument 0 | test.cpp:29:30:29:36 | command |
+| test.cpp:43:18:43:23 | call to getenv | test.cpp:43:7:43:16 | Argument 0 |
+| test.cpp:43:18:43:23 | call to getenv | test.cpp:43:18:43:34 | Argument 0 indirection |
+| test.cpp:43:18:43:34 | (const char *)... | test.cpp:43:7:43:16 | Argument 0 |
+| test.cpp:43:18:43:34 | (const char *)... | test.cpp:43:18:43:34 | Argument 0 indirection |
+| test.cpp:43:18:43:34 | Argument 0 indirection | test.cpp:29:30:29:36 | *command |
 | test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | (const char *)... |
 | test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | (const char *)... |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
@@ -53,22 +53,26 @@ edges
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | (const char *)... |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:2:117:13 | Argument 0 |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:2:117:13 | Argument 0 |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | Argument 0 indirection |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | Argument 0 indirection |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | array to pointer conversion |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | array to pointer conversion |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | printWrapper output argument |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | printWrapper output argument |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:121:9:121:10 | (const char *)... |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:121:9:121:10 | (const char *)... |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:121:9:121:10 | i4 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:121:9:121:10 | i4 |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:2:122:13 | Argument 0 |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:2:122:13 | Argument 0 |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | Argument 0 indirection |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | Argument 0 indirection |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | i4 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | i4 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | i4 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | i4 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | printWrapper output argument |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:122:15:122:16 | printWrapper output argument |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | (const char *)... |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | (const char *)... |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
@@ -77,15 +81,20 @@ edges
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... |
+| argvLocal.c:117:2:117:13 | Argument 0 | argvLocal.c:117:15:117:16 | printWrapper output argument |
+| argvLocal.c:117:15:117:16 | Argument 0 indirection | argvLocal.c:117:15:117:16 | printWrapper output argument |
 | argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:121:9:121:10 | (const char *)... |
 | argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:121:9:121:10 | i4 |
+| argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:122:2:122:13 | Argument 0 |
+| argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:122:15:122:16 | Argument 0 indirection |
 | argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:122:15:122:16 | i4 |
 | argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:122:15:122:16 | i4 |
-| argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:122:15:122:16 | printWrapper output argument |
 | argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:135:9:135:12 | (const char *)... |
 | argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:135:9:135:12 | ... ++ |
 | argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:136:15:136:18 | -- ... |
 | argvLocal.c:117:15:117:16 | printWrapper output argument | argvLocal.c:136:15:136:18 | -- ... |
+| argvLocal.c:122:2:122:13 | Argument 0 | argvLocal.c:122:15:122:16 | printWrapper output argument |
+| argvLocal.c:122:15:122:16 | Argument 0 indirection | argvLocal.c:122:15:122:16 | printWrapper output argument |
 | argvLocal.c:122:15:122:16 | printWrapper output argument | argvLocal.c:135:9:135:12 | (const char *)... |
 | argvLocal.c:122:15:122:16 | printWrapper output argument | argvLocal.c:135:9:135:12 | ... ++ |
 | argvLocal.c:122:15:122:16 | printWrapper output argument | argvLocal.c:136:15:136:18 | -- ... |
@@ -94,12 +103,14 @@ edges
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | (const char *)... |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
+| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:2:128:13 | Argument 0 |
+| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:2:128:13 | Argument 0 |
+| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | Argument 0 indirection |
+| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | Argument 0 indirection |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | array to pointer conversion |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | array to pointer conversion |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | printWrapper output argument |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | printWrapper output argument |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:131:9:131:14 | (const char *)... |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:131:9:131:14 | (const char *)... |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:131:9:131:14 | ... + ... |
@@ -108,6 +119,8 @@ edges
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:132:15:132:20 | ... + ... |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:132:15:132:20 | ... + ... |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:132:15:132:20 | ... + ... |
+| argvLocal.c:128:2:128:13 | Argument 0 | argvLocal.c:128:15:128:16 | printWrapper output argument |
+| argvLocal.c:128:15:128:16 | Argument 0 indirection | argvLocal.c:128:15:128:16 | printWrapper output argument |
 | argvLocal.c:128:15:128:16 | printWrapper output argument | argvLocal.c:131:9:131:14 | (const char *)... |
 | argvLocal.c:128:15:128:16 | printWrapper output argument | argvLocal.c:131:9:131:14 | ... + ... |
 | argvLocal.c:128:15:128:16 | printWrapper output argument | argvLocal.c:132:15:132:20 | ... + ... |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/globalVars/UncontrolledFormatStringThroughGlobalVar.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/globalVars/UncontrolledFormatStringThroughGlobalVar.expected
@@ -21,16 +21,19 @@ edges
 | globalVars.c:12:2:12:15 | Store | globalVars.c:8:7:8:10 | copy |
 | globalVars.c:15:21:15:23 | val | globalVars.c:16:2:16:12 | Store |
 | globalVars.c:16:2:16:12 | Store | globalVars.c:9:7:9:11 | copy2 |
-| globalVars.c:24:11:24:14 | argv | globalVars.c:11:22:11:25 | *argv |
-| globalVars.c:24:11:24:14 | argv | globalVars.c:11:22:11:25 | *argv |
-| globalVars.c:24:11:24:14 | argv | globalVars.c:11:22:11:25 | argv |
-| globalVars.c:24:11:24:14 | argv | globalVars.c:11:22:11:25 | argv |
+| globalVars.c:24:2:24:9 | Argument 0 | globalVars.c:11:22:11:25 | argv |
+| globalVars.c:24:11:24:14 | Argument 0 indirection | globalVars.c:11:22:11:25 | *argv |
+| globalVars.c:24:11:24:14 | argv | globalVars.c:24:2:24:9 | Argument 0 |
+| globalVars.c:24:11:24:14 | argv | globalVars.c:24:2:24:9 | Argument 0 |
+| globalVars.c:24:11:24:14 | argv | globalVars.c:24:11:24:14 | Argument 0 indirection |
+| globalVars.c:24:11:24:14 | argv | globalVars.c:24:11:24:14 | Argument 0 indirection |
 | globalVars.c:27:9:27:12 | copy | globalVars.c:27:9:27:12 | (const char *)... |
 | globalVars.c:27:9:27:12 | copy | globalVars.c:27:9:27:12 | copy |
 | globalVars.c:30:15:30:18 | copy | globalVars.c:30:15:30:18 | copy |
 | globalVars.c:30:15:30:18 | copy | globalVars.c:30:15:30:18 | copy |
 | globalVars.c:30:15:30:18 | copy | globalVars.c:30:15:30:18 | copy |
-| globalVars.c:35:11:35:14 | copy | globalVars.c:15:21:15:23 | val |
+| globalVars.c:35:2:35:9 | Argument 0 | globalVars.c:15:21:15:23 | val |
+| globalVars.c:35:11:35:14 | copy | globalVars.c:35:2:35:9 | Argument 0 |
 | globalVars.c:38:9:38:13 | copy2 | globalVars.c:38:9:38:13 | (const char *)... |
 | globalVars.c:38:9:38:13 | copy2 | globalVars.c:38:9:38:13 | copy2 |
 | globalVars.c:41:15:41:19 | copy2 | globalVars.c:41:15:41:19 | copy2 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -47,16 +47,18 @@ edges
 | test.cpp:214:23:214:23 | s | test.cpp:215:21:215:21 | s |
 | test.cpp:220:21:220:21 | s | test.cpp:221:21:221:21 | s |
 | test.cpp:220:21:220:21 | s | test.cpp:221:21:221:21 | s |
-| test.cpp:227:24:227:29 | call to getenv | test.cpp:214:23:214:23 | s |
-| test.cpp:227:24:227:29 | call to getenv | test.cpp:220:21:220:21 | s |
 | test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | (size_t)... |
 | test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | local_size |
 | test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | local_size |
-| test.cpp:227:24:227:37 | (const char *)... | test.cpp:214:23:214:23 | s |
-| test.cpp:227:24:227:37 | (const char *)... | test.cpp:220:21:220:21 | s |
+| test.cpp:227:24:227:29 | call to getenv | test.cpp:235:2:235:9 | Argument 0 |
+| test.cpp:227:24:227:29 | call to getenv | test.cpp:237:2:237:8 | Argument 0 |
 | test.cpp:227:24:227:37 | (const char *)... | test.cpp:229:9:229:18 | (size_t)... |
 | test.cpp:227:24:227:37 | (const char *)... | test.cpp:229:9:229:18 | local_size |
 | test.cpp:227:24:227:37 | (const char *)... | test.cpp:229:9:229:18 | local_size |
+| test.cpp:227:24:227:37 | (const char *)... | test.cpp:235:2:235:9 | Argument 0 |
+| test.cpp:227:24:227:37 | (const char *)... | test.cpp:237:2:237:8 | Argument 0 |
+| test.cpp:235:2:235:9 | Argument 0 | test.cpp:214:23:214:23 | s |
+| test.cpp:237:2:237:8 | Argument 0 | test.cpp:220:21:220:21 | s |
 | test.cpp:241:2:241:32 | Chi [array content] | test.cpp:279:17:279:20 | get_size output argument [array content] |
 | test.cpp:241:2:241:32 | Chi [array content] | test.cpp:295:18:295:21 | get_size output argument [array content] |
 | test.cpp:241:18:241:23 | call to getenv | test.cpp:241:2:241:32 | Chi [array content] |


### PR DESCRIPTION
When we added operands as dataflow nodes in https://github.com/github/codeql/pull/3785 we hid these nodes in path explanations as they would otherwise double the length of the paths.
However, since `ArgumentNodes` are also `OperandNodes`, this also prevents arguments from appearing in path explanations. This makes paths much more difficult to understand.

This PR ensures that arguments are no longer hidden in path explanations.