### PR TITLE
C++: Add clang-cl.exe to `compiledAsMicrosoft()`.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -276,7 +276,10 @@ class File extends Container, @file {
       c.getAFileCompiled() = this and
       (
         c.getAnArgument() = "--microsoft" or
-        c.getAnArgument().toLowerCase().replaceAll("\\", "/").matches("%/cl.exe")
+        c.getAnArgument()
+            .toLowerCase()
+            .replaceAll("\\", "/")
+            .matches(["%/cl.exe", "%/clang-cl.exe"])
       )
     )
     or


### PR DESCRIPTION
`clang-cl.exe` emulates `cl.exe` in features, and should thus also be considered as a Microsoft-compatible compiler.