### PR TITLE
C++: Add a test of memory freed queries with strdup.

### DIFF
--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/MemoryNeverFreed.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/MemoryNeverFreed.expected
@@ -10,3 +10,4 @@
 | test.cpp:89:18:89:23 | call to malloc | This memory is never freed |
 | test.cpp:156:3:156:26 | new | This memory is never freed |
 | test.cpp:157:3:157:26 | new[] | This memory is never freed |
+| test.cpp:167:14:167:19 | call to strdup | This memory is never freed |

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/test.cpp
@@ -156,3 +156,15 @@ int overloadedNew() {
   new(std::nothrow) int(3); // BAD
   new(std::nothrow) int[2]; // BAD
 }
+
+// --- strdup ---
+
+char *strdup(const char *s1);
+void output_msg(const char *msg);
+
+void test_strdup() {
+	char msg[] = "OctoCat";
+	char *cpy = strdup(msg); // BAD
+
+	output_msg(cpy);
+}


### PR DESCRIPTION
For https://github.com/github/codeql-c-analysis-team/issues/258.

It looks like `cpp/memory-never-freed` gets it without difficulty.