### PR TITLE
JS: Refactor AdditionalFlowStep -> SharedFlowStep unit type

### DIFF
--- a/javascript/ql/src/Security/CWE-327/BadRandomness.ql
+++ b/javascript/ql/src/Security/CWE-327/BadRandomness.ql
@@ -87,11 +87,6 @@ private DataFlow::Node goodRandom(DataFlow::TypeTracker t, DataFlow::SourceNode 
   or
   exists(DataFlow::TypeTracker t2 | t = t2.smallstep(goodRandom(t2, source), result))
   or
-  // re-using the collection steps for `Set`.
-  exists(DataFlow::TypeTracker t2 |
-    result = CollectionsTypeTracking::collectionStep(goodRandom(t2, source), t, t2)
-  )
-  or
   InsecureRandomness::isAdditionalTaintStep(goodRandom(t.continue(), source), result) and
   // bit shifts and multiplication by powers of two are generally used for constructing larger numbers from smaller numbers.
   not exists(BinaryExpr binop | binop = result.asExpr() |

--- a/javascript/ql/src/meta/analysis-quality/TaintSteps.ql
+++ b/javascript/ql/src/meta/analysis-quality/TaintSteps.ql
@@ -15,17 +15,17 @@ predicate relevantStep(DataFlow::Node pred, DataFlow::Node succ) {
   (
     TaintTracking::sharedTaintStep(pred, succ)
     or
-    any(DataFlow::AdditionalFlowStep cfg).step(pred, succ)
+    DataFlow::SharedFlowStep::step(pred, succ)
     or
-    any(DataFlow::AdditionalFlowStep cfg).step(pred, succ, _, _)
+    DataFlow::SharedFlowStep::step(pred, succ, _, _)
     or
-    any(DataFlow::AdditionalFlowStep cfg).loadStep(pred, succ, _)
+    DataFlow::SharedFlowStep::loadStep(pred, succ, _)
     or
-    any(DataFlow::AdditionalFlowStep cfg).storeStep(pred, succ, _)
+    DataFlow::SharedFlowStep::storeStep(pred, succ, _)
     or
-    any(DataFlow::AdditionalFlowStep cfg).loadStoreStep(pred, succ, _, _)
+    DataFlow::SharedFlowStep::loadStoreStep(pred, succ, _, _)
     or
-    any(DataFlow::AdditionalFlowStep cfg).loadStoreStep(pred, succ, _)
+    DataFlow::SharedFlowStep::loadStoreStep(pred, succ, _)
   ) and
   not pred.getFile() instanceof IgnoredFile and
   not succ.getFile() instanceof IgnoredFile

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -125,16 +125,14 @@ private module ArrayDataFlow {
   /**
    * A step for storing an element on an array using `arr.push(e)` or `arr.unshift(e)`.
    */
-  private class ArrayAppendStep extends DataFlow::AdditionalFlowStep, DataFlow::MethodCallNode {
-    ArrayAppendStep() {
-      this.getMethodName() = "push" or
-      this.getMethodName() = "unshift"
-    }
-
+  private class ArrayAppendStep extends DataFlow::SharedFlowStep {
     override predicate storeStep(DataFlow::Node element, DataFlow::SourceNode obj, string prop) {
       prop = arrayElement() and
-      element = this.getAnArgument() and
-      obj.getAMethodCall() = this
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = ["push", "unshift"] and
+        element = call.getAnArgument() and
+        obj.getAMethodCall() = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -234,12 +234,12 @@ private module ArrayDataFlow {
   /**
    * A step for creating an array and storing the elements in the array.
    */
-  private class ArrayCreationStep extends DataFlow::AdditionalFlowStep, DataFlow::ArrayCreationNode {
+  private class ArrayCreationStep extends DataFlow::SharedFlowStep {
     override predicate storeStep(DataFlow::Node element, DataFlow::SourceNode obj, string prop) {
-      exists(int i |
-        element = this.getElement(i) and
-        obj = this and
-        if this = any(PromiseAllCreation c).getArrayNode()
+      exists(DataFlow::ArrayCreationNode array, int i |
+        element = array.getElement(i) and
+        obj = array and
+        if array = any(PromiseAllCreation c).getArrayNode()
         then prop = arrayElement(i)
         else prop = arrayElement()
       )

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -250,13 +250,14 @@ private module ArrayDataFlow {
    * A step modelling that `splice` can insert elements into an array.
    * For example in `array.splice(i, del, e)`: if `e` is tainted, then so is `array
    */
-  private class ArraySpliceStep extends DataFlow::AdditionalFlowStep, DataFlow::MethodCallNode {
-    ArraySpliceStep() { this.getMethodName() = "splice" }
-
+  private class ArraySpliceStep extends DataFlow::SharedFlowStep {
     override predicate storeStep(DataFlow::Node element, DataFlow::SourceNode obj, string prop) {
-      prop = arrayElement() and
-      element = getArgument(2) and
-      this = obj.getAMethodCall()
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "splice" and
+        prop = arrayElement() and
+        element = call.getArgument(2) and
+        call = obj.getAMethodCall()
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -265,13 +265,14 @@ private module ArrayDataFlow {
    * A step for modelling `concat`.
    * For example in `e = arr1.concat(arr2, arr3)`: if any of the `arr` is tainted, then so is `e`.
    */
-  private class ArrayConcatStep extends DataFlow::AdditionalFlowStep, DataFlow::MethodCallNode {
-    ArrayConcatStep() { this.getMethodName() = "concat" }
-
+  private class ArrayConcatStep extends DataFlow::SharedFlowStep {
     override predicate loadStoreStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
-      prop = arrayElement() and
-      (pred = this.getReceiver() or pred = this.getAnArgument()) and
-      succ = this
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "concat" and
+        prop = arrayElement() and
+        (pred = call.getReceiver() or pred = call.getAnArgument()) and
+        succ = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -289,17 +289,4 @@ private module ArrayDataFlow {
       )
     }
   }
-
-  /**
-   * A step for modelling `for of` iteration on arrays.
-   */
-  private class ForOfStep extends PreCallGraphStep {
-    override predicate loadStep(DataFlow::Node obj, DataFlow::Node e, string prop) {
-      exists(ForOfStmt forOf |
-        obj = forOf.getIterationDomain().flow() and
-        e = DataFlow::lvalueNode(forOf.getLValue()) and
-        prop = arrayElement()
-      )
-    }
-  }
 }

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -181,16 +181,14 @@ private module ArrayDataFlow {
    * A step for retrieving an element from an array using `.pop()` or `.shift()`.
    * E.g. `array.pop()`.
    */
-  private class ArrayPopStep extends DataFlow::AdditionalFlowStep, DataFlow::MethodCallNode {
-    ArrayPopStep() {
-      getMethodName() = "pop" or
-      getMethodName() = "shift"
-    }
-
+  private class ArrayPopStep extends DataFlow::SharedFlowStep {
     override predicate loadStep(DataFlow::Node obj, DataFlow::Node element, string prop) {
-      prop = arrayElement() and
-      obj = this.getReceiver() and
-      element = this
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = ["pop", "shift"] and
+        prop = arrayElement() and
+        obj = call.getReceiver() and
+        element = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -279,17 +279,14 @@ private module ArrayDataFlow {
   /**
    * A step for modelling that elements from an array `arr` also appear in the result from calling `slice`/`splice`/`filter`.
    */
-  private class ArraySliceStep extends DataFlow::AdditionalFlowStep, DataFlow::MethodCallNode {
-    ArraySliceStep() {
-      this.getMethodName() = "slice" or
-      this.getMethodName() = "splice" or
-      this.getMethodName() = "filter"
-    }
-
+  private class ArraySliceStep extends DataFlow::SharedFlowStep {
     override predicate loadStoreStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
-      prop = arrayElement() and
-      pred = this.getReceiver() and
-      succ = this
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = ["slice", "splice", "filter"] and
+        prop = arrayElement() and
+        pred = call.getReceiver() and
+        succ = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -84,16 +84,17 @@ private module ArrayDataFlow {
    * A step modelling the creation of an Array using the `Array.from(x)` method.
    * The step copies the elements of the argument (set, array, or iterator elements) into the resulting array.
    */
-  private class ArrayFrom extends DataFlow::AdditionalFlowStep, DataFlow::CallNode {
-    ArrayFrom() { this = DataFlow::globalVarRef("Array").getAMemberCall("from") }
-
+  private class ArrayFrom extends DataFlow::SharedFlowStep {
     override predicate loadStoreStep(
       DataFlow::Node pred, DataFlow::Node succ, string fromProp, string toProp
     ) {
-      pred = this.getArgument(0) and
-      succ = this and
-      fromProp = arrayLikeElement() and
-      toProp = arrayElement()
+      exists(DataFlow::CallNode call |
+        call = DataFlow::globalVarRef("Array").getAMemberCall("from") and
+        pred = call.getArgument(0) and
+        succ = call and
+        fromProp = arrayLikeElement() and
+        toProp = arrayElement()
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Collections.qll
+++ b/javascript/ql/src/semmle/javascript/Collections.qll
@@ -233,16 +233,17 @@ private module CollectionDataFlow {
   /**
    * A step for a call to `values` on a Map or a Set.
    */
-  private class MapAndSetValues extends CollectionFlowStep, DataFlow::MethodCallNode {
-    MapAndSetValues() { this.getMethodName() = "values" }
-
-    override predicate loadStore(
-      DataFlow::Node pred, DataFlow::Node succ, PseudoProperty fromProp, PseudoProperty toProp
+  private class MapAndSetValues extends PreCallGraphStep {
+    override predicate loadStoreStep(
+      DataFlow::Node pred, DataFlow::SourceNode succ, string fromProp, string toProp
     ) {
-      pred = this.getReceiver() and
-      succ = this and
-      fromProp = [mapValueAll(), setElement()] and
-      toProp = iteratorElement()
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "values" and
+        pred = call.getReceiver() and
+        succ = call and
+        fromProp = [mapValueAll(), setElement()] and
+        toProp = iteratorElement()
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Collections.qll
+++ b/javascript/ql/src/semmle/javascript/Collections.qll
@@ -6,6 +6,7 @@
 
 import javascript
 private import semmle.javascript.dataflow.internal.StepSummary
+private import semmle.javascript.dataflow.internal.PreCallGraphStep
 private import DataFlow::PseudoProperties
 
 /**
@@ -123,13 +124,13 @@ private module CollectionDataFlow {
   /**
    * A step for `Set.add()` method, which adds an element to a Set.
    */
-  private class SetAdd extends CollectionFlowStep, DataFlow::MethodCallNode {
-    SetAdd() { this.getMethodName() = "add" }
-
-    override predicate store(DataFlow::Node element, DataFlow::SourceNode obj, PseudoProperty prop) {
-      this = obj.getAMethodCall() and
-      element = this.getArgument(0) and
-      prop = setElement()
+  private class SetAdd extends PreCallGraphStep {
+    override predicate storeStep(DataFlow::Node element, DataFlow::SourceNode obj, string prop) {
+      exists(DataFlow::MethodCallNode call |
+        call = obj.getAMethodCall("add") and
+        element = call.getArgument(0) and
+        prop = setElement()
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Collections.qll
+++ b/javascript/ql/src/semmle/javascript/Collections.qll
@@ -10,17 +10,11 @@ private import DataFlow::PseudoProperties
 
 /**
  * A pseudo-property used in a data-flow/type-tracking step for collections.
- *
- * By extending `TypeTrackingPseudoProperty` the class enables the use of the collection related pseudo-properties in type-tracking predicates.
  */
-private class PseudoProperty extends TypeTrackingPseudoProperty {
+private class PseudoProperty extends string {
   PseudoProperty() {
     this = [arrayLikeElement(), "1"] or // the "1" is required for the `ForOfStep`.
     this = any(CollectionDataFlow::MapSet step).getAPseudoProperty()
-  }
-
-  override PseudoProperty getLoadStoreToProp() {
-    exists(CollectionFlowStep step | step.loadStore(_, _, this, result))
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/Collections.qll
+++ b/javascript/ql/src/semmle/javascript/Collections.qll
@@ -250,16 +250,17 @@ private module CollectionDataFlow {
   /**
    * A step for a call to `keys` on a Set.
    */
-  private class SetKeys extends CollectionFlowStep, DataFlow::MethodCallNode {
-    SetKeys() { this.getMethodName() = "keys" }
-
-    override predicate loadStore(
-      DataFlow::Node pred, DataFlow::Node succ, PseudoProperty fromProp, PseudoProperty toProp
+  private class SetKeys extends PreCallGraphStep {
+    override predicate loadStoreStep(
+      DataFlow::Node pred, DataFlow::SourceNode succ, string fromProp, string toProp
     ) {
-      pred = this.getReceiver() and
-      succ = this and
-      fromProp = setElement() and
-      toProp = iteratorElement()
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "keys" and
+        pred = call.getReceiver() and
+        succ = call and
+        fromProp = setElement() and
+        toProp = iteratorElement()
+      )
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/Collections.qll
+++ b/javascript/ql/src/semmle/javascript/Collections.qll
@@ -181,13 +181,14 @@ private module CollectionDataFlow {
   /**
    * A step for a call to `forEach` on a Set or Map.
    */
-  private class SetMapForEach extends CollectionFlowStep, DataFlow::MethodCallNode {
-    SetMapForEach() { this.getMethodName() = "forEach" }
-
-    override predicate load(DataFlow::Node obj, DataFlow::Node element, PseudoProperty prop) {
-      obj = this.getReceiver() and
-      element = this.getCallback(0).getParameter(0) and
-      prop = [setElement(), mapValueAll()]
+  private class SetMapForEach extends PreCallGraphStep {
+    override predicate loadStep(DataFlow::Node obj, DataFlow::Node element, string prop) {
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "forEach" and
+        obj = call.getReceiver() and
+        element = call.getCallback(0).getParameter(0) and
+        prop = [setElement(), mapValueAll()]
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Collections.qll
+++ b/javascript/ql/src/semmle/javascript/Collections.qll
@@ -196,14 +196,15 @@ private module CollectionDataFlow {
    * A call to the `get` method on a Map.
    * If the key of the call to `get` has a known string value, then only the value corresponding to that key will be retrieved. (The known string value is encoded as part of the pseudo-property)
    */
-  private class MapGet extends CollectionFlowStep, DataFlow::MethodCallNode {
-    MapGet() { this.getMethodName() = "get" }
-
-    override predicate load(DataFlow::Node obj, DataFlow::Node element, PseudoProperty prop) {
-      obj = this.getReceiver() and
-      element = this and
-      // reading the join of known and unknown values
-      (prop = mapValue(this.getArgument(0)) or prop = mapValueUnknownKey())
+  private class MapGet extends PreCallGraphStep {
+    override predicate loadStep(DataFlow::Node obj, DataFlow::Node element, string prop) {
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "get" and
+        obj = call.getReceiver() and
+        element = call and
+        // reading the join of known and unknown values
+        (prop = mapValue(call.getArgument(0)) or prop = mapValueUnknownKey())
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Collections.qll
+++ b/javascript/ql/src/semmle/javascript/Collections.qll
@@ -137,16 +137,17 @@ private module CollectionDataFlow {
   /**
    * A step for the `Set` constructor, which copies any elements from the first argument into the resulting set.
    */
-  private class SetConstructor extends CollectionFlowStep, DataFlow::NewNode {
-    SetConstructor() { this = DataFlow::globalVarRef("Set").getAnInstantiation() }
-
-    override predicate loadStore(
-      DataFlow::Node pred, DataFlow::Node succ, PseudoProperty fromProp, PseudoProperty toProp
+  private class SetConstructor extends PreCallGraphStep {
+    override predicate loadStoreStep(
+      DataFlow::Node pred, DataFlow::SourceNode succ, string fromProp, string toProp
     ) {
-      pred = this.getArgument(0) and
-      succ = this and
-      fromProp = arrayLikeElement() and
-      toProp = setElement()
+      exists(DataFlow::NewNode invoke |
+        invoke = DataFlow::globalVarRef("Set").getAnInstantiation() and
+        pred = invoke.getArgument(0) and
+        succ = invoke and
+        fromProp = arrayLikeElement() and
+        toProp = setElement()
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
@@ -305,6 +305,7 @@ module AccessPath {
    * }
    * ```
    */
+  pragma[inline]
   DataFlow::Node getAReferenceTo(Root root, string path) {
     path = fromReference(result, root) and
     not root.isGlobal()
@@ -327,6 +328,7 @@ module AccessPath {
    * })(NS = NS || {});
    * ```
    */
+  pragma[inline]
   DataFlow::Node getAReferenceTo(string path) {
     path = fromReference(result, DataFlow::globalAccessPathRootPseudoNode())
   }
@@ -347,6 +349,7 @@ module AccessPath {
    * }
    * ```
    */
+  pragma[inline]
   DataFlow::Node getAnAssignmentTo(Root root, string path) {
     path = fromRhs(result, root) and
     not root.isGlobal()
@@ -367,6 +370,7 @@ module AccessPath {
    *  })(foo = foo || {});
    * ```
    */
+  pragma[inline]
   DataFlow::Node getAnAssignmentTo(string path) {
     path = fromRhs(result, DataFlow::globalAccessPathRootPseudoNode())
   }
@@ -376,6 +380,7 @@ module AccessPath {
    *
    * See `getAReferenceTo` and `getAnAssignmentTo` for more details.
    */
+  pragma[inline]
   DataFlow::Node getAReferenceOrAssignmentTo(string path) {
     result = getAReferenceTo(path)
     or
@@ -387,6 +392,7 @@ module AccessPath {
    *
    * See `getAReferenceTo` and `getAnAssignmentTo` for more details.
    */
+  pragma[inline]
   DataFlow::Node getAReferenceOrAssignmentTo(Root root, string path) {
     result = getAReferenceTo(root, path)
     or

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -214,13 +214,6 @@ module PromiseTypeTracking {
       result = PromiseTypeTracking::promiseStep(mid, summary)
     )
   }
-
-  /**
-   * A class enabling the use of the `resolveField` as a pseudo-property in type-tracking predicates.
-   */
-  private class ResolveFieldAsTypeTrackingProperty extends TypeTrackingPseudoProperty {
-    ResolveFieldAsTypeTrackingProperty() { this = Promises::valueProp() }
-  }
 }
 
 private import semmle.javascript.dataflow.internal.PreCallGraphStep

--- a/javascript/ql/src/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/StandardLibrary.qll
@@ -74,23 +74,13 @@ private class ArrayIterationCallbackAsPartialInvoke extends DataFlow::PartialInv
  * A flow step propagating the exception thrown from a callback to a method whose name coincides
  * a built-in Array iteration method, such as `forEach` or `map`.
  */
-private class IteratorExceptionStep extends DataFlow::MethodCallNode, DataFlow::AdditionalFlowStep {
-  IteratorExceptionStep() {
-    exists(string name | name = getMethodName() |
-      name = "forEach" or
-      name = "each" or
-      name = "map" or
-      name = "filter" or
-      name = "some" or
-      name = "every" or
-      name = "fold" or
-      name = "reduce"
-    )
-  }
-
+private class IteratorExceptionStep extends DataFlow::SharedFlowStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = getAnArgument().(DataFlow::FunctionNode).getExceptionalReturn() and
-    succ = this.getExceptionalReturn()
+    exists(DataFlow::MethodCallNode call |
+      call.getMethodName() = ["forEach", "each", "map", "filter", "some", "every", "fold", "reduce"] and
+      pred = call.getAnArgument().(DataFlow::FunctionNode).getExceptionalReturn() and
+      succ = call.getExceptionalReturn()
+    )
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -551,19 +551,16 @@ abstract class LabeledBarrierGuardNode extends BarrierGuardNode {
  * of the standard library. Override `Configuration::isAdditionalFlowStep`
  * for analysis-specific flow steps.
  */
-cached
 abstract class AdditionalFlowStep extends DataFlow::Node {
   /**
    * Holds if `pred` &rarr; `succ` should be considered a data flow edge.
    */
-  cached
   predicate step(DataFlow::Node pred, DataFlow::Node succ) { none() }
 
   /**
    * Holds if `pred` &rarr; `succ` should be considered a data flow edge
    * transforming values with label `predlbl` to have label `succlbl`.
    */
-  cached
   predicate step(
     DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel predlbl,
     DataFlow::FlowLabel succlbl
@@ -577,7 +574,6 @@ abstract class AdditionalFlowStep extends DataFlow::Node {
    * Holds if `pred` should be stored in the object `succ` under the property `prop`.
    * The object `succ` must be a `DataFlow::SourceNode` for the object wherein the value is stored.
    */
-  cached
   predicate storeStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) { none() }
 
   /**
@@ -585,7 +581,6 @@ abstract class AdditionalFlowStep extends DataFlow::Node {
    *
    * Holds if the property `prop` of the object `pred` should be loaded into `succ`.
    */
-  cached
   predicate loadStep(DataFlow::Node pred, DataFlow::Node succ, string prop) { none() }
 
   /**
@@ -593,7 +588,6 @@ abstract class AdditionalFlowStep extends DataFlow::Node {
    *
    * Holds if the property `prop` should be copied from the object `pred` to the object `succ`.
    */
-  cached
   predicate loadStoreStep(DataFlow::Node pred, DataFlow::Node succ, string prop) { none() }
 
   /**
@@ -601,7 +595,6 @@ abstract class AdditionalFlowStep extends DataFlow::Node {
    *
    * Holds if the property `loadProp` should be copied from the object `pred` to the property `storeProp` of object `succ`.
    */
-  cached
   predicate loadStoreStep(
     DataFlow::Node pred, DataFlow::Node succ, string loadProp, string storeProp
   ) {

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -886,13 +886,12 @@ abstract class AdditionalSink extends DataFlow::Node {
  * Additional flow step to model flow from import specifiers into the SSA variable
  * corresponding to the imported variable.
  */
-private class FlowStepThroughImport extends AdditionalFlowStep, DataFlow::ValueNode {
-  override ImportSpecifier astNode;
-
+private class FlowStepThroughImport extends SharedFlowStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    Stages::FlowSteps::ref() and
-    pred = this and
-    succ = DataFlow::ssaDefinitionNode(SSA::definition(astNode))
+    exists(ImportSpecifier specifier |
+      pred = DataFlow::valueNode(specifier) and
+      succ = DataFlow::ssaDefinitionNode(SSA::definition(specifier))
+    )
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -544,6 +544,12 @@ abstract class LabeledBarrierGuardNode extends BarrierGuardNode {
 }
 
 /**
+ * DEPRECATED. Subclasses should extend `SharedFlowStep` instead, unless the subclass
+ * is part of a query, in which case it should be moved into the `isAdditionalFlowStep` predicate
+ * of the relevant data-flow configuration.
+ * Other uses of the predicate in this class should instead reference the predicates in the
+ * `SharedFlowStep::` module, such as `SharedFlowStep::step`.
+ *
  * A data flow edge that should be added to all data flow configurations in
  * addition to standard data flow edges.
  *
@@ -551,7 +557,10 @@ abstract class LabeledBarrierGuardNode extends BarrierGuardNode {
  * of the standard library. Override `Configuration::isAdditionalFlowStep`
  * for analysis-specific flow steps.
  */
-abstract class AdditionalFlowStep extends DataFlow::Node {
+deprecated class AdditionalFlowStep = LegacyAdditionalFlowStep;
+
+// Internal version of AdditionalFlowStep that we can reference without deprecation warnings.
+abstract private class LegacyAdditionalFlowStep extends DataFlow::Node {
   /**
    * Holds if `pred` &rarr; `succ` should be considered a data flow edge.
    */
@@ -729,32 +738,32 @@ module SharedFlowStep {
  */
 private class AdditionalFlowStepAsSharedStep extends SharedFlowStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    any(AdditionalFlowStep s).step(pred, succ)
+    any(LegacyAdditionalFlowStep s).step(pred, succ)
   }
 
   override predicate step(
     DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel predlbl,
     DataFlow::FlowLabel succlbl
   ) {
-    any(AdditionalFlowStep s).step(pred, succ, predlbl, succlbl)
+    any(LegacyAdditionalFlowStep s).step(pred, succ, predlbl, succlbl)
   }
 
   override predicate storeStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
-    any(AdditionalFlowStep s).storeStep(pred, succ, prop)
+    any(LegacyAdditionalFlowStep s).storeStep(pred, succ, prop)
   }
 
   override predicate loadStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
-    any(AdditionalFlowStep s).loadStep(pred, succ, prop)
+    any(LegacyAdditionalFlowStep s).loadStep(pred, succ, prop)
   }
 
   override predicate loadStoreStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
-    any(AdditionalFlowStep s).loadStoreStep(pred, succ, prop)
+    any(LegacyAdditionalFlowStep s).loadStoreStep(pred, succ, prop)
   }
 
   override predicate loadStoreStep(
     DataFlow::Node pred, DataFlow::Node succ, string loadProp, string storeProp
   ) {
-    any(AdditionalFlowStep s).loadStoreStep(pred, succ, loadProp, storeProp)
+    any(LegacyAdditionalFlowStep s).loadStoreStep(pred, succ, loadProp, storeProp)
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -605,8 +605,7 @@ abstract class AdditionalFlowStep extends DataFlow::Node {
   predicate loadStoreStep(
     DataFlow::Node pred, DataFlow::Node succ, string loadProp, string storeProp
   ) {
-    loadProp = storeProp and
-    loadStoreStep(pred, succ, loadProp)
+    none()
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -828,13 +828,13 @@ module TaintTracking {
   /**
    * A taint propagating data flow edge arising from URL parameter parsing.
    */
-  private class UrlSearchParamsTaintStep extends DataFlow::AdditionalFlowStep, DataFlow::ValueNode {
+  private class UrlSearchParamsTaintStep extends DataFlow::SharedFlowStep {
     /**
      * Holds if `succ` is a `URLSearchParams` providing access to the
      * parameters encoded in `pred`.
      */
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      isUrlSearchParams(succ, pred) and succ = this
+      isUrlSearchParams(succ, pred)
     }
 
     /**
@@ -847,17 +847,14 @@ module TaintTracking {
      *    which can be accessed using a `get` or `getAll` call. (See getableUrlPseudoProperty())
      */
     override predicate storeStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
-      succ = this and
-      (
-        prop = ["searchParams", "hash", "search", hiddenUrlPseudoProperty()] and
-        exists(DataFlow::NewNode newUrl | succ = newUrl |
-          newUrl = DataFlow::globalVarRef("URL").getAnInstantiation() and
-          pred = newUrl.getArgument(0)
-        )
-        or
-        prop = getableUrlPseudoProperty() and
-        isUrlSearchParams(succ, pred)
+      prop = ["searchParams", "hash", "search", hiddenUrlPseudoProperty()] and
+      exists(DataFlow::NewNode newUrl | succ = newUrl |
+        newUrl = DataFlow::globalVarRef("URL").getAnInstantiation() and
+        pred = newUrl.getArgument(0)
       )
+      or
+      prop = getableUrlPseudoProperty() and
+      isUrlSearchParams(succ, pred)
     }
 
     /**
@@ -869,7 +866,6 @@ module TaintTracking {
     override predicate loadStoreStep(
       DataFlow::Node pred, DataFlow::Node succ, string loadProp, string storeProp
     ) {
-      succ = this and
       loadProp = hiddenUrlPseudoProperty() and
       storeProp = getableUrlPseudoProperty() and
       exists(DataFlow::PropRead read | read = succ |
@@ -884,7 +880,6 @@ module TaintTracking {
      * This step is used to load the value stored in the pseudo-property `getableUrlPseudoProperty()`.
      */
     override predicate loadStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
-      succ = this and
       prop = getableUrlPseudoProperty() and
       // this is a call to `get` or `getAll` on a `URLSearchParams` object
       exists(string m, DataFlow::MethodCallNode call | call = succ |

--- a/javascript/ql/src/semmle/javascript/dataflow/TrackedNodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TrackedNodes.qll
@@ -102,7 +102,7 @@ private module NodeTracking {
   predicate localFlowStep(DataFlow::Node pred, DataFlow::Node succ) {
     pred = succ.getAPredecessor()
     or
-    any(DataFlow::AdditionalFlowStep afs).step(pred, succ)
+    DataFlow::SharedFlowStep::step(pred, succ)
     or
     localExceptionStep(pred, succ)
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
@@ -358,6 +358,15 @@ class SharedTypeTrackingStep extends Unit {
    * Holds if type-tracking should step from the `prop` property of `pred` to the same property in `succ`.
    */
   predicate loadStoreStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) { none() }
+
+  /**
+   * Holds if type-tracking should step from the `loadProp` property of `pred` to the `storeProp` property in `succ`.
+   */
+  predicate loadStoreStep(
+    DataFlow::Node pred, DataFlow::SourceNode succ, string loadProp, string storeProp
+  ) {
+    none()
+  }
 }
 
 /** Provides access to the steps contributed by subclasses of `SharedTypeTrackingStep`. */
@@ -388,6 +397,15 @@ module SharedTypeTrackingStep {
    */
   predicate loadStoreStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
     any(SharedTypeTrackingStep s).loadStoreStep(pred, succ, prop)
+  }
+
+  /**
+   * Holds if type-tracking should step from the `loadProp` property of `pred` to the `storeProp` property in `succ`.
+   */
+  predicate loadStoreStep(
+    DataFlow::Node pred, DataFlow::SourceNode succ, string loadProp, string storeProp
+  ) {
+    any(SharedTypeTrackingStep s).loadStoreStep(pred, succ, loadProp, storeProp)
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -39,9 +39,9 @@ predicate localFlowStep(
 ) {
   pred = succ.getAPredecessor() and predlbl = succlbl
   or
-  any(DataFlow::AdditionalFlowStep afs).step(pred, succ) and predlbl = succlbl
+  DataFlow::SharedFlowStep::step(pred, succ) and predlbl = succlbl
   or
-  any(DataFlow::AdditionalFlowStep afs).step(pred, succ, predlbl, succlbl)
+  DataFlow::SharedFlowStep::step(pred, succ, predlbl, succlbl)
   or
   exists(boolean vp | configuration.isAdditionalFlowStep(pred, succ, vp) |
     vp = true and

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/PreCallGraphStep.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/PreCallGraphStep.qll
@@ -16,7 +16,7 @@ private class Unit extends TUnit {
  * Internal extension point for adding flow edges prior to call graph construction
  * and type tracking.
  *
- * Steps added here will be added to both `AdditionalFlowStep` and `AdditionalTypeTrackingStep`.
+ * Steps added here will be added to both `SharedFlowStep` and `SharedTypeTrackingStep`.
  *
  * Contributing steps that rely on type tracking will lead to negative recursion.
  */
@@ -77,18 +77,6 @@ module PreCallGraphStep {
   }
 }
 
-private class NodeWithPreCallGraphStep extends DataFlow::Node {
-  NodeWithPreCallGraphStep() {
-    PreCallGraphStep::step(this, _)
-    or
-    PreCallGraphStep::storeStep(this, _, _)
-    or
-    PreCallGraphStep::loadStep(this, _, _)
-    or
-    PreCallGraphStep::loadStoreStep(this, _, _)
-  }
-}
-
 private class SharedFlowStepFromPreCallGraph extends DataFlow::SharedFlowStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     PreCallGraphStep::step(pred, succ)
@@ -107,25 +95,20 @@ private class SharedFlowStepFromPreCallGraph extends DataFlow::SharedFlowStep {
   }
 }
 
-private class AdditionalTypeTrackingStepFromPreCallGraph extends NodeWithPreCallGraphStep,
-  DataFlow::AdditionalTypeTrackingStep {
+private class SharedTypeTrackingStepFromPreCallGraph extends DataFlow::SharedTypeTrackingStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = this and
-    PreCallGraphStep::step(this, succ)
+    PreCallGraphStep::step(pred, succ)
   }
 
   override predicate storeStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
-    pred = this and
-    PreCallGraphStep::storeStep(this, succ, prop)
+    PreCallGraphStep::storeStep(pred, succ, prop)
   }
 
   override predicate loadStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
-    pred = this and
-    PreCallGraphStep::loadStep(this, succ, prop)
+    PreCallGraphStep::loadStep(pred, succ, prop)
   }
 
   override predicate loadStoreStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
-    pred = this and
-    PreCallGraphStep::loadStoreStep(this, succ, prop)
+    PreCallGraphStep::loadStoreStep(pred, succ, prop)
   }
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/PreCallGraphStep.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/PreCallGraphStep.qll
@@ -89,26 +89,21 @@ private class NodeWithPreCallGraphStep extends DataFlow::Node {
   }
 }
 
-private class AdditionalFlowStepFromPreCallGraph extends NodeWithPreCallGraphStep,
-  DataFlow::AdditionalFlowStep {
+private class SharedFlowStepFromPreCallGraph extends DataFlow::SharedFlowStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = this and
-    PreCallGraphStep::step(this, succ)
+    PreCallGraphStep::step(pred, succ)
   }
 
   override predicate storeStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
-    pred = this and
-    PreCallGraphStep::storeStep(this, succ, prop)
+    PreCallGraphStep::storeStep(pred, succ, prop)
   }
 
   override predicate loadStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
-    pred = this and
-    PreCallGraphStep::loadStep(this, succ, prop)
+    PreCallGraphStep::loadStep(pred, succ, prop)
   }
 
   override predicate loadStoreStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
-    pred = this and
-    PreCallGraphStep::loadStoreStep(this, succ, prop)
+    PreCallGraphStep::loadStoreStep(pred, succ, prop)
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/PreCallGraphStep.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/PreCallGraphStep.qll
@@ -40,6 +40,15 @@ class PreCallGraphStep extends Unit {
    * Holds if there is a step from the `prop` property of `pred` to the same property in `succ`.
    */
   predicate loadStoreStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) { none() }
+
+  /**
+   * Holds if there is a step from the `loadProp` property of `pred` to the `storeProp` property in `succ`.
+   */
+  predicate loadStoreStep(
+    DataFlow::Node pred, DataFlow::SourceNode succ, string loadProp, string storeProp
+  ) {
+    none()
+  }
 }
 
 module PreCallGraphStep {
@@ -75,6 +84,15 @@ module PreCallGraphStep {
   predicate loadStoreStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
     any(PreCallGraphStep s).loadStoreStep(pred, succ, prop)
   }
+
+  /**
+   * Holds if there is a step from the `loadProp` property of `pred` to the `storeProp` property in `succ`.
+   */
+  predicate loadStoreStep(
+    DataFlow::Node pred, DataFlow::SourceNode succ, string loadProp, string storeProp
+  ) {
+    any(PreCallGraphStep s).loadStoreStep(pred, succ, loadProp, storeProp)
+  }
 }
 
 private class SharedFlowStepFromPreCallGraph extends DataFlow::SharedFlowStep {
@@ -93,6 +111,12 @@ private class SharedFlowStepFromPreCallGraph extends DataFlow::SharedFlowStep {
   override predicate loadStoreStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
     PreCallGraphStep::loadStoreStep(pred, succ, prop)
   }
+
+  override predicate loadStoreStep(
+    DataFlow::Node pred, DataFlow::Node succ, string loadProp, string storeProp
+  ) {
+    PreCallGraphStep::loadStoreStep(pred, succ, loadProp, storeProp)
+  }
 }
 
 private class SharedTypeTrackingStepFromPreCallGraph extends DataFlow::SharedTypeTrackingStep {
@@ -110,5 +134,11 @@ private class SharedTypeTrackingStepFromPreCallGraph extends DataFlow::SharedTyp
 
   override predicate loadStoreStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
     PreCallGraphStep::loadStoreStep(pred, succ, prop)
+  }
+
+  override predicate loadStoreStep(
+    DataFlow::Node pred, DataFlow::SourceNode succ, string loadProp, string storeProp
+  ) {
+    PreCallGraphStep::loadStoreStep(pred, succ, loadProp, storeProp)
   }
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/StepSummary.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/StepSummary.qll
@@ -111,17 +111,17 @@ module StepSummary {
       basicLoadStep(pred, succ, prop) and
       summary = LoadStep(prop)
       or
-      any(AdditionalTypeTrackingStep st).storeStep(pred, succ, prop) and
+      SharedTypeTrackingStep::storeStep(pred, succ, prop) and
       summary = StoreStep(prop)
       or
-      any(AdditionalTypeTrackingStep st).loadStep(pred, succ, prop) and
+      SharedTypeTrackingStep::loadStep(pred, succ, prop) and
       summary = LoadStep(prop)
       or
-      any(AdditionalTypeTrackingStep st).loadStoreStep(pred, succ, prop) and
+      SharedTypeTrackingStep::loadStoreStep(pred, succ, prop) and
       summary = CopyStep(prop)
     )
     or
-    any(AdditionalTypeTrackingStep st).step(pred, succ) and
+    SharedTypeTrackingStep::step(pred, succ) and
     summary = LevelStep()
     or
     // Store to global access path

--- a/javascript/ql/src/semmle/javascript/frameworks/EventEmitter.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/EventEmitter.qll
@@ -194,9 +194,9 @@ module EventDispatch {
 }
 
 /**
- * A taint-step that models data-flow between event handlers and event dispatchers.
+ * A flow-step that models data-flow between event handlers and event dispatchers.
  */
-private class EventEmitterTaintStep extends DataFlow::SharedFlowStep {
+private class EventEmitterFlowStep extends DataFlow::SharedFlowStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(EventRegistration reg, EventDispatch dispatch |
       reg = dispatch.getAReceiver() and

--- a/javascript/ql/src/semmle/javascript/frameworks/EventEmitter.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/EventEmitter.qll
@@ -196,24 +196,20 @@ module EventDispatch {
 /**
  * A taint-step that models data-flow between event handlers and event dispatchers.
  */
-private class EventEmitterTaintStep extends DataFlow::AdditionalFlowStep {
-  EventRegistration reg;
-  EventDispatch dispatch;
-
-  EventEmitterTaintStep() {
-    this = dispatch and
-    reg = dispatch.getAReceiver() and
-    not dispatch.getChannel() != reg.getChannel()
-  }
-
+private class EventEmitterTaintStep extends DataFlow::SharedFlowStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(int i | i >= 0 |
-      pred = dispatch.getSentItem(i) and
-      succ = reg.getReceivedItem(i)
+    exists(EventRegistration reg, EventDispatch dispatch |
+      reg = dispatch.getAReceiver() and
+      not dispatch.getChannel() != reg.getChannel()
+    |
+      exists(int i | i >= 0 |
+        pred = dispatch.getSentItem(i) and
+        succ = reg.getReceivedItem(i)
+      )
+      or
+      dispatch = reg.getAReturnDispatch() and
+      pred = reg.getAReturnedValue() and
+      succ = dispatch
     )
-    or
-    dispatch = reg.getAReturnDispatch() and
-    pred = reg.getAReturnedValue() and
-    succ = dispatch
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -708,8 +708,8 @@ module HTTP {
       override DataFlow::SourceNode getRouteHandler(DataFlow::SourceNode access) {
         result instanceof RouteHandlerCandidate and
         exists(
-          DataFlow::Node input, TypeTrackingPseudoProperty key, CollectionFlowStep store,
-          CollectionFlowStep load, DataFlow::Node storeTo, DataFlow::Node loadFrom
+          DataFlow::Node input, string key, CollectionFlowStep store, CollectionFlowStep load,
+          DataFlow::Node storeTo, DataFlow::Node loadFrom
         |
           this.flowsTo(storeTo) and
           store.store(input, storeTo, key) and

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -6,6 +6,7 @@ import javascript
 private import semmle.javascript.DynamicPropertyAccess
 private import semmle.javascript.dataflow.internal.StepSummary
 private import semmle.javascript.dataflow.internal.CallGraphs
+private import DataFlow::PseudoProperties as PseudoProperties
 
 module HTTP {
   /**
@@ -689,33 +690,30 @@ module HTTP {
       isDecoratedCall(result, candidate)
     }
 
+    private string mapValueProp() {
+      result = [PseudoProperties::mapValueAll(), PseudoProperties::mapValueUnknownKey()]
+    }
+
     /**
      * A collection that contains one or more route potential handlers.
      */
-    private class ContainerCollection extends HTTP::RouteHandlerCandidateContainer::Range {
+    private class ContainerCollection extends HTTP::RouteHandlerCandidateContainer::Range,
+      DataFlow::NewNode {
       ContainerCollection() {
         this = DataFlow::globalVarRef("Map").getAnInstantiation() and // restrict to Map for now
-        exists(
-          CollectionFlowStep store, DataFlow::Node storeTo, DataFlow::Node input,
-          RouteHandlerCandidate candidate
-        |
-          this.flowsTo(storeTo) and
-          store.store(input, storeTo, _) and
-          candidate.flowsTo(input)
+        exists(DataFlow::Node use |
+          DataFlow::SharedTypeTrackingStep::storeStep(use, this, mapValueProp()) and
+          use.getALocalSource() instanceof RouteHandlerCandidate
         )
       }
 
       override DataFlow::SourceNode getRouteHandler(DataFlow::SourceNode access) {
-        result instanceof RouteHandlerCandidate and
-        exists(
-          DataFlow::Node input, string key, CollectionFlowStep store, CollectionFlowStep load,
-          DataFlow::Node storeTo, DataFlow::Node loadFrom
-        |
-          this.flowsTo(storeTo) and
-          store.store(input, storeTo, key) and
+        exists(DataFlow::Node input, string key, DataFlow::Node loadFrom |
           getAPossiblyDecoratedHandler(result).flowsTo(input) and
+          DataFlow::SharedTypeTrackingStep::storeStep(input, this, key) and
           ref(this).flowsTo(loadFrom) and
-          load.load(loadFrom, access, key)
+          DataFlow::SharedTypeTrackingStep::loadStep(loadFrom, access,
+            [key, PseudoProperties::mapValueAll()])
         )
       }
     }

--- a/javascript/ql/src/semmle/javascript/frameworks/Immutable.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Immutable.qll
@@ -164,22 +164,15 @@ private module Immutable {
   /**
    * A dataflow step for an immutable collection.
    */
-  class ImmutableConstructionStep extends DataFlow::AdditionalFlowStep {
-    ImmutableConstructionStep() { this = [loadStep(_, _), storeStep(_, _), step(_)] }
-
+  class ImmutableConstructionStep extends DataFlow::SharedFlowStep {
     override predicate loadStep(DataFlow::Node pred, DataFlow::Node succ, string prop) {
-      this = loadStep(pred, prop) and
-      succ = this
+      succ = loadStep(pred, prop)
     }
 
     override predicate storeStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
-      this = storeStep(pred, prop) and
-      succ = this
+      succ = storeStep(pred, prop)
     }
 
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      this = step(pred) and
-      succ = this
-    }
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) { succ = step(pred) }
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -360,9 +360,9 @@ module LodashUnderscore {
   /**
    * A data flow step propagating an exception thrown from a callback to a Lodash/Underscore function.
    */
-  private class ExceptionStep extends DataFlow::CallNode, DataFlow::AdditionalFlowStep {
-    ExceptionStep() {
-      exists(string name | this = member(name).getACall() |
+  private class ExceptionStep extends DataFlow::SharedFlowStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::CallNode call, string name |
         // Members ending with By, With, or While indicate that they are a variant of
         // another function that takes a callback.
         name.matches("%By") or
@@ -386,12 +386,11 @@ module LodashUnderscore {
         name = "replace" or
         name = "some" or
         name = "transform"
+      |
+        call = member(name).getACall() and
+        pred = call.getAnArgument().(DataFlow::FunctionNode).getExceptionalReturn() and
+        succ = call.getExceptionalReturn()
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getAnArgument().(DataFlow::FunctionNode).getExceptionalReturn() and
-      succ = this.getExceptionalReturn()
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Next.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Next.qll
@@ -140,20 +140,14 @@ module NextJS {
   /**
    * A step modelling the flow from the server-computed props object to the default exported React component that renders the page.
    */
-  class NextJSStaticReactComponentPropsStep extends DataFlow::AdditionalFlowStep,
-    DataFlow::ValueNode {
-    Module pageModule;
-    ReactComponent component;
-
-    NextJSStaticReactComponentPropsStep() {
-      pageModule = getAPagesModule() and
-      this.getAstNode() = component and
-      this = pageModule.getAnExportedValue("default").getALocalSource()
-    }
-
+  class NextJSStaticReactComponentPropsStep extends DataFlow::SharedFlowStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getAPropsSource(pageModule) and
-      succ = component.getADirectPropsAccess()
+      exists(Module pageModule, ReactComponent component |
+        pageModule = getAPagesModule() and
+        pageModule.getAnExportedValue("default").getALocalSource() = DataFlow::valueNode(component) and
+        pred = getAPropsSource(pageModule) and
+        succ = component.getADirectPropsAccess()
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Next.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Next.qll
@@ -126,17 +126,14 @@ module NextJS {
   /**
    * A step modelling the flow from the server-computed props object to the default exported function that renders the page.
    */
-  class NextJSStaticPropsStep extends DataFlow::AdditionalFlowStep, DataFlow::FunctionNode {
-    Module pageModule;
-
-    NextJSStaticPropsStep() {
-      pageModule = getAPagesModule() and
-      this = pageModule.getAnExportedValue("default").getAFunctionValue()
-    }
-
+  class NextJSStaticPropsStep extends DataFlow::SharedFlowStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getAPropsSource(pageModule) and
-      succ = this.getParameter(0)
+      exists(Module pageModule, DataFlow::FunctionNode function |
+        pageModule = getAPagesModule() and
+        function = pageModule.getAnExportedValue("default").getAFunctionValue() and
+        pred = getAPropsSource(pageModule) and
+        succ = function.getParameter(0)
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
+++ b/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
@@ -219,7 +219,7 @@ module Stages {
       or
       AccessPath::DominatingPaths::hasDominatingWrite(_)
       or
-      any(DataFlow::AdditionalFlowStep s).step(_, _)
+      DataFlow::SharedFlowStep::step(_, _)
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
@@ -255,15 +255,12 @@ module ExternalAPIUsedWithUntrustedData {
       not exists(DataFlow::Node arg |
         arg = this.getAnArgument() and not arg instanceof DeepObjectSink
       |
-        TaintTracking::sharedTaintStep(arg, _)
-        or
-        exists(DataFlow::AdditionalFlowStep s |
-          s.step(arg, _) or
-          s.step(arg, _, _, _) or
-          s.loadStep(arg, _, _) or
-          s.storeStep(arg, _, _) or
-          s.loadStoreStep(arg, _, _)
-        )
+        TaintTracking::sharedTaintStep(arg, _) or
+        DataFlow::SharedFlowStep::step(arg, _) or
+        DataFlow::SharedFlowStep::step(arg, _, _, _) or
+        DataFlow::SharedFlowStep::loadStep(arg, _, _) or
+        DataFlow::SharedFlowStep::storeStep(arg, _, _) or
+        DataFlow::SharedFlowStep::loadStoreStep(arg, _, _)
       )
     }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/PrototypePollutingAssignment.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/PrototypePollutingAssignment.qll
@@ -100,10 +100,10 @@ module PrototypePollutingAssignment {
     // users wouldn't bother to call Object.create in that case.
     result = DataFlow::globalVarRef("Object").getAMemberCall("create")
     or
-    // Allow use of AdditionalFlowSteps to track a bit further
+    // Allow use of SharedFlowSteps to track a bit further
     exists(DataFlow::Node mid |
       prototypeLessObject(t.continue()).flowsTo(mid) and
-      any(DataFlow::AdditionalFlowStep s).step(mid, result)
+      DataFlow::SharedFlowStep::step(mid, result)
     )
     or
     exists(DataFlow::TypeTracker t2 | result = prototypeLessObject(t2).track(t2, t))

--- a/javascript/ql/test/library-tests/frameworks/Collections/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/Collections/test.expected
@@ -26,3 +26,6 @@ typeTracking
 | tst.js:2:16:2:23 | source() | tst.js:37:14:37:14 | e |
 | tst.js:2:16:2:23 | source() | tst.js:45:14:45:14 | e |
 | tst.js:2:16:2:23 | source() | tst.js:53:8:53:21 | map.get("key") |
+| tst.js:2:16:2:23 | source() | tst.js:59:8:59:22 | map2.get("foo") |
+| tst.js:2:16:2:23 | source() | tst.js:64:8:64:26 | map3.get(unknown()) |
+| tst.js:2:16:2:23 | source() | tst.js:69:8:69:26 | map3.get(unknown()) |

--- a/javascript/ql/test/library-tests/frameworks/Collections/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/Collections/test.ql
@@ -22,10 +22,6 @@ DataFlow::SourceNode trackSource(DataFlow::TypeTracker t, DataFlow::SourceNode s
   start = result
   or
   exists(DataFlow::TypeTracker t2 | t = t2.step(trackSource(t2, start), result))
-  or
-  exists(DataFlow::TypeTracker t2 |
-    result = CollectionsTypeTracking::collectionStep(trackSource(t2, start), t, t2)
-  )
 }
 
 query DataFlow::SourceNode typeTracking(DataFlow::Node start) {

--- a/javascript/ql/test/library-tests/frameworks/Collections/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/Collections/tst.js
@@ -54,17 +54,17 @@
   sink(map.get("nonExistingKey")); // OK. 
 
   // unknown write, known read
-  var map2 = new map();
+  var map2 = new Map();
   map2.set(unknown(), source); 
-  sink(map2.get("foo")); // NOT OK (for data-flow). OK for type-tracking.
+  sink(map2.get("foo")); // NOT OK (for data-flow).
 
   // unknown write, unknown read
-  var map3 = new map();
+  var map3 = new Map();
   map3.set(unknown(), source); 
-  sink(map3.get(unknown())); // NOT OK (for data-flow). OK for type-tracking.
+  sink(map3.get(unknown())); // NOT OK (for data-flow).
 
   // known write, unknown read
-  var map4 = new map();
+  var map4 = new Map();
   map4.set("foo", source); 
-  sink(map3.get(unknown())); // NOT OK (for data-flow). OK for type-tracking.
+  sink(map3.get(unknown())); // NOT OK (for data-flow).
 })();

--- a/javascript/ql/test/library-tests/frameworks/Electron/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/Electron/tests.ql
@@ -9,7 +9,7 @@ query predicate clientRequest_getADataNode(Electron::ElectronClientRequest cr, D
 query predicate clientRequest(Electron::ElectronClientRequest cr) { any() }
 
 query predicate ipcFlow(DataFlow::Node pred, DataFlow::Node succ) {
-  exists(DataFlow::AdditionalFlowStep afs | afs.step(pred, succ))
+  DataFlow::SharedFlowStep::step(pred, succ)
 }
 
 query predicate remoteFlowSources(RemoteFlowSource source) { any() }

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/test.expected
@@ -1,4 +1,4 @@
-taintSteps
+flowSteps
 | customEmitter.js:5:20:5:24 | "bar" | customEmitter.js:6:19:6:22 | data |
 | customEmitter.js:12:21:12:25 | "baz" | customEmitter.js:13:23:13:26 | data |
 | customEmitter.js:12:21:12:25 | "baz" | customEmitter.js:22:14:22:18 | yData |

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/test.ql
@@ -1,6 +1,6 @@
 import javascript
 
-query predicate taintSteps(DataFlow::Node pred, DataFlow::Node succ) {
+query predicate flowSteps(DataFlow::Node pred, DataFlow::Node succ) {
   DataFlow::SharedFlowStep::step(pred, succ)
 }
 

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/test.ql
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate taintSteps(DataFlow::Node pred, DataFlow::Node succ) {
-  exists(DataFlow::AdditionalFlowStep step | step.step(pred, succ))
+  DataFlow::SharedFlowStep::step(pred, succ)
 }
 
 query predicate eventEmitter(EventEmitter e) { any() }

--- a/javascript/ql/test/library-tests/frameworks/SocketIO/AdditionalFlowStep.qll
+++ b/javascript/ql/test/library-tests/frameworks/SocketIO/AdditionalFlowStep.qll
@@ -1,5 +1,5 @@
 import javascript
 
 query predicate test_AdditionalFlowStep(DataFlow::Node pred, DataFlow::Node succ) {
-  exists(DataFlow::AdditionalFlowStep step | step.step(pred, succ) | any())
+  DataFlow::SharedFlowStep::step(pred, succ)
 }

--- a/javascript/ql/test/library-tests/frameworks/WebSocket/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/WebSocket/test.expected
@@ -21,7 +21,7 @@ serverSend
 serverReceive
 | server.js:7:3:9:4 | ws.on(' ... );\\n\\t\\t}) |
 | sockjs.js:9:5:12:6 | conn.on ... \\n    }) |
-taintStep
+flowSteps
 | browser.js:5:15:5:32 | 'Hi from browser!' | server.js:7:38:7:44 | message |
 | browser.js:21:13:21:18 | 'test' | sockjs.js:9:31:9:37 | message |
 | client.js:7:11:7:27 | 'Hi from client!' | server.js:7:38:7:44 | message |

--- a/javascript/ql/test/library-tests/frameworks/WebSocket/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/WebSocket/test.ql
@@ -12,7 +12,7 @@ query ServerWebSocket::SendNode serverSend() { any() }
 
 query ServerWebSocket::ReceiveNode serverReceive() { any() }
 
-query predicate taintStep(DataFlow::Node pred, DataFlow::Node succ) {
+query predicate flowSteps(DataFlow::Node pred, DataFlow::Node succ) {
   DataFlow::SharedFlowStep::step(pred, succ)
 }
 

--- a/javascript/ql/test/library-tests/frameworks/WebSocket/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/WebSocket/test.ql
@@ -13,7 +13,7 @@ query ServerWebSocket::SendNode serverSend() { any() }
 query ServerWebSocket::ReceiveNode serverReceive() { any() }
 
 query predicate taintStep(DataFlow::Node pred, DataFlow::Node succ) {
-  any(DataFlow::AdditionalFlowStep s).step(pred, succ)
+  DataFlow::SharedFlowStep::step(pred, succ)
 }
 
 query RemoteFlowSource remoteFlow() { any() }


### PR DESCRIPTION
Follow up to https://github.com/github/codeql/pull/5396, replacing all uses of `AdditionalFlowStep` with the new `SharedFlowStep` class, based on a unit type.

The one exception is the `CollectionFlowStep` hierarchy which have been ported to `PreCallGraphStep` as it's a much better fit. Previously, our models had to opt into collection type-tracking steps, now everyone gets it for free.
- This is not a behaviour-preserving change, but factoring it into a separate branch wasn't practical as we'd have to introduce new concepts immediately to be deprecated in the following PR.
- The `SetAdd` commit is the first one with semantic changes.

Evaluations: (internal links)
- [Whole PR](https://github.com/dsp-testing/asgerf-dca/tree/run/js/shared-flow-step4/reports) shows good performance.
- [Just the semantic-changing part](https://github.com/dsp-testing/asgerf-dca/tree/run/js/shared-flow-step-NoCollectionStep4/reports) in isolation also looks good. The 4 new call edges are due to the new pre-call graph steps.