### PR TITLE
JS: expand outDir support in tsconfig files

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -407,7 +407,7 @@ public class AutoBuild {
     // codeql-javascript-*.json files
     patterns.add("**/.eslintrc*");
     patterns.add("**/package.json");
-    patterns.add("**/tsconfig.json");
+    patterns.add("**/tsconfig*.json");
     patterns.add("**/codeql-javascript-*.json");
 
     // include any explicitly specified extensions

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -43,7 +43,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2021-03-08";
+  public static final String EXTRACTOR_VERSION = "2021-03-19";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/slashAndExtension/index.js
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/slashAndExtension/index.js
@@ -1,0 +1,2 @@
+var foo1 = require('./lib/index.js');
+var foo2 = require('./src/index.ts');

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/slashAndExtension/package.json
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/slashAndExtension/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "foo",
+    "main": "./lib/index.js"
+}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/slashAndExtension/src/index.ts
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/slashAndExtension/src/index.ts
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/slashAndExtension/tsconfig.json
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/slashAndExtension/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig",
+    "compilerOptions": {
+        "module": "commonjs",
+        "rootDir": "./src",
+        "outDir": "./lib"
+    }
+}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/tests.expected
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/tests.expected
@@ -1,3 +1,4 @@
+resolveableImport
 | nonUniqueInclude/index.js:1:12:1:38 | require ... oo.js') | nonUniqueInclude/src/foo.ts:1:1:1:27 | <toplevel> |
 | nonUniqueInclude/index.js:2:12:2:39 | require ... oo.js') | nonUniqueInclude/src2/foo.ts:1:1:1:27 | <toplevel> |
 | nonUniqueInclude/index.js:3:12:3:34 | require ... oo.ts') | nonUniqueInclude/src/foo.ts:1:1:1:27 | <toplevel> |
@@ -10,3 +11,7 @@
 | simpleOutDir/index.js:2:12:2:36 | require ... ex.ts') | simpleOutDir/src/index.ts:1:1:1:27 | <toplevel> |
 | simpleOutDir/index.js:4:12:4:33 | require ... index') | simpleOutDir/src/index.ts:1:1:1:27 | <toplevel> |
 | simpleOutDir/index.js:5:12:5:33 | require ... index') | simpleOutDir/src/index.ts:1:1:1:27 | <toplevel> |
+| slashAndExtension/index.js:1:12:1:36 | require ... ex.js') | slashAndExtension/src/index.ts:1:1:1:27 | <toplevel> |
+| slashAndExtension/index.js:2:12:2:36 | require ... ex.ts') | slashAndExtension/src/index.ts:1:1:1:27 | <toplevel> |
+getMain
+| slashAndExtension/package.json:1:1:4:1 | {\\n    " ... x.js"\\n} | slashAndExtension/src/index.ts:1:1:1:27 | <toplevel> |

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/tests.ql
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/tests.ql
@@ -5,3 +5,5 @@ query predicate resolveableImport(Import imp, Module mod) {
   not imp.getTopLevel().isExterns() and
   not mod.getTopLevel().isExterns()
 }
+
+query Module getMain(PackageJSON json) { result = json.getMainModule() }


### PR DESCRIPTION
And also slightly expand which files are recognized as `tsconfig.json` files. 

Recognizes the source in CVE-2021-27405

[Evaluation looks fine](https://github.com/dsp-testing/erik-krogh-dca/tree/run/moreOutDir-nightly-security/reports). 