### PR TITLE
Python: Prevent potentially bad join order

### DIFF
--- a/python/ql/src/semmle/python/objects/Classes.qll
+++ b/python/ql/src/semmle/python/objects/Classes.qll
@@ -61,8 +61,8 @@ abstract class ClassObjectInternal extends ObjectInternal {
   pragma[noinline]
   override predicate binds(ObjectInternal instance, string name, ObjectInternal descriptor) {
     instance = this and
-    PointsToInternal::attributeRequired(this, name) and
-    this.lookup(name, descriptor, _) and
+    PointsToInternal::attributeRequired(this, pragma[only_bind_into](name)) and
+    this.lookup(pragma[only_bind_into](name), descriptor, _) and
     descriptor.isDescriptor() = true
   }
 

--- a/python/ql/src/semmle/python/objects/Constants.qll
+++ b/python/ql/src/semmle/python/objects/Constants.qll
@@ -34,9 +34,11 @@ abstract class ConstantObjectInternal extends ObjectInternal {
 
   pragma[noinline]
   override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) {
-    PointsToInternal::attributeRequired(this, name) and
+    PointsToInternal::attributeRequired(pragma[only_bind_into](this), pragma[only_bind_into](name)) and
     exists(ObjectInternal cls_attr, CfgOrigin attr_orig |
-      this.getClass().(ClassObjectInternal).lookup(name, cls_attr, attr_orig) and
+      this.getClass()
+          .(ClassObjectInternal)
+          .lookup(pragma[only_bind_into](name), cls_attr, attr_orig) and
       cls_attr.isDescriptor() = true and
       cls_attr.descriptorGetInstance(this, value, origin)
     )

--- a/python/ql/src/semmle/python/objects/Instances.qll
+++ b/python/ql/src/semmle/python/objects/Instances.qll
@@ -30,18 +30,19 @@ abstract class InstanceObject extends ObjectInternal {
 
   pragma[noinline]
   private predicate classAttribute(string name, ObjectInternal cls_attr) {
-    PointsToInternal::attributeRequired(this, name) and
-    this.getClass().(ClassObjectInternal).lookup(name, cls_attr, _)
+    PointsToInternal::attributeRequired(this, pragma[only_bind_into](name)) and
+    this.getClass().(ClassObjectInternal).lookup(pragma[only_bind_into](name), cls_attr, _)
   }
 
   pragma[noinline]
   private predicate selfAttribute(string name, ObjectInternal value, CfgOrigin origin) {
-    PointsToInternal::attributeRequired(this, name) and
+    PointsToInternal::attributeRequired(this, pragma[only_bind_into](name)) and
     exists(EssaVariable self, PythonFunctionObjectInternal init, Context callee |
       this.initializer(init, callee) and
       self_variable_reaching_init_exit(self) and
       self.getScope() = init.getScope() and
-      AttributePointsTo::variableAttributePointsTo(self, callee, name, value, origin)
+      AttributePointsTo::variableAttributePointsTo(self, callee, pragma[only_bind_into](name),
+        value, origin)
     )
   }
 
@@ -316,9 +317,11 @@ class UnknownInstanceInternal extends TUnknownInstance, ObjectInternal {
 
   pragma[noinline]
   override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) {
-    PointsToInternal::attributeRequired(this, name) and
+    PointsToInternal::attributeRequired(this, pragma[only_bind_into](name)) and
     exists(ObjectInternal cls_attr, CfgOrigin attr_orig |
-      this.getClass().(ClassObjectInternal).lookup(name, cls_attr, attr_orig)
+      this.getClass()
+          .(ClassObjectInternal)
+          .lookup(pragma[only_bind_into](name), cls_attr, attr_orig)
     |
       cls_attr.isDescriptor() = false and value = cls_attr and origin = attr_orig
       or
@@ -456,8 +459,8 @@ class SuperInstance extends TSuperInstance, ObjectInternal {
   /* Helper for `attribute` */
   pragma[noinline]
   private predicate attribute_descriptor(string name, ObjectInternal cls_attr, CfgOrigin attr_orig) {
-    PointsToInternal::attributeRequired(this, name) and
-    this.lookup(name, cls_attr, attr_orig)
+    PointsToInternal::attributeRequired(this, pragma[only_bind_into](name)) and
+    this.lookup(pragma[only_bind_into](name), cls_attr, attr_orig)
   }
 
   private predicate lookup(string name, ObjectInternal value, CfgOrigin origin) {

--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -524,6 +524,7 @@ module PointsToInternal {
     )
   }
 
+  pragma[noinline]
   private boolean ssa_filter_definition_bool(
     PyEdgeRefinement def, PointsToContext context, ObjectInternal value, ControlFlowNode origin
   ) {

--- a/python/ql/src/semmle/python/pointsto/PointsToContext.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsToContext.qll
@@ -184,7 +184,11 @@ class PointsToContext extends TPointsToContext {
 
   /** Holds if this context can apply to the CFG node `n`. */
   pragma[inline]
-  predicate appliesTo(ControlFlowNode n) { this.appliesToScope(n.getScope()) }
+  predicate appliesTo(ControlFlowNode n) {
+    exists(Scope s |
+      this.appliesToScope(pragma[only_bind_into](s)) and pragma[only_bind_into](s) = n.getScope()
+    )
+  }
 
   /** Holds if this context is a call context. */
   predicate isCall() { this = TCallContext(_, _, _) }


### PR DESCRIPTION
This has no effect on the current compilation (indeed,
`ssa_filter_definition_bool` is not currently inlined), but will
prevent this from ever occurring, should the heuristics for inlining
ever change...