### PR TITLE
JS: Various SQL model improvements

### DIFF
--- a/javascript/change-notes/2021-03-30-sql-models.md
+++ b/javascript/change-notes/2021-03-30-sql-models.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* The SQL library models for `mysql`, `mysql2`, `mssql`, `pg`, `sqlite3`, `sequelize`, and `@google-cloud/spanner` have improved,
+  leading to more SQL injection sinks.

--- a/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
@@ -342,24 +342,17 @@ private module Sqlite {
   }
 
   /** Gets an expression that constructs a Sqlite database instance. */
-  API::Node newDb() {
+  API::Node database() {
     // new require('sqlite3').Database()
     result = sqlite().getMember("Database").getInstance()
+    or
+    result = API::Node::ofType("sqlite3", "Database")
   }
 
   /** A call to a Sqlite query method. */
   private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
     QueryCall() {
-      exists(string meth |
-        meth = "all" or
-        meth = "each" or
-        meth = "exec" or
-        meth = "get" or
-        meth = "prepare" or
-        meth = "run"
-      |
-        this = newDb().getMember(meth).getACall()
-      )
+      this = database().getMember(["all", "each", "exec", "get", "prepare", "run"]).getACall()
     }
 
     override DataFlow::Node getAQueryArgument() { result = getArgument(0) }

--- a/javascript/ql/test/library-tests/frameworks/SQL/Credentials.expected
+++ b/javascript/ql/test/library-tests/frameworks/SQL/Credentials.expected
@@ -6,6 +6,7 @@
 | mysql1.js:7:14:7:21 | 'secret' | password |
 | mysql1a.js:10:9:10:12 | 'me' | user name |
 | mysql1a.js:11:13:11:20 | 'secret' | password |
+| mysql2-promise.js:8:9:8:14 | 'root' | user name |
 | mysql2.js:7:21:7:25 | 'bob' | user name |
 | mysql2.js:8:21:8:28 | 'secret' | password |
 | mysql2tst.js:8:9:8:14 | 'root' | user name |

--- a/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
+++ b/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
@@ -23,8 +23,12 @@
 | mysqlImport.js:3:18:5:1 | {\\n    s ... = ?',\\n} |
 | postgres1.js:37:21:37:24 | text |
 | postgres2.js:30:16:30:41 | 'SELECT ... number' |
+| postgres2.js:43:15:43:26 | 'SELECT 123' |
+| postgres2.js:46:15:46:47 | new Cur ... users') |
+| postgres2.js:46:26:46:46 | 'SELECT ...  users' |
 | postgres3.js:15:16:15:40 | 'SELECT ... s name' |
 | postgres5.js:8:21:8:25 | query |
+| postgres-types.ts:4:18:4:29 | 'SELECT 123' |
 | postgresImport.js:4:18:4:43 | 'SELECT ... number' |
 | sequelize2.js:10:17:10:118 | 'SELECT ... Y name' |
 | sequelize.js:8:17:8:118 | 'SELECT ... Y name' |

--- a/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
+++ b/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
@@ -54,6 +54,7 @@
 | spanner.js:19:16:19:34 | { sql: "SQL code" } |
 | spanner.js:19:23:19:32 | "SQL code" |
 | spannerImport.js:4:8:4:17 | "SQL code" |
+| sqlite-types.ts:4:12:4:49 | "UPDATE ... id = ?" |
 | sqlite.js:7:8:7:45 | "UPDATE ... id = ?" |
 | sqliteArray.js:6:12:6:49 | "UPDATE ... id = ?" |
 | sqliteImport.js:2:8:2:44 | "UPDATE ... id = ?" |

--- a/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
+++ b/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
@@ -1,9 +1,11 @@
 | mssql1.js:7:40:7:72 | select  ... e id =  |
 | mssql1.js:7:75:7:79 | value |
+| mssql1.js:10:19:10:30 | 'SELECT 123' |
 | mssql2.js:5:15:5:34 | 'select 1 as number' |
 | mssql2.js:13:15:13:66 | 'create ...  table' |
 | mssql2.js:22:24:22:43 | 'select 1 as number' |
 | mssql2.js:29:30:29:81 | 'create ...  table' |
+| mssql-types.ts:7:31:7:42 | 'SELECT 123' |
 | mysql1.js:13:18:13:43 | 'SELECT ... lution' |
 | mysql1.js:18:18:22:1 | {\\n    s ... vid']\\n} |
 | mysql1a.js:17:18:17:43 | 'SELECT ... lution' |

--- a/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
+++ b/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
@@ -41,6 +41,7 @@
 | sequelizeImport.js:3:17:3:118 | 'SELECT ... Y name' |
 | spanner2.js:5:26:5:35 | "SQL code" |
 | spanner2.js:7:35:7:44 | "SQL code" |
+| spanner-types.ts:4:12:4:23 | 'SELECT 123' |
 | spanner.js:6:8:6:17 | "SQL code" |
 | spanner.js:7:8:7:26 | { sql: "SQL code" } |
 | spanner.js:7:15:7:24 | "SQL code" |
@@ -59,6 +60,8 @@
 | spanner.js:18:16:18:25 | "SQL code" |
 | spanner.js:19:16:19:34 | { sql: "SQL code" } |
 | spanner.js:19:23:19:32 | "SQL code" |
+| spanner.js:23:12:23:23 | 'SELECT 123' |
+| spanner.js:26:12:26:38 | 'UPDATE ... = @baz' |
 | spannerImport.js:4:8:4:17 | "SQL code" |
 | sqlite-types.ts:4:12:4:49 | "UPDATE ... id = ?" |
 | sqlite.js:7:8:7:45 | "UPDATE ... id = ?" |

--- a/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
+++ b/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
@@ -33,6 +33,10 @@
 | postgres-types.ts:4:18:4:29 | 'SELECT 123' |
 | postgresImport.js:4:18:4:43 | 'SELECT ... number' |
 | sequelize2.js:10:17:10:118 | 'SELECT ... Y name' |
+| sequelize2.js:12:17:15:1 | {\\n  que ... [123]\\n} |
+| sequelize2.js:13:10:13:20 | 'SELECT $1' |
+| sequelize2.js:17:31:17:41 | '123 + 345' |
+| sequelize-types.ts:7:24:7:35 | 'SELECT 123' |
 | sequelize.js:8:17:8:118 | 'SELECT ... Y name' |
 | sequelizeImport.js:3:17:3:118 | 'SELECT ... Y name' |
 | spanner2.js:5:26:5:35 | "SQL code" |

--- a/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
+++ b/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
@@ -7,10 +7,18 @@
 | mysql1.js:13:18:13:43 | 'SELECT ... lution' |
 | mysql1.js:18:18:22:1 | {\\n    s ... vid']\\n} |
 | mysql1a.js:17:18:17:43 | 'SELECT ... lution' |
+| mysql2-promise.js:14:3:14:62 | 'SELECT ... ` > 45' |
+| mysql2-promise.js:23:3:23:56 | 'SELECT ... e` > ?' |
+| mysql2-promise.js:31:19:31:39 | 'SELECT ...  users' |
+| mysql2-promise.js:32:21:32:41 | 'SELECT ...  users' |
+| mysql2-types.ts:4:16:4:36 | 'SELECT ...  users' |
 | mysql2.js:12:12:12:37 | 'SELECT ... lution' |
 | mysql2tst.js:14:3:14:62 | 'SELECT ... ` > 45' |
 | mysql2tst.js:23:3:23:56 | 'SELECT ... e` > ?' |
+| mysql2tst.js:31:19:31:39 | 'SELECT ...  users' |
+| mysql2tst.js:32:21:32:41 | 'SELECT ...  users' |
 | mysql3.js:14:20:14:52 | 'SELECT ... etable' |
+| mysql3.js:26:14:26:31 | 'SELECT something' |
 | mysql4.js:14:18:14:20 | sql |
 | mysqlImport.js:3:18:5:1 | {\\n    s ... = ?',\\n} |
 | postgres1.js:37:21:37:24 | text |

--- a/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
+++ b/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
@@ -62,6 +62,7 @@
 | spanner.js:19:23:19:32 | "SQL code" |
 | spanner.js:23:12:23:23 | 'SELECT 123' |
 | spanner.js:26:12:26:38 | 'UPDATE ... = @baz' |
+| spanner.js:31:18:31:24 | queries |
 | spannerImport.js:4:8:4:17 | "SQL code" |
 | sqlite-types.ts:4:12:4:49 | "UPDATE ... id = ?" |
 | sqlite.js:7:8:7:45 | "UPDATE ... id = ?" |

--- a/javascript/ql/test/library-tests/frameworks/SQL/mssql-types.ts
+++ b/javascript/ql/test/library-tests/frameworks/SQL/mssql-types.ts
@@ -1,0 +1,9 @@
+import { ConnectionPool } from "mssql";
+
+class Foo {
+  constructor(private pool: ConnectionPool) {}
+
+  doSomething() {
+    this.pool.request().query('SELECT 123');
+  }
+}

--- a/javascript/ql/test/library-tests/frameworks/SQL/mssql1.js
+++ b/javascript/ql/test/library-tests/frameworks/SQL/mssql1.js
@@ -6,6 +6,8 @@ async () => {
         const pool = await sql.connect('mssql://username:password@localhost/database')
         const result = await sql.query`select * from mytable where id = ${value}`
         console.dir(result)
+
+        sql.query('SELECT 123');
     } catch (err) {
         // ... error checks 
     }

--- a/javascript/ql/test/library-tests/frameworks/SQL/mysql2-promise.js
+++ b/javascript/ql/test/library-tests/frameworks/SQL/mysql2-promise.js
@@ -1,9 +1,9 @@
 // Adapted from the documentation of https://github.com/sidorares/node-mysql2,
 // which is licensed under the MIT license; see file node-mysql2-License.
-const mysql = require('mysql2');
+const mysql = require('mysql2/promise');
  
 // create the connection to database
-const connection = mysql.createConnection({
+const connection = await mysql.createConnection({
   host: 'localhost',
   user: 'root',
   database: 'test'

--- a/javascript/ql/test/library-tests/frameworks/SQL/mysql2-types.ts
+++ b/javascript/ql/test/library-tests/frameworks/SQL/mysql2-types.ts
@@ -1,0 +1,5 @@
+import { Connection } from "mysql2";
+
+export function doSomething(conn: Connection) {
+    conn.query('SELECT * FROM users');
+}

--- a/javascript/ql/test/library-tests/frameworks/SQL/mysql3.js
+++ b/javascript/ql/test/library-tests/frameworks/SQL/mysql3.js
@@ -21,3 +21,7 @@ pool.getConnection(function(err, connection) {
     // Don't use the connection here, it has been returned to the pool. 
   });
 });
+
+pool.on('connection', conn => {
+  conn.query('SELECT something');
+});

--- a/javascript/ql/test/library-tests/frameworks/SQL/postgres-types.ts
+++ b/javascript/ql/test/library-tests/frameworks/SQL/postgres-types.ts
@@ -1,0 +1,5 @@
+import { Client } from "pg";
+
+function submitSomething(client: Client) {
+    client.query('SELECT 123');
+}

--- a/javascript/ql/test/library-tests/frameworks/SQL/postgres2.js
+++ b/javascript/ql/test/library-tests/frameworks/SQL/postgres2.js
@@ -38,3 +38,9 @@ pool.connect(function(err, client, done) {
     //output: 1 
   });
 });
+
+let client2 = await pool.connect();
+client2.query('SELECT 123');
+
+const Cursor = require('pg-cursor');
+client2.query(new Cursor('SELECT * from users'));

--- a/javascript/ql/test/library-tests/frameworks/SQL/sequelize-types.ts
+++ b/javascript/ql/test/library-tests/frameworks/SQL/sequelize-types.ts
@@ -1,0 +1,9 @@
+import Sequelize from 'sequelize';
+
+export class Foo {
+    constructor(private seq: Sequelize) {}
+
+    method() {
+        this.seq.query('SELECT 123');
+    }
+}

--- a/javascript/ql/test/library-tests/frameworks/SQL/sequelize2.js
+++ b/javascript/ql/test/library-tests/frameworks/SQL/sequelize2.js
@@ -9,3 +9,9 @@ const sequelize = new Sequelize('database', {
 });
 sequelize.query('SELECT * FROM Products WHERE (name LIKE \'%' + criteria + '%\') AND deletedAt IS NULL) ORDER BY name');
 
+sequelize.query({
+  query: 'SELECT $1',
+  values: [123]
+});
+
+let value = Sequelize.literal('123 + 345');

--- a/javascript/ql/test/library-tests/frameworks/SQL/spanner-types.ts
+++ b/javascript/ql/test/library-tests/frameworks/SQL/spanner-types.ts
@@ -1,0 +1,5 @@
+import { Database } from "@google-cloud/spanner";
+
+export function doSomething(db: Database) {
+    db.run('SELECT 123');
+}

--- a/javascript/ql/test/library-tests/frameworks/SQL/spanner.js
+++ b/javascript/ql/test/library-tests/frameworks/SQL/spanner.js
@@ -17,6 +17,18 @@ db.runTransaction((err, tx) => {
   tx.runStream({ sql: "SQL code" });
   tx.runUpdate("SQL code");
   tx.runUpdate({ sql: "SQL code" });
+
+  const queries = [
+    {
+      sql: 'SELECT 123',
+    },
+    {
+      sql: 'UPDATE foo SET bar = @baz',
+      params: {key: 'baz', value: '123'}
+    }
+  ];
+  
+  tx.batchUpdate(queries, () => {});
 });
 
 exports.instance = instance;

--- a/javascript/ql/test/library-tests/frameworks/SQL/sqlite-types.ts
+++ b/javascript/ql/test/library-tests/frameworks/SQL/sqlite-types.ts
@@ -1,0 +1,5 @@
+import { Database } from "sqlite3";
+
+export function doSomething(db: Database) {
+    db.run("UPDATE tbl SET name = ? WHERE id = ?", "bar", 2);
+}


### PR DESCRIPTION
Uses `API::Node::ofType` in every SQL model and adds some more API methods and aliases we didn't previously recognize.

[Evaluation](https://github.com/dsp-testing/asgerf-dca/tree/run/js/sql-models3/reports) shows 72 new sinks, 1 new alert which seems like a TP.