### PR TITLE
C#: Remove `unique` wrappers from `DataFlow::Node::get(EnclosingCallable|ControlFlowNode)`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -47,14 +47,14 @@ class Node extends TNode {
   cached
   final DataFlowCallable getEnclosingCallable() {
     Stages::DataFlowStage::forceCachingInSameStage() and
-    result = unique(DataFlowCallable c | c = this.(NodeImpl).getEnclosingCallableImpl() | c)
+    result = this.(NodeImpl).getEnclosingCallableImpl()
   }
 
   /** Gets the control flow node corresponding to this node, if any. */
   cached
   final ControlFlow::Node getControlFlowNode() {
     Stages::DataFlowStage::forceCachingInSameStage() and
-    result = unique(ControlFlow::Node n | n = this.(NodeImpl).getControlFlowNodeImpl() | n)
+    result = this.(NodeImpl).getControlFlowNodeImpl()
   }
 
   /** Gets a textual representation of this node. */


### PR DESCRIPTION
The `unique` wrappers were originally introduced to guide the optimizer about the functionality of these predicates, to get better join-orders. However, functionality does not survive across stages, so (since these predicates are cached), functionality was only available in the `DataFlowImplCommon` stage. As of https://github.com/github/codeql/pull/5338, functionality is no longer needed to get good join-orders, so we may as well remove the wrappers.

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/986/