### PR TITLE
Python: Make `API::Node::getACall` return a `CallCfgNode`

### DIFF
--- a/python/change-notes/2021-03-22-getacall-callcfgnode.md
+++ b/python/change-notes/2021-03-22-getacall-callcfgnode.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The `API::Node::getACall` method now has the more specific return type `DataFlow::CallCfgNode`, which improves the ease of use when working with calls to API functions.

--- a/python/ql/src/semmle/python/ApiGraphs.qll
+++ b/python/ql/src/semmle/python/ApiGraphs.qll
@@ -55,7 +55,7 @@ module API {
     /**
      * Gets a call to the function represented by this API component.
      */
-    DataFlow::Node getACall() { result = getReturn().getAnImmediateUse() }
+    DataFlow::CallCfgNode getACall() { result = getReturn().getAnImmediateUse() }
 
     /**
      * Gets a node representing member `m` of this API component.


### PR DESCRIPTION
This should eliminate the need for explicit casting to
`CallCfgNode` (which does not appear in our code as far as I can see,
but was observed in an external contribution).