### PR TITLE
Python: Ensure first type-tracking predicate is private

### DIFF
--- a/python/ql/src/semmle/python/Concepts.qll
+++ b/python/ql/src/semmle/python/Concepts.qll
@@ -563,7 +563,9 @@ module Cryptography {
     /** Provides classes for modeling new key-pair generation APIs. */
     module KeyGeneration {
       /** Gets a back-reference to the keysize argument `arg` that was used to generate a new key-pair. */
-      DataFlow::LocalSourceNode keysizeBacktracker(DataFlow::TypeBackTracker t, DataFlow::Node arg) {
+      private DataFlow::LocalSourceNode keysizeBacktracker(
+        DataFlow::TypeBackTracker t, DataFlow::Node arg
+      ) {
         t.start() and
         arg = any(KeyGeneration::Range r).getKeySizeArg() and
         result = arg.getALocalSource()

--- a/python/ql/src/semmle/python/dataflow/new/TypeTracker.qll
+++ b/python/ql/src/semmle/python/dataflow/new/TypeTracker.qll
@@ -180,7 +180,7 @@ private newtype TTypeTracker = MkTypeTracker(Boolean hasCall, OptionalAttributeN
  * It is recommended that all uses of this type are written in the following form,
  * for tracking some type `myType`:
  * ```
- * DataFlow::LocalSourceNode myType(DataFlow::TypeTracker t) {
+ * private DataFlow::LocalSourceNode myType(DataFlow::TypeTracker t) {
  *   t.start() and
  *   result = < source of myType >
  *   or
@@ -341,7 +341,7 @@ private newtype TTypeBackTracker = MkTypeBackTracker(Boolean hasReturn, Optional
  * for back-tracking some callback type `myCallback`:
  *
  * ```
- * DataFlow::LocalSourceNode myCallback(DataFlow::TypeBackTracker t) {
+ * private DataFlow::LocalSourceNode myCallback(DataFlow::TypeBackTracker t) {
  *   t.start() and
  *   result = (< some API call >).getArgument(< n >).getALocalSource()
  *   or

--- a/python/ql/src/semmle/python/frameworks/Cryptography.qll
+++ b/python/ql/src/semmle/python/frameworks/Cryptography.qll
@@ -80,7 +80,7 @@ private module CryptographyModel {
       DataFlow::TypeTracker t, int keySize, DataFlow::Node origin
     ) {
       t.start() and
-      result.asCfgNode().(CallNode).getFunction() = curveClassWithKeySize(keySize).asCfgNode() and
+      result.(DataFlow::CallCfgNode).getFunction() = curveClassWithKeySize(keySize) and
       origin = result
       or
       // Due to bad performance when using normal setup with we have inlined that code and forced a join

--- a/python/ql/src/semmle/python/frameworks/Cryptography.qll
+++ b/python/ql/src/semmle/python/frameworks/Cryptography.qll
@@ -76,7 +76,7 @@ private module CryptographyModel {
     }
 
     /** Gets a reference to a predefined curve class instance with a specific key size (in bits), as well as the origin of the class. */
-    private DataFlow::Node curveClassInstanceWithKeySize(
+    private DataFlow::LocalSourceNode curveClassInstanceWithKeySize(
       DataFlow::TypeTracker t, int keySize, DataFlow::Node origin
     ) {
       t.start() and

--- a/python/ql/src/semmle/python/frameworks/Cryptography.qll
+++ b/python/ql/src/semmle/python/frameworks/Cryptography.qll
@@ -102,7 +102,7 @@ private module CryptographyModel {
 
     /** Gets a reference to a predefined curve class instance with a specific key size (in bits), as well as the origin of the class. */
     DataFlow::Node curveClassInstanceWithKeySize(int keySize, DataFlow::Node origin) {
-      result = curveClassInstanceWithKeySize(DataFlow::TypeTracker::end(), keySize, origin)
+      curveClassInstanceWithKeySize(DataFlow::TypeTracker::end(), keySize, origin).flowsTo(result)
     }
   }
 

--- a/python/ql/test/experimental/dataflow/typetracking/moduleattr.ql
+++ b/python/ql/test/experimental/dataflow/typetracking/moduleattr.ql
@@ -2,7 +2,7 @@ import python
 import semmle.python.dataflow.new.DataFlow
 import semmle.python.dataflow.new.TypeTracker
 
-DataFlow::LocalSourceNode module_tracker(TypeTracker t) {
+private DataFlow::LocalSourceNode module_tracker(TypeTracker t) {
   t.start() and
   result = DataFlow::importNode("module")
   or
@@ -13,7 +13,7 @@ query DataFlow::Node module_tracker() {
   module_tracker(DataFlow::TypeTracker::end()).flowsTo(result)
 }
 
-DataFlow::LocalSourceNode module_attr_tracker(TypeTracker t) {
+private DataFlow::LocalSourceNode module_attr_tracker(TypeTracker t) {
   t.startInAttr("attr") and
   result = module_tracker()
   or

--- a/python/ql/test/experimental/dataflow/typetracking/tracked.ql
+++ b/python/ql/test/experimental/dataflow/typetracking/tracked.ql
@@ -6,7 +6,7 @@ import TestUtilities.InlineExpectationsTest
 // -----------------------------------------------------------------------------
 // tracked
 // -----------------------------------------------------------------------------
-DataFlow::LocalSourceNode tracked(TypeTracker t) {
+private DataFlow::LocalSourceNode tracked(TypeTracker t) {
   t.start() and
   result.asCfgNode() = any(NameNode n | n.getId() = "tracked")
   or
@@ -34,14 +34,14 @@ class TrackedTest extends InlineExpectationsTest {
 // -----------------------------------------------------------------------------
 // int + str
 // -----------------------------------------------------------------------------
-DataFlow::LocalSourceNode int_type(TypeTracker t) {
+private DataFlow::LocalSourceNode int_type(TypeTracker t) {
   t.start() and
   result.asCfgNode() = any(CallNode c | c.getFunction().(NameNode).getId() = "int")
   or
   exists(TypeTracker t2 | result = int_type(t2).track(t2, t))
 }
 
-DataFlow::LocalSourceNode string_type(TypeTracker t) {
+private DataFlow::LocalSourceNode string_type(TypeTracker t) {
   t.start() and
   result.asCfgNode() = any(CallNode c | c.getFunction().(NameNode).getId() = "str")
   or
@@ -83,7 +83,7 @@ class TrackedStringTest extends InlineExpectationsTest {
 // -----------------------------------------------------------------------------
 // tracked_self
 // -----------------------------------------------------------------------------
-DataFlow::LocalSourceNode tracked_self(TypeTracker t) {
+private DataFlow::LocalSourceNode tracked_self(TypeTracker t) {
   t.start() and
   exists(Function f |
     f.isMethod() and


### PR DESCRIPTION
Updating the tests might not have been too important, but ensures we have a consistent use throughout our codebase :blush: 