### PR TITLE
Java: Add StringBuildingType

### DIFF
--- a/java/ql/src/Likely Bugs/Likely Typos/StringBufferCharInit.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/StringBufferCharInit.ql
@@ -13,12 +13,7 @@
 import java
 
 class NewStringBufferOrBuilder extends ClassInstanceExpr {
-  NewStringBufferOrBuilder() {
-    exists(Class c | c = this.getConstructedType() |
-      c.hasQualifiedName("java.lang", "StringBuilder") or
-      c.hasQualifiedName("java.lang", "StringBuffer")
-    )
-  }
+  NewStringBufferOrBuilder() { getConstructedType() instanceof StringBuildingType }
 
   string getName() { result = this.getConstructedType().getName() }
 }

--- a/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
+++ b/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
@@ -44,8 +44,7 @@ predicate objectToString(MethodAccess ma) {
 class StringContainer extends RefType {
   StringContainer() {
     this instanceof TypeString or
-    this.hasQualifiedName("java.lang", "StringBuilder") or
-    this.hasQualifiedName("java.lang", "StringBuffer") or
+    this instanceof StringBuildingType or
     this.hasQualifiedName("java.util", "StringTokenizer") or
     this.(Array).getComponentType() instanceof StringContainer
   }

--- a/java/ql/src/semmle/code/java/JDK.qll
+++ b/java/ql/src/semmle/code/java/JDK.qll
@@ -46,6 +46,11 @@ class TypeStringBuilder extends Class {
   TypeStringBuilder() { this.hasQualifiedName("java.lang", "StringBuilder") }
 }
 
+/** Class `java.lang.StringBuffer` or `java.lang.StringBuilder`. */
+class StringBuildingType extends Class {
+  StringBuildingType() { this instanceof TypeStringBuffer or this instanceof TypeStringBuilder }
+}
+
 /** The class `java.lang.System`. */
 class TypeSystem extends Class {
   TypeSystem() { this.hasQualifiedName("java.lang", "System") }

--- a/java/ql/src/semmle/code/java/StringFormat.qll
+++ b/java/ql/src/semmle/code/java/StringFormat.qll
@@ -210,10 +210,7 @@ private predicate printMethod(Method m, int i) {
     (t.hasQualifiedName("java.io", "PrintWriter") or t.hasQualifiedName("java.io", "PrintStream")) and
     (m.hasName("print") or m.hasName("println"))
     or
-    (
-      t.hasQualifiedName("java.lang", "StringBuilder") or
-      t.hasQualifiedName("java.lang", "StringBuffer")
-    ) and
+    t instanceof StringBuildingType and
     (m.hasName("append") or m.hasName("insert"))
     or
     t instanceof TypeString and m.hasName("valueOf")

--- a/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSteps.qll
@@ -152,8 +152,7 @@ private class NumberTaintPreservingCallable extends TaintPreservingCallable {
 
 /** Holds for the types `StringBuilder`, `StringBuffer`, and `StringWriter`. */
 private predicate stringBuilderType(RefType t) {
-  t.hasQualifiedName("java.lang", "StringBuilder") or
-  t.hasQualifiedName("java.lang", "StringBuffer") or
+  t instanceof StringBuildingType or
   t.hasQualifiedName("java.io", "StringWriter")
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -552,10 +552,7 @@ module StringBuilderVarModule {
    * build up a query using string concatenation.
    */
   class StringBuilderVar extends LocalVariableDecl {
-    StringBuilderVar() {
-      this.getType() instanceof TypeStringBuilder or
-      this.getType() instanceof TypeStringBuffer
-    }
+    StringBuilderVar() { getType() instanceof StringBuildingType }
 
     /**
      * Gets a call that adds something to this string builder, from the argument at the given index.


### PR DESCRIPTION
`StringBuffer` and `StringBuilder` have the same internal superclass `AbstractStringBuilder` and therefore have nearly the same methods.
Therefore most often queries don't care whether `StringBuffer` or `StringBuilder` is used (as seen by the queries updated by this pull request). For convenience this pull request introduces `StringBuildingType` which matches both types (but **only** these types).