### PR TITLE
Docs: Fix broken link to cached "RemoteFlowSource"

### DIFF
--- a/docs/codeql/codeql-language-guides/data-flow-cheat-sheet-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/data-flow-cheat-sheet-for-javascript.rst
@@ -130,7 +130,7 @@ System and Network
     - `FileSystemWriteAccess <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/Concepts.qll/type.Concepts$FileSystemWriteAccess.html>`__ -- writing to the contents of a file
 - `PersistentReadAccess <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/Concepts.qll/type.Concepts$PersistentReadAccess.html>`__ -- reading from persistent storage, like cookies
 - `PersistentWriteAccess <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/Concepts.qll/type.Concepts$PersistentWriteAccess.html>`__ -- writing to persistent storage
-- `RemoteFlowSource <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/security/dataflow/RemoteFlowSources.qll/type.RemoteFlowSources$RemoteFlowSource.html>`__ -- source of untrusted user input
+- `RemoteFlowSource <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/security/dataflow/RemoteFlowSources.qll/type.RemoteFlowSources$Cached$RemoteFlowSource.html>`__ -- source of untrusted user input
 - `SystemCommandExecution <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/Concepts.qll/type.Concepts$SystemCommandExecution.html>`__ -- execution of a system command
 
 Files

--- a/docs/codeql/codeql-language-guides/specifying-additional-remote-flow-sources-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/specifying-additional-remote-flow-sources-for-javascript.rst
@@ -12,7 +12,7 @@ You can model potential sources of untrusted user input in your code without mak
    Specifying remote flow sources in external files is currently in beta and subject to change.
 
 As mentioned in the :doc:`Data flow cheat sheet for JavaScript <data-flow-cheat-sheet-for-javascript>`, the CodeQL libraries for JavaScript
-provide a class `RemoteFlowSource <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/security/dataflow/RemoteFlowSources.qll/type.RemoteFlowSources$RemoteFlowSource.html>`__ to represent sources of untrusted user input, sometimes also referred to as remote flow
+provide a class `RemoteFlowSource <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/security/dataflow/RemoteFlowSources.qll/type.RemoteFlowSources$Cached$RemoteFlowSource.html>`__ to represent sources of untrusted user input, sometimes also referred to as remote flow
 sources.
 
 To model a new source of untrusted input, such as a previously unmodelled library API, you can


### PR DESCRIPTION
Tiny drive-by link fix, as a follow-up to https://github.com/github/codeql/pull/5265. Pinged the JavaScript team for a review, just to be sure 😊 

