### PR TITLE
Java: CWE-327 Query to detect insecure cipher suites and protocols in Tomcat server configuration

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-327/InsecureTomcatCipherConfig.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/InsecureTomcatCipherConfig.qhelp
@@ -1,0 +1,46 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>The Apache Tomcat server is the most widely used application server for deploying Java 
+  EE applications. Tomcat allows to configure cipher suites and TLS/SSL protocols in its 
+  configuration file <code>server.xml</code>. A cipher suite is a set of cryptographic 
+  algorithms used during SSL or TLS sessions to secure network connections between the client 
+  and the server. The set of algorithms that cipher suites usually contain include: a key 
+  exchange algorithm, a bulk encryption algorithm, and a Message Authentication Code 
+  (MAC) algorithm.</p>
+  
+<p>Old versions of TLS/SSL protocols such as SSLv3 and TLSv1, and old versions of cipher suites 
+  with encryption ciphers such as RC4 and 3DES, and message authentication algorithms such as 
+  SHA1 and MD5 offer insufficient transport layer protection therefore are vulnerable to attacks.</p>
+</overview>
+
+<recommendation>
+<p>Only use strong TLS protocols such as TLSv1.3 and strong cipher suites such as 
+  <code>TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384</code> as of 2021.</p>
+</recommendation>
+
+<example>
+<p>The following two examples show two ways of configuring protocols and cipher suites. In the 
+  'BAD' case, weak protocols and cipher suites are enabled. In the 'GOOD' case, only strong 
+  protocols and cipher suites are enabled.</p>
+<sample src="server.xml" />
+</example>
+
+<references>
+<li>
+  OWASP:
+  <a href="https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection">WSTG - v4.1 Weak SSL TLS Ciphers</a>
+</li>
+
+<li>
+  Louisiana State University:
+  <a href="https://grok.lsu.edu/article.aspx?articleid=17596">Recommendations: SSL/TLS Protocols and Cipher Suites</a>
+</li>
+
+<li>
+  Apache Tomcat 9 Configuration Reference:
+  <a href="https://tomcat.apache.org/tomcat-9.0-doc/config/http.html">The HTTP Connector</a>
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-327/InsecureTomcatCipherConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/InsecureTomcatCipherConfig.ql
@@ -1,0 +1,93 @@
+/**
+ * @name Insecure Cipher Suites and Protocols in Tomcat Server Configuration
+ * @description Obsolete TLS/SSL protocols, and obsolete cipher suites or null cipher is configured
+ * in the Tomcat server, which offers insufficient transport layer protection.
+ * @kind problem
+ * @id java/insecure-tomcat-cipher-config
+ * @tags security
+ *       external/cwe-327
+ *       external/cwe-310
+ */
+
+import java
+import ServerXML
+
+/**
+ * Holds if obsolete protocols are allowed. `TLSv1.2` & `TLSv1.3` is expected to be explicitly enabled.
+ * `TLSv1.1` may also be accepted since the protocol itself doesn't have known security issues. The
+ * check excludes SSLv2, SSLv3, and TLSv1 using regex for explicitly specified obsolete protocols without
+ * the starting "-".
+ */
+predicate allowInsecureProtocol(ServerConnector connector) {
+  exists(string protocol |
+    (
+      protocol = connector.getJseeSslProtocol()
+      or
+      protocol = connector.getEnabledJseeSslProtocols()
+      or
+      protocol = connector.getEnabledAprSslProtocols()
+      or
+      exists(ServerSSLHostConfig hostConfig |
+        hostConfig.getParent() = connector and protocol = hostConfig.getProtocols()
+      )
+    ) and
+    (
+      protocol = "all" // SSLv2Hello,TLSv1,TLSv1.1,TLSv1.2,TLSv1.3
+      or
+      protocol.regexpMatch(".*(?<!-)(SSLv2|SSLv3|TLSv1([^.]|$)).*") // e.g. all -TLSv1.1 -TLSv1 -SSLv2 -SSLv3
+    )
+  )
+}
+
+/**
+ * Holds if insecure TLS/SSL cipher suites are enabled. The simple check excludes null/RC4/3DES/CBC
+ * encryption algorithms and MD5/SHA-1 hash algorithms using a regex for explicitly specified weak
+ * cipher suites without the starting "-" or "!".
+ */
+predicate allowInsecureCipherSuites(ServerConnector connector) {
+  exists(string ciphers |
+    (
+      ciphers = connector.getJseeCiphers() // e.g. TLS_RSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_ECDSA_WITH_NULL_SHA
+      or
+      ciphers = connector.getAprCiphers() // e.g. ALL:+HIGH:!ADH:!EXP:!SSLv2:!SSLv3:!MEDIUM:!LOW:!NULL:!aNULL
+      or
+      exists(ServerSSLHostConfig hostConfig |
+        hostConfig.getParent() = connector and ciphers = hostConfig.getCiphers()
+      )
+    ) and
+    ciphers
+        .regexpMatch([
+            ".*(?<![-!])\\b(?:\\w+(?:NULL|RC4|3DES|CBC)\\w+|\\w+(MD5|SHA))\\b(?:,.*|$)",
+            ".*(?<![-!])\\b(NULL|SSLv2|SSLv3)\\b(?::.*|$)"
+          ])
+  )
+}
+
+/**
+ * Holds if the `ServerXMLFile` serverFile is a non-production deployment file indicated by:
+ *    a) in a non-production directory
+ *    b) with a non-production file name
+ */
+predicate isNonProdConfig(ServerXMLFile serverFile) {
+  serverFile.getFile().getAbsolutePath().matches(["%dev%", "%test%", "%sample%"])
+}
+
+from ServerConnector connector
+where
+  (
+    connector.isHttpsScheme() and
+    connector.isSecure()
+    or
+    connector.isSSLEnabled()
+  ) and
+  (
+    allowInsecureProtocol(connector) or
+    allowInsecureCipherSuites(connector)
+  ) and
+  not connector.isProxy() and
+  (
+    not isNonProdConfig(connector.getFile()) or
+    connector.getFile().getAbsolutePath().matches("%codeql%") // CodeQL test cases
+  )
+select connector,
+  "Tomcat server configuration should not allow obsolete protocols and/or weak cipher suites"

--- a/java/ql/src/experimental/Security/CWE/CWE-327/ServerXML.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/ServerXML.qll
@@ -1,0 +1,120 @@
+/**
+ * Provides classes for analyzing the Apache Tomcat `server.xml`.
+ */
+
+import java
+
+/**
+ * Holds if any `server.xml` files are included in this snapshot.
+ */
+predicate isServerXMLIncluded() { exists(ServerXMLFile serverXML) }
+
+/**
+ * The main server configuration file, typically called `server.xml` used by Apache Tomcat.
+ */
+class ServerXMLFile extends XMLFile {
+  ServerXMLFile() {
+    count(XMLElement e | e = this.getAChild()) = 1 and
+    this.getAChild().getName() = "Server"
+  }
+}
+
+/**
+ * An XML element in a `ServerXMLFile`.
+ */
+class ServerXMLElement extends XMLElement {
+  ServerXMLElement() { this.getFile() instanceof ServerXMLFile }
+
+  /**
+   * Gets the value for this element, with leading and trailing whitespace trimmed.
+   */
+  string getValue() { result = allCharactersString().trim() }
+}
+
+/**
+ * The root `<Server>` element in a `server.xml` file.
+ */
+class Server extends ServerXMLElement {
+  Server() { getName() = "Server" }
+}
+
+/**
+ * The `<Service>` element in a `server.xml` file.
+ */
+class ServerService extends ServerXMLElement {
+  ServerService() {
+    getName() = "Service" and
+    getAttributeValue("name").trim() = "Catalina" and
+    getParent() instanceof Server
+  }
+}
+
+/**
+ * A `<Connector>` element in a `server.xml` file, nested under a `<Service>` element.
+ */
+class ServerConnector extends ServerXMLElement {
+  ServerConnector() {
+    getName() = "Connector" and
+    getParent() instanceof ServerService
+  }
+
+  /** Holds if the scheme is `https` for an SSL Connector. */
+  predicate isHttpsScheme() { getAttributeValue("scheme").trim() = "https" }
+
+  /** Holds if the connector is used as a proxy. */
+  predicate isProxy() { exists(XMLAttribute attr | attr = getAttribute("proxyName")) }
+
+  /**
+   * Holds if the `secure` attribute is set to `true` on an SSL Connector or a non SSL connector
+   * that is receiving SSL data.
+   */
+  predicate isSecure() { getAttributeValue("secure").trim() = "true" }
+
+  /** Holds if SSL traffic is enabled on a connector. */
+  predicate isSSLEnabled() { getAttributeValue("SSLEnabled").trim() = "true" }
+
+  /** Protocol of the connector, which can be JSSE (NIO/NIO2) or Native (APR). */
+  string getProtocol() { result = getAttributeValue("protocol").trim() }
+
+  /** TLS/SSL protocol configuration specific to JSEE connectors, default to TLS and deprecated in v8.5. */
+  string getJseeSslProtocol() { result = getAttributeValue("sslProtocol").trim() }
+
+  /** Enabled TLS/SSL protocol configuration specific to JSEE connectors, deprecated in v8.5. */
+  string getEnabledJseeSslProtocols() { result = getAttributeValue("sslEnabledProtocols").trim() }
+
+  /** Enabled TLS/SSL protocol configuration specific to APR connectors, deprecated in v8.5. */
+  string getEnabledAprSslProtocols() { result = getAttributeValue("SSLProtocol").trim() }
+
+  /** Cipher configuration specific to JSEE connectors, deprecated in v8.5. */
+  string getJseeCiphers() { result = getAttributeValue("ciphers").trim() }
+
+  /** Cipher configuration specific to APR connectors, deprecated in v8.5. */
+  string getAprCiphers() { result = getAttributeValue("SSLCipherSuite").trim() }
+}
+
+/**
+ * A `<SSLHostConfig>` element in a `server.xml` file, nested under a `<Connector>` element. It is a
+ * new configuration in v8.5 and above that supports multiple TLS virtual hosts for a single connector
+ * with each virtual host able to support multiple certificates.
+ */
+class ServerSSLHostConfig extends ServerXMLElement {
+  ServerSSLHostConfig() {
+    getName() = "SSLHostConfig" and
+    getParent() instanceof ServerConnector
+  }
+
+  /**
+   * Allowed TLS/SSL protocols, which can be `SSLv2Hello`, `SSLv3`, `TLSv1`, `TLSv1.1`, `TLSv1.2`,
+   * `TLSv1.3`, or `all` and the default value is `all`. Each token in the list can be prefixed with
+   * a plus sign ("+") or a minus sign ("-"). A plus sign adds the protocol, a minus sign removes it
+   * from the current list.
+   */
+  string getProtocols() { result = getAttributeValue("protocols").trim() }
+
+  /**
+   * The ciphers to enable using the OpenSSL syntax. Alternatively, a comma separated list of ciphers
+   * using the standard OpenSSL cipher names or the standard JSSE cipher names may be used. The default
+   * value is `HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!kRSA`.
+   */
+  string getCiphers() { result = getAttributeValue("ciphers").trim() }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-327/server.xml
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/server.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Server port="8005" shutdown="SHUTDOWN">
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="80" protocol="HTTP/1.1" connectionTimeout="20000" redirectPort="443" />
+    <Connector port="8080" protocol="HTTP/1.1" connectionTimeout="20000" />
+
+    <!-- BAD: weak protocols and cipher suites are enabled. -->
+    <Connector port="443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig protocols="all" ciphers="TLS_RSA_WITH_AES_128_CBC_SHA256, TLS_RSA_WITH_AES_256_CBC_SHA256, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_CBC_SHA">
+                <Certificate certificateKeyFile="conf/privkey.pem"
+                             certificateFile="conf/fullchain.pem"
+                             certificateChainFile="conf/fullchain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+
+    <!-- GOOD: only strong protocols and cipher suites are enabled. -->
+    <Connector port="443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig protocols="TLSv1.2" ciphers="TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384">
+                <Certificate certificateKeyFile="conf/privkey.pem"
+                             certificateFile="conf/fullchain.pem"
+                             certificateChainFile="conf/fullchain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="443" />
+
+    <!-- You should set jvmRoute yearEnd support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <Context path="corpapp" docBase="corpapp"/>
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent yearEnd using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/java/ql/test/experimental/query-tests/security/CWE-327/InsecureTomcatCipherConfig.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-327/InsecureTomcatCipherConfig.expected
@@ -1,0 +1,2 @@
+| server2.xml:93:5:101:17 | Connector | Tomcat server configuration should not allow obsolete protocols and/or weak cipher suites |
+| server.xml:115:1:118:3 | Connector | Tomcat server configuration should not allow obsolete protocols and/or weak cipher suites |

--- a/java/ql/test/experimental/query-tests/security/CWE-327/InsecureTomcatCipherConfig.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-327/InsecureTomcatCipherConfig.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-327/InsecureTomcatCipherConfig.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-327/server.xml
+++ b/java/ql/test/experimental/query-tests/security/CWE-327/server.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 80
+    -->
+    <Connector port="80" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="443" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="80" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="443" />
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the
+         AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    -->
+    <!--
+    <Connector port="443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!-- 
+    <Connector port="443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" SSLProtocol="all -TLSv1.1 -TLSv1 -SSLv2 -SSLv3" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+    
+<Connector protocol="org.apache.coyote.http11.Http11NioProtocol" port="443" maxThreads="200" scheme="https" secure="true" SSLEnabled="true"
+           keystoreFile="/usr/local/apache-tomcat-8.5.9/keystore/mykeystore" keystorePass="myKeystorepass" clientAuth="false" sslProtocol="TLS" 
+           ciphers="TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_ECDH_ECDSA_WITH_RC4_128_SHA,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDH_RSA_WITH_RC4_128_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_RC4_128_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDH_ECDSA_WITH_NULL_SHA,TLS_ECDH_RSA_WITH_NULL_SHA,TLS_ECDHE_ECDSA_WITH_NULL_SHA"
+/>
+
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="443" />
+
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/java/ql/test/experimental/query-tests/security/CWE-327/server2.xml
+++ b/java/ql/test/experimental/query-tests/security/CWE-327/server2.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed yearEnd the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file yearEnd You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed yearEnd in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due yearEnd use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm yearEnd authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="80" protocol="HTTP/1.1" connectionTimeout="20000" redirectPort="443" />
+    <Connector port="8080" protocol="HTTP/1.1" connectionTimeout="20000" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the
+         AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    --><!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA"/>
+        </SSLHostConfig>
+    </Connector>-->
+    <Connector port="443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig protocols="all" ciphers="TLS_RSA_WITH_AES_128_CBC_SHA256, TLS_RSA_WITH_AES_256_CBC_SHA256, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_CBC_SHA">
+                <Certificate certificateKeyFile="conf/privkey.pem"
+                             certificateFile="conf/fullchain.pem"
+                             certificateChainFile="conf/fullchain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="443" />
+
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on yearEnd the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute yearEnd support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how yearEnd)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm yearEnd prevent attempts yearEnd guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <Context path="corpapp" docBase="corpapp"/>
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent yearEnd using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>


### PR DESCRIPTION
The Apache Tomcat server is the most widely used application server for deploying Java EE applications. Tomcat allows to configure cipher suites and TLS/SSL protocols in its configuration file <code>server.xml</code>. A cipher suite is a set of cryptographic algorithms used during SSL or TLS sessions to secure network connections between the client and the server. The set of algorithms that cipher suites usually include: a key exchange algorithm, a bulk encryption algorithm, and a Message Authentication Code (MAC) algorithm.
  
Old versions of TLS/SSL protocols such as <code>SSLv3</code> and <code>TLSv1</code>, and old versions of cipher suites with encryption ciphers such as <code>RC4</code> and <code>3DES</code>, and message authentication algorithms such as <code>SHA1</code> and <code>MD5</code> offer insufficient transport layer protection therefore are vulnerable to attacks.

The query detects the following two scenarios:
- insecure protocols configured
- insecure ciphers configured

As strength of cipher suites change over time, the query doesn't check hardcoded cipher suites to make the query more flexible. Instead it checks known ciphers such as <code>RC4</code>, <code>CBC</code>, and <code>SHA-1</code>.

Please consider to merge the PR. Thanks. 