### PR TITLE
Python: Improve `CallCfgNode` interface

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -180,7 +180,7 @@ class CfgNode extends Node, TCfgNode {
 }
 
 /** A data-flow node corresponding to a `CallNode` in the control-flow graph. */
-class CallCfgNode extends CfgNode {
+class CallCfgNode extends CfgNode, LocalSourceNode {
   override CallNode node;
 
   /**


### PR DESCRIPTION
Call nodes are always local sources (specifically sources of the return
value of the call), and so inheriting from `LocalSourceNode` will have
no effect on results, but _should_ make it a bit more smooth to use the
API.

---

This is a somewhat minor change, so I'm not sure it merits a change note, but do let me know if you feel otherwise, and I'll add one.