### PR TITLE
Replace toString use

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
@@ -72,7 +72,7 @@ class WrongCheckErrorOperatorNew extends FunctionCall {
   }
 
   /**
-   * Holds if `(std::nothrow)` exists in call `operator new`.
+   * Holds if `(std::nothrow)` or `(std::noexcept)` exists in call `operator new`.
    */
   predicate isExistsNothrow() { getTarget().isNoExcept() or getTarget().isNoThrow() }
 }

--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
@@ -74,7 +74,7 @@ class WrongCheckErrorOperatorNew extends FunctionCall {
   /**
    * Holds if `(std::nothrow)` exists in call `operator new`.
    */
-  predicate isExistsNothrow() { this.getAChild().toString() = "nothrow" }
+  predicate isExistsNothrow() { getTarget().isNoExcept() or getTarget().isNoThrow() }
 }
 
 from WrongCheckErrorOperatorNew op

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/WrongInDetectingAndHandlingMemoryAllocationErrors.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/WrongInDetectingAndHandlingMemoryAllocationErrors.expected
@@ -1,5 +1,5 @@
 | test.cpp:30:15:30:26 | call to operator new[] | memory allocation error check is incorrect or missing |
 | test.cpp:38:9:38:20 | call to operator new[] | memory allocation error check is incorrect or missing |
-| test.cpp:50:13:50:38 | call to operator new[] | memory allocation error check is incorrect or missing |
-| test.cpp:51:22:51:47 | call to operator new[] | memory allocation error check is incorrect or missing |
-| test.cpp:53:18:53:43 | call to operator new[] | memory allocation error check is incorrect or missing |
+| test.cpp:81:18:81:43 | call to operator new[] | memory allocation error check is incorrect or missing |
+| test.cpp:87:14:87:39 | call to operator new[] | memory allocation error check is incorrect or missing |
+| test.cpp:92:13:92:38 | call to operator new[] | memory allocation error check is incorrect or missing |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/WrongInDetectingAndHandlingMemoryAllocationErrors.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/WrongInDetectingAndHandlingMemoryAllocationErrors.expected
@@ -1,5 +1,5 @@
 | test.cpp:30:15:30:26 | call to operator new[] | memory allocation error check is incorrect or missing |
 | test.cpp:38:9:38:20 | call to operator new[] | memory allocation error check is incorrect or missing |
-| test.cpp:81:18:81:43 | call to operator new[] | memory allocation error check is incorrect or missing |
-| test.cpp:87:14:87:39 | call to operator new[] | memory allocation error check is incorrect or missing |
-| test.cpp:92:13:92:38 | call to operator new[] | memory allocation error check is incorrect or missing |
+| test.cpp:50:13:50:38 | call to operator new[] | memory allocation error check is incorrect or missing |
+| test.cpp:51:22:51:47 | call to operator new[] | memory allocation error check is incorrect or missing |
+| test.cpp:53:18:53:43 | call to operator new[] | memory allocation error check is incorrect or missing |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-570/semmle/tests/test.cpp
@@ -14,8 +14,8 @@ using namespace std;
 
 void* operator new(std::size_t _Size);
 void* operator new[](std::size_t _Size);
-void* operator new( std::size_t count, const std::nothrow_t& tag );
-void* operator new[]( std::size_t count, const std::nothrow_t& tag );
+void* operator new( std::size_t count, const std::nothrow_t& tag ) noexcept;
+void* operator new[]( std::size_t count, const std::nothrow_t& tag ) noexcept;
 
 void badNew_0_0()
 {


### PR DESCRIPTION
Using `toString` in query logic is not good practice.

These kinds of changes can have subtle effects so I've run a diff query: https://lgtm.com/query/5866409770224514073/ .

I *think* the new results (beginning on page 3) are for calls to a 'non-allocating' new (see https://en.cppreference.com/w/cpp/memory/new/operator_new), that is `nothrow` not because it returns `0` on an allocation error, but because it doesn't *have* allocation errors.  If someone can confirm this makes sense, I'll add an exclusion in the query for that version of `new`.

The lost results (on page 4) LGTM.