### PR TITLE
Inline testing: Allow multiple actual values in InlineExpectationsTest

### DIFF
--- a/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -242,10 +242,8 @@ private string expectationPattern() {
 }
 
 private newtype TFailureLocatable =
-  TActualResult(
-    InlineExpectationsTest test, Location location, string element, string tag, string value
-  ) {
-    test.hasActualResult(location, element, tag, value)
+  TActualResult(InlineExpectationsTest test, Location location, string element, string tag) {
+    test.hasActualResult(location, element, tag, _)
   } or
   TValidExpectation(LineComment comment, string tag, string value, string knownFailure) {
     exists(TColumn column, string tags |
@@ -276,9 +274,8 @@ class ActualResult extends FailureLocatable, TActualResult {
   Location location;
   string element;
   string tag;
-  string value;
 
-  ActualResult() { this = TActualResult(test, location, element, tag, value) }
+  ActualResult() { this = TActualResult(test, location, element, tag) }
 
   override string toString() { result = element }
 
@@ -288,7 +285,7 @@ class ActualResult extends FailureLocatable, TActualResult {
 
   override string getTag() { result = tag }
 
-  override string getValue() { result = value }
+  override string getValue() { test.hasActualResult(location, element, tag, result) }
 }
 
 abstract private class Expectation extends FailureLocatable {

--- a/cpp/ql/test/TestUtilities/dataflow/FlowTestCommon.qll
+++ b/cpp/ql/test/TestUtilities/dataflow/FlowTestCommon.qll
@@ -16,6 +16,10 @@ private import semmle.code.cpp.ir.dataflow.DataFlow::DataFlow as IRDataFlow
 private import semmle.code.cpp.dataflow.DataFlow::DataFlow as ASTDataFlow
 import TestUtilities.InlineExpectationsTest
 
+string stringOfLocation(Location loc) {
+  result = loc.getStartLine().toString() + ":" + loc.getStartColumn()
+}
+
 class IRFlowTest extends InlineExpectationsTest {
   IRFlowTest() { this = "IRFlowTest" }
 
@@ -27,14 +31,12 @@ class IRFlowTest extends InlineExpectationsTest {
       conf.hasFlow(source, sink) and
       n = strictcount(IRDataFlow::Node otherSource | conf.hasFlow(otherSource, sink)) and
       (
-        n = 1 and value = ""
+        n = 1 and value = ["", stringOfLocation(source.getLocation())]
         or
         // If there is more than one source for this sink
         // we specify the source location explicitly.
         n > 1 and
-        value =
-          source.getLocation().getStartLine().toString() + ":" +
-            source.getLocation().getStartColumn()
+        value = stringOfLocation(source.getLocation())
       ) and
       location = sink.getLocation() and
       element = sink.toString()
@@ -55,14 +57,12 @@ class ASTFlowTest extends InlineExpectationsTest {
       conf.hasFlow(source, sink) and
       n = strictcount(ASTDataFlow::Node otherSource | conf.hasFlow(otherSource, sink)) and
       (
-        n = 1 and value = ""
+        n = 1 and value = ["", stringOfLocation(source.getLocation())]
         or
         // If there is more than one source for this sink
         // we specify the source location explicitly.
         n > 1 and
-        value =
-          source.getLocation().getStartLine().toString() + ":" +
-            source.getLocation().getStartColumn()
+        value = stringOfLocation(source.getLocation())
       ) and
       location = sink.getLocation() and
       element = sink.toString()

--- a/java/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/java/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -242,10 +242,8 @@ private string expectationPattern() {
 }
 
 private newtype TFailureLocatable =
-  TActualResult(
-    InlineExpectationsTest test, Location location, string element, string tag, string value
-  ) {
-    test.hasActualResult(location, element, tag, value)
+  TActualResult(InlineExpectationsTest test, Location location, string element, string tag) {
+    test.hasActualResult(location, element, tag, _)
   } or
   TValidExpectation(LineComment comment, string tag, string value, string knownFailure) {
     exists(TColumn column, string tags |
@@ -276,9 +274,8 @@ class ActualResult extends FailureLocatable, TActualResult {
   Location location;
   string element;
   string tag;
-  string value;
 
-  ActualResult() { this = TActualResult(test, location, element, tag, value) }
+  ActualResult() { this = TActualResult(test, location, element, tag) }
 
   override string toString() { result = element }
 
@@ -288,7 +285,7 @@ class ActualResult extends FailureLocatable, TActualResult {
 
   override string getTag() { result = tag }
 
-  override string getValue() { result = value }
+  override string getValue() { test.hasActualResult(location, element, tag, result) }
 }
 
 abstract private class Expectation extends FailureLocatable {

--- a/python/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/python/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -242,10 +242,8 @@ private string expectationPattern() {
 }
 
 private newtype TFailureLocatable =
-  TActualResult(
-    InlineExpectationsTest test, Location location, string element, string tag, string value
-  ) {
-    test.hasActualResult(location, element, tag, value)
+  TActualResult(InlineExpectationsTest test, Location location, string element, string tag) {
+    test.hasActualResult(location, element, tag, _)
   } or
   TValidExpectation(LineComment comment, string tag, string value, string knownFailure) {
     exists(TColumn column, string tags |
@@ -276,9 +274,8 @@ class ActualResult extends FailureLocatable, TActualResult {
   Location location;
   string element;
   string tag;
-  string value;
 
-  ActualResult() { this = TActualResult(test, location, element, tag, value) }
+  ActualResult() { this = TActualResult(test, location, element, tag) }
 
   override string toString() { result = element }
 
@@ -288,7 +285,7 @@ class ActualResult extends FailureLocatable, TActualResult {
 
   override string getTag() { result = tag }
 
-  override string getValue() { result = value }
+  override string getValue() { test.hasActualResult(location, element, tag, result) }
 }
 
 abstract private class Expectation extends FailureLocatable {


### PR DESCRIPTION
In the C++ dataflow tests we annotate sinks with their source's location (as a value for a test tag). To save a few keystrokes we only require the source location when there's more than 1 source.

However, it recently came up in a [PR discussion](https://github.com/github/codeql/pull/3364#discussion_r594941441) that it's sometimes nice to optionally be able to specify the source location even though there's just one source.

This PR changes the InlineExpectationsTest framework so that a `TActualResult` can have a set of values for a tag, and a test annotation is satisfied if the value of that tag is in the set of actual values.