### PR TITLE
C++: Inline Location::isBefore

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Location.qll
+++ b/cpp/ql/src/semmle/code/cpp/Location.qll
@@ -72,6 +72,7 @@ class Location extends @location {
   }
 
   /** Holds if `this` comes on a line strictly before `l`. */
+  pragma[inline]
   predicate isBefore(Location l) {
     this.getFile() = l.getFile() and this.getEndLine() < l.getStartLine()
   }


### PR DESCRIPTION
The `Location::isBefore` predicate (which is used as part of IR construction) is very large. Inlining the predicate gives much better intermediate tuple sizes:

Tuple counts on `main` (on `kamailio/kamailio)`:
```codeql
Tuple counts for Location::Location::isBefore_dispred#bb/2@4b4216:
  1         ~0%     {1} r1 = CONSTANT(unique int)[4]
  11542     ~0%     {1} r2 = JOIN r1 WITH stmts_12#join_rhs ON FIRST 1 OUTPUT Rhs.1 'this'
  11542     ~0%     {2} r3 = JOIN r2 WITH Location::Location::fullLocationInfo_dispred#ffffff ON FIRST 1 OUTPUT Lhs.0 'this', Rhs.4
  11542     ~1%     {3} r4 = JOIN r3 WITH Location::Location::getFile_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'this', Lhs.1
  101279334 ~4%     {3} r5 = JOIN r4 WITH Location::Location::getFile_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'l', Lhs.1 'this', Lhs.2
  54350041  ~1%     {3} r6 = JOIN r5 WITH project#stmts ON FIRST 1 OUTPUT Lhs.0 'l', Lhs.1 'this', Lhs.2
  54350041  ~0%     {8} r7 = JOIN r6 WITH Location::Location::fullLocationInfo_dispred#ffffff ON FIRST 1 OUTPUT Lhs.1 'this', Lhs.2, Lhs.0 'l', Rhs.1, Rhs.2, Rhs.3, Rhs.4, Rhs.5
  24933617  ~0%     {8} r8 = SELECT r7 ON In.1 < In.4
  24933617  ~2%     {2} r9 = SCAN r8 OUTPUT In.0 'this', In.2 'l'
                    return r9
[...]
Tuple counts for IRConstruction::isStrictlyForwardGoto#f/1@b3c7bb:
  1        ~0%     {1} r1 = CONSTANT(unique int)[4]
  13213    ~0%     {2} r2 = JOIN r1 WITH stmts_102#join_rhs ON FIRST 1 OUTPUT Rhs.1 'goto', Rhs.2
  13213    ~0%     {3} r3 = JOIN r2 WITH Stmt::JumpStmt::getTarget_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'goto', Lhs.1
  13213    ~0%     {3} r4 = JOIN r3 WITH stmts ON FIRST 1 OUTPUT Lhs.2, Rhs.2, Lhs.1 'goto'
  11862    ~1%     {1} r5 = JOIN r4 WITH Location::Location::isBefore_dispred#bb ON FIRST 2 OUTPUT Lhs.2 'goto'
                    return r5
```

With this PR:
```codeql
Tuple counts for IRConstruction::isStrictlyForwardGoto#f/1@02921d:
  1       ~0%     {1} r1 = CONSTANT(unique int)[4]
  13213   ~0%     {2} r2 = JOIN r1 WITH stmts_102#join_rhs ON FIRST 1 OUTPUT Rhs.1 'goto', Rhs.2
  13213   ~0%     {3} r3 = JOIN r2 WITH Stmt::JumpStmt::getTarget_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'goto', Lhs.1
  13213   ~3%     {3} r4 = JOIN r3 WITH stmts ON FIRST 1 OUTPUT Lhs.2, Lhs.1 'goto', Rhs.2
  13213   ~0%     {4} r5 = JOIN r4 WITH Location::Location::fullLocationInfo_dispred#ffffff ON FIRST 1 OUTPUT Lhs.2, Lhs.1 'goto', Lhs.0, Rhs.4
  13213   ~0%     {9} r6 = JOIN r5 WITH Location::Location::fullLocationInfo_dispred#ffffff ON FIRST 1 OUTPUT Lhs.1 'goto', Lhs.2, Lhs.0, Lhs.3, Rhs.1, Rhs.2, Rhs.3, Rhs.4, Rhs.5
  11862   ~3%     {9} r7 = SELECT r6 ON In.3 < In.5
  11862   ~3%     {3} r8 = SCAN r7 OUTPUT In.2, In.0 'goto', In.1
  11862   ~0%     {3} r9 = JOIN r8 WITH Location::Location::getFile_dispred#ff ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.1 'goto'
  11862   ~1%     {1} r10 = JOIN r9 WITH Location::Location::getFile_dispred#ff ON FIRST 2 OUTPUT Lhs.2 'goto'
                  return r10
```

CPP-differences: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1892/