### PR TITLE
C++: Fix FP in cpp/assign-where-compare-meant

### DIFF
--- a/cpp/change-notes/2021-04-06-assign-where-compare-meant.md
+++ b/cpp/change-notes/2021-04-06-assign-where-compare-meant.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The 'Assignment where comparison was intended' (cpp/assign-where-compare-meant) query has been improved to flag fewer benign assignments in conditionals.

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
@@ -19,10 +19,6 @@
 | test.cpp:144:32:144:36 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:150:32:150:36 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:153:46:153:50 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:160:7:160:12 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:162:7:162:12 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:163:7:163:12 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:164:7:164:12 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:166:22:166:27 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:168:24:168:29 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:169:23:169:28 | ... = ... | Use of '=' where '==' may have been intended. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
@@ -19,3 +19,11 @@
 | test.cpp:144:32:144:36 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:150:32:150:36 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:153:46:153:50 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:160:7:160:12 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:162:7:162:12 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:163:7:163:12 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:164:7:164:12 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:166:22:166:27 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:168:24:168:29 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:169:23:169:28 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:171:7:171:12 | ... = ... | Use of '=' where '==' may have been intended. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
@@ -153,3 +153,21 @@ void f3(int x, int y) {
   if((x == 10) || ((z == z) && (x == 1)) && (y = 2)) { // BAD
   }
 }
+
+bool use(int);
+
+void f4(int x, bool b) {
+  if((x = 10) && use(x)) {} // GOOD [FALSE POSITIVE]: This is likely just a short-hand way of writing an assignment
+                            // followed by a boolean check.
+  if((x = 10) && b && use(x)) {} // GOOD [FALSE POSITIVE]: Same reason as above
+  if((x = 10) && use(x) && b) {} // GOOD [FALSE POSITIVE]: Same reason as above
+  if((x = 10) && (use(x) && b)) {} // GOOD [FALSE POSITIVE]: Same reason as above
+
+  if(use(x) && b && (x = 10)) {} // BAD: The assignment is the last thing that happens in the comparison.
+                                 // This doesn't match the usual pattern.
+  if((use(x) && b) && (x = 10)) {} // BAD: Same reason as above
+  if(use(x) && (b && (x = 10))) {} // BAD: Same reason as above
+
+  if((x = 10) || use(x)) {} // BAD: This doesn't follow the usual style of writing an assignment in
+                            // a boolean check.
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
@@ -157,11 +157,11 @@ void f3(int x, int y) {
 bool use(int);
 
 void f4(int x, bool b) {
-  if((x = 10) && use(x)) {} // GOOD [FALSE POSITIVE]: This is likely just a short-hand way of writing an assignment
+  if((x = 10) && use(x)) {} // GOOD: This is likely just a short-hand way of writing an assignment
                             // followed by a boolean check.
-  if((x = 10) && b && use(x)) {} // GOOD [FALSE POSITIVE]: Same reason as above
-  if((x = 10) && use(x) && b) {} // GOOD [FALSE POSITIVE]: Same reason as above
-  if((x = 10) && (use(x) && b)) {} // GOOD [FALSE POSITIVE]: Same reason as above
+  if((x = 10) && b && use(x)) {} // GOOD: Same reason as above
+  if((x = 10) && use(x) && b) {} // GOOD: Same reason as above
+  if((x = 10) && (use(x) && b)) {} // GOOD: Same reason as above
 
   if(use(x) && b && (x = 10)) {} // BAD: The assignment is the last thing that happens in the comparison.
                                  // This doesn't match the usual pattern.


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/5318 and https://github.com/github/codeql-c-analysis-team/issues/241.

In https://github.com/github/codeql-c-analysis-team/issues/241 we agreed to make the parenthesis around `a = b` in `if((a = b) && c)` silence the alert from `cpp/assign-where-compare-meant`. We already do that in _some_ cases, and I think that allowing this in general will remove some results we want to keep. For example, see the one in `Hamlib/Hamlib` here: https://lgtm.com/query/303802313727635589/.

This PR adds another disjunction to the predicate that decides if we want to allow an assignment. We now allow this pattern:
```cpp
if((a = b) && use(a)) {}
```

but we still flag this:
```cpp
if((a = b) && use(b)) {}
```