### PR TITLE
C++: Use GVN in AV Rule 79

### DIFF
--- a/cpp/change-notes/2021-03-17-av-rule-79.md
+++ b/cpp/change-notes/2021-03-17-av-rule-79.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The 'Resource not released in destructor' (cpp/resource-not-released-in-destructor) query has been improved to recognize more releases of resources.

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -99,10 +99,11 @@ private predicate exprReleases(Expr e, Expr released, string kind) {
       e.(FunctionCall).getTarget().(MemberFunction).getAnOverridingFunction+() = f
     ) and
     e.(FunctionCall).getArgument(arg) = released and
-    exprReleases(_, exprOrDereference(f.getParameter(arg).getAnAccess()), kind)
+    exprReleases(_,
+      exprOrDereference(globalValueNumber(f.getParameter(arg).getAnAccess()).getAnExpr()), kind)
   )
   or
-  exists(Function f, ThisExpr innerThis, Expr likeInnerThis |
+  exists(Function f, ThisExpr innerThis |
     // `e` is a call to a method that releases `this`, and `released`
     // is the object that is called
     (
@@ -111,8 +112,7 @@ private predicate exprReleases(Expr e, Expr released, string kind) {
     ) and
     e.(FunctionCall).getQualifier() = exprOrDereference(released) and
     innerThis.getEnclosingFunction() = f and
-    globalValueNumber(innerThis) = globalValueNumber(likeInnerThis) and
-    exprReleases(_, likeInnerThis, kind)
+    exprReleases(_, globalValueNumber(innerThis).getAnExpr(), kind)
   )
 }
 

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -13,6 +13,7 @@
 
 import cpp
 import Critical.NewDelete
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 
 /**
  * An expression that acquires a resource, and the kind of resource that is acquired.  The
@@ -101,7 +102,7 @@ private predicate exprReleases(Expr e, Expr released, string kind) {
     exprReleases(_, exprOrDereference(f.getParameter(arg).getAnAccess()), kind)
   )
   or
-  exists(Function f, ThisExpr innerThis |
+  exists(Function f, ThisExpr innerThis, Expr likeInnerThis |
     // `e` is a call to a method that releases `this`, and `released`
     // is the object that is called
     (
@@ -110,7 +111,8 @@ private predicate exprReleases(Expr e, Expr released, string kind) {
     ) and
     e.(FunctionCall).getQualifier() = exprOrDereference(released) and
     innerThis.getEnclosingFunction() = f and
-    exprReleases(_, innerThis, kind)
+    globalValueNumber(innerThis) = globalValueNumber(likeInnerThis) and
+    exprReleases(_, likeInnerThis, kind)
   )
 }
 


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/5412.

Consider [this allocation](https://lgtm.com/projects/g/coin3d/coin/snapshot/f91ad7f35d0a659a39e5a1d30309b2db7ac0517a/files/src/shadows/SoShadowGroup.cpp?sort=name&dir=ASC&mode=heatmap#L391) which is being freed [here](https://lgtm.com/projects/g/coin3d/coin/snapshot/f91ad7f35d0a659a39e5a1d30309b2db7ac0517a/files/src/shadows/SoShadowGroup.cpp?sort=name&dir=ASC&mode=heatmap#L498) by a call to `unref`. At the very bottom of `unref` is this piece of code that does the actual free'ing:
```cpp
if (refcount == 0) {
  SoBase * base = const_cast<SoBase *>(this);
  base->destroy();
}
```
Prior to this PR, we did not recognize that the call to `base->destroy()` was free'ing `this`. This PR uses `GVN` to make this connection between `this` and `base`.

Performance looks fine on `coin3d/coin` and Linux. It doesn't seem to have a big impact on the usual ~80 projects on LGTM. I added the user of the issue's project to show that the change _does_ have an impact on their specific codebase: https://lgtm.com/query/1742353848607434356/

<s>I suppose we could make a similar extension to the other recursive case in `exprReleases`, but for simplicity, I chose to keep that one as-is.</s> The change was so simple that I extended the other case as well in 2abf4c068f79785126a617a40b048c064b786f36. The only change on the 80 projects is still just the original user's project: https://lgtm.com/query/8218180625489198233/