### PR TITLE
Java: Fix some predicates being incorrect for Records

### DIFF
--- a/java/ql/src/semmle/code/java/Type.qll
+++ b/java/ql/src/semmle/code/java/Type.qll
@@ -633,6 +633,10 @@ class Class extends RefType, @class {
  */
 class Record extends Class {
   Record() { isRecord(this) }
+
+  // JLS 16 §8.10: A record class is implicitly final.
+  /** Always holds; a record class is implicitly final. */
+  override predicate isFinal() { any() }
 }
 
 /** An intersection type. */
@@ -768,22 +772,27 @@ class NestedType extends RefType {
    * because one of the following holds:
    *
    * - it is a member type of an interface,
-   * - it is a member interface, or
-   * - it is a nested enum type.
+   * - it is a nested interface, or
+   * - it is a nested enum type, or
+   * - it is a nested record type.
    *
-   * See JLS v8, section 8.5.1 (Static Member Type Declarations),
-   * section 8.9 (Enums) and section 9.5 (Member Type Declarations).
+   * See JLS 16, section 9.1.1.3 ("`static` interfaces"), section 9.5
+   * ("Member Class and Interface Declarations"), section 8.9 ("Enum Classes")
+   * and section 8.10 ("Record Classes").
    */
   override predicate isStatic() {
     super.isStatic()
     or
-    // JLS 8.5.1: A member interface is implicitly static.
+    // JLS 16 §9.1.1.3: A nested interface is implicitly static.
     this instanceof Interface
     or
-    // JLS 8.9: A nested enum type is implicitly static.
+    // JLS 16 §8.9: A nested enum type is implicitly static.
     this instanceof EnumType
     or
-    // JLS 9.5: A member type declaration in an interface is implicitly public and static
+    // JLS 16 §8.10: A nested record is implicitly static.
+    this instanceof Record
+    or
+    // JLS 16 §9.5: A member type declaration in an interface is implicitly public and static
     exists(Interface i | this = i.getAMember())
   }
 }

--- a/java/ql/test/library-tests/record-classes/MyFinalRecord.java
+++ b/java/ql/test/library-tests/record-classes/MyFinalRecord.java
@@ -1,0 +1,1 @@
+final record MyFinalRecord() { }

--- a/java/ql/test/library-tests/record-classes/MyRecord.java
+++ b/java/ql/test/library-tests/record-classes/MyRecord.java
@@ -1,0 +1,2 @@
+// Records are implicitly final
+record MyRecord() { }

--- a/java/ql/test/library-tests/record-classes/RecordClasses.expected
+++ b/java/ql/test/library-tests/record-classes/RecordClasses.expected
@@ -1,0 +1,6 @@
+| MyFinalRecord.java:1:14:1:26 | MyFinalRecord | final=true | static=false | Record |
+| MyRecord.java:2:8:2:15 | MyRecord | final=true | static=false | Record |
+| Test.java:3:12:3:13 | R1 | final=true | static=true | Record |
+| Test.java:4:25:4:26 | R2 | final=true | static=true | Record |
+| Test.java:8:12:8:13 | R3 | final=true | static=true | Record,SuperInterface |
+| Test.java:12:16:12:26 | LocalRecord | final=true | static=true | Record |

--- a/java/ql/test/library-tests/record-classes/RecordClasses.ql
+++ b/java/ql/test/library-tests/record-classes/RecordClasses.ql
@@ -1,0 +1,8 @@
+import java
+
+from Record r, boolean isFinal, boolean isStatic, string superTypes
+where
+  (if r.isFinal() then isFinal = true else isFinal = false) and
+  (if r.isStatic() then isStatic = true else isStatic = false) and
+  superTypes = concat(RefType superType | superType = r.getASupertype() | superType.toString(), ",")
+select r, "final=" + isFinal, "static=" + isStatic, superTypes

--- a/java/ql/test/library-tests/record-classes/Test.java
+++ b/java/ql/test/library-tests/record-classes/Test.java
@@ -1,0 +1,14 @@
+class Test {
+    // Nested records are implicitly static
+    record R1() { }
+    static final record R2() { }
+
+    interface SuperInterface { }
+
+    record R3() implements SuperInterface { }
+
+    void test() {
+        // Nested records are implicitly static
+        record LocalRecord() { }
+    }
+}

--- a/java/ql/test/library-tests/record-classes/options
+++ b/java/ql/test/library-tests/record-classes/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args --enable-preview -source 15 -target 15


### PR DESCRIPTION
Properly implements the predicates for `Record` classes and adds tests.

Note: At the current state this pull request is pointless because `Modifiable.hasModifier` reports implicit modifiers (see #5472); once this has been fixed, this pulll request is necessary.