### PR TITLE
JS: recognize headers/url from the HTTP request to a server WebSocket.

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
@@ -77,6 +77,11 @@ nodes
 | tst.js:98:29:98:35 | req.url |
 | tst.js:100:19:100:25 | tainted |
 | tst.js:100:19:100:25 | tainted |
+| tst.js:108:11:108:27 | url |
+| tst.js:108:17:108:27 | request.url |
+| tst.js:108:17:108:27 | request.url |
+| tst.js:109:27:109:29 | url |
+| tst.js:109:27:109:29 | url |
 edges
 | tst.js:14:9:14:52 | tainted | tst.js:18:13:18:19 | tainted |
 | tst.js:14:9:14:52 | tainted | tst.js:18:13:18:19 | tainted |
@@ -152,6 +157,10 @@ edges
 | tst.js:98:19:98:52 | url.par ... ery.url | tst.js:98:9:98:52 | tainted |
 | tst.js:98:29:98:35 | req.url | tst.js:98:19:98:42 | url.par ... , true) |
 | tst.js:98:29:98:35 | req.url | tst.js:98:19:98:42 | url.par ... , true) |
+| tst.js:108:11:108:27 | url | tst.js:109:27:109:29 | url |
+| tst.js:108:11:108:27 | url | tst.js:109:27:109:29 | url |
+| tst.js:108:17:108:27 | request.url | tst.js:108:11:108:27 | url |
+| tst.js:108:17:108:27 | request.url | tst.js:108:11:108:27 | url |
 #select
 | tst.js:18:5:18:20 | request(tainted) | tst.js:14:29:14:35 | req.url | tst.js:18:13:18:19 | tainted | The $@ of this request depends on $@. | tst.js:18:13:18:19 | tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
 | tst.js:20:5:20:24 | request.get(tainted) | tst.js:14:29:14:35 | req.url | tst.js:20:17:20:23 | tainted | The $@ of this request depends on $@. | tst.js:20:17:20:23 | tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
@@ -173,3 +182,4 @@ edges
 | tst.js:90:5:90:33 | JSDOM.f ... ms.foo) | tst.js:90:19:90:28 | ctx.params | tst.js:90:19:90:32 | ctx.params.foo | The $@ of this request depends on $@. | tst.js:90:19:90:32 | ctx.params.foo | URL | tst.js:90:19:90:28 | ctx.params | a user-provided value |
 | tst.js:92:5:92:33 | JSDOM.f ... ms.foo) | tst.js:92:19:92:28 | ctx.params | tst.js:92:19:92:32 | ctx.params.foo | The $@ of this request depends on $@. | tst.js:92:19:92:32 | ctx.params.foo | URL | tst.js:92:19:92:28 | ctx.params | a user-provided value |
 | tst.js:100:5:100:26 | new Web ... ainted) | tst.js:98:29:98:35 | req.url | tst.js:100:19:100:25 | tainted | The $@ of this request depends on $@. | tst.js:100:19:100:25 | tainted | URL | tst.js:98:29:98:35 | req.url | a user-provided value |
+| tst.js:109:20:109:30 | new ws(url) | tst.js:108:17:108:27 | request.url | tst.js:109:27:109:29 | url | The $@ of this request depends on $@. | tst.js:109:27:109:29 | url | URL | tst.js:108:17:108:27 | request.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-918/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-918/tst.js
@@ -99,3 +99,13 @@ var server = http.createServer(async function(req, res) {
 
     new WebSocket(tainted); // NOT OK
 });
+
+
+import * as ws from 'ws';
+
+new ws.Server({ port: 8080 }).on('connection', function(socket, request) {
+  socket.on('message', function(message) {
+    const url = request.url;
+    const socket = new ws(url);
+  });
+});


### PR DESCRIPTION
[An evaluation looks good](https://github.com/dsp-testing/erik-krogh-dca/tree/run/socketInput-default-security-3/reports).  
The new log-injection result looks good.   
But I don't know why the other new results appeared. 