### PR TITLE
C++: Test taint regression

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
@@ -35,6 +35,10 @@ edges
 | test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer |
 | test.cpp:76:12:76:17 | fgets output argument | test.cpp:79:10:79:13 | (const char *)... |
 | test.cpp:76:12:76:17 | fgets output argument | test.cpp:79:10:79:13 | data |
+| test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | (const char *)... |
+| test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
+| test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | (const char *)... |
+| test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer |
 nodes
 | test.cpp:24:30:24:36 | *command | semmle.label | *command |
 | test.cpp:24:30:24:36 | command | semmle.label | command |
@@ -70,6 +74,11 @@ nodes
 | test.cpp:79:10:79:13 | (const char *)... | semmle.label | (const char *)... |
 | test.cpp:79:10:79:13 | (const char *)... | semmle.label | (const char *)... |
 | test.cpp:79:10:79:13 | data | semmle.label | data |
+| test.cpp:98:17:98:22 | buffer | semmle.label | buffer |
+| test.cpp:98:17:98:22 | recv output argument | semmle.label | recv output argument |
+| test.cpp:99:15:99:20 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:99:15:99:20 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:99:15:99:20 | buffer | semmle.label | buffer |
 #select
 | test.cpp:26:10:26:16 | command | test.cpp:42:18:42:23 | call to getenv | test.cpp:26:10:26:16 | command | The value of this argument may come from $@ and is being passed to system | test.cpp:42:18:42:23 | call to getenv | call to getenv |
 | test.cpp:31:10:31:16 | command | test.cpp:43:18:43:23 | call to getenv | test.cpp:31:10:31:16 | command | The value of this argument may come from $@ and is being passed to system | test.cpp:43:18:43:23 | call to getenv | call to getenv |
@@ -77,3 +86,4 @@ nodes
 | test.cpp:63:10:63:13 | data | test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | data | The value of this argument may come from $@ and is being passed to system | test.cpp:56:12:56:17 | buffer | buffer |
 | test.cpp:78:10:78:15 | buffer | test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer | The value of this argument may come from $@ and is being passed to system | test.cpp:76:12:76:17 | buffer | buffer |
 | test.cpp:79:10:79:13 | data | test.cpp:76:12:76:17 | buffer | test.cpp:79:10:79:13 | data | The value of this argument may come from $@ and is being passed to system | test.cpp:76:12:76:17 | buffer | buffer |
+| test.cpp:99:15:99:20 | buffer | test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer | The value of this argument may come from $@ and is being passed to LoadLibrary | test.cpp:98:17:98:22 | buffer | buffer |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
@@ -39,6 +39,10 @@ edges
 | test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | (const char *)... |
 | test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer |
+| test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | (const char *)... |
+| test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
+| test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | (const char *)... |
+| test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer |
 nodes
 | test.cpp:24:30:24:36 | *command | semmle.label | *command |
 | test.cpp:24:30:24:36 | command | semmle.label | command |
@@ -79,6 +83,11 @@ nodes
 | test.cpp:99:15:99:20 | (const char *)... | semmle.label | (const char *)... |
 | test.cpp:99:15:99:20 | (const char *)... | semmle.label | (const char *)... |
 | test.cpp:99:15:99:20 | buffer | semmle.label | buffer |
+| test.cpp:106:17:106:22 | buffer | semmle.label | buffer |
+| test.cpp:106:17:106:22 | recv output argument | semmle.label | recv output argument |
+| test.cpp:107:15:107:20 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:107:15:107:20 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:107:15:107:20 | buffer | semmle.label | buffer |
 #select
 | test.cpp:26:10:26:16 | command | test.cpp:42:18:42:23 | call to getenv | test.cpp:26:10:26:16 | command | The value of this argument may come from $@ and is being passed to system | test.cpp:42:18:42:23 | call to getenv | call to getenv |
 | test.cpp:31:10:31:16 | command | test.cpp:43:18:43:23 | call to getenv | test.cpp:31:10:31:16 | command | The value of this argument may come from $@ and is being passed to system | test.cpp:43:18:43:23 | call to getenv | call to getenv |
@@ -87,3 +96,4 @@ nodes
 | test.cpp:78:10:78:15 | buffer | test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer | The value of this argument may come from $@ and is being passed to system | test.cpp:76:12:76:17 | buffer | buffer |
 | test.cpp:79:10:79:13 | data | test.cpp:76:12:76:17 | buffer | test.cpp:79:10:79:13 | data | The value of this argument may come from $@ and is being passed to system | test.cpp:76:12:76:17 | buffer | buffer |
 | test.cpp:99:15:99:20 | buffer | test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer | The value of this argument may come from $@ and is being passed to LoadLibrary | test.cpp:98:17:98:22 | buffer | buffer |
+| test.cpp:107:15:107:20 | buffer | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer | The value of this argument may come from $@ and is being passed to LoadLibrary | test.cpp:106:17:106:22 | buffer | buffer |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/test.cpp
@@ -86,7 +86,7 @@ void testReferencePointer2()
 
 typedef unsigned long size_t;
 
-void accept(int arg, char *buf, size_t bufSize);
+void accept(int arg, char *buf, size_t *bufSize);
 void recv(int arg, char *buf, size_t bufSize);
 void LoadLibrary(const char *arg);
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/test.cpp
@@ -104,6 +104,6 @@ void testAcceptRecv(int socket1, int socket2)
 
 		accept(socket2, 0, 0);
 		recv(socket2, buffer, 1024);
-		LoadLibrary(buffer); // BAD: using data from recv [NOT DETECTED]
+		LoadLibrary(buffer); // BAD: using data from recv
 	}
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/test.cpp
@@ -81,3 +81,29 @@ void testReferencePointer2()
 		system(data2); // BAD [NOT DETECTED]
 	}
 }
+
+// ---
+
+typedef unsigned long size_t;
+
+void accept(int arg, char *buf, size_t bufSize);
+void recv(int arg, char *buf, size_t bufSize);
+void LoadLibrary(const char *arg);
+
+void testAcceptRecv(int socket1, int socket2)
+{
+	{
+		char buffer[1024];
+
+		recv(socket1, buffer, 1024);
+		LoadLibrary(buffer); // BAD: using data from recv
+	}
+	
+	{
+		char buffer[1024];
+
+		accept(socket2, 0, 0);
+		recv(socket2, buffer, 1024);
+		LoadLibrary(buffer); // BAD: using data from recv [NOT DETECTED]
+	}
+}


### PR DESCRIPTION
Add a test that captures the essence of the recent SAMATE regressions, at least the part that of them that I've been investigating.

@MathiasVP it *does* appear to be caused by the models changes in https://github.com/github/codeql/pull/5217, specifically the `SideEffectFunction` model for `Accept`.  The second commit of this PR demonstrates this.  I don't have a clue how or why this happens though.  Do you have any thoughts on it?

Not ready for merge.  The second commit disables part of the model to work around the issue, it isn't an actual fix.