### PR TITLE
[Java] CWE-488: Exposure of Data Element to Wrong Session

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-488/WrongSession.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-488/WrongSession.java
@@ -1,0 +1,85 @@
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class WrongSessionController {
+
+    volatile String name = "test";
+
+    private int timeBase = 1000;
+
+    @RequestMapping("/bad1")
+    @ResponseBody
+    public void bad1(String greetee, HttpServletResponse response) throws Exception{
+        if (!StringUtils.isEmpty(greetee)) {
+            timeBase = Integer.parseInt(greetee);
+        }
+
+        PrintWriter pw = response.getWriter();
+        pw.println("bad1 " + timeBase);
+    }
+
+    @RequestMapping("/bad2")
+    @ResponseBody
+    public void bad2(String greetee, HttpServletResponse response) throws Exception{
+        if (!ObjectUtils.isEmpty(greetee)) {
+            name = greetee;
+        }
+        PrintWriter pw = response.getWriter();
+        pw.println("bad2 " + name);
+    }
+
+    @RequestMapping("/bad3")
+    @ResponseBody
+    public void bad3(String greetee, HttpServletResponse response) throws Exception{
+        boolean result = StringUtils.isEmpty(greetee);
+        if (!result) {
+            name = greetee;
+        }
+
+        PrintWriter pw = response.getWriter();
+        pw.println("bad3 " + name);
+    }
+
+    @RequestMapping("/good1")
+    @ResponseBody
+    public void good1(String greetee, HttpServletResponse response) throws Exception{
+        boolean result = StringUtils.isEmpty(greetee);
+        if (!result) {
+            name = greetee;
+        }else {
+            name = "test";
+        }
+
+        PrintWriter pw = response.getWriter();
+        pw.println("good1 " + name);
+    }
+
+    @RequestMapping("/good2")
+    @ResponseBody
+    public void good2(String greetee, HttpServletResponse response) throws Exception{
+        boolean result = StringUtils.isEmpty(greetee);
+        if (result) {
+            throw new Exception("greetee is not null");
+        }
+        name = greetee;
+        PrintWriter pw = response.getWriter();
+        pw.println("good2 " + name);
+    }
+
+    @RequestMapping("/good3")
+    @ResponseBody
+    public void good3(@RequestParam(value = "interval", required = false, defaultValue = "100") final String interval, HttpServletResponse response) throws Exception{
+        if (!StringUtils.isEmpty(interval)) {
+            timeBase = Integer.parseInt(interval);
+        }
+        PrintWriter pw = response.getWriter();
+        pw.println("ws1 " + name);
+    }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-488/WrongSession.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-488/WrongSession.qhelp
@@ -1,0 +1,38 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>The software does not sufficiently enforce boundaries between the states of different sessions, causing data to be 
+provided to, or used by, the wrong session.</p>
+
+</overview>
+<recommendation>
+
+<p>Do not use member fields to store information in the Servlet.</p>
+
+</recommendation>
+<example>
+
+<p>The following examples show the bad case and the good case respectively.Bad case, such as <code>bad1</code> to 
+<code>bad3</code>, when a non-<code>final</code> member field is used to store user input and the verification is 
+ incorrect, there may be information leakage. Good case, such as <code>good1</code> to <code>good3</code>, after
+ correct processing of user input, assign values to non-<code>final</code> member variables.</p>
+
+<sample src="WrongSession.java" />
+
+</example>
+<references>
+
+<li>
+  Java owasp: Members of Spring components should be injected: 
+  <a href="https://rules.sonarsource.com/java/tag/owasp/RSPEC-3749">Members of Spring components should be injected</a>
+</li>
+
+<li>
+  Common Architectural Weakness Enumeration (CAWE): 
+  <a href="https://www.serc.net/wp-content/uploads/2017/08/SC2017S_05.3_CAWE_S.pdf">Architectural Weaknesses vs Bugs</a>
+</li>
+
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-488/WrongSession.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-488/WrongSession.qhelp
@@ -31,7 +31,7 @@ provided to, or used by, the wrong session.</p>
 
 <li>
   Common Architectural Weakness Enumeration (CAWE): 
-  <a href="https://www.serc.net/wp-content/uploads/2017/08/SC2017S_05.3_CAWE_S.pdf">Architectural Weaknesses vs Bugs</a>
+  <a href="https://www.serc.net/wp-content/uploads/2017/08/SC2017S_05.3_CAWE_S.pdf">An Example of a CAWE Entry</a>
 </li>
 
 </references>

--- a/java/ql/src/experimental/Security/CWE/CWE-488/WrongSession.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-488/WrongSession.ql
@@ -1,0 +1,36 @@
+/**
+ * @name Exposure of Data Element to Wrong Session
+ * @description Different sessions can use non-final member
+ *              fields, causing data to be provided to the wrong session.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/wrong-session
+ * @tags security
+ *       external/cwe/cwe-488
+ */
+
+import java
+import WrongSessionLib
+import semmle.code.java.dataflow.FlowSources
+import DataFlow::PathGraph
+
+class WrongSessionConfig extends TaintTracking::Configuration {
+  WrongSessionConfig() { this = "WrongSessionConfig" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source instanceof RemoteFlowSource and
+    not hasDefaultValue(source) and
+    source.getEnclosingCallable() instanceof RequestMethod
+  }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof WrongSessionSink }
+}
+
+from
+  DataFlow::PathNode source, DataFlow::PathNode sink, WrongSessionConfig conf, InputJudgeConfig ijc
+where
+  conf.hasFlowPath(source, sink) and
+  ijc.hasFlow(source.getNode(), _)
+select sink.getNode(), source, sink, "Wrong session might include code from $@.", source.getNode(),
+  "this user input"

--- a/java/ql/src/experimental/Security/CWE/CWE-488/WrongSessionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-488/WrongSessionLib.qll
@@ -72,7 +72,7 @@ predicate hasDefaultValue(Node node) {
 class RequestMethod extends Method {
   RequestMethod() {
     (
-      this instanceof ServletRequestMethod
+      isServletRequestMethod(this)
       or
       this instanceof SpringControllerMethod
     ) and

--- a/java/ql/src/experimental/Security/CWE/CWE-488/WrongSessionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-488/WrongSessionLib.qll
@@ -1,0 +1,83 @@
+import java
+import DataFlow
+import semmle.code.java.UnitTests
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.dataflow.TaintTracking2
+import semmle.code.java.frameworks.Servlets
+import semmle.code.java.frameworks.struts.StrutsActions
+import semmle.code.java.frameworks.spring.SpringController
+
+/** Taint-tracking configuration tracing flow from remote input source to do a blank check on remote input. */
+class InputJudgeConfig extends TaintTracking2::Configuration {
+  InputJudgeConfig() { this = "InputJudgeConfig" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source instanceof RemoteFlowSource and
+    not hasDefaultValue(source) and
+    source.getEnclosingCallable() instanceof RequestMethod
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma, BarrierGuard bg | ma = bg |
+      ma.getMethod().getName() = ["isNullOrEmpty", "isEmpty"] and
+      ma.getMethod().getNumberOfParameters() = 1 and
+      ma.getArgument(0) = sink.asExpr() and
+      exists(WrongSessionSink ws | bg.controls(ws.getExpr().getBasicBlock(), false))
+    )
+    or
+    exists(MethodAccess ma, BarrierGuard bg | ma = bg |
+      ma.getMethod().hasName("isNotEmpty") and
+      ma.getMethod().getNumberOfParameters() = 1 and
+      ma.getArgument(0) = sink.asExpr() and
+      exists(WrongSessionSink ws | bg.controls(ws.getExpr().getBasicBlock(), true))
+    )
+    or
+    exists(NEExpr nee, IfStmt is, BarrierGuard bg | nee = bg and is.getCondition() = nee |
+      (
+        nee.getRightOperand() instanceof Literal and
+        nee.getLeftOperand() = sink.asExpr()
+        or
+        nee.getLeftOperand() instanceof Literal and
+        nee.getRightOperand() = sink.asExpr()
+      ) and
+      exists(WrongSessionSink ws | bg.controls(ws.getExpr().getBasicBlock(), true))
+    )
+  }
+}
+
+/** A sink that assigning remote input to a non `final` field variable. */
+class WrongSessionSink extends DataFlow::ExprNode {
+  WrongSessionSink() {
+    exists(AssignExpr ae, FieldAccess fa, IfStmt is, ExprStmt es | ae.getParent() = es |
+      not exists(is.getElse()) and
+      es.getParent*() = is.getAChild() and
+      not fa.getField().isFinal() and
+      ae.getDest() = fa and
+      ae.getRhs() = this.asExpr()
+    )
+  }
+}
+
+/** Determine whether the source is set to the default value. */
+predicate hasDefaultValue(Node node) {
+  exists(SpringControllerMethod scm |
+    node.asParameter() = scm.getAParameter() and
+    node.asParameter().hasAnnotation("org.springframework.web.bind.annotation", "RequestParam") and
+    node.asParameter().getAnAnnotation().getValue("defaultValue").toString() !=
+      "\"\\n\\t\\t\\n\\t\\t\\n\\n\\t\\t\\t\\t\\n\"" //The default value of defaultValue annotation is "\\n\\t\\t\\n\\t\\t\\n\\n\\t\\t\\t\\t\\n"
+  )
+}
+
+/** The request method in `Servlet` or `SpringController`. */
+class RequestMethod extends Method {
+  RequestMethod() {
+    (
+      this instanceof ServletRequestMethod
+      or
+      this instanceof SpringControllerMethod
+    ) and
+    not this instanceof TestMethod and
+    not this.getName().regexpMatch("(?!).*test.*") and
+    not exists(this.getLocation().getFile().getAbsolutePath().indexOf("/src/test/java"))
+  }
+}

--- a/java/ql/src/semmle/code/java/frameworks/Servlets.qll
+++ b/java/ql/src/semmle/code/java/frameworks/Servlets.qll
@@ -337,3 +337,16 @@ predicate isRequestGetParamMethod(MethodAccess ma) {
   ma.getMethod() instanceof ServletRequestGetParameterMapMethod or
   ma.getMethod() instanceof HttpServletRequestGetQueryStringMethod
 }
+
+/**
+ * The method is `doGet` or `doPost`.
+ */
+class ServletRequestMethod extends Method {
+  ServletRequestMethod() {
+    this.getDeclaringType() instanceof ServletClass and
+    this.getNumberOfParameters() = 2 and
+    this.getParameter(0).getType() instanceof ServletRequest and
+    this.getParameter(1).getType() instanceof ServletResponse and
+    this.getName().regexpMatch("doGet|doPost")
+  }
+}

--- a/java/ql/src/semmle/code/java/frameworks/Servlets.qll
+++ b/java/ql/src/semmle/code/java/frameworks/Servlets.qll
@@ -337,16 +337,3 @@ predicate isRequestGetParamMethod(MethodAccess ma) {
   ma.getMethod() instanceof ServletRequestGetParameterMapMethod or
   ma.getMethod() instanceof HttpServletRequestGetQueryStringMethod
 }
-
-/**
- * The method is `doGet` or `doPost`.
- */
-class ServletRequestMethod extends Method {
-  ServletRequestMethod() {
-    this.getDeclaringType() instanceof ServletClass and
-    this.getNumberOfParameters() = 2 and
-    this.getParameter(0).getType() instanceof ServletRequest and
-    this.getParameter(1).getType() instanceof ServletResponse and
-    this.getName().regexpMatch("doGet|doPost")
-  }
-}

--- a/java/ql/test/experimental/query-tests/security/CWE-488/WrongSession.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-488/WrongSession.expected
@@ -1,0 +1,19 @@
+edges
+| WrongSession.java:19:22:19:35 | greetee : String | WrongSession.java:21:24:21:48 | parseInt(...) |
+| WrongSession.java:30:22:30:35 | greetee : String | WrongSession.java:32:20:32:26 | greetee |
+| WrongSession.java:40:22:40:35 | greetee : String | WrongSession.java:43:20:43:26 | greetee |
+| WrongSessionServlet1.java:14:26:14:52 | getParameter(...) : String | WrongSessionServlet1.java:17:19:17:25 | greetee |
+nodes
+| WrongSession.java:19:22:19:35 | greetee : String | semmle.label | greetee : String |
+| WrongSession.java:21:24:21:48 | parseInt(...) | semmle.label | parseInt(...) |
+| WrongSession.java:30:22:30:35 | greetee : String | semmle.label | greetee : String |
+| WrongSession.java:32:20:32:26 | greetee | semmle.label | greetee |
+| WrongSession.java:40:22:40:35 | greetee : String | semmle.label | greetee : String |
+| WrongSession.java:43:20:43:26 | greetee | semmle.label | greetee |
+| WrongSessionServlet1.java:14:26:14:52 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| WrongSessionServlet1.java:17:19:17:25 | greetee | semmle.label | greetee |
+#select
+| WrongSession.java:21:24:21:48 | parseInt(...) | WrongSession.java:19:22:19:35 | greetee : String | WrongSession.java:21:24:21:48 | parseInt(...) | Wrong session might include code from $@. | WrongSession.java:19:22:19:35 | greetee | this user input |
+| WrongSession.java:32:20:32:26 | greetee | WrongSession.java:30:22:30:35 | greetee : String | WrongSession.java:32:20:32:26 | greetee | Wrong session might include code from $@. | WrongSession.java:30:22:30:35 | greetee | this user input |
+| WrongSession.java:43:20:43:26 | greetee | WrongSession.java:40:22:40:35 | greetee : String | WrongSession.java:43:20:43:26 | greetee | Wrong session might include code from $@. | WrongSession.java:40:22:40:35 | greetee | this user input |
+| WrongSessionServlet1.java:17:19:17:25 | greetee | WrongSessionServlet1.java:14:26:14:52 | getParameter(...) : String | WrongSessionServlet1.java:17:19:17:25 | greetee | Wrong session might include code from $@. | WrongSessionServlet1.java:14:26:14:52 | getParameter(...) | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-488/WrongSession.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-488/WrongSession.java
@@ -1,0 +1,85 @@
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class WrongSession {
+
+    volatile String name = "test";
+
+    private int timeBase = 1000;
+
+    @RequestMapping("/bad1")
+    @ResponseBody
+    public void bad1(String greetee, HttpServletResponse response) throws Exception{
+        if (!StringUtils.isEmpty(greetee)) {
+            timeBase = Integer.parseInt(greetee);
+        }
+
+        PrintWriter pw = response.getWriter();
+        pw.println("bad1 " + timeBase);
+    }
+
+    @RequestMapping("/bad2")
+    @ResponseBody
+    public void bad2(String greetee, HttpServletResponse response) throws Exception{
+        if (!ObjectUtils.isEmpty(greetee)) {
+            name = greetee;
+        }
+        PrintWriter pw = response.getWriter();
+        pw.println("bad2 " + name);
+    }
+
+    @RequestMapping("/bad3")
+    @ResponseBody
+    public void bad3(String greetee, HttpServletResponse response) throws Exception{
+        boolean result = StringUtils.isEmpty(greetee);
+        if (!result) {
+            name = greetee;
+        }
+
+        PrintWriter pw = response.getWriter();
+        pw.println("bad3 " + name);
+    }
+
+    @RequestMapping("/good1")
+    @ResponseBody
+    public void good1(String greetee, HttpServletResponse response) throws Exception{
+        boolean result = StringUtils.isEmpty(greetee);
+        if (!result) {
+            name = greetee;
+        }else {
+            name = "test";
+        }
+
+        PrintWriter pw = response.getWriter();
+        pw.println("good1 " + name);
+    }
+
+    @RequestMapping("/good2")
+    @ResponseBody
+    public void good2(String greetee, HttpServletResponse response) throws Exception{
+        boolean result = StringUtils.isEmpty(greetee);
+        if (result) {
+            throw new Exception("greetee is not null");
+        }
+        name = greetee;
+        PrintWriter pw = response.getWriter();
+        pw.println("good2 " + name);
+    }
+
+    @RequestMapping("/good3")
+    @ResponseBody
+    public void good3(@RequestParam(value = "interval", required = false, defaultValue = "100") final String interval, HttpServletResponse response) throws Exception{
+        if (!StringUtils.isEmpty(interval)) {
+            timeBase = Integer.parseInt(interval);
+        }
+        PrintWriter pw = response.getWriter();
+        pw.println("ws1 " + name);
+    }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-488/WrongSession.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-488/WrongSession.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-488/WrongSession.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-488/WrongSessionServlet.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-488/WrongSessionServlet.java
@@ -1,0 +1,27 @@
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.util.StringUtils;
+
+public class WrongSessionServlet extends HttpServlet {
+
+    private String key;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        test(req,resp);
+    }
+
+    protected void test(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String greetee = req.getParameter("greetee");
+
+        if (!StringUtils.isEmpty(greetee)) {
+            key = greetee;
+        }
+
+        PrintWriter pw = resp.getWriter();
+        pw.println("test " + key);
+    }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-488/WrongSessionServlet1.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-488/WrongSessionServlet1.java
@@ -1,0 +1,23 @@
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.util.StringUtils;
+
+public class WrongSessionServlet1 extends HttpServlet {
+
+    private String key;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String greetee = req.getParameter("greetee");
+
+        if (!StringUtils.isEmpty(greetee)) {
+            key = greetee;
+        }
+
+        PrintWriter pw = resp.getWriter();
+        pw.println("doGet " + key);
+    }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-488/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-488/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/servlet-api-2.4:${testdir}/../../../../stubs/springframework-5.2.3/

--- a/java/ql/test/stubs/springframework-5.2.3/org/springframework/core/annotation/AliasFor.java
+++ b/java/ql/test/stubs/springframework-5.2.3/org/springframework/core/annotation/AliasFor.java
@@ -1,0 +1,21 @@
+package org.springframework.core.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+@Documented
+public @interface AliasFor {
+    @AliasFor("attribute")
+    String value() default "";
+
+    @AliasFor("value")
+    String attribute() default "";
+ 
+    Class<? extends Annotation> annotation() default Annotation.class;
+}

--- a/java/ql/test/stubs/springframework-5.2.3/org/springframework/util/ObjectUtils.java
+++ b/java/ql/test/stubs/springframework-5.2.3/org/springframework/util/ObjectUtils.java
@@ -1,0 +1,202 @@
+package org.springframework.util;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+import org.springframework.lang.Nullable;
+
+public abstract class ObjectUtils {
+
+    private static final int INITIAL_HASH = 7;
+    private static final int MULTIPLIER = 31;
+    private static final String EMPTY_STRING = "";
+    private static final String NULL_STRING = "null";
+    private static final String ARRAY_START = "{";
+    private static final String ARRAY_END = "}";
+    private static final String EMPTY_ARRAY = "{}";
+    private static final String ARRAY_ELEMENT_SEPARATOR = ", ";
+    private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
+
+    public ObjectUtils() {
+    }
+
+    public static boolean isCheckedException(Throwable ex) {
+        return false;
+    }
+
+    public static boolean isCompatibleWithThrowsClause(Throwable ex, @Nullable Class<?>... declaredExceptions) {
+        return false;
+    }
+
+    public static boolean isArray(@Nullable Object obj) {
+        return false;
+    }
+
+    public static boolean isEmpty(@Nullable Object[] array) {
+        return false;
+    }
+
+    public static boolean isEmpty(@Nullable Object obj) {
+        return false;
+    }
+
+    @Nullable
+    public static Object unwrapOptional(@Nullable Object obj) {
+        return null;
+    }
+
+    public static boolean containsElement(@Nullable Object[] array, Object element) {
+        return true;
+    }
+
+    public static boolean containsConstant(Enum<?>[] enumValues, String constant) {
+        return true;
+    }
+
+    public static boolean containsConstant(Enum<?>[] enumValues, String constant, boolean caseSensitive) {  
+        return true;
+    }
+
+    public static <E extends Enum<?>> E caseInsensitiveValueOf(E[] enumValues, String constant) {
+        return null;
+    }
+
+    public static <A, O extends A> A[] addObjectToArray(@Nullable A[] array, @Nullable O obj) {
+        return null;
+    }
+
+    public static Object[] toObjectArray(@Nullable Object source) {
+        return null;
+    }
+
+    public static boolean nullSafeEquals(@Nullable Object o1, @Nullable Object o2) {
+        return false;
+    }
+
+    private static boolean arrayEquals(Object o1, Object o2) {
+        return false;
+    }
+
+    public static int nullSafeHashCode(@Nullable Object obj) {
+        return 1;
+    }
+
+    public static int nullSafeHashCode(@Nullable Object[] array) {
+        return 1;
+    }
+
+    public static int nullSafeHashCode(@Nullable boolean[] array) {
+        return 1;
+    }
+
+    public static int nullSafeHashCode(@Nullable byte[] array) {
+        return 1;
+    }
+
+    public static int nullSafeHashCode(@Nullable char[] array) {
+        return 1;
+    }
+
+    public static int nullSafeHashCode(@Nullable double[] array) {
+        return 1;
+    }
+
+    public static int nullSafeHashCode(@Nullable float[] array) {
+        return 1;
+    }
+
+    public static int nullSafeHashCode(@Nullable int[] array) {
+        return 1;
+    }
+
+    public static int nullSafeHashCode(@Nullable long[] array) {
+        return 1;
+    }
+
+    public static int nullSafeHashCode(@Nullable short[] array) {
+        return 1;
+    }
+
+    /** @deprecated */
+    @Deprecated
+    public static int hashCode(boolean bool) {
+        return 1;
+    }
+
+    /** @deprecated */
+    @Deprecated
+    public static int hashCode(double dbl) {
+        return 1;
+    }
+
+    /** @deprecated */
+    @Deprecated
+    public static int hashCode(float flt) {
+        return 1;
+    }
+
+    /** @deprecated */
+    @Deprecated
+    public static int hashCode(long lng) {
+        return 1;
+    }
+
+    public static String identityToString(@Nullable Object obj) {
+        return "";
+    }
+
+    public static String getIdentityHexString(Object obj) {
+        return "";
+    }
+
+    public static String getDisplayString(@Nullable Object obj) {
+        return "";
+    }
+
+    public static String nullSafeClassName(@Nullable Object obj) {
+        return "";
+    }
+
+    public static String nullSafeToString(@Nullable Object obj) {
+        return "";
+    }
+
+    public static String nullSafeToString(@Nullable Object[] array) {
+        return "";
+    }
+
+    public static String nullSafeToString(@Nullable boolean[] array) {
+        return "";
+    }
+
+    public static String nullSafeToString(@Nullable byte[] array) {
+        return "";
+    }
+
+    public static String nullSafeToString(@Nullable char[] array) {
+        return "";
+    }
+
+    public static String nullSafeToString(@Nullable double[] array) {
+        return "";
+    }
+
+    public static String nullSafeToString(@Nullable float[] array) {
+        return "";
+    }
+
+    public static String nullSafeToString(@Nullable int[] array) {
+        return "";
+    }
+
+    public static String nullSafeToString(@Nullable long[] array) {
+        return "";
+    }
+
+    public static String nullSafeToString(@Nullable short[] array) {
+        return "";
+    }
+}

--- a/java/ql/test/stubs/springframework-5.2.3/org/springframework/util/StringUtils.java
+++ b/java/ql/test/stubs/springframework-5.2.3/org/springframework/util/StringUtils.java
@@ -1,0 +1,30 @@
+package org.springframework.util;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.StringTokenizer;
+import java.util.TimeZone;
+import org.springframework.lang.Nullable;
+
+public abstract class StringUtils {
+  
+    @Deprecated
+    public static boolean isEmpty(@Nullable Object str) {
+        return true;
+    }
+
+}

--- a/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/GetMapping.java
+++ b/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/GetMapping.java
@@ -1,0 +1,51 @@
+package org.springframework.web.bind.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RequestMapping(
+    method = {RequestMethod.GET}
+)
+public @interface GetMapping {
+    @AliasFor(
+        annotation = RequestMapping.class
+    )
+    String name() default "";
+
+    @AliasFor(
+        annotation = RequestMapping.class
+    )
+    String[] value() default {};
+
+    @AliasFor(
+        annotation = RequestMapping.class
+    )
+    String[] path() default {};
+
+    @AliasFor(
+        annotation = RequestMapping.class
+    )
+    String[] params() default {};
+
+    @AliasFor(
+        annotation = RequestMapping.class
+    )
+    String[] headers() default {};
+
+    @AliasFor(
+        annotation = RequestMapping.class
+    )
+    String[] consumes() default {};
+
+    @AliasFor(
+        annotation = RequestMapping.class
+    )
+    String[] produces() default {};
+}

--- a/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/Mapping.java
+++ b/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/Mapping.java
@@ -1,0 +1,4 @@
+package org.springframework.web.bind.annotation;
+
+public @interface Mapping {
+}

--- a/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/RequestMapping.java
+++ b/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/RequestMapping.java
@@ -1,11 +1,32 @@
 package org.springframework.web.bind.annotation;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
 
 @Target(value={ElementType.METHOD,ElementType.TYPE})
 @Retention(value=RetentionPolicy.RUNTIME)
 @Documented
+@Mapping
 public @interface RequestMapping {
+    String name() default "";
+
+    @AliasFor("path")
+    String[] value() default {};
+
+    @AliasFor("value")
+    String[] path() default {};
 
     RequestMethod[] method() default {};
+
+    String[] params() default {};
+
+    String[] headers() default {};
+
+    String[] consumes() default {};
+
+    String[] produces() default {};
 }

--- a/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/RequestParam.java
+++ b/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/RequestParam.java
@@ -1,8 +1,23 @@
 package org.springframework.web.bind.annotation;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
 
-@Target(value=ElementType.PARAMETER)
-@Retention(value=RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface RequestParam { }
+public @interface RequestParam {
+    @AliasFor("name")
+    String value() default "";
+
+    @AliasFor("value")
+    String name() default "";
+
+    boolean required() default true;
+
+    String defaultValue() default "\n\t\t\n\t\t\n\ue000\ue001\ue002\n\t\t\t\t\n";
+}

--- a/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/ResponseBody.java
+++ b/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/ResponseBody.java
@@ -1,4 +1,4 @@
-package org.springframework.stereotype;
+package org.springframework.web.bind.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -6,9 +6,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface Controller {
-    String value() default "";
+public @interface ResponseBody {
 }


### PR DESCRIPTION
Store the value of the request parameter in a non-final member field. When the program does not correctly process the request value, it will cause the data to be provided to the wrong session or used by the wrong session. For example, in the following program, when user `A` The input value is `admin`, and the program outputs the `password` of `admin`. User `B` has no input value, and the program will output the `password` of user `A`.

```java

String name;

@Override
protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
    String tempName = req.getParameter("name");
    if (!StringUtils.isEmpty(tempName)) {
        name = tempName;
    }

    .... // Query the password corresponding to the user name
     
    PrintWriter pw = resp.getWriter();
    pw.println("user : " + name + "    password is : " + password);
}
```