### PR TITLE
C++: Mark CallSideEffect instructions as conflated

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRConsistency.qll
@@ -445,6 +445,8 @@ module InstructionConsistency {
     isOnAliasedDefinitionChain(instr)
     or
     instr.getOpcode() instanceof Opcode::InitializeNonLocal
+    or
+    instr.getOpcode() instanceof Opcode::CallSideEffect
   }
 
   query predicate notMarkedAsConflated(

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -71,6 +71,8 @@ private module Cached {
     or
     instruction.getOpcode() instanceof Opcode::InitializeNonLocal
     or
+    instruction.getOpcode() instanceof Opcode::CallSideEffect
+    or
     // Chi instructions track virtual variables, and therefore a chi instruction is
     // conflated if it's associated with the aliased virtual variable.
     exists(OldInstruction oldInstruction | instruction = getChi(oldInstruction) |

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRConsistency.qll
@@ -445,6 +445,8 @@ module InstructionConsistency {
     isOnAliasedDefinitionChain(instr)
     or
     instr.getOpcode() instanceof Opcode::InitializeNonLocal
+    or
+    instr.getOpcode() instanceof Opcode::CallSideEffect
   }
 
   query predicate notMarkedAsConflated(

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -168,6 +168,8 @@ predicate hasConflatedMemoryResult(Instruction instruction) {
   instruction instanceof AliasedDefinitionInstruction
   or
   instruction.getOpcode() instanceof Opcode::InitializeNonLocal
+  or
+  instruction.getOpcode() instanceof Opcode::CallSideEffect
 }
 
 Instruction getRegisterOperandDefinition(Instruction instruction, RegisterOperandTag tag) {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRConsistency.qll
@@ -445,6 +445,8 @@ module InstructionConsistency {
     isOnAliasedDefinitionChain(instr)
     or
     instr.getOpcode() instanceof Opcode::InitializeNonLocal
+    or
+    instr.getOpcode() instanceof Opcode::CallSideEffect
   }
 
   query predicate notMarkedAsConflated(

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -71,6 +71,8 @@ private module Cached {
     or
     instruction.getOpcode() instanceof Opcode::InitializeNonLocal
     or
+    instruction.getOpcode() instanceof Opcode::CallSideEffect
+    or
     // Chi instructions track virtual variables, and therefore a chi instruction is
     // conflated if it's associated with the aliased virtual variable.
     exists(OldInstruction oldInstruction | instruction = getChi(oldInstruction) |

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRConsistency.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRConsistency.qll
@@ -445,6 +445,8 @@ module InstructionConsistency {
     isOnAliasedDefinitionChain(instr)
     or
     instr.getOpcode() instanceof Opcode::InitializeNonLocal
+    or
+    instr.getOpcode() instanceof Opcode::CallSideEffect
   }
 
   query predicate notMarkedAsConflated(

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/IRConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/IRConstruction.qll
@@ -188,6 +188,8 @@ private module Cached {
     instruction instanceof AliasedDefinitionInstruction
     or
     instruction.getOpcode() instanceof Opcode::InitializeNonLocal
+    or
+    instruction.getOpcode() instanceof Opcode::CallSideEffect
   }
 
   cached

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRConsistency.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRConsistency.qll
@@ -445,6 +445,8 @@ module InstructionConsistency {
     isOnAliasedDefinitionChain(instr)
     or
     instr.getOpcode() instanceof Opcode::InitializeNonLocal
+    or
+    instr.getOpcode() instanceof Opcode::CallSideEffect
   }
 
   query predicate notMarkedAsConflated(

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -71,6 +71,8 @@ private module Cached {
     or
     instruction.getOpcode() instanceof Opcode::InitializeNonLocal
     or
+    instruction.getOpcode() instanceof Opcode::CallSideEffect
+    or
     // Chi instructions track virtual variables, and therefore a chi instruction is
     // conflated if it's associated with the aliased virtual variable.
     exists(OldInstruction oldInstruction | instruction = getChi(oldInstruction) |


### PR DESCRIPTION
As far as I know, `CallSideEffect` instructions (if present) always updates the `{AllAliasedMemory}` virtual variable, and should thus be marked as having a conflated result.

CPP-differences: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1857/