### PR TITLE
CodeQL CLI Docs: Mention that QL packs use SemVer versioning

### DIFF
--- a/docs/codeql/codeql-cli/about-ql-packs.rst
+++ b/docs/codeql/codeql-cli/about-ql-packs.rst
@@ -79,7 +79,7 @@ The following properties are supported in ``qlpack.yml`` files.
    * - ``version``
      - ``0.0.0``
      - All packs
-     - A version number for this QL pack. This field is not currently used by any commands, but may be required by future releases of CodeQL.
+     - A version number for this QL pack. This must be a valid semantic version that meets the `SemVer v2.0.0 specification <https://semver.org/spec/v2.0.0.html>`__.
    * - ``libraryPathDependencies``
      - ``codeql-javascript``
      - Optional


### PR DESCRIPTION
Update the description of the `version` field in `qlpack.yml` to reflect that the version must be a valid v2.0.0 semantic version meeting [this spec](https://semver.org/spec/v2.0.0.html), and to remove the statement that the field is unused since as of v2.4.5, the field is now used by CodeQL commands like `codeql database analyze`.