### PR TITLE
Python: Add stub structure to `experimental` for external contributions

### DIFF
--- a/python/ql/src/experimental/semmle/python/Concepts.qll
+++ b/python/ql/src/experimental/semmle/python/Concepts.qll
@@ -8,7 +8,7 @@
  * provide concrete subclasses.
  */
 
-import python
+private import python
 private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.dataflow.new.RemoteFlowSources
 private import semmle.python.dataflow.new.TaintTracking

--- a/python/ql/src/experimental/semmle/python/Concepts.qll
+++ b/python/ql/src/experimental/semmle/python/Concepts.qll
@@ -1,0 +1,15 @@
+/**
+ * This version resides in the experimental area and provides a space for
+ * external contributors to place new concepts, keeping to our preferred
+ * structure while remaining in the experimental area.
+ *
+ * Provides abstract classes representing generic concepts such as file system
+ * access or system command execution, for which individual framework libraries
+ * provide concrete subclasses.
+ */
+
+import python
+private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.dataflow.new.RemoteFlowSources
+private import semmle.python.dataflow.new.TaintTracking
+private import experimental.semmle.python.Frameworks

--- a/python/ql/src/experimental/semmle/python/Frameworks.qll
+++ b/python/ql/src/experimental/semmle/python/Frameworks.qll
@@ -1,0 +1,5 @@
+/**
+ * Helper file that imports all framework modeling.
+ */
+
+private import experimental.semmle.python.frameworks.Stdlib

--- a/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
@@ -1,0 +1,11 @@
+/**
+ * Provides classes modeling security-relevant aspects of the standard libraries.
+ * Note: some modeling is done internally in the dataflow/taint tracking implementation.
+ */
+
+private import python
+private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.dataflow.new.TaintTracking
+private import semmle.python.dataflow.new.RemoteFlowSources
+private import experimental.semmle.python.Concepts
+private import semmle.python.ApiGraphs


### PR DESCRIPTION
This PR adds the structure to `experimental` that we wish contributors to follow.