### PR TITLE
JS: Require that the MetacharEscapeSanitizer is a global replace call

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -28,7 +28,7 @@ module Shared {
   abstract class SanitizerGuard extends TaintTracking::SanitizerGuardNode { }
 
   /**
-   * A regexp replacement involving an HTML meta-character, viewed as a sanitizer for
+   * A global regexp replacement involving an HTML meta-character, viewed as a sanitizer for
    * XSS vulnerabilities.
    *
    * The XSS queries do not attempt to reason about correctness or completeness of sanitizers,
@@ -36,6 +36,7 @@ module Shared {
    */
   class MetacharEscapeSanitizer extends Sanitizer, StringReplaceCall {
     MetacharEscapeSanitizer() {
+      this.isGlobal() and
       exists(RegExpConstant c |
         c.getLiteral() = getRegExp().asExpr() and
         c.getValue().regexpMatch("['\"&<>]")

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -653,6 +653,13 @@ nodes
 | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:428:7:428:39 | target |
+| tst.js:428:16:428:32 | document.location |
+| tst.js:428:16:428:32 | document.location |
+| tst.js:428:16:428:39 | documen ... .search |
+| tst.js:430:18:430:23 | target |
+| tst.js:430:18:430:89 | target. ... data>') |
+| tst.js:430:18:430:89 | target. ... data>') |
 | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:38 | document.location |
 | typeahead.js:20:22:20:38 | document.location |
@@ -1283,6 +1290,12 @@ edges
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:428:7:428:39 | target | tst.js:430:18:430:23 | target |
+| tst.js:428:16:428:32 | document.location | tst.js:428:16:428:39 | documen ... .search |
+| tst.js:428:16:428:32 | document.location | tst.js:428:16:428:39 | documen ... .search |
+| tst.js:428:16:428:39 | documen ... .search | tst.js:428:7:428:39 | target |
+| tst.js:430:18:430:23 | target | tst.js:430:18:430:89 | target. ... data>') |
+| tst.js:430:18:430:23 | target | tst.js:430:18:430:89 | target. ... data>') |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
 | typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
@@ -1491,6 +1504,7 @@ edges
 | tst.js:417:18:417:24 | payload | tst.js:416:17:416:31 | window.location | tst.js:417:18:417:24 | payload | Cross-site scripting vulnerability due to $@. | tst.js:416:17:416:31 | window.location | user-provided value |
 | tst.js:421:20:421:27 | match[1] | tst.js:419:15:419:29 | window.location | tst.js:421:20:421:27 | match[1] | Cross-site scripting vulnerability due to $@. | tst.js:419:15:419:29 | window.location | user-provided value |
 | tst.js:424:18:424:51 | window. ... '#')[1] | tst.js:424:18:424:32 | window.location | tst.js:424:18:424:51 | window. ... '#')[1] | Cross-site scripting vulnerability due to $@. | tst.js:424:18:424:32 | window.location | user-provided value |
+| tst.js:430:18:430:89 | target. ... data>') | tst.js:428:16:428:32 | document.location | tst.js:430:18:430:89 | target. ... data>') | Cross-site scripting vulnerability due to $@. | tst.js:428:16:428:32 | document.location | user-provided value |
 | typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:38 | document.location | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:38 | document.location | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
 | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -660,6 +660,13 @@ nodes
 | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:428:7:428:39 | target |
+| tst.js:428:16:428:32 | document.location |
+| tst.js:428:16:428:32 | document.location |
+| tst.js:428:16:428:39 | documen ... .search |
+| tst.js:430:18:430:23 | target |
+| tst.js:430:18:430:89 | target. ... data>') |
+| tst.js:430:18:430:89 | target. ... data>') |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:10:16:10:18 | loc |
@@ -1300,6 +1307,12 @@ edges
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:428:7:428:39 | target | tst.js:430:18:430:23 | target |
+| tst.js:428:16:428:32 | document.location | tst.js:428:16:428:39 | documen ... .search |
+| tst.js:428:16:428:32 | document.location | tst.js:428:16:428:39 | documen ... .search |
+| tst.js:428:16:428:39 | documen ... .search | tst.js:428:7:428:39 | target |
+| tst.js:430:18:430:23 | target | tst.js:430:18:430:89 | target. ... data>') |
+| tst.js:430:18:430:23 | target | tst.js:430:18:430:89 | target. ... data>') |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
@@ -423,3 +423,11 @@ function hash2() {
 
   document.write(window.location.hash.split('#')[1]); // NOT OK
 }
+
+function nonGlobalSanitizer() {
+  var target = document.location.search
+
+  $("#foo").html(target.replace(/<metadata>[\s\S]*<\/metadata>/, '<metadata></metadata>')); // NOT OK
+
+  $("#foo").html(target.replace(/<|>/g, '')); // OK
+}


### PR DESCRIPTION
Is a step towards getting a TP for CVE-2020-7750

An [evaluation using `Xss.ql` and `XssThroughDom.ql`](https://github.com/dsp-testing/erik-krogh-dca/tree/run/globalSanitizer-nightly-xss/reports) looks good. 