### PR TITLE
Docs: Prepare supported languages/frameworks for 1.27 release

### DIFF
--- a/docs/codeql/support/conf.py
+++ b/docs/codeql/support/conf.py
@@ -16,7 +16,7 @@
 
 ##############################################################################
 #
-# Modified 22052019. 
+# Modified 22032021. 
 
 # The configuration values below are specific to the supported languages and frameworks project
 # To amend html_theme_options, update version/release number, or add more sphinx extensions,
@@ -41,9 +41,9 @@ project = u'Supported languages and frameworks for LGTM Enterprise'
 
 # The version info for this project, if different from version and release in main conf.py file.
 # The short X.Y version.
-version = u'1.26'
+version = u'1.27'
 # The full version, including alpha/beta/rc tags.
-release = u'1.26'
+release = u'1.27'
 
 # -- Project-specifc options for HTML output ----------------------------------------------
 

--- a/docs/codeql/support/framework-support.rst
+++ b/docs/codeql/support/framework-support.rst
@@ -10,6 +10,4 @@ The libraries and queries in version |version| have been explicitly checked agai
     If you're interested in other libraries or frameworks, you can extend the analysis to cover them. 
     For example, by extending the data flow libraries to include data sources and sinks for additional libraries or frameworks.
 
-.. There is currently no built-in support for libraries or frameworks for C/C++.
-
 .. include:: reusables/frameworks.rst

--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -7,9 +7,9 @@ C and C++ built-in support
    :widths: auto
 
    Name, Category
-   `Bloomberg Standard Library <https://github.com/bloomberg/bde>`__, TODO
-   `Berkeley socket API library <https://en.wikipedia.org/wiki/Berkeley_sockets#Socket_API_functions>`__, API library
-   string.h, TODO
+   `Bloomberg Standard Library <https://github.com/bloomberg/bde>`__, Utility library
+   `Berkeley socket API library <https://en.wikipedia.org/wiki/Berkeley_sockets#Socket_API_functions>`__, Network communicator
+   string.h, String library
 
 C# built-in support
 ================================

--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -89,8 +89,8 @@ Java built-in support
    :widths: auto
 
    Name, Category
-   Apache Commons, Language library (?)
-   Guava, TODO
+   Apache Commons Lang, utility library
+   Guava, utility and collections library
    Hibernate, Database
    iBatis / MyBatis, Database
    Java Persistence API (JPA), Database

--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -7,9 +7,9 @@ C and C++ built-in support
    :widths: auto
 
    Name, Category
-   `Bloomberg Standard Library <https://github.com/bloomberg/bde>`__, xxx
+   `Bloomberg Standard Library <https://github.com/bloomberg/bde>`__, TODO
    `Berkeley socket API library <https://en.wikipedia.org/wiki/Berkeley_sockets#Socket_API_functions>`__, API library
-   string.h, xxx
+   string.h, TODO
 
 C# built-in support
 ================================
@@ -90,7 +90,7 @@ Java built-in support
 
    Name, Category
    Apache Commons, Language library (?)
-   Guava, xxx
+   Guava, TODO
    Hibernate, Database
    iBatis / MyBatis, Database
    Java Persistence API (JPA), Database
@@ -115,28 +115,28 @@ JavaScript and TypeScript built-in support
    Name, Category
    angular (modern version), HTML framework
    angular.js (legacy version), HTML framework
-   apollo-link-http, xxx
+   apollo-link-http, TODO
    axios, Network communicator
    browser, Runtime environment
    electron, Runtime environment
    express, Server
-   Formik
+   Formik, TODO
    hapi, Server
-   Immutable.js, xxx
+   Immutable.js, TODO
    jquery, Utility library
    koa, Server
    lodash, Utility library
-   marked, xxx
+   marked, TODO
    mongodb, Database
    mssql, Database
-   Multer, xxx
+   Multer, TODO
    mysql, Database
    node, Runtime environment
    postgres, Database
-   pug, xxx
+   pug, TODO
    ramda, Utility library
    react, HTML framework
-   react-helmet, xxx
+   react-helmet, TODO
    request, Network communicator
    sequelize, Database
    socket.io, Network communicator
@@ -144,8 +144,8 @@ JavaScript and TypeScript built-in support
    superagent, Network communicator
    underscore, Utility library
    vue, HTML framework
-   vue-router, xxx
-   xml2js, xxx
+   vue-router, TODO
+   xml2js, TODO
 
 
 

--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -1,4 +1,15 @@
-.. There is currently no built-in support for libraries or frameworks for C/C++.
+C and C++ built-in support
+================================
+
+.. csv-table:: 
+   :header-rows: 1
+   :class: fullWidthTable
+   :widths: auto
+
+   Name, Category
+   `Bloomberg Standard Library <https://github.com/bloomberg/bde>`__, xxx
+   `Berkeley socket API library <https://en.wikipedia.org/wiki/Berkeley_sockets#Socket_API_functions>`__, API library
+   string.h, xxx
 
 C# built-in support
 ================================
@@ -78,6 +89,8 @@ Java built-in support
    :widths: auto
 
    Name, Category
+   Apache Commons, Language library (?)
+   Guava, xxx
    Hibernate, Database
    iBatis / MyBatis, Database
    Java Persistence API (JPA), Database
@@ -102,21 +115,28 @@ JavaScript and TypeScript built-in support
    Name, Category
    angular (modern version), HTML framework
    angular.js (legacy version), HTML framework
+   apollo-link-http, xxx
    axios, Network communicator
    browser, Runtime environment
    electron, Runtime environment
    express, Server
+   Formik
    hapi, Server
+   Immutable.js, xxx
    jquery, Utility library
    koa, Server
    lodash, Utility library
+   marked, xxx
    mongodb, Database
    mssql, Database
+   Multer, xxx
    mysql, Database
    node, Runtime environment
    postgres, Database
+   pug, xxx
    ramda, Utility library
    react, HTML framework
+   react-helmet, xxx
    request, Network communicator
    sequelize, Database
    socket.io, Network communicator
@@ -124,6 +144,8 @@ JavaScript and TypeScript built-in support
    superagent, Network communicator
    underscore, Utility library
    vue, HTML framework
+   vue-router, xxx
+   xml2js, xxx
 
 
 

--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -89,8 +89,9 @@ Java built-in support
    :widths: auto
 
    Name, Category
-   Apache Commons Lang, utility library
-   Guava, utility and collections library
+   Apache Commons Lang, Utility library
+   Apache HTTP components, Network communicator
+   Guava, Utility and collections library
    Hibernate, Database
    iBatis / MyBatis, Database
    Java Persistence API (JPA), Database
@@ -115,28 +116,21 @@ JavaScript and TypeScript built-in support
    Name, Category
    angular (modern version), HTML framework
    angular.js (legacy version), HTML framework
-   apollo-link-http, TODO
    axios, Network communicator
    browser, Runtime environment
    electron, Runtime environment
    express, Server
-   Formik, TODO
    hapi, Server
-   Immutable.js, TODO
    jquery, Utility library
    koa, Server
    lodash, Utility library
-   marked, TODO
    mongodb, Database
    mssql, Database
-   Multer, TODO
    mysql, Database
    node, Runtime environment
    postgres, Database
-   pug, TODO
    ramda, Utility library
    react, HTML framework
-   react-helmet, TODO
    request, Network communicator
    sequelize, Database
    socket.io, Network communicator
@@ -144,9 +138,6 @@ JavaScript and TypeScript built-in support
    superagent, Network communicator
    underscore, Utility library
    vue, HTML framework
-   vue-router, TODO
-   xml2js, TODO
-
 
 
 Python built-in support


### PR DESCRIPTION
We'll need to republish https://help.semmle.com/QL/ql-support/framework-support/ for the next release of LGTM Enterprise.

Updated framework support for 1.27: 
- [Preview](https://github.com/github/codeql/blob/shati-patel/docs-bump-version/docs/codeql/support/reusables/frameworks.rst)
- [Source](https://github.com/github/codeql/pull/5479/files#diff-cc238c9bbccb5064f59f7eb3f626569c4933f3a4dd1865e631acf1f607845918)