### PR TITLE
JS: consider quoted string concatenations as sanitizers for js/shell-command-injection-from-environment

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/ShellCommandInjectionFromEnvironmentCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ShellCommandInjectionFromEnvironmentCustomizations.qll
@@ -55,4 +55,14 @@ module ShellCommandInjectionFromEnvironment {
   class ShellCommandSink extends Sink, DataFlow::ValueNode {
     ShellCommandSink() { any(SystemCommandExecution sys).isShellInterpreted(this) }
   }
+
+  /**
+   * A string-concatenation leaf that is sorounded by quotes, seen as a sanitizer for command-injection.
+   */
+  class QuotingConcatSanitizer extends Sanitizer, StringOps::ConcatenationLeaf {
+    QuotingConcatSanitizer() {
+      this.getNextLeaf().getStringValue().regexpMatch("(\"|').*") and
+      this.getPreviousLeaf().getStringValue().regexpMatch(".*(\"|')")
+    }
+  }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ShellCommandInjectionFromEnvironmentCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ShellCommandInjectionFromEnvironmentCustomizations.qll
@@ -57,7 +57,7 @@ module ShellCommandInjectionFromEnvironment {
   }
 
   /**
-   * A string-concatenation leaf that is sorounded by quotes, seen as a sanitizer for command-injection.
+   * A string-concatenation leaf that is surrounded by quotes, seen as a sanitizer for command-injection.
    */
   class QuotingConcatSanitizer extends Sanitizer, StringOps::ConcatenationLeaf {
     QuotingConcatSanitizer() {

--- a/javascript/ql/test/query-tests/Security/CWE-078/UselessUseOfCat.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UselessUseOfCat.expected
@@ -61,6 +61,7 @@ syncCommand
 | tst_shell-command-injection-from-environment.js:5:2:5:62 | cp.exec ... emp")]) |
 | tst_shell-command-injection-from-environment.js:6:2:6:54 | cp.exec ... temp")) |
 | tst_shell-command-injection-from-environment.js:9:2:9:58 | execa.s ... temp")) |
+| tst_shell-command-injection-from-environment.js:12:2:12:34 | execa.s ... + safe) |
 | uselesscat.js:16:1:16:29 | execSyn ... uinfo') |
 | uselesscat.js:18:1:18:26 | execSyn ... path}`) |
 | uselesscat.js:20:1:20:36 | execSyn ... wc -l') |

--- a/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js
@@ -7,4 +7,7 @@ var cp = require('child_process'),
 
 	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
 	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+
+	const safe = "\"" + path.join(__dirname, "temp") + "\"";
+	execa.shellSync('rm -rf ' + safe); // OK
 });


### PR DESCRIPTION
I encountered [this result](https://lgtm.com/projects/g/jamovi/jamovi-compiler/snapshot/e912724a44de6e149f79b774f2848ccfb6843418/files/index.js?sort=name&dir=ASC&mode=heatmap#xb39ee584ae63c83c:1) in the anomalous query results.    

The shell script is constructed like: 
```JavaScript
let cmd = '"' + source + '" --some --more --hardcoded --args'
```

And I don't think we should flag it.  
If the source is completely attacker controlled, then it's trivial to escape the quotes, but most of what `js/shell-command-injection-from-environment` flags is accidental spaces in paths, which the quotes protects against. 

[An evaluation](https://github.com/dsp-testing/erik-krogh-dca/blob/run/quotedShell-default-shellFromEnv/reports/alert-comparison.md) shows unaffected performance, and that a few results we no longer flag. 