### PR TITLE
JS: Make SourceNode and PropRef.getBase non-recursive, again

### DIFF
--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -228,6 +228,13 @@ private predicate isCreateRequire(DataFlow::Node nd) {
     nd = prop.getValuePattern().flow()
   )
   or
+  exists(ImportDeclaration decl, NamedImportSpecifier spec |
+    decl.getImportedPath().getValue() = "module" and
+    spec = decl.getASpecifier() and
+    spec.getImportedName() = "createRequire" and
+    nd = spec.flow()
+  )
+  or
   isCreateRequire(nd.getAPredecessor())
 }
 

--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -202,6 +202,34 @@ private class RequireVariable extends Variable {
  */
 private predicate moduleInFile(Module m, File f) { m.getFile() = f }
 
+private predicate isModuleModule(DataFlow::Node nd) {
+  exists(ImportDeclaration imp |
+    imp.getImportedPath().getValue() = "module" and
+    nd = [
+      DataFlow::destructuredModuleImportNode(imp),
+      DataFlow::valueNode(imp.getASpecifier().(ImportNamespaceSpecifier))
+    ]
+  )
+  or
+  isModuleModule(nd.getAPredecessor())
+}
+
+private predicate isCreateRequire(DataFlow::Node nd) {
+  exists(PropAccess prop |
+    isModuleModule(prop.getBase().flow()) and
+    prop.getPropertyName() = "createRequire" and
+    nd = prop.flow()
+  )
+  or
+  exists(PropertyPattern prop |
+    isModuleModule(prop.getObjectPattern().flow()) and
+    prop.getName() = "createRequire" and
+    nd = prop.getValuePattern().flow()
+  )
+  or
+  isCreateRequire(nd.getAPredecessor())
+}
+
 /**
  * Holds if `nd` may refer to `require`, either directly or modulo local data flow.
  */
@@ -215,16 +243,11 @@ private predicate isRequire(DataFlow::Node nd) {
   or
   // `import { createRequire } from 'module';`.
   // specialized to ES2015 modules to avoid recursion in the `DataFlow::moduleImport()` predicate and to avoid
-  // negative recursion between `Import.getImportedModuleNode()` and `Import.getImportedModule()`.
-  exists(ImportDeclaration imp, DataFlow::SourceNode baseObj |
-    imp.getImportedPath().getValue() = "module"
-  |
-    baseObj =
-      [
-        DataFlow::destructuredModuleImportNode(imp),
-        DataFlow::valueNode(imp.getASpecifier().(ImportNamespaceSpecifier))
-      ] and
-    nd = baseObj.getAPropertyRead("createRequire").getACall()
+  // negative recursion between `Import.getImportedModuleNode()` and `Import.getImportedModule()`, and
+  // to avoid depending on `SourceNode` as this would make `SourceNode::Range` recursive.
+  exists(CallExpr call |
+    isCreateRequire(call.getCallee().flow()) and
+    nd = call.flow()
   )
 }
 

--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -205,10 +205,11 @@ private predicate moduleInFile(Module m, File f) { m.getFile() = f }
 private predicate isModuleModule(DataFlow::Node nd) {
   exists(ImportDeclaration imp |
     imp.getImportedPath().getValue() = "module" and
-    nd = [
-      DataFlow::destructuredModuleImportNode(imp),
-      DataFlow::valueNode(imp.getASpecifier().(ImportNamespaceSpecifier))
-    ]
+    nd =
+      [
+        DataFlow::destructuredModuleImportNode(imp),
+        DataFlow::valueNode(imp.getASpecifier().(ImportNamespaceSpecifier))
+      ]
   )
   or
   isModuleModule(nd.getAPredecessor())

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -724,7 +724,7 @@ module DataFlow {
     override ParameterField prop;
 
     override Node getBase() {
-      result = thisNode(prop.getDeclaringClass().getConstructor().getBody())
+      thisNode(result, prop.getDeclaringClass().getConstructor().getBody())
     }
 
     override Expr getPropertyNameExpr() {
@@ -758,7 +758,7 @@ module DataFlow {
     }
 
     override Node getBase() {
-      result = thisNode(prop.getDeclaringClass().getConstructor().getBody())
+      thisNode(result, prop.getDeclaringClass().getConstructor().getBody())
     }
 
     override Expr getPropertyNameExpr() { result = prop.getNameExpr() }

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -492,6 +492,7 @@ module DataFlow {
      * Gets the data flow node corresponding to the base object
      * whose property is read from or written to.
      */
+    cached
     abstract Node getBase();
 
     /**
@@ -595,7 +596,10 @@ module DataFlow {
 
     PropLValueAsPropWrite() { astNode instanceof LValue }
 
-    override Node getBase() { result = valueNode(astNode.getBase()) }
+    override Node getBase() {
+      result = valueNode(astNode.getBase()) and
+      Stages::DataFlowStage::ref()
+    }
 
     override Expr getPropertyNameExpr() { result = astNode.getPropertyNameExpr() }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -337,7 +337,7 @@ module SourceNode {
   /** INTERNAL. DO NOT USE. */
   module Internal {
     /** An empty class that some tests are using to enforce that SourceNode is non-recursive. */
-    abstract class RecursionGuard extends DataFlow::Node {}
+    abstract class RecursionGuard extends DataFlow::Node { }
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -34,7 +34,11 @@ private import semmle.javascript.internal.CachedStages
  * ```
  */
 class SourceNode extends DataFlow::Node {
-  SourceNode() { this instanceof SourceNode::Range }
+  SourceNode() {
+    this instanceof SourceNode::Range
+    or
+    none() and this instanceof SourceNode::Internal::RecursionGuard
+  }
 
   /**
    * Holds if this node flows into `sink` in zero or more local (that is,
@@ -328,6 +332,12 @@ module SourceNode {
       // Include return nodes because they model the implicit Promise creation in async functions.
       DataFlow::functionReturnNode(this, _)
     }
+  }
+
+  /** INTERNAL. DO NOT USE. */
+  module Internal {
+    /** An empty class that some tests are using to enforce that SourceNode is non-recursive. */
+    abstract class RecursionGuard extends DataFlow::Node {}
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
+++ b/javascript/ql/src/semmle/javascript/internal/CachedStages.qll
@@ -133,6 +133,8 @@ module Stages {
       exists(any(DataFlow::Node node).toString())
       or
       exists(any(AccessPath a).getAnInstanceIn(_))
+      or
+      exists(any(DataFlow::PropRef ref).getBase())
     }
   }
 

--- a/javascript/ql/test/library-tests/RecursionPrevention/SourceNodeRange.expected
+++ b/javascript/ql/test/library-tests/RecursionPrevention/SourceNodeRange.expected
@@ -1,0 +1,1 @@
+| Success |

--- a/javascript/ql/test/library-tests/RecursionPrevention/SourceNodeRange.ql
+++ b/javascript/ql/test/library-tests/RecursionPrevention/SourceNodeRange.ql
@@ -1,0 +1,16 @@
+/**
+ * Test that fails to compile if the domain of `SourceNode::Range` depends on `SourceNode` (recursively).
+ *
+ * This tests adds a negative dependency `SourceNode --!--> SourceNode::Range`
+ * so that the undesired edge `SourceNode::Range --> SourceNode` completes a negative cycle.
+ */
+
+import javascript
+
+class BadSourceNodeRange extends DataFlow::SourceNode::Internal::RecursionGuard {
+  BadSourceNodeRange() {
+    not this instanceof DataFlow::SourceNode::Range
+  }
+}
+
+select "Success"

--- a/javascript/ql/test/library-tests/RecursionPrevention/SourceNodeRange.ql
+++ b/javascript/ql/test/library-tests/RecursionPrevention/SourceNodeRange.ql
@@ -8,9 +8,7 @@
 import javascript
 
 class BadSourceNodeRange extends DataFlow::SourceNode::Internal::RecursionGuard {
-  BadSourceNodeRange() {
-    not this instanceof DataFlow::SourceNode::Range
-  }
+  BadSourceNodeRange() { not this instanceof DataFlow::SourceNode::Range }
 }
 
 select "Success"


### PR DESCRIPTION
- Makes `SourceNode` non-recursive (really, this time)
- Makes `PropRef.getBase` non-recursive by fixing an accidental reference to `SourceNode`
- Caches `PropRef.getBase`

Although https://github.com/github/codeql/pull/5499 was supposed to make `SourceNode` non-recursive, I had missed one recursive dependency going through `SourceNode -> AngularJS -> Import -> NodeJS/createRequire -> SourceNode`. My earlier attempt in https://github.com/github/codeql/pull/4772 fixed that by making all string literals `SourceNode` but that was a little too costly, so now I've instead made `createRequire` not depend on `SourceNode`.

[Evaluation](https://github.com/dsp-testing/asgerf-dca/tree/run/js/non-recursive-propref5/reports) (internal link) looks good; an average 1% speed-up and a <1% increase is cache size.