### PR TITLE
Improve JAX-WS models

### DIFF
--- a/java/change-notes/2021-03-22-jax-rs-improvements.md
+++ b/java/change-notes/2021-03-22-jax-rs-improvements.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added support for detecting XSS via JAX-RS sinks, and propagating tainted data via various container types (e.g. Form, Cookie, MultivaluedMap).

--- a/java/change-notes/2021-03-22-jax-ws-improvements.md
+++ b/java/change-notes/2021-03-22-jax-ws-improvements.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added support for detecting XSS via JAX-WS sinks, and propagating tainted data via various container types (e.g. Form, Cookie, MultivaluedMap).

--- a/java/change-notes/2021-03-22-jax-ws-improvements.md
+++ b/java/change-notes/2021-03-22-jax-ws-improvements.md
@@ -1,2 +1,0 @@
-lgtm,codescanning
-* Added support for detecting XSS via JAX-WS sinks, and propagating tainted data via various container types (e.g. Form, Cookie, MultivaluedMap).

--- a/java/ql/src/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/src/semmle/code/java/dataflow/ExternalFlow.qll
@@ -72,6 +72,7 @@ private module Frameworks {
   private import semmle.code.java.frameworks.ApacheHttp
   private import semmle.code.java.frameworks.apache.Lang
   private import semmle.code.java.frameworks.guava.Guava
+  private import semmle.code.java.frameworks.JaxWS
 }
 
 private predicate sourceModelCsv(string row) {

--- a/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
@@ -255,19 +255,19 @@ class MessageBodyReaderRead extends Method {
   }
 }
 
-/** An `@Produces` annotation that describes which MIME types can be produced by this resource. */
+/** An `@Produces` annotation that describes which content types can be produced by this resource. */
 class JaxRSProducesAnnotation extends JaxRSAnnotation {
   JaxRSProducesAnnotation() { getType().hasQualifiedName("javax.ws.rs", "Produces") }
 
   /**
-   * Gets a declared MIME type that can be produced by this resource.
+   * Gets a declared content type that can be produced by this resource.
    */
-  string getADeclaredMimeType() {
+  string getADeclaredContentType() {
     result = getAValue().(CompileTimeConstantExpr).getStringValue()
     or
     exists(Field jaxMediaType |
       // Accesses to static fields on `MediaType` class do not have constant strings in the database
-      // so convert the field name to a mime type string
+      // so convert the field name to a content type string
       jaxMediaType.getDeclaringType().hasQualifiedName("javax.ws.rs.core", "MediaType") and
       jaxMediaType.getAnAccess() = getAValue() and
       // e.g. MediaType.TEXT_PLAIN => text/plain
@@ -276,7 +276,7 @@ class JaxRSProducesAnnotation extends JaxRSAnnotation {
   }
 }
 
-/** An `@Consumes` annotation that describes MIME types can be consumed by this resource. */
+/** An `@Consumes` annotation that describes content types can be consumed by this resource. */
 class JaxRSConsumesAnnotation extends JaxRSAnnotation {
   JaxRSConsumesAnnotation() { getType().hasQualifiedName("javax.ws.rs", "Consumes") }
 }

--- a/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
@@ -1,3 +1,8 @@
+/**
+ * Definitions relating to JAX-WS (Java/Jakarta API for XML Web Services) and JAX-RS
+ * (Java/Jakarta API for RESTful Web Services).
+ */
+
 import java
 private import semmle.code.java.dataflow.ExternalFlow
 

--- a/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
@@ -1,10 +1,16 @@
 import java
 private import semmle.code.java.dataflow.ExternalFlow
 
-string getAJaxWsPackage() { result in ["javax.ws.rs", "jakarta.ws.rs"] }
+/**
+ * Gets a name for the root package of JAX-RS.
+ */
+string getAJaxRsPackage() { result in ["javax.ws.rs", "jakarta.ws.rs"] }
 
+/**
+ * Gets a name for package `subpackage` within the JAX-RS hierarchy.
+ */
 bindingset[subpackage]
-string getAJaxWsPackage(string subpackage) { result = getAJaxWsPackage() + "." + subpackage }
+string getAJaxRsPackage(string subpackage) { result = getAJaxRsPackage() + "." + subpackage }
 
 /**
  * A JAX WS endpoint is constructed by the container, and its methods
@@ -34,7 +40,7 @@ class JaxWsEndpoint extends Class {
 private predicate hasPathAnnotation(Annotatable annotatable) {
   exists(AnnotationType a |
     a = annotatable.getAnAnnotation().getType() and
-    a.getPackage().getName() = getAJaxWsPackage()
+    a.getPackage().getName() = getAJaxRsPackage()
   |
     a.hasName("Path")
   )
@@ -47,7 +53,7 @@ class JaxRsResourceMethod extends Method {
   JaxRsResourceMethod() {
     exists(AnnotationType a |
       a = this.getAnAnnotation().getType() and
-      a.getPackage().getName() = getAJaxWsPackage()
+      a.getPackage().getName() = getAJaxRsPackage()
     |
       a.hasName("GET") or
       a.hasName("POST") or
@@ -184,7 +190,7 @@ class JaxRsInjectionAnnotation extends JaxRSAnnotation {
   JaxRsInjectionAnnotation() {
     exists(AnnotationType a |
       a = getType() and
-      a.getPackage().getName() = getAJaxWsPackage()
+      a.getPackage().getName() = getAJaxRsPackage()
     |
       a.hasName("BeanParam") or
       a.hasName("CookieParam") or
@@ -195,17 +201,17 @@ class JaxRsInjectionAnnotation extends JaxRSAnnotation {
       a.hasName("QueryParam")
     )
     or
-    getType().hasQualifiedName(getAJaxWsPackage("core"), "Context")
+    getType().hasQualifiedName(getAJaxRsPackage("core"), "Context")
   }
 }
 
 class JaxRsResponse extends Class {
-  JaxRsResponse() { this.hasQualifiedName(getAJaxWsPackage("core"), "Response") }
+  JaxRsResponse() { this.hasQualifiedName(getAJaxRsPackage("core"), "Response") }
 }
 
 class JaxRsResponseBuilder extends Class {
   JaxRsResponseBuilder() {
-    this.hasQualifiedName(getAJaxWsPackage("core"), "Response$ResponseBuilder")
+    this.hasQualifiedName(getAJaxRsPackage("core"), "Response$ResponseBuilder")
   }
 }
 
@@ -213,7 +219,7 @@ class JaxRsResponseBuilder extends Class {
  * The class `javax.ws.rs.client.Client`.
  */
 class JaxRsClient extends RefType {
-  JaxRsClient() { this.hasQualifiedName(getAJaxWsPackage("client"), "Client") }
+  JaxRsClient() { this.hasQualifiedName(getAJaxRsPackage("client"), "Client") }
 }
 
 /**
@@ -226,7 +232,7 @@ class JaxRsBeanParamConstructor extends Constructor {
       c = resourceClass.getAnInjectableCallable()
     |
       p = c.getAParameter() and
-      p.getAnAnnotation().getType().hasQualifiedName(getAJaxWsPackage(), "BeanParam") and
+      p.getAnAnnotation().getType().hasQualifiedName(getAJaxRsPackage(), "BeanParam") and
       this.getDeclaringType().getSourceDeclaration() = p.getType().(RefType).getSourceDeclaration()
     ) and
     forall(Parameter p | p = getAParameter() |
@@ -239,7 +245,7 @@ class JaxRsBeanParamConstructor extends Constructor {
  * The class `javax.ws.rs.ext.MessageBodyReader`.
  */
 class MessageBodyReader extends GenericInterface {
-  MessageBodyReader() { this.hasQualifiedName(getAJaxWsPackage("ext"), "MessageBodyReader") }
+  MessageBodyReader() { this.hasQualifiedName(getAJaxRsPackage("ext"), "MessageBodyReader") }
 }
 
 /**
@@ -265,7 +271,7 @@ class MessageBodyReaderRead extends Method {
 
 /** An `@Produces` annotation that describes which content types can be produced by this resource. */
 class JaxRSProducesAnnotation extends JaxRSAnnotation {
-  JaxRSProducesAnnotation() { getType().hasQualifiedName(getAJaxWsPackage(), "Produces") }
+  JaxRSProducesAnnotation() { getType().hasQualifiedName(getAJaxRsPackage(), "Produces") }
 
   /**
    * Gets a declared content type that can be produced by this resource.
@@ -276,7 +282,7 @@ class JaxRSProducesAnnotation extends JaxRSAnnotation {
     exists(Field jaxMediaType |
       // Accesses to static fields on `MediaType` class do not have constant strings in the database
       // so convert the field name to a content type string
-      jaxMediaType.getDeclaringType().hasQualifiedName(getAJaxWsPackage("core"), "MediaType") and
+      jaxMediaType.getDeclaringType().hasQualifiedName(getAJaxRsPackage("core"), "MediaType") and
       jaxMediaType.getAnAccess() = getAValue() and
       // e.g. MediaType.TEXT_PLAIN => text/plain
       result = jaxMediaType.getName().toLowerCase().replaceAll("_", "/")
@@ -286,7 +292,7 @@ class JaxRSProducesAnnotation extends JaxRSAnnotation {
 
 /** An `@Consumes` annotation that describes content types can be consumed by this resource. */
 class JaxRSConsumesAnnotation extends JaxRSAnnotation {
-  JaxRSConsumesAnnotation() { getType().hasQualifiedName(getAJaxWsPackage(), "Consumes") }
+  JaxRSConsumesAnnotation() { getType().hasQualifiedName(getAJaxRsPackage(), "Consumes") }
 }
 
 /**

--- a/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
@@ -257,15 +257,14 @@ class MessageBodyReaderRead extends Method {
 
 /** An `@Produces` annotation that describes which MIME types can be produced by this resource. */
 class JaxRSProducesAnnotation extends JaxRSAnnotation {
-  JaxRSProducesAnnotation() {
-    getType().hasQualifiedName("javax.ws.rs", "Produces")
-  }
+  JaxRSProducesAnnotation() { getType().hasQualifiedName("javax.ws.rs", "Produces") }
 
   /**
    * Gets a declared MIME type that can be produced by this resource.
    */
   string getADeclaredMimeType() {
-    result = getAValue().(CompileTimeConstantExpr).getStringValue() or
+    result = getAValue().(CompileTimeConstantExpr).getStringValue()
+    or
     exists(Field jaxMediaType |
       // Accesses to static fields on `MediaType` class do not have constant strings in the database
       // so convert the field name to a mime type string
@@ -279,7 +278,5 @@ class JaxRSProducesAnnotation extends JaxRSAnnotation {
 
 /** An `@Consumes` annotation that describes MIME types can be consumed by this resource. */
 class JaxRSConsumesAnnotation extends JaxRSAnnotation {
-  JaxRSConsumesAnnotation() {
-    getType().hasQualifiedName("javax.ws.rs", "Consumes")
-  }
+  JaxRSConsumesAnnotation() { getType().hasQualifiedName("javax.ws.rs", "Consumes") }
 }

--- a/java/ql/src/semmle/code/java/security/UrlRedirect.qll
+++ b/java/ql/src/semmle/code/java/security/UrlRedirect.qll
@@ -35,3 +35,17 @@ private class ApacheUrlRedirectSink extends UrlRedirectSink {
     )
   }
 }
+
+/** A URL redirection sink from JAX-WS */
+private class JaxWsUrlRedirectSink extends UrlRedirectSink {
+  JaxWsUrlRedirectSink() {
+    exists(MethodAccess ma |
+      ma.getMethod()
+          .getDeclaringType()
+          .getAnAncestor()
+          .hasQualifiedName("javax.ws.rs.core", "Response") and
+      ma.getMethod().getName() in ["seeOther", "temporaryRedirect"] and
+      this.asExpr() = ma.getArgument(0)
+    )
+  }
+}

--- a/java/ql/src/semmle/code/java/security/UrlRedirect.qll
+++ b/java/ql/src/semmle/code/java/security/UrlRedirect.qll
@@ -37,14 +37,14 @@ private class ApacheUrlRedirectSink extends UrlRedirectSink {
   }
 }
 
-/** A URL redirection sink from JAX-WS */
-private class JaxWsUrlRedirectSink extends UrlRedirectSink {
-  JaxWsUrlRedirectSink() {
+/** A URL redirection sink from JAX-RS */
+private class JaxRsUrlRedirectSink extends UrlRedirectSink {
+  JaxRsUrlRedirectSink() {
     exists(MethodAccess ma |
       ma.getMethod()
           .getDeclaringType()
           .getAnAncestor()
-          .hasQualifiedName(getAJaxWsPackage("core"), "Response") and
+          .hasQualifiedName(getAJaxRsPackage("core"), "Response") and
       ma.getMethod().getName() in ["seeOther", "temporaryRedirect"] and
       this.asExpr() = ma.getArgument(0)
     )

--- a/java/ql/src/semmle/code/java/security/UrlRedirect.qll
+++ b/java/ql/src/semmle/code/java/security/UrlRedirect.qll
@@ -4,6 +4,7 @@ import java
 import semmle.code.java.dataflow.DataFlow
 import semmle.code.java.frameworks.Servlets
 import semmle.code.java.frameworks.ApacheHttp
+private import semmle.code.java.frameworks.JaxWS
 
 /** A URL redirection sink */
 abstract class UrlRedirectSink extends DataFlow::Node { }
@@ -43,7 +44,7 @@ private class JaxWsUrlRedirectSink extends UrlRedirectSink {
       ma.getMethod()
           .getDeclaringType()
           .getAnAncestor()
-          .hasQualifiedName("javax.ws.rs.core", "Response") and
+          .hasQualifiedName(getAJaxWsPackage("core"), "Response") and
       ma.getMethod().getName() in ["seeOther", "temporaryRedirect"] and
       this.asExpr() = ma.getArgument(0)
     )

--- a/java/ql/src/semmle/code/java/security/XSS.qll
+++ b/java/ql/src/semmle/code/java/security/XSS.qll
@@ -1,6 +1,7 @@
 /** Provides classes to reason about Cross-site scripting (XSS) vulnerabilities. */
 
 import java
+import semmle.code.java.frameworks.JaxWS
 import semmle.code.java.frameworks.Servlets
 import semmle.code.java.frameworks.android.WebView
 import semmle.code.java.frameworks.spring.SpringController
@@ -96,6 +97,16 @@ private class DefaultXssSink extends XssSink {
         // String.
         returnType instanceof RawClass
       )
+    )
+    or
+    exists(JaxRsResourceMethod resourceMethod, ReturnStmt rs |
+      resourceMethod = any(JaxRsResourceClass resourceClass).getAResourceMethod() and
+      rs.getEnclosingCallable() = resourceMethod and
+      this.asExpr() = rs.getResult()
+    |
+      not exists(resourceMethod.getProducesAnnotation())
+      or
+      resourceMethod.getProducesAnnotation().getADeclaredMimeType() = "text/plain"
     )
   }
 }

--- a/java/ql/src/semmle/code/java/security/XSS.qll
+++ b/java/ql/src/semmle/code/java/security/XSS.qll
@@ -106,7 +106,7 @@ private class DefaultXssSink extends XssSink {
     |
       not exists(resourceMethod.getProducesAnnotation())
       or
-      resourceMethod.getProducesAnnotation().getADeclaredMimeType() = "text/plain"
+      resourceMethod.getProducesAnnotation().getADeclaredContentType() = "text/plain"
     )
   }
 }


### PR DESCRIPTION
This includes @lcartey's definition of JAX-WS sinks, plus models for the various wrapper types it uses to represent user-controlled data.

Contributes to https://github.com/github/codeql-java-team/issues/37

Other JAX tasks to do in separate PRs:

* ~Note open-redirect sinks in ResponseBuilder~ (now done here)
* Add tests (@owen-mc is currently working on this)
* ~Determine whether the framework promises to sanitise certain e.g. URI parts -- for example, is it possible to use UriBuilder.scheme(...) to inject something dangerous, or does the contract promise we'll check you're writing one of http, https, file ... rather than `<script>...</script>`~ (assuming these are dangerous for now, as they're allowed to contain template parameters in particular, which suggests quite a broad acceptable charset)