### PR TITLE
Fix ReDOS in cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
@@ -93,7 +93,7 @@ class QuotedCommandInCreateProcessFunctionConfiguration extends DataFlow2::Confi
 
 bindingset[s]
 predicate isQuotedOrNoSpaceApplicationNameOnCmd(string s) {
-  s.regexpMatch("\"([^\"])*\"(\\s|.)*") // The first element (path) is quoted
+  s.regexpMatch("\"([^\"])*\"[\\s\\S]*") // The first element (path) is quoted
   or
   s.regexpMatch("[^\\s]+") // There are no spaces in the string
 }


### PR DESCRIPTION
The sub-regex `(\s|.)*` aims to capture arbitrary string content (in contrast to `.*` which doesn't match newlines), but it is unsafe, since non-newline whitespace can match both alternatives.

This caused an evaluator crash in the wild.

Replace with `[\s\S]*`, which matches everything in a safe way.