### PR TITLE
JS: cache more predicates

### DIFF
--- a/javascript/ql/src/semmle/javascript/BasicBlocks.qll
+++ b/javascript/ql/src/semmle/javascript/BasicBlocks.qll
@@ -119,7 +119,8 @@ private predicate bbIPostDominates(BasicBlock dom, BasicBlock bb) =
  * At the database level, a basic block is represented by its first control flow node.
  */
 class BasicBlock extends @cfg_node, NodeInStmtContainer {
-  BasicBlock() { startsBB(this) }
+  cached
+  BasicBlock() { Stages::BasicBlocks::ref() and startsBB(this) }
 
   /** Gets a basic block succeeding this one. */
   BasicBlock getASuccessor() { succBB(this, result) }

--- a/javascript/ql/src/semmle/javascript/SSA.qll
+++ b/javascript/ql/src/semmle/javascript/SSA.qll
@@ -627,6 +627,7 @@ abstract class SsaPseudoDefinition extends SsaImplicitDefinition {
   /**
    * Gets an input of this pseudo-definition.
    */
+  cached
   abstract SsaVariable getAnInput();
 
   override VarDef getAContributingVarDef() {
@@ -649,6 +650,7 @@ class SsaPhiNode extends SsaPseudoDefinition, TPhi {
   /**
    * Gets the input to this phi node coming from the given predecessor block.
    */
+  cached
   SsaVariable getInputFromBlock(BasicBlock bb) {
     bb = getBasicBlock().getAPredecessor() and
     result = getDefReachingEndOf(bb, getSourceVariable())

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -149,6 +149,7 @@ module DataFlow {
      * For more information, see
      * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
      */
+    cached
     predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn
     ) {
@@ -171,6 +172,7 @@ module DataFlow {
     int getEndColumn() { hasLocationInfo(_, _, _, _, result) }
 
     /** Gets a textual representation of this element. */
+    cached
     string toString() { none() }
 
     /**
@@ -294,12 +296,13 @@ module DataFlow {
     override predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn
     ) {
+      Stages::DataFlowStage::ref() and
       astNode.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
     }
 
     override File getFile() { result = astNode.getFile() }
 
-    override string toString() { result = astNode.toString() }
+    override string toString() { Stages::DataFlowStage::ref() and result = astNode.toString() }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/AccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/AccessPaths.qll
@@ -16,6 +16,7 @@
  */
 
 import javascript
+private import semmle.javascript.internal.CachedStages
 
 /**
  * A representation of a property name that is either statically known or is
@@ -88,7 +89,9 @@ class AccessPath extends TAccessPath {
   /**
    * Gets an expression in `bb` represented by this access path.
    */
+  cached
   Expr getAnInstanceIn(BasicBlock bb) {
+    Stages::DataFlowStage::ref() and
     exists(SsaVariable var |
       this = MkSsaRoot(var) and
       result = getARefinementOf*(var).getAUseIn(bb)

--- a/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
+++ b/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
@@ -126,6 +126,10 @@ module Stages {
       exists(any(Expr e).getExceptionTarget())
       or
       exists(DataFlow::ssaDefinitionNode(_))
+      or
+      any(DataFlow::Node node).hasLocationInfo(_, _, _, _, _)
+      or
+      exists(any(DataFlow::Node node).toString())
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
+++ b/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
@@ -24,6 +24,7 @@ import javascript
 private import StmtContainers
 private import semmle.javascript.dataflow.internal.PreCallGraphStep
 private import semmle.javascript.dataflow.internal.FlowSteps
+private import semmle.javascript.dataflow.internal.AccessPaths
 
 /**
  * Contains a `cached module` for each stage.
@@ -130,6 +131,8 @@ module Stages {
       any(DataFlow::Node node).hasLocationInfo(_, _, _, _, _)
       or
       exists(any(DataFlow::Node node).toString())
+      or
+      exists(any(AccessPath a).getAnInstanceIn(_))
     }
   }
 


### PR DESCRIPTION
I looked at which predicates are often used in the last stage, and then I `cached` some of them. 

[An evaluation](https://github.com/dsp-testing/erik-krogh-dca/tree/run/moreCache-nightly-security/reports) shows ~4% improvement on the security suite. 