### PR TITLE
JS: add taint-step for URL construction in js/request-forgery

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/RequestForgery.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RequestForgery.qll
@@ -31,5 +31,9 @@ module RequestForgery {
     override predicate isSanitizerEdge(DataFlow::Node source, DataFlow::Node sink) {
       sanitizingPrefixEdge(source, sink)
     }
+
+    override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+      isAdditionalRequestForgeryStep(pred, succ)
+    }
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RequestForgeryCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RequestForgeryCustomizations.qll
@@ -59,4 +59,14 @@ module RequestForgery {
 
     override string getKind() { result = kind }
   }
+
+  /**
+   * Holds if there is a taint step from `pred` to `succ` for request forgery.
+   */
+  predicate isAdditionalRequestForgeryStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(DataFlow::NewNode url | url = DataFlow::globalVarRef("URL").getAnInstantiation() |
+      succ = url and
+      pred = url.getArgument(0)
+    )
+  }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
@@ -82,6 +82,12 @@ nodes
 | tst.js:108:17:108:27 | request.url |
 | tst.js:109:27:109:29 | url |
 | tst.js:109:27:109:29 | url |
+| tst.js:115:11:115:42 | url |
+| tst.js:115:17:115:42 | new URL ... , base) |
+| tst.js:115:25:115:35 | request.url |
+| tst.js:115:25:115:35 | request.url |
+| tst.js:117:27:117:29 | url |
+| tst.js:117:27:117:29 | url |
 edges
 | tst.js:14:9:14:52 | tainted | tst.js:18:13:18:19 | tainted |
 | tst.js:14:9:14:52 | tainted | tst.js:18:13:18:19 | tainted |
@@ -161,6 +167,11 @@ edges
 | tst.js:108:11:108:27 | url | tst.js:109:27:109:29 | url |
 | tst.js:108:17:108:27 | request.url | tst.js:108:11:108:27 | url |
 | tst.js:108:17:108:27 | request.url | tst.js:108:11:108:27 | url |
+| tst.js:115:11:115:42 | url | tst.js:117:27:117:29 | url |
+| tst.js:115:11:115:42 | url | tst.js:117:27:117:29 | url |
+| tst.js:115:17:115:42 | new URL ... , base) | tst.js:115:11:115:42 | url |
+| tst.js:115:25:115:35 | request.url | tst.js:115:17:115:42 | new URL ... , base) |
+| tst.js:115:25:115:35 | request.url | tst.js:115:17:115:42 | new URL ... , base) |
 #select
 | tst.js:18:5:18:20 | request(tainted) | tst.js:14:29:14:35 | req.url | tst.js:18:13:18:19 | tainted | The $@ of this request depends on $@. | tst.js:18:13:18:19 | tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
 | tst.js:20:5:20:24 | request.get(tainted) | tst.js:14:29:14:35 | req.url | tst.js:20:17:20:23 | tainted | The $@ of this request depends on $@. | tst.js:20:17:20:23 | tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
@@ -183,3 +194,4 @@ edges
 | tst.js:92:5:92:33 | JSDOM.f ... ms.foo) | tst.js:92:19:92:28 | ctx.params | tst.js:92:19:92:32 | ctx.params.foo | The $@ of this request depends on $@. | tst.js:92:19:92:32 | ctx.params.foo | URL | tst.js:92:19:92:28 | ctx.params | a user-provided value |
 | tst.js:100:5:100:26 | new Web ... ainted) | tst.js:98:29:98:35 | req.url | tst.js:100:19:100:25 | tainted | The $@ of this request depends on $@. | tst.js:100:19:100:25 | tainted | URL | tst.js:98:29:98:35 | req.url | a user-provided value |
 | tst.js:109:20:109:30 | new ws(url) | tst.js:108:17:108:27 | request.url | tst.js:109:27:109:29 | url | The $@ of this request depends on $@. | tst.js:109:27:109:29 | url | URL | tst.js:108:17:108:27 | request.url | a user-provided value |
+| tst.js:117:20:117:30 | new ws(url) | tst.js:115:25:115:35 | request.url | tst.js:117:27:117:29 | url | The $@ of this request depends on $@. | tst.js:117:27:117:29 | url | URL | tst.js:115:25:115:35 | request.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-918/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-918/tst.js
@@ -109,3 +109,11 @@ new ws.Server({ port: 8080 }).on('connection', function(socket, request) {
     const socket = new ws(url);
   });
 });
+
+new ws.Server({ port: 8080 }).on('connection', function (socket, request) {
+  socket.on('message', function (message) {
+    const url = new URL(request.url, base);
+    const target = new URL(url.pathname, base);
+    const socket = new ws(url);
+  });
+});


### PR DESCRIPTION
Gets a TP for CVE-2021-21322 

[Evaluation was uneventful](https://github.com/dsp-testing/erik-krogh-dca/tree/run/urlStep-default-requestForgery/reports). 

---  

We already have [a data-flow step for the tainted properties in a URL](https://github.com/github/codeql/blob/main/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll#L859-L864), but we didn't treat the URL itself as being tainted.  