### PR TITLE
Java: Add severity and precision metadata to experimental queries.

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-036/OpenStream.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-036/OpenStream.ql
@@ -1,8 +1,13 @@
 /**
  * @name openStream called on URLs created from remote source
  * @description Calling openStream on URLs created from remote source
- * can lead to local file disclosure.
+ *              can lead to local file disclosure.
  * @kind path-problem
+ * @problem.severity warning
+ * @precision medium
+ * @id java/openstream-called-on-tainted-url
+ * @tags security
+ *       external/cwe/cwe-036
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
@@ -1,7 +1,12 @@
 /**
  * @name Unsafe certificate trust
- * @description Unsafe implementation of the interface X509TrustManager and SSLSocket/SSLEngine ignores all SSL certificate validation errors when establishing an HTTPS connection, thereby making the app vulnerable to man-in-the-middle attacks.
+ * @description Unsafe implementation of the interface X509TrustManager and
+ *              SSLSocket/SSLEngine ignores all SSL certificate validation
+ *              errors when establishing an HTTPS connection, thereby making
+ *              the app vulnerable to man-in-the-middle attacks.
  * @kind problem
+ * @problem.severity warning
+ * @precision medium
  * @id java/unsafe-cert-trust
  * @tags security
  *       external/cwe-273

--- a/java/ql/src/experimental/Security/CWE/CWE-295/JxBrowserWithoutCertValidation.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/JxBrowserWithoutCertValidation.ql
@@ -1,7 +1,11 @@
 /**
  * @name JxBrowser with disabled certificate validation
- * @description Insecure configuration of JxBrowser disables certificate validation making the app vulnerable to man-in-the-middle attacks.
+ * @description Insecure configuration of JxBrowser disables certificate
+ *              validation making the app vulnerable to man-in-the-middle
+ *              attacks.
  * @kind problem
+ * @problem.severity warning
+ * @precision medium
  * @id java/jxbrowser/disabled-certificate-validation
  * @tags security
  *       external/cwe/cwe-295

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureJavaMail.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureJavaMail.ql
@@ -1,8 +1,12 @@
 /**
- * @id java/insecure-smtp-ssl
  * @name Insecure JavaMail SSL Configuration
- * @description Java application configured to use authenticated mail session over SSL does not validate the SSL certificate to properly ensure that it is actually associated with that host.
+ * @description Java application configured to use authenticated mail session
+ *              over SSL does not validate the SSL certificate to properly
+ *              ensure that it is actually associated with that host.
  * @kind problem
+ * @problem.severity warning
+ * @precision medium
+ * @id java/insecure-smtp-ssl
  * @tags security
  *       external/cwe-297
  */

--- a/java/ql/src/experimental/Security/CWE/CWE-312/CleartextStorageSharedPrefs.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-312/CleartextStorageSharedPrefs.ql
@@ -1,7 +1,11 @@
 /**
  * @name Cleartext storage of sensitive information using `SharedPreferences` on Android
- * @description Cleartext Storage of Sensitive Information using SharedPreferences on Android allows access for users with root privileges or unexpected exposure from chained vulnerabilities.
+ * @description Cleartext Storage of Sensitive Information using
+ *              SharedPreferences on Android allows access for users with root
+ *              privileges or unexpected exposure from chained vulnerabilities.
  * @kind problem
+ * @problem.severity warning
+ * @precision medium
  * @id java/android/cleartext-storage-shared-prefs
  * @tags security
  *       external/cwe/cwe-312

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
@@ -2,6 +2,8 @@
  * @name Weak encryption: Insufficient key size
  * @description Finds uses of encryption algorithms with too small a key size
  * @kind problem
+ * @problem.severity warning
+ * @precision medium
  * @id java/insufficient-key-size
  * @tags security
  *       external/cwe/cwe-326

--- a/java/ql/src/experimental/Security/CWE/CWE-489/EJBMain.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-489/EJBMain.ql
@@ -2,6 +2,8 @@
  * @name Main Method in Enterprise Java Bean
  * @description Java EE applications with a main method.
  * @kind problem
+ * @problem.severity warning
+ * @precision medium
  * @id java/main-method-in-enterprise-bean
  * @tags security
  *       external/cwe-489

--- a/java/ql/src/experimental/Security/CWE/CWE-489/WebComponentMain.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-489/WebComponentMain.ql
@@ -2,6 +2,8 @@
  * @name Main Method in Java EE Web Components
  * @description Java EE web applications with a main method.
  * @kind problem
+ * @problem.severity warning
+ * @precision medium
  * @id java/main-method-in-web-components
  * @tags security
  *       external/cwe-489

--- a/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
@@ -1,7 +1,12 @@
 /**
  * @name Directories and files exposure
- * @description A directory listing provides an attacker with the complete index of all the resources located inside of the complete web directory, which could yield files containing sensitive information like source code and credentials to the attacker.
+ * @description A directory listing provides an attacker with the complete
+ *              index of all the resources located inside of the complete web
+ *              directory, which could yield files containing sensitive
+ *              information like source code and credentials to the attacker.
  * @kind problem
+ * @problem.severity warning
+ * @precision medium
  * @id java/server-directory-listing
  * @tags security
  *       external/cwe-548

--- a/java/ql/src/experimental/Security/CWE/CWE-555/PasswordInConfigurationFile.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-555/PasswordInConfigurationFile.ql
@@ -2,6 +2,8 @@
  * @name Password in configuration file
  * @description Finds passwords in configuration files.
  * @kind problem
+ * @problem.severity warning
+ * @precision medium
  * @id java/password-in-configuration
  * @tags security
  *       external/cwe/cwe-555

--- a/java/ql/src/experimental/Security/CWE/CWE-939/IncorrectURLVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-939/IncorrectURLVerification.ql
@@ -1,8 +1,12 @@
 /**
- * @id java/incorrect-url-verification
  * @name Incorrect URL verification
- * @description Apps that rely on URL parsing to verify that a given URL is pointing to a trusted server are susceptible to wrong ways of URL parsing and verification.
+ * @description Apps that rely on URL parsing to verify that a given URL is
+ *              pointing to a trusted server are susceptible to wrong ways of
+ *              URL parsing and verification.
  * @kind problem
+ * @problem.severity warning
+ * @precision medium
+ * @id java/incorrect-url-verification
  * @tags security
  *       external/cwe-939
  */


### PR DESCRIPTION
I've added `@problem.severity warning` and `@precision medium` to the experimental queries that didn't have this metadata. I haven't made any effort to assign correct severity/precision, but simply arbitrarily chosen `warning/medium`, as the metadata would need more careful evaluation upon promotion anyway.