### PR TITLE
Java: Remove value steps from taint steps.

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -46,7 +46,8 @@ predicate localAdditionalTaintStep(DataFlow::Node src, DataFlow::Node sink) {
   localAdditionalTaintUpdateStep(src.asExpr(),
     sink.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr())
   or
-  summaryStep(src, sink, "taint")
+  summaryStep(src, sink, "taint") and
+  not summaryStep(src, sink, "value")
   or
   exists(Argument arg |
     src.asExpr() = arg and


### PR DESCRIPTION
This allows us to e.g. specify a taint step from `Argument` to `ReturnValue` and a value step from `Argument[-1]` to `ReturnValue` without the latter becoming both a taint and a value step.