### PR TITLE
JS: cache TypeBackTracker::prepend

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
@@ -9,6 +9,7 @@
 private import javascript
 private import internal.FlowSteps
 private import internal.StepSummary
+private import semmle.javascript.internal.CachedStages
 
 private newtype TTypeTracker = MkTypeTracker(Boolean hasCall, OptionalPropertyName prop)
 
@@ -51,7 +52,9 @@ class TypeTracker extends TTypeTracker {
   /** Gets the summary resulting from appending `step` to this type-tracking summary. */
   cached
   TypeTracker append(StepSummary step) {
-    step = LevelStep() and result = this
+    Stages::TypeTracking::ref() and
+    step = LevelStep() and
+    result = this
     or
     exists(string toProp | step = LoadStoreStep(prop, toProp) |
       result = MkTypeTracker(hasCall, toProp)
@@ -214,8 +217,11 @@ class TypeBackTracker extends TTypeBackTracker {
   TypeBackTracker() { this = MkTypeBackTracker(hasReturn, prop) }
 
   /** Gets the summary resulting from prepending `step` to this type-tracking summary. */
+  cached
   TypeBackTracker prepend(StepSummary step) {
-    step = LevelStep() and result = this
+    Stages::TypeTracking::ref() and
+    step = LevelStep() and
+    result = this
     or
     exists(string fromProp | step = LoadStoreStep(fromProp, prop) |
       result = MkTypeBackTracker(hasReturn, fromProp)

--- a/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
+++ b/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
@@ -181,6 +181,10 @@ module Stages {
       PreCallGraphStep::loadStep(_, _, _)
       or
       basicLoadStep(_, _, _)
+      or
+      exists(any(DataFlow::TypeTracker t).append(_))
+      or
+      exists(any(DataFlow::TypeBackTracker t).prepend(_))
     }
   }
 


### PR DESCRIPTION
We already cached `TypeTracker::append()`, and it also makes sense to cache `TypeBackTracker::prepend()`.   
I tried it out a while ago, but the predicate ended up in its own stage, which didn't help performance.   
Now I can put it in the `TypeTracking` stage :smiley:, so now we get a performance improvement. 


[An evaluation on nightly](https://github.com/dsp-testing/erik-krogh-dca/tree/run/cachePrepend-nightly-security-2/reports) shows a small performance improvement.   
[A larger evaluation with lots of reruns](https://github.com/dsp-testing/erik-krogh-dca/tree/run/cachePrepend-default-security-2/reports), show about the same improvement. 

So the speedup looks real, but minor.  