### PR TITLE
C++: read and store steps for smart pointers in AST dataflow

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -7,7 +7,6 @@ private import semmle.code.cpp.dataflow.internal.FlowVar
 private import semmle.code.cpp.models.interfaces.DataFlow
 private import semmle.code.cpp.controlflow.Guards
 private import semmle.code.cpp.dataflow.internal.AddressFlow
-private import semmle.code.cpp.models.interfaces.PointerWrapper
 
 cached
 private newtype TNode =

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -521,22 +521,6 @@ predicate localFlowStep(Node nodeFrom, Node nodeTo) {
   FieldFlow::fieldFlow(nodeFrom, nodeTo)
 }
 
-private predicate pointerWrapperFlow(Node nodeFrom, Node nodeTo) {
-  // post-update-smart-pointer-`operator->` -> `post-update`-qualifier
-  exists(PointerWrapper wrapper, Call call |
-    call = wrapper.getAnUnwrapperFunction().getACallToThisFunction() and
-    nodeFrom.(PostUpdateNode).getPreUpdateNode().asExpr() = call and
-    nodeTo.asDefiningArgument() = call.getQualifier()
-  )
-  or
-  // smart-pointer-qualifier -> smart-pointer-`operator->`
-  exists(PointerWrapper wrapper, Call call |
-    call = wrapper.getAnUnwrapperFunction().getACallToThisFunction() and
-    nodeFrom.asExpr() = call.getQualifier() and
-    nodeTo.asExpr() = call
-  )
-}
-
 /**
  * INTERNAL: do not use.
  *
@@ -602,8 +586,6 @@ predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
     nodeFrom.(PostUpdateNode).getPreUpdateNode().asExpr() = call and
     nodeTo.asDefiningArgument() = call.getQualifier()
   )
-  or
-  pointerWrapperFlow(nodeFrom, nodeTo)
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/SmartPointer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/SmartPointer.qll
@@ -1,4 +1,5 @@
 import semmle.code.cpp.models.interfaces.Taint
+import semmle.code.cpp.models.interfaces.DataFlow
 import semmle.code.cpp.models.interfaces.PointerWrapper
 
 /**
@@ -11,6 +12,20 @@ private class UniqueOrSharedPtr extends Class, PointerWrapper {
     result.(OverloadedPointerDereferenceFunction).getDeclaringType() = this
     or
     result.getClassAndName(["operator->", "get"]) = this
+  }
+}
+
+/** Any function that unwraps a pointer wrapper class to reveal the underlying pointer. */
+private class PointerWrapperDataFlow extends DataFlowFunction {
+  PointerWrapperDataFlow() { this = any(PointerWrapper wrapper).getAnUnwrapperFunction() }
+
+  override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
+    input.isQualifierAddress() and output.isReturnValue()
+    or
+    input.isQualifierObject() and output.isReturnValueDeref()
+    or
+    input.isReturnValueDeref() and
+    output.isQualifierObject()
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/SmartPointer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/SmartPointer.qll
@@ -17,7 +17,10 @@ private class UniqueOrSharedPtr extends Class, PointerWrapper {
 
 /** Any function that unwraps a pointer wrapper class to reveal the underlying pointer. */
 private class PointerWrapperDataFlow extends DataFlowFunction {
-  PointerWrapperDataFlow() { this = any(PointerWrapper wrapper).getAnUnwrapperFunction() }
+  PointerWrapperDataFlow() {
+    this = any(PointerWrapper wrapper).getAnUnwrapperFunction() and
+    not this.getUnspecifiedType() instanceof ReferenceType
+  }
 
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
     input.isQualifierAddress() and output.isReturnValue()

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -3269,6 +3269,26 @@
 | smart_pointer.cpp:65:48:65:53 | call to source | smart_pointer.cpp:65:28:65:46 | call to make_unique | TAINT |
 | smart_pointer.cpp:65:58:65:58 | 0 | smart_pointer.cpp:65:28:65:46 | call to make_unique | TAINT |
 | smart_pointer.cpp:66:10:66:10 | ref arg p | smart_pointer.cpp:67:10:67:10 | p |  |
+| smart_pointer.cpp:76:45:76:45 | p | smart_pointer.cpp:77:5:77:5 | p |  |
+| smart_pointer.cpp:76:45:76:45 | p | smart_pointer.cpp:78:10:78:10 | p |  |
+| smart_pointer.cpp:76:45:76:45 | p | smart_pointer.cpp:79:10:79:10 | p |  |
+| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:81:5:81:5 | q |  |
+| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:82:10:82:10 | q |  |
+| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:83:10:83:10 | q |  |
+| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:84:10:84:10 | q |  |
+| smart_pointer.cpp:77:5:77:5 | ref arg p | smart_pointer.cpp:78:10:78:10 | p |  |
+| smart_pointer.cpp:77:5:77:5 | ref arg p | smart_pointer.cpp:79:10:79:10 | p |  |
+| smart_pointer.cpp:77:5:77:19 | ... = ... | smart_pointer.cpp:77:8:77:8 | x [post update] |  |
+| smart_pointer.cpp:77:12:77:17 | call to source | smart_pointer.cpp:77:5:77:19 | ... = ... |  |
+| smart_pointer.cpp:78:10:78:10 | ref arg p | smart_pointer.cpp:79:10:79:10 | p |  |
+| smart_pointer.cpp:81:5:81:5 | ref arg q | smart_pointer.cpp:82:10:82:10 | q |  |
+| smart_pointer.cpp:81:5:81:5 | ref arg q | smart_pointer.cpp:83:10:83:10 | q |  |
+| smart_pointer.cpp:81:5:81:5 | ref arg q | smart_pointer.cpp:84:10:84:10 | q |  |
+| smart_pointer.cpp:81:5:81:22 | ... = ... | smart_pointer.cpp:81:11:81:11 | x [post update] |  |
+| smart_pointer.cpp:81:15:81:20 | call to source | smart_pointer.cpp:81:5:81:22 | ... = ... |  |
+| smart_pointer.cpp:82:10:82:10 | ref arg q | smart_pointer.cpp:83:10:83:10 | q |  |
+| smart_pointer.cpp:82:10:82:10 | ref arg q | smart_pointer.cpp:84:10:84:10 | q |  |
+| smart_pointer.cpp:83:10:83:10 | ref arg q | smart_pointer.cpp:84:10:84:10 | q |  |
 | standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:39:45:39:51 | source1 |  |
 | standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:40:11:40:17 | source1 |  |
 | standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:41:12:41:18 | source1 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -3223,72 +3223,91 @@
 | smart_pointer.cpp:11:30:11:50 | call to make_shared | smart_pointer.cpp:12:11:12:11 | p |  |
 | smart_pointer.cpp:11:30:11:50 | call to make_shared | smart_pointer.cpp:13:10:13:10 | p |  |
 | smart_pointer.cpp:11:52:11:57 | call to source | smart_pointer.cpp:11:30:11:50 | call to make_shared | TAINT |
-| smart_pointer.cpp:12:11:12:11 | p | smart_pointer.cpp:12:10:12:10 | call to operator* | TAINT |
+| smart_pointer.cpp:12:11:12:11 | p | smart_pointer.cpp:12:10:12:10 | call to operator* |  |
 | smart_pointer.cpp:12:11:12:11 | ref arg p | smart_pointer.cpp:13:10:13:10 | p |  |
 | smart_pointer.cpp:17:32:17:54 | call to make_shared | smart_pointer.cpp:18:11:18:11 | p |  |
 | smart_pointer.cpp:17:32:17:54 | call to make_shared | smart_pointer.cpp:19:10:19:10 | p |  |
-| smart_pointer.cpp:18:11:18:11 | p | smart_pointer.cpp:18:10:18:10 | call to operator* | TAINT |
+| smart_pointer.cpp:18:10:18:10 | ref arg call to operator* | smart_pointer.cpp:18:11:18:11 | ref arg p |  |
+| smart_pointer.cpp:18:11:18:11 | p | smart_pointer.cpp:18:10:18:10 | call to operator* |  |
 | smart_pointer.cpp:18:11:18:11 | ref arg p | smart_pointer.cpp:19:10:19:10 | p |  |
 | smart_pointer.cpp:23:30:23:50 | call to make_unique | smart_pointer.cpp:24:11:24:11 | p |  |
 | smart_pointer.cpp:23:30:23:50 | call to make_unique | smart_pointer.cpp:25:10:25:10 | p |  |
 | smart_pointer.cpp:23:52:23:57 | call to source | smart_pointer.cpp:23:30:23:50 | call to make_unique | TAINT |
-| smart_pointer.cpp:24:11:24:11 | p | smart_pointer.cpp:24:10:24:10 | call to operator* | TAINT |
+| smart_pointer.cpp:24:11:24:11 | p | smart_pointer.cpp:24:10:24:10 | call to operator* |  |
 | smart_pointer.cpp:24:11:24:11 | ref arg p | smart_pointer.cpp:25:10:25:10 | p |  |
 | smart_pointer.cpp:29:32:29:54 | call to make_unique | smart_pointer.cpp:30:11:30:11 | p |  |
 | smart_pointer.cpp:29:32:29:54 | call to make_unique | smart_pointer.cpp:31:10:31:10 | p |  |
-| smart_pointer.cpp:30:11:30:11 | p | smart_pointer.cpp:30:10:30:10 | call to operator* | TAINT |
+| smart_pointer.cpp:30:10:30:10 | ref arg call to operator* | smart_pointer.cpp:30:11:30:11 | ref arg p |  |
+| smart_pointer.cpp:30:11:30:11 | p | smart_pointer.cpp:30:10:30:10 | call to operator* |  |
 | smart_pointer.cpp:30:11:30:11 | ref arg p | smart_pointer.cpp:31:10:31:10 | p |  |
 | smart_pointer.cpp:35:30:35:50 | call to make_shared | smart_pointer.cpp:37:6:37:6 | p |  |
 | smart_pointer.cpp:35:30:35:50 | call to make_shared | smart_pointer.cpp:38:10:38:10 | p |  |
 | smart_pointer.cpp:35:30:35:50 | call to make_shared | smart_pointer.cpp:39:11:39:11 | p |  |
+| smart_pointer.cpp:37:5:37:5 | call to operator* [post update] | smart_pointer.cpp:37:6:37:6 | ref arg p |  |
 | smart_pointer.cpp:37:5:37:17 | ... = ... | smart_pointer.cpp:37:5:37:5 | call to operator* [post update] |  |
-| smart_pointer.cpp:37:6:37:6 | p | smart_pointer.cpp:37:5:37:5 | call to operator* | TAINT |
+| smart_pointer.cpp:37:6:37:6 | p | smart_pointer.cpp:37:5:37:5 | call to operator* |  |
 | smart_pointer.cpp:37:6:37:6 | ref arg p | smart_pointer.cpp:38:10:38:10 | p |  |
 | smart_pointer.cpp:37:6:37:6 | ref arg p | smart_pointer.cpp:39:11:39:11 | p |  |
 | smart_pointer.cpp:37:10:37:15 | call to source | smart_pointer.cpp:37:5:37:17 | ... = ... |  |
 | smart_pointer.cpp:38:10:38:10 | ref arg p | smart_pointer.cpp:39:11:39:11 | p |  |
-| smart_pointer.cpp:39:11:39:11 | p | smart_pointer.cpp:39:10:39:10 | call to operator* | TAINT |
+| smart_pointer.cpp:39:11:39:11 | p | smart_pointer.cpp:39:10:39:10 | call to operator* |  |
 | smart_pointer.cpp:43:29:43:51 | call to unique_ptr | smart_pointer.cpp:45:6:45:6 | p |  |
 | smart_pointer.cpp:43:29:43:51 | call to unique_ptr | smart_pointer.cpp:46:10:46:10 | p |  |
 | smart_pointer.cpp:43:29:43:51 | call to unique_ptr | smart_pointer.cpp:47:11:47:11 | p |  |
+| smart_pointer.cpp:45:5:45:5 | call to operator* [post update] | smart_pointer.cpp:45:6:45:6 | ref arg p |  |
 | smart_pointer.cpp:45:5:45:17 | ... = ... | smart_pointer.cpp:45:5:45:5 | call to operator* [post update] |  |
-| smart_pointer.cpp:45:6:45:6 | p | smart_pointer.cpp:45:5:45:5 | call to operator* | TAINT |
+| smart_pointer.cpp:45:6:45:6 | p | smart_pointer.cpp:45:5:45:5 | call to operator* |  |
 | smart_pointer.cpp:45:6:45:6 | ref arg p | smart_pointer.cpp:46:10:46:10 | p |  |
 | smart_pointer.cpp:45:6:45:6 | ref arg p | smart_pointer.cpp:47:11:47:11 | p |  |
 | smart_pointer.cpp:45:10:45:15 | call to source | smart_pointer.cpp:45:5:45:17 | ... = ... |  |
 | smart_pointer.cpp:46:10:46:10 | ref arg p | smart_pointer.cpp:47:11:47:11 | p |  |
-| smart_pointer.cpp:47:11:47:11 | p | smart_pointer.cpp:47:10:47:10 | call to operator* | TAINT |
+| smart_pointer.cpp:47:11:47:11 | p | smart_pointer.cpp:47:10:47:10 | call to operator* |  |
 | smart_pointer.cpp:51:30:51:50 | call to make_shared | smart_pointer.cpp:52:10:52:10 | p |  |
 | smart_pointer.cpp:51:52:51:57 | call to source | smart_pointer.cpp:51:30:51:50 | call to make_shared | TAINT |
-| smart_pointer.cpp:52:10:52:10 | p | smart_pointer.cpp:52:12:52:14 | call to get | TAINT |
+| smart_pointer.cpp:52:10:52:10 | p | smart_pointer.cpp:52:12:52:14 | call to get |  |
+| smart_pointer.cpp:52:12:52:14 | ref arg call to get | smart_pointer.cpp:52:10:52:10 | ref arg p |  |
 | smart_pointer.cpp:56:30:56:50 | call to make_unique | smart_pointer.cpp:57:10:57:10 | p |  |
 | smart_pointer.cpp:56:52:56:57 | call to source | smart_pointer.cpp:56:30:56:50 | call to make_unique | TAINT |
-| smart_pointer.cpp:57:10:57:10 | p | smart_pointer.cpp:57:12:57:14 | call to get | TAINT |
+| smart_pointer.cpp:57:10:57:10 | p | smart_pointer.cpp:57:12:57:14 | call to get |  |
+| smart_pointer.cpp:57:12:57:14 | ref arg call to get | smart_pointer.cpp:57:10:57:10 | ref arg p |  |
 | smart_pointer.cpp:65:28:65:46 | call to make_unique | smart_pointer.cpp:66:10:66:10 | p |  |
 | smart_pointer.cpp:65:28:65:46 | call to make_unique | smart_pointer.cpp:67:10:67:10 | p |  |
 | smart_pointer.cpp:65:48:65:53 | call to source | smart_pointer.cpp:65:28:65:46 | call to make_unique | TAINT |
 | smart_pointer.cpp:65:58:65:58 | 0 | smart_pointer.cpp:65:28:65:46 | call to make_unique | TAINT |
+| smart_pointer.cpp:66:10:66:10 | p | smart_pointer.cpp:66:11:66:11 | call to operator-> |  |
 | smart_pointer.cpp:66:10:66:10 | ref arg p | smart_pointer.cpp:67:10:67:10 | p |  |
-| smart_pointer.cpp:76:45:76:45 | p | smart_pointer.cpp:77:5:77:5 | p |  |
-| smart_pointer.cpp:76:45:76:45 | p | smart_pointer.cpp:78:10:78:10 | p |  |
-| smart_pointer.cpp:76:45:76:45 | p | smart_pointer.cpp:79:10:79:10 | p |  |
-| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:81:5:81:5 | q |  |
-| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:82:10:82:10 | q |  |
-| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:83:10:83:10 | q |  |
-| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:84:10:84:10 | q |  |
-| smart_pointer.cpp:77:5:77:5 | ref arg p | smart_pointer.cpp:78:10:78:10 | p |  |
-| smart_pointer.cpp:77:5:77:5 | ref arg p | smart_pointer.cpp:79:10:79:10 | p |  |
-| smart_pointer.cpp:77:5:77:19 | ... = ... | smart_pointer.cpp:77:8:77:8 | x [post update] |  |
-| smart_pointer.cpp:77:12:77:17 | call to source | smart_pointer.cpp:77:5:77:19 | ... = ... |  |
-| smart_pointer.cpp:78:10:78:10 | ref arg p | smart_pointer.cpp:79:10:79:10 | p |  |
-| smart_pointer.cpp:81:5:81:5 | ref arg q | smart_pointer.cpp:82:10:82:10 | q |  |
-| smart_pointer.cpp:81:5:81:5 | ref arg q | smart_pointer.cpp:83:10:83:10 | q |  |
-| smart_pointer.cpp:81:5:81:5 | ref arg q | smart_pointer.cpp:84:10:84:10 | q |  |
-| smart_pointer.cpp:81:5:81:22 | ... = ... | smart_pointer.cpp:81:11:81:11 | x [post update] |  |
-| smart_pointer.cpp:81:15:81:20 | call to source | smart_pointer.cpp:81:5:81:22 | ... = ... |  |
-| smart_pointer.cpp:82:10:82:10 | ref arg q | smart_pointer.cpp:83:10:83:10 | q |  |
-| smart_pointer.cpp:82:10:82:10 | ref arg q | smart_pointer.cpp:84:10:84:10 | q |  |
-| smart_pointer.cpp:83:10:83:10 | ref arg q | smart_pointer.cpp:84:10:84:10 | q |  |
+| smart_pointer.cpp:67:10:67:10 | p | smart_pointer.cpp:67:11:67:11 | call to operator-> |  |
+| smart_pointer.cpp:76:45:76:45 | p | smart_pointer.cpp:77:3:77:3 | p |  |
+| smart_pointer.cpp:76:45:76:45 | p | smart_pointer.cpp:78:8:78:8 | p |  |
+| smart_pointer.cpp:76:45:76:45 | p | smart_pointer.cpp:79:8:79:8 | p |  |
+| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:81:3:81:3 | q |  |
+| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:82:8:82:8 | q |  |
+| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:83:8:83:8 | q |  |
+| smart_pointer.cpp:76:67:76:67 | q | smart_pointer.cpp:84:8:84:8 | q |  |
+| smart_pointer.cpp:77:3:77:3 | p | smart_pointer.cpp:77:4:77:4 | call to operator-> |  |
+| smart_pointer.cpp:77:3:77:3 | ref arg p | smart_pointer.cpp:78:8:78:8 | p |  |
+| smart_pointer.cpp:77:3:77:3 | ref arg p | smart_pointer.cpp:79:8:79:8 | p |  |
+| smart_pointer.cpp:77:3:77:17 | ... = ... | smart_pointer.cpp:77:6:77:6 | x [post update] |  |
+| smart_pointer.cpp:77:3:77:17 | ... = ... | smart_pointer.cpp:78:11:78:11 | x |  |
+| smart_pointer.cpp:77:4:77:4 | call to operator-> [post update] | smart_pointer.cpp:77:3:77:3 | ref arg p |  |
+| smart_pointer.cpp:77:10:77:15 | call to source | smart_pointer.cpp:77:3:77:17 | ... = ... |  |
+| smart_pointer.cpp:78:8:78:8 | p | smart_pointer.cpp:78:9:78:9 | call to operator-> |  |
+| smart_pointer.cpp:78:8:78:8 | ref arg p | smart_pointer.cpp:79:8:79:8 | p |  |
+| smart_pointer.cpp:79:8:79:8 | p | smart_pointer.cpp:79:9:79:9 | call to operator-> |  |
+| smart_pointer.cpp:81:3:81:3 | q | smart_pointer.cpp:81:4:81:4 | call to operator-> |  |
+| smart_pointer.cpp:81:3:81:3 | ref arg q | smart_pointer.cpp:82:8:82:8 | q |  |
+| smart_pointer.cpp:81:3:81:3 | ref arg q | smart_pointer.cpp:83:8:83:8 | q |  |
+| smart_pointer.cpp:81:3:81:3 | ref arg q | smart_pointer.cpp:84:8:84:8 | q |  |
+| smart_pointer.cpp:81:3:81:20 | ... = ... | smart_pointer.cpp:81:9:81:9 | x [post update] |  |
+| smart_pointer.cpp:81:3:81:20 | ... = ... | smart_pointer.cpp:82:14:82:14 | x |  |
+| smart_pointer.cpp:81:4:81:4 | call to operator-> [post update] | smart_pointer.cpp:81:3:81:3 | ref arg q |  |
+| smart_pointer.cpp:81:13:81:18 | call to source | smart_pointer.cpp:81:3:81:20 | ... = ... |  |
+| smart_pointer.cpp:82:8:82:8 | q | smart_pointer.cpp:82:9:82:9 | call to operator-> |  |
+| smart_pointer.cpp:82:8:82:8 | ref arg q | smart_pointer.cpp:83:8:83:8 | q |  |
+| smart_pointer.cpp:82:8:82:8 | ref arg q | smart_pointer.cpp:84:8:84:8 | q |  |
+| smart_pointer.cpp:83:8:83:8 | q | smart_pointer.cpp:83:9:83:9 | call to operator-> |  |
+| smart_pointer.cpp:83:8:83:8 | ref arg q | smart_pointer.cpp:84:8:84:8 | q |  |
+| smart_pointer.cpp:84:8:84:8 | q | smart_pointer.cpp:84:9:84:9 | call to operator-> |  |
 | standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:39:45:39:51 | source1 |  |
 | standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:40:11:40:17 | source1 |  |
 | standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:41:12:41:18 | source1 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -3223,45 +3223,41 @@
 | smart_pointer.cpp:11:30:11:50 | call to make_shared | smart_pointer.cpp:12:11:12:11 | p |  |
 | smart_pointer.cpp:11:30:11:50 | call to make_shared | smart_pointer.cpp:13:10:13:10 | p |  |
 | smart_pointer.cpp:11:52:11:57 | call to source | smart_pointer.cpp:11:30:11:50 | call to make_shared | TAINT |
-| smart_pointer.cpp:12:11:12:11 | p | smart_pointer.cpp:12:10:12:10 | call to operator* |  |
+| smart_pointer.cpp:12:11:12:11 | p | smart_pointer.cpp:12:10:12:10 | call to operator* | TAINT |
 | smart_pointer.cpp:12:11:12:11 | ref arg p | smart_pointer.cpp:13:10:13:10 | p |  |
 | smart_pointer.cpp:17:32:17:54 | call to make_shared | smart_pointer.cpp:18:11:18:11 | p |  |
 | smart_pointer.cpp:17:32:17:54 | call to make_shared | smart_pointer.cpp:19:10:19:10 | p |  |
-| smart_pointer.cpp:18:10:18:10 | ref arg call to operator* | smart_pointer.cpp:18:11:18:11 | ref arg p |  |
-| smart_pointer.cpp:18:11:18:11 | p | smart_pointer.cpp:18:10:18:10 | call to operator* |  |
+| smart_pointer.cpp:18:11:18:11 | p | smart_pointer.cpp:18:10:18:10 | call to operator* | TAINT |
 | smart_pointer.cpp:18:11:18:11 | ref arg p | smart_pointer.cpp:19:10:19:10 | p |  |
 | smart_pointer.cpp:23:30:23:50 | call to make_unique | smart_pointer.cpp:24:11:24:11 | p |  |
 | smart_pointer.cpp:23:30:23:50 | call to make_unique | smart_pointer.cpp:25:10:25:10 | p |  |
 | smart_pointer.cpp:23:52:23:57 | call to source | smart_pointer.cpp:23:30:23:50 | call to make_unique | TAINT |
-| smart_pointer.cpp:24:11:24:11 | p | smart_pointer.cpp:24:10:24:10 | call to operator* |  |
+| smart_pointer.cpp:24:11:24:11 | p | smart_pointer.cpp:24:10:24:10 | call to operator* | TAINT |
 | smart_pointer.cpp:24:11:24:11 | ref arg p | smart_pointer.cpp:25:10:25:10 | p |  |
 | smart_pointer.cpp:29:32:29:54 | call to make_unique | smart_pointer.cpp:30:11:30:11 | p |  |
 | smart_pointer.cpp:29:32:29:54 | call to make_unique | smart_pointer.cpp:31:10:31:10 | p |  |
-| smart_pointer.cpp:30:10:30:10 | ref arg call to operator* | smart_pointer.cpp:30:11:30:11 | ref arg p |  |
-| smart_pointer.cpp:30:11:30:11 | p | smart_pointer.cpp:30:10:30:10 | call to operator* |  |
+| smart_pointer.cpp:30:11:30:11 | p | smart_pointer.cpp:30:10:30:10 | call to operator* | TAINT |
 | smart_pointer.cpp:30:11:30:11 | ref arg p | smart_pointer.cpp:31:10:31:10 | p |  |
 | smart_pointer.cpp:35:30:35:50 | call to make_shared | smart_pointer.cpp:37:6:37:6 | p |  |
 | smart_pointer.cpp:35:30:35:50 | call to make_shared | smart_pointer.cpp:38:10:38:10 | p |  |
 | smart_pointer.cpp:35:30:35:50 | call to make_shared | smart_pointer.cpp:39:11:39:11 | p |  |
-| smart_pointer.cpp:37:5:37:5 | call to operator* [post update] | smart_pointer.cpp:37:6:37:6 | ref arg p |  |
 | smart_pointer.cpp:37:5:37:17 | ... = ... | smart_pointer.cpp:37:5:37:5 | call to operator* [post update] |  |
-| smart_pointer.cpp:37:6:37:6 | p | smart_pointer.cpp:37:5:37:5 | call to operator* |  |
+| smart_pointer.cpp:37:6:37:6 | p | smart_pointer.cpp:37:5:37:5 | call to operator* | TAINT |
 | smart_pointer.cpp:37:6:37:6 | ref arg p | smart_pointer.cpp:38:10:38:10 | p |  |
 | smart_pointer.cpp:37:6:37:6 | ref arg p | smart_pointer.cpp:39:11:39:11 | p |  |
 | smart_pointer.cpp:37:10:37:15 | call to source | smart_pointer.cpp:37:5:37:17 | ... = ... |  |
 | smart_pointer.cpp:38:10:38:10 | ref arg p | smart_pointer.cpp:39:11:39:11 | p |  |
-| smart_pointer.cpp:39:11:39:11 | p | smart_pointer.cpp:39:10:39:10 | call to operator* |  |
+| smart_pointer.cpp:39:11:39:11 | p | smart_pointer.cpp:39:10:39:10 | call to operator* | TAINT |
 | smart_pointer.cpp:43:29:43:51 | call to unique_ptr | smart_pointer.cpp:45:6:45:6 | p |  |
 | smart_pointer.cpp:43:29:43:51 | call to unique_ptr | smart_pointer.cpp:46:10:46:10 | p |  |
 | smart_pointer.cpp:43:29:43:51 | call to unique_ptr | smart_pointer.cpp:47:11:47:11 | p |  |
-| smart_pointer.cpp:45:5:45:5 | call to operator* [post update] | smart_pointer.cpp:45:6:45:6 | ref arg p |  |
 | smart_pointer.cpp:45:5:45:17 | ... = ... | smart_pointer.cpp:45:5:45:5 | call to operator* [post update] |  |
-| smart_pointer.cpp:45:6:45:6 | p | smart_pointer.cpp:45:5:45:5 | call to operator* |  |
+| smart_pointer.cpp:45:6:45:6 | p | smart_pointer.cpp:45:5:45:5 | call to operator* | TAINT |
 | smart_pointer.cpp:45:6:45:6 | ref arg p | smart_pointer.cpp:46:10:46:10 | p |  |
 | smart_pointer.cpp:45:6:45:6 | ref arg p | smart_pointer.cpp:47:11:47:11 | p |  |
 | smart_pointer.cpp:45:10:45:15 | call to source | smart_pointer.cpp:45:5:45:17 | ... = ... |  |
 | smart_pointer.cpp:46:10:46:10 | ref arg p | smart_pointer.cpp:47:11:47:11 | p |  |
-| smart_pointer.cpp:47:11:47:11 | p | smart_pointer.cpp:47:10:47:10 | call to operator* |  |
+| smart_pointer.cpp:47:11:47:11 | p | smart_pointer.cpp:47:10:47:10 | call to operator* | TAINT |
 | smart_pointer.cpp:51:30:51:50 | call to make_shared | smart_pointer.cpp:52:10:52:10 | p |  |
 | smart_pointer.cpp:51:52:51:57 | call to source | smart_pointer.cpp:51:30:51:50 | call to make_shared | TAINT |
 | smart_pointer.cpp:52:10:52:10 | p | smart_pointer.cpp:52:12:52:14 | call to get |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -3308,6 +3308,15 @@
 | smart_pointer.cpp:83:8:83:8 | q | smart_pointer.cpp:83:9:83:9 | call to operator-> |  |
 | smart_pointer.cpp:83:8:83:8 | ref arg q | smart_pointer.cpp:84:8:84:8 | q |  |
 | smart_pointer.cpp:84:8:84:8 | q | smart_pointer.cpp:84:9:84:9 | call to operator-> |  |
+| smart_pointer.cpp:87:17:87:18 | pa | smart_pointer.cpp:88:5:88:6 | pa |  |
+| smart_pointer.cpp:88:5:88:20 | ... = ... | smart_pointer.cpp:88:9:88:9 | x [post update] |  |
+| smart_pointer.cpp:88:13:88:18 | call to source | smart_pointer.cpp:88:5:88:20 | ... = ... |  |
+| smart_pointer.cpp:92:25:92:50 | call to unique_ptr | smart_pointer.cpp:93:11:93:11 | p |  |
+| smart_pointer.cpp:92:25:92:50 | call to unique_ptr | smart_pointer.cpp:94:8:94:8 | p |  |
+| smart_pointer.cpp:93:11:93:11 | p | smart_pointer.cpp:93:13:93:15 | call to get |  |
+| smart_pointer.cpp:93:11:93:11 | ref arg p | smart_pointer.cpp:94:8:94:8 | p |  |
+| smart_pointer.cpp:93:13:93:15 | ref arg call to get | smart_pointer.cpp:93:11:93:11 | ref arg p |  |
+| smart_pointer.cpp:94:8:94:8 | p | smart_pointer.cpp:94:9:94:9 | call to operator-> |  |
 | standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:39:45:39:51 | source1 |  |
 | standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:40:11:40:17 | source1 |  |
 | standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:41:12:41:18 | source1 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
@@ -9,7 +9,7 @@ template<typename T> void sink(std::unique_ptr<T>&);
 
 void test_make_shared() {
     std::shared_ptr<int> p = std::make_shared<int>(source());
-    sink(*p); // $ MISSING: ast,ir
+    sink(*p); // $ ast MISSING: ir
     sink(p); // $ ast,ir
 }
 
@@ -21,7 +21,7 @@ void test_make_shared_array() {
 
 void test_make_unique() {
     std::unique_ptr<int> p = std::make_unique<int>(source());
-    sink(*p); // $ MISSING: ast,ir
+    sink(*p); // $ ast MISSING: ir
     sink(p); // $ ast,ir
 }
 

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
@@ -9,7 +9,7 @@ template<typename T> void sink(std::unique_ptr<T>&);
 
 void test_make_shared() {
     std::shared_ptr<int> p = std::make_shared<int>(source());
-    sink(*p); // $ ast MISSING: ir
+    sink(*p); // $ ast,ir
     sink(p); // $ ast,ir
 }
 
@@ -21,7 +21,7 @@ void test_make_shared_array() {
 
 void test_make_unique() {
     std::unique_ptr<int> p = std::make_unique<int>(source());
-    sink(*p); // $ ast MISSING: ir
+    sink(*p); // $ ast,ir
     sink(p); // $ ast,ir
 }
 
@@ -82,4 +82,14 @@ void test_operator_arrow(std::unique_ptr<A> p, std::unique_ptr<B> q) {
   sink(q->a1.x); // $ ast MISSING: ir
   sink(q->a1.y);
   sink(q->a2.x);
+}
+
+void taint_x(A* pa) {
+    pa->x = source();
+}
+
+void reverse_taint_smart_pointer() {
+  std::unique_ptr<A> p = std::unique_ptr<A>(new A);
+  taint_x(p.get());
+  sink(p->x); // $ ast MISSING: ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
@@ -9,7 +9,7 @@ template<typename T> void sink(std::unique_ptr<T>&);
 
 void test_make_shared() {
     std::shared_ptr<int> p = std::make_shared<int>(source());
-    sink(*p); // $ ast,ir
+    sink(*p); // $ MISSING: ast,ir
     sink(p); // $ ast,ir
 }
 
@@ -21,7 +21,7 @@ void test_make_shared_array() {
 
 void test_make_unique() {
     std::unique_ptr<int> p = std::make_unique<int>(source());
-    sink(*p); // $ ast,ir
+    sink(*p); // $ MISSING: ast,ir
     sink(p); // $ ast,ir
 }
 
@@ -35,16 +35,16 @@ void test_reverse_taint_shared() {
     std::shared_ptr<int> p = std::make_shared<int>();
 
     *p = source();
-    sink(p); // $ ast MISSING: ir
-    sink(*p); // $ ast MISSING: ir
+    sink(p); // $ MISSING: ast,ir
+    sink(*p); // $ MISSING: ast,ir
 }
 
 void test_reverse_taint_unique() {
     std::unique_ptr<int> p = std::unique_ptr<int>();
 
     *p = source();
-    sink(p); // $ ast MISSING: ir
-    sink(*p); // $ ast MISSING: ir
+    sink(p); // $ MISSING: ast,ir
+    sink(*p); // $ MISSING: ast,ir
 }
 
 void test_shared_get() {

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
@@ -35,16 +35,16 @@ void test_reverse_taint_shared() {
     std::shared_ptr<int> p = std::make_shared<int>();
 
     *p = source();
-    sink(p); // $ MISSING: ast,ir
-    sink(*p); // $ MISSING: ast,ir
+    sink(p); // $ ast MISSING: ir
+    sink(*p); // $ ast MISSING: ir
 }
 
 void test_reverse_taint_unique() {
     std::unique_ptr<int> p = std::unique_ptr<int>();
 
     *p = source();
-    sink(p); // $ MISSING: ast,ir
-    sink(*p); // $ MISSING: ast,ir
+    sink(p); // $ ast MISSING: ir
+    sink(*p); // $ ast MISSING: ir
 }
 
 void test_shared_get() {
@@ -75,11 +75,11 @@ struct B {
 
 void test_operator_arrow(std::unique_ptr<A> p, std::unique_ptr<B> q) {
   p->x = source();
-  sink(p->x); // $ MISSING: ast,ir
+  sink(p->x); // $ ast MISSING: ir
   sink(p->y);
 
   q->a1.x = source();
-  sink(q->a1.x); // $ MISSING: ast,ir
+  sink(q->a1.x); // $ ast MISSING: ir
   sink(q->a1.y);
   sink(q->a2.x);
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
@@ -66,3 +66,20 @@ void test_shared_field_member() {
     sink(p->x); // $ MISSING: ast,ir
     sink(p->y); // not tainted
 }
+
+struct B {
+  A a1;
+  A a2;
+  int z;
+};
+
+void test_operator_arrow(std::unique_ptr<A> p, std::unique_ptr<B> q) {
+  p->x = source();
+  sink(p->x); // $ MISSING: ast,ir
+  sink(p->y);
+
+  q->a1.x = source();
+  sink(q->a1.x); // $ MISSING: ast,ir
+  sink(q->a1.y);
+  sink(q->a2.x);
+}


### PR DESCRIPTION
Part of https://github.com/github/codeql-c-analysis-team/issues/255.

This PR uses the pointer wrapper model from https://github.com/github/codeql/pull/5543 to ensure we have flow "out of" the target (i.e., the post-update node) of a store step that represents an assignment to a field of a smart pointer in AST dataflow.

Similarly, we ensure that we have flow "into" the call that represents the source of a read step that represents a field read of a smart pointer.

CPP-differences: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1890/