### PR TITLE
Python: Prevent bad TC and add a bit of caching

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -1517,9 +1517,12 @@ predicate forReadStep(CfgNode nodeFrom, Content c, Node nodeTo) {
     or
     c instanceof SetElementContent
     or
-    c.(TupleElementContent).getIndex() <= 7
+    c = small_tuple()
   )
 }
+
+pragma[noinline]
+TupleElementContent small_tuple() { result.getIndex() <= 7 }
 
 /**
  * Holds if `nodeTo` is a read of an attribute (corresponding to `c`) of the object in `nodeFrom`.

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -1517,7 +1517,7 @@ predicate forReadStep(CfgNode nodeFrom, Content c, Node nodeTo) {
     or
     c instanceof SetElementContent
     or
-    c instanceof TupleElementContent
+    c.(TupleElementContent).getIndex() <= 7
   )
 }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -467,14 +467,22 @@ class BarrierGuard extends GuardNode {
   }
 }
 
+private predicate comes_from_cfgnode(Node node) {
+  exists(Node second |
+    simpleLocalFlowStep(any(CfgNode c), second) and
+    simpleLocalFlowStep*(second, node)
+  )
+}
+
 /**
  * A data flow node that is a source of local flow. This includes things like
  * - Expressions
  * - Function parameters
  */
 class LocalSourceNode extends Node {
+  cached
   LocalSourceNode() {
-    not simpleLocalFlowStep+(any(CfgNode n), this) and
+    not comes_from_cfgnode(this) and
     not this instanceof ModuleVariableNode
     or
     this = any(ModuleVariableNode mvn).getARead()

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -468,8 +468,8 @@ class BarrierGuard extends GuardNode {
 }
 
 private predicate comes_from_cfgnode(Node node) {
-  exists(Node second |
-    simpleLocalFlowStep(any(CfgNode c), second) and
+  exists(CfgNode first, Node second |
+    simpleLocalFlowStep(first, second) and
     simpleLocalFlowStep*(second, node)
   )
 }

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -530,15 +530,12 @@ private module Cached {
    * The slightly backwards parametering ordering is to force correct indexing.
    */
   cached
-  predicate hasLocalSource(Node sink, Node source) {
-    // Declaring `source` to be a `SourceNode` currently causes a redundant check in the
-    // recursive case, so instead we check it explicitly here.
-    source = sink and
-    source instanceof LocalSourceNode
+  predicate hasLocalSource(Node sink, LocalSourceNode source) {
+    source = sink
     or
-    exists(Node mid |
-      hasLocalSource(mid, source) and
-      simpleLocalFlowStep(mid, sink)
+    exists(Node second |
+      simpleLocalFlowStep(source, second) and
+      simpleLocalFlowStep*(second, sink)
     )
   }
 


### PR DESCRIPTION
Using `simpleLocalFlowStep+` with the first argument specialised to
`CfgNode` was causing the compiler to turn this into a very slowly
converging manual TC computation.

Instead, we use `simpleLocalFlowStep*` (which is fast) and then join
that with a single step from any `CfgNode`. This should amount to the
same thing.

I also noticed that the charpred for `LocalSourceNode` was getting
recomputed a lot, so this is now cached. (The recomputation was
especially bad since it relied on `simpleLocalFlowStep+`, but anyway
it's a good idea not to recompute this.)