### PR TITLE
JS: Step through replace() callbacks and make MetacharEscapeSanitizer more precise

### DIFF
--- a/javascript/change-notes/2021-03-17-precise-regex-replace.md
+++ b/javascript/change-notes/2021-03-17-precise-regex-replace.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* The analysis of regular expression-based sanitization patterns has improved,
+  leading to more true-positive results, in particular for the XSS queries.

--- a/javascript/ql/src/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/StandardLibrary.qll
@@ -107,7 +107,7 @@ class StringReplaceCall extends DataFlow::MethodCallNode {
   }
 
   /** Gets the regular expression passed as the first argument to `replace`, if any. */
-  DataFlow::RegExpLiteralNode getRegExp() { result.flowsTo(getArgument(0)) }
+  DataFlow::RegExpCreationNode getRegExp() { result.flowsTo(getArgument(0)) }
 
   /** Gets a string that is being replaced by this call. */
   string getAReplacedString() {

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -1624,6 +1624,9 @@ class RegExpCreationNode extends DataFlow::SourceNode {
     result = this.(RegExpLiteralNode).getFlags()
   }
 
+  /** Holds if the constructed predicate has the `g` flag. */
+  predicate isGlobal() { RegExp::isGlobal(getFlags()) }
+
   /** Gets a data flow node referring to this regular expression. */
   private DataFlow::SourceNode getAReference(DataFlow::TypeTracker t) {
     t.start() and

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -697,8 +697,26 @@ module TaintTracking {
           name = "encodeURIComponent" or
           name = "decodeURIComponent"
         )
+        or
+        // In and out of .replace callbacks
+        exists(StringReplaceCall call |
+          // Into the callback if the regexp does not sanitize matches
+          hasWildcardReplaceRegExp(call) and
+          pred = call.getReceiver() and
+          succ = call.getReplacementCallback().getParameter(0)
+          or
+          // Out of the callback
+          pred = call.getReplacementCallback().getReturnNode() and
+          succ = call
+        )
       )
     }
+  }
+
+  /** Holds if the given call takes a regexp containing a wildcard. */
+  pragma[noinline]
+  private predicate hasWildcardReplaceRegExp(StringReplaceCall call) {
+    RegExp::isWildcardLike(call.getRegExp().getRoot().getAChild*())
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -28,19 +28,13 @@ module Shared {
   abstract class SanitizerGuard extends TaintTracking::SanitizerGuardNode { }
 
   /**
-   * A global regexp replacement involving an HTML meta-character, viewed as a sanitizer for
+   * A global regexp replacement involving the `<`, `'`, or `"` meta-character, viewed as a sanitizer for
    * XSS vulnerabilities.
-   *
-   * The XSS queries do not attempt to reason about correctness or completeness of sanitizers,
-   * so any such replacement stops taint propagation.
    */
   class MetacharEscapeSanitizer extends Sanitizer, StringReplaceCall {
     MetacharEscapeSanitizer() {
-      this.isGlobal() and
-      exists(RegExpConstant c |
-        c.getLiteral() = getRegExp().asExpr() and
-        c.getValue().regexpMatch("['\"&<>]")
-      )
+      isGlobal() and
+      RegExp::alwaysMatchesMetaCharacter(getRegExp().getRoot(), ["<", "'", "\""])
     }
   }
 

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -124,6 +124,11 @@ typeInferenceMismatch
 | static-capture-groups.js:2:17:2:24 | source() | static-capture-groups.js:27:14:27:22 | RegExp.$1 |
 | static-capture-groups.js:32:17:32:24 | source() | static-capture-groups.js:38:10:38:18 | RegExp.$1 |
 | static-capture-groups.js:42:12:42:19 | source() | static-capture-groups.js:43:14:43:22 | RegExp.$1 |
+| string-replace.js:3:13:3:20 | source() | string-replace.js:14:10:14:13 | data |
+| string-replace.js:3:13:3:20 | source() | string-replace.js:18:10:18:13 | data |
+| string-replace.js:3:13:3:20 | source() | string-replace.js:21:6:21:41 | safe(). ...  taint) |
+| string-replace.js:3:13:3:20 | source() | string-replace.js:22:6:22:48 | safe(). ...  taint) |
+| string-replace.js:3:13:3:20 | source() | string-replace.js:24:6:24:45 | taint.r ...  + '!') |
 | thisAssignments.js:4:17:4:24 | source() | thisAssignments.js:5:10:5:18 | obj.field |
 | thisAssignments.js:7:19:7:26 | source() | thisAssignments.js:8:10:8:20 | this.field2 |
 | tst.js:2:13:2:20 | source() | tst.js:4:10:4:10 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/string-replace.js
+++ b/javascript/ql/test/library-tests/TaintTracking/string-replace.js
@@ -1,0 +1,24 @@
+import 'dummy';
+
+let taint = source();
+
+taint.replace('foo', data => {
+    sink(data); // OK - can only be the value 'foo'
+});
+
+taint.replace(/\d+/, data => {
+    sink(data); // OK - can only be digits
+});
+
+taint.replace(/[^a-z]+/, data => {
+    sink(data); // NOT OK
+});
+
+taint.replace(/&[^&]+;/, data => {
+    sink(data); // NOT OK
+});
+
+sink(safe().replace('foo', data => taint)); // NOT OK
+sink(safe().replace('foo', data => data + taint)); // NOT OK
+
+sink(taint.replace('foo', data => data + '!')); // NOT OK -- propagates through replace call

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -269,6 +269,9 @@ nodes
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted |
+| sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:48:19:48:46 | tainted ... /g, '') |
+| sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search |
 | stored-xss.js:2:39:2:62 | documen ... .search |
 | stored-xss.js:3:35:3:58 | documen ... .search |
@@ -889,6 +892,7 @@ edges
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:33:29:33:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:38:29:38:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:45:29:45:35 | tainted |
+| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:23:29:23:35 | tainted | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' |
@@ -901,6 +905,8 @@ edges
 | sanitiser.js:38:29:38:35 | tainted | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
@@ -1310,6 +1316,7 @@ edges
 | sanitiser.js:33:21:33:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:33:21:33:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
 | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
+| sanitiser.js:48:19:48:46 | tainted ... /g, '') | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:48:19:48:46 | tainted ... /g, '') | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
 | stored-xss.js:5:20:5:52 | session ... ssion') | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') | Cross-site scripting vulnerability due to $@. | stored-xss.js:2:39:2:62 | documen ... .search | user-provided value |
 | stored-xss.js:8:20:8:48 | localSt ... local') | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:8:20:8:48 | localSt ... local') | Cross-site scripting vulnerability due to $@. | stored-xss.js:3:35:3:58 | documen ... .search | user-provided value |
 | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" | Cross-site scripting vulnerability due to $@. | stored-xss.js:3:35:3:58 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -276,6 +276,9 @@ nodes
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted |
+| sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:48:19:48:46 | tainted ... /g, '') |
+| sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search |
 | stored-xss.js:2:39:2:62 | documen ... .search |
 | stored-xss.js:3:35:3:58 | documen ... .search |
@@ -913,6 +916,7 @@ edges
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:33:29:33:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:38:29:38:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:45:29:45:35 | tainted |
+| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:23:29:23:35 | tainted | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' |
@@ -925,6 +929,8 @@ edges
 | sanitiser.js:38:29:38:35 | tainted | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/sanitiser.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/sanitiser.js
@@ -44,4 +44,6 @@ function test() {
   } else {
     elt.innerHTML = '<b>' + tainted + '</b>'; // NOT OK
   }
+
+  elt.innerHTML = tainted.replace(/<\w+/g, ''); // NOT OK
 }


### PR DESCRIPTION
Adds steps into and out of the callback of a `replace()` call and makes XSS sanitizer `MetacharEscapeSanitizer` more precise.

`MetacharEscapeSanitizer` previously treated any `replace` as a sanitizer if its RegExp contained any of the characters `'"<>&` (and the replace was global).

The original idea here was to have a seperate query flag bad sanitizers, but sometimes a RegExp just contains those characters but doesn't actually look like a sanitizer in any way, meaning that the 'bad sanitizer' queries can't flag it.

We now analyze the RegExp and require that for at least one of the characters `'"<`, it must match every occurrence of that character. I would have liked to require just `<`, but we still need to include `'"` to avoid FPs in quoted attribute values (even though it's bad style to not escape `<` in those cases).

We don't include `&>` anymore, as there is no context in which escaping `&` or `>` is sufficient on its own -- it must always be paired with one of the above to have any chance of being safe. Note that this doesn't mean you don't have to escape `&`, it just means it's _never enough on its own_ so we don't get FPs by omitting it.

[Evaluation](https://github.com/dsp-testing/asgerf-dca/tree/run/js/more-string-steps4/reports) (internal link) looks fine. A couple of new results were found.