### PR TITLE
Java: Add value predicates for float and double literals; improve tests

### DIFF
--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -653,11 +653,23 @@ class LongLiteral extends Literal, @longliteral {
 
 /** A floating point literal. For example, `4.2f`. */
 class FloatingPointLiteral extends Literal, @floatingpointliteral {
+  /**
+   * Gets the value of this literal as CodeQL 64-bit `float`. The value will
+   * be parsed as Java 32-bit `float` and then converted to a CodeQL `float`.
+   */
+  float getFloatValue() { result = getValue().toFloat() }
+
   override string getAPrimaryQlClass() { result = "FloatingPointLiteral" }
 }
 
 /** A double literal. For example, `4.2`. */
 class DoubleLiteral extends Literal, @doubleliteral {
+  /**
+   * Gets the value of this literal as CodeQL 64-bit `float`. The result will
+   * have the same effective value as the Java `double` literal.
+   */
+  float getDoubleValue() { result = getValue().toFloat() }
+
   override string getAPrimaryQlClass() { result = "DoubleLiteral" }
 }
 

--- a/java/ql/test/library-tests/literals/literalBoolean.expected
+++ b/java/ql/test/library-tests/literals/literalBoolean.expected
@@ -1,1 +1,3 @@
-| literals/Literals.java:11:22:11:25 | true |
+| literals/Literals.java:11:22:11:25 | true | true | true |
+| literals/Literals.java:16:3:16:6 | true | true | true |
+| literals/Literals.java:17:3:17:7 | false | false | false |

--- a/java/ql/test/library-tests/literals/literalBoolean.ql
+++ b/java/ql/test/library-tests/literals/literalBoolean.ql
@@ -2,4 +2,4 @@ import semmle.code.java.Expr
 
 from BooleanLiteral lit
 where lit.getCompilationUnit().fromSource()
-select lit
+select lit, lit.getValue(), lit.getBooleanValue()

--- a/java/ql/test/library-tests/literals/literalChar.expected
+++ b/java/ql/test/library-tests/literals/literalChar.expected
@@ -1,1 +1,10 @@
-| literals/Literals.java:12:22:12:24 | 'x' |
+| literals/Literals.java:12:22:12:24 | 'x' | x |
+| literals/Literals.java:21:3:21:5 | 'a' | a |
+| literals/Literals.java:22:3:22:10 | '\\u0061' | a |
+| literals/Literals.java:23:3:23:10 | '\\u0000' | \u0000 |
+| literals/Literals.java:24:3:24:6 | '\\0' | \u0000 |
+| literals/Literals.java:25:3:25:6 | '\\n' | \n |
+| literals/Literals.java:26:3:26:6 | '\\0' | \u0000 |
+| literals/Literals.java:27:3:27:6 | '\\\\' | \\ |
+| literals/Literals.java:28:3:28:6 | '\\'' | ' |
+| literals/Literals.java:29:3:29:8 | '\\123' | S |

--- a/java/ql/test/library-tests/literals/literalChar.ql
+++ b/java/ql/test/library-tests/literals/literalChar.ql
@@ -1,4 +1,4 @@
 import semmle.code.java.Expr
 
 from CharacterLiteral lit
-select lit
+select lit, lit.getValue()

--- a/java/ql/test/library-tests/literals/literalDouble.expected
+++ b/java/ql/test/library-tests/literals/literalDouble.expected
@@ -1,1 +1,16 @@
-| literals/Literals.java:10:22:10:27 | 456.0D |
+| literals/Literals.java:10:22:10:27 | 456.0D | 456.0 | 456.0 |
+| literals/Literals.java:33:3:33:5 | 0.0 | 0.0 | 0.0 |
+| literals/Literals.java:34:3:34:4 | 0d | 0.0 | 0.0 |
+| literals/Literals.java:35:3:35:5 | .0d | 0.0 | 0.0 |
+| literals/Literals.java:36:3:36:4 | .0 | 0.0 | 0.0 |
+| literals/Literals.java:37:4:37:6 | 0.d | 0.0 | 0.0 |
+| literals/Literals.java:38:4:38:6 | 0.d | 0.0 | 0.0 |
+| literals/Literals.java:39:3:39:22 | 1.234567890123456789 | 1.2345678901234567 | 1.2345678901234567 |
+| literals/Literals.java:40:3:40:24 | 1.55555555555555555555 | 1.5555555555555556 | 1.5555555555555556 |
+| literals/Literals.java:42:3:42:5 | 1e1 | 10.0 | 10.0 |
+| literals/Literals.java:43:3:43:24 | 1.7976931348623157E308 | 1.7976931348623157E308 | 1.7976931348623157E308 |
+| literals/Literals.java:44:4:44:25 | 1.7976931348623157E308 | 1.7976931348623157E308 | 1.7976931348623157E308 |
+| literals/Literals.java:45:3:45:28 | 0x1.f_ffff_ffff_ffffP+1023 | 1.7976931348623157E308 | 1.7976931348623157E308 |
+| literals/Literals.java:46:3:46:10 | 4.9e-324 | 4.9E-324 | 4.9E-324 |
+| literals/Literals.java:47:3:47:28 | 0x0.0_0000_0000_0001P-1022 | 4.9E-324 | 4.9E-324 |
+| literals/Literals.java:48:3:48:13 | 0x1.0P-1074 | 4.9E-324 | 4.9E-324 |

--- a/java/ql/test/library-tests/literals/literalDouble.ql
+++ b/java/ql/test/library-tests/literals/literalDouble.ql
@@ -1,4 +1,4 @@
 import semmle.code.java.Expr
 
 from DoubleLiteral lit
-select lit
+select lit, lit.getValue(), lit.getDoubleValue()

--- a/java/ql/test/library-tests/literals/literalFloat.expected
+++ b/java/ql/test/library-tests/literals/literalFloat.expected
@@ -1,1 +1,16 @@
-| literals/Literals.java:9:22:9:27 | 123.0F |
+| literals/Literals.java:9:22:9:27 | 123.0F | 123.0 | 123.0 |
+| literals/Literals.java:52:3:52:6 | 0.0f | 0.0 | 0.0 |
+| literals/Literals.java:53:3:53:4 | 0f | 0.0 | 0.0 |
+| literals/Literals.java:54:3:54:5 | .0f | 0.0 | 0.0 |
+| literals/Literals.java:55:4:55:6 | 0.f | 0.0 | 0.0 |
+| literals/Literals.java:56:4:56:6 | 0.f | 0.0 | 0.0 |
+| literals/Literals.java:57:3:57:10 | 1_0_0.0f | 100.0 | 100.0 |
+| literals/Literals.java:58:3:58:23 | 1.234567890123456789f | 1.2345679 | 1.2345679 |
+| literals/Literals.java:59:3:59:25 | 1.55555555555555555555f | 1.5555556 | 1.5555556 |
+| literals/Literals.java:61:3:61:6 | 1e1f | 10.0 | 10.0 |
+| literals/Literals.java:62:3:62:15 | 3.4028235e38f | 3.4028235E38 | 3.4028235E38 |
+| literals/Literals.java:63:4:63:16 | 3.4028235e38f | 3.4028235E38 | 3.4028235E38 |
+| literals/Literals.java:64:3:64:18 | 0x1.fffffeP+127f | 3.4028235E38 | 3.4028235E38 |
+| literals/Literals.java:65:3:65:10 | 1.4e-45f | 1.4E-45 | 1.4E-45 |
+| literals/Literals.java:66:3:66:18 | 0x0.000002P-126f | 1.4E-45 | 1.4E-45 |
+| literals/Literals.java:67:3:67:13 | 0x1.0P-149f | 1.4E-45 | 1.4E-45 |

--- a/java/ql/test/library-tests/literals/literalFloat.ql
+++ b/java/ql/test/library-tests/literals/literalFloat.ql
@@ -1,4 +1,4 @@
 import semmle.code.java.Expr
 
 from FloatingPointLiteral lit
-select lit
+select lit, lit.getValue(), lit.getFloatValue()

--- a/java/ql/test/library-tests/literals/literalInteger.expected
+++ b/java/ql/test/library-tests/literals/literalInteger.expected
@@ -1,8 +1,20 @@
-| literals/Literals.java:7:22:7:24 | 123 |
-| literals/Literals.java:14:16:14:26 | -2147483648 |
-| literals/Literals.java:16:21:16:30 | 2147483647 |
-| literals/Literals.java:18:20:18:29 | 0x80000000 |
-| literals/Literals.java:20:10:20:11 | 23 |
-| literals/Literals.java:20:15:20:16 | 19 |
-| literals/Literals.java:21:10:21:11 | 23 |
-| literals/Literals.java:21:15:21:16 | 19 |
+| literals/Literals.java:7:22:7:24 | 123 | 123 | 123 |
+| literals/Literals.java:71:3:71:3 | 0 | 0 | 0 |
+| literals/Literals.java:72:3:72:5 | 0_0 | 0 | 0 |
+| literals/Literals.java:73:3:73:7 | 0___0 | 0 | 0 |
+| literals/Literals.java:74:3:74:6 | 0_12 | 10 | 10 |
+| literals/Literals.java:75:3:75:7 | 0X012 | 18 | 18 |
+| literals/Literals.java:76:3:76:10 | 0xaBcDeF | 11259375 | 11259375 |
+| literals/Literals.java:77:3:77:6 | 0B11 | 3 | 3 |
+| literals/Literals.java:78:3:78:12 | 0x80000000 | -2147483648 | -2147483648 |
+| literals/Literals.java:79:3:79:12 | 2147483647 | 2147483647 | 2147483647 |
+| literals/Literals.java:80:3:80:13 | -2147483648 | -2147483648 | -2147483648 |
+| literals/Literals.java:82:3:82:13 | 0x7fff_ffff | 2147483647 | 2147483647 |
+| literals/Literals.java:83:3:83:16 | 0177_7777_7777 | 2147483647 | 2147483647 |
+| literals/Literals.java:84:3:84:43 | 0b0111_1111_1111_1111_1111_1111_1111_1111 | 2147483647 | 2147483647 |
+| literals/Literals.java:85:3:85:13 | 0x8000_0000 | -2147483648 | -2147483648 |
+| literals/Literals.java:86:3:86:16 | 0200_0000_0000 | -2147483648 | -2147483648 |
+| literals/Literals.java:87:3:87:43 | 0b1000_0000_0000_0000_0000_0000_0000_0000 | -2147483648 | -2147483648 |
+| literals/Literals.java:88:3:88:13 | 0xffff_ffff | -1 | -1 |
+| literals/Literals.java:89:3:89:16 | 0377_7777_7777 | -1 | -1 |
+| literals/Literals.java:90:3:90:43 | 0b1111_1111_1111_1111_1111_1111_1111_1111 | -1 | -1 |

--- a/java/ql/test/library-tests/literals/literalInteger.ql
+++ b/java/ql/test/library-tests/literals/literalInteger.ql
@@ -1,4 +1,4 @@
 import semmle.code.java.Expr
 
 from IntegerLiteral lit
-select lit
+select lit, lit.getValue(), lit.getIntValue()

--- a/java/ql/test/library-tests/literals/literalLong.expected
+++ b/java/ql/test/library-tests/literals/literalLong.expected
@@ -1,4 +1,20 @@
-| literals/Literals.java:8:22:8:25 | 456L |
-| literals/Literals.java:15:18:15:38 | -9223372036854775808l |
-| literals/Literals.java:17:23:17:42 | 9223372036854775807l |
-| literals/Literals.java:19:22:19:40 | 0x8000000000000000L |
+| literals/Literals.java:8:22:8:25 | 456L | 456 |
+| literals/Literals.java:94:3:94:4 | 0l | 0 |
+| literals/Literals.java:95:3:95:4 | 0L | 0 |
+| literals/Literals.java:96:3:96:6 | 0_0L | 0 |
+| literals/Literals.java:97:3:97:8 | 0___0L | 0 |
+| literals/Literals.java:98:3:98:7 | 0_12L | 10 |
+| literals/Literals.java:99:3:99:8 | 0X012L | 18 |
+| literals/Literals.java:100:3:100:11 | 0xaBcDeFL | 11259375 |
+| literals/Literals.java:101:3:101:7 | 0B11L | 3 |
+| literals/Literals.java:102:3:102:22 | 9223372036854775807L | 9223372036854775807 |
+| literals/Literals.java:103:3:103:23 | -9223372036854775808L | -9223372036854775808 |
+| literals/Literals.java:105:3:105:24 | 0x7fff_ffff_ffff_ffffL | 9223372036854775807 |
+| literals/Literals.java:106:3:106:30 | 07_7777_7777_7777_7777_7777L | 9223372036854775807 |
+| literals/Literals.java:107:3:107:84 | 0b0111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111L | 9223372036854775807 |
+| literals/Literals.java:108:3:108:24 | 0x8000_0000_0000_0000L | -9223372036854775808 |
+| literals/Literals.java:109:3:109:31 | 010_0000_0000_0000_0000_0000L | -9223372036854775808 |
+| literals/Literals.java:110:3:110:84 | 0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L | -9223372036854775808 |
+| literals/Literals.java:111:3:111:24 | 0xffff_ffff_ffff_ffffL | -1 |
+| literals/Literals.java:112:3:112:31 | 017_7777_7777_7777_7777_7777L | -1 |
+| literals/Literals.java:113:3:113:84 | 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111L | -1 |

--- a/java/ql/test/library-tests/literals/literalLong.ql
+++ b/java/ql/test/library-tests/literals/literalLong.ql
@@ -1,4 +1,4 @@
 import semmle.code.java.Expr
 
 from LongLiteral lit
-select lit
+select lit, lit.getValue()

--- a/java/ql/test/library-tests/literals/literalString.expected
+++ b/java/ql/test/library-tests/literals/literalString.expected
@@ -1,6 +1,20 @@
-| literals/Literals.java:6:22:6:37 | "literal string" |
-| literals/Literals.java:22:22:22:38 | "hello" + "world" |
-| literals/Literals.java:23:24:23:47 | "hello" + ", " + "world" |
-| literals/Literals.java:24:23:24:52 | "hello" + ", " + "world" + "!" |
-| literals/Literals.java:25:22:25:36 | "hello,\\tworld" |
-| literals/Literals.java:26:30:26:48 | "hello,\\u0009world" |
+| literals/Literals.java:6:22:6:37 | "literal string" | literal string | literal string |
+| literals/Literals.java:117:3:117:19 | "hello" + "world" | helloworld | helloworld |
+| literals/Literals.java:118:3:118:17 | "hello,\\tworld" | hello,\tworld | hello,\tworld |
+| literals/Literals.java:119:3:119:21 | "hello,\\u0009world" | hello,\tworld | hello,\tworld |
+| literals/Literals.java:120:3:120:10 | "\\u0061" | a | a |
+| literals/Literals.java:121:3:121:6 | "\\0" | \u0000 | \u0000 |
+| literals/Literals.java:122:3:122:9 | "\\0000" | \u00000 | \u00000 |
+| literals/Literals.java:123:3:123:6 | "\\"" | " | " |
+| literals/Literals.java:124:3:124:6 | "\\'" | ' | ' |
+| literals/Literals.java:125:3:125:6 | "\\n" | \n | \n |
+| literals/Literals.java:126:3:126:6 | "\\\\" | \\ | \\ |
+| literals/Literals.java:127:3:127:13 | "test \\123" | test S | test S |
+| literals/Literals.java:128:3:128:9 | "\\1234" | S4 | S4 |
+| literals/Literals.java:129:3:129:13 | "\\u0061567" | a567 | a567 |
+| literals/Literals.java:130:3:130:13 | "\\u1234567" | \u1234567 | \u1234567 |
+| literals/Literals.java:131:3:131:18 | "\\uaBcDeF\\u0aB1" | \uabcdeF\u0ab1 | \uabcdeF\u0ab1 |
+| literals/Literals.java:132:3:132:16 | "\\uD800\\uDC00" | \ud800\udc00 | \ud800\udc00 |
+| literals/Literals.java:134:3:134:10 | "\\uD800" | ? | ? |
+| literals/Literals.java:135:3:135:10 | "\\uDC00" | ? | ? |
+| literals/Literals.java:136:3:136:31 | "hello\\uD800hello\\uDC00world" | hello?hello?world | hello?hello?world |

--- a/java/ql/test/library-tests/literals/literalString.ql
+++ b/java/ql/test/library-tests/literals/literalString.ql
@@ -2,4 +2,4 @@ import semmle.code.java.Expr
 
 from StringLiteral lit
 where lit.getFile().(CompilationUnit).fromSource()
-select lit
+select lit, lit.getValue(), lit.getRepresentedString()

--- a/java/ql/test/library-tests/literals/literals/Literals.java
+++ b/java/ql/test/library-tests/literals/literals/Literals.java
@@ -11,17 +11,128 @@ public class Literals {
 		System.out.println(true);
 		System.out.println('x');
 	}
-	int min_int = -2147483648;
-	long min_long = -9223372036854775808l;
-	int neg_max_int = -2147483647;
-	long neg_max_long = -9223372036854775807l;
-	int alt_min_int = 0x80000000;
-	long alt_min_long = 0x8000000000000000L;
-	int i = 23 + 19;
-	int j = 23  +19;
-	String twostrings = "hello" + "world";
-	String threestrings = "hello" + ", " + "world";
-	String fourstrings = "hello" + ", " + "world" + "!";
-	String escape_seq = "hello,\tworld";
-	String unicode_escape_seq = "hello,\u0009world";
+
+	boolean[] booleans = {
+		true,
+		false
+	};
+
+	char[] chars = {
+		'a',
+		'\u0061', // 'a'
+		'\u0000',
+		'\0',
+		'\n',
+		'\0',
+		'\\',
+		'\'',
+		'\123' // octal escape sequence for 'S'
+	};
+
+	double[] doubles = {
+		0.0,
+		0d,
+		.0d,
+		.0,
+		-0.d,
+		+0.d,
+		1.234567890123456789,
+		1.55555555555555555555,
+		// From the JLS
+		1e1,
+		1.7976931348623157E308,
+		-1.7976931348623157E308,
+		0x1.f_ffff_ffff_ffffP+1023,
+		4.9e-324,
+		0x0.0_0000_0000_0001P-1022,
+		0x1.0P-1074
+	};
+
+	float[] floats = {
+		0.0f,
+		0f,
+		.0f,
+		-0.f,
+		+0.f,
+		1_0_0.0f,
+		1.234567890123456789f,
+		1.55555555555555555555f,
+		// From the JLS
+		1e1f,
+		3.4028235e38f,
+		-3.4028235e38f,
+		0x1.fffffeP+127f,
+		1.4e-45f,
+		0x0.000002P-126f,
+		0x1.0P-149f
+	};
+
+	int[] ints = {
+		0,
+		0_0,
+		0___0,
+		0_12, // octal
+		0X012, // hex
+		0xaBcDeF, // hex
+		0B11, // binary
+		0x80000000,
+		2147483647,
+		-2147483648,
+		// From the JLS
+		0x7fff_ffff,
+		0177_7777_7777, // octal
+		0b0111_1111_1111_1111_1111_1111_1111_1111, // binary
+		0x8000_0000,
+		0200_0000_0000,
+		0b1000_0000_0000_0000_0000_0000_0000_0000,
+		0xffff_ffff,
+		0377_7777_7777,
+		0b1111_1111_1111_1111_1111_1111_1111_1111
+	};
+
+	long[] longs = {
+		0l,
+		0L,
+		0_0L,
+		0___0L,
+		0_12L, // octal
+		0X012L, // hex
+		0xaBcDeFL, // hex
+		0B11L, // binary
+		9223372036854775807L,
+		-9223372036854775808L,
+		// From the JLS
+		0x7fff_ffff_ffff_ffffL,
+		07_7777_7777_7777_7777_7777L, // octal
+		0b0111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111L, // binary
+		0x8000_0000_0000_0000L,
+		010_0000_0000_0000_0000_0000L,
+		0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L,
+		0xffff_ffff_ffff_ffffL,
+		017_7777_7777_7777_7777_7777L,
+		0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111L
+	};
+
+	String[] strings = {
+		"hello" + "world", // two separate literals
+		"hello,\tworld",
+		"hello,\u0009world",
+		"\u0061", // 'a'
+		"\0",
+		"\0000",
+		"\"",
+		"\'",
+		"\n",
+		"\\",
+		"test \123", // octal escape sequence for 'S'
+		"\1234", // octal escape followed by '4'
+		"\u0061567", // escape sequence for 'a' followed by "567"
+		"\u1234567", // '\u1234' followed by "567"
+		"\uaBcDeF\u0aB1", // '\uABCD' followed by "eF" followed by '\u0AB1'
+		"\uD800\uDC00", // surrogate pair
+		// Unpaired surrogates
+		"\uD800",
+		"\uDC00",
+		"hello\uD800hello\uDC00world"
+	};
 }


### PR DESCRIPTION
Adds the predicates:
- `FloatingPointLiteral.getFloatValue()`
- `DoubleLiteral.getDoubleValue()`

Improves existing literal tests.