### PR TITLE
Java: Add URLClassLoader, WebClient SSRF sinks

### DIFF
--- a/java/change-notes/2021-07-01-url-classloader-reactive-webclient.md
+++ b/java/change-notes/2021-07-01-url-classloader-reactive-webclient.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added support for two new APIs susceptible to server-side request forgery (SSRF): using a `URLClassLoader`, and using Spring Web Reactive's `WebClient`.

--- a/java/ql/src/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/src/semmle/code/java/dataflow/ExternalFlow.qll
@@ -217,6 +217,12 @@ private predicate sinkModelCsv(string row) {
       "java.net;URL;false;openStream;;;Argument[-1];open-url",
       "java.net.http;HttpRequest;false;newBuilder;;;Argument[0];open-url",
       "java.net.http;HttpRequest$Builder;false;uri;;;Argument[0];open-url",
+      "java.net;URLClassLoader;false;URLClassLoader;(URL[]);;Argument[0];open-url",
+      "java.net;URLClassLoader;false;URLClassLoader;(URL[],ClassLoader);;Argument[0];open-url",
+      "java.net;URLClassLoader;false;URLClassLoader;(URL[],ClassLoader,URLStreamHandlerFactory);;Argument[0];open-url",
+      "java.net;URLClassLoader;false;URLClassLoader;(String,URL[],ClassLoader);;Argument[1];open-url",
+      "java.net;URLClassLoader;false;URLClassLoader;(String,URL[],ClassLoader,URLStreamHandlerFactory);;Argument[1];open-url",
+      "java.net;URLClassLoader;false;newInstance;;;Argument[0];open-url",
       // Create file
       "java.io;FileOutputStream;false;FileOutputStream;;;Argument[0];create-file",
       "java.io;RandomAccessFile;false;RandomAccessFile;;;Argument[0];create-file",

--- a/java/ql/src/semmle/code/java/frameworks/spring/SpringWebClient.qll
+++ b/java/ql/src/semmle/code/java/frameworks/spring/SpringWebClient.qll
@@ -45,7 +45,9 @@ private class UrlOpenSink extends SinkModelCsv {
         "org.springframework.web.client;RestTemplate;false;postForEntity;;;Argument[0];open-url",
         "org.springframework.web.client;RestTemplate;false;postForLocation;;;Argument[0];open-url",
         "org.springframework.web.client;RestTemplate;false;postForObject;;;Argument[0];open-url",
-        "org.springframework.web.client;RestTemplate;false;put;;;Argument[0];open-url"
+        "org.springframework.web.client;RestTemplate;false;put;;;Argument[0];open-url",
+        "org.springframework.web.reactive.function.client;WebClient;false;create;;;Argument[0];open-url",
+        "org.springframework.web.reactive.function.client;WebClient$Builder;false;baseUrl;;;Argument[0];open-url"
       ]
   }
 }

--- a/java/ql/test/query-tests/security/CWE-918/ReactiveWebClientSSRF.java
+++ b/java/ql/test/query-tests/security/CWE-918/ReactiveWebClientSSRF.java
@@ -1,0 +1,49 @@
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ReactiveWebClientSSRF extends HttpServlet {
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            String url = request.getParameter("uri");
+            WebClient webClient = WebClient.create(url); // $ SSRF
+
+            Mono<String> result = webClient.get()
+                    .uri("/")
+                    .retrieve()
+                    .bodyToMono(String.class);
+
+            result.block();
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            String url = request.getParameter("uri");
+            WebClient webClient = WebClient.builder()
+                    .defaultHeader("User-Agent", "Java")
+                    .baseUrl(url) // $ SSRF
+                    .build();
+
+
+            Mono<String> result = webClient.get()
+                    .uri("/")
+                    .retrieve()
+                    .bodyToMono(String.class);
+
+            result.block();
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+}

--- a/java/ql/test/query-tests/security/CWE-918/URLClassLoaderSSRF.java
+++ b/java/ql/test/query-tests/security/CWE-918/URLClassLoaderSSRF.java
@@ -1,0 +1,98 @@
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class URLClassLoaderSSRF extends HttpServlet {
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            String url = request.getParameter("uri");
+            URI uri = new URI(url);
+            URLClassLoader urlClassLoader = new URLClassLoader(new URL[]{uri.toURL()}); // $ SSRF
+            Class<?> test = urlClassLoader.loadClass("test");
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            String url = request.getParameter("uri");
+            URI uri = new URI(url);
+            URLClassLoader urlClassLoader = new URLClassLoader(new URL[]{uri.toURL()}, URLClassLoaderSSRF.class.getClassLoader()); // $ SSRF
+            Class<?> test = urlClassLoader.loadClass("test");
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    protected void doPut(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            String url = request.getParameter("uri");
+            URI uri = new URI(url);
+
+            URLStreamHandlerFactory urlStreamHandlerFactory = TomcatURLStreamHandlerFactory.getInstance();
+            URLClassLoader urlClassLoader = new URLClassLoader(new URL[]{uri.toURL()}, URLClassLoaderSSRF.class.getClassLoader(), urlStreamHandlerFactory); // $ SSRF
+            urlClassLoader.findResource("test");
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            String url = request.getParameter("uri");
+            URI uri = new URI(url);
+            URLClassLoader urlClassLoader = URLClassLoader.newInstance(new URL[]{uri.toURL()}); // $ SSRF
+            urlClassLoader.getResourceAsStream("test");
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    protected void doOptions(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            String url = request.getParameter("uri");
+            URI uri = new URI(url);
+            URLClassLoader urlClassLoader = 
+                new URLClassLoader("testClassLoader", 
+                    new URL[]{new URL[]{uri.toURL()}}, 
+                    URLClassLoaderSSRF.class.getClassLoader()
+                ); // $ SSRF
+
+            Class<?> rceTest = urlClassLoader.loadClass("RCETest");
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    protected void doTrace(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            String url = request.getParameter("uri");
+            URI uri = new URI(url);
+            URLStreamHandlerFactory urlStreamHandlerFactory = TomcatURLStreamHandlerFactory.getInstance();
+
+            URLClassLoader urlClassLoader =
+                new URLClassLoader("testClassLoader",
+                    new URL[]{uri.toURL()}, 
+                    URLClassLoaderSSRF.class.getClassLoader(), 
+                    urlStreamHandlerFactory
+                ); // $ SSRF
+
+            Class<?> rceTest = urlClassLoader.loadClass("RCETest");
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+}

--- a/java/ql/test/query-tests/security/CWE-918/URLClassLoaderSSRF.java
+++ b/java/ql/test/query-tests/security/CWE-918/URLClassLoaderSSRF.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLStreamHandlerFactory;
 
 public class URLClassLoaderSSRF extends HttpServlet {
 
@@ -39,7 +40,7 @@ public class URLClassLoaderSSRF extends HttpServlet {
             String url = request.getParameter("uri");
             URI uri = new URI(url);
 
-            URLStreamHandlerFactory urlStreamHandlerFactory = TomcatURLStreamHandlerFactory.getInstance();
+            URLStreamHandlerFactory urlStreamHandlerFactory = null;
             URLClassLoader urlClassLoader = new URLClassLoader(new URL[]{uri.toURL()}, URLClassLoaderSSRF.class.getClassLoader(), urlStreamHandlerFactory); // $ SSRF
             urlClassLoader.findResource("test");
         } catch (Exception e) {
@@ -64,11 +65,11 @@ public class URLClassLoaderSSRF extends HttpServlet {
         try {
             String url = request.getParameter("uri");
             URI uri = new URI(url);
-            URLClassLoader urlClassLoader = 
-                new URLClassLoader("testClassLoader", 
-                    new URL[]{new URL[]{uri.toURL()}}, 
+            URLClassLoader urlClassLoader =
+                new URLClassLoader("testClassLoader",
+                    new URL[]{uri.toURL()}, // $ SSRF
                     URLClassLoaderSSRF.class.getClassLoader()
-                ); // $ SSRF
+                );
 
             Class<?> rceTest = urlClassLoader.loadClass("RCETest");
         } catch (Exception e) {
@@ -81,14 +82,14 @@ public class URLClassLoaderSSRF extends HttpServlet {
         try {
             String url = request.getParameter("uri");
             URI uri = new URI(url);
-            URLStreamHandlerFactory urlStreamHandlerFactory = TomcatURLStreamHandlerFactory.getInstance();
+            URLStreamHandlerFactory urlStreamHandlerFactory = null;
 
             URLClassLoader urlClassLoader =
                 new URLClassLoader("testClassLoader",
-                    new URL[]{uri.toURL()}, 
-                    URLClassLoaderSSRF.class.getClassLoader(), 
+                    new URL[]{uri.toURL()}, // $ SSRF
+                    URLClassLoaderSSRF.class.getClassLoader(),
                     urlStreamHandlerFactory
-                ); // $ SSRF
+                );
 
             Class<?> rceTest = urlClassLoader.loadClass("RCETest");
         } catch (Exception e) {

--- a/java/ql/test/query-tests/security/CWE-918/options
+++ b/java/ql/test/query-tests/security/CWE-918/options
@@ -1,1 +1,2 @@
-//semmle-extractor-options: --javac-args -source 11 -target 11 -cp ${testdir}/../../../stubs/springframework-5.3.8:${testdir}/../../../stubs/javax-ws-rs-api-2.1.1:${testdir}/../../../stubs/javax-ws-rs-api-3.0.0:${testdir}/../../../stubs/apache-http-4.4.13/:${testdir}/../../../stubs/servlet-api-2.4/
+//semmle-extractor-options: --javac-args -source 11 -target 11 -cp ${testdir}/../../../stubs/springframework-5.3.8:${testdir}/../../../stubs/javax-ws-rs-api-2.1.1:${testdir}/../../../stubs/javax-ws-rs-api-3.0.0:${testdir}/../../../stubs/apache-http-4.4.13/:${testdir}/../../../stubs/servlet-api-2.4/:${testdir}/../../../stubs/projectreactor-3.4.3/
+

--- a/java/ql/test/stubs/projectreactor-3.4.3/reactor/core/publisher/Mono.java
+++ b/java/ql/test/stubs/projectreactor-3.4.3/reactor/core/publisher/Mono.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2011-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.core.publisher;
+
+public abstract class Mono<T> {
+	public T block() {
+		return null;
+	}
+}

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/web/reactive/function/client/DefaultWebClientBuilder.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/web/reactive/function/client/DefaultWebClientBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.function.client;
+
+final class DefaultWebClientBuilder implements WebClient.Builder {
+
+    public DefaultWebClientBuilder() {
+    }
+
+    @Override
+    public WebClient.Builder baseUrl(String baseUrl) {
+        return this;
+    }
+
+    @Override
+    public WebClient.Builder defaultHeader(String header, String... values) {
+        return this;
+    }
+
+
+    @Override
+    public WebClient build() {
+        return null;
+    }
+
+}

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/web/reactive/function/client/WebClient.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/web/reactive/function/client/WebClient.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.function.client;
+
+import reactor.core.publisher.Mono;
+
+/**
+    Spring Reactor WebClient interface stub
+ */
+public interface WebClient {
+
+	RequestHeadersUriSpec<?> get();
+	RequestHeadersUriSpec<?> head();
+	RequestBodyUriSpec post();
+	RequestBodyUriSpec put();
+	RequestBodyUriSpec patch();
+	RequestHeadersUriSpec<?> delete();
+	RequestHeadersUriSpec<?> options();
+
+	static WebClient create(String baseUrl) {
+		return null;
+	}
+
+	static WebClient create() {
+		return null;
+	}
+
+	static WebClient.Builder builder() {
+		return null;
+	}
+
+	interface Builder {
+		Builder baseUrl(String baseUrl);
+		Builder defaultHeader(String header, String... values);
+		WebClient build();
+	}
+
+	interface UriSpec<S extends RequestHeadersSpec<?>> {
+		S uri(String uri, Object... uriVariables);
+	}
+
+	interface RequestBodySpec extends RequestHeadersSpec<RequestBodySpec> {
+	}
+
+	interface RequestBodyUriSpec extends RequestBodySpec, RequestHeadersUriSpec<RequestBodySpec> {
+	}
+
+	interface ResponseSpec {
+		<T> Mono<T> bodyToMono(Class<T> elementClass);
+	}
+
+	interface RequestHeadersUriSpec<S extends RequestHeadersSpec<S>>
+			extends UriSpec<S>, RequestHeadersSpec<S> {
+	}
+
+	interface RequestHeadersSpec<S extends RequestHeadersSpec<S>> {
+		ResponseSpec retrieve();
+	}
+}


### PR DESCRIPTION
Added 2 new SSRF sinks: URLClassLoader and Spring WebFlux's WebClient.
URLClassLoader is used for loading a jar file from remote source.
WebClient is a reactive Http Client, added in Spring WebFlux framework.