### PR TITLE
JS: recognize client websockets as ClientRequests

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/WebSocket.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/WebSocket.qll
@@ -81,7 +81,7 @@ module ClientWebSocket {
   /**
    * A client WebSocket instance.
    */
-  class ClientSocket extends EventEmitter::Range, DataFlow::SourceNode {
+  class ClientSocket extends EventEmitter::Range, DataFlow::NewNode, ClientRequest::Range {
     SocketClass socketClass;
 
     ClientSocket() { this = socketClass.getAnInstantiation() }
@@ -90,6 +90,26 @@ module ClientWebSocket {
      * Gets the WebSocket library name.
      */
     LibraryName getLibrary() { result = socketClass.getLibrary() }
+
+    override DataFlow::Node getUrl() { result = getArgument(0) }
+
+    override DataFlow::Node getHost() { none() }
+
+    override DataFlow::Node getADataNode() {
+      exists(SendNode send |
+        send.getEmitter() = this and
+        result = send.getSentItem(_)
+      )
+    }
+
+    override DataFlow::Node getAResponseDataNode(string responseType, boolean promise) {
+      responseType = "json" and
+      promise = false and
+      exists(WebSocketReceiveNode receiver |
+        receiver.getEmitter() = this and
+        result = receiver.getReceivedItem(_)
+      )
+    }
   }
 
   /**

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -83,6 +83,7 @@ test_ClientRequest
 | tst.js:269:13:269:48 | httpPro ... ptions) |
 | tst.js:271:3:271:61 | proxy.w ... 080' }) |
 | tst.js:274:1:283:2 | httpPro ... true\\n}) |
+| tst.js:286:20:286:55 | new Web ... :8080') |
 test_getADataNode
 | tst.js:53:5:53:23 | axios({data: data}) | tst.js:53:18:53:21 | data |
 | tst.js:57:5:57:39 | axios.p ... data2}) | tst.js:57:19:57:23 | data1 |
@@ -121,6 +122,7 @@ test_getADataNode
 | tst.js:249:1:251:2 | form.su ... e();\\n}) | tst.js:246:26:246:43 | Buffer.from("foo") |
 | tst.js:249:1:251:2 | form.su ... e();\\n}) | tst.js:247:24:247:68 | request ... o.png') |
 | tst.js:257:1:262:2 | form.su ... rs()\\n}) | tst.js:255:25:255:35 | 'new_value' |
+| tst.js:286:20:286:55 | new Web ... :8080') | tst.js:288:21:288:35 | 'Hello Server!' |
 test_getHost
 | tst.js:87:5:87:39 | http.ge ...  host}) | tst.js:87:34:87:37 | host |
 | tst.js:89:5:89:23 | axios({host: host}) | tst.js:89:18:89:21 | host |
@@ -218,6 +220,7 @@ test_getUrl
 | tst.js:267:1:267:61 | httpPro ... 9000'}) | tst.js:267:37:267:59 | 'http:/ ... t:9000' |
 | tst.js:271:3:271:61 | proxy.w ... 080' }) | tst.js:271:33:271:58 | 'http:/ ... m:8080' |
 | tst.js:274:1:283:2 | httpPro ... true\\n}) | tst.js:275:13:281:5 | {\\n      ... ,\\n    } |
+| tst.js:286:20:286:55 | new Web ... :8080') | tst.js:286:34:286:54 | 'ws://l ... t:8080' |
 test_getAResponseDataNode
 | tst.js:19:5:19:23 | requestPromise(url) | tst.js:19:5:19:23 | requestPromise(url) | text | true |
 | tst.js:21:5:21:23 | superagent.get(url) | tst.js:21:5:21:23 | superagent.get(url) | stream | true |
@@ -284,3 +287,4 @@ test_getAResponseDataNode
 | tst.js:231:5:233:6 | needle. ... \\n    }) | tst.js:231:50:231:53 | body | json | false |
 | tst.js:235:5:237:6 | needle. ... \\n    }) | tst.js:235:67:235:70 | resp | fetch.response | false |
 | tst.js:235:5:237:6 | needle. ... \\n    }) | tst.js:235:73:235:76 | body | json | false |
+| tst.js:286:20:286:55 | new Web ... :8080') | tst.js:291:44:291:53 | event.data | json | false |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -281,3 +281,13 @@ httpProxy.createProxyServer({
     },
     changeOrigin: true
 }).listen(8000);
+
+function webSocket() {
+    const socket = new WebSocket('ws://localhost:8080');
+    socket.addEventListener('open', function (event) {
+        socket.send('Hello Server!');
+    });
+    socket.addEventListener('message', function (event) {
+        console.log("Data from server: " + event.data);
+    });
+}

--- a/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
@@ -57,6 +57,14 @@ nodes
 | tst.js:74:29:74:35 | req.url |
 | tst.js:76:19:76:25 | tainted |
 | tst.js:76:19:76:25 | tainted |
+| tst.js:81:9:81:52 | tainted |
+| tst.js:81:19:81:42 | url.par ... , true) |
+| tst.js:81:19:81:48 | url.par ... ).query |
+| tst.js:81:19:81:52 | url.par ... ery.url |
+| tst.js:81:29:81:35 | req.url |
+| tst.js:81:29:81:35 | req.url |
+| tst.js:83:19:83:25 | tainted |
+| tst.js:83:19:83:25 | tainted |
 edges
 | tst.js:14:9:14:52 | tainted | tst.js:18:13:18:19 | tainted |
 | tst.js:14:9:14:52 | tainted | tst.js:18:13:18:19 | tainted |
@@ -113,6 +121,13 @@ edges
 | tst.js:74:19:74:52 | url.par ... ery.url | tst.js:74:9:74:52 | tainted |
 | tst.js:74:29:74:35 | req.url | tst.js:74:19:74:42 | url.par ... , true) |
 | tst.js:74:29:74:35 | req.url | tst.js:74:19:74:42 | url.par ... , true) |
+| tst.js:81:9:81:52 | tainted | tst.js:83:19:83:25 | tainted |
+| tst.js:81:9:81:52 | tainted | tst.js:83:19:83:25 | tainted |
+| tst.js:81:19:81:42 | url.par ... , true) | tst.js:81:19:81:48 | url.par ... ).query |
+| tst.js:81:19:81:48 | url.par ... ).query | tst.js:81:19:81:52 | url.par ... ery.url |
+| tst.js:81:19:81:52 | url.par ... ery.url | tst.js:81:9:81:52 | tainted |
+| tst.js:81:29:81:35 | req.url | tst.js:81:19:81:42 | url.par ... , true) |
+| tst.js:81:29:81:35 | req.url | tst.js:81:19:81:42 | url.par ... , true) |
 #select
 | tst.js:18:5:18:20 | request(tainted) | tst.js:14:29:14:35 | req.url | tst.js:18:13:18:19 | tainted | The $@ of this request depends on $@. | tst.js:18:13:18:19 | tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
 | tst.js:20:5:20:24 | request.get(tainted) | tst.js:14:29:14:35 | req.url | tst.js:20:17:20:23 | tainted | The $@ of this request depends on $@. | tst.js:20:17:20:23 | tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
@@ -130,3 +145,4 @@ edges
 | tst.js:64:3:64:38 | client. ... inted}) | tst.js:58:29:58:35 | req.url | tst.js:64:30:64:36 | tainted | The $@ of this request depends on $@. | tst.js:64:30:64:36 | tainted | URL | tst.js:58:29:58:35 | req.url | a user-provided value |
 | tst.js:68:3:68:38 | client. ... inted}) | tst.js:58:29:58:35 | req.url | tst.js:68:30:68:36 | tainted | The $@ of this request depends on $@. | tst.js:68:30:68:36 | tainted | URL | tst.js:58:29:58:35 | req.url | a user-provided value |
 | tst.js:76:5:76:26 | JSDOM.f ... ainted) | tst.js:74:29:74:35 | req.url | tst.js:76:19:76:25 | tainted | The $@ of this request depends on $@. | tst.js:76:19:76:25 | tainted | URL | tst.js:74:29:74:35 | req.url | a user-provided value |
+| tst.js:83:5:83:26 | new Web ... ainted) | tst.js:81:29:81:35 | req.url | tst.js:83:19:83:25 | tainted | The $@ of this request depends on $@. | tst.js:83:19:83:25 | tainted | URL | tst.js:81:29:81:35 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-918/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-918/tst.js
@@ -75,3 +75,10 @@ var server = http.createServer(async function(req, res) {
 
     JSDOM.fromURL(tainted); // NOT OK
 });
+
+import {JSDOM} from "jsdom";
+var server = http.createServer(async function(req, res) {
+    var tainted = url.parse(req.url, true).query.url;
+
+    new WebSocket(tainted); // NOT OK
+});


### PR DESCRIPTION
Recognizes the sink in CVE-2021-21322 (I'm about 95% sure it's the right sink for the CVE).  

[Evaluation looks fine](https://github.com/dsp-testing/erik-krogh-dca/tree/run/clientSocket-nightly-security-3/reports), no change in results or performance. 