### PR TITLE
JS: Change kind of summary-extraction queries to table

### DIFF
--- a/javascript/ql/src/experimental/Summaries/ExtractFlowStepSummaries.ql
+++ b/javascript/ql/src/experimental/Summaries/ExtractFlowStepSummaries.ql
@@ -5,7 +5,7 @@
  *              user-controlled exit node of portal `p1` to an escaping entry node of portal `p2`,
  *              and have label `lbl2` at that point. Moreover, the path from `p1` to `p2` contains
  *              no sanitizers specified by configuration `cfg`.
- * @kind flow-step-summary
+ * @kind table
  * @id js/step-summary-extraction
  */
 

--- a/javascript/ql/src/experimental/Summaries/ExtractSinkSummaries.ql
+++ b/javascript/ql/src/experimental/Summaries/ExtractSinkSummaries.ql
@@ -3,7 +3,7 @@
  * @description Extracts sink summaries, that is, tuples `(p, lbl, cfg)` representing the fact
  *              that data with flow label `lbl` may flow from a user-controlled exit node of portal
  *              `p` to a known sink for configuration `cfg`.
- * @kind sink-summary
+ * @kind table
  * @id js/sink-summary-extraction
  */
 

--- a/javascript/ql/src/experimental/Summaries/ExtractSourceSummaries.ql
+++ b/javascript/ql/src/experimental/Summaries/ExtractSourceSummaries.ql
@@ -3,7 +3,7 @@
  * @description Extracts source summaries, that is, tuples `(p, lbl, cfg)` representing the fact
  *              that data may flow from a known source for configuration `cfg` to an escaping entry
  *              node of portal `p`, and have flow label `lbl` at that point.
- * @kind source-summary
+ * @kind table
  * @id js/source-summary-extraction
  */
 


### PR DESCRIPTION
As of recently, `codeql query compile --check-only` fails when using these query kinds.

@max-schaefer 