### PR TITLE
Java: Query for detecting Jakarta Expression Language injections

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-094/FlowUtils.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/FlowUtils.qll
@@ -5,7 +5,7 @@ import semmle.code.java.dataflow.FlowSources
  * Holds if `fromNode` to `toNode` is a dataflow step that returns data from
  * a bean by calling one of its getters.
  */
-predicate returnsDataFromBean(DataFlow::Node fromNode, DataFlow::Node toNode) {
+predicate hasGetterFlow(DataFlow::Node fromNode, DataFlow::Node toNode) {
   exists(MethodAccess ma, Method m | ma.getMethod() = m |
     m instanceof GetterMethod and
     ma.getQualifier() = fromNode.asExpr() and

--- a/java/ql/src/experimental/Security/CWE/CWE-094/InjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/InjectionLib.qll
@@ -1,0 +1,14 @@
+import java
+import semmle.code.java.dataflow.FlowSources
+
+/**
+ * Holds if `fromNode` to `toNode` is a dataflow step that returns data from
+ * a bean by calling one of its getters.
+ */
+predicate returnsDataFromBean(DataFlow::Node fromNode, DataFlow::Node toNode) {
+  exists(MethodAccess ma, Method m | ma.getMethod() = m |
+    m instanceof GetterMethod and
+    ma.getQualifier() = fromNode.asExpr() and
+    ma = toNode.asExpr()
+  )
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.qhelp
@@ -1,0 +1,65 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+Jakarta Expression Language (EL) is an expression language for Java applications.
+There are a single language specification and multiple implementations
+such as Glassfish, Juel, Apache Commons EL, etc.
+The language allows invocation of methods available in the JVM.
+If an expression is built using attacker-controlled data,
+and then evaluated, then it may allow the attacker to run arbitrary code.
+</p>
+</overview>
+
+<recommendation>
+<p>
+It is generally recommended to avoid using untrusted data in an EL expression.
+Before using untrusted data to build an EL expressoin, the data should be validated
+to ensure it is not evaluated as expression language. If the EL implementaion offers
+configuring a sandbox for EL expression, they should be run in a restircitive sandbox
+that allows accessing only explicitly allowed classes. If the EL implementation
+does not allow sandboxing, consider using other expressiong language implementations
+with sandboxing capabilities such as Apache Commons JEXL or the Spring Expression Language.
+</p>
+</recommendation>
+
+<example>
+<p>
+The following example shows how untrusted data is used to build and run an expression
+using the JUEL interpreter:
+</p>
+<sample src="UnsafeExpressionEvaluationWithJUEL.java" />
+
+<p>
+JUEL does not allow to run expression in a sandbox. To prevent running arbitrary code,
+incoming data has to be checked before including to an expression. The next example
+uses a Regex pattern to check whether a user tries to run an allowed exression or not:
+</p>
+<sample src="SaferExpressionEvaluationWithJUEL.java" />
+
+</example>
+
+<references>
+<li>
+  Eclipse Foundation:
+  <a href="https://projects.eclipse.org/projects/ee4j.el">Jakarta Expression Language</a>.
+</li>
+<li>
+  Jakarta EE documentation:
+  <a href="https://javadoc.io/doc/jakarta.el/jakarta.el-api/latest/index.html">Jakarta Expression Language API</a>
+</li>
+<li>
+  OWASP:
+  <a href="https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection">Expression Language Injection</a>.
+</li>
+<li>
+  JUEL:
+  <a href="http://juel.sourceforge.net">Home page</a>
+</li>
+<li>
+  Apache Foundation:
+  <a href="https://commons.apache.org/dormant/commons-el/">Apache Commons EL</a>
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.qhelp
@@ -57,9 +57,5 @@ uses a Regex pattern to check whether a user tries to run an allowed expression 
   JUEL:
   <a href="http://juel.sourceforge.net">Home page</a>
 </li>
-<li>
-  Apache Foundation:
-  <a href="https://commons.apache.org/dormant/commons-el/">Apache Commons EL</a>
-</li>
 </references>
 </qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.qhelp
@@ -4,22 +4,22 @@
 <overview>
 <p>
 Jakarta Expression Language (EL) is an expression language for Java applications.
-There are a single language specification and multiple implementations
+There is a single language specification and multiple implementations
 such as Glassfish, Juel, Apache Commons EL, etc.
 The language allows invocation of methods available in the JVM.
 If an expression is built using attacker-controlled data,
-and then evaluated, then it may allow the attacker to run arbitrary code.
+and then evaluated, it may allow the attacker to run arbitrary code.
 </p>
 </overview>
 
 <recommendation>
 <p>
 It is generally recommended to avoid using untrusted data in an EL expression.
-Before using untrusted data to build an EL expressoin, the data should be validated
-to ensure it is not evaluated as expression language. If the EL implementaion offers
-configuring a sandbox for EL expression, they should be run in a restircitive sandbox
+Before using untrusted data to build an EL expression, the data should be validated
+to ensure it is not evaluated as expression language. If the EL implementation offers
+configuring a sandbox for EL expressions, they should be run in a restrictive sandbox
 that allows accessing only explicitly allowed classes. If the EL implementation
-does not allow sandboxing, consider using other expressiong language implementations
+does not support sandboxing, consider using other expression language implementations
 with sandboxing capabilities such as Apache Commons JEXL or the Spring Expression Language.
 </p>
 </recommendation>
@@ -32,9 +32,9 @@ using the JUEL interpreter:
 <sample src="UnsafeExpressionEvaluationWithJUEL.java" />
 
 <p>
-JUEL does not allow to run expression in a sandbox. To prevent running arbitrary code,
-incoming data has to be checked before including to an expression. The next example
-uses a Regex pattern to check whether a user tries to run an allowed exression or not:
+JUEL does not support to run expressions in a sandbox. To prevent running arbitrary code,
+incoming data has to be checked before including it in an expression. The next example
+uses a Regex pattern to check whether a user tries to run an allowed expression or not:
 </p>
 <sample src="SaferExpressionEvaluationWithJUEL.java" />
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.qhelp
@@ -29,14 +29,14 @@ with sandboxing capabilities such as Apache Commons JEXL or the Spring Expressio
 The following example shows how untrusted data is used to build and run an expression
 using the JUEL interpreter:
 </p>
-<sample src="UnsafeExpressionEvaluationWithJUEL.java" />
+<sample src="UnsafeExpressionEvaluationWithJuel.java" />
 
 <p>
-JUEL does not support to run expressions in a sandbox. To prevent running arbitrary code,
+JUEL does not support running expressions in a sandbox. To prevent running arbitrary code,
 incoming data has to be checked before including it in an expression. The next example
 uses a Regex pattern to check whether a user tries to run an allowed expression or not:
 </p>
-<sample src="SaferExpressionEvaluationWithJUEL.java" />
+<sample src="SaferExpressionEvaluationWithJuel.java" />
 
 </example>
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.ql
@@ -1,0 +1,20 @@
+/**
+ * @name Java EE Expression Language injection
+ * @description Evaluation of a user-controlled Jave EE expression
+ *              may lead to arbitrary code execution.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/javaee-expression-injection
+ * @tags security
+ *       external/cwe/cwe-094
+ */
+
+import java
+import JavaEEExpressionInjectionLib
+import DataFlow::PathGraph
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, JavaEEExpressionInjectionConfig conf
+where conf.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Java EE Expression Language injection from $@.",
+  source.getNode(), "this user input"

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.ql
@@ -1,6 +1,6 @@
 /**
- * @name Java EE Expression Language injection
- * @description Evaluation of a user-controlled Jave EE expression
+ * @name Jakarta Expression Language injection
+ * @description Evaluation of a user-controlled expression
  *              may lead to arbitrary code execution.
  * @kind path-problem
  * @problem.severity error
@@ -11,10 +11,10 @@
  */
 
 import java
-import JavaEEExpressionInjectionLib
+import JakartaExpressionInjectionLib
 import DataFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, JavaEEExpressionInjectionConfig conf
+from DataFlow::PathNode source, DataFlow::PathNode sink, JakartaExpressionInjectionConfig conf
 where conf.hasFlowPath(source, sink)
-select sink.getNode(), source, sink, "Java EE Expression Language injection from $@.",
+select sink.getNode(), source, sink, "Jakarta Expression Language injection from $@.",
   source.getNode(), "this user input"

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
@@ -77,22 +77,26 @@ private class TaintPropagatingCall extends Call {
   }
 }
 
-private class ELProcessor extends RefType {
-  ELProcessor() { hasQualifiedName("javax.el", "ELProcessor") }
+private class JakartaType extends RefType {
+  JakartaType() { getPackage().hasName(["javax.el", "jakarta.el"]) }
 }
 
-private class ExpressionFactory extends RefType {
-  ExpressionFactory() { hasQualifiedName("javax.el", "ExpressionFactory") }
+private class ELProcessor extends JakartaType {
+  ELProcessor() { hasName("ELProcessor") }
 }
 
-private class ValueExpression extends RefType {
-  ValueExpression() { hasQualifiedName("javax.el", "ValueExpression") }
+private class ExpressionFactory extends JakartaType {
+  ExpressionFactory() { hasName("ExpressionFactory") }
 }
 
-private class MethodExpression extends RefType {
-  MethodExpression() { hasQualifiedName("javax.el", "MethodExpression") }
+private class ValueExpression extends JakartaType {
+  ValueExpression() { hasName("ValueExpression") }
+}
+
+private class MethodExpression extends JakartaType {
+  MethodExpression() { hasName("MethodExpression") }
 }
 
 private class LambdaExpression extends RefType {
-  LambdaExpression() { hasQualifiedName("javax.el", "LambdaExpression") }
+  LambdaExpression() { hasName("LambdaExpression") }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
@@ -97,6 +97,6 @@ private class MethodExpression extends JakartaType {
   MethodExpression() { hasName("MethodExpression") }
 }
 
-private class LambdaExpression extends RefType {
+private class LambdaExpression extends JakartaType {
   LambdaExpression() { hasName("LambdaExpression") }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
@@ -5,10 +5,10 @@ import semmle.code.java.dataflow.TaintTracking
 
 /**
  * A taint-tracking configuration for unsafe user input
- * that is used to construct and evaluate a Java EE expression.
+ * that is used to construct and evaluate an expression.
  */
-class JavaEEExpressionInjectionConfig extends TaintTracking::Configuration {
-  JavaEEExpressionInjectionConfig() { this = "JavaEEExpressionInjectionConfig" }
+class JakartaExpressionInjectionConfig extends TaintTracking::Configuration {
+  JakartaExpressionInjectionConfig() { this = "JakartaExpressionInjectionConfig" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
@@ -22,7 +22,7 @@ class JavaEEExpressionInjectionConfig extends TaintTracking::Configuration {
 
 /**
  * A sink for Expresssion Language injection vulnerabilities,
- * i.e. method calls that run evaluation of a Java EE expression.
+ * i.e. method calls that run evaluation of an expression.
  */
 private class ExpressionEvaluationSink extends DataFlow::ExprNode {
   ExpressionEvaluationSink() {

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
@@ -44,6 +44,10 @@ private class ExpressionEvaluationSink extends DataFlow::ExprNode {
       m.getDeclaringType() instanceof ELProcessor and
       m.hasName(["eval", "getValue", "setValue"]) and
       ma.getArgument(0) = taintFrom
+      or
+      m.getDeclaringType() instanceof ELProcessor and
+      m.hasName("setVariable") and
+      ma.getArgument(1) = taintFrom
     )
   }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
@@ -56,15 +56,17 @@ private class TaintPropagatingCall extends Call {
 
   TaintPropagatingCall() {
     taintFromExpr = this.getArgument(1) and
-    exists(Method m | this.(MethodAccess).getMethod() = m |
-      m.getDeclaringType() instanceof ExpressionFactory and
-      m.hasName(["createValueExpression", "createMethodExpression"]) and
-      taintFromExpr.getType() instanceof TypeString
-    )
-    or
-    exists(Constructor c | this.(ConstructorCall).getConstructor() = c |
-      c.getDeclaringType() instanceof LambdaExpression and
-      taintFromExpr.getType() instanceof ValueExpression
+    (
+      exists(Method m | this.(MethodAccess).getMethod() = m |
+        m.getDeclaringType() instanceof ExpressionFactory and
+        m.hasName(["createValueExpression", "createMethodExpression"]) and
+        taintFromExpr.getType() instanceof TypeString
+      )
+      or
+      exists(Constructor c | this.(ConstructorCall).getConstructor() = c |
+        c.getDeclaringType() instanceof LambdaExpression and
+        taintFromExpr.getType() instanceof ValueExpression
+      )
     )
   }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
@@ -1,5 +1,5 @@
 import java
-import InjectionLib
+import FlowUtils
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.TaintTracking
 
@@ -16,7 +16,7 @@ class JakartaExpressionInjectionConfig extends TaintTracking::Configuration {
 
   override predicate isAdditionalTaintStep(DataFlow::Node fromNode, DataFlow::Node toNode) {
     any(TaintPropagatingCall c).taintFlow(fromNode, toNode) or
-    returnsDataFromBean(fromNode, toNode)
+    hasGetterFlow(fromNode, toNode)
   }
 }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjectionLib.qll
@@ -1,0 +1,98 @@
+import java
+import InjectionLib
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.dataflow.TaintTracking
+
+/**
+ * A taint-tracking configuration for unsafe user input
+ * that is used to construct and evaluate a Java EE expression.
+ */
+class JavaEEExpressionInjectionConfig extends TaintTracking::Configuration {
+  JavaEEExpressionInjectionConfig() { this = "JavaEEExpressionInjectionConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof ExpressionEvaluationSink }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node fromNode, DataFlow::Node toNode) {
+    any(TaintPropagatingCall c).taintFlow(fromNode, toNode) or
+    returnsDataFromBean(fromNode, toNode)
+  }
+}
+
+/**
+ * A sink for Expresssion Language injection vulnerabilities,
+ * i.e. method calls that run evaluation of a Java EE expression.
+ */
+private class ExpressionEvaluationSink extends DataFlow::ExprNode {
+  ExpressionEvaluationSink() {
+    exists(MethodAccess ma, Method m, Expr taintFrom |
+      ma.getMethod() = m and taintFrom = this.asExpr()
+    |
+      m.getDeclaringType() instanceof ValueExpression and
+      m.hasName(["getValue", "setValue"]) and
+      ma.getQualifier() = taintFrom
+      or
+      m.getDeclaringType() instanceof MethodExpression and
+      m.hasName("invoke") and
+      ma.getQualifier() = taintFrom
+      or
+      m.getDeclaringType() instanceof LambdaExpression and
+      m.hasName("invoke") and
+      ma.getQualifier() = taintFrom
+      or
+      m.getDeclaringType() instanceof ELProcessor and
+      m.hasName(["eval", "getValue", "setValue"]) and
+      ma.getArgument(0) = taintFrom
+    )
+  }
+}
+
+/**
+ * Defines method calls that propagate tainted expressions.
+ */
+private class TaintPropagatingCall extends Call {
+  Expr taintFromExpr;
+
+  TaintPropagatingCall() {
+    taintFromExpr = this.getArgument(1) and
+    exists(Method m | this.(MethodAccess).getMethod() = m |
+      m.getDeclaringType() instanceof ExpressionFactory and
+      m.hasName(["createValueExpression", "createMethodExpression"]) and
+      taintFromExpr.getType() instanceof TypeString
+    )
+    or
+    exists(Constructor c | this.(ConstructorCall).getConstructor() = c |
+      c.getDeclaringType() instanceof LambdaExpression and
+      taintFromExpr.getType() instanceof ValueExpression
+    )
+  }
+
+  /**
+   * Holds if `fromNode` to `toNode` is a dataflow step that propagates
+   * tainted data.
+   */
+  predicate taintFlow(DataFlow::Node fromNode, DataFlow::Node toNode) {
+    fromNode.asExpr() = taintFromExpr and toNode.asExpr() = this
+  }
+}
+
+private class ELProcessor extends RefType {
+  ELProcessor() { hasQualifiedName("javax.el", "ELProcessor") }
+}
+
+private class ExpressionFactory extends RefType {
+  ExpressionFactory() { hasQualifiedName("javax.el", "ExpressionFactory") }
+}
+
+private class ValueExpression extends RefType {
+  ValueExpression() { hasQualifiedName("javax.el", "ValueExpression") }
+}
+
+private class MethodExpression extends RefType {
+  MethodExpression() { hasQualifiedName("javax.el", "MethodExpression") }
+}
+
+private class LambdaExpression extends RefType {
+  LambdaExpression() { hasQualifiedName("javax.el", "LambdaExpression") }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JexlInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JexlInjectionLib.qll
@@ -1,5 +1,5 @@
 import java
-import InjectionLib
+import FlowUtils
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.TaintTracking
 
@@ -17,7 +17,7 @@ class JexlInjectionConfig extends TaintTracking::Configuration {
 
   override predicate isAdditionalTaintStep(DataFlow::Node fromNode, DataFlow::Node toNode) {
     any(TaintPropagatingJexlMethodCall c).taintFlow(fromNode, toNode) or
-    returnsDataFromBean(fromNode, toNode)
+    hasGetterFlow(fromNode, toNode)
   }
 }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JexlInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JexlInjectionLib.qll
@@ -1,4 +1,5 @@
 import java
+import InjectionLib
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.TaintTracking
 
@@ -149,18 +150,6 @@ private predicate createsJexlEngine(DataFlow::Node fromNode, DataFlow::Node toNo
     cc.getConstructedType() instanceof UnifiedJexl and
     cc.getArgument(0) = fromNode.asExpr() and
     cc = toNode.asExpr()
-  )
-}
-
-/**
- * Holds if `fromNode` to `toNode` is a dataflow step that returns data from
- * a bean by calling one of its getters.
- */
-private predicate returnsDataFromBean(DataFlow::Node fromNode, DataFlow::Node toNode) {
-  exists(MethodAccess ma, Method m | ma.getMethod() = m |
-    m instanceof GetterMethod and
-    ma.getQualifier() = fromNode.asExpr() and
-    ma = toNode.asExpr()
   )
 }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/SaferExpressionEvaluationWithJuel.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/SaferExpressionEvaluationWithJuel.java
@@ -1,7 +1,7 @@
 String input = getRemoteUserInput();
 String pattern = "(inside|outside)\\.(temperature|humidity)";
 if (!input.matches(pattern)) {
-    throw new IllegalArgumentException("Unexpected exression");
+    throw new IllegalArgumentException("Unexpected expression");
 }
 String expression = "${" + input + "}";
 ExpressionFactory factory = new de.odysseus.el.ExpressionFactoryImpl();

--- a/java/ql/src/experimental/Security/CWE/CWE-094/SaferExpressionEvaluationWithJuel.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/SaferExpressionEvaluationWithJuel.java
@@ -1,0 +1,10 @@
+String input = getRemoteUserInput();
+String pattern = "(inside|outside)\\.(temperature|humidity)";
+if (!input.matches(pattern)) {
+    throw new IllegalArgumentException("Unexpected exression");
+}
+String expression = "${" + input + "}";
+ExpressionFactory factory = new de.odysseus.el.ExpressionFactoryImpl();
+ValueExpression e = factory.createValueExpression(context, expression, Object.class);
+SimpleContext context = getContext();
+Object result = e.getValue(context);

--- a/java/ql/src/experimental/Security/CWE/CWE-094/UnsafeExpressionEvaluationWithJuel.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/UnsafeExpressionEvaluationWithJuel.java
@@ -1,0 +1,5 @@
+String expression = "${" + getRemoteUserInput() + "}";
+ExpressionFactory factory = new de.odysseus.el.ExpressionFactoryImpl();
+ValueExpression e = factory.createValueExpression(context, expression, Object.class);
+SimpleContext context = getContext();
+Object result = e.getValue(context);

--- a/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.expected
@@ -1,0 +1,59 @@
+edges
+| JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:24:31:24:40 | expression : String |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:30:24:30:33 | expression : String |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:37:24:37:33 | expression : String |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:44:24:44:33 | expression : String |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:54:24:54:33 | expression : String |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:61:24:61:33 | expression : String |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:70:24:70:33 | expression : String |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:79:24:79:33 | expression : String |
+| JakartaExpressionInjection.java:30:24:30:33 | expression : String | JakartaExpressionInjection.java:32:28:32:37 | expression |
+| JakartaExpressionInjection.java:37:24:37:33 | expression : String | JakartaExpressionInjection.java:39:32:39:41 | expression |
+| JakartaExpressionInjection.java:44:24:44:33 | expression : String | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression |
+| JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression |
+| JakartaExpressionInjection.java:54:24:54:33 | expression : String | JakartaExpressionInjection.java:56:32:56:41 | expression |
+| JakartaExpressionInjection.java:61:24:61:33 | expression : String | JakartaExpressionInjection.java:64:33:64:96 | createValueExpression(...) : ValueExpression |
+| JakartaExpressionInjection.java:61:24:61:33 | expression : String | JakartaExpressionInjection.java:65:13:65:13 | e |
+| JakartaExpressionInjection.java:61:24:61:33 | expression : String | JakartaExpressionInjection.java:65:13:65:13 | e : ValueExpression |
+| JakartaExpressionInjection.java:64:33:64:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression |
+| JakartaExpressionInjection.java:64:33:64:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:65:13:65:13 | e |
+| JakartaExpressionInjection.java:64:33:64:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:65:13:65:13 | e : ValueExpression |
+| JakartaExpressionInjection.java:65:13:65:13 | e : ValueExpression | JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression |
+| JakartaExpressionInjection.java:70:24:70:33 | expression : String | JakartaExpressionInjection.java:73:33:73:96 | createValueExpression(...) : ValueExpression |
+| JakartaExpressionInjection.java:70:24:70:33 | expression : String | JakartaExpressionInjection.java:74:13:74:13 | e |
+| JakartaExpressionInjection.java:70:24:70:33 | expression : String | JakartaExpressionInjection.java:74:13:74:13 | e : ValueExpression |
+| JakartaExpressionInjection.java:73:33:73:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression |
+| JakartaExpressionInjection.java:73:33:73:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:74:13:74:13 | e |
+| JakartaExpressionInjection.java:73:33:73:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:74:13:74:13 | e : ValueExpression |
+| JakartaExpressionInjection.java:74:13:74:13 | e : ValueExpression | JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression |
+| JakartaExpressionInjection.java:79:24:79:33 | expression : String | JakartaExpressionInjection.java:83:13:83:13 | e |
+nodes
+| JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:30:24:30:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:32:28:32:37 | expression | semmle.label | expression |
+| JakartaExpressionInjection.java:37:24:37:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:39:32:39:41 | expression | semmle.label | expression |
+| JakartaExpressionInjection.java:44:24:44:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression | semmle.label | new LambdaExpression(...) : LambdaExpression |
+| JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression | semmle.label | lambdaExpression |
+| JakartaExpressionInjection.java:54:24:54:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:56:32:56:41 | expression | semmle.label | expression |
+| JakartaExpressionInjection.java:61:24:61:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:64:33:64:96 | createValueExpression(...) : ValueExpression | semmle.label | createValueExpression(...) : ValueExpression |
+| JakartaExpressionInjection.java:65:13:65:13 | e | semmle.label | e |
+| JakartaExpressionInjection.java:65:13:65:13 | e : ValueExpression | semmle.label | e : ValueExpression |
+| JakartaExpressionInjection.java:70:24:70:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:73:33:73:96 | createValueExpression(...) : ValueExpression | semmle.label | createValueExpression(...) : ValueExpression |
+| JakartaExpressionInjection.java:74:13:74:13 | e | semmle.label | e |
+| JakartaExpressionInjection.java:74:13:74:13 | e : ValueExpression | semmle.label | e : ValueExpression |
+| JakartaExpressionInjection.java:79:24:79:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:83:13:83:13 | e | semmle.label | e |
+#select
+| JakartaExpressionInjection.java:32:28:32:37 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:32:28:32:37 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:39:32:39:41 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:39:32:39:41 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:56:32:56:41 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:56:32:56:41 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:65:13:65:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:65:13:65:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:74:13:74:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:74:13:74:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:83:13:83:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:83:13:83:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.expected
@@ -10,22 +10,9 @@ edges
 | JakartaExpressionInjection.java:30:24:30:33 | expression : String | JakartaExpressionInjection.java:32:28:32:37 | expression |
 | JakartaExpressionInjection.java:37:24:37:33 | expression : String | JakartaExpressionInjection.java:39:32:39:41 | expression |
 | JakartaExpressionInjection.java:44:24:44:33 | expression : String | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression |
-| JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression |
 | JakartaExpressionInjection.java:54:24:54:33 | expression : String | JakartaExpressionInjection.java:56:32:56:41 | expression |
-| JakartaExpressionInjection.java:61:24:61:33 | expression : String | JakartaExpressionInjection.java:64:33:64:96 | createValueExpression(...) : ValueExpression |
 | JakartaExpressionInjection.java:61:24:61:33 | expression : String | JakartaExpressionInjection.java:65:13:65:13 | e |
-| JakartaExpressionInjection.java:61:24:61:33 | expression : String | JakartaExpressionInjection.java:65:13:65:13 | e : ValueExpression |
-| JakartaExpressionInjection.java:64:33:64:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression |
-| JakartaExpressionInjection.java:64:33:64:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:65:13:65:13 | e |
-| JakartaExpressionInjection.java:64:33:64:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:65:13:65:13 | e : ValueExpression |
-| JakartaExpressionInjection.java:65:13:65:13 | e : ValueExpression | JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression |
-| JakartaExpressionInjection.java:70:24:70:33 | expression : String | JakartaExpressionInjection.java:73:33:73:96 | createValueExpression(...) : ValueExpression |
 | JakartaExpressionInjection.java:70:24:70:33 | expression : String | JakartaExpressionInjection.java:74:13:74:13 | e |
-| JakartaExpressionInjection.java:70:24:70:33 | expression : String | JakartaExpressionInjection.java:74:13:74:13 | e : ValueExpression |
-| JakartaExpressionInjection.java:73:33:73:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression |
-| JakartaExpressionInjection.java:73:33:73:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:74:13:74:13 | e |
-| JakartaExpressionInjection.java:73:33:73:96 | createValueExpression(...) : ValueExpression | JakartaExpressionInjection.java:74:13:74:13 | e : ValueExpression |
-| JakartaExpressionInjection.java:74:13:74:13 | e : ValueExpression | JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression |
 | JakartaExpressionInjection.java:79:24:79:33 | expression : String | JakartaExpressionInjection.java:83:13:83:13 | e |
 nodes
 | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
@@ -35,18 +22,13 @@ nodes
 | JakartaExpressionInjection.java:37:24:37:33 | expression : String | semmle.label | expression : String |
 | JakartaExpressionInjection.java:39:32:39:41 | expression | semmle.label | expression |
 | JakartaExpressionInjection.java:44:24:44:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:48:49:48:104 | new LambdaExpression(...) : LambdaExpression | semmle.label | new LambdaExpression(...) : LambdaExpression |
 | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression | semmle.label | lambdaExpression |
 | JakartaExpressionInjection.java:54:24:54:33 | expression : String | semmle.label | expression : String |
 | JakartaExpressionInjection.java:56:32:56:41 | expression | semmle.label | expression |
 | JakartaExpressionInjection.java:61:24:61:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:64:33:64:96 | createValueExpression(...) : ValueExpression | semmle.label | createValueExpression(...) : ValueExpression |
 | JakartaExpressionInjection.java:65:13:65:13 | e | semmle.label | e |
-| JakartaExpressionInjection.java:65:13:65:13 | e : ValueExpression | semmle.label | e : ValueExpression |
 | JakartaExpressionInjection.java:70:24:70:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:73:33:73:96 | createValueExpression(...) : ValueExpression | semmle.label | createValueExpression(...) : ValueExpression |
 | JakartaExpressionInjection.java:74:13:74:13 | e | semmle.label | e |
-| JakartaExpressionInjection.java:74:13:74:13 | e : ValueExpression | semmle.label | e : ValueExpression |
 | JakartaExpressionInjection.java:79:24:79:33 | expression : String | semmle.label | expression : String |
 | JakartaExpressionInjection.java:83:13:83:13 | e | semmle.label | e |
 #select

--- a/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.expected
@@ -5,15 +5,17 @@ edges
 | JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:44:24:44:33 | expression : String |
 | JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:54:24:54:33 | expression : String |
 | JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:61:24:61:33 | expression : String |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:70:24:70:33 | expression : String |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:79:24:79:33 | expression : String |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:68:24:68:33 | expression : String |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:77:24:77:33 | expression : String |
+| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:86:24:86:33 | expression : String |
 | JakartaExpressionInjection.java:30:24:30:33 | expression : String | JakartaExpressionInjection.java:32:28:32:37 | expression |
 | JakartaExpressionInjection.java:37:24:37:33 | expression : String | JakartaExpressionInjection.java:39:32:39:41 | expression |
 | JakartaExpressionInjection.java:44:24:44:33 | expression : String | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression |
 | JakartaExpressionInjection.java:54:24:54:33 | expression : String | JakartaExpressionInjection.java:56:32:56:41 | expression |
-| JakartaExpressionInjection.java:61:24:61:33 | expression : String | JakartaExpressionInjection.java:65:13:65:13 | e |
-| JakartaExpressionInjection.java:70:24:70:33 | expression : String | JakartaExpressionInjection.java:74:13:74:13 | e |
-| JakartaExpressionInjection.java:79:24:79:33 | expression : String | JakartaExpressionInjection.java:83:13:83:13 | e |
+| JakartaExpressionInjection.java:61:24:61:33 | expression : String | JakartaExpressionInjection.java:63:43:63:52 | expression |
+| JakartaExpressionInjection.java:68:24:68:33 | expression : String | JakartaExpressionInjection.java:72:13:72:13 | e |
+| JakartaExpressionInjection.java:77:24:77:33 | expression : String | JakartaExpressionInjection.java:81:13:81:13 | e |
+| JakartaExpressionInjection.java:86:24:86:33 | expression : String | JakartaExpressionInjection.java:90:13:90:13 | e |
 nodes
 | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | JakartaExpressionInjection.java:24:31:24:40 | expression : String | semmle.label | expression : String |
@@ -26,16 +28,19 @@ nodes
 | JakartaExpressionInjection.java:54:24:54:33 | expression : String | semmle.label | expression : String |
 | JakartaExpressionInjection.java:56:32:56:41 | expression | semmle.label | expression |
 | JakartaExpressionInjection.java:61:24:61:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:65:13:65:13 | e | semmle.label | e |
-| JakartaExpressionInjection.java:70:24:70:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:74:13:74:13 | e | semmle.label | e |
-| JakartaExpressionInjection.java:79:24:79:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:83:13:83:13 | e | semmle.label | e |
+| JakartaExpressionInjection.java:63:43:63:52 | expression | semmle.label | expression |
+| JakartaExpressionInjection.java:68:24:68:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:72:13:72:13 | e | semmle.label | e |
+| JakartaExpressionInjection.java:77:24:77:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:81:13:81:13 | e | semmle.label | e |
+| JakartaExpressionInjection.java:86:24:86:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:90:13:90:13 | e | semmle.label | e |
 #select
 | JakartaExpressionInjection.java:32:28:32:37 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:32:28:32:37 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
 | JakartaExpressionInjection.java:39:32:39:41 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:39:32:39:41 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
 | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
 | JakartaExpressionInjection.java:56:32:56:41 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:56:32:56:41 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
-| JakartaExpressionInjection.java:65:13:65:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:65:13:65:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
-| JakartaExpressionInjection.java:74:13:74:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:74:13:74:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
-| JakartaExpressionInjection.java:83:13:83:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:83:13:83:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:63:43:63:52 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:63:43:63:52 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:72:13:72:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:72:13:72:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:81:13:81:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:81:13:81:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:90:13:90:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:90:13:90:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.expected
@@ -1,46 +1,46 @@
 edges
-| JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:24:31:24:40 | expression : String |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:30:24:30:33 | expression : String |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:37:24:37:33 | expression : String |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:44:24:44:33 | expression : String |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:54:24:54:33 | expression : String |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:61:24:61:33 | expression : String |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:68:24:68:33 | expression : String |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:77:24:77:33 | expression : String |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | JakartaExpressionInjection.java:86:24:86:33 | expression : String |
-| JakartaExpressionInjection.java:30:24:30:33 | expression : String | JakartaExpressionInjection.java:32:28:32:37 | expression |
-| JakartaExpressionInjection.java:37:24:37:33 | expression : String | JakartaExpressionInjection.java:39:32:39:41 | expression |
-| JakartaExpressionInjection.java:44:24:44:33 | expression : String | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression |
-| JakartaExpressionInjection.java:54:24:54:33 | expression : String | JakartaExpressionInjection.java:56:32:56:41 | expression |
-| JakartaExpressionInjection.java:61:24:61:33 | expression : String | JakartaExpressionInjection.java:63:43:63:52 | expression |
-| JakartaExpressionInjection.java:68:24:68:33 | expression : String | JakartaExpressionInjection.java:72:13:72:13 | e |
-| JakartaExpressionInjection.java:77:24:77:33 | expression : String | JakartaExpressionInjection.java:81:13:81:13 | e |
-| JakartaExpressionInjection.java:86:24:86:33 | expression : String | JakartaExpressionInjection.java:90:13:90:13 | e |
+| JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:25:31:25:40 | expression : String |
+| JakartaExpressionInjection.java:25:31:25:40 | expression : String | JakartaExpressionInjection.java:32:24:32:33 | expression : String |
+| JakartaExpressionInjection.java:25:31:25:40 | expression : String | JakartaExpressionInjection.java:40:24:40:33 | expression : String |
+| JakartaExpressionInjection.java:25:31:25:40 | expression : String | JakartaExpressionInjection.java:48:24:48:33 | expression : String |
+| JakartaExpressionInjection.java:25:31:25:40 | expression : String | JakartaExpressionInjection.java:59:24:59:33 | expression : String |
+| JakartaExpressionInjection.java:25:31:25:40 | expression : String | JakartaExpressionInjection.java:67:24:67:33 | expression : String |
+| JakartaExpressionInjection.java:25:31:25:40 | expression : String | JakartaExpressionInjection.java:75:24:75:33 | expression : String |
+| JakartaExpressionInjection.java:25:31:25:40 | expression : String | JakartaExpressionInjection.java:85:24:85:33 | expression : String |
+| JakartaExpressionInjection.java:25:31:25:40 | expression : String | JakartaExpressionInjection.java:95:24:95:33 | expression : String |
+| JakartaExpressionInjection.java:32:24:32:33 | expression : String | JakartaExpressionInjection.java:34:28:34:37 | expression |
+| JakartaExpressionInjection.java:40:24:40:33 | expression : String | JakartaExpressionInjection.java:42:32:42:41 | expression |
+| JakartaExpressionInjection.java:48:24:48:33 | expression : String | JakartaExpressionInjection.java:53:13:53:28 | lambdaExpression |
+| JakartaExpressionInjection.java:59:24:59:33 | expression : String | JakartaExpressionInjection.java:61:32:61:41 | expression |
+| JakartaExpressionInjection.java:67:24:67:33 | expression : String | JakartaExpressionInjection.java:69:43:69:52 | expression |
+| JakartaExpressionInjection.java:75:24:75:33 | expression : String | JakartaExpressionInjection.java:79:13:79:13 | e |
+| JakartaExpressionInjection.java:85:24:85:33 | expression : String | JakartaExpressionInjection.java:89:13:89:13 | e |
+| JakartaExpressionInjection.java:95:24:95:33 | expression : String | JakartaExpressionInjection.java:99:13:99:13 | e |
 nodes
-| JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| JakartaExpressionInjection.java:24:31:24:40 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:30:24:30:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:32:28:32:37 | expression | semmle.label | expression |
-| JakartaExpressionInjection.java:37:24:37:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:39:32:39:41 | expression | semmle.label | expression |
-| JakartaExpressionInjection.java:44:24:44:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression | semmle.label | lambdaExpression |
-| JakartaExpressionInjection.java:54:24:54:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:56:32:56:41 | expression | semmle.label | expression |
-| JakartaExpressionInjection.java:61:24:61:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:63:43:63:52 | expression | semmle.label | expression |
-| JakartaExpressionInjection.java:68:24:68:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:72:13:72:13 | e | semmle.label | e |
-| JakartaExpressionInjection.java:77:24:77:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:81:13:81:13 | e | semmle.label | e |
-| JakartaExpressionInjection.java:86:24:86:33 | expression : String | semmle.label | expression : String |
-| JakartaExpressionInjection.java:90:13:90:13 | e | semmle.label | e |
+| JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| JakartaExpressionInjection.java:25:31:25:40 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:32:24:32:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:34:28:34:37 | expression | semmle.label | expression |
+| JakartaExpressionInjection.java:40:24:40:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:42:32:42:41 | expression | semmle.label | expression |
+| JakartaExpressionInjection.java:48:24:48:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:53:13:53:28 | lambdaExpression | semmle.label | lambdaExpression |
+| JakartaExpressionInjection.java:59:24:59:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:61:32:61:41 | expression | semmle.label | expression |
+| JakartaExpressionInjection.java:67:24:67:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:69:43:69:52 | expression | semmle.label | expression |
+| JakartaExpressionInjection.java:75:24:75:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:79:13:79:13 | e | semmle.label | e |
+| JakartaExpressionInjection.java:85:24:85:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:89:13:89:13 | e | semmle.label | e |
+| JakartaExpressionInjection.java:95:24:95:33 | expression : String | semmle.label | expression : String |
+| JakartaExpressionInjection.java:99:13:99:13 | e | semmle.label | e |
 #select
-| JakartaExpressionInjection.java:32:28:32:37 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:32:28:32:37 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
-| JakartaExpressionInjection.java:39:32:39:41 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:39:32:39:41 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
-| JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:49:13:49:28 | lambdaExpression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
-| JakartaExpressionInjection.java:56:32:56:41 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:56:32:56:41 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
-| JakartaExpressionInjection.java:63:43:63:52 | expression | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:63:43:63:52 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
-| JakartaExpressionInjection.java:72:13:72:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:72:13:72:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
-| JakartaExpressionInjection.java:81:13:81:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:81:13:81:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
-| JakartaExpressionInjection.java:90:13:90:13 | e | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:90:13:90:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:22:25:22:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:34:28:34:37 | expression | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:34:28:34:37 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:42:32:42:41 | expression | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:42:32:42:41 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:53:13:53:28 | lambdaExpression | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:53:13:53:28 | lambdaExpression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:61:32:61:41 | expression | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:61:32:61:41 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:69:43:69:52 | expression | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:69:43:69:52 | expression | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:79:13:79:13 | e | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:79:13:79:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:89:13:89:13 | e | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:89:13:89:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) | this user input |
+| JakartaExpressionInjection.java:99:13:99:13 | e | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) : InputStream | JakartaExpressionInjection.java:99:13:99:13 | e | Jakarta Expression Language injection from $@. | JakartaExpressionInjection.java:23:25:23:47 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.java
@@ -57,6 +57,13 @@ public class JakartaExpressionInjection {
         });
     }
 
+    private static void testWithELProcessorSetVariable() throws IOException {
+        testWithSocket(expression -> {
+            ELProcessor processor = new ELProcessor();
+            processor.setVariable("test", expression);
+        });
+    }
+
     private static void testWithJuelValueExpressionGetValue() throws IOException {
         testWithSocket(expression -> {
             ExpressionFactory factory = new de.odysseus.el.ExpressionFactoryImpl();

--- a/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.java
@@ -15,6 +15,7 @@ import javax.el.ValueExpression;
 
 public class JakartaExpressionInjection {
     
+    // calls a consumer with a string received from a socket
     private static void testWithSocket(Consumer<String> action) throws IOException {
         try (ServerSocket serverSocket = new ServerSocket(0)) {
             try (Socket socket = serverSocket.accept()) {
@@ -26,6 +27,7 @@ public class JakartaExpressionInjection {
         }
     }
 
+    // BAD (untrusted input to ELProcessor.eval)
     private static void testWithELProcessorEval() throws IOException {
         testWithSocket(expression -> {
             ELProcessor processor = new ELProcessor();
@@ -33,6 +35,7 @@ public class JakartaExpressionInjection {
         });
     }
 
+    // BAD (untrusted input to ELProcessor.getValue)
     private static void testWithELProcessorGetValue() throws IOException {
         testWithSocket(expression -> {   
             ELProcessor processor = new ELProcessor();
@@ -40,6 +43,7 @@ public class JakartaExpressionInjection {
         });
     }
 
+    // BAD (untrusted input to LambdaExpression.invoke)
     private static void testWithLambdaExpressionInvoke() throws IOException {
         testWithSocket(expression -> {
             ExpressionFactory factory = ELManager.getExpressionFactory();
@@ -50,6 +54,7 @@ public class JakartaExpressionInjection {
         });
     }
 
+    // BAD (untrusted input to ELProcessor.setValue)
     private static void testWithELProcessorSetValue() throws IOException {
         testWithSocket(expression -> {
             ELProcessor processor = new ELProcessor();
@@ -57,6 +62,7 @@ public class JakartaExpressionInjection {
         });
     }
 
+    // BAD (untrusted input to ELProcessor.setVariable)
     private static void testWithELProcessorSetVariable() throws IOException {
         testWithSocket(expression -> {
             ELProcessor processor = new ELProcessor();
@@ -64,6 +70,7 @@ public class JakartaExpressionInjection {
         });
     }
 
+    // BAD (untrusted input to ValueExpression.getValue when it was created by JUEL)
     private static void testWithJuelValueExpressionGetValue() throws IOException {
         testWithSocket(expression -> {
             ExpressionFactory factory = new de.odysseus.el.ExpressionFactoryImpl();
@@ -73,6 +80,7 @@ public class JakartaExpressionInjection {
         });
     }
 
+    // BAD (untrusted input to ValueExpression.setValue when it was created by JUEL)
     private static void testWithJuelValueExpressionSetValue() throws IOException {
         testWithSocket(expression -> {
             ExpressionFactory factory = new de.odysseus.el.ExpressionFactoryImpl();
@@ -82,6 +90,7 @@ public class JakartaExpressionInjection {
         });
     }
 
+    // BAD (untrusted input to MethodExpression.invoke when it was created by JUEL)
     private static void testWithJuelMethodExpressionInvoke() throws IOException {
         testWithSocket(expression -> {
             ExpressionFactory factory = new de.odysseus.el.ExpressionFactoryImpl();

--- a/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.java
@@ -1,0 +1,87 @@
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.function.Consumer;
+
+import javax.el.ELContext;
+import javax.el.ELManager;
+import javax.el.ELProcessor;
+import javax.el.ExpressionFactory;
+import javax.el.LambdaExpression;
+import javax.el.MethodExpression;
+import javax.el.StandardELContext;
+import javax.el.ValueExpression;
+
+public class JakartaExpressionInjection {
+    
+    private static void testWithSocket(Consumer<String> action) throws IOException {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            try (Socket socket = serverSocket.accept()) {
+                byte[] bytes = new byte[1024];
+                int n = socket.getInputStream().read(bytes);
+                String expression = new String(bytes, 0, n);
+                action.accept(expression);
+            }
+        }
+    }
+
+    private static void testWithELProcessorEval() throws IOException {
+        testWithSocket(expression -> {
+            ELProcessor processor = new ELProcessor();
+            processor.eval(expression);
+        });
+    }
+
+    private static void testWithELProcessorGetValue() throws IOException {
+        testWithSocket(expression -> {   
+            ELProcessor processor = new ELProcessor();
+            processor.getValue(expression, Object.class);
+        });
+    }
+
+    private static void testWithLambdaExpressionInvoke() throws IOException {
+        testWithSocket(expression -> {
+            ExpressionFactory factory = ELManager.getExpressionFactory();
+            StandardELContext context = new StandardELContext(factory);
+            ValueExpression valueExpression = factory.createValueExpression(context, expression, Object.class);
+            LambdaExpression lambdaExpression = new LambdaExpression(new ArrayList<>(), valueExpression);
+            lambdaExpression.invoke(context, new Object[0]);
+        });
+    }
+
+    private static void testWithELProcessorSetValue() throws IOException {
+        testWithSocket(expression -> {
+            ELProcessor processor = new ELProcessor();
+            processor.setValue(expression, new Object());
+        });
+    }
+
+    private static void testWithJuelValueExpressionGetValue() throws IOException {
+        testWithSocket(expression -> {
+            ExpressionFactory factory = new de.odysseus.el.ExpressionFactoryImpl();
+            ELContext context = new de.odysseus.el.util.SimpleContext();
+            ValueExpression e = factory.createValueExpression(context, expression, Object.class);
+            e.getValue(context);
+        });
+    }
+
+    private static void testWithJuelValueExpressionSetValue() throws IOException {
+        testWithSocket(expression -> {
+            ExpressionFactory factory = new de.odysseus.el.ExpressionFactoryImpl();
+            ELContext context = new de.odysseus.el.util.SimpleContext();
+            ValueExpression e = factory.createValueExpression(context, expression, Object.class);
+            e.setValue(context, new Object());
+        });
+    }
+
+    private static void testWithJuelMethodExpressionInvoke() throws IOException {
+        testWithSocket(expression -> {
+            ExpressionFactory factory = new de.odysseus.el.ExpressionFactoryImpl();
+            ELContext context = new de.odysseus.el.util.SimpleContext();
+            MethodExpression e = factory.createMethodExpression(context, expression, Object.class, new Class[0]);
+            e.invoke(context, new Object[0]);
+        });
+    }
+
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/JakartaExpressionInjection.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-094/JakartaExpressionInjection.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-094/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-094/options
@@ -1,2 +1,1 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/springframework-5.2.3:${testdir}/../../../../stubs/mvel2-2.4.7:${testdir}/../../../../stubs/jsr223-api:${testdir}/../../../../stubs/apache-commons-jexl-2.1.1:${testdir}/../../../../stubs/apache-commons-jexl-3.1:${testdir}/../../../../stubs/scriptengine
-
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/springframework-5.2.3:${testdir}/../../../../stubs/mvel2-2.4.7:${testdir}/../../../../stubs/jsr223-api:${testdir}/../../../../stubs/apache-commons-jexl-2.1.1:${testdir}/../../../../stubs/apache-commons-jexl-3.1:${testdir}/../../../../stubs/scriptengine:${testdir}/../../../../stubs/java-ee-el:${testdir}/../../../../stubs/juel-2.2

--- a/java/ql/test/stubs/java-ee-el/javax/el/ELContext.java
+++ b/java/ql/test/stubs/java-ee-el/javax/el/ELContext.java
@@ -1,0 +1,3 @@
+package javax.el;
+
+public class ELContext {}

--- a/java/ql/test/stubs/java-ee-el/javax/el/ELManager.java
+++ b/java/ql/test/stubs/java-ee-el/javax/el/ELManager.java
@@ -1,0 +1,5 @@
+package javax.el;
+
+public class ELManager {
+    public static ExpressionFactory getExpressionFactory() { return null; }
+}

--- a/java/ql/test/stubs/java-ee-el/javax/el/ELProcessor.java
+++ b/java/ql/test/stubs/java-ee-el/javax/el/ELProcessor.java
@@ -4,4 +4,5 @@ public class ELProcessor {
     public Object eval(String expression) { return null; }
     public Object getValue(String expression, Class<?> expectedType) { return null; }
     public void setValue(String expression, Object value) {}
+    public void setVariable(String var, String expression) {}
 }

--- a/java/ql/test/stubs/java-ee-el/javax/el/ELProcessor.java
+++ b/java/ql/test/stubs/java-ee-el/javax/el/ELProcessor.java
@@ -1,0 +1,7 @@
+package javax.el;
+
+public class ELProcessor {
+    public Object eval(String expression) { return null; }
+    public Object getValue(String expression, Class<?> expectedType) { return null; }
+    public void setValue(String expression, Object value) {}
+}

--- a/java/ql/test/stubs/java-ee-el/javax/el/ExpressionFactory.java
+++ b/java/ql/test/stubs/java-ee-el/javax/el/ExpressionFactory.java
@@ -1,0 +1,17 @@
+package javax.el;
+
+public class ExpressionFactory {
+    public MethodExpression createMethodExpression(ELContext context, String expression, Class<?> expectedReturnType,
+            Class<?>[] expectedParamTypes) {
+
+        return null;
+    }
+
+    public ValueExpression createValueExpression(ELContext context, String expression, Class<?> expectedType) {
+        return null;
+    }
+
+    public ValueExpression createValueExpression(Object instance, Class<?> expectedType) {
+        return null;
+    }
+}

--- a/java/ql/test/stubs/java-ee-el/javax/el/LambdaExpression.java
+++ b/java/ql/test/stubs/java-ee-el/javax/el/LambdaExpression.java
@@ -1,0 +1,8 @@
+package javax.el;
+
+import java.util.List;
+
+public class LambdaExpression {
+    public LambdaExpression(List<String> formalParameters, ValueExpression expression) {}
+    public Object invoke(Object... args) { return null; }
+}

--- a/java/ql/test/stubs/java-ee-el/javax/el/MethodExpression.java
+++ b/java/ql/test/stubs/java-ee-el/javax/el/MethodExpression.java
@@ -1,0 +1,5 @@
+package javax.el;
+
+public class MethodExpression {
+    public Object invoke(ELContext context, Object[] params) { return null; }
+}

--- a/java/ql/test/stubs/java-ee-el/javax/el/StandardELContext.java
+++ b/java/ql/test/stubs/java-ee-el/javax/el/StandardELContext.java
@@ -1,0 +1,5 @@
+package javax.el;
+
+public class StandardELContext extends ELContext {
+    public StandardELContext(ExpressionFactory factory) {}
+}

--- a/java/ql/test/stubs/java-ee-el/javax/el/ValueExpression.java
+++ b/java/ql/test/stubs/java-ee-el/javax/el/ValueExpression.java
@@ -1,0 +1,6 @@
+package javax.el;
+
+public class ValueExpression {
+    public Object getValue(ELContext context) { return null; }
+    public void setValue(ELContext context, Object value) {}
+}

--- a/java/ql/test/stubs/juel-2.2/de/odysseus/el/ExpressionFactoryImpl.java
+++ b/java/ql/test/stubs/juel-2.2/de/odysseus/el/ExpressionFactoryImpl.java
@@ -1,0 +1,5 @@
+package de.odysseus.el;
+
+import javax.el.ExpressionFactory;
+
+public class ExpressionFactoryImpl extends ExpressionFactory {}

--- a/java/ql/test/stubs/juel-2.2/de/odysseus/el/util/SimpleContext.java
+++ b/java/ql/test/stubs/juel-2.2/de/odysseus/el/util/SimpleContext.java
@@ -1,0 +1,5 @@
+package de.odysseus.el.util;
+
+import javax.el.ELContext;
+
+public class SimpleContext extends ELContext {}


### PR DESCRIPTION
Jakarta EE contains a specification for an expression language (EL) and API for interpreters. There are multiple implementations of the API, for example, JUEL, Apache Commons EL, Glassfish has its own implementation. The language allows invocation of methods available in the JVM. If an expression is built using attacker-controlled data, and then evaluated, it may allow the attacker to run arbitrary code in the worst case.

I'd like to propose a new experimental query that looks for potential expression injections when an application uses the Jakarta EL.

Jakarta EE used to be Java EE in the past. Originally, the API for the EL was located in the `javax.el` package. After Eclipse Foundation had taken over Java EE, the package was renamed to `jakarta.el`. The query covers both versions.

The query detects [a known RCE in OpenFaces](https://github.com/TeamDev-Archive/OpenFaces/issues/175).