### PR TITLE
JS: Add model of pg-promise

### DIFF
--- a/javascript/change-notes/2021-03-29-pg-promise.md
+++ b/javascript/change-notes/2021-03-29-pg-promise.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* SQL injection sinks from the `pg-promise` library are now recognized.

--- a/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
@@ -166,14 +166,24 @@ private module Postgres {
   API::Node pgPromise() { result = API::moduleImport("pg-promise") }
 
   /** Gets an initialized `pg-promise` library. */
-  API::Node pgpMain() { result = pgPromise().getReturn() }
+  API::Node pgpMain() {
+    result = pgPromise().getReturn()
+    or
+    result = API::Node::ofType("pg-promise", "IMain")
+  }
 
   /** Gets a database from `pg-promise`. */
-  API::Node pgpDatabase() { result = pgpMain().getReturn() }
+  API::Node pgpDatabase() {
+    result = pgpMain().getReturn()
+    or
+    result = API::Node::ofType("pg-promise", "IDatabase")
+  }
 
   /** Gets a connection created from a `pg-promise` database. */
   API::Node pgpConnection() {
     result = pgpDatabase().getMember("connect").getReturn().getPromised()
+    or
+    result = API::Node::ofType("pg-promise", "IConnected")
   }
 
   /** Gets a `pg-promise` task object. */
@@ -185,10 +195,16 @@ private module Postgres {
       or
       result = taskMethod.getParameter(0).getMember("cnd").getParameter(0)
     )
+    or
+    result = API::Node::ofType("pg-promise", "ITask")
   }
 
   /** Gets a `pg-promise` object which supports querying (database, connection, or task). */
-  API::Node pgpObject() { result = [pgpDatabase(), pgpConnection(), pgpTask()] }
+  API::Node pgpObject() {
+    result = [pgpDatabase(), pgpConnection(), pgpTask()]
+    or
+    result = API::Node::ofType("pg-promise", "IBaseProtocol")
+  }
 
   private string pgpQueryMethodName() {
     result =

--- a/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
@@ -93,7 +93,7 @@ private module MySql {
 }
 
 /**
- * Provides classes modelling the `pg` package.
+ * Provides classes modelling the PostgreSQL packages, such as `pg` and `pg-promise`.
  */
 private module Postgres {
   API::Node pg() {

--- a/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
@@ -96,8 +96,14 @@ private module MySql {
  * Provides classes modelling the `pg` package.
  */
 private module Postgres {
+  API::Node pg() {
+    result = API::moduleImport("pg")
+    or
+    result = pgpMain().getMember("pg")
+  }
+
   /** Gets a reference to the `Client` constructor in the `pg` package, for example `require('pg').Client`. */
-  API::Node newClient() { result = API::moduleImport("pg").getMember("Client") }
+  API::Node newClient() { result = pg().getMember("Client") }
 
   /** Gets a freshly created Postgres client instance. */
   API::Node client() {
@@ -105,19 +111,25 @@ private module Postgres {
     or
     // pool.connect(function(err, client) { ... })
     result = pool().getMember("connect").getParameter(0).getParameter(1)
+    or
+    result = pgpConnection().getMember("client")
   }
 
   /** Gets a constructor that when invoked constructs a new connection pool. */
   API::Node newPool() {
     // new require('pg').Pool()
-    result = API::moduleImport("pg").getMember("Pool")
+    result = pg().getMember("Pool")
     or
     // new require('pg-pool')
     result = API::moduleImport("pg-pool")
   }
 
-  /** Gets an expression that constructs a new connection pool. */
-  API::Node pool() { result = newPool().getInstance() }
+  /** Gets an API node that refers to a connection pool. */
+  API::Node pool() {
+    result = newPool().getInstance()
+    or
+    result = pgpDatabase().getMember("$pool")
+  }
 
   /** A call to the Postgres `query` method. */
   private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
@@ -137,16 +149,125 @@ private module Postgres {
 
     Credentials() {
       exists(string prop |
-        this = [newClient(), newPool()].getParameter(0).getMember(prop).getARhs().asExpr() and
-        (
-          prop = "user" and kind = "user name"
-          or
-          prop = "password" and kind = prop
-        )
+        this = [newClient(), newPool()].getParameter(0).getMember(prop).getARhs().asExpr()
+        or
+        this = pgPromise().getParameter(0).getMember(prop).getARhs().asExpr()
+      |
+        prop = "user" and kind = "user name"
+        or
+        prop = "password" and kind = prop
       )
     }
 
     override string getCredentialsKind() { result = kind }
+  }
+
+  /** Gets a node referring to the `pg-promise` library (which is not itself a Promise). */
+  API::Node pgPromise() { result = API::moduleImport("pg-promise") }
+
+  /** Gets an initialized `pg-promise` library. */
+  API::Node pgpMain() { result = pgPromise().getReturn() }
+
+  /** Gets a database from `pg-promise`. */
+  API::Node pgpDatabase() { result = pgpMain().getReturn() }
+
+  /** Gets a connection created from a `pg-promise` database. */
+  API::Node pgpConnection() {
+    result = pgpDatabase().getMember("connect").getReturn().getPromised()
+  }
+
+  /** Gets a `pg-promise` task object. */
+  API::Node pgpTask() {
+    exists(API::Node taskMethod |
+      taskMethod = pgpObject().getMember(["task", "taskIf", "tx", "txIf"])
+    |
+      result = taskMethod.getParameter([0, 1]).getParameter(0)
+      or
+      result = taskMethod.getParameter(0).getMember("cnd").getParameter(0)
+    )
+  }
+
+  /** Gets a `pg-promise` object which supports querying (database, connection, or task). */
+  API::Node pgpObject() { result = [pgpDatabase(), pgpConnection(), pgpTask()] }
+
+  private string pgpQueryMethodName() {
+    result =
+      [
+        "any", "each", "many", "manyOrNone", "map", "multi", "multiResult", "none", "one",
+        "oneOrNone", "query", "result"
+      ]
+  }
+
+  /** A call that executes a SQL query via `pg-promise`. */
+  private class PgPromiseQueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
+    PgPromiseQueryCall() { this = pgpObject().getMember(pgpQueryMethodName()).getACall() }
+
+    /** Gets an argument interpreted as a SQL string, not including raw interpolation variables. */
+    private DataFlow::Node getADirectQueryArgument() {
+      result = getArgument(0)
+      or
+      result = getOptionArgument(0, "text")
+    }
+
+    /**
+     * Gets an interpolation parameter whose value is interpreted literally, or is not escaped appropriately for its context.
+     *
+     * For example, the following are raw placeholders: $1:raw, $1^, ${prop}:raw, $(prop)^
+     */
+    private string getARawParameterName() {
+      exists(string sqlString, string placeholderRegexp, string regexp |
+        placeholderRegexp = "\\$(\\d+|[{(\\[/]\\w+[})\\]/])" and // For example: $1 or ${prop}
+        sqlString = getADirectQueryArgument().getStringValue()
+      |
+        // Match $1:raw or ${prop}:raw
+        regexp = placeholderRegexp + "(:raw|\\^)" and
+        result =
+          sqlString
+              .regexpFind(regexp, _, _)
+              .regexpCapture(regexp, 1)
+              .regexpReplaceAll("[^\\w\\d]", "")
+        or
+        // Match $1:value or ${prop}:value unless enclosed by single quotes (:value prevents breaking out of single quotes)
+        regexp = placeholderRegexp + "(:value|\\#)" and
+        result =
+          sqlString
+              .regexpReplaceAll("'[^']*'", "''")
+              .regexpFind(regexp, _, _)
+              .regexpCapture(regexp, 1)
+              .regexpReplaceAll("[^\\w\\d]", "")
+      )
+    }
+
+    /** Gets the argument holding the values to plug into placeholders. */
+    private DataFlow::Node getValues() {
+      result = getArgument(1)
+      or
+      result = getOptionArgument(0, "values")
+    }
+
+    /** Gets a value that is plugged into a raw placeholder variable, making it a sink for SQL injection. */
+    private DataFlow::Node getARawValue() {
+      result = getValues() and getARawParameterName() = "1" // Special case: if the argument is not an array or object, it's just plugged into $1
+      or
+      exists(DataFlow::SourceNode values | values = getValues().getALocalSource() |
+        result = values.getAPropertyWrite(getARawParameterName()).getRhs()
+        or
+        // Array literals do not have PropWrites with property names so handle them separately,
+        // and also translate to 0-based indexing.
+        result = values.(DataFlow::ArrayCreationNode).getElement(getARawParameterName().toInt() - 1)
+      )
+    }
+
+    override DataFlow::Node getAQueryArgument() {
+      result = getADirectQueryArgument()
+      or
+      result = getARawValue()
+    }
+  }
+
+  /** An expression that is interpreted as SQL by `pg-promise`. */
+  class PgPromiseQueryString extends SQL::SqlString {
+    PgPromiseQueryString() { this = any(PgPromiseQueryCall qc).getAQueryArgument().asExpr() }
   }
 }
 

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
@@ -37,6 +37,7 @@
 | mongoose.js:97:2:97:52 | Documen ... query)) |
 | mongoose.js:99:2:99:50 | Documen ... query)) |
 | mongoose.js:113:2:113:53 | Documen ... () { }) |
+| pg-promise-types.ts:8:5:8:22 | this.db.one(taint) |
 | pg-promise.js:9:3:9:15 | db.any(query) |
 | pg-promise.js:10:3:10:16 | db.many(query) |
 | pg-promise.js:11:3:11:22 | db.manyOrNone(query) |
@@ -55,6 +56,9 @@
 | pg-promise.js:36:3:43:4 | db.one( ...  ]\\n  }) |
 | pg-promise.js:44:3:50:4 | db.one( ...  }\\n  }) |
 | pg-promise.js:51:3:58:4 | db.one( ...  }\\n  }) |
+| pg-promise.js:60:14:60:25 | t.one(query) |
+| pg-promise.js:63:17:63:28 | t.one(query) |
+| pg-promise.js:64:10:64:21 | t.one(query) |
 | socketio.js:11:5:11:54 | db.run( ... ndle}`) |
 | tst2.js:7:3:7:62 | sql.que ... ms.id}` |
 | tst2.js:9:3:9:85 | new sql ...  + "'") |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
@@ -37,6 +37,24 @@
 | mongoose.js:97:2:97:52 | Documen ... query)) |
 | mongoose.js:99:2:99:50 | Documen ... query)) |
 | mongoose.js:113:2:113:53 | Documen ... () { }) |
+| pg-promise.js:9:3:9:15 | db.any(query) |
+| pg-promise.js:10:3:10:16 | db.many(query) |
+| pg-promise.js:11:3:11:22 | db.manyOrNone(query) |
+| pg-promise.js:12:3:12:15 | db.map(query) |
+| pg-promise.js:13:3:13:17 | db.multi(query) |
+| pg-promise.js:14:3:14:23 | db.mult ... (query) |
+| pg-promise.js:15:3:15:16 | db.none(query) |
+| pg-promise.js:16:3:16:15 | db.one(query) |
+| pg-promise.js:17:3:17:21 | db.oneOrNone(query) |
+| pg-promise.js:18:3:18:17 | db.query(query) |
+| pg-promise.js:19:3:19:18 | db.result(query) |
+| pg-promise.js:21:3:23:4 | db.one( ... OK\\n  }) |
+| pg-promise.js:24:3:27:4 | db.one( ... OK\\n  }) |
+| pg-promise.js:28:3:31:4 | db.one( ... er\\n  }) |
+| pg-promise.js:32:3:35:4 | db.one( ... OK\\n  }) |
+| pg-promise.js:36:3:43:4 | db.one( ...  ]\\n  }) |
+| pg-promise.js:44:3:50:4 | db.one( ...  }\\n  }) |
+| pg-promise.js:51:3:58:4 | db.one( ...  }\\n  }) |
 | socketio.js:11:5:11:54 | db.run( ... ndle}`) |
 | tst2.js:7:3:7:62 | sql.que ... ms.id}` |
 | tst2.js:9:3:9:85 | new sql ...  + "'") |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -206,6 +206,59 @@ nodes
 | mongooseModelClient.js:12:22:12:29 | req.body |
 | mongooseModelClient.js:12:22:12:29 | req.body |
 | mongooseModelClient.js:12:22:12:32 | req.body.id |
+| pg-promise.js:6:7:7:55 | query |
+| pg-promise.js:6:15:7:55 | "SELECT ...  PRICE" |
+| pg-promise.js:7:16:7:34 | req.params.category |
+| pg-promise.js:7:16:7:34 | req.params.category |
+| pg-promise.js:9:10:9:14 | query |
+| pg-promise.js:9:10:9:14 | query |
+| pg-promise.js:10:11:10:15 | query |
+| pg-promise.js:10:11:10:15 | query |
+| pg-promise.js:11:17:11:21 | query |
+| pg-promise.js:11:17:11:21 | query |
+| pg-promise.js:12:10:12:14 | query |
+| pg-promise.js:12:10:12:14 | query |
+| pg-promise.js:13:12:13:16 | query |
+| pg-promise.js:13:12:13:16 | query |
+| pg-promise.js:14:18:14:22 | query |
+| pg-promise.js:14:18:14:22 | query |
+| pg-promise.js:15:11:15:15 | query |
+| pg-promise.js:15:11:15:15 | query |
+| pg-promise.js:16:10:16:14 | query |
+| pg-promise.js:16:10:16:14 | query |
+| pg-promise.js:17:16:17:20 | query |
+| pg-promise.js:17:16:17:20 | query |
+| pg-promise.js:18:12:18:16 | query |
+| pg-promise.js:18:12:18:16 | query |
+| pg-promise.js:19:13:19:17 | query |
+| pg-promise.js:19:13:19:17 | query |
+| pg-promise.js:22:11:22:15 | query |
+| pg-promise.js:22:11:22:15 | query |
+| pg-promise.js:30:13:30:25 | req.params.id |
+| pg-promise.js:30:13:30:25 | req.params.id |
+| pg-promise.js:30:13:30:25 | req.params.id |
+| pg-promise.js:34:13:34:25 | req.params.id |
+| pg-promise.js:34:13:34:25 | req.params.id |
+| pg-promise.js:34:13:34:25 | req.params.id |
+| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:39:7:39:19 | req.params.id |
+| pg-promise.js:39:7:39:19 | req.params.id |
+| pg-promise.js:39:7:39:19 | req.params.id |
+| pg-promise.js:40:7:40:21 | req.params.name |
+| pg-promise.js:40:7:40:21 | req.params.name |
+| pg-promise.js:40:7:40:21 | req.params.name |
+| pg-promise.js:41:7:41:20 | req.params.foo |
+| pg-promise.js:41:7:41:20 | req.params.foo |
+| pg-promise.js:47:11:47:23 | req.params.id |
+| pg-promise.js:47:11:47:23 | req.params.id |
+| pg-promise.js:47:11:47:23 | req.params.id |
+| pg-promise.js:54:11:54:23 | req.params.id |
+| pg-promise.js:54:11:54:23 | req.params.id |
+| pg-promise.js:54:11:54:23 | req.params.id |
+| pg-promise.js:56:14:56:29 | req.params.title |
+| pg-promise.js:56:14:56:29 | req.params.title |
+| pg-promise.js:56:14:56:29 | req.params.title |
 | redis.js:10:16:10:23 | req.body |
 | redis.js:10:16:10:23 | req.body |
 | redis.js:10:16:10:27 | req.body.key |
@@ -553,6 +606,52 @@ edges
 | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:22:12:32 | req.body.id |
 | mongooseModelClient.js:12:22:12:32 | req.body.id | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } |
 | mongooseModelClient.js:12:22:12:32 | req.body.id | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:9:10:9:14 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:9:10:9:14 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:10:11:10:15 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:10:11:10:15 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:11:17:11:21 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:11:17:11:21 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:12:10:12:14 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:12:10:12:14 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:13:12:13:16 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:13:12:13:16 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:14:18:14:22 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:14:18:14:22 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:15:11:15:15 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:15:11:15:15 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:16:10:16:14 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:16:10:16:14 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:17:16:17:20 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:17:16:17:20 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:18:12:18:16 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:18:12:18:16 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:19:13:19:17 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:19:13:19:17 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:22:11:22:15 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:22:11:22:15 | query |
+| pg-promise.js:6:15:7:55 | "SELECT ...  PRICE" | pg-promise.js:6:7:7:55 | query |
+| pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:6:15:7:55 | "SELECT ...  PRICE" |
+| pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:6:15:7:55 | "SELECT ...  PRICE" |
+| pg-promise.js:30:13:30:25 | req.params.id | pg-promise.js:30:13:30:25 | req.params.id |
+| pg-promise.js:34:13:34:25 | req.params.id | pg-promise.js:34:13:34:25 | req.params.id |
+| pg-promise.js:39:7:39:19 | req.params.id | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:39:7:39:19 | req.params.id | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:39:7:39:19 | req.params.id | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:39:7:39:19 | req.params.id | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:39:7:39:19 | req.params.id | pg-promise.js:39:7:39:19 | req.params.id |
+| pg-promise.js:40:7:40:21 | req.params.name | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:40:7:40:21 | req.params.name | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:40:7:40:21 | req.params.name | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:40:7:40:21 | req.params.name | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:40:7:40:21 | req.params.name | pg-promise.js:40:7:40:21 | req.params.name |
+| pg-promise.js:41:7:41:20 | req.params.foo | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:41:7:41:20 | req.params.foo | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:41:7:41:20 | req.params.foo | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:41:7:41:20 | req.params.foo | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] |
+| pg-promise.js:47:11:47:23 | req.params.id | pg-promise.js:47:11:47:23 | req.params.id |
+| pg-promise.js:54:11:54:23 | req.params.id | pg-promise.js:54:11:54:23 | req.params.id |
+| pg-promise.js:56:14:56:29 | req.params.title | pg-promise.js:56:14:56:29 | req.params.title |
 | redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key |
 | redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key |
 | redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key |
@@ -665,6 +764,28 @@ edges
 | mongooseJsonParse.js:23:19:23:23 | query | mongooseJsonParse.js:20:30:20:43 | req.query.data | mongooseJsonParse.js:23:19:23:23 | query | This query depends on $@. | mongooseJsonParse.js:20:30:20:43 | req.query.data | a user-provided value |
 | mongooseModelClient.js:11:16:11:24 | { id: v } | mongooseModelClient.js:10:22:10:29 | req.body | mongooseModelClient.js:11:16:11:24 | { id: v } | This query depends on $@. | mongooseModelClient.js:10:22:10:29 | req.body | a user-provided value |
 | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | This query depends on $@. | mongooseModelClient.js:12:22:12:29 | req.body | a user-provided value |
+| pg-promise.js:9:10:9:14 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:9:10:9:14 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:10:11:10:15 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:10:11:10:15 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:11:17:11:21 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:11:17:11:21 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:12:10:12:14 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:12:10:12:14 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:13:12:13:16 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:13:12:13:16 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:14:18:14:22 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:14:18:14:22 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:15:11:15:15 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:15:11:15:15 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:16:10:16:14 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:16:10:16:14 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:17:16:17:20 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:17:16:17:20 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:18:12:18:16 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:18:12:18:16 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:19:13:19:17 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:19:13:19:17 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:22:11:22:15 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:22:11:22:15 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:30:13:30:25 | req.params.id | pg-promise.js:30:13:30:25 | req.params.id | pg-promise.js:30:13:30:25 | req.params.id | This query depends on $@. | pg-promise.js:30:13:30:25 | req.params.id | a user-provided value |
+| pg-promise.js:34:13:34:25 | req.params.id | pg-promise.js:34:13:34:25 | req.params.id | pg-promise.js:34:13:34:25 | req.params.id | This query depends on $@. | pg-promise.js:34:13:34:25 | req.params.id | a user-provided value |
+| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | pg-promise.js:39:7:39:19 | req.params.id | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | This query depends on $@. | pg-promise.js:39:7:39:19 | req.params.id | a user-provided value |
+| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | pg-promise.js:40:7:40:21 | req.params.name | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | This query depends on $@. | pg-promise.js:40:7:40:21 | req.params.name | a user-provided value |
+| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | pg-promise.js:41:7:41:20 | req.params.foo | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | This query depends on $@. | pg-promise.js:41:7:41:20 | req.params.foo | a user-provided value |
+| pg-promise.js:39:7:39:19 | req.params.id | pg-promise.js:39:7:39:19 | req.params.id | pg-promise.js:39:7:39:19 | req.params.id | This query depends on $@. | pg-promise.js:39:7:39:19 | req.params.id | a user-provided value |
+| pg-promise.js:40:7:40:21 | req.params.name | pg-promise.js:40:7:40:21 | req.params.name | pg-promise.js:40:7:40:21 | req.params.name | This query depends on $@. | pg-promise.js:40:7:40:21 | req.params.name | a user-provided value |
+| pg-promise.js:47:11:47:23 | req.params.id | pg-promise.js:47:11:47:23 | req.params.id | pg-promise.js:47:11:47:23 | req.params.id | This query depends on $@. | pg-promise.js:47:11:47:23 | req.params.id | a user-provided value |
+| pg-promise.js:54:11:54:23 | req.params.id | pg-promise.js:54:11:54:23 | req.params.id | pg-promise.js:54:11:54:23 | req.params.id | This query depends on $@. | pg-promise.js:54:11:54:23 | req.params.id | a user-provided value |
+| pg-promise.js:56:14:56:29 | req.params.title | pg-promise.js:56:14:56:29 | req.params.title | pg-promise.js:56:14:56:29 | req.params.title | This query depends on $@. | pg-promise.js:56:14:56:29 | req.params.title | a user-provided value |
 | redis.js:10:16:10:27 | req.body.key | redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key | This query depends on $@. | redis.js:10:16:10:23 | req.body | a user-provided value |
 | redis.js:18:16:18:18 | key | redis.js:12:15:12:22 | req.body | redis.js:18:16:18:18 | key | This query depends on $@. | redis.js:12:15:12:22 | req.body | a user-provided value |
 | redis.js:19:43:19:45 | key | redis.js:12:15:12:22 | req.body | redis.js:19:43:19:45 | key | This query depends on $@. | redis.js:12:15:12:22 | req.body | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -206,6 +206,11 @@ nodes
 | mongooseModelClient.js:12:22:12:29 | req.body |
 | mongooseModelClient.js:12:22:12:29 | req.body |
 | mongooseModelClient.js:12:22:12:32 | req.body.id |
+| pg-promise-types.ts:7:9:7:28 | taint |
+| pg-promise-types.ts:7:17:7:28 | req.params.x |
+| pg-promise-types.ts:7:17:7:28 | req.params.x |
+| pg-promise-types.ts:8:17:8:21 | taint |
+| pg-promise-types.ts:8:17:8:21 | taint |
 | pg-promise.js:6:7:7:55 | query |
 | pg-promise.js:6:15:7:55 | "SELECT ...  PRICE" |
 | pg-promise.js:7:16:7:34 | req.params.category |
@@ -612,6 +617,10 @@ edges
 | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:22:12:32 | req.body.id |
 | mongooseModelClient.js:12:22:12:32 | req.body.id | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } |
 | mongooseModelClient.js:12:22:12:32 | req.body.id | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } |
+| pg-promise-types.ts:7:9:7:28 | taint | pg-promise-types.ts:8:17:8:21 | taint |
+| pg-promise-types.ts:7:9:7:28 | taint | pg-promise-types.ts:8:17:8:21 | taint |
+| pg-promise-types.ts:7:17:7:28 | req.params.x | pg-promise-types.ts:7:9:7:28 | taint |
+| pg-promise-types.ts:7:17:7:28 | req.params.x | pg-promise-types.ts:7:9:7:28 | taint |
 | pg-promise.js:6:7:7:55 | query | pg-promise.js:9:10:9:14 | query |
 | pg-promise.js:6:7:7:55 | query | pg-promise.js:9:10:9:14 | query |
 | pg-promise.js:6:7:7:55 | query | pg-promise.js:10:11:10:15 | query |
@@ -776,6 +785,7 @@ edges
 | mongooseJsonParse.js:23:19:23:23 | query | mongooseJsonParse.js:20:30:20:43 | req.query.data | mongooseJsonParse.js:23:19:23:23 | query | This query depends on $@. | mongooseJsonParse.js:20:30:20:43 | req.query.data | a user-provided value |
 | mongooseModelClient.js:11:16:11:24 | { id: v } | mongooseModelClient.js:10:22:10:29 | req.body | mongooseModelClient.js:11:16:11:24 | { id: v } | This query depends on $@. | mongooseModelClient.js:10:22:10:29 | req.body | a user-provided value |
 | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | This query depends on $@. | mongooseModelClient.js:12:22:12:29 | req.body | a user-provided value |
+| pg-promise-types.ts:8:17:8:21 | taint | pg-promise-types.ts:7:17:7:28 | req.params.x | pg-promise-types.ts:8:17:8:21 | taint | This query depends on $@. | pg-promise-types.ts:7:17:7:28 | req.params.x | a user-provided value |
 | pg-promise.js:9:10:9:14 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:9:10:9:14 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
 | pg-promise.js:10:11:10:15 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:10:11:10:15 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
 | pg-promise.js:11:17:11:21 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:11:17:11:21 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -259,6 +259,12 @@ nodes
 | pg-promise.js:56:14:56:29 | req.params.title |
 | pg-promise.js:56:14:56:29 | req.params.title |
 | pg-promise.js:56:14:56:29 | req.params.title |
+| pg-promise.js:60:20:60:24 | query |
+| pg-promise.js:60:20:60:24 | query |
+| pg-promise.js:63:23:63:27 | query |
+| pg-promise.js:63:23:63:27 | query |
+| pg-promise.js:64:16:64:20 | query |
+| pg-promise.js:64:16:64:20 | query |
 | redis.js:10:16:10:23 | req.body |
 | redis.js:10:16:10:23 | req.body |
 | redis.js:10:16:10:27 | req.body.key |
@@ -630,6 +636,12 @@ edges
 | pg-promise.js:6:7:7:55 | query | pg-promise.js:19:13:19:17 | query |
 | pg-promise.js:6:7:7:55 | query | pg-promise.js:22:11:22:15 | query |
 | pg-promise.js:6:7:7:55 | query | pg-promise.js:22:11:22:15 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:60:20:60:24 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:60:20:60:24 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:63:23:63:27 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:63:23:63:27 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:64:16:64:20 | query |
+| pg-promise.js:6:7:7:55 | query | pg-promise.js:64:16:64:20 | query |
 | pg-promise.js:6:15:7:55 | "SELECT ...  PRICE" | pg-promise.js:6:7:7:55 | query |
 | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:6:15:7:55 | "SELECT ...  PRICE" |
 | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:6:15:7:55 | "SELECT ...  PRICE" |
@@ -786,6 +798,9 @@ edges
 | pg-promise.js:47:11:47:23 | req.params.id | pg-promise.js:47:11:47:23 | req.params.id | pg-promise.js:47:11:47:23 | req.params.id | This query depends on $@. | pg-promise.js:47:11:47:23 | req.params.id | a user-provided value |
 | pg-promise.js:54:11:54:23 | req.params.id | pg-promise.js:54:11:54:23 | req.params.id | pg-promise.js:54:11:54:23 | req.params.id | This query depends on $@. | pg-promise.js:54:11:54:23 | req.params.id | a user-provided value |
 | pg-promise.js:56:14:56:29 | req.params.title | pg-promise.js:56:14:56:29 | req.params.title | pg-promise.js:56:14:56:29 | req.params.title | This query depends on $@. | pg-promise.js:56:14:56:29 | req.params.title | a user-provided value |
+| pg-promise.js:60:20:60:24 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:60:20:60:24 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:63:23:63:27 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:63:23:63:27 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
+| pg-promise.js:64:16:64:20 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:64:16:64:20 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
 | redis.js:10:16:10:27 | req.body.key | redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key | This query depends on $@. | redis.js:10:16:10:23 | req.body | a user-provided value |
 | redis.js:18:16:18:18 | key | redis.js:12:15:12:22 | req.body | redis.js:18:16:18:18 | key | This query depends on $@. | redis.js:12:15:12:22 | req.body | a user-provided value |
 | redis.js:19:43:19:45 | key | redis.js:12:15:12:22 | req.body | redis.js:19:43:19:45 | key | This query depends on $@. | redis.js:12:15:12:22 | req.body | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/pg-promise-types.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/pg-promise-types.ts
@@ -1,0 +1,13 @@
+import { IDatabase } from "pg-promise";
+
+export class Foo {
+  db: IDatabase;
+
+  onRequest(req, res) {
+    let taint = req.params.x;
+    this.db.one(taint); // NOT OK
+    res.end();
+  }
+}
+
+require('express')().get('/foo', (req, res) => new Foo().onRequest(req, res));

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/pg-promise.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/pg-promise.js
@@ -56,4 +56,11 @@ require('express')().get('/foo', (req, res) => {
       title: req.params.title, // NOT OK - enclosed by wrong type of quote
     }
   });
+  db.task(t => {
+      return t.one(query); // NOT OK
+  });
+  db.task(
+    { cnd: t => t.one(query) }, // NOT OK
+    t => t.one(query) // NOT OK
+  );
 });

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/pg-promise.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/pg-promise.js
@@ -1,0 +1,59 @@
+const pgp = require('pg-promise')();
+
+require('express')().get('/foo', (req, res) => {
+  const db = pgp(process.env['DB_CONNECTION_STRING']);
+
+  var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
+             + req.params.category + "' ORDER BY PRICE";
+  
+  db.any(query); // NOT OK
+  db.many(query); // NOT OK
+  db.manyOrNone(query); // NOT OK
+  db.map(query); // NOT OK
+  db.multi(query); // NOT OK
+  db.multiResult(query); // NOT OK
+  db.none(query); // NOT OK
+  db.one(query); // NOT OK
+  db.oneOrNone(query); // NOT OK
+  db.query(query); // NOT OK
+  db.result(query); // NOT OK
+  
+  db.one({
+    text: query // NOT OK
+  });
+  db.one({
+    text: 'SELECT * FROM news where id = $1', // OK
+    values: req.params.id, // OK
+  });
+  db.one({
+    text: 'SELECT * FROM news where id = $1:raw',
+    values: req.params.id, // NOT OK - interpreted as raw parameter
+  });
+  db.one({
+    text: 'SELECT * FROM news where id = $1^',
+    values: req.params.id, // NOT OK
+  });
+  db.one({
+    text: 'SELECT * FROM news where id = $1:raw AND name = $2:raw AND foo = $3',
+    values: [
+      req.params.id, // NOT OK
+      req.params.name, // NOT OK
+      req.params.foo, // OK - not using raw interpolation
+    ]
+  });
+  db.one({
+    text: 'SELECT * FROM news where id = ${id}:raw AND name = ${name}',
+    values: {
+      id: req.params.id, // NOT OK
+      name: req.params.name, // OK - not using raw interpolation
+    }
+  });
+  db.one({
+    text: "SELECT * FROM news where id = ${id}:value AND name LIKE '%${name}:value%' AND title LIKE \"%${title}:value%\"",
+    values: {
+      id: req.params.id, // NOT OK
+      name: req.params.name, // OK - :value cannot break out of single quotes
+      title: req.params.title, // NOT OK - enclosed by wrong type of quote
+    }
+  });
+});


### PR DESCRIPTION
Adds a model of [pg-promise](https://www.npmjs.com/package/pg-promise), a PostgreSQL connector library.

Evaluations: (internal link)
- [On 10 projects using pg-promise](https://github.com/dsp-testing/asgerf-dca/blob/run/js/pg-promise3/reports) shows 231 new sinks and 30 new alerts.
- [Default slugs](https://github.com/dsp-testing/asgerf-dca/tree/run/js/pg-promise2/reports) from a slightly older version of the PR shows acceptable performance.