### PR TITLE
Java: Remove `unique` wrapper from `DataFlow::Node::getEnclosingCallable()`

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -80,19 +80,15 @@ class Node extends TNode {
     result = this.(ImplicitPostUpdateNode).getPreUpdateNode().getType()
   }
 
-  private Callable getEnclosingCallableImpl() {
+  /** Gets the callable in which this node occurs. */
+  Callable getEnclosingCallable() {
     result = this.asExpr().getEnclosingCallable() or
     result = this.asParameter().getCallable() or
     result = this.(ImplicitVarargsArray).getCall().getEnclosingCallable() or
     result = this.(InstanceParameterNode).getCallable() or
     result = this.(ImplicitInstanceAccess).getInstanceAccess().getEnclosingCallable() or
     result = this.(MallocNode).getClassInstanceExpr().getEnclosingCallable() or
-    result = this.(ImplicitPostUpdateNode).getPreUpdateNode().getEnclosingCallableImpl()
-  }
-
-  /** Gets the callable in which this node occurs. */
-  Callable getEnclosingCallable() {
-    result = unique(DataFlowCallable c | c = this.getEnclosingCallableImpl() | c)
+    result = this.(ImplicitPostUpdateNode).getPreUpdateNode().getEnclosingCallable()
   }
 
   private Type getImprovedTypeBound() {


### PR DESCRIPTION
Should no longer be needed after https://github.com/github/codeql/pull/5338.

https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/1294/ (excludes `google/guava` which failed to build).