### PR TITLE
Remove Enterprise 1.23 special instructions and replace references

### DIFF
--- a/docs/codeql/codeql-cli/getting-started-with-the-codeql-cli.rst
+++ b/docs/codeql/codeql-cli/getting-started-with-the-codeql-cli.rst
@@ -138,7 +138,7 @@ see ":doc:`About QL packs <about-ql-packs>`."
            
    - For the queries used in a particular LGTM Enterprise release, check out the
      branch tagged with the relevant release number. For example, the branch
-     tagged ``v1.23.0`` corresponds to LGTM Enterprise 1.23. You must use this
+     tagged ``v1.27.0`` corresponds to LGTM Enterprise 1.27. You must use this
      version if you want to upload data to LGTM Enterprise. For further
      information, see `Preparing CodeQL databases to upload to LGTM 
      <https://help.semmle.com/lgtm-enterprise/admin/help/prepare-database-upload.html>`__

--- a/docs/codeql/codeql-cli/testing-custom-queries.rst
+++ b/docs/codeql/codeql-cli/testing-custom-queries.rst
@@ -13,20 +13,6 @@ on the query and the expected results until the actual results and the expected
 results exactly match. This topic shows you how to create test files and execute
 tests on them using the ``test run`` subcommand.
 
-.. container:: toggle
-
-   .. container:: name
-
-      **Information for LGTM Enterprise 1.23 users**
-
-   CodeQL tests are a new feature in CodeQL CLI version 2.0.2.
-   
-   If you are an LGTM Enterprise 1.23 user, you should still use CodeQL CLI
-   version 2.0.1 to prepare databases to upload to your instance of LGTM. You
-   can use version 2.0.2 (or newer) to test your custom queries, but databases
-   created with versions newer than 2.0.1 are not compatible with LGTM
-   Enterprise 1.23. For more information, see ":ref:`Getting started with the CodeQL CLI <using-two-versions-of-the-codeql-cli>`."
-
 Setting up a test QL pack for custom queries
 --------------------------------------------
 

--- a/docs/codeql/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code.rst
@@ -64,7 +64,7 @@ There are two ways to do this:
       **Click to show information for LGTM Enterprise users**
 
    Your local version of the CodeQL queries and libraries should match your version of LGTM Enterprise. For example, if you
-   use LGTM Enterprise 1.23, then you should clone the ``1.23.0`` branch of the `starter workspace <https://github.com/github/vscode-codeql-starter/>`__ (or the appropriate ``1.23.x`` branch, corresponding to each maintenance release).
+   use LGTM Enterprise 1.27, then you should clone the ``1.27.0`` branch of the `starter workspace <https://github.com/github/vscode-codeql-starter/>`__ (or the appropriate ``1.27.x`` branch, corresponding to each maintenance release).
    
    This ensures that the queries and libraries you write in VS Code also work in the query console on LGTM Enterprise.
 


### PR DESCRIPTION
This PR removes special instructions for LGTM 1.23, and replaces leftover references to 1.23, since version Enterprise 1.27 has now been released. 