### PR TITLE
JS: Add SharedTaintStep (again)

### DIFF
--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-javascript-and-typescript.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-javascript-and-typescript.rst
@@ -439,23 +439,24 @@ additional taint step from the first argument of ``resolveSymlinks`` to its resu
   }
 
 We might even consider adding this as a default taint step to be used by all taint-tracking configurations. In order to do this, we need
-to wrap it in a new subclass of ``TaintTracking::AdditionalTaintStep`` like this:
+to wrap it in a new subclass of ``TaintTracking::SharedTaintStep`` like this:
 
 .. code-block:: ql
 
-  class StepThroughResolveSymlinks extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-    StepThroughResolveSymlinks() { this = DataFlow::moduleImport("resolve-symlinks").getACall() }
-
+  class StepThroughResolveSymlinks extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = this.getArgument(0) and
-      succ = this
+      exists(DataFlow::CallNode c |
+        c = DataFlow::moduleImport("resolve-symlinks").getACall() and
+        pred = c.getArgument(0) and
+        succ = c
+      )
     }
   }
 
 If we add this definition to the standard library, it will be picked up by all taint-tracking configurations. Obviously, one has to be
 careful when adding such new additional taint steps to ensure that they really make sense for `all` configurations.
 
-Analogous to ``TaintTracking::AdditionalTaintStep``, there is also a class ``DataFlow::AdditionalFlowStep`` that can be extended to add
+Analogous to ``TaintTracking::SharedTaintStep``, there is also a class ``DataFlow::AdditionalFlowStep`` that can be extended to add
 extra steps to all data-flow configurations, and hence also to all taint-tracking configurations.
 
 Exercises

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-javascript-and-typescript.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-javascript-and-typescript.rst
@@ -456,7 +456,7 @@ to wrap it in a new subclass of ``TaintTracking::SharedTaintStep`` like this:
 If we add this definition to the standard library, it will be picked up by all taint-tracking configurations. Obviously, one has to be
 careful when adding such new additional taint steps to ensure that they really make sense for `all` configurations.
 
-Analogous to ``TaintTracking::SharedTaintStep``, there is also a class ``DataFlow::AdditionalFlowStep`` that can be extended to add
+Analogous to ``TaintTracking::SharedTaintStep``, there is also a class ``DataFlow::SharedFlowStep`` that can be extended to add
 extra steps to all data-flow configurations, and hence also to all taint-tracking configurations.
 
 Exercises

--- a/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.ql
+++ b/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.ql
@@ -27,7 +27,7 @@ private DataFlow::Node remoteFlow(DataFlow::TypeTracker t) {
   exists(DataFlow::TypeTracker t2, DataFlow::Node prev | prev = remoteFlow(t2) |
     t2 = t.smallstep(prev, result)
     or
-    any(TaintTracking::AdditionalTaintStep dts).step(prev, result) and
+    TaintTracking::sharedTaintStep(prev, result) and
     t = t2
   )
 }

--- a/javascript/ql/src/experimental/semmle/javascript/security/dataflow/ResourceExhaustion.qll
+++ b/javascript/ql/src/experimental/semmle/javascript/security/dataflow/ResourceExhaustion.qll
@@ -37,7 +37,7 @@ module ResourceExhaustion {
   }
 
   predicate isRestrictedAdditionalTaintStep(DataFlow::Node src, DataFlow::Node dst) {
-    any(TaintTracking::AdditionalTaintStep dts).step(src, dst) and
+    TaintTracking::sharedTaintStep(src, dst) and
     not dst.asExpr() instanceof AddExpr and
     not dst.(DataFlow::MethodCallNode).calls(src, "toString")
   }

--- a/javascript/ql/src/meta/analysis-quality/TaintSteps.ql
+++ b/javascript/ql/src/meta/analysis-quality/TaintSteps.ql
@@ -13,7 +13,7 @@ import CallGraphQuality
 
 predicate relevantStep(DataFlow::Node pred, DataFlow::Node succ) {
   (
-    any(TaintTracking::AdditionalTaintStep dts).step(pred, succ)
+    TaintTracking::sharedTaintStep(pred, succ)
     or
     any(DataFlow::AdditionalFlowStep cfg).step(pred, succ)
     or

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -9,12 +9,9 @@ module ArrayTaintTracking {
   /**
    * A taint propagating data flow edge caused by the builtin array functions.
    */
-  private class ArrayFunctionTaintStep extends TaintTracking::AdditionalTaintStep,
-    DataFlow::CallNode {
-    ArrayFunctionTaintStep() { arrayFunctionTaintStep(_, _, this) }
-
+  private class ArrayFunctionTaintStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      arrayFunctionTaintStep(pred, succ, this)
+      arrayFunctionTaintStep(pred, succ, _)
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -10,7 +10,7 @@ module ArrayTaintTracking {
    * A taint propagating data flow edge caused by the builtin array functions.
    */
   private class ArrayFunctionTaintStep extends TaintTracking::SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
       arrayFunctionTaintStep(pred, succ, _)
     }
   }

--- a/javascript/ql/src/semmle/javascript/Base64.qll
+++ b/javascript/ql/src/semmle/javascript/Base64.qll
@@ -67,14 +67,12 @@ module Base64 {
    * Note that we currently do not model base64 encoding as a taint-propagating data flow edge
    * to avoid false positives.
    */
-  private class Base64DecodingStep extends TaintTracking::AdditionalTaintStep {
-    Decode dec;
-
-    Base64DecodingStep() { this = dec }
-
+  private class Base64DecodingStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = dec.getInput() and
-      succ = dec.getOutput()
+      exists(Decode dec |
+        pred = dec.getInput() and
+        succ = dec.getOutput()
+      )
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/Extend.qll
+++ b/javascript/ql/src/semmle/javascript/Extend.qll
@@ -165,14 +165,12 @@ private class FunctionalExtendCallShallow extends ExtendCall {
  * A taint propagating data flow edge from the objects flowing into an extend call to its return value
  * and to the source of the destination object.
  */
-private class ExtendCallTaintStep extends TaintTracking::AdditionalTaintStep {
-  ExtendCall extend;
-
-  ExtendCallTaintStep() { this = extend }
-
+private class ExtendCallTaintStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = extend.getASourceOperand() and succ = extend.getDestinationOperand().getALocalSource()
-    or
-    pred = extend.getAnOperand() and succ = extend
+    exists(ExtendCall extend |
+      pred = extend.getASourceOperand() and succ = extend.getDestinationOperand().getALocalSource()
+      or
+      pred = extend.getAnOperand() and succ = extend
+    )
   }
 }

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -491,14 +491,13 @@ private module AsyncReturnSteps {
   /**
    * A data-flow step for ordinary return from an async function in a taint configuration.
    */
-  private class AsyncTaintReturn extends TaintTracking::AdditionalTaintStep, DataFlow::FunctionNode {
-    Function f;
-
-    AsyncTaintReturn() { this.getFunction() = f and f.isAsync() }
-
+  private class AsyncTaintReturn extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      returnExpr(f, pred, _) and
-      succ.(DataFlow::FunctionReturnNode).getFunction() = f
+      exists(Function f |
+        f.isAsync() and
+        returnExpr(f, pred, _) and
+        succ.(DataFlow::FunctionReturnNode).getFunction() = f
+      )
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -398,70 +398,65 @@ module PromiseFlow {
 }
 
 /**
- * Holds if taint propagates from `pred` to `succ` through promises.
+ * DEPRECATED. Use `TaintTracking::promiseStep` instead.
  */
-predicate promiseTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
-  // from `x` to `new Promise((res, rej) => res(x))`
-  pred = succ.(PromiseDefinition).getResolveParameter().getACall().getArgument(0)
-  or
-  // from `x` to `Promise.resolve(x)`
-  pred = succ.(PromiseCreationCall).getValue() and
-  not succ instanceof PromiseAllCreation
-  or
-  // from `arr` to `Promise.all(arr)`
-  pred = succ.(PromiseAllCreation).getArrayNode()
-  or
-  exists(DataFlow::MethodCallNode thn | thn.getMethodName() = "then" |
-    // from `p` to `x` in `p.then(x => ...)`
-    pred = thn.getReceiver() and
-    succ = thn.getCallback(0).getParameter(0)
-    or
-    // from `v` to `p.then(x => return v)`
-    pred = thn.getCallback([0 .. 1]).getAReturn() and
-    succ = thn
-  )
-  or
-  exists(DataFlow::MethodCallNode catch | catch.getMethodName() = "catch" |
-    // from `p` to `p.catch(..)`
-    pred = catch.getReceiver() and
-    succ = catch
-    or
-    // from `v` to `p.catch(x => return v)`
-    pred = catch.getCallback(0).getAReturn() and
-    succ = catch
-  )
-  or
-  // from `p` to `p.finally(..)`
-  exists(DataFlow::MethodCallNode finally | finally.getMethodName() = "finally" |
-    pred = finally.getReceiver() and
-    succ = finally
-  )
-  or
-  // from `x` to `await x`
-  exists(AwaitExpr await |
-    pred.getEnclosingExpr() = await.getOperand() and
-    succ.getEnclosingExpr() = await
-  )
-  or
-  exists(DataFlow::CallNode mapSeries |
-    mapSeries = DataFlow::moduleMember("bluebird", "mapSeries").getACall()
-  |
-    // from `xs` to `x` in `require("bluebird").mapSeries(xs, (x) => {...})`.
-    pred = mapSeries.getArgument(0) and
-    succ = mapSeries.getABoundCallbackParameter(1, 0)
-    or
-    // from `y` to `require("bluebird").mapSeries(x, x => y)`.
-    pred = mapSeries.getCallback(1).getAReturn() and
-    succ = mapSeries
-  )
-}
+deprecated predicate promiseTaintStep = TaintTracking::promiseStep/2;
 
-/**
- * An additional taint step that involves promises.
- */
 private class PromiseTaintStep extends TaintTracking::SharedTaintStep {
-  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    promiseTaintStep(pred, succ)
+  override predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
+    // from `x` to `new Promise((res, rej) => res(x))`
+    pred = succ.(PromiseDefinition).getResolveParameter().getACall().getArgument(0)
+    or
+    // from `x` to `Promise.resolve(x)`
+    pred = succ.(PromiseCreationCall).getValue() and
+    not succ instanceof PromiseAllCreation
+    or
+    // from `arr` to `Promise.all(arr)`
+    pred = succ.(PromiseAllCreation).getArrayNode()
+    or
+    exists(DataFlow::MethodCallNode thn | thn.getMethodName() = "then" |
+      // from `p` to `x` in `p.then(x => ...)`
+      pred = thn.getReceiver() and
+      succ = thn.getCallback(0).getParameter(0)
+      or
+      // from `v` to `p.then(x => return v)`
+      pred = thn.getCallback([0 .. 1]).getAReturn() and
+      succ = thn
+    )
+    or
+    exists(DataFlow::MethodCallNode catch | catch.getMethodName() = "catch" |
+      // from `p` to `p.catch(..)`
+      pred = catch.getReceiver() and
+      succ = catch
+      or
+      // from `v` to `p.catch(x => return v)`
+      pred = catch.getCallback(0).getAReturn() and
+      succ = catch
+    )
+    or
+    // from `p` to `p.finally(..)`
+    exists(DataFlow::MethodCallNode finally | finally.getMethodName() = "finally" |
+      pred = finally.getReceiver() and
+      succ = finally
+    )
+    or
+    // from `x` to `await x`
+    exists(AwaitExpr await |
+      pred.getEnclosingExpr() = await.getOperand() and
+      succ.getEnclosingExpr() = await
+    )
+    or
+    exists(DataFlow::CallNode mapSeries |
+      mapSeries = DataFlow::moduleMember("bluebird", "mapSeries").getACall()
+    |
+      // from `xs` to `x` in `require("bluebird").mapSeries(xs, (x) => {...})`.
+      pred = mapSeries.getArgument(0) and
+      succ = mapSeries.getABoundCallbackParameter(1, 0)
+      or
+      // from `y` to `require("bluebird").mapSeries(x, x => y)`.
+      pred = mapSeries.getCallback(1).getAReturn() and
+      succ = mapSeries
+    )
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -459,13 +459,9 @@ predicate promiseTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
 /**
  * An additional taint step that involves promises.
  */
-private class PromiseTaintStep extends TaintTracking::AdditionalTaintStep {
-  DataFlow::Node source;
-
-  PromiseTaintStep() { promiseTaintStep(source, this) }
-
+private class PromiseTaintStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = source and succ = this
+    promiseTaintStep(pred, succ)
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -612,14 +612,12 @@ private module ClosurePromise {
   /**
    * Taint steps through closure promise methods.
    */
-  private class ClosurePromiseTaintStep extends TaintTracking::AdditionalTaintStep {
-    DataFlow::Node pred;
-
-    ClosurePromiseTaintStep() {
+  private class ClosurePromiseTaintStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       // static methods in goog.Promise
       exists(DataFlow::CallNode call, string name |
         call = Closure::moduleImport("goog.Promise." + name).getACall() and
-        this = call and
+        succ = call and
         pred = call.getAnArgument()
       |
         name = "all" or
@@ -631,12 +629,10 @@ private module ClosurePromise {
       // promise created through goog.promise.withResolver()
       exists(DataFlow::CallNode resolver |
         resolver = Closure::moduleImport("goog.Promise.withResolver").getACall() and
-        this = resolver.getAPropertyRead("promise") and
+        succ = resolver.getAPropertyRead("promise") and
         pred = resolver.getAMethodCall("resolve").getArgument(0)
       )
     }
-
-    override predicate step(DataFlow::Node src, DataFlow::Node dst) { src = pred and dst = this }
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -904,7 +904,7 @@ private DataFlow::Node regExpSource(DataFlow::Node re, DataFlow::TypeBackTracker
   exists(DataFlow::TypeBackTracker t2, DataFlow::Node succ | succ = regExpSource(re, t2) |
     t2 = t.smallstep(result, succ)
     or
-    any(TaintTracking::AdditionalTaintStep dts).step(result, succ) and
+    TaintTracking::sharedTaintStep(result, succ) and
     t = t2
   )
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -653,7 +653,10 @@ private class SharedStepAsAdditionalFlowStep extends AdditionalFlowStep {
     any(SharedFlowStep st).step(pred, succ) and succ = this
   }
 
-  override predicate step(DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel predlbl, DataFlow::FlowLabel succlbl) {
+  override predicate step(
+    DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel predlbl,
+    DataFlow::FlowLabel succlbl
+  ) {
     any(SharedFlowStep st).step(pred, succ, predlbl, succlbl) and succ = this
   }
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -490,9 +490,6 @@ module TaintTracking {
           prop.isComputed() and f = prop.getNameExpr()
         )
         or
-        // awaiting a tainted expression gives a tainted result
-        e.(AwaitExpr).getOperand() = f
-        or
         // spreading a tainted object into an object literal gives a tainted object
         e.(ObjectExpr).getAProperty().(SpreadProperty).getInit().(SpreadElement).getOperand() = f
         or

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -356,11 +356,8 @@ module TaintTracking {
    * a map, not as a real object. In this case, it makes sense to consider the entire
    * map to be tainted as soon as one of its entries is.
    */
-  private class DictionaryTaintStep extends AdditionalTaintStep {
-    DictionaryTaintStep() { dictionaryTaintStep(_, this) }
-
+  private class DictionaryTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      succ = this and
       dictionaryTaintStep(pred, succ)
     }
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -312,9 +312,8 @@ module TaintTracking {
    */
   cached
   private module Cached {
-    cached predicate forceStage() {
-      Stages::Taint::ref()
-    }
+    cached
+    predicate forceStage() { Stages::Taint::ref() }
 
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
@@ -963,7 +962,8 @@ module TaintTracking {
         getACaptureSetter(pred) = getANodeReachingCaptureRef(succ)
         or
         exists(StringReplaceCall replace |
-          getANodeReachingCaptureRef(succ) = replace.getReplacementCallback().getFunction().getEntry() and
+          getANodeReachingCaptureRef(succ) =
+            replace.getReplacementCallback().getFunction().getEntry() and
           pred = replace.getReceiver()
         )
       }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -537,35 +537,30 @@ module TaintTracking {
    * A taint-propagating data flow edge from the first (and only) argument in a call to
    * `RegExp.prototype.exec` to its result.
    */
-  private class RegExpExecTaintStep extends AdditionalTaintStep {
-    DataFlow::MethodCallNode self;
-
-    RegExpExecTaintStep() {
-      this = self and
-      self.getReceiver().analyze().getAType() = TTRegExp() and
-      self.getMethodName() = "exec" and
-      self.getNumArgument() = 1
-    }
-
+  private class RegExpExecTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = self.getArgument(0) and
-      succ = this
+      exists(DataFlow::MethodCallNode call |
+        call.getReceiver().analyze().getAType() = TTRegExp() and
+        call.getMethodName() = "exec" and
+        call.getNumArgument() = 1 and
+        pred = call.getArgument(0) and
+        succ = call
+      )
     }
   }
 
   /**
    * A taint propagating data flow edge arising from calling `String.prototype.match()`.
    */
-  private class StringMatchTaintStep extends AdditionalTaintStep, DataFlow::MethodCallNode {
-    StringMatchTaintStep() {
-      this.getMethodName() = "match" and
-      this.getNumArgument() = 1 and
-      this.getArgument(0).analyze().getAType() = TTRegExp()
-    }
-
+  private class StringMatchTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = this.getReceiver() and
-      succ = this
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "match" and
+        call.getNumArgument() = 1 and
+        call.getArgument(0).analyze().getAType() = TTRegExp() and
+        pred = call.getReceiver() and
+        succ = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -217,13 +217,23 @@ module TaintTracking {
    * Note: For performance reasons, all subclasses of this class should be part
    * of the standard library. Override `Configuration::isAdditionalTaintStep`
    * for analysis-specific taint steps.
+   *
+   * This class has multiple kinds of `step` predicates; these all have the same
+   * effect on taint-tracking configurations. However, the categorization of steps
+   * allows some data-flow configurations to opt in to specific kinds of taint steps.
    */
   class SharedTaintStep extends Unit {
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
      * data flow edge.
      */
-    abstract predicate step(DataFlow::Node pred, DataFlow::Node succ);
+    predicate step(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge, in the URI category.
+     */
+    predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
   }
 
   /**
@@ -233,6 +243,12 @@ module TaintTracking {
     any(SharedTaintStep step).step(pred, succ)
     or
     any(AdditionalTaintStep step).step(pred, succ)
+    or
+    uriStep(pred, succ)
+  }
+
+  predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).uriStep(pred, succ)
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -234,6 +234,15 @@ module TaintTracking {
      * data flow edge, in the URI category.
      */
     predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge, in the heuristic category.
+     *
+     * Note that this set of steps will be empty unless libraries from
+     * `semmle.javascript.heuristics` are explicitly imported.
+     */
+    predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
   }
 
   /**
@@ -243,6 +252,8 @@ module TaintTracking {
     any(SharedTaintStep step).step(pred, succ)
     or
     any(AdditionalTaintStep step).step(pred, succ)
+    or
+    any(SharedTaintStep step).heuristicStep(pred, succ)
     or
     uriStep(pred, succ)
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -567,11 +567,12 @@ module TaintTracking {
   /**
    * A taint propagating data flow edge arising from JSON unparsing.
    */
-  private class JsonStringifyTaintStep extends AdditionalTaintStep, DataFlow::CallNode {
-    JsonStringifyTaintStep() { this instanceof JsonStringifyCall }
-
+  private class JsonStringifyTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getArgument(0) and succ = this
+      exists(JsonStringifyCall call |
+        pred = call.getArgument(0) and
+        succ = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -403,21 +403,15 @@ module TaintTracking {
    * taint to flow from `v` to any read of `c2.props.p`, where `c2`
    * also is an instance of `C`.
    */
-  private class ReactComponentPropsTaintStep extends AdditionalTaintStep {
-    DataFlow::Node source;
-
-    ReactComponentPropsTaintStep() {
+  private class ReactComponentPropsTaintStep extends SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(ReactComponent c, string name, DataFlow::PropRead prn |
         prn = c.getAPropRead(name) or
         prn = c.getAPreviousPropsSource().getAPropertyRead(name)
       |
-        source = c.getACandidatePropsValue(name) and
-        this = prn
+        pred = c.getACandidatePropsValue(name) and
+        succ = prn
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = source and succ = this
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -520,17 +520,12 @@ module TaintTracking {
   /**
    * A taint propagating data flow edge arising from string formatting.
    */
-  private class StringFormattingTaintStep extends AdditionalTaintStep {
-    PrintfStyleCall call;
-
-    StringFormattingTaintStep() {
-      this = call and
-      call.returnsFormatted()
-    }
-
+  private class StringFormattingTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      succ = this and
-      (
+      exists(PrintfStyleCall call |
+        call.returnsFormatted() and
+        succ = call
+      |
         pred = call.getFormatString()
         or
         pred = call.getFormatArgument(_)

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -579,14 +579,12 @@ module TaintTracking {
   /**
    * A taint propagating data flow edge arising from JSON parsing.
    */
-  private class JsonParserTaintStep extends AdditionalTaintStep, DataFlow::CallNode {
-    JsonParserCall call;
-
-    JsonParserTaintStep() { this = call }
-
+  private class JsonParserTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = call.getInput() and
-      succ = call.getOutput()
+      exists(JsonParserCall call |
+        pred = call.getInput() and
+        succ = call.getOutput()
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -421,11 +421,8 @@ module TaintTracking {
    * Note that since we cannot easily distinguish string append from addition,
    * we consider any `+` operation to propagate taint.
    */
-  class StringConcatenationTaintStep extends AdditionalTaintStep {
-    StringConcatenationTaintStep() { StringConcatenation::taintStep(_, this) }
-
+  class StringConcatenationTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      succ = this and
       StringConcatenation::taintStep(pred, succ)
     }
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -686,11 +686,13 @@ module TaintTracking {
   /**
    * A taint propagating data flow edge arising from sorting.
    */
-  private class SortTaintStep extends AdditionalTaintStep, DataFlow::MethodCallNode {
-    SortTaintStep() { getMethodName() = "sort" }
-
+  private class SortTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getReceiver() and succ = this
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "sort" and
+        pred = call.getReceiver() and
+        succ = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -223,6 +223,9 @@ module TaintTracking {
    * allows some data-flow configurations to opt in to specific kinds of taint steps.
    */
   class SharedTaintStep extends Unit {
+    // Each step relation in this class should have a cached version in the `Cached` module
+    // and be included in the `sharedTaintStep` predicate.
+
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
      * data flow edge.

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -431,11 +431,8 @@ module TaintTracking {
    * A taint propagating data flow edge arising from string manipulation
    * functions defined in the standard library.
    */
-  private class StringManipulationTaintStep extends AdditionalTaintStep, DataFlow::ValueNode {
-    StringManipulationTaintStep() { stringManipulationStep(_, this) }
-
+  private class StringManipulationTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      succ = this and
       stringManipulationStep(pred, succ)
     }
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -313,26 +313,26 @@ module TaintTracking {
   cached
   private module Cached {
     /**
-    * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-    * data flow edge, which doesn't fit into a more specific category.
-    */
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge, which doesn't fit into a more specific category.
+     */
     cached
     predicate genericStep(DataFlow::Node pred, DataFlow::Node succ) {
       any(SharedTaintStep step).step(pred, succ)
     }
 
     /**
-    * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-    * data flow edge, contribued by the heuristics library.
-    */
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge, contribued by the heuristics library.
+     */
     cached
     predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
       any(SharedTaintStep step).heuristicStep(pred, succ)
     }
 
     /**
-    * Holds if `pred -> succ` is an edge contributed by an `AdditionalTaintStep` instance.
-    */
+     * Holds if `pred -> succ` is an edge contributed by an `AdditionalTaintStep` instance.
+     */
     cached
     predicate legacyAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
       any(AdditionalTaintStep step).step(pred, succ)
@@ -344,96 +344,97 @@ module TaintTracking {
     cached
     module Public {
       /**
-      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-      * data flow edge through a URI library function.
-      */
+       * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+       * data flow edge through a URI library function.
+       */
       cached
       predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).uriStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
+       */
       cached
       predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).persistentStorageStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
+       */
       cached
       predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).heapStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
+       */
       cached
       predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).arrayStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through the
-      * properties of a view compenent, such as the `state` or `props` of a React component.
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through the
+       * properties of a view compenent, such as the `state` or `props` of a React component.
+       */
       cached
       predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).viewComponentStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through string
-      * concatenation.
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through string
+       * concatenation.
+       */
       cached
       predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).stringConcatenationStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through string manipulation
-      * (other than concatenation).
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through string manipulation
+       * (other than concatenation).
+       */
       cached
       predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).stringManipulationStep(pred, succ)
       }
 
       /**
-      *  Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-      * data flow edge through data serialization, such as `JSON.stringify`.
-      */
+       *  Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+       * data flow edge through data serialization, such as `JSON.stringify`.
+       */
       cached
       predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).serializeStep(pred, succ)
       }
 
       /**
-      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-      * data flow edge through data deserialization, such as `JSON.parse`.
-      */
+       * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+       * data flow edge through data deserialization, such as `JSON.parse`.
+       */
       cached
       predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).deserializeStep(pred, succ)
       }
 
       /**
-      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-      * data flow edge through a promise.
-      *
-      * These steps consider a promise object to tainted if it can resolve to
-      * a tainted value.
-      */
+       * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+       * data flow edge through a promise.
+       *
+       * These steps consider a promise object to tainted if it can resolve to
+       * a tainted value.
+       */
       cached
       predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).promiseStep(pred, succ)
       }
     }
   }
+
   import Cached::Public
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -338,7 +338,7 @@ module TaintTracking {
      */
     cached
     predicate legacyAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
-      any(AdditionalTaintStep step).step(pred, succ)
+      any(InternalAdditionalTaintStep step).step(pred, succ)
     }
 
     /**
@@ -469,6 +469,12 @@ module TaintTracking {
   }
 
   /**
+   * DEPRECATED. Subclasses should extend `SharedTaintStep` instead, unless the subclass
+   * is part of a query, in which case it should be moved into the `isAdditionalTaintStep` predicate
+   * of the relevant taint-tracking configuration.
+   * Other uses of the `step` relation in this class should instead use the `TaintTracking::sharedTaintStep`
+   * predicate.
+   *
    * A taint-propagating data flow edge that should be added to all taint tracking
    * configurations in addition to standard data flow edges.
    *
@@ -476,7 +482,10 @@ module TaintTracking {
    * of the standard library. Override `Configuration::isAdditionalTaintStep`
    * for analysis-specific taint steps.
    */
-  abstract class AdditionalTaintStep extends DataFlow::Node {
+  deprecated class AdditionalTaintStep = InternalAdditionalTaintStep;
+
+  /** Internal version of `AdditionalTaintStep` that won't trigger deprecation warnings. */
+  abstract private class InternalAdditionalTaintStep extends DataFlow::Node {
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
      * data flow edge.

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -308,112 +308,133 @@ module TaintTracking {
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge, which doesn't fit into a more specific category.
+   * Module existing only to ensure all taint steps are cached as a single stage.
    */
   cached
-  private predicate genericStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).step(pred, succ)
-  }
+  private module Cached {
+    /**
+    * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+    * data flow edge, which doesn't fit into a more specific category.
+    */
+    cached
+    predicate genericStep(DataFlow::Node pred, DataFlow::Node succ) {
+      any(SharedTaintStep step).step(pred, succ)
+    }
 
-  /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge, contribued by the heuristics library.
-   */
-  cached
-  private predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).heuristicStep(pred, succ)
-  }
+    /**
+    * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+    * data flow edge, contribued by the heuristics library.
+    */
+    cached
+    predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
+      any(SharedTaintStep step).heuristicStep(pred, succ)
+    }
 
-  /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through a URI library function.
-   */
-  cached
-  predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).uriStep(pred, succ)
-  }
+    /**
+    * Holds if `pred -> succ` is an edge contributed by an `AdditionalTaintStep` instance.
+    */
+    cached
+    predicate legacyAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+      any(AdditionalTaintStep step).step(pred, succ)
+    }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
-   */
-  cached
-  predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).persistentStorageStep(pred, succ)
-  }
+    /**
+     * Public taint step relations.
+     */
+    cached
+    module Public {
+      /**
+      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+      * data flow edge through a URI library function.
+      */
+      cached
+      predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).uriStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
-   */
-  cached
-  predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).heapStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
+      */
+      cached
+      predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).persistentStorageStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
-   */
-  cached
-  predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).arrayStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
+      */
+      cached
+      predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).heapStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through the
-   * properties of a view compenent, such as the `state` or `props` of a React component.
-   */
-  cached
-  predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).viewComponentStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
+      */
+      cached
+      predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).arrayStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through string
-   * concatenation.
-   */
-  cached
-  predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).stringConcatenationStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through the
+      * properties of a view compenent, such as the `state` or `props` of a React component.
+      */
+      cached
+      predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).viewComponentStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through string manipulation
-   * (other than concatenation).
-   */
-  cached
-  predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).stringManipulationStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through string
+      * concatenation.
+      */
+      cached
+      predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).stringConcatenationStep(pred, succ)
+      }
 
-  /**
-   *  Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through data serialization, such as `JSON.stringify`.
-   */
-  cached
-  predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).serializeStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through string manipulation
+      * (other than concatenation).
+      */
+      cached
+      predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).stringManipulationStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through data deserialization, such as `JSON.parse`.
-   */
-  cached
-  predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).deserializeStep(pred, succ)
-  }
+      /**
+      *  Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+      * data flow edge through data serialization, such as `JSON.stringify`.
+      */
+      cached
+      predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).serializeStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through data deserialization, such as `JSON.parse`.
-   *
-   * These steps consider a promise object to tainted if it can resolve to
-   * a tainted value.
-   */
-  cached
-  predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).promiseStep(pred, succ)
+      /**
+      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+      * data flow edge through data deserialization, such as `JSON.parse`.
+      */
+      cached
+      predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).deserializeStep(pred, succ)
+      }
+
+      /**
+      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+      * data flow edge through data deserialization, such as `JSON.parse`.
+      *
+      * These steps consider a promise object to tainted if it can resolve to
+      * a tainted value.
+      */
+      cached
+      predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).promiseStep(pred, succ)
+      }
+    }
   }
+  import Cached::Public
 
   /**
    * Holds if `pred -> succ` is a taint propagating data flow edge through a string operation.
@@ -425,20 +446,12 @@ module TaintTracking {
   }
 
   /**
-   * Holds if `pred -> succ` is an edge contributed by an `AdditionalTaintStep` instance.
-   */
-  cached
-  private predicate legacyAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(AdditionalTaintStep step).step(pred, succ)
-  }
-
-  /**
    * Holds if `pred -> succ` is an edge used by all taint-tracking configurations.
    */
   predicate sharedTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
-    legacyAdditionalTaintStep(pred, succ) or
-    genericStep(pred, succ) or
-    heuristicStep(pred, succ) or
+    Cached::legacyAdditionalTaintStep(pred, succ) or
+    Cached::genericStep(pred, succ) or
+    Cached::heuristicStep(pred, succ) or
     uriStep(pred, succ) or
     persistentStorageStep(pred, succ) or
     heapStep(pred, succ) or

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -231,35 +231,185 @@ module TaintTracking {
 
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-     * data flow edge, in the URI category.
+     * data flow edge through URI manipulation.
+     *
+     * Does not include string operations that aren't specific to URIs, such
+     * as concatenation and substring operations.
      */
     predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
 
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-     * data flow edge, in the heuristic category.
+     * data flow edge contributed by the heuristics library.
      *
-     * Note that this set of steps will be empty unless libraries from
-     * `semmle.javascript.heuristics` are explicitly imported.
+     * Such steps are provided by the `semmle.javascript.heuristics` libraries
+     * and will default to be being empty if those libraries are not imported.
      */
     predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through persistent storage.
+     */
+    predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through the heap.
+     */
+    predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through the `state` or `props` or a React component.
+     */
+    predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through string concatenation.
+     */
+    predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through string manipulation (other than concatenation).
+     */
+    predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through data serialization, such as `JSON.stringify`.
+     */
+    predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through data deserialization, such as `JSON.parse`.
+     */
+    predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+  }
+
+  /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge, which doesn't fit into a more specific category.
+   */
+  cached
+  private predicate genericStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).step(pred, succ)
+  }
+
+  /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge, contribued by the heuristics library.
+   */
+  cached
+  private predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).heuristicStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge through a URI library function.
+   */
+  cached
+  predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).uriStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
+   */
+  cached
+  predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).persistentStorageStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
+   */
+  cached
+  predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).heapStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through the
+   * properties of a view compenent, such as the `state` or `props` of a React component.
+   */
+  cached
+  predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).viewComponentStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through string
+   * concatenation.
+   */
+  cached
+  predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).stringConcatenationStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through string manipulation
+   * (other than concatenation).
+   */
+  cached
+  predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).stringManipulationStep(pred, succ)
+  }
+
+  /**
+   *  Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge through data serialization, such as `JSON.stringify`.
+   */
+  cached
+  predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).serializeStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge through data deserialization, such as `JSON.parse`.
+   */
+  cached
+  predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).deserializeStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through a string operation.
+   */
+  pragma[inline]
+  predicate stringStep(DataFlow::Node pred, DataFlow::Node succ) {
+    stringConcatenationStep(pred, succ) or
+    stringManipulationStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is an edge contributed by an `AdditionalTaintStep` instance.
+   */
+  cached
+  private predicate legacyAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(AdditionalTaintStep step).step(pred, succ)
   }
 
   /**
    * Holds if `pred -> succ` is an edge used by all taint-tracking configurations.
    */
-  cached predicate sharedTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).step(pred, succ)
-    or
-    any(AdditionalTaintStep step).step(pred, succ)
-    or
-    any(SharedTaintStep step).heuristicStep(pred, succ)
-    or
-    uriStep(pred, succ)
-  }
-
-  predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).uriStep(pred, succ)
+  predicate sharedTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    legacyAdditionalTaintStep(pred, succ) or
+    genericStep(pred, succ) or
+    heuristicStep(pred, succ) or
+    uriStep(pred, succ) or
+    persistentStorageStep(pred, succ) or
+    heapStep(pred, succ) or
+    viewComponentStep(pred, succ) or
+    stringConcatenationStep(pred, succ) or
+    stringManipulationStep(pred, succ) or
+    serializeStep(pred, succ) or
+    deserializeStep(pred, succ)
   }
 
   /**
@@ -276,17 +426,6 @@ module TaintTracking {
      * data flow edge.
      */
     abstract predicate step(DataFlow::Node pred, DataFlow::Node succ);
-  }
-
-  /**
-   * A taint propagating data flow edge through object or array elements and
-   * promises.
-   */
-  private class HeapTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      Stages::Taint::ref() and
-      heapStep(pred, succ)
-    }
   }
 
   /** Gets a data flow node referring to the client side URL. */
@@ -319,44 +458,54 @@ module TaintTracking {
   }
 
   /**
-   * Holds if there is taint propagation through the heap from `pred` to `succ`.
+   * A taint propagating data flow edge through object or array elements and
+   * promises.
    */
-  private predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(Expr e, Expr f | e = succ.asExpr() and f = pred.asExpr() |
-      exists(Property prop | e.(ObjectExpr).getAProperty() = prop |
-        prop.isComputed() and f = prop.getNameExpr()
+  private class HeapTaintStep extends SharedTaintStep {
+    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(Expr e, Expr f | e = succ.asExpr() and f = pred.asExpr() |
+        exists(Property prop | e.(ObjectExpr).getAProperty() = prop |
+          prop.isComputed() and f = prop.getNameExpr()
+        )
+        or
+        // awaiting a tainted expression gives a tainted result
+        e.(AwaitExpr).getOperand() = f
+        or
+        // spreading a tainted object into an object literal gives a tainted object
+        e.(ObjectExpr).getAProperty().(SpreadProperty).getInit().(SpreadElement).getOperand() = f
+        or
+        // spreading a tainted value into an array literal gives a tainted array
+        e.(ArrayExpr).getAnElement().(SpreadElement).getOperand() = f
       )
       or
-      // awaiting a tainted expression gives a tainted result
-      e.(AwaitExpr).getOperand() = f
+      // arrays with tainted elements and objects with tainted property names are tainted
+      succ.(DataFlow::ArrayCreationNode).getAnElement() = pred and
+      not any(PromiseAllCreation call).getArrayNode() = succ
       or
-      // spreading a tainted object into an object literal gives a tainted object
-      e.(ObjectExpr).getAProperty().(SpreadProperty).getInit().(SpreadElement).getOperand() = f
+      // reading from a tainted object yields a tainted result
+      succ.(DataFlow::PropRead).getBase() = pred
       or
-      // spreading a tainted value into an array literal gives a tainted array
-      e.(ArrayExpr).getAnElement().(SpreadElement).getOperand() = f
-    )
-    or
-    // arrays with tainted elements and objects with tainted property names are tainted
-    succ.(DataFlow::ArrayCreationNode).getAnElement() = pred and
-    not any(PromiseAllCreation call).getArrayNode() = succ
-    or
-    // reading from a tainted object yields a tainted result
-    succ.(DataFlow::PropRead).getBase() = pred and
-    not AccessPath::DominatingPaths::hasDominatingWrite(succ) and
-    not isSafeClientSideUrlProperty(succ)
-    or
-    // iterating over a tainted iterator taints the loop variable
-    exists(ForOfStmt fos |
-      pred = DataFlow::valueNode(fos.getIterationDomain()) and
-      succ = DataFlow::lvalueNode(fos.getLValue())
-    )
-    or
-    // taint-tracking rest patterns in l-values. E.g. `const {...spread} = foo()` or `const [...spread] = foo()`.
-    exists(DestructuringPattern pattern |
-      pred = DataFlow::lvalueNode(pattern) and
-      succ = DataFlow::lvalueNode(pattern.getRest())
-    )
+      // arrays with tainted elements and objects with tainted property names are tainted
+      succ.(DataFlow::ArrayCreationNode).getAnElement() = pred and
+      not any(PromiseAllCreation call).getArrayNode() = succ
+      or
+      // reading from a tainted object yields a tainted result
+      succ.(DataFlow::PropRead).getBase() = pred and
+      not AccessPath::DominatingPaths::hasDominatingWrite(succ) and
+      not isSafeClientSideUrlProperty(succ)
+      or
+      // iterating over a tainted iterator taints the loop variable
+      exists(ForOfStmt fos |
+        pred = DataFlow::valueNode(fos.getIterationDomain()) and
+        succ = DataFlow::lvalueNode(fos.getLValue())
+      )
+      or
+      // taint-tracking rest patterns in l-values. E.g. `const {...spread} = foo()` or `const [...spread] = foo()`.
+      exists(DestructuringPattern pattern |
+        pred = DataFlow::lvalueNode(pattern) and
+        succ = DataFlow::lvalueNode(pattern.getRest())
+      )
+    }
   }
 
   /**
@@ -365,19 +514,12 @@ module TaintTracking {
    * A taint propagating data flow edge through persistent storage.
    */
   deprecated class PersistentStorageTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      persistentStorageStep(pred, succ)
+    override predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(PersistentReadAccess read |
+        pred = read.getAWrite().getValue() and
+        succ = read
+      )
     }
-  }
-
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
-   */
-  predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(PersistentReadAccess read |
-      pred = read.getAWrite().getValue() and
-      succ = read
-    )
   }
 
   predicate arrayFunctionTaintStep = ArrayTaintTracking::arrayFunctionTaintStep/3;
@@ -393,19 +535,15 @@ module TaintTracking {
    * map to be tainted as soon as one of its entries is.
    */
   private class DictionaryTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      dictionaryTaintStep(pred, succ)
+    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(AssignExpr assgn, IndexExpr idx, DataFlow::ObjectLiteralNode obj |
+        assgn.getTarget() = idx and
+        obj.flowsToExpr(idx.getBase()) and
+        not exists(idx.getPropertyName()) and
+        pred = DataFlow::valueNode(assgn.getRhs()) and
+        succ = obj
+      )
     }
-  }
-
-  /** Holds if there is a step `pred -> succ` used by `DictionaryTaintStep`. */
-  private predicate dictionaryTaintStep(DataFlow::Node pred, DataFlow::ObjectLiteralNode succ) {
-    exists(AssignExpr assgn, IndexExpr idx |
-      assgn.getTarget() = idx and
-      succ.flowsToExpr(idx.getBase()) and
-      not exists(idx.getPropertyName()) and
-      pred = DataFlow::valueNode(assgn.getRhs())
-    )
   }
 
   /**
@@ -415,7 +553,7 @@ module TaintTracking {
    * also is an instance of `C`.
    */
   private class ReactComponentStateTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(ReactComponent c, DataFlow::PropRead prn, DataFlow::PropWrite pwn |
         (
           c.getACandidateStateSource().flowsTo(pwn.getBase()) or
@@ -440,7 +578,7 @@ module TaintTracking {
    * also is an instance of `C`.
    */
   private class ReactComponentPropsTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(ReactComponent c, string name, DataFlow::PropRead prn |
         prn = c.getAPropRead(name) or
         prn = c.getAPreviousPropsSource().getAPropertyRead(name)
@@ -458,7 +596,7 @@ module TaintTracking {
    * we consider any `+` operation to propagate taint.
    */
   class StringConcatenationTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
       StringConcatenation::taintStep(pred, succ)
     }
   }
@@ -468,96 +606,91 @@ module TaintTracking {
    * functions defined in the standard library.
    */
   private class StringManipulationTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      stringManipulationStep(pred, succ)
-    }
-  }
-
-  /**
-   * Holds if taint can propagate from `pred` to `succ` with a step related to string manipulation.
-   */
-  private predicate stringManipulationStep(DataFlow::Node pred, DataFlow::ValueNode succ) {
-    // string operations that propagate taint
-    exists(string name | name = succ.getAstNode().(MethodCallExpr).getMethodName() |
-      pred.asExpr() = succ.getAstNode().(MethodCallExpr).getReceiver() and
-      (
-        // sorted, interesting, properties of String.prototype
-        name = "anchor" or
-        name = "big" or
-        name = "blink" or
-        name = "bold" or
-        name = "concat" or
-        name = "fixed" or
-        name = "fontcolor" or
-        name = "fontsize" or
-        name = "italics" or
-        name = "link" or
-        name = "padEnd" or
-        name = "padStart" or
-        name = "repeat" or
-        name = "replace" or
-        name = "replaceAll" or
-        name = "slice" or
-        name = "small" or
-        name = "split" or
-        name = "strike" or
-        name = "sub" or
-        name = "substr" or
-        name = "substring" or
-        name = "sup" or
-        name = "toLocaleLowerCase" or
-        name = "toLocaleUpperCase" or
-        name = "toLowerCase" or
-        name = "toUpperCase" or
-        name = "trim" or
-        name = "trimLeft" or
-        name = "trimRight" or
-        // sorted, interesting, properties of Object.prototype
-        name = "toString" or
-        name = "valueOf" or
-        // sorted, interesting, properties of Array.prototype
-        name = "join"
-      )
-      or
-      exists(int i | pred.asExpr() = succ.getAstNode().(MethodCallExpr).getArgument(i) |
-        name = "concat"
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node target) {
+      exists(DataFlow::ValueNode succ | target = succ |
+        // string operations that propagate taint
+        exists(string name | name = succ.getAstNode().(MethodCallExpr).getMethodName() |
+          pred.asExpr() = succ.getAstNode().(MethodCallExpr).getReceiver() and
+          (
+            // sorted, interesting, properties of String.prototype
+            name = "anchor" or
+            name = "big" or
+            name = "blink" or
+            name = "bold" or
+            name = "concat" or
+            name = "fixed" or
+            name = "fontcolor" or
+            name = "fontsize" or
+            name = "italics" or
+            name = "link" or
+            name = "padEnd" or
+            name = "padStart" or
+            name = "repeat" or
+            name = "replace" or
+            name = "replaceAll" or
+            name = "slice" or
+            name = "small" or
+            name = "split" or
+            name = "strike" or
+            name = "sub" or
+            name = "substr" or
+            name = "substring" or
+            name = "sup" or
+            name = "toLocaleLowerCase" or
+            name = "toLocaleUpperCase" or
+            name = "toLowerCase" or
+            name = "toUpperCase" or
+            name = "trim" or
+            name = "trimLeft" or
+            name = "trimRight" or
+            // sorted, interesting, properties of Object.prototype
+            name = "toString" or
+            name = "valueOf" or
+            // sorted, interesting, properties of Array.prototype
+            name = "join"
+          )
+          or
+          exists(int i | pred.asExpr() = succ.getAstNode().(MethodCallExpr).getArgument(i) |
+            name = "concat"
+            or
+            name = ["replace", "replaceAll"] and i = 1
+          )
+        )
         or
-        name = ["replace", "replaceAll"] and i = 1
+        // standard library constructors that propagate taint: `RegExp` and `String`
+        exists(DataFlow::InvokeNode invk, string gv | gv = "RegExp" or gv = "String" |
+          succ = invk and
+          invk = DataFlow::globalVarRef(gv).getAnInvocation() and
+          pred = invk.getArgument(0)
+        )
+        or
+        // String.fromCharCode and String.fromCodePoint
+        exists(int i, MethodCallExpr mce |
+          mce = succ.getAstNode() and
+          pred.asExpr() = mce.getArgument(i) and
+          (mce.getMethodName() = "fromCharCode" or mce.getMethodName() = "fromCodePoint")
+        )
+        or
+        // `(encode|decode)URI(Component)?` propagate taint
+        exists(DataFlow::CallNode c, string name |
+          succ = c and
+          c = DataFlow::globalVarRef(name).getACall() and
+          pred = c.getArgument(0)
+        |
+          name = "encodeURI" or
+          name = "decodeURI" or
+          name = "encodeURIComponent" or
+          name = "decodeURIComponent"
+        )
       )
-    )
-    or
-    // standard library constructors that propagate taint: `RegExp` and `String`
-    exists(DataFlow::InvokeNode invk, string gv | gv = "RegExp" or gv = "String" |
-      succ = invk and
-      invk = DataFlow::globalVarRef(gv).getAnInvocation() and
-      pred = invk.getArgument(0)
-    )
-    or
-    // String.fromCharCode and String.fromCodePoint
-    exists(int i, MethodCallExpr mce |
-      mce = succ.getAstNode() and
-      pred.asExpr() = mce.getArgument(i) and
-      (mce.getMethodName() = "fromCharCode" or mce.getMethodName() = "fromCodePoint")
-    )
-    or
-    // `(encode|decode)URI(Component)?` propagate taint
-    exists(DataFlow::CallNode c, string name |
-      succ = c and
-      c = DataFlow::globalVarRef(name).getACall() and
-      pred = c.getArgument(0)
-    |
-      name = "encodeURI" or
-      name = "decodeURI" or
-      name = "encodeURIComponent" or
-      name = "decodeURIComponent"
-    )
+    }
   }
 
   /**
    * A taint propagating data flow edge arising from string formatting.
    */
   private class StringFormattingTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(PrintfStyleCall call |
         call.returnsFormatted() and
         succ = call
@@ -580,7 +713,7 @@ module TaintTracking {
    * `RegExp.prototype.exec` to its result.
    */
   private class RegExpExecTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
         call = execMethodCall() and
         call.getNumArgument() = 1 and
@@ -600,7 +733,7 @@ module TaintTracking {
    * A taint propagating data flow edge arising from calling `String.prototype.match()`.
    */
   private class StringMatchTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
         call = matchMethodCall() and
         call.getNumArgument() = 1 and
@@ -614,7 +747,7 @@ module TaintTracking {
    * A taint propagating data flow edge arising from JSON unparsing.
    */
   private class JsonStringifyTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(JsonStringifyCall call |
         pred = call.getArgument(0) and
         succ = call
@@ -626,7 +759,7 @@ module TaintTracking {
    * A taint propagating data flow edge arising from JSON parsing.
    */
   private class JsonParserTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(JsonParserCall call |
         pred = call.getInput() and
         succ = call.getOutput()
@@ -733,7 +866,7 @@ module TaintTracking {
    * A taint propagating data flow edge arising from sorting.
    */
   private class SortTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
         call.getMethodName() = "sort" and
         pred = call.getReceiver() and
@@ -746,12 +879,12 @@ module TaintTracking {
    * A taint step through an exception constructor, such as `x` to `new Error(x)`.
    */
   class ErrorConstructorTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::NewNode invoke, string name |
         invoke = DataFlow::globalVarRef(name).getAnInvocation() and
         pred = invoke.getArgument(0) and
         succ = invoke
-        |
+      |
         name = "Error" or
         name = "EvalError" or
         name = "RangeError" or

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -225,7 +225,6 @@ module TaintTracking {
   class SharedTaintStep extends Unit {
     // Each step relation in this class should have a cached version in the `Cached` module
     // and be included in the `sharedTaintStep` predicate.
-
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
      * data flow edge.

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -308,7 +308,8 @@ module TaintTracking {
   }
 
   /**
-   * Module existing only to ensure all taint steps are cached as a single stage.
+   * Module existing only to ensure all taint steps are cached as a single stage,
+   * and without the the `Unit` type column.
    */
   cached
   private module Cached {

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -15,6 +15,7 @@
 
 import javascript
 private import semmle.javascript.dataflow.internal.FlowSteps as FlowSteps
+private import semmle.javascript.dataflow.internal.Unit
 private import semmle.javascript.dataflow.InferredTypes
 private import semmle.javascript.internal.CachedStages
 
@@ -139,7 +140,7 @@ module TaintTracking {
 
     final override predicate isAdditionalFlowStep(DataFlow::Node pred, DataFlow::Node succ) {
       isAdditionalTaintStep(pred, succ) or
-      any(AdditionalTaintStep dts).step(pred, succ)
+      sharedTaintStep(pred, succ)
     }
 
     final override predicate isAdditionalFlowStep(
@@ -211,17 +212,42 @@ module TaintTracking {
    * A taint-propagating data flow edge that should be added to all taint tracking
    * configurations in addition to standard data flow edges.
    *
+   * This class is a singleton, and thus subclasses do not need to specify a characteristic predicate.
+   *
    * Note: For performance reasons, all subclasses of this class should be part
    * of the standard library. Override `Configuration::isAdditionalTaintStep`
    * for analysis-specific taint steps.
    */
-  cached
+  class SharedTaintStep extends Unit {
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge.
+     */
+    abstract predicate step(DataFlow::Node pred, DataFlow::Node succ);
+  }
+
+  /**
+   * Holds if `pred -> succ` is an edge used by all taint-tracking configurations.
+   */
+  cached predicate sharedTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).step(pred, succ)
+    or
+    any(AdditionalTaintStep step).step(pred, succ)
+  }
+
+  /**
+   * A taint-propagating data flow edge that should be added to all taint tracking
+   * configurations in addition to standard data flow edges.
+   *
+   * Note: For performance reasons, all subclasses of this class should be part
+   * of the standard library. Override `Configuration::isAdditionalTaintStep`
+   * for analysis-specific taint steps.
+   */
   abstract class AdditionalTaintStep extends DataFlow::Node {
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
      * data flow edge.
      */
-    cached
     abstract predicate step(DataFlow::Node pred, DataFlow::Node succ);
   }
 
@@ -312,14 +338,12 @@ module TaintTracking {
   /**
    * A taint propagating data flow edge through persistent storage.
    */
-  class PersistentStorageTaintStep extends AdditionalTaintStep {
-    PersistentReadAccess read;
-
-    PersistentStorageTaintStep() { this = read }
-
+  class PersistentStorageTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = read.getAWrite().getValue() and
-      succ = read
+      exists(PersistentReadAccess read |
+        pred = read.getAWrite().getValue() and
+        succ = read
+      )
     }
   }
 
@@ -360,10 +384,8 @@ module TaintTracking {
    * taint to flow from `v` to any read of `c2.state.p`, where `c2`
    * also is an instance of `C`.
    */
-  private class ReactComponentStateTaintStep extends AdditionalTaintStep {
-    DataFlow::Node source;
-
-    ReactComponentStateTaintStep() {
+  private class ReactComponentStateTaintStep extends SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(ReactComponent c, DataFlow::PropRead prn, DataFlow::PropWrite pwn |
         (
           c.getACandidateStateSource().flowsTo(pwn.getBase()) or
@@ -375,13 +397,9 @@ module TaintTracking {
         )
       |
         prn.getPropertyName() = pwn.getPropertyName() and
-        this = prn and
-        source = pwn.getRhs()
+        succ = prn and
+        pred = pwn.getRhs()
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = source and succ = this
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -536,13 +536,6 @@ module TaintTracking {
       not any(PromiseAllCreation call).getArrayNode() = succ
       or
       // reading from a tainted object yields a tainted result
-      succ.(DataFlow::PropRead).getBase() = pred
-      or
-      // arrays with tainted elements and objects with tainted property names are tainted
-      succ.(DataFlow::ArrayCreationNode).getAnElement() = pred and
-      not any(PromiseAllCreation call).getArrayNode() = succ
-      or
-      // reading from a tainted object yields a tainted result
       succ.(DataFlow::PropRead).getBase() = pred and
       not AccessPath::DominatingPaths::hasDominatingWrite(succ) and
       not isSafeClientSideUrlProperty(succ)

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -288,6 +288,15 @@ module TaintTracking {
      * data flow edge through data deserialization, such as `JSON.parse`.
      */
     predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through a promise.
+     *
+     * These steps consider a promise object to tainted if it can resolve to
+     * a tainted value.
+     */
+    predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
   }
 
   /**
@@ -379,6 +388,18 @@ module TaintTracking {
   }
 
   /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge through data deserialization, such as `JSON.parse`.
+   *
+   * These steps consider a promise object to tainted if it can resolve to
+   * a tainted value.
+   */
+  cached
+  predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).promiseStep(pred, succ)
+  }
+
+  /**
    * Holds if `pred -> succ` is a taint propagating data flow edge through a string operation.
    */
   pragma[inline]
@@ -409,7 +430,8 @@ module TaintTracking {
     stringConcatenationStep(pred, succ) or
     stringManipulationStep(pred, succ) or
     serializeStep(pred, succ) or
-    deserializeStep(pred, succ)
+    deserializeStep(pred, succ) or
+    promiseStep(pred, succ)
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -699,9 +699,13 @@ module TaintTracking {
   /**
    * A taint step through an exception constructor, such as `x` to `new Error(x)`.
    */
-  class ErrorConstructorTaintStep extends AdditionalTaintStep, DataFlow::InvokeNode {
-    ErrorConstructorTaintStep() {
-      exists(string name | this = DataFlow::globalVarRef(name).getAnInvocation() |
+  class ErrorConstructorTaintStep extends SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::NewNode invoke, string name |
+        invoke = DataFlow::globalVarRef(name).getAnInvocation() and
+        pred = invoke.getArgument(0) and
+        succ = invoke
+        |
         name = "Error" or
         name = "EvalError" or
         name = "RangeError" or
@@ -710,11 +714,6 @@ module TaintTracking {
         name = "TypeError" or
         name = "URIError"
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getArgument(0) and
-      succ = this
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -1114,6 +1114,6 @@ module TaintTracking {
    */
   predicate localTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
     DataFlow::localFlowStep(pred, succ) or
-    any(AdditionalTaintStep s).step(pred, succ)
+    sharedTaintStep(pred, succ)
   }
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -569,6 +569,12 @@ module TaintTracking {
     }
   }
 
+  pragma[nomagic]
+  private DataFlow::MethodCallNode execMethodCall() {
+    result.getMethodName() = "exec" and
+    result.getReceiver().analyze().getAType() = TTRegExp()
+  }
+
   /**
    * A taint-propagating data flow edge from the first (and only) argument in a call to
    * `RegExp.prototype.exec` to its result.
@@ -576,13 +582,18 @@ module TaintTracking {
   private class RegExpExecTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
-        call.getReceiver().analyze().getAType() = TTRegExp() and
-        call.getMethodName() = "exec" and
+        call = execMethodCall() and
         call.getNumArgument() = 1 and
         pred = call.getArgument(0) and
         succ = call
       )
     }
+  }
+
+  pragma[nomagic]
+  private DataFlow::MethodCallNode matchMethodCall() {
+    result.getMethodName() = "match" and
+    result.getArgument(0).analyze().getAType() = TTRegExp()
   }
 
   /**
@@ -591,9 +602,8 @@ module TaintTracking {
   private class StringMatchTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
-        call.getMethodName() = "match" and
+        call = matchMethodCall() and
         call.getNumArgument() = 1 and
-        call.getArgument(0).analyze().getAType() = TTRegExp() and
         pred = call.getReceiver() and
         succ = call
       )

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -333,15 +333,24 @@ module TaintTracking {
   }
 
   /**
+   * DEPRECATED. Use the predicate `TaintTracking::persistentStorageStep` instead.
+   *
    * A taint propagating data flow edge through persistent storage.
    */
-  class PersistentStorageTaintStep extends SharedTaintStep {
+  deprecated class PersistentStorageTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(PersistentReadAccess read |
-        pred = read.getAWrite().getValue() and
-        succ = read
-      )
+      persistentStorageStep(pred, succ)
     }
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
+   */
+  predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(PersistentReadAccess read |
+      pred = read.getAWrite().getValue() and
+      succ = read
+    )
   }
 
   predicate arrayFunctionTaintStep = ArrayTaintTracking::arrayFunctionTaintStep/3;

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -255,13 +255,10 @@ module TaintTracking {
    * A taint propagating data flow edge through object or array elements and
    * promises.
    */
-  private class HeapTaintStep extends AdditionalTaintStep {
-    HeapTaintStep() { heapStep(_, this) }
-
+  private class HeapTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       Stages::Taint::ref() and
-      heapStep(pred, succ) and
-      succ = this
+      heapStep(pred, succ)
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -261,6 +261,14 @@ module TaintTracking {
 
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through arrays.
+     *
+     * These steps considers an array to be tainted if it contains tainted elements.
+     */
+    predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
      * data flow edge through the `state` or `props` or a React component.
      */
     predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
@@ -340,6 +348,14 @@ module TaintTracking {
   cached
   predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
     any(SharedTaintStep step).heapStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
+   */
+  cached
+  predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).arrayStep(pred, succ)
   }
 
   /**
@@ -426,6 +442,7 @@ module TaintTracking {
     uriStep(pred, succ) or
     persistentStorageStep(pred, succ) or
     heapStep(pred, succ) or
+    arrayStep(pred, succ) or
     viewComponentStep(pred, succ) or
     stringConcatenationStep(pred, succ) or
     stringManipulationStep(pred, succ) or
@@ -541,7 +558,7 @@ module TaintTracking {
     }
   }
 
-  predicate arrayFunctionTaintStep = ArrayTaintTracking::arrayFunctionTaintStep/3;
+  deprecated predicate arrayFunctionTaintStep = ArrayTaintTracking::arrayFunctionTaintStep/3;
 
   /**
    * A taint propagating data flow edge for assignments of the form `o[k] = v`, where

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -583,49 +583,6 @@ module TaintTracking {
   }
 
   /**
-   * A taint propagating data flow edge for assignments of the form `c1.state.p = v`,
-   * where `c1` is an instance of React component `C`; in this case, we consider
-   * taint to flow from `v` to any read of `c2.state.p`, where `c2`
-   * also is an instance of `C`.
-   */
-  private class ReactComponentStateTaintStep extends SharedTaintStep {
-    override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(ReactComponent c, DataFlow::PropRead prn, DataFlow::PropWrite pwn |
-        (
-          c.getACandidateStateSource().flowsTo(pwn.getBase()) or
-          c.getADirectStateAccess().flowsTo(pwn.getBase())
-        ) and
-        (
-          c.getAPreviousStateSource().flowsTo(prn.getBase()) or
-          c.getADirectStateAccess().flowsTo(prn.getBase())
-        )
-      |
-        prn.getPropertyName() = pwn.getPropertyName() and
-        succ = prn and
-        pred = pwn.getRhs()
-      )
-    }
-  }
-
-  /**
-   * A taint propagating data flow edge for assignments of the form `c1.props.p = v`,
-   * where `c1` is an instance of React component `C`; in this case, we consider
-   * taint to flow from `v` to any read of `c2.props.p`, where `c2`
-   * also is an instance of `C`.
-   */
-  private class ReactComponentPropsTaintStep extends SharedTaintStep {
-    override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(ReactComponent c, string name, DataFlow::PropRead prn |
-        prn = c.getAPropRead(name) or
-        prn = c.getAPreviousPropsSource().getAPropertyRead(name)
-      |
-        pred = c.getACandidatePropsValue(name) and
-        succ = prn
-      )
-    }
-  }
-
-  /**
    * A taint propagating data flow edge arising from string concatenations.
    *
    * Note that since we cannot easily distinguish string append from addition,

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -312,6 +312,10 @@ module TaintTracking {
    */
   cached
   private module Cached {
+    cached predicate forceStage() {
+      Stages::Taint::ref()
+    }
+
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
      * data flow edge, which doesn't fit into a more specific category.

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -423,7 +423,7 @@ module TaintTracking {
 
       /**
       * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-      * data flow edge through data deserialization, such as `JSON.parse`.
+      * data flow edge through a promise.
       *
       * These steps consider a promise object to tainted if it can resolve to
       * a tainted value.

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/Unit.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/Unit.qll
@@ -1,0 +1,8 @@
+private newtype TUnit = MkUnit()
+
+/**
+ * A class with only one instance.
+ */
+class Unit extends TUnit {
+  final string toString() { result = "Unit" }
+}

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/Unit.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/Unit.qll
@@ -4,5 +4,6 @@ private newtype TUnit = MkUnit()
  * A class with only one instance.
  */
 class Unit extends TUnit {
+  /** Gets a textual representation of this element. */
   final string toString() { result = "Unit" }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Angular2.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Angular2.qll
@@ -590,7 +590,9 @@ module Angular2 {
   private class MatTableDataSourceStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::NewNode invoke |
-        invoke = DataFlow::moduleMember("@angular/material/table", "MatTableDataSource").getAnInstantiation() and
+        invoke =
+          DataFlow::moduleMember("@angular/material/table", "MatTableDataSource")
+              .getAnInstantiation() and
         pred = [invoke.getArgument(0), invoke.getAPropertyWrite("data").getRhs()] and
         succ = invoke
       )

--- a/javascript/ql/src/semmle/javascript/frameworks/AsyncPackage.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AsyncPackage.qll
@@ -168,12 +168,14 @@ module AsyncPackage {
    */
   private class IterationOutputTaintStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(DataFlow::FunctionNode iteratee, DataFlow::FunctionNode final, int i, IterationCall call |
+      exists(
+        DataFlow::FunctionNode iteratee, DataFlow::FunctionNode final, int i, IterationCall call
+      |
         iteratee = call.getIteratorCallback().getALocalSource() and
         final = call.getFinalCallback() and // Require a closure to avoid spurious call/return mismatch.
         pred = getLastParameter(iteratee).getACall().getArgument(i) and
         succ = final.getParameter(i) and
-        exists (string name | name = call.getName() |
+        exists(string name | name = call.getName() |
           name = "concat" or
           name = "map" or
           name = "reduce" or

--- a/javascript/ql/src/semmle/javascript/frameworks/Classnames.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Classnames.qll
@@ -24,7 +24,11 @@ private class PlainStep extends TaintTracking::SharedTaintStep {
 private class BindStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(DataFlow::CallNode bind | bind = classnames().getAMemberCall("bind") |
-      pred = [succ.(DataFlow::CallNode).getAnArgument(), bind.getAnArgument(), bind.getOptionArgument(_, _)] and
+      pred =
+        [
+          succ.(DataFlow::CallNode).getAnArgument(), bind.getAnArgument(),
+          bind.getOptionArgument(_, _)
+        ] and
       succ = bind.getACall()
     )
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/Classnames.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Classnames.qll
@@ -8,32 +8,24 @@ private DataFlow::SourceNode classnames() {
   result = DataFlow::moduleImport(["classnames", "classnames/dedupe", "classnames/bind"])
 }
 
-private class PlainStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-  PlainStep() {
-    this = classnames().getACall()
-    or
-    this = DataFlow::moduleImport("clsx").getACall()
-  }
-
+private class PlainStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = getAnArgument() and
-    succ = this
+    exists(DataFlow::CallNode call |
+      call = [classnames().getACall(), DataFlow::moduleImport("clsx").getACall()] and
+      pred = call.getAnArgument() and
+      succ = call
+    )
   }
 }
 
 /**
  * Step from `x` or `y` to the result of `classnames.bind(x)(y)`.
  */
-private class BindStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-  DataFlow::CallNode bind;
-
-  BindStep() {
-    bind = classnames().getAMemberCall("bind") and
-    this = bind.getACall()
-  }
-
+private class BindStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = [getAnArgument(), bind.getAnArgument(), bind.getOptionArgument(_, _)] and
-    succ = this
+    exists(DataFlow::CallNode bind | bind = classnames().getAMemberCall("bind") |
+      pred = [succ.(DataFlow::CallNode).getAnArgument(), bind.getAnArgument(), bind.getOptionArgument(_, _)] and
+      succ = bind.getACall()
+    )
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/ClosureLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClosureLibrary.qll
@@ -7,12 +7,12 @@ import javascript
 module ClosureLibrary {
   private import DataFlow
 
-  private class StringStep extends TaintTracking::AdditionalTaintStep, CallNode {
-    Node pred;
-
-    StringStep() {
-      exists(string name | this = Closure::moduleImport("goog.string." + name).getACall() |
-        pred = getAnArgument() and
+  private class StringStep extends TaintTracking::SharedTaintStep {
+    override predicate step(Node pred, Node succ) {
+      exists(string name, CallNode call |
+        call = Closure::moduleImport("goog.string." + name).getACall() and succ = call
+      |
+        pred = call.getAnArgument() and
         (
           name = "canonicalizeNewlines" or
           name = "capitalize" or
@@ -39,18 +39,13 @@ module ClosureLibrary {
           name = "whitespaceEscape"
         )
         or
-        pred = getArgument(0) and
+        pred = call.getArgument(0) and
         (
           name = "truncate" or
           name = "truncateMiddle" or
           name = "unescapeEntitiesWithDocument"
         )
       )
-    }
-
-    override predicate step(Node src, Node dst) {
-      src = pred and
-      dst = this
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/ComposedFunctions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ComposedFunctions.qll
@@ -112,7 +112,10 @@ module FunctionCompositionCall {
 
 private class ComposedFunctionTaintStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(int fnIndex, DataFlow::FunctionNode fn, FunctionCompositionCall composed, DataFlow::CallNode call |
+    exists(
+      int fnIndex, DataFlow::FunctionNode fn, FunctionCompositionCall composed,
+      DataFlow::CallNode call
+    |
       fn = composed.getOperandFunction(fnIndex) and
       call = composed.getACall()
     |

--- a/javascript/ql/src/semmle/javascript/frameworks/ComposedFunctions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ComposedFunctions.qll
@@ -110,20 +110,12 @@ module FunctionCompositionCall {
   }
 }
 
-/**
- * A taint step for a composed function.
- */
-private class ComposedFunctionTaintStep extends TaintTracking::AdditionalTaintStep {
-  FunctionCompositionCall composed;
-  DataFlow::CallNode call;
-
-  ComposedFunctionTaintStep() {
-    call = composed.getACall() and
-    this = call
-  }
-
+private class ComposedFunctionTaintStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(int fnIndex, DataFlow::FunctionNode fn | fn = composed.getOperandFunction(fnIndex) |
+    exists(int fnIndex, DataFlow::FunctionNode fn, FunctionCompositionCall composed, DataFlow::CallNode call |
+      fn = composed.getOperandFunction(fnIndex) and
+      call = composed.getACall()
+    |
       // flow into the first function
       fnIndex = composed.getNumOperand() - 1 and
       exists(int callArgIndex |
@@ -140,7 +132,7 @@ private class ComposedFunctionTaintStep extends TaintTracking::AdditionalTaintSt
       // flow out of the composed call
       fnIndex = 0 and
       pred = fn.getReturnNode() and
-      succ = this
+      succ = call
     )
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/DateFunctions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/DateFunctions.qll
@@ -29,24 +29,26 @@ private module DateFns {
    *
    * A format string can use single-quotes to include mostly arbitrary text.
    */
-  private class FormatStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-    FormatStep() { this = formatFunction().getACall() }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getArgument(1) and
-      succ = this
+  private class FormatStep extends TaintTracking::SharedTaintStep {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::CallNode call |
+        call = formatFunction().getACall() and
+        pred = call.getArgument(1) and
+        succ = call
+      )
     }
   }
 
   /**
    * Taint step of form: `f -> format(f)(date)`
    */
-  private class CurriedFormatStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-    CurriedFormatStep() { this = curriedFormatFunction().getACall() }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getArgument(0) and
-      succ = getACall()
+  private class CurriedFormatStep extends TaintTracking::SharedTaintStep {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::CallNode call |
+        call = curriedFormatFunction().getACall() and
+        pred = call.getArgument(0) and
+        succ = call.getACall()
+      )
     }
   }
 }
@@ -66,12 +68,13 @@ private module Moment {
    *
    * The format string can use backslash-escaping to include mostly arbitrary text.
    */
-  private class MomentFormatStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-    MomentFormatStep() { this = moment().getMember("format").getACall() }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getArgument(0) and
-      succ = this
+  private class MomentFormatStep extends TaintTracking::SharedTaintStep {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::CallNode call |
+        call = moment().getMember("format").getACall() and
+        pred = call.getArgument(0) and
+        succ = call
+      )
     }
   }
 }
@@ -82,12 +85,13 @@ private module DateFormat {
    *
    * The format string can use single-quotes to include mostly arbitrary text.
    */
-  private class DateFormatStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-    DateFormatStep() { this = DataFlow::moduleImport("dateformat").getACall() }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getArgument(1) and
-      succ = this
+  private class DateFormatStep extends TaintTracking::SharedTaintStep {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::CallNode call |
+        call = DataFlow::moduleImport("dateformat").getACall() and
+        pred = call.getArgument(1) and
+        succ = call
+      )
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Firebase.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Firebase.qll
@@ -275,7 +275,7 @@ module Firebase {
       result.hasUnderlyingType("firebase", "database.DataSnapshot")
     )
     or
-    promiseTaintStep(snapshot(t), result)
+    TaintTracking::promiseStep(snapshot(t), result)
     or
     exists(DataFlow::TypeTracker t2 | result = snapshot(t2).track(t2, t))
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/JWT.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/JWT.qll
@@ -11,12 +11,13 @@ private module JwtDecode {
   /**
    * A taint-step for `succ = require("jwt-decode")(pred)`.
    */
-  private class JwtDecodeStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-    JwtDecodeStep() { this = DataFlow::moduleImport("jwt-decode").getACall() }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = this.getArgument(0) and
-      succ = this
+  private class JwtDecodeStep extends TaintTracking::SharedTaintStep {
+    override predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::CallNode call |
+        call = DataFlow::moduleImport("jwt-decode").getACall() and
+        pred = call.getArgument(0) and
+        succ = call
+      )
     }
   }
 }
@@ -28,12 +29,13 @@ private module JsonWebToken {
   /**
    * A taint-step for `require("jsonwebtoken").verify(pred, "key", (err succ) => {...})`.
    */
-  private class VerifyStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-    VerifyStep() { this = DataFlow::moduleMember("jsonwebtoken", "verify").getACall() }
-
+  private class VerifyStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = this.getArgument(0) and
-      succ = this.getABoundCallbackParameter(2, 1)
+      exists(DataFlow::CallNode call |
+        call = DataFlow::moduleMember("jsonwebtoken", "verify").getACall() and
+        pred = call.getArgument(0) and
+        succ = call.getABoundCallbackParameter(2, 1)
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -440,11 +440,9 @@ module LodashUnderscore {
   /**
    * A model for taint-steps involving (non-function) underscore methods.
    */
-  private class UnderscoreTaintStep extends TaintTracking::AdditionalTaintStep {
-    UnderscoreTaintStep() { underscoreTaintStep(this, _) }
-
+  private class UnderscoreTaintStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      underscoreTaintStep(pred, succ) and pred = this
+      underscoreTaintStep(pred, succ)
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
@@ -7,45 +7,45 @@ import javascript
 /**
  * A taint step for the `marked` library, that converts markdown to HTML.
  */
-private class MarkedStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-  MarkedStep() {
-    this = DataFlow::globalVarRef("marked").getACall()
-    or
-    this = DataFlow::moduleImport("marked").getACall()
-  }
-
+private class MarkedStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    succ = this and
-    pred = this.getArgument(0)
+    exists(DataFlow::CallNode call |
+      call = DataFlow::globalVarRef("marked").getACall()
+      or
+      call = DataFlow::moduleImport("marked").getACall()
+    |
+      succ = call and
+      pred = call.getArgument(0)
+    )
   }
 }
 
 /**
  * A taint step for the `markdown-table` library.
  */
-private class MarkdownTableStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-  MarkdownTableStep() { this = DataFlow::moduleImport("markdown-table").getACall() }
-
+private class MarkdownTableStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    succ = this and
-    pred = this.getArgument(0)
+    exists(DataFlow::CallNode call | call = DataFlow::moduleImport("markdown-table").getACall() |
+      succ = call and
+      pred = call.getArgument(0)
+    )
   }
 }
 
 /**
  * A taint step for the `showdown` library.
  */
-private class ShowDownStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-  ShowDownStep() {
-    this =
-      [DataFlow::globalVarRef("showdown"), DataFlow::moduleImport("showdown")]
-          .getAConstructorInvocation("Converter")
-          .getAMemberCall(["makeHtml", "makeMd"])
-  }
-
+private class ShowDownStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    succ = this and
-    pred = this.getArgument(0)
+    exists(DataFlow::CallNode call |
+      call =
+        [DataFlow::globalVarRef("showdown"), DataFlow::moduleImport("showdown")]
+            .getAConstructorInvocation("Converter")
+            .getAMemberCall(["makeHtml", "makeMd"])
+    |
+      succ = call and
+      pred = call.getArgument(0)
+    )
   }
 }
 
@@ -93,16 +93,16 @@ private module Unified {
   /**
    * A taint step for the `unified` library.
    */
-  class UnifiedStep extends TaintTracking::AdditionalTaintStep, UnifiedChain {
-    UnifiedStep() {
-      // sanitizer. Mostly looking for `rehype-sanitize`, but also other plugins with `sanitize` in their name.
-      not this.getAUsedPlugin().getALocalSource() =
-        DataFlow::moduleImport(any(string s | s.matches("%sanitize%")))
-    }
-
+  class UnifiedStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getInput() and
-      succ = getOutput()
+      exists(UnifiedChain chain |
+        // sanitizer. Mostly looking for `rehype-sanitize`, but also other plugins with `sanitize` in their name.
+        not chain.getAUsedPlugin().getALocalSource() =
+          DataFlow::moduleImport(any(string s | s.matches("%sanitize%")))
+      |
+        pred = chain.getInput() and
+        succ = chain.getOutput()
+      )
     }
   }
 }
@@ -110,11 +110,11 @@ private module Unified {
 /**
  * A taint step for the `snarkdown` library.
  */
-private class SnarkdownStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-  SnarkdownStep() { this = DataFlow::moduleImport("snarkdown").getACall() }
-
+private class SnarkdownStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    this = succ and
-    pred = this.getArgument(0)
+    exists(DataFlow::CallNode call | call = DataFlow::moduleImport("snarkdown").getACall() |
+      call = succ and
+      pred = call.getArgument(0)
+    )
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -291,33 +291,30 @@ module NodeJSLib {
   /**
    * A call to a path-module method that preserves taint.
    */
-  private class PathFlowTarget extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-    DataFlow::Node tainted;
-
-    PathFlowTarget() {
-      exists(string methodName | this = NodeJSLib::Path::moduleMember(methodName).getACall() |
+  private class PathFlowStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::CallNode call, string methodName |
+        call = NodeJSLib::Path::moduleMember(methodName).getACall() and
+        succ = call
+      |
         // getters
-        methodName = "basename" and tainted = getArgument(0)
+        methodName = "basename" and pred = call.getArgument(0)
         or
-        methodName = "dirname" and tainted = getArgument(0)
+        methodName = "dirname" and pred = call.getArgument(0)
         or
-        methodName = "extname" and tainted = getArgument(0)
+        methodName = "extname" and pred = call.getArgument(0)
         or
         // transformers
-        methodName = "join" and tainted = getAnArgument()
+        methodName = "join" and pred = call.getAnArgument()
         or
-        methodName = "normalize" and tainted = getArgument(0)
+        methodName = "normalize" and pred = call.getArgument(0)
         or
-        methodName = "relative" and tainted = getArgument([0 .. 1])
+        methodName = "relative" and pred = call.getArgument([0 .. 1])
         or
-        methodName = "resolve" and tainted = getAnArgument()
+        methodName = "resolve" and pred = call.getAnArgument()
         or
-        methodName = "toNamespacedPath" and tainted = getArgument(0)
+        methodName = "toNamespacedPath" and pred = call.getArgument(0)
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = tainted and succ = this
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -321,25 +321,19 @@ module NodeJSLib {
   /**
    * A call to a fs-module method that preserves taint.
    */
-  private class FsFlowTarget extends TaintTracking::AdditionalTaintStep {
-    DataFlow::Node tainted;
-
-    FsFlowTarget() {
+  private class FsFlowStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::CallNode call, string methodName |
         call = FS::moduleMember(methodName).getACall()
       |
         methodName = "realpathSync" and
-        tainted = call.getArgument(0) and
-        this = call
+        pred = call.getArgument(0) and
+        succ = call
         or
         methodName = "realpath" and
-        tainted = call.getArgument(0) and
-        this = call.getCallback(1).getParameter(1)
+        pred = call.getArgument(0) and
+        succ = call.getCallback(1).getParameter(1)
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = tainted and succ = this
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -340,16 +340,16 @@ module NodeJSLib {
   /**
    * A model of taint propagation through `new Buffer` and `Buffer.from`.
    */
-  private class BufferTaintStep extends TaintTracking::AdditionalTaintStep, DataFlow::InvokeNode {
-    BufferTaintStep() {
-      this = DataFlow::globalVarRef("Buffer").getAnInstantiation()
-      or
-      this = DataFlow::globalVarRef("Buffer").getAMemberInvocation("from")
-    }
-
+  private class BufferTaintStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getArgument(0) and
-      succ = this
+      exists(DataFlow::InvokeNode invoke |
+        invoke = DataFlow::globalVarRef("Buffer").getAnInstantiation()
+        or
+        invoke = DataFlow::globalVarRef("Buffer").getAMemberInvocation("from")
+      |
+        pred = invoke.getArgument(0) and
+        succ = invoke
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/PropertyProjection.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/PropertyProjection.qll
@@ -134,14 +134,12 @@ private class SimplePropertyProjection extends PropertyProjection::Range {
 /**
  * A taint step for a property projection.
  */
-private class PropertyProjectionTaintStep extends TaintTracking::AdditionalTaintStep {
-  PropertyProjection projection;
-
-  PropertyProjectionTaintStep() { projection = this }
-
+private class PropertyProjectionTaintStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     // reading from a tainted object yields a tainted result
-    this = succ and
-    pred = projection.getObject()
+    exists(PropertyProjection projection |
+      pred = projection.getObject() and
+      succ = projection
+    )
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/React.qll
@@ -795,3 +795,46 @@ private class HigherOrderComponentStep extends PreCallGraphStep {
     )
   }
 }
+
+/**
+ * A taint propagating data flow edge for assignments of the form `c1.state.p = v`,
+ * where `c1` is an instance of React component `C`; in this case, we consider
+ * taint to flow from `v` to any read of `c2.state.p`, where `c2`
+ * also is an instance of `C`.
+ */
+private class StateTaintStep extends TaintTracking::SharedTaintStep {
+  override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(ReactComponent c, DataFlow::PropRead prn, DataFlow::PropWrite pwn |
+      (
+        c.getACandidateStateSource().flowsTo(pwn.getBase()) or
+        c.getADirectStateAccess().flowsTo(pwn.getBase())
+      ) and
+      (
+        c.getAPreviousStateSource().flowsTo(prn.getBase()) or
+        c.getADirectStateAccess().flowsTo(prn.getBase())
+      )
+    |
+      prn.getPropertyName() = pwn.getPropertyName() and
+      succ = prn and
+      pred = pwn.getRhs()
+    )
+  }
+}
+
+/**
+ * A taint propagating data flow edge for assignments of the form `c1.props.p = v`,
+ * where `c1` is an instance of React component `C`; in this case, we consider
+ * taint to flow from `v` to any read of `c2.props.p`, where `c2`
+ * also is an instance of `C`.
+ */
+private class PropsTaintStep extends TaintTracking::SharedTaintStep {
+  override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(ReactComponent c, string name, DataFlow::PropRead prn |
+      prn = c.getAPropRead(name) or
+      prn = c.getAPreviousPropsSource().getAPropertyRead(name)
+    |
+      pred = c.getACandidatePropsValue(name) and
+      succ = prn
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/React.qll
@@ -50,6 +50,12 @@ abstract class ReactComponent extends ASTNode {
   abstract DataFlow::SourceNode getAComponentCreatorReference();
 
   /**
+   * Gets a reference to an instance of this component.
+   */
+  pragma[noinline]
+  DataFlow::SourceNode getAnInstanceReference() { result = ref() }
+
+  /**
    * Gets a reference to this component.
    */
   DataFlow::Node ref() { result.analyze().getAValue() = getAbstractComponent() }
@@ -70,20 +76,19 @@ abstract class ReactComponent extends ASTNode {
    * Gets an access to the `state` object of this component.
    */
   DataFlow::SourceNode getADirectStateAccess() {
-    result.(DataFlow::PropRef).accesses(ref(), "state")
+    result = getAnInstanceReference().getAPropertyReference("state")
   }
 
   /**
    * Gets a data flow node that reads a prop of this component.
    */
-  DataFlow::PropRead getAPropRead() { getADirectPropsAccess().flowsTo(result.getBase()) }
+  DataFlow::PropRead getAPropRead() { result = getADirectPropsAccess().getAPropertyRead() }
 
   /**
    * Gets a data flow node that reads prop `name` of this component.
    */
   DataFlow::PropRead getAPropRead(string name) {
-    result = getAPropRead() and
-    result.getPropertyName() = name
+    result = getADirectPropsAccess().getAPropertyRead(name)
   }
 
   /**
@@ -93,7 +98,7 @@ abstract class ReactComponent extends ASTNode {
   DataFlow::SourceNode getAStateAccess() {
     result = getADirectStateAccess()
     or
-    exists(DataFlow::PropRef prn | result = prn | getAStateAccess().flowsTo(prn.getBase()))
+    result = getAStateAccess().getAPropertyReference()
   }
 
   /**
@@ -116,18 +121,17 @@ abstract class ReactComponent extends ASTNode {
   /**
    * Gets a call to method `name` on this component.
    */
-  DataFlow::MethodCallNode getAMethodCall(string name) { result.calls(ref(), name) }
+  DataFlow::MethodCallNode getAMethodCall(string name) {
+    result = getAnInstanceReference().getAMethodCall(name)
+  }
 
   /**
    * Gets a value that will become (part of) the state
    * object of this component, for example an assignment to `this.state`.
    */
   DataFlow::SourceNode getACandidateStateSource() {
-    exists(DataFlow::PropWrite pwn, DataFlow::Node rhs |
-      // a direct definition: `this.state = o`
-      result.flowsTo(rhs) and
-      pwn.writes(ref(), "state", rhs)
-    )
+    // a direct definition: `this.state = o`
+    result = getAnInstanceReference().getAPropertySource("state")
     or
     exists(DataFlow::MethodCallNode mce, DataFlow::SourceNode arg0 |
       mce = getAMethodCall("setState") or
@@ -314,7 +318,8 @@ abstract private class SharedReactPreactClassComponent extends ReactComponent, C
   }
 
   override DataFlow::SourceNode getADirectPropsAccess() {
-    result.(DataFlow::PropRef).accesses(ref(), "props") or
+    result = getAnInstanceReference().getAPropertyRead("props")
+    or
     result = DataFlow::parameterNode(getConstructor().getBody().getParameter(0))
   }
 
@@ -437,7 +442,7 @@ class ES5Component extends ReactComponent, ObjectExpr {
   override Function getStaticMethod(string name) { none() }
 
   override DataFlow::SourceNode getADirectPropsAccess() {
-    result.(DataFlow::PropRef).accesses(ref(), "props")
+    result = getAnInstanceReference().getAPropertyRead("props")
   }
 
   override AbstractValue getAbstractComponent() { result = TAbstractObjectLiteral(this) }

--- a/javascript/ql/src/semmle/javascript/frameworks/RxJS.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/RxJS.qll
@@ -7,12 +7,12 @@ private import javascript
 /**
  * A step `x -> y` in `x.subscribe(y => ...)`, modeling flow out of an rxjs Observable.
  */
-private class RxJsSubscribeStep extends TaintTracking::AdditionalTaintStep, DataFlow::MethodCallNode {
-  RxJsSubscribeStep() { getMethodName() = "subscribe" }
-
-  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = getReceiver() and
-    succ = getCallback(0).getParameter(0)
+private class RxJsSubscribeStep extends TaintTracking::SharedTaintStep {
+  override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(DataFlow::MethodCallNode call | call.getMethodName() = "subscribe" |
+      pred = call.getReceiver() and
+      succ = call.getCallback(0).getParameter(0)
+    )
   }
 }
 
@@ -54,24 +54,24 @@ private predicate isIdentityPipe(DataFlow::CallNode pipe) {
 /**
  * A step in or out of the map callback in a call of form `x.pipe(map(y => ...))`.
  */
-private class RxJsPipeMapStep extends TaintTracking::AdditionalTaintStep, DataFlow::MethodCallNode {
-  RxJsPipeMapStep() { getMethodName() = "pipe" }
-
-  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = getReceiver() and
-    succ = pipeInput(getArgument(0).getALocalSource())
-    or
-    exists(int i |
-      pred = pipeOutput(getArgument(i).getALocalSource()) and
-      succ = pipeInput(getArgument(i + 1).getALocalSource())
+private class RxJsPipeMapStep extends TaintTracking::SharedTaintStep {
+  override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(DataFlow::MethodCallNode call | call.getMethodName() = "pipe" |
+      pred = call.getReceiver() and
+      succ = pipeInput(call.getArgument(0).getALocalSource())
+      or
+      exists(int i |
+        pred = pipeOutput(call.getArgument(i).getALocalSource()) and
+        succ = pipeInput(call.getArgument(i + 1).getALocalSource())
+      )
+      or
+      pred = pipeOutput(call.getLastArgument().getALocalSource()) and
+      succ = call
+      or
+      // Handle a common case where the last step is `catchError`.
+      isIdentityPipe(call.getLastArgument().getALocalSource()) and
+      pred = pipeOutput(call.getArgument(call.getNumArgument() - 2)) and
+      succ = call
     )
-    or
-    pred = pipeOutput(getLastArgument().getALocalSource()) and
-    succ = this
-    or
-    // Handle a common case where the last step is `catchError`.
-    isIdentityPipe(getLastArgument().getALocalSource()) and
-    pred = pipeOutput(getArgument(getNumArgument() - 2)) and
-    succ = this
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Typeahead.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Typeahead.qll
@@ -126,11 +126,13 @@ module Typeahead {
   /**
    * A taint step that models that a function in the `source` of typeahead.js is used to determine the input to the suggestion function.
    */
-  private class TypeaheadSourceTaintStep extends TypeaheadSource, TaintTracking::AdditionalTaintStep {
+  private class TypeaheadSourceTaintStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       // Matches `$(...).typeahead({..}, {source: function(q, cb) {..;cb(<pred>);..}, templates: { suggestion: function(<succ>) {} } })`.
-      pred = this.getAFunctionValue().getParameter([1 .. 2]).getACall().getAnArgument() and
-      succ = this.getASuggestion()
+      exists(TypeaheadSource typeahead |
+        pred = typeahead.getAFunctionValue().getParameter([1 .. 2]).getACall().getAnArgument() and
+        succ = typeahead.getASuggestion()
+      )
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
@@ -9,7 +9,8 @@ import javascript
  *
  * A taint propagating data flow edge arising from an operation in a URI library.
  */
-deprecated abstract class UriLibraryStep extends DataFlow::ValueNode, TaintTracking::AdditionalTaintStep { }
+abstract deprecated class UriLibraryStep extends DataFlow::ValueNode,
+  TaintTracking::AdditionalTaintStep { }
 
 /**
  * Provides classes for working with [urijs](http://medialize.github.io/URI.js/) code.
@@ -298,7 +299,9 @@ private module ClosureLibraryUri {
    */
   private class ArgumentStep extends TaintTracking::SharedTaintStep {
     override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(DataFlow::InvokeNode invoke, int arg | pred = invoke.getArgument(arg) and succ = invoke |
+      exists(DataFlow::InvokeNode invoke, int arg |
+        pred = invoke.getArgument(arg) and succ = invoke
+      |
         // goog.Uri constructor
         invoke = Closure::moduleImport("goog.Uri").getAnInstantiation() and arg = 0
         or

--- a/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
@@ -10,6 +10,7 @@ import javascript
  * A taint propagating data flow edge arising from an operation in a URI library.
  */
 abstract deprecated class UriLibraryStep extends DataFlow::ValueNode {
+  /** Holds if `pred -> succ` is a step through a URI library function. */
   predicate step(DataFlow::Node pred, DataFlow::Node succ) { none() }
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
@@ -9,8 +9,9 @@ import javascript
  *
  * A taint propagating data flow edge arising from an operation in a URI library.
  */
-abstract deprecated class UriLibraryStep extends DataFlow::ValueNode,
-  TaintTracking::AdditionalTaintStep { }
+abstract deprecated class UriLibraryStep extends DataFlow::ValueNode {
+  predicate step(DataFlow::Node pred, DataFlow::Node succ) { none() }
+}
 
 /**
  * Provides classes for working with [urijs](http://medialize.github.io/URI.js/) code.

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -525,22 +525,17 @@ module Vue {
    * of `inst = new Vue({ ..., data: { prop: source } })`, if the
    * `div` element is part of the template for `inst`.
    */
-  class VHtmlSourceWrite extends TaintTracking::AdditionalTaintStep {
-    VHtmlAttribute attr;
-
-    VHtmlSourceWrite() {
-      exists(Vue::Instance instance, string expr |
+  class VHtmlSourceWrite extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(Vue::Instance instance, string expr, VHtmlAttribute attr |
         attr.getAttr().getRoot() =
           instance.getTemplateElement().(Vue::Template::HtmlElement).getElement() and
         expr = attr.getAttr().getValue() and
         // only support for simple identifier expressions
         expr.regexpMatch("(?i)[a-z0-9_]+") and
-        this = instance.getAPropertyValue(expr)
+        pred = instance.getAPropertyValue(expr) and
+        succ = attr
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = this and succ = attr
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -307,7 +307,12 @@ module Vue {
     private DataFlow::PropWrite getAPropertyValueWrite(string name) {
       result = getData().getALocalSource().getAPropertyWrite(name)
       or
-      result = getABoundFunction().getALocalSource().(DataFlow::FunctionNode).getReceiver().getAPropertyWrite(name)
+      result =
+        getABoundFunction()
+            .getALocalSource()
+            .(DataFlow::FunctionNode)
+            .getReceiver()
+            .getAPropertyWrite(name)
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -501,6 +501,49 @@ module Vue {
     }
   }
 
+  /**
+   * A Vue `v-html` attribute.
+   */
+  class VHtmlAttribute extends DataFlow::Node {
+    HTML::Attribute attr;
+
+    VHtmlAttribute() {
+      this.(DataFlow::HtmlAttributeNode).getAttribute() = attr and attr.getName() = "v-html"
+    }
+
+    /**
+     * Gets the HTML attribute of this sink.
+     */
+    HTML::Attribute getAttr() { result = attr }
+  }
+
+  /**
+   * A taint propagating data flow edge through a string interpolation of a
+   * Vue instance property to a `v-html` attribute.
+   *
+   * As an example, `<div v-html="prop"/>` reads the `prop` property
+   * of `inst = new Vue({ ..., data: { prop: source } })`, if the
+   * `div` element is part of the template for `inst`.
+   */
+  class VHtmlSourceWrite extends TaintTracking::AdditionalTaintStep {
+    VHtmlAttribute attr;
+
+    VHtmlSourceWrite() {
+      exists(Vue::Instance instance, string expr |
+        attr.getAttr().getRoot() =
+          instance.getTemplateElement().(Vue::Template::HtmlElement).getElement() and
+        expr = attr.getAttr().getValue() and
+        // only support for simple identifier expressions
+        expr.regexpMatch("(?i)[a-z0-9_]+") and
+        this = instance.getAPropertyValue(expr)
+      )
+    }
+
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      pred = this and succ = attr
+    }
+  }
+
   /*
    * Provides classes for working with Vue templates.
    */

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -490,19 +490,15 @@ module Vue {
   /**
    * A taint propagating data flow edge through a Vue instance property.
    */
-  class InstanceHeapStep extends TaintTracking::AdditionalTaintStep {
-    DataFlow::Node src;
-
-    InstanceHeapStep() {
+  class InstanceHeapStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(Instance i, string name, DataFlow::FunctionNode bound |
         bound.flowsTo(i.getABoundFunction()) and
         not bound.getFunction() instanceof ArrowFunctionExpr and
-        bound.getReceiver().getAPropertyRead(name) = this and
-        src = i.getAPropertyValue(name)
+        succ = bound.getReceiver().getAPropertyRead(name) and
+        pred = i.getAPropertyValue(name)
       )
     }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) { pred = src and succ = this }
   }
 
   /*

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -303,20 +303,19 @@ module Vue {
       result = getOptionSource(_).getAPropertySource()
     }
 
+    pragma[noinline]
+    private DataFlow::PropWrite getAPropertyValueWrite(string name) {
+      result = getData().getALocalSource().getAPropertyWrite(name)
+      or
+      result = getABoundFunction().getALocalSource().(DataFlow::FunctionNode).getReceiver().getAPropertyWrite(name)
+    }
+
     /**
      * Gets the data flow node that flows into the property `name` of this instance, or is
      * returned form a getter defining that property.
      */
     DataFlow::Node getAPropertyValue(string name) {
-      exists(DataFlow::SourceNode obj | obj.getAPropertyWrite(name).getRhs() = result |
-        obj.flowsTo(getData())
-        or
-        exists(DataFlow::FunctionNode bound |
-          bound.flowsTo(getABoundFunction()) and
-          not bound.getFunction() instanceof ArrowFunctionExpr and
-          obj = bound.getReceiver()
-        )
-      )
+      result = getAPropertyValueWrite(name).getRhs()
       or
       exists(DataFlow::FunctionNode getter |
         getter.flowsTo(getAccessor(name, DataFlow::MemberKind::getter())) and

--- a/javascript/ql/src/semmle/javascript/frameworks/XmlParsers.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/XmlParsers.qll
@@ -276,14 +276,12 @@ module XML {
     }
   }
 
-  private class XMLParserTaintStep extends js::TaintTracking::AdditionalTaintStep {
-    XML::ParserInvocation parser;
-
-    XMLParserTaintStep() { this.asExpr() = parser }
-
-    override predicate step(js::DataFlow::Node pred, js::DataFlow::Node succ) {
-      pred.asExpr() = parser.getSourceArgument() and
-      succ = parser.getAResult()
+  private class XMLParserTaintStep extends js::TaintTracking::SharedTaintStep {
+    override predicate deserializeStep(js::DataFlow::Node pred, js::DataFlow::Node succ) {
+      exists(XML::ParserInvocation parser |
+        pred.asExpr() = parser.getSourceArgument() and
+        succ = parser.getAResult()
+      )
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
@@ -12,9 +12,7 @@ import javascript
  * The target of a heuristic additional flow step in a security query.
  */
 deprecated class HeuristicAdditionalTaintStep extends DataFlow::Node {
-  HeuristicAdditionalTaintStep() {
-    any(TaintTracking::SharedTaintStep step).heuristicStep(_, this)
-  }
+  HeuristicAdditionalTaintStep() { any(TaintTracking::SharedTaintStep step).heuristicStep(_, this) }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
@@ -1,5 +1,5 @@
 /**
- * Provides classes that heuristically increase the extent of `TaintTracking::AdditionalTaintStep`.
+ * Provides classes that heuristically increase the extent of `TaintTracking::SharedTaintStep`.
  *
  * Note: This module should not be a permanent part of the standard library imports.
  */

--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
@@ -7,16 +7,24 @@
 import javascript
 
 /**
- * A heuristic additional flow step in a security query.
+ * DEPRECATED.
+ *
+ * The target of a heuristic additional flow step in a security query.
  */
-abstract class HeuristicAdditionalTaintStep extends DataFlow::ValueNode { }
+deprecated class HeuristicAdditionalTaintStep extends DataFlow::Node {
+  HeuristicAdditionalTaintStep() {
+    any(TaintTracking::SharedTaintStep step).heuristicStep(_, this)
+  }
+}
 
 /**
  * A call to `tainted.replace(x, y)` that preserves taint.
  */
-private class HeuristicStringManipulationTaintStep extends HeuristicAdditionalTaintStep,
-  TaintTracking::AdditionalTaintStep, StringReplaceCall {
-  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = getReceiver() and succ = this
+private class HeuristicStringManipulationTaintStep extends TaintTracking::SharedTaintStep {
+  override predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(StringReplaceCall call |
+      pred = call.getReceiver() and
+      succ = call
+    )
   }
 }

--- a/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
+++ b/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
@@ -243,7 +243,7 @@ module Stages {
     predicate backref() {
       1 = 1
       or
-      any(TaintTracking::AdditionalTaintStep step).step(_, _)
+      TaintTracking::heapStep(_, _)
       or
       exists(RemoteFlowSource r)
     }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
@@ -71,11 +71,9 @@ module DomBasedXss {
       DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel predlbl,
       DataFlow::FlowLabel succlbl
     ) {
-      exists(TaintTracking::AdditionalTaintStep step |
-        step.step(pred, succ) and
-        predlbl.isData() and
-        succlbl.isTaint()
-      )
+      TaintTracking::sharedTaintStep(pred, succ) and
+      predlbl.isData() and
+      succlbl.isTaint()
     }
 
     override predicate isSanitizer(DataFlow::Node node) {

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
@@ -14,6 +14,11 @@ module DomBasedXss {
   deprecated class Configuration = HtmlInjectionConfiguration;
 
   /**
+   * DEPRECATED. Use `Vue::VHtmlSourceWrite` instead.
+   */
+  deprecated class VHtmlSourceWrite = Vue::VHtmlSourceWrite;
+
+  /**
    * A taint-tracking configuration for reasoning about XSS.
    */
   class HtmlInjectionConfiguration extends TaintTracking::Configuration {

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
@@ -255,7 +255,7 @@ module ExternalAPIUsedWithUntrustedData {
       not exists(DataFlow::Node arg |
         arg = this.getAnArgument() and not arg instanceof DeepObjectSink
       |
-        any(TaintTracking::AdditionalTaintStep s).step(arg, _)
+        TaintTracking::sharedTaintStep(arg, _)
         or
         exists(DataFlow::AdditionalFlowStep s |
           s.step(arg, _) or

--- a/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandArgument.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandArgument.qll
@@ -52,7 +52,7 @@ private DataFlow::SourceNode argumentList(SystemCommandExecution sys, DataFlow::
     result = pred.backtrack(t2, t)
     or
     t = t2.continue() and
-    TaintTracking::arrayFunctionTaintStep(any(DataFlow::Node n | result.flowsTo(n)), pred, _)
+    TaintTracking::arrayStep(any(DataFlow::Node n | result.flowsTo(n)), pred)
   )
 }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/PrototypePollutingAssignment.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/PrototypePollutingAssignment.qll
@@ -100,7 +100,7 @@ module PrototypePollutingAssignment {
     // users wouldn't bother to call Object.create in that case.
     result = DataFlow::globalVarRef("Object").getAMemberCall("create")
     or
-    // Allow use of AdditionalFlowSteps and AdditionalTaintSteps to track a bit further
+    // Allow use of AdditionalFlowSteps to track a bit further
     exists(DataFlow::Node mid |
       prototypeLessObject(t.continue()).flowsTo(mid) and
       any(DataFlow::AdditionalFlowStep s).step(mid, result)

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -659,7 +659,7 @@ module TaintedPath {
       )
     )
     or
-    promiseTaintStep(src, dst) and srclabel = dstlabel
+    TaintTracking::promiseStep(src, dst) and srclabel = dstlabel
     or
     TaintTracking::persistentStorageStep(src, dst) and srclabel = dstlabel
     or

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -661,7 +661,7 @@ module TaintedPath {
     or
     promiseTaintStep(src, dst) and srclabel = dstlabel
     or
-    any(TaintTracking::PersistentStorageTaintStep st).step(src, dst) and srclabel = dstlabel
+    TaintTracking::persistentStorageStep(src, dst) and srclabel = dstlabel
     or
     exists(DataFlow::PropRead read | read = dst |
       src = read.getBase() and

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -649,7 +649,7 @@ module TaintedPath {
     srclabel instanceof Label::PosixPath and
     dstlabel instanceof Label::PosixPath and
     (
-      any(UriLibraryStep step).step(src, dst)
+      TaintTracking::uriStep(src, dst)
       or
       exists(DataFlow::CallNode decode |
         decode.getCalleeName() = "decodeURIComponent" or decode.getCalleeName() = "decodeURI"

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -338,7 +338,7 @@ module DomBasedXss {
   /**
    * A Vue `v-html` attribute, viewed as an XSS sink.
    */
-  class VHtmlSink extends Vue::VHtmlAttribute, DomBasedXss::Sink {}
+  class VHtmlSink extends Vue::VHtmlAttribute, DomBasedXss::Sink { }
 
   /**
    * A property read from a safe property is considered a sanitizer.

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -338,45 +338,7 @@ module DomBasedXss {
   /**
    * A Vue `v-html` attribute, viewed as an XSS sink.
    */
-  class VHtmlSink extends DomBasedXss::Sink {
-    HTML::Attribute attr;
-
-    VHtmlSink() {
-      this.(DataFlow::HtmlAttributeNode).getAttribute() = attr and attr.getName() = "v-html"
-    }
-
-    /**
-     * Gets the HTML attribute of this sink.
-     */
-    HTML::Attribute getAttr() { result = attr }
-  }
-
-  /**
-   * A taint propagating data flow edge through a string interpolation of a
-   * Vue instance property to a `v-html` attribute.
-   *
-   * As an example, `<div v-html="prop"/>` reads the `prop` property
-   * of `inst = new Vue({ ..., data: { prop: source } })`, if the
-   * `div` element is part of the template for `inst`.
-   */
-  class VHtmlSourceWrite extends TaintTracking::AdditionalTaintStep {
-    VHtmlSink attr;
-
-    VHtmlSourceWrite() {
-      exists(Vue::Instance instance, string expr |
-        attr.getAttr().getRoot() =
-          instance.getTemplateElement().(Vue::Template::HtmlElement).getElement() and
-        expr = attr.getAttr().getValue() and
-        // only support for simple identifier expressions
-        expr.regexpMatch("(?i)[a-z0-9_]+") and
-        this = instance.getAPropertyValue(expr)
-      )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = this and succ = attr
-    }
-  }
+  class VHtmlSink extends Vue::VHtmlAttribute, DomBasedXss::Sink {}
 
   /**
    * A property read from a safe property is considered a sanitizer.

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.expected
@@ -1,0 +1,67 @@
+| closureUri.js:5:19:5:19 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:6:11:6:11 | x | closureUri.js:6:1:6:12 | Uri.parse(x) |
+| closureUri.js:7:13:7:13 | x | closureUri.js:7:1:7:17 | Uri.resolve(x, y) |
+| closureUri.js:7:16:7:16 | y | closureUri.js:7:1:7:17 | Uri.resolve(x, y) |
+| closureUri.js:8:12:8:17 | scheme | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
+| closureUri.js:8:26:8:31 | domain | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
+| closureUri.js:8:40:8:43 | path | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
+| closureUri.js:10:1:10:3 | uri | closureUri.js:10:1:10:16 | uri.setScheme(x) |
+| closureUri.js:10:15:10:15 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:11:1:11:3 | uri | closureUri.js:11:1:11:18 | uri.setUserInfo(x) |
+| closureUri.js:12:1:12:3 | uri | closureUri.js:12:1:12:16 | uri.setDomain(x) |
+| closureUri.js:12:15:12:15 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:13:1:13:3 | uri | closureUri.js:13:1:13:14 | uri.setPort(x) |
+| closureUri.js:14:1:14:3 | uri | closureUri.js:14:1:14:14 | uri.setPath(x) |
+| closureUri.js:14:13:14:13 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:15:1:15:3 | uri | closureUri.js:15:1:15:15 | uri.setQuery(x) |
+| closureUri.js:16:1:16:3 | uri | closureUri.js:16:1:16:18 | uri.setFragment(x) |
+| closureUri.js:18:1:18:3 | uri | closureUri.js:18:1:18:15 | uri.setQuery(x) |
+| closureUri.js:18:1:18:15 | uri.setQuery(x) | closureUri.js:18:1:18:26 | uri.set ... Path(y) |
+| closureUri.js:18:1:18:26 | uri.set ... Path(y) | closureUri.js:18:1:18:39 | uri.set ... heme(z) |
+| closureUri.js:18:25:18:25 | y | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:18:38:18:38 | z | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:22:19:22:21 | uri | closureUri.js:22:1:22:25 | utils.a ... uri, z) |
+| closureUri.js:23:15:23:17 | uri | closureUri.js:23:1:23:18 | utils.getPath(uri) |
+| closureUri.js:27:22:27:22 | x | closureUri.js:27:1:27:23 | stringU ... code(x) |
+| closureUri.js:28:22:28:22 | x | closureUri.js:28:1:28:23 | stringU ... code(x) |
+| path-parse.js:4:12:4:12 | x | path-parse.js:4:1:4:13 | path.parse(x) |
+| path-parse.js:5:12:5:12 | x | path-parse.js:5:1:5:13 | path_parse(x) |
+| path-parse.js:6:18:6:18 | x | path-parse.js:6:1:6:19 | path.posix.parse(x) |
+| path-parse.js:7:18:7:18 | x | path-parse.js:7:1:7:19 | path_parse.posix(x) |
+| path-parse.js:8:18:8:18 | x | path-parse.js:8:1:8:19 | path.win32.parse(x) |
+| path-parse.js:9:18:9:18 | x | path-parse.js:9:1:9:19 | path_parse.win32(x) |
+| punycode.js:3:25:3:25 | x | punycode.js:3:9:3:26 | punycode.decode(x) |
+| punycode.js:5:21:5:21 | x | punycode.js:5:5:5:22 | punycode.encode(x) |
+| punycode.js:7:24:7:24 | x | punycode.js:7:5:7:25 | punycod ... code(x) |
+| punycode.js:9:22:9:22 | x | punycode.js:9:5:9:23 | punycode.toASCII(x) |
+| query-string.js:3:27:3:27 | x | query-string.js:3:9:3:28 | queryString.parse(x) |
+| query-string.js:5:25:5:25 | x | query-string.js:5:5:5:26 | querySt ... ract(x) |
+| query-string.js:7:26:7:26 | x | query-string.js:7:5:7:27 | querySt ... eUrl(x) |
+| query-string.js:9:27:9:27 | x | query-string.js:9:5:9:28 | querySt ... gify(x) |
+| query-string_import.js:3:7:3:7 | x | query-string_import.js:3:1:3:8 | parse(x) |
+| querystring.js:3:28:3:28 | x | querystring.js:3:9:3:29 | queryst ... cape(x) |
+| querystring.js:5:23:5:23 | x | querystring.js:5:5:5:24 | querystring.parse(x) |
+| querystring.js:7:27:7:27 | x | querystring.js:7:5:7:28 | queryst ... gify(x) |
+| querystring.js:9:26:9:26 | x | querystring.js:9:5:9:27 | queryst ... cape(x) |
+| querystringify.js:3:30:3:30 | x | querystringify.js:3:9:3:31 | queryst ... arse(x) |
+| querystringify.js:5:30:5:30 | x | querystringify.js:5:5:5:31 | queryst ... gify(x) |
+| uri-js.js:3:19:3:19 | x | uri-js.js:3:9:3:20 | URI.parse(x) |
+| uri-js.js:5:19:5:19 | x | uri-js.js:5:5:5:20 | URI.serialize(x) |
+| uri-js.js:7:17:7:17 | x | uri-js.js:7:5:7:18 | URI.resolve(x) |
+| uri-js.js:9:19:9:19 | x | uri-js.js:9:5:9:20 | URI.normalize(x) |
+| urijs.js:12:17:12:17 | x | urijs.js:12:9:12:18 | new URI(x) |
+| urijs.js:14:5:14:5 | u | urijs.js:14:5:14:17 | u.username(x) |
+| urijs.js:14:16:14:16 | x | urijs.js:14:5:14:17 | u.username(x) |
+| urijs.js:16:5:16:5 | u | urijs.js:16:5:17:16 | u\\n    .username(x) |
+| urijs.js:16:5:17:16 | u\\n    .username(x) | urijs.js:16:5:18:11 | u\\n    . ... .tld(x) |
+| urijs.js:17:15:17:15 | x | urijs.js:16:5:17:16 | u\\n    .username(x) |
+| urijs.js:18:10:18:10 | x | urijs.js:16:5:18:11 | u\\n    . ... .tld(x) |
+| urijs.js:20:9:20:9 | u | urijs.js:20:9:20:26 | u.normalizeQuery() |
+| url-parse.js:3:15:3:15 | x | url-parse.js:3:9:3:19 | parse(x, y) |
+| url-parse.js:3:18:3:18 | y | url-parse.js:3:9:3:19 | parse(x, y) |
+| url-parse.js:4:5:4:5 | r | url-parse.js:4:5:4:19 | r.set('foo', x) |
+| url-parse.js:4:18:4:18 | x | url-parse.js:4:5:4:19 | r.set('foo', x) |
+| url.js:3:19:3:19 | x | url.js:3:9:3:20 | url.parse(x) |
+| url.js:5:16:5:16 | x | url.js:5:5:5:17 | url.format(x) |
+| url.js:7:17:7:17 | x | url.js:7:5:7:21 | url.resolve(x, y) |
+| url.js:7:20:7:20 | y | url.js:7:5:7:21 | url.resolve(x, y) |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.ql
@@ -1,5 +1,5 @@
 import javascript
 
-from UriLibraryStep step, DataFlow::Node pred, DataFlow::Node succ
-where step.step(pred, succ)
+from DataFlow::Node pred, DataFlow::Node succ
+where TaintTracking::uriStep(pred, succ)
 select pred, succ

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.ql
@@ -1,0 +1,5 @@
+import javascript
+
+from UriLibraryStep step, DataFlow::Node pred, DataFlow::Node succ
+where step.step(pred, succ)
+select pred, succ

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/tests.expected
@@ -29,73 +29,73 @@ urijs
 | urijs.js:10:1:10:3 | URI |
 | urijs.js:12:13:12:15 | URI |
 uriLibraryStep
-| closureUri.js:5:11:5:20 | new Uri(x) | closureUri.js:5:19:5:19 | x | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:6:1:6:12 | Uri.parse(x) | closureUri.js:6:11:6:11 | x | closureUri.js:6:1:6:12 | Uri.parse(x) |
-| closureUri.js:7:1:7:17 | Uri.resolve(x, y) | closureUri.js:7:13:7:13 | x | closureUri.js:7:1:7:17 | Uri.resolve(x, y) |
-| closureUri.js:7:1:7:17 | Uri.resolve(x, y) | closureUri.js:7:16:7:16 | y | closureUri.js:7:1:7:17 | Uri.resolve(x, y) |
-| closureUri.js:8:1:8:57 | Uri.cre ... , frag) | closureUri.js:8:12:8:17 | scheme | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
-| closureUri.js:8:1:8:57 | Uri.cre ... , frag) | closureUri.js:8:26:8:31 | domain | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
-| closureUri.js:8:1:8:57 | Uri.cre ... , frag) | closureUri.js:8:40:8:43 | path | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
-| closureUri.js:10:1:10:16 | uri.setScheme(x) | closureUri.js:10:1:10:3 | uri | closureUri.js:10:1:10:16 | uri.setScheme(x) |
-| closureUri.js:10:1:10:16 | uri.setScheme(x) | closureUri.js:10:15:10:15 | x | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:11:1:11:18 | uri.setUserInfo(x) | closureUri.js:11:1:11:3 | uri | closureUri.js:11:1:11:18 | uri.setUserInfo(x) |
-| closureUri.js:12:1:12:16 | uri.setDomain(x) | closureUri.js:12:1:12:3 | uri | closureUri.js:12:1:12:16 | uri.setDomain(x) |
-| closureUri.js:12:1:12:16 | uri.setDomain(x) | closureUri.js:12:15:12:15 | x | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:13:1:13:14 | uri.setPort(x) | closureUri.js:13:1:13:3 | uri | closureUri.js:13:1:13:14 | uri.setPort(x) |
-| closureUri.js:14:1:14:14 | uri.setPath(x) | closureUri.js:14:1:14:3 | uri | closureUri.js:14:1:14:14 | uri.setPath(x) |
-| closureUri.js:14:1:14:14 | uri.setPath(x) | closureUri.js:14:13:14:13 | x | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:15:1:15:15 | uri.setQuery(x) | closureUri.js:15:1:15:3 | uri | closureUri.js:15:1:15:15 | uri.setQuery(x) |
-| closureUri.js:16:1:16:18 | uri.setFragment(x) | closureUri.js:16:1:16:3 | uri | closureUri.js:16:1:16:18 | uri.setFragment(x) |
-| closureUri.js:18:1:18:15 | uri.setQuery(x) | closureUri.js:18:1:18:3 | uri | closureUri.js:18:1:18:15 | uri.setQuery(x) |
-| closureUri.js:18:1:18:26 | uri.set ... Path(y) | closureUri.js:18:1:18:15 | uri.setQuery(x) | closureUri.js:18:1:18:26 | uri.set ... Path(y) |
-| closureUri.js:18:1:18:26 | uri.set ... Path(y) | closureUri.js:18:25:18:25 | y | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:18:1:18:39 | uri.set ... heme(z) | closureUri.js:18:1:18:26 | uri.set ... Path(y) | closureUri.js:18:1:18:39 | uri.set ... heme(z) |
-| closureUri.js:18:1:18:39 | uri.set ... heme(z) | closureUri.js:18:38:18:38 | z | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:22:1:22:25 | utils.a ... uri, z) | closureUri.js:22:19:22:21 | uri | closureUri.js:22:1:22:25 | utils.a ... uri, z) |
-| closureUri.js:23:1:23:18 | utils.getPath(uri) | closureUri.js:23:15:23:17 | uri | closureUri.js:23:1:23:18 | utils.getPath(uri) |
-| closureUri.js:27:1:27:23 | stringU ... code(x) | closureUri.js:27:22:27:22 | x | closureUri.js:27:1:27:23 | stringU ... code(x) |
-| closureUri.js:28:1:28:23 | stringU ... code(x) | closureUri.js:28:22:28:22 | x | closureUri.js:28:1:28:23 | stringU ... code(x) |
-| path-parse.js:4:1:4:13 | path.parse(x) | path-parse.js:4:12:4:12 | x | path-parse.js:4:1:4:13 | path.parse(x) |
-| path-parse.js:5:1:5:13 | path_parse(x) | path-parse.js:5:12:5:12 | x | path-parse.js:5:1:5:13 | path_parse(x) |
-| path-parse.js:6:1:6:19 | path.posix.parse(x) | path-parse.js:6:18:6:18 | x | path-parse.js:6:1:6:19 | path.posix.parse(x) |
-| path-parse.js:7:1:7:19 | path_parse.posix(x) | path-parse.js:7:18:7:18 | x | path-parse.js:7:1:7:19 | path_parse.posix(x) |
-| path-parse.js:8:1:8:19 | path.win32.parse(x) | path-parse.js:8:18:8:18 | x | path-parse.js:8:1:8:19 | path.win32.parse(x) |
-| path-parse.js:9:1:9:19 | path_parse.win32(x) | path-parse.js:9:18:9:18 | x | path-parse.js:9:1:9:19 | path_parse.win32(x) |
-| punycode.js:3:9:3:26 | punycode.decode(x) | punycode.js:3:25:3:25 | x | punycode.js:3:9:3:26 | punycode.decode(x) |
-| punycode.js:5:5:5:22 | punycode.encode(x) | punycode.js:5:21:5:21 | x | punycode.js:5:5:5:22 | punycode.encode(x) |
-| punycode.js:7:5:7:25 | punycod ... code(x) | punycode.js:7:24:7:24 | x | punycode.js:7:5:7:25 | punycod ... code(x) |
-| punycode.js:9:5:9:23 | punycode.toASCII(x) | punycode.js:9:22:9:22 | x | punycode.js:9:5:9:23 | punycode.toASCII(x) |
-| query-string.js:3:9:3:28 | queryString.parse(x) | query-string.js:3:27:3:27 | x | query-string.js:3:9:3:28 | queryString.parse(x) |
-| query-string.js:5:5:5:26 | querySt ... ract(x) | query-string.js:5:25:5:25 | x | query-string.js:5:5:5:26 | querySt ... ract(x) |
-| query-string.js:7:5:7:27 | querySt ... eUrl(x) | query-string.js:7:26:7:26 | x | query-string.js:7:5:7:27 | querySt ... eUrl(x) |
-| query-string.js:9:5:9:28 | querySt ... gify(x) | query-string.js:9:27:9:27 | x | query-string.js:9:5:9:28 | querySt ... gify(x) |
-| query-string_import.js:3:1:3:8 | parse(x) | query-string_import.js:3:7:3:7 | x | query-string_import.js:3:1:3:8 | parse(x) |
-| querystring.js:3:9:3:29 | queryst ... cape(x) | querystring.js:3:28:3:28 | x | querystring.js:3:9:3:29 | queryst ... cape(x) |
-| querystring.js:5:5:5:24 | querystring.parse(x) | querystring.js:5:23:5:23 | x | querystring.js:5:5:5:24 | querystring.parse(x) |
-| querystring.js:7:5:7:28 | queryst ... gify(x) | querystring.js:7:27:7:27 | x | querystring.js:7:5:7:28 | queryst ... gify(x) |
-| querystring.js:9:5:9:27 | queryst ... cape(x) | querystring.js:9:26:9:26 | x | querystring.js:9:5:9:27 | queryst ... cape(x) |
-| querystringify.js:3:9:3:31 | queryst ... arse(x) | querystringify.js:3:30:3:30 | x | querystringify.js:3:9:3:31 | queryst ... arse(x) |
-| querystringify.js:5:5:5:31 | queryst ... gify(x) | querystringify.js:5:30:5:30 | x | querystringify.js:5:5:5:31 | queryst ... gify(x) |
-| uri-js.js:3:9:3:20 | URI.parse(x) | uri-js.js:3:19:3:19 | x | uri-js.js:3:9:3:20 | URI.parse(x) |
-| uri-js.js:5:5:5:20 | URI.serialize(x) | uri-js.js:5:19:5:19 | x | uri-js.js:5:5:5:20 | URI.serialize(x) |
-| uri-js.js:7:5:7:18 | URI.resolve(x) | uri-js.js:7:17:7:17 | x | uri-js.js:7:5:7:18 | URI.resolve(x) |
-| uri-js.js:9:5:9:20 | URI.normalize(x) | uri-js.js:9:19:9:19 | x | uri-js.js:9:5:9:20 | URI.normalize(x) |
-| urijs.js:12:9:12:18 | new URI(x) | urijs.js:12:17:12:17 | x | urijs.js:12:9:12:18 | new URI(x) |
-| urijs.js:14:5:14:17 | u.username(x) | urijs.js:14:5:14:5 | u | urijs.js:14:5:14:17 | u.username(x) |
-| urijs.js:14:5:14:17 | u.username(x) | urijs.js:14:16:14:16 | x | urijs.js:14:5:14:17 | u.username(x) |
-| urijs.js:16:5:17:16 | u\\n    .username(x) | urijs.js:16:5:16:5 | u | urijs.js:16:5:17:16 | u\\n    .username(x) |
-| urijs.js:16:5:17:16 | u\\n    .username(x) | urijs.js:17:15:17:15 | x | urijs.js:16:5:17:16 | u\\n    .username(x) |
-| urijs.js:16:5:18:11 | u\\n    . ... .tld(x) | urijs.js:16:5:17:16 | u\\n    .username(x) | urijs.js:16:5:18:11 | u\\n    . ... .tld(x) |
-| urijs.js:16:5:18:11 | u\\n    . ... .tld(x) | urijs.js:18:10:18:10 | x | urijs.js:16:5:18:11 | u\\n    . ... .tld(x) |
-| urijs.js:20:9:20:26 | u.normalizeQuery() | urijs.js:20:9:20:9 | u | urijs.js:20:9:20:26 | u.normalizeQuery() |
-| url-parse.js:3:9:3:19 | parse(x, y) | url-parse.js:3:15:3:15 | x | url-parse.js:3:9:3:19 | parse(x, y) |
-| url-parse.js:3:9:3:19 | parse(x, y) | url-parse.js:3:18:3:18 | y | url-parse.js:3:9:3:19 | parse(x, y) |
-| url-parse.js:4:5:4:19 | r.set('foo', x) | url-parse.js:4:5:4:5 | r | url-parse.js:4:5:4:19 | r.set('foo', x) |
-| url-parse.js:4:5:4:19 | r.set('foo', x) | url-parse.js:4:18:4:18 | x | url-parse.js:4:5:4:19 | r.set('foo', x) |
-| url.js:3:9:3:20 | url.parse(x) | url.js:3:19:3:19 | x | url.js:3:9:3:20 | url.parse(x) |
-| url.js:5:5:5:17 | url.format(x) | url.js:5:16:5:16 | x | url.js:5:5:5:17 | url.format(x) |
-| url.js:7:5:7:21 | url.resolve(x, y) | url.js:7:17:7:17 | x | url.js:7:5:7:21 | url.resolve(x, y) |
-| url.js:7:5:7:21 | url.resolve(x, y) | url.js:7:20:7:20 | y | url.js:7:5:7:21 | url.resolve(x, y) |
+| closureUri.js:5:19:5:19 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:6:11:6:11 | x | closureUri.js:6:1:6:12 | Uri.parse(x) |
+| closureUri.js:7:13:7:13 | x | closureUri.js:7:1:7:17 | Uri.resolve(x, y) |
+| closureUri.js:7:16:7:16 | y | closureUri.js:7:1:7:17 | Uri.resolve(x, y) |
+| closureUri.js:8:12:8:17 | scheme | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
+| closureUri.js:8:26:8:31 | domain | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
+| closureUri.js:8:40:8:43 | path | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
+| closureUri.js:10:1:10:3 | uri | closureUri.js:10:1:10:16 | uri.setScheme(x) |
+| closureUri.js:10:15:10:15 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:11:1:11:3 | uri | closureUri.js:11:1:11:18 | uri.setUserInfo(x) |
+| closureUri.js:12:1:12:3 | uri | closureUri.js:12:1:12:16 | uri.setDomain(x) |
+| closureUri.js:12:15:12:15 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:13:1:13:3 | uri | closureUri.js:13:1:13:14 | uri.setPort(x) |
+| closureUri.js:14:1:14:3 | uri | closureUri.js:14:1:14:14 | uri.setPath(x) |
+| closureUri.js:14:13:14:13 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:15:1:15:3 | uri | closureUri.js:15:1:15:15 | uri.setQuery(x) |
+| closureUri.js:16:1:16:3 | uri | closureUri.js:16:1:16:18 | uri.setFragment(x) |
+| closureUri.js:18:1:18:3 | uri | closureUri.js:18:1:18:15 | uri.setQuery(x) |
+| closureUri.js:18:1:18:15 | uri.setQuery(x) | closureUri.js:18:1:18:26 | uri.set ... Path(y) |
+| closureUri.js:18:1:18:26 | uri.set ... Path(y) | closureUri.js:18:1:18:39 | uri.set ... heme(z) |
+| closureUri.js:18:25:18:25 | y | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:18:38:18:38 | z | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:22:19:22:21 | uri | closureUri.js:22:1:22:25 | utils.a ... uri, z) |
+| closureUri.js:23:15:23:17 | uri | closureUri.js:23:1:23:18 | utils.getPath(uri) |
+| closureUri.js:27:22:27:22 | x | closureUri.js:27:1:27:23 | stringU ... code(x) |
+| closureUri.js:28:22:28:22 | x | closureUri.js:28:1:28:23 | stringU ... code(x) |
+| path-parse.js:4:12:4:12 | x | path-parse.js:4:1:4:13 | path.parse(x) |
+| path-parse.js:5:12:5:12 | x | path-parse.js:5:1:5:13 | path_parse(x) |
+| path-parse.js:6:18:6:18 | x | path-parse.js:6:1:6:19 | path.posix.parse(x) |
+| path-parse.js:7:18:7:18 | x | path-parse.js:7:1:7:19 | path_parse.posix(x) |
+| path-parse.js:8:18:8:18 | x | path-parse.js:8:1:8:19 | path.win32.parse(x) |
+| path-parse.js:9:18:9:18 | x | path-parse.js:9:1:9:19 | path_parse.win32(x) |
+| punycode.js:3:25:3:25 | x | punycode.js:3:9:3:26 | punycode.decode(x) |
+| punycode.js:5:21:5:21 | x | punycode.js:5:5:5:22 | punycode.encode(x) |
+| punycode.js:7:24:7:24 | x | punycode.js:7:5:7:25 | punycod ... code(x) |
+| punycode.js:9:22:9:22 | x | punycode.js:9:5:9:23 | punycode.toASCII(x) |
+| query-string.js:3:27:3:27 | x | query-string.js:3:9:3:28 | queryString.parse(x) |
+| query-string.js:5:25:5:25 | x | query-string.js:5:5:5:26 | querySt ... ract(x) |
+| query-string.js:7:26:7:26 | x | query-string.js:7:5:7:27 | querySt ... eUrl(x) |
+| query-string.js:9:27:9:27 | x | query-string.js:9:5:9:28 | querySt ... gify(x) |
+| query-string_import.js:3:7:3:7 | x | query-string_import.js:3:1:3:8 | parse(x) |
+| querystring.js:3:28:3:28 | x | querystring.js:3:9:3:29 | queryst ... cape(x) |
+| querystring.js:5:23:5:23 | x | querystring.js:5:5:5:24 | querystring.parse(x) |
+| querystring.js:7:27:7:27 | x | querystring.js:7:5:7:28 | queryst ... gify(x) |
+| querystring.js:9:26:9:26 | x | querystring.js:9:5:9:27 | queryst ... cape(x) |
+| querystringify.js:3:30:3:30 | x | querystringify.js:3:9:3:31 | queryst ... arse(x) |
+| querystringify.js:5:30:5:30 | x | querystringify.js:5:5:5:31 | queryst ... gify(x) |
+| uri-js.js:3:19:3:19 | x | uri-js.js:3:9:3:20 | URI.parse(x) |
+| uri-js.js:5:19:5:19 | x | uri-js.js:5:5:5:20 | URI.serialize(x) |
+| uri-js.js:7:17:7:17 | x | uri-js.js:7:5:7:18 | URI.resolve(x) |
+| uri-js.js:9:19:9:19 | x | uri-js.js:9:5:9:20 | URI.normalize(x) |
+| urijs.js:12:17:12:17 | x | urijs.js:12:9:12:18 | new URI(x) |
+| urijs.js:14:5:14:5 | u | urijs.js:14:5:14:17 | u.username(x) |
+| urijs.js:14:16:14:16 | x | urijs.js:14:5:14:17 | u.username(x) |
+| urijs.js:16:5:16:5 | u | urijs.js:16:5:17:16 | u\\n    .username(x) |
+| urijs.js:16:5:17:16 | u\\n    .username(x) | urijs.js:16:5:18:11 | u\\n    . ... .tld(x) |
+| urijs.js:17:15:17:15 | x | urijs.js:16:5:17:16 | u\\n    .username(x) |
+| urijs.js:18:10:18:10 | x | urijs.js:16:5:18:11 | u\\n    . ... .tld(x) |
+| urijs.js:20:9:20:9 | u | urijs.js:20:9:20:26 | u.normalizeQuery() |
+| url-parse.js:3:15:3:15 | x | url-parse.js:3:9:3:19 | parse(x, y) |
+| url-parse.js:3:18:3:18 | y | url-parse.js:3:9:3:19 | parse(x, y) |
+| url-parse.js:4:5:4:5 | r | url-parse.js:4:5:4:19 | r.set('foo', x) |
+| url-parse.js:4:18:4:18 | x | url-parse.js:4:5:4:19 | r.set('foo', x) |
+| url.js:3:19:3:19 | x | url.js:3:9:3:20 | url.parse(x) |
+| url.js:5:16:5:16 | x | url.js:5:5:5:17 | url.format(x) |
+| url.js:7:17:7:17 | x | url.js:7:5:7:21 | url.resolve(x, y) |
+| url.js:7:20:7:20 | y | url.js:7:5:7:21 | url.resolve(x, y) |
 url
 | url.js:3:9:3:17 | url.parse |
 | url.js:5:5:5:14 | url.format |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/tests.ql
@@ -12,8 +12,8 @@ query predicate uridashjs(DataFlow::Node n) { n = uridashjs::uridashjsMember(_) 
 
 query predicate urijs(DataFlow::Node n) { n = urijs::urijs() }
 
-query predicate uriLibraryStep(UriLibraryStep step, DataFlow::Node pred, DataFlow::Node succ) {
-  step.step(pred, succ)
+query predicate uriLibraryStep(DataFlow::Node pred, DataFlow::Node succ) {
+  TaintTracking::uriStep(pred, succ)
 }
 
 query predicate url(DataFlow::Node n) { n = url::urlMember(_) }

--- a/javascript/ql/test/library-tests/frameworks/Vue/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/tests.expected
@@ -81,8 +81,12 @@ instance
 | tst.js:94:2:96:3 | new Vue ...  f,\\n\\t}) |
 | tst.js:99:2:104:3 | new Vue ... \\t\\t}\\n\\t}) |
 instance_heapStep
-| tst.js:102:20:102:29 | this.dataA | tst.js:100:18:100:19 | 42 | tst.js:102:20:102:29 | this.dataA |
-| tst.js:102:20:102:29 | this.dataA | tst.js:102:20:102:23 | this | tst.js:102:20:102:29 | this.dataA |
+| Unit | compont-with-route.vue:31:14:31:34 | this.$r ... ery.foo | compont-with-route.vue:2:8:2:21 | v-html=dataA |
+| Unit | single-component-file-1.vue:6:40:6:41 | 42 | single-component-file-1.vue:2:8:2:21 | v-html=dataA |
+| Unit | single-file-component-3-script.js:4:37:4:38 | 42 | single-file-component-3.vue:2:8:2:21 | v-html=dataA |
+| Unit | single-file-component-4.vue:15:14:15:15 | 42 | single-file-component-4.vue:2:8:2:21 | v-html=dataA |
+| Unit | single-file-component-5.vue:13:14:13:15 | 42 | single-file-component-5.vue:2:8:2:21 | v-html=dataA |
+| Unit | tst.js:100:18:100:19 | 42 | tst.js:102:20:102:29 | this.dataA |
 templateElement
 | compont-with-route.vue:1:1:3:11 | <template>...</> |
 | compont-with-route.vue:2:5:51:9 | <p>...</> |
@@ -109,12 +113,12 @@ templateElement
 | single-file-component-5.vue:4:1:16:9 | <script>...</> |
 | single-file-component-5.vue:17:1:18:8 | <style>...</> |
 vhtmlSourceWrite
-| compont-with-route.vue:31:14:31:34 | this.$r ... ery.foo | compont-with-route.vue:31:14:31:30 | this.$route.query | compont-with-route.vue:31:14:31:34 | this.$r ... ery.foo |
-| compont-with-route.vue:31:14:31:34 | this.$r ... ery.foo | compont-with-route.vue:31:14:31:34 | this.$r ... ery.foo | compont-with-route.vue:2:8:2:21 | v-html=dataA |
-| single-component-file-1.vue:6:40:6:41 | 42 | single-component-file-1.vue:6:40:6:41 | 42 | single-component-file-1.vue:2:8:2:21 | v-html=dataA |
-| single-file-component-3-script.js:4:37:4:38 | 42 | single-file-component-3-script.js:4:37:4:38 | 42 | single-file-component-3.vue:2:8:2:21 | v-html=dataA |
-| single-file-component-4.vue:15:14:15:15 | 42 | single-file-component-4.vue:15:14:15:15 | 42 | single-file-component-4.vue:2:8:2:21 | v-html=dataA |
-| single-file-component-5.vue:13:14:13:15 | 42 | single-file-component-5.vue:13:14:13:15 | 42 | single-file-component-5.vue:2:8:2:21 | v-html=dataA |
+| Unit | compont-with-route.vue:31:14:31:34 | this.$r ... ery.foo | compont-with-route.vue:2:8:2:21 | v-html=dataA |
+| Unit | single-component-file-1.vue:6:40:6:41 | 42 | single-component-file-1.vue:2:8:2:21 | v-html=dataA |
+| Unit | single-file-component-3-script.js:4:37:4:38 | 42 | single-file-component-3.vue:2:8:2:21 | v-html=dataA |
+| Unit | single-file-component-4.vue:15:14:15:15 | 42 | single-file-component-4.vue:2:8:2:21 | v-html=dataA |
+| Unit | single-file-component-5.vue:13:14:13:15 | 42 | single-file-component-5.vue:2:8:2:21 | v-html=dataA |
+| Unit | tst.js:100:18:100:19 | 42 | tst.js:102:20:102:29 | this.dataA |
 xssSink
 | compont-with-route.vue:2:8:2:21 | v-html=dataA |
 | single-component-file-1.vue:2:8:2:21 | v-html=dataA |

--- a/javascript/ql/test/library-tests/frameworks/Vue/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/Vue/tests.ql
@@ -20,9 +20,7 @@ query predicate templateElement(Vue::Template::Element template) { any() }
 
 import semmle.javascript.security.dataflow.DomBasedXss
 
-query predicate vhtmlSourceWrite(
-  Vue::VHtmlSourceWrite w, DataFlow::Node pred, DataFlow::Node succ
-) {
+query predicate vhtmlSourceWrite(Vue::VHtmlSourceWrite w, DataFlow::Node pred, DataFlow::Node succ) {
   w.step(pred, succ)
 }
 

--- a/javascript/ql/test/library-tests/frameworks/Vue/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/Vue/tests.ql
@@ -21,7 +21,7 @@ query predicate templateElement(Vue::Template::Element template) { any() }
 import semmle.javascript.security.dataflow.DomBasedXss
 
 query predicate vhtmlSourceWrite(
-  DomBasedXss::VHtmlSourceWrite w, DataFlow::Node pred, DataFlow::Node succ
+  Vue::VHtmlSourceWrite w, DataFlow::Node pred, DataFlow::Node succ
 ) {
   w.step(pred, succ)
 }

--- a/javascript/ql/test/tutorials/Analyzing data flow in JavaScript/Global data flow/query5.ql
+++ b/javascript/ql/test/tutorials/Analyzing data flow in JavaScript/Global data flow/query5.ql
@@ -1,11 +1,12 @@
 import javascript
 
-class StepThroughResolveSymlinks extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-  StepThroughResolveSymlinks() { this = DataFlow::moduleImport("resolve-symlinks").getACall() }
-
+class StepThroughResolveSymlinks extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = this.getArgument(0) and
-    succ = this
+    exists(DataFlow::CallNode c |
+      c = DataFlow::moduleImport("resolve-symlinks").getACall() and
+      pred = c.getArgument(0) and
+      succ = c
+    )
   }
 }
 


### PR DESCRIPTION
Revival of https://github.com/github/codeql/pull/3603 without the string base-type stuff.

Converts `AdditionalTaintStep` to a unit-type class called `SharedTaintStep`:
- `AdditionalTaintStep` remains as a deprecated class.
- Converting `AdditionalTaintStep` into a unit type would be a breaking change, hence the new class.
- The new class name should help indicate that it should not be subclassed in a query.

[Evaluation](https://github.com/dsp-testing/asgerf-dca/tree/run/js/shared-taint-step2/reports) looks good