### PR TITLE
Python: Allow absolute imports from source directory

### DIFF
--- a/python/ql/src/semmle/python/Files.qll
+++ b/python/ql/src/semmle/python/Files.qll
@@ -72,6 +72,33 @@ class File extends Container {
    * are specified to be extracted.
    */
   string getContents() { file_contents(this, result) }
+
+  /** Holds if this file is likely to get executed directly, and thus act as an entry point for execution. */
+  predicate maybeExecutedDirectly() {
+    // Only consider files in the source code, and not things like the standard library
+    exists(this.getRelativePath()) and
+    (
+      // The file doesn't have the extension `.py` but still contains Python statements
+      not this.getExtension().matches("py%") and
+      exists(Stmt s | s.getLocation().getFile() = this)
+      or
+      // The file contains the usual `if __name__ == '__main__':` construction
+      exists(If i, Name name, StrConst main, Cmpop op |
+        i.getScope().(Module).getFile() = this and
+        op instanceof Eq and
+        i.getTest().(Compare).compares(name, op, main) and
+        name.getId() = "__name__" and
+        main.getText() = "__main__"
+      )
+      or
+      // The file contains a `#!` line referencing the python interpreter
+      exists(Comment c |
+        c.getLocation().getFile() = this and
+        c.getLocation().getStartLine() = 1 and
+        c.getText().regexpMatch("^#! */.*python(2|3)?[ \\\\t]*$")
+      )
+    )
+  }
 }
 
 private predicate occupied_line(File f, int n) {
@@ -121,6 +148,9 @@ class Folder extends Container {
     this.getBaseName().regexpMatch("[^\\d\\W]\\w*") and
     result = this.getParent().getImportRoot(n)
   }
+
+  /** Holds if execution may start in a file in this directory. */
+  predicate mayContainEntryPoint() { any(File f | f.getParent() = this).maybeExecutedDirectly() }
 }
 
 /**

--- a/python/ql/src/semmle/python/Files.qll
+++ b/python/ql/src/semmle/python/Files.qll
@@ -74,7 +74,7 @@ class File extends Container {
   string getContents() { file_contents(this, result) }
 
   /** Holds if this file is likely to get executed directly, and thus act as an entry point for execution. */
-  predicate maybeExecutedDirectly() {
+  predicate isPossibleEntryPoint() {
     // Only consider files in the source code, and not things like the standard library
     exists(this.getRelativePath()) and
     (
@@ -148,9 +148,6 @@ class Folder extends Container {
     this.getBaseName().regexpMatch("[^\\d\\W]\\w*") and
     result = this.getParent().getImportRoot(n)
   }
-
-  /** Holds if execution may start in a file in this directory. */
-  predicate mayContainEntryPoint() { any(File f | f.getParent() = this).maybeExecutedDirectly() }
 }
 
 /**

--- a/python/ql/src/semmle/python/Module.qll
+++ b/python/ql/src/semmle/python/Module.qll
@@ -204,8 +204,13 @@ private string moduleNameFromBase(Container file) {
 string moduleNameFromFile(Container file) {
   exists(string basename |
     basename = moduleNameFromBase(file) and
-    legalShortName(basename) and
+    legalShortName(basename)
+  |
     result = moduleNameFromFile(file.getParent()) + "." + basename
+    or
+    // If execution can start in the folder containing this module, then we will assume `file` can
+    // be imported as an absolute import, and hence return `basename` as a possible name.
+    file.getParent().(Folder).mayContainEntryPoint() and result = basename
   )
   or
   isPotentialSourcePackage(file) and

--- a/python/ql/src/semmle/python/Module.qll
+++ b/python/ql/src/semmle/python/Module.qll
@@ -211,7 +211,7 @@ private predicate transitively_imported_from_entry_point(File file) {
     importer.getParent() = file.getParent() and
     exists(ImportExpr i | i.getLocation().getFile() = importer and i.getName() = file.getStem())
   |
-    importer.maybeExecutedDirectly() or transitively_imported_from_entry_point(importer)
+    importer.isPossibleEntryPoint() or transitively_imported_from_entry_point(importer)
   )
 }
 

--- a/python/ql/test/3/library-tests/modules/entry_point/hash_bang/main.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/hash_bang/main.py
@@ -1,0 +1,7 @@
+#! /usr/bin/python3
+print(__file__)
+import module
+import package
+import namespace_package
+import namespace_package.namespace_package_main
+print(module.message)

--- a/python/ql/test/3/library-tests/modules/entry_point/hash_bang/module.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/hash_bang/module.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+message = "Hello world!"

--- a/python/ql/test/3/library-tests/modules/entry_point/hash_bang/namespace_package/namespace_package_main.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/hash_bang/namespace_package/namespace_package_main.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+import namespace_package.namespace_package_module

--- a/python/ql/test/3/library-tests/modules/entry_point/hash_bang/namespace_package/namespace_package_module.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/hash_bang/namespace_package/namespace_package_module.py
@@ -1,0 +1,1 @@
+print(__file__.split("entry_point")[1])

--- a/python/ql/test/3/library-tests/modules/entry_point/hash_bang/package/__init__.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/hash_bang/package/__init__.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+from . import package_main

--- a/python/ql/test/3/library-tests/modules/entry_point/hash_bang/package/package_main.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/hash_bang/package/package_main.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+from . import package_module

--- a/python/ql/test/3/library-tests/modules/entry_point/hash_bang/package/package_module.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/hash_bang/package/package_module.py
@@ -1,0 +1,1 @@
+print(__file__.split("entry_point")[1])

--- a/python/ql/test/3/library-tests/modules/entry_point/modules.expected
+++ b/python/ql/test/3/library-tests/modules/entry_point/modules.expected
@@ -1,0 +1,16 @@
+| main | hash_bang/main.py:0:0:0:0 | Script main |
+| main | name_main/main.py:0:0:0:0 | Module main |
+| module | hash_bang/module.py:0:0:0:0 | Module module |
+| module | name_main/module.py:0:0:0:0 | Module module |
+| package | hash_bang/package:0:0:0:0 | Package package |
+| package | name_main/package:0:0:0:0 | Package package |
+| package | no_py_extension/package:0:0:0:0 | Package package |
+| package.__init__ | hash_bang/package/__init__.py:0:0:0:0 | Module package.__init__ |
+| package.__init__ | name_main/package/__init__.py:0:0:0:0 | Module package.__init__ |
+| package.__init__ | no_py_extension/package/__init__.py:0:0:0:0 | Module package.__init__ |
+| package.package_main | hash_bang/package/package_main.py:0:0:0:0 | Module package.package_main |
+| package.package_main | name_main/package/package_main.py:0:0:0:0 | Module package.package_main |
+| package.package_main | no_py_extension/package/package_main.py:0:0:0:0 | Module package.package_main |
+| package.package_module | hash_bang/package/package_module.py:0:0:0:0 | Module package.package_module |
+| package.package_module | name_main/package/package_module.py:0:0:0:0 | Module package.package_module |
+| package.package_module | no_py_extension/package/package_module.py:0:0:0:0 | Module package.package_module |

--- a/python/ql/test/3/library-tests/modules/entry_point/modules.expected
+++ b/python/ql/test/3/library-tests/modules/entry_point/modules.expected
@@ -1,5 +1,3 @@
-| main | hash_bang/main.py:0:0:0:0 | Script main |
-| main | name_main/main.py:0:0:0:0 | Module main |
 | module | hash_bang/module.py:0:0:0:0 | Module module |
 | module | name_main/module.py:0:0:0:0 | Module module |
 | package | hash_bang/package:0:0:0:0 | Package package |

--- a/python/ql/test/3/library-tests/modules/entry_point/modules.ql
+++ b/python/ql/test/3/library-tests/modules/entry_point/modules.ql
@@ -1,0 +1,4 @@
+import python
+
+from Module m
+select m.getName(), m

--- a/python/ql/test/3/library-tests/modules/entry_point/name_main/main.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/name_main/main.py
@@ -1,0 +1,8 @@
+print(__file__)
+import module
+import package
+import namespace_package
+import namespace_package.namespace_package_main
+
+if __name__ == '__main__':
+   print(module.message)

--- a/python/ql/test/3/library-tests/modules/entry_point/name_main/module.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/name_main/module.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+message = "Hello world!"

--- a/python/ql/test/3/library-tests/modules/entry_point/name_main/namespace_package/namespace_package_main.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/name_main/namespace_package/namespace_package_main.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+import namespace_package.namespace_package_module

--- a/python/ql/test/3/library-tests/modules/entry_point/name_main/namespace_package/namespace_package_module.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/name_main/namespace_package/namespace_package_module.py
@@ -1,0 +1,1 @@
+print(__file__.split("entry_point")[1])

--- a/python/ql/test/3/library-tests/modules/entry_point/name_main/package/__init__.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/name_main/package/__init__.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+from . import package_main

--- a/python/ql/test/3/library-tests/modules/entry_point/name_main/package/package_main.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/name_main/package/package_main.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+from . import package_module

--- a/python/ql/test/3/library-tests/modules/entry_point/name_main/package/package_module.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/name_main/package/package_module.py
@@ -1,0 +1,1 @@
+print(__file__.split("entry_point")[1])

--- a/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/main.secretpy
+++ b/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/main.secretpy
@@ -1,0 +1,6 @@
+print(__file__)
+import module
+import package
+import namespace_package
+import namespace_package.namespace_package_main
+print(module.message)

--- a/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/module.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/module.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+message = "Hello world!"

--- a/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/namespace_package/namespace_package_main.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/namespace_package/namespace_package_main.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+import namespace_package.namespace_package_module

--- a/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/namespace_package/namespace_package_module.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/namespace_package/namespace_package_module.py
@@ -1,0 +1,1 @@
+print(__file__.split("entry_point")[1])

--- a/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/package/__init__.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/package/__init__.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+from . import package_main

--- a/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/package/package_main.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/package/package_main.py
@@ -1,0 +1,2 @@
+print(__file__.split("entry_point")[1])
+from . import package_module

--- a/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/package/package_module.py
+++ b/python/ql/test/3/library-tests/modules/entry_point/no_py_extension/package/package_module.py
@@ -1,0 +1,1 @@
+print(__file__.split("entry_point")[1])

--- a/python/ql/test/3/library-tests/modules/entry_point/options
+++ b/python/ql/test/3/library-tests/modules/entry_point/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --lang=3 --path bogus -R . --filter=include:**/*.secretpy


### PR DESCRIPTION
#5506 revisited, and #5552 reverted. 

To fix the performance issues, we greatly restrict the set of modules that have a new name under this scheme. The previous PR considered any file that coexisted with an executable Python script to be importable using its name as an absolute import. This PR limits itself to just those files that are _actually_ imported.

One change to the tests was needed, which reflects the fact that the two `main.py` files no longer have the name `main` (which makes sense, since they're never imported under this name). Crucially, `module` is still a valid name for both of the `module.py` files