### PR TITLE
JS: detect fs modules that pass through a reduce call

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -480,7 +480,7 @@ module NodeJSLib {
         )
         or
         // const fs = require('fs');
-        // module.exports = methods.reduce((obj, method) => {
+        // let fs_copy = methods.reduce((obj, method) => {
         //  obj[method] = fs[method];
         //  return obj;
         // }, {});

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -2168,6 +2168,109 @@ nodes
 | other-fs-libraries.js:42:53:42:56 | path |
 | other-fs-libraries.js:42:53:42:56 | path |
 | other-fs-libraries.js:42:53:42:56 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:24:49:30 | req.url |
+| other-fs-libraries.js:49:24:49:30 | req.url |
+| other-fs-libraries.js:49:24:49:30 | req.url |
+| other-fs-libraries.js:49:24:49:30 | req.url |
+| other-fs-libraries.js:49:24:49:30 | req.url |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:52:24:52:27 | path |
 | pupeteer.js:5:9:5:71 | tainted |
 | pupeteer.js:5:9:5:71 | tainted |
 | pupeteer.js:5:9:5:71 | tainted |
@@ -6421,6 +6524,150 @@ edges
 | other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
 | other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
 | other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:51:19:51:22 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:43 | url.par ... ).query | other-fs-libraries.js:49:14:49:48 | url.par ... ry.path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:14:49:48 | url.par ... ry.path | other-fs-libraries.js:49:7:49:48 | path |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
+| other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:49:14:49:37 | url.par ... , true) |
 | pupeteer.js:5:9:5:71 | tainted | pupeteer.js:9:28:9:34 | tainted |
 | pupeteer.js:5:9:5:71 | tainted | pupeteer.js:9:28:9:34 | tainted |
 | pupeteer.js:5:9:5:71 | tainted | pupeteer.js:9:28:9:34 | tainted |
@@ -8046,6 +8293,8 @@ edges
 | other-fs-libraries.js:40:35:40:38 | path | other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:40:35:40:38 | path | This path depends on $@. | other-fs-libraries.js:38:24:38:30 | req.url | a user-provided value |
 | other-fs-libraries.js:41:50:41:53 | path | other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:41:50:41:53 | path | This path depends on $@. | other-fs-libraries.js:38:24:38:30 | req.url | a user-provided value |
 | other-fs-libraries.js:42:53:42:56 | path | other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:42:53:42:56 | path | This path depends on $@. | other-fs-libraries.js:38:24:38:30 | req.url | a user-provided value |
+| other-fs-libraries.js:51:19:51:22 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:51:19:51:22 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
+| other-fs-libraries.js:52:24:52:27 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:52:24:52:27 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
 | pupeteer.js:9:28:9:34 | tainted | pupeteer.js:5:28:5:53 | parseTo ... t).name | pupeteer.js:9:28:9:34 | tainted | This path depends on $@. | pupeteer.js:5:28:5:53 | parseTo ... t).name | a user-provided value |
 | pupeteer.js:13:37:13:43 | tainted | pupeteer.js:5:28:5:53 | parseTo ... t).name | pupeteer.js:13:37:13:43 | tainted | This path depends on $@. | pupeteer.js:5:28:5:53 | parseTo ... t).name | a user-provided value |
 | tainted-access-paths.js:8:19:8:22 | path | tainted-access-paths.js:6:24:6:30 | req.url | tainted-access-paths.js:8:19:8:22 | path | This path depends on $@. | tainted-access-paths.js:6:24:6:30 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/my-async-fs-module.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/my-async-fs-module.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const {promisify} = require('bluebird');
+
+const methods = [
+  'readFile',
+  'writeFile',
+  'readFileSync',
+  'writeFileSync'
+];
+
+module.exports = methods.reduce((obj, method) => {
+  obj[method] = promisify(fs[method]);
+  return obj;
+}, {});

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
@@ -41,3 +41,13 @@ http.createServer(function(req, res) {
   require("bluebird").promisify(fs.readFileSync)(path); // NOT OK
   require("bluebird").promisifyAll(fs).readFileSync(path); // NOT OK
 });
+
+
+const asyncFS = require("./my-async-fs-module");
+
+http.createServer(function(req, res) {
+  var path = url.parse(req.url, true).query.path;
+
+  fs.readFileSync(path); // NOT OK
+  asyncFS.readFileSync(path); // NOT OK
+});


### PR DESCRIPTION
Detects the sink in CVE-2020-26299

[An evaluation on `TaintedPath.ql`](https://github.com/dsp-testing/erik-krogh-dca/tree/run/moreFS-default-taintedPath/reports) was uneventful. 