### PR TITLE
JS: Make Dependency.info work even if version string can't be parsed

### DIFF
--- a/javascript/ql/src/semmle/javascript/dependencies/Dependencies.qll
+++ b/javascript/ql/src/semmle/javascript/dependencies/Dependencies.qll
@@ -127,16 +127,20 @@ class ExternalNPMDependency extends NPMDependency {
     exists(PackageDependencies pkgdeps | this = pkgdeps.getPropValue(result))
   }
 
-  override string getVersion() {
+  private string getVersionNumber() {
     exists(string versionRange | versionRange = this.(JSONString).getValue() |
       // extract a concrete version from the version range; currently,
       // we handle exact versions as well as `<=`, `>=`, `~` and `^` ranges
       result = versionRange.regexpCapture("(?:[><]=|[=~^])?v?(\\d+(\\.\\d+){1,2})", 1)
-      or
-      // if no version is specified, report version `unknown`
-      result = "unknown" and
-      (versionRange = "" or versionRange = "*")
     )
+  }
+
+  override string getVersion() {
+    result = getVersionNumber()
+    or
+    // if no version is specified or could not be parsed, report version `unknown`
+    not exists(getVersionNumber()) and
+    result = "unknown"
   }
 
   override Import getAnImport() {

--- a/javascript/ql/test/library-tests/NPM/src/package.json
+++ b/javascript/ql/test/library-tests/NPM/src/package.json
@@ -7,7 +7,9 @@
       "web": "http://mine.com"
   }],
   "dependencies": {
-      "esprima": "*"
+      "esprima": "*",
+      "something": "1.2.3-alpha.beta",
+      "foo": "! garbage string we \nreally can't parse %"
   },
   "devDependencies": {
       "mocha": "1.0"

--- a/javascript/ql/test/library-tests/NPM/tests.expected
+++ b/javascript/ql/test/library-tests/NPM/tests.expected
@@ -1,6 +1,8 @@
 dependencies
-| src/package.json:1:1:18:1 | {\\n  "na ... "\\n  }\\n} | esprima | * |
-| src/package.json:1:1:18:1 | {\\n  "na ... "\\n  }\\n} | mocha | 1.0 |
+| src/package.json:1:1:20:1 | {\\n  "na ... "\\n  }\\n} | esprima | * |
+| src/package.json:1:1:20:1 | {\\n  "na ... "\\n  }\\n} | foo | ! garbage string we \nreally can't parse % |
+| src/package.json:1:1:20:1 | {\\n  "na ... "\\n  }\\n} | mocha | 1.0 |
+| src/package.json:1:1:20:1 | {\\n  "na ... "\\n  }\\n} | something | 1.2.3-alpha.beta |
 importedFile
 | src/lib/tst2.js:1:1:1:13 | require("..") | src/index.js:0:0:0:0 | src/index.js |
 | src/node_modules/nested/tst3.js:1:1:1:29 | require ... odule') | src/node_modules/third-party-module/fancy.js:0:0:0:0 | src/node_modules/third-party-module/fancy.js |
@@ -29,16 +31,27 @@ modules
 | src/node_modules/third-party-module | third-party-module | src/node_modules/third-party-module/fancy.js:1:1:4:0 | <toplevel> |
 npm
 | src/node_modules/third-party-module/package.json:1:1:5:1 | {\\n  "na ... y.js"\\n} | third-party-module | 23.4.0 |
-| src/package.json:1:1:18:1 | {\\n  "na ... "\\n  }\\n} | test-package | 0.1.0 |
+| src/package.json:1:1:20:1 | {\\n  "na ... "\\n  }\\n} | test-package | 0.1.0 |
 getMainModule
 | src/node_modules/b/package.json:1:1:4:1 | {\\n  "na ... "lib"\\n} | b | src/node_modules/b/lib/index.js:1:1:2:0 | <toplevel> |
 | src/node_modules/c/package.json:1:1:4:1 | {\\n  "na ... src/"\\n} | c | src/node_modules/c/src/index.js:1:1:2:0 | <toplevel> |
 | src/node_modules/d/package.json:1:1:4:1 | {\\n  "na ... main"\\n} | d | src/node_modules/d/main.js:1:1:2:0 | <toplevel> |
 | src/node_modules/third-party-module/package.json:1:1:5:1 | {\\n  "na ... y.js"\\n} | third-party-module | src/node_modules/third-party-module/fancy.js:1:1:4:0 | <toplevel> |
-| src/package.json:1:1:18:1 | {\\n  "na ... "\\n  }\\n} | test-package | src/index.js:1:1:4:0 | <toplevel> |
+| src/package.json:1:1:20:1 | {\\n  "na ... "\\n  }\\n} | test-package | src/index.js:1:1:4:0 | <toplevel> |
 packageJSON
 | src/node_modules/b/package.json:1:1:4:1 | {\\n  "na ... "lib"\\n} |
 | src/node_modules/c/package.json:1:1:4:1 | {\\n  "na ... src/"\\n} |
 | src/node_modules/d/package.json:1:1:4:1 | {\\n  "na ... main"\\n} |
 | src/node_modules/third-party-module/package.json:1:1:5:1 | {\\n  "na ... y.js"\\n} |
-| src/package.json:1:1:18:1 | {\\n  "na ... "\\n  }\\n} |
+| src/package.json:1:1:20:1 | {\\n  "na ... "\\n  }\\n} |
+dependencyInfo
+| src/index.js:1:1:4:0 | <toplevel> | test-package | 0.1.0 |
+| src/lib/tst2.js:1:1:1:14 | <toplevel> | test-package | 0.1.0 |
+| src/lib/tst.js:1:1:4:0 | <toplevel> | test-package | 0.1.0 |
+| src/node_modules/third-party-module/fancy.js:1:1:4:0 | <toplevel> | third-party-module | 23.4.0 |
+| src/package.json:10:18:10:20 | "*" | esprima | unknown |
+| src/package.json:11:20:11:37 | "1.2.3-alpha.beta" | something | unknown |
+| src/package.json:12:14:12:57 | "! garb ... arse %" | foo | unknown |
+| src/package.json:15:16:15:20 | "1.0" | mocha | 1.0 |
+| src/tst2.js:1:1:1:13 | <toplevel> | test-package | 0.1.0 |
+| src/tst.js:1:1:2:38 | <toplevel> | test-package | 0.1.0 |

--- a/javascript/ql/test/library-tests/NPM/tests.ql
+++ b/javascript/ql/test/library-tests/NPM/tests.ql
@@ -1,4 +1,5 @@
 import javascript
+import semmle.javascript.dependencies.Dependencies
 
 query predicate dependencies(PackageJSON pkgjson, string pkg, string version) {
   pkgjson.declaresDependency(pkg, version)
@@ -24,3 +25,7 @@ query predicate getMainModule(PackageJSON pkg, string name, Module mod) {
 }
 
 query predicate packageJSON(PackageJSON json) { any() }
+
+query predicate dependencyInfo(Dependency dep, string name, string version) {
+  dep.info(name, version)
+}


### PR DESCRIPTION
A minor thing that's be bothering me from time to time is that `any(Dependency d).info(name, _)` doesn't work for package names where the version string couldn't be parsed. We already map unknown versions to `unknown` in some cases.