### PR TITLE
C#: Exclude jump-to-def information for elements with too many locations

### DIFF
--- a/csharp/ql/src/definitions.qll
+++ b/csharp/ql/src/definitions.qll
@@ -187,5 +187,11 @@ cached
 Declaration definitionOf(Use use, string kind) {
   result = use.getDefinition() and
   result.fromSource() and
-  kind = use.getUseType()
+  kind = use.getUseType() and
+  // Some entities have many locations. This can arise for files that
+  // are duplicated multiple times in the database at different
+  // locations. Rather than letting the result set explode, we just
+  // exclude results that are "too ambiguous" -- we could also arbitrarily
+  // pick one location later on.
+  strictcount(result.getLocation()) < 10
 }


### PR DESCRIPTION
In databases which include multiple duplicated files, we can get an explosion of definition locations that can cause this query to produce too many results for the CodeQL toolchain. This PR restricts the `definitions.ql` query to producing definition/uses for definitions with fewer than 10 locations. This replicates the logic used in the C++ `definitions.qll` library which faces similar problems.