### PR TITLE
JS: Fix query ID for UntrustedCheckout

### DIFF
--- a/javascript/ql/src/experimental/Security/CWE-094/UntrustedCheckout.ql
+++ b/javascript/ql/src/experimental/Security/CWE-094/UntrustedCheckout.ql
@@ -6,7 +6,7 @@
  * @kind problem
  * @problem.severity warning
  * @precision low
- * @id js/actions/pull_request_target
+ * @id js/actions/pull-request-target
  * @tags actions
  *       security
  *       external/cwe/cwe-094


### PR DESCRIPTION
The query ID should not contain underscores

@RasmusWL 