### PR TITLE
Docs: Link to CodeQL CLI manual from the sidebar

### DIFF
--- a/docs/codeql/codeql-cli/codeql-cli-reference.rst
+++ b/docs/codeql/codeql-cli/codeql-cli-reference.rst
@@ -21,11 +21,3 @@ Learn more about the files you can use when running CodeQL processes and the res
 - :doc:`SARIF output <sarif-output>`: CodeQL supports SARIF as an output format for sharing static analysis results.
 - :doc:`Exit codes <exit-codes>`: The CodeQL CLI reports the status of each command it runs as an exit code.
   This exit code provides information for subsequent commands or for other tools that rely on the CodeQL CLI.
-
-.. _cli-commands:
-
-CodeQL CLI manual
------------------
-
-To view detailed information about each CodeQL CLI command,
-including its usage and options, add the ``--help`` flag or visit the "`CodeQL CLI manual <../manual>`__."

--- a/docs/codeql/codeql-cli/index.rst
+++ b/docs/codeql/codeql-cli/index.rst
@@ -18,4 +18,4 @@ CodeQL CLI
 
    using-the-codeql-cli
    codeql-cli-reference
-   
+   CodeQL CLI manual <https://codeql.github.com/docs/codeql-cli/manual>


### PR DESCRIPTION
The CodeQL CLI manual is currently difficult to access from the sidebar. From internal feedback:
> - The [main body](https://codeql.github.com/docs/codeql-cli/codeql-cli-reference/) of the page text contains a bulleted list of links for the first four topics, and a separate large heading `CodeQL CLI manual` that is not actually a link to the manual. To actually go to the manual pages, the user must go to the right edge of the paragraph and realise there is a hyperlink at the end of the sentence.
> - The `CodeQL CLI manual` link in the left sidebar goes to the anchor https://codeql.github.com/docs/codeql-cli/codeql-cli-reference/#codeql-cli-manual, when it should instead go to the manual pages https://codeql.github.com/docs/codeql-cli/manual/

This PR adds the CLI manual as a top-level page under "[CodeQL CLI](https://codeql.github.com/docs/codeql-cli/)" instead of a subsection under the CLI reference.

![image](https://user-images.githubusercontent.com/42641846/113908149-21bca380-97ce-11eb-98d1-e8732d2c9261.png)

**Note**: I've had to use an absolute link to https://codeql.github.com/docs/codeql-cli/manual/ (see [toctree](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree) syntax). We can't use a relative link like  `../manual` in this case since the manual is a separate, auto-generated Sphinx project and doesn't "exist" in this repo. (Tried that and failed in https://github.com/github/codeql/pull/5123 😉)

