### PR TITLE
JS: Recognize object transformations to exported values when looking for library inputs

### DIFF
--- a/javascript/change-notes/2021-03-19-async-execute.md
+++ b/javascript/change-notes/2021-03-19-async-execute.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* The command injection security queries now recognize additional sinks.
+  Affected packages are
+    [async-execute](https://npmjs.com/package/async-execute)

--- a/javascript/ql/src/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/src/semmle/javascript/PackageExports.qll
@@ -42,7 +42,7 @@ PackageJSON getTopmostPackageJSON() {
  * Gets a value exported by the main module from one of the topmost `package.json` files (see `getTopmostPackageJSON`).
  * The value is either directly the `module.exports` value, a nested property of `module.exports`, or a method on an exported class.
  */
-DataFlow::Node getAValueExportedByPackage() {
+private DataFlow::Node getAValueExportedByPackage() {
   result = getAnExportFromModule(getTopmostPackageJSON().getMainModule())
   or
   result = getAValueExportedByPackage().(DataFlow::PropWrite).getRhs()
@@ -72,7 +72,7 @@ DataFlow::Node getAValueExportedByPackage() {
   )
   or
   // *****
-  // Various standard library methods for transforming exported objects.
+  // Common styles of transforming exported objects.
   // *****
   //
   // Object.defineProperties
@@ -96,7 +96,7 @@ DataFlow::Node getAValueExportedByPackage() {
           .getAReturn()
   )
   or
-  // Object.assign
+  // Object.assign and friends
   exists(ExtendCall assign |
     getAValueExportedByPackage() = [assign, assign.getDestinationOperand()] and
     result = assign.getASourceOperand()
@@ -113,7 +113,7 @@ DataFlow::Node getAValueExportedByPackage() {
     result = map.getReceiver()
   )
   or
-  // Object.{fromEntries, freeze, entries, values}
+  // Object.{fromEntries, freeze, seal, entries, values}
   exists(DataFlow::MethodCallNode freeze |
     freeze =
       DataFlow::globalVarRef("Object")

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
@@ -253,6 +253,12 @@ class TypeBackTracker extends TTypeBackTracker {
   predicate start() { hasReturn = false and prop = "" }
 
   /**
+   * Holds if this is the starting point of type backtracking, and the value is in the property named `propName`.
+   * The type tracking only ends after the property has been stored.
+   */
+  predicate isInProp(PropertyName propName) { hasReturn = false and prop = propName }
+
+  /**
    * Holds if this is the end point of type tracking.
    */
   predicate end() { prop = "" }

--- a/javascript/ql/src/semmle/javascript/frameworks/SystemCommandExecutors.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SystemCommandExecutors.qll
@@ -43,9 +43,15 @@ private predicate execApi(string mod, int cmdArg, int optionsArg, boolean shell)
   )
   or
   shell = true and
-  mod = "exec" and
-  optionsArg = -2 and
-  cmdArg = 0
+  (
+    mod = "exec" and
+    optionsArg = -2 and
+    cmdArg = 0
+    or
+    mod = "async-execute" and
+    optionsArg = 1 and
+    cmdArg = 0
+  )
 }
 
 private class SystemCommandExecutors extends SystemCommandExecution, DataFlow::InvokeNode {

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
@@ -209,6 +209,10 @@ nodes
 | lib/lib.js:413:39:413:42 | name |
 | lib/lib.js:414:24:414:27 | name |
 | lib/lib.js:414:24:414:27 | name |
+| lib/lib.js:418:20:418:23 | name |
+| lib/lib.js:418:20:418:23 | name |
+| lib/lib.js:419:25:419:28 | name |
+| lib/lib.js:419:25:419:28 | name |
 edges
 | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name |
 | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name |
@@ -452,6 +456,10 @@ edges
 | lib/lib.js:413:39:413:42 | name | lib/lib.js:414:24:414:27 | name |
 | lib/lib.js:413:39:413:42 | name | lib/lib.js:414:24:414:27 | name |
 | lib/lib.js:413:39:413:42 | name | lib/lib.js:414:24:414:27 | name |
+| lib/lib.js:418:20:418:23 | name | lib/lib.js:419:25:419:28 | name |
+| lib/lib.js:418:20:418:23 | name | lib/lib.js:419:25:419:28 | name |
+| lib/lib.js:418:20:418:23 | name | lib/lib.js:419:25:419:28 | name |
+| lib/lib.js:418:20:418:23 | name | lib/lib.js:419:25:419:28 | name |
 #select
 | lib/lib2.js:4:10:4:25 | "rm -rf " + name | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name | $@ based on library input is later used in $@. | lib/lib2.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/lib2.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/lib2.js:8:10:8:25 | "rm -rf " + name | lib/lib2.js:7:32:7:35 | name | lib/lib2.js:8:22:8:25 | name | $@ based on library input is later used in $@. | lib/lib2.js:8:10:8:25 | "rm -rf " + name | String concatenation | lib/lib2.js:8:2:8:26 | cp.exec ... + name) | shell command |
@@ -511,3 +519,4 @@ edges
 | lib/lib.js:366:17:366:56 | "learn  ... + model | lib/lib.js:360:20:360:23 | opts | lib/lib.js:366:28:366:42 | this.learn_args | $@ based on library input is later used in $@. | lib/lib.js:366:17:366:56 | "learn  ... + model | String concatenation | lib/lib.js:367:3:367:18 | cp.exec(command) | shell command |
 | lib/lib.js:406:10:406:25 | "rm -rf " + name | lib/lib.js:405:39:405:42 | name | lib/lib.js:406:22:406:25 | name | $@ based on library input is later used in $@. | lib/lib.js:406:10:406:25 | "rm -rf " + name | String concatenation | lib/lib.js:406:2:406:26 | cp.exec ... + name) | shell command |
 | lib/lib.js:414:12:414:27 | "rm -rf " + name | lib/lib.js:413:39:413:42 | name | lib/lib.js:414:24:414:27 | name | $@ based on library input is later used in $@. | lib/lib.js:414:12:414:27 | "rm -rf " + name | String concatenation | lib/lib.js:414:2:414:28 | asyncEx ... + name) | shell command |
+| lib/lib.js:419:13:419:28 | "rm -rf " + name | lib/lib.js:418:20:418:23 | name | lib/lib.js:419:25:419:28 | name | $@ based on library input is later used in $@. | lib/lib.js:419:13:419:28 | "rm -rf " + name | String concatenation | lib/lib.js:419:3:419:29 | asyncEx ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
@@ -205,6 +205,10 @@ nodes
 | lib/lib.js:405:39:405:42 | name |
 | lib/lib.js:406:22:406:25 | name |
 | lib/lib.js:406:22:406:25 | name |
+| lib/lib.js:413:39:413:42 | name |
+| lib/lib.js:413:39:413:42 | name |
+| lib/lib.js:414:24:414:27 | name |
+| lib/lib.js:414:24:414:27 | name |
 edges
 | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name |
 | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name |
@@ -444,6 +448,10 @@ edges
 | lib/lib.js:405:39:405:42 | name | lib/lib.js:406:22:406:25 | name |
 | lib/lib.js:405:39:405:42 | name | lib/lib.js:406:22:406:25 | name |
 | lib/lib.js:405:39:405:42 | name | lib/lib.js:406:22:406:25 | name |
+| lib/lib.js:413:39:413:42 | name | lib/lib.js:414:24:414:27 | name |
+| lib/lib.js:413:39:413:42 | name | lib/lib.js:414:24:414:27 | name |
+| lib/lib.js:413:39:413:42 | name | lib/lib.js:414:24:414:27 | name |
+| lib/lib.js:413:39:413:42 | name | lib/lib.js:414:24:414:27 | name |
 #select
 | lib/lib2.js:4:10:4:25 | "rm -rf " + name | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name | $@ based on library input is later used in $@. | lib/lib2.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/lib2.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/lib2.js:8:10:8:25 | "rm -rf " + name | lib/lib2.js:7:32:7:35 | name | lib/lib2.js:8:22:8:25 | name | $@ based on library input is later used in $@. | lib/lib2.js:8:10:8:25 | "rm -rf " + name | String concatenation | lib/lib2.js:8:2:8:26 | cp.exec ... + name) | shell command |
@@ -502,3 +510,4 @@ edges
 | lib/lib.js:351:10:351:27 | "rm -rf " + unsafe | lib/lib.js:349:29:349:34 | unsafe | lib/lib.js:351:22:351:27 | unsafe | $@ based on library input is later used in $@. | lib/lib.js:351:10:351:27 | "rm -rf " + unsafe | String concatenation | lib/lib.js:351:2:351:28 | cp.exec ... unsafe) | shell command |
 | lib/lib.js:366:17:366:56 | "learn  ... + model | lib/lib.js:360:20:360:23 | opts | lib/lib.js:366:28:366:42 | this.learn_args | $@ based on library input is later used in $@. | lib/lib.js:366:17:366:56 | "learn  ... + model | String concatenation | lib/lib.js:367:3:367:18 | cp.exec(command) | shell command |
 | lib/lib.js:406:10:406:25 | "rm -rf " + name | lib/lib.js:405:39:405:42 | name | lib/lib.js:406:22:406:25 | name | $@ based on library input is later used in $@. | lib/lib.js:406:10:406:25 | "rm -rf " + name | String concatenation | lib/lib.js:406:2:406:26 | cp.exec ... + name) | shell command |
+| lib/lib.js:414:12:414:27 | "rm -rf " + name | lib/lib.js:413:39:413:42 | name | lib/lib.js:414:24:414:27 | name | $@ based on library input is later used in $@. | lib/lib.js:414:12:414:27 | "rm -rf " + name | String concatenation | lib/lib.js:414:2:414:28 | asyncEx ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
@@ -408,3 +408,8 @@ module.exports.sanitizer3 = function (name) {
 	var sanitized = yetAnohterSanitizer(name);
 	cp.exec("rm -rf " + sanitized); // OK
 }
+
+var asyncExec = require("async-execute");
+module.exports.asyncStuff = function (name) {
+	asyncExec("rm -rf " + name); // NOT OK
+}

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
@@ -413,3 +413,30 @@ var asyncExec = require("async-execute");
 module.exports.asyncStuff = function (name) {
 	asyncExec("rm -rf " + name); // NOT OK
 }
+
+const myFuncs = {
+	myFunc: function (name) {
+		asyncExec("rm -rf " + name); // NOT OK
+	}
+};
+
+module.exports.blabity = {};
+
+Object.defineProperties(
+	module.exports.blabity,
+	Object.assign(
+		{},
+		Object.entries(myFuncs).reduce(
+			(props, [ key, value ]) => Object.assign(
+				props,
+				{
+					[key]: {
+						value,
+						configurable: true,
+					},
+				},
+			),
+			{}
+		)
+	)
+);


### PR DESCRIPTION
And a drive-by model of `async-execute`.  

Gets a TP/TN for CVE-2021-3190 

I'll do a run-on-all together with https://github.com/github/codeql/pull/5439 before merging. 