### PR TITLE
Python: Prototype for automated modeling

### DIFF
--- a/python/ql/src/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/semmle/python/frameworks/Django.qll
@@ -2081,20 +2081,21 @@ private module Django {
     module Field {
       /** Gets a reference to the `django.forms.fields.Field` class or any subclass. */
       API::Node subclassRef() {
-        exists(string modName, string clsName |
+        exists(string moduleName, string className |
           // canonical definition
           result =
             API::moduleImport("django")
                 .getMember("forms")
-                .getMember(modName)
-                .getMember(clsName)
+                .getMember(moduleName)
+                .getMember(className)
                 .getASubclass*()
           or
           // alias from `django.forms`
-          result = API::moduleImport("django").getMember("forms").getMember(clsName).getASubclass*()
+          result =
+            API::moduleImport("django").getMember("forms").getMember(className).getASubclass*()
         |
-          modName = "fields" and
-          clsName in [
+          moduleName = "fields" and
+          className in [
               "Field",
               // Known subclasses
               "BooleanField", "IntegerField", "CharField", "SlugField", "DateTimeField",
@@ -2106,8 +2107,8 @@ private module Django {
             ]
           or
           // Known subclasses from `django.forms.models`
-          modName = "models" and
-          clsName in ["ModelChoiceField", "ModelMultipleChoiceField", "InlineForeignKeyField"]
+          moduleName = "models" and
+          className in ["ModelChoiceField", "ModelMultipleChoiceField", "InlineForeignKeyField"]
         )
         or
         // other Field subclasses defined in Django

--- a/python/ql/src/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/semmle/python/frameworks/Django.qll
@@ -1526,8 +1526,11 @@ private module Django {
        *  - https://docs.djangoproject.com/en/3.1/ref/class-based-views/
        */
       module View {
-        /** Gets a reference to the `django.views.generic.View` class or any subclass. */
-        API::Node subclassRef() {
+        /**
+         * Get a references to: the `django.views.generic.View` class, or any subclass
+         * that has explicitly been modeled in the CodeQL libraries.
+         */
+        API::Node modeledSubclassRef() {
           exists(string moduleName, string className |
             // canonical definition
             result =
@@ -1536,7 +1539,6 @@ private module Django {
                   .getMember("generic")
                   .getMember(moduleName)
                   .getMember(className)
-                  .getASubclass*()
             or
             // alias from `django.view.generic`
             result =
@@ -1544,7 +1546,6 @@ private module Django {
                   .getMember("view")
                   .getMember("generic")
                   .getMember(className)
-                  .getASubclass*()
           |
             moduleName = "base" and
             className in ["RedirectView", "TemplateView", "View"]
@@ -1566,8 +1567,11 @@ private module Django {
           )
           or
           // `django.views.View` alias
-          result = API::moduleImport("django").getMember("views").getMember("View").getASubclass*()
+          result = API::moduleImport("django").getMember("views").getMember("View")
         }
+
+        /** Gets a reference to the `django.views.generic.View` class or any subclass. */
+        API::Node subclassRef() { result = modeledSubclassRef().getASubclass*() }
       }
     }
 
@@ -1638,29 +1642,29 @@ private module Django {
      * See https://docs.djangoproject.com/en/3.1/ref/forms/api/
      */
     module Form {
-      /** Gets a reference to the `django.forms.forms.BaseForm` class or any subclass. */
-      API::Node subclassRef() {
+      /**
+       * Get a references to: the `django.forms.forms.BaseForm` class, or any subclass
+       * that has explicitly been modeled in the CodeQL libraries.
+       */
+      API::Node modeledSubclassRef() {
         // canonical definition
         result =
           API::moduleImport("django")
               .getMember("forms")
               .getMember("forms")
               .getMember(["BaseForm", "Form"])
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
               .getMember("forms")
               .getMember("models")
               .getMember(["BaseModelForm", "ModelForm"])
-              .getASubclass*()
         or
         // aliases from `django.forms`
         result =
           API::moduleImport("django")
               .getMember("forms")
               .getMember(["BaseForm", "Form", "BaseModelForm", "ModelForm"])
-              .getASubclass*()
         or
         // other Form subclasses defined in Django
         result =
@@ -1669,7 +1673,6 @@ private module Django {
               .getMember("admin")
               .getMember("forms")
               .getMember(["AdminAuthenticationForm", "AdminPasswordChangeForm"])
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
@@ -1677,7 +1680,6 @@ private module Django {
               .getMember("admin")
               .getMember("helpers")
               .getMember("ActionForm")
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
@@ -1686,7 +1688,6 @@ private module Django {
               .getMember("views")
               .getMember("main")
               .getMember("ChangeListSearchForm")
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
@@ -1698,7 +1699,6 @@ private module Django {
                   "AdminPasswordChangeForm", "PasswordChangeForm", "AuthenticationForm",
                   "UserCreationForm"
                 ])
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
@@ -1706,22 +1706,22 @@ private module Django {
               .getMember("flatpages")
               .getMember("forms")
               .getMember("FlatpageForm")
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
               .getMember("forms")
               .getMember("formsets")
               .getMember("ManagementForm")
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
               .getMember("forms")
               .getMember("models")
               .getMember(["ModelForm", "BaseModelForm"])
-              .getASubclass*()
       }
+
+      /** Gets a reference to the `django.forms.forms.BaseForm` class or any subclass. */
+      API::Node subclassRef() { result = modeledSubclassRef().getASubclass*() }
     }
 
     /**
@@ -1731,8 +1731,11 @@ private module Django {
      * See https://docs.djangoproject.com/en/3.1/ref/forms/fields/
      */
     module Field {
-      /** Gets a reference to the `django.forms.fields.Field` class or any subclass. */
-      API::Node subclassRef() {
+      /**
+       * Get a references to: the `django.forms.fields.Field` class, or any subclass
+       * that has explicitly been modeled in the CodeQL libraries.
+       */
+      API::Node modeledSubclassRef() {
         exists(string moduleName, string className |
           // canonical definition
           result =
@@ -1740,11 +1743,9 @@ private module Django {
                 .getMember("forms")
                 .getMember(moduleName)
                 .getMember(className)
-                .getASubclass*()
           or
           // alias from `django.forms`
-          result =
-            API::moduleImport("django").getMember("forms").getMember(className).getASubclass*()
+          result = API::moduleImport("django").getMember("forms").getMember(className)
         |
           moduleName = "fields" and
           className in [
@@ -1770,7 +1771,6 @@ private module Django {
               .getMember("auth")
               .getMember("forms")
               .getMember(["ReadOnlyPasswordHashField", "UsernameField"])
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
@@ -1783,7 +1783,6 @@ private module Django {
                   "MultiLineStringField", "MultiPointField", "MultiPolygonField", "PointField",
                   "PolygonField"
                 ])
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
@@ -1792,7 +1791,6 @@ private module Django {
               .getMember("forms")
               .getMember("array")
               .getMember(["SimpleArrayField", "SplitArrayField"])
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
@@ -1801,7 +1799,6 @@ private module Django {
               .getMember("forms")
               .getMember("hstore")
               .getMember("HStoreField")
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
@@ -1813,15 +1810,16 @@ private module Django {
                   "BaseRangeField", "DateRangeField", "DateTimeRangeField", "DecimalRangeField",
                   "IntegerRangeField"
                 ])
-              .getASubclass*()
         or
         result =
           API::moduleImport("django")
               .getMember("forms")
               .getMember("models")
               .getMember(["InlineForeignKeyField", "ModelChoiceField", "ModelMultipleChoiceField"])
-              .getASubclass*()
       }
+
+      /** Gets a reference to the `django.forms.fields.Field` class or any subclass. */
+      API::Node subclassRef() { result = modeledSubclassRef().getASubclass*() }
     }
   }
 

--- a/python/ql/src/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/semmle/python/frameworks/Django.qll
@@ -1519,402 +1519,54 @@ private module Django {
     /** Provides models for the `django.views` module */
     module views {
       /**
-       * Gets a reference to the attribute `attr_name` of the `django.views` module.
-       * WARNING: Only holds for a few predefined attributes.
+       * Provides models for the `django.views.generic.View` class and subclasses.
+       *
+       * See
+       *  - https://docs.djangoproject.com/en/3.1/topics/class-based-views/
+       *  - https://docs.djangoproject.com/en/3.1/ref/class-based-views/
        */
-      private DataFlow::Node views_attr(DataFlow::TypeTracker t, string attr_name) {
-        // for 1.11.x, see: https://github.com/django/django/blob/stable/1.11.x/django/views/__init__.py
-        attr_name in ["generic", "View"] and
-        (
-          t.start() and
-          result = DataFlow::importNode("django.views" + "." + attr_name)
-          or
-          t.startInAttr(attr_name) and
-          result = views()
-        )
-        or
-        // Due to bad performance when using normal setup with `views_attr(t2, attr_name).track(t2, t)`
-        // we have inlined that code and forced a join
-        exists(DataFlow::TypeTracker t2 |
-          exists(DataFlow::StepSummary summary |
-            views_attr_first_join(t2, attr_name, result, summary) and
-            t = t2.append(summary)
-          )
-        )
-      }
-
-      pragma[nomagic]
-      private predicate views_attr_first_join(
-        DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res,
-        DataFlow::StepSummary summary
-      ) {
-        DataFlow::StepSummary::step(views_attr(t2, attr_name), res, summary)
-      }
-
-      /**
-       * Gets a reference to the attribute `attr_name` of the `django.views` module.
-       * WARNING: Only holds for a few predefined attributes.
-       */
-      private DataFlow::Node views_attr(string attr_name) {
-        result = views_attr(DataFlow::TypeTracker::end(), attr_name)
-      }
-
-      // -------------------------------------------------------------------------
-      // django.views.generic
-      // -------------------------------------------------------------------------
-      /** Gets a reference to the `django.views.generic` module. */
-      DataFlow::Node generic() { result = views_attr("generic") }
-
-      /** Provides models for the `django.views.generic` module */
-      module generic {
-        /**
-         * Gets a reference to the attribute `attr_name` of the `django.views.generic` module.
-         * WARNING: Only holds for a few predefined attributes.
-         */
-        private DataFlow::Node generic_attr(DataFlow::TypeTracker t, string attr_name) {
-          // for 3.1.x see: https://github.com/django/django/blob/stable/3.1.x/django/views/generic/__init__.py
-          // same for 1.11.x see: https://github.com/django/django/blob/stable/1.11.x/django/views/generic/__init__.py
-          attr_name in [
-              "View", "TemplateView", "RedirectView", "ArchiveIndexView", "YearArchiveView",
-              "MonthArchiveView", "WeekArchiveView", "DayArchiveView", "TodayArchiveView",
-              "DateDetailView", "DetailView", "FormView", "CreateView", "UpdateView", "DeleteView",
-              "ListView", "GenericViewError",
-              // modules
-              "base", "dates", "detail", "edit", "list"
-            ] and
-          (
-            t.start() and
-            result = DataFlow::importNode("django.views.generic" + "." + attr_name)
+      module View {
+        /** Gets a reference to the `django.views.generic.View` class or any subclass. */
+        API::Node subclassRef() {
+          exists(string moduleName, string className |
+            // canonical definition
+            result =
+              API::moduleImport("django")
+                  .getMember("views")
+                  .getMember("generic")
+                  .getMember(moduleName)
+                  .getMember(className)
+                  .getASubclass*()
             or
-            t.startInAttr(attr_name) and
-            result = generic()
-          )
-          or
-          // Due to bad performance when using normal setup with `generic_attr(t2, attr_name).track(t2, t)`
-          // we have inlined that code and forced a join
-          exists(DataFlow::TypeTracker t2 |
-            exists(DataFlow::StepSummary summary |
-              generic_attr_first_join(t2, attr_name, result, summary) and
-              t = t2.append(summary)
-            )
-          )
-        }
-
-        pragma[nomagic]
-        private predicate generic_attr_first_join(
-          DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res,
-          DataFlow::StepSummary summary
-        ) {
-          DataFlow::StepSummary::step(generic_attr(t2, attr_name), res, summary)
-        }
-
-        /**
-         * Gets a reference to the attribute `attr_name` of the `django.views.generic` module.
-         * WARNING: Only holds for a few predefined attributes.
-         */
-        private DataFlow::Node generic_attr(string attr_name) {
-          result = generic_attr(DataFlow::TypeTracker::end(), attr_name)
-        }
-
-        // -------------------------------------------------------------------------
-        // django.views.generic.base
-        // -------------------------------------------------------------------------
-        /** Gets a reference to the `django.views.generic.base` module. */
-        DataFlow::Node base() { result = generic_attr("base") }
-
-        /** Provides models for the `django.views.generic.base` module */
-        module base {
-          /**
-           * Gets a reference to the attribute `attr_name` of the `django.views.generic.base` module.
-           * WARNING: Only holds for a few predefined attributes.
-           */
-          private DataFlow::Node base_attr(DataFlow::TypeTracker t, string attr_name) {
-            attr_name in ["RedirectView", "TemplateView", "View"] and
-            (
-              t.start() and
-              result = DataFlow::importNode("django.views.generic.base" + "." + attr_name)
-              or
-              t.startInAttr(attr_name) and
-              result = base()
-            )
+            // alias from `django.view.generic`
+            result =
+              API::moduleImport("django")
+                  .getMember("view")
+                  .getMember("generic")
+                  .getMember(className)
+                  .getASubclass*()
+          |
+            moduleName = "base" and
+            className in ["RedirectView", "TemplateView", "View"]
             or
-            // Due to bad performance when using normal setup with `base_attr(t2, attr_name).track(t2, t)`
-            // we have inlined that code and forced a join
-            exists(DataFlow::TypeTracker t2 |
-              exists(DataFlow::StepSummary summary |
-                base_attr_first_join(t2, attr_name, result, summary) and
-                t = t2.append(summary)
-              )
-            )
-          }
-
-          pragma[nomagic]
-          private predicate base_attr_first_join(
-            DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res,
-            DataFlow::StepSummary summary
-          ) {
-            DataFlow::StepSummary::step(base_attr(t2, attr_name), res, summary)
-          }
-
-          /**
-           * Gets a reference to the attribute `attr_name` of the `django.views.generic.base` module.
-           * WARNING: Only holds for a few predefined attributes.
-           */
-          DataFlow::Node base_attr(string attr_name) {
-            result = base_attr(DataFlow::TypeTracker::end(), attr_name)
-          }
-        }
-
-        // -------------------------------------------------------------------------
-        // django.views.generic.dates
-        // -------------------------------------------------------------------------
-        /** Gets a reference to the `django.views.generic.dates` module. */
-        DataFlow::Node dates() { result = generic_attr("dates") }
-
-        /** Provides models for the `django.views.generic.dates` module */
-        module dates {
-          /**
-           * Gets a reference to the attribute `attr_name` of the `django.views.generic.dates` module.
-           * WARNING: Only holds for a few predefined attributes.
-           */
-          private DataFlow::Node dates_attr(DataFlow::TypeTracker t, string attr_name) {
-            attr_name in [
+            moduleName = "dates" and
+            className in [
                 "ArchiveIndexView", "DateDetailView", "DayArchiveView", "MonthArchiveView",
                 "TodayArchiveView", "WeekArchiveView", "YearArchiveView"
-              ] and
-            (
-              t.start() and
-              result = DataFlow::importNode("django.views.generic.dates" + "." + attr_name)
-              or
-              t.startInAttr(attr_name) and
-              result = dates()
-            )
+              ]
             or
-            // Due to bad performance when using normal setup with `dates_attr(t2, attr_name).track(t2, t)`
-            // we have inlined that code and forced a join
-            exists(DataFlow::TypeTracker t2 |
-              exists(DataFlow::StepSummary summary |
-                dates_attr_first_join(t2, attr_name, result, summary) and
-                t = t2.append(summary)
-              )
-            )
-          }
-
-          pragma[nomagic]
-          private predicate dates_attr_first_join(
-            DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res,
-            DataFlow::StepSummary summary
-          ) {
-            DataFlow::StepSummary::step(dates_attr(t2, attr_name), res, summary)
-          }
-
-          /**
-           * Gets a reference to the attribute `attr_name` of the `django.views.generic.dates` module.
-           * WARNING: Only holds for a few predefined attributes.
-           */
-          DataFlow::Node dates_attr(string attr_name) {
-            result = dates_attr(DataFlow::TypeTracker::end(), attr_name)
-          }
-        }
-
-        // -------------------------------------------------------------------------
-        // django.views.generic.detail
-        // -------------------------------------------------------------------------
-        /** Gets a reference to the `django.views.generic.detail` module. */
-        DataFlow::Node detail() { result = generic_attr("detail") }
-
-        /** Provides models for the `django.views.generic.detail` module */
-        module detail {
-          /**
-           * Gets a reference to the attribute `attr_name` of the `django.views.generic.detail` module.
-           * WARNING: Only holds for a few predefined attributes.
-           */
-          private DataFlow::Node detail_attr(DataFlow::TypeTracker t, string attr_name) {
-            attr_name in ["DetailView"] and
-            (
-              t.start() and
-              result = DataFlow::importNode("django.views.generic.detail" + "." + attr_name)
-              or
-              t.startInAttr(attr_name) and
-              result = detail()
-            )
+            moduleName = "detail" and
+            className = "DetailView"
             or
-            // Due to bad performance when using normal setup with `detail_attr(t2, attr_name).track(t2, t)`
-            // we have inlined that code and forced a join
-            exists(DataFlow::TypeTracker t2 |
-              exists(DataFlow::StepSummary summary |
-                detail_attr_first_join(t2, attr_name, result, summary) and
-                t = t2.append(summary)
-              )
-            )
-          }
-
-          pragma[nomagic]
-          private predicate detail_attr_first_join(
-            DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res,
-            DataFlow::StepSummary summary
-          ) {
-            DataFlow::StepSummary::step(detail_attr(t2, attr_name), res, summary)
-          }
-
-          /**
-           * Gets a reference to the attribute `attr_name` of the `django.views.generic.detail` module.
-           * WARNING: Only holds for a few predefined attributes.
-           */
-          DataFlow::Node detail_attr(string attr_name) {
-            result = detail_attr(DataFlow::TypeTracker::end(), attr_name)
-          }
-        }
-
-        // -------------------------------------------------------------------------
-        // django.views.generic.edit
-        // -------------------------------------------------------------------------
-        /** Gets a reference to the `django.views.generic.edit` module. */
-        DataFlow::Node edit() { result = generic_attr("edit") }
-
-        /** Provides models for the `django.views.generic.edit` module */
-        module edit {
-          /**
-           * Gets a reference to the attribute `attr_name` of the `django.views.generic.edit` module.
-           * WARNING: Only holds for a few predefined attributes.
-           */
-          private DataFlow::Node edit_attr(DataFlow::TypeTracker t, string attr_name) {
-            attr_name in ["CreateView", "DeleteView", "FormView", "UpdateView"] and
-            (
-              t.start() and
-              result = DataFlow::importNode("django.views.generic.edit" + "." + attr_name)
-              or
-              t.startInAttr(attr_name) and
-              result = edit()
-            )
+            moduleName = "edit" and
+            className in ["CreateView", "DeleteView", "FormView", "UpdateView"]
             or
-            // Due to bad performance when using normal setup with `edit_attr(t2, attr_name).track(t2, t)`
-            // we have inlined that code and forced a join
-            exists(DataFlow::TypeTracker t2 |
-              exists(DataFlow::StepSummary summary |
-                edit_attr_first_join(t2, attr_name, result, summary) and
-                t = t2.append(summary)
-              )
-            )
-          }
-
-          pragma[nomagic]
-          private predicate edit_attr_first_join(
-            DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res,
-            DataFlow::StepSummary summary
-          ) {
-            DataFlow::StepSummary::step(edit_attr(t2, attr_name), res, summary)
-          }
-
-          /**
-           * Gets a reference to the attribute `attr_name` of the `django.views.generic.edit` module.
-           * WARNING: Only holds for a few predefined attributes.
-           */
-          DataFlow::Node edit_attr(string attr_name) {
-            result = edit_attr(DataFlow::TypeTracker::end(), attr_name)
-          }
-        }
-
-        // -------------------------------------------------------------------------
-        // django.views.generic.list
-        // -------------------------------------------------------------------------
-        /** Gets a reference to the `django.views.generic.list` module. */
-        DataFlow::Node list() { result = generic_attr("list") }
-
-        /** Provides models for the `django.views.generic.list` module */
-        module list {
-          /**
-           * Gets a reference to the attribute `attr_name` of the `django.views.generic.list` module.
-           * WARNING: Only holds for a few predefined attributes.
-           */
-          private DataFlow::Node list_attr(DataFlow::TypeTracker t, string attr_name) {
-            attr_name in ["ListView"] and
-            (
-              t.start() and
-              result = DataFlow::importNode("django.views.generic.list" + "." + attr_name)
-              or
-              t.startInAttr(attr_name) and
-              result = list()
-            )
-            or
-            // Due to bad performance when using normal setup with `list_attr(t2, attr_name).track(t2, t)`
-            // we have inlined that code and forced a join
-            exists(DataFlow::TypeTracker t2 |
-              exists(DataFlow::StepSummary summary |
-                list_attr_first_join(t2, attr_name, result, summary) and
-                t = t2.append(summary)
-              )
-            )
-          }
-
-          pragma[nomagic]
-          private predicate list_attr_first_join(
-            DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res,
-            DataFlow::StepSummary summary
-          ) {
-            DataFlow::StepSummary::step(list_attr(t2, attr_name), res, summary)
-          }
-
-          /**
-           * Gets a reference to the attribute `attr_name` of the `django.views.generic.list` module.
-           * WARNING: Only holds for a few predefined attributes.
-           */
-          DataFlow::Node list_attr(string attr_name) {
-            result = list_attr(DataFlow::TypeTracker::end(), attr_name)
-          }
-        }
-
-        /**
-         * Provides models for the `django.views.generic.View` class and subclasses.
-         *
-         * See
-         *  - https://docs.djangoproject.com/en/3.1/topics/class-based-views/
-         *  - https://docs.djangoproject.com/en/3.1/ref/class-based-views/
-         */
-        module View {
-          /** Gets a reference to the `django.views.generic.View` class or any subclass. */
-          private DataFlow::Node subclassRef(DataFlow::TypeTracker t) {
-            t.start() and
-            result =
-              generic_attr([
-                  "View",
-                  // Known Views
-                  "TemplateView", "RedirectView", "ArchiveIndexView", "YearArchiveView",
-                  "MonthArchiveView", "WeekArchiveView", "DayArchiveView", "TodayArchiveView",
-                  "DateDetailView", "DetailView", "FormView", "CreateView", "UpdateView",
-                  "DeleteView", "ListView"
-                ])
-            or
-            // aliases
-            t.start() and
-            (
-              // django.views.View
-              result = views_attr("View")
-              or
-              // django.views.generic.base.*
-              result = base::base_attr(_)
-              or
-              // django.views.generic.dates.*
-              result = dates::dates_attr(_)
-              or
-              // django.views.generic.detail.*
-              result = detail::detail_attr(_)
-              or
-              // django.views.generic.edit.*
-              result = edit::edit_attr(_)
-              or
-              // django.views.generic.list.*
-              result = list::list_attr(_)
-            )
-            or
-            // subclasses in project code
-            result.asExpr().(ClassExpr).getABase() = subclassRef(t.continue()).asExpr()
-            or
-            exists(DataFlow::TypeTracker t2 | result = subclassRef(t2).track(t2, t))
-          }
-
-          /** Gets a reference to the `django.views.generic.View` class or any subclass. */
-          DataFlow::Node subclassRef() { result = subclassRef(DataFlow::TypeTracker::end()) }
+            moduleName = "list" and
+            className = "ListView"
+          )
+          or
+          // `django.views.View` alias
+          result = API::moduleImport("django").getMember("views").getMember("View").getASubclass*()
         }
       }
     }
@@ -2389,7 +2041,7 @@ private module Django {
    */
   class DjangoViewClassFromSuperClass extends DjangoViewClass {
     DjangoViewClassFromSuperClass() {
-      this.getABase() = django::views::generic::View::subclassRef().asExpr()
+      this.getABase() = django::views::View::subclassRef().getAUse().asExpr()
     }
   }
 

--- a/python/ql/src/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/semmle/python/frameworks/Django.qll
@@ -16,7 +16,284 @@ private import semmle.python.regex
  * Provides models for the `django` PyPI package.
  * See https://www.djangoproject.com/.
  */
-private module Django {
+module Django {
+  /** Provides models for the `django.views` module */
+  module Views {
+    /**
+     * Provides models for the `django.views.generic.View` class and subclasses.
+     *
+     * See
+     *  - https://docs.djangoproject.com/en/3.1/topics/class-based-views/
+     *  - https://docs.djangoproject.com/en/3.1/ref/class-based-views/
+     */
+    module View {
+      /**
+       * An `API::Node` for references to `django.views.generic.View` or any subclass
+       * that has explicitly been modeled in the CodeQL libraries.
+       */
+      abstract class ModeledSubclass extends API::Node {
+        override string toString() { result = this.(API::Node).toString() }
+      }
+
+      /** A Django view subclass in the `django` package. */
+      private class DjangoViewSubclassesInDjango extends ModeledSubclass {
+        DjangoViewSubclassesInDjango() {
+          exists(string moduleName, string className |
+            // canonical definition
+            this =
+              API::moduleImport("django")
+                  .getMember("views")
+                  .getMember("generic")
+                  .getMember(moduleName)
+                  .getMember(className)
+            or
+            // aliases from `django.views.generic`
+            this =
+              API::moduleImport("django")
+                  .getMember("views")
+                  .getMember("generic")
+                  .getMember(className)
+          |
+            moduleName = "base" and
+            className in ["RedirectView", "TemplateView", "View"]
+            or
+            moduleName = "dates" and
+            className in [
+                "ArchiveIndexView", "DateDetailView", "DayArchiveView", "MonthArchiveView",
+                "TodayArchiveView", "WeekArchiveView", "YearArchiveView"
+              ]
+            or
+            moduleName = "detail" and
+            className = "DetailView"
+            or
+            moduleName = "edit" and
+            className in ["CreateView", "DeleteView", "FormView", "UpdateView"]
+            or
+            moduleName = "list" and
+            className = "ListView"
+          )
+          or
+          // `django.views.View` alias
+          this = API::moduleImport("django").getMember("views").getMember("View")
+        }
+      }
+
+      /** Gets a reference to the `django.views.generic.View` class or any subclass. */
+      API::Node subclassRef() { result = any(ModeledSubclass subclass).getASubclass*() }
+    }
+  }
+
+  /** Provides models for django forms (defined in the `django.forms` module) */
+  module Forms {
+    /**
+     * Provides models for the `django.forms.forms.BaseForm` class and subclasses. This
+     * is usually used by the `django.forms.forms.Form` class, which is also available
+     * under the more commonly used alias `django.forms.Form`.
+     *
+     * See https://docs.djangoproject.com/en/3.1/ref/forms/api/
+     */
+    module Form {
+      /**
+       * An `API::Node` for references to `django.forms.forms.BaseForm` or any subclass
+       * that has explicitly been modeled in the CodeQL libraries.
+       */
+      abstract class ModeledSubclass extends API::Node {
+        override string toString() { result = this.(API::Node).toString() }
+      }
+
+      /** A Django form subclass in the `django` package. */
+      private class DjangoFormSubclassesInDjango extends ModeledSubclass {
+        DjangoFormSubclassesInDjango() {
+          // canonical definition
+          this =
+            API::moduleImport("django")
+                .getMember("forms")
+                .getMember("forms")
+                .getMember(["BaseForm", "Form"])
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("forms")
+                .getMember("models")
+                .getMember(["BaseModelForm", "ModelForm"])
+          or
+          // aliases from `django.forms`
+          this =
+            API::moduleImport("django")
+                .getMember("forms")
+                .getMember(["BaseForm", "Form", "BaseModelForm", "ModelForm"])
+          or
+          // other Form subclasses defined in Django
+          this =
+            API::moduleImport("django")
+                .getMember("contrib")
+                .getMember("admin")
+                .getMember("forms")
+                .getMember(["AdminAuthenticationForm", "AdminPasswordChangeForm"])
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("contrib")
+                .getMember("admin")
+                .getMember("helpers")
+                .getMember("ActionForm")
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("contrib")
+                .getMember("admin")
+                .getMember("views")
+                .getMember("main")
+                .getMember("ChangeListSearchForm")
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("contrib")
+                .getMember("auth")
+                .getMember("forms")
+                .getMember([
+                    "PasswordResetForm", "UserChangeForm", "SetPasswordForm",
+                    "AdminPasswordChangeForm", "PasswordChangeForm", "AuthenticationForm",
+                    "UserCreationForm"
+                  ])
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("contrib")
+                .getMember("flatpages")
+                .getMember("forms")
+                .getMember("FlatpageForm")
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("forms")
+                .getMember("formsets")
+                .getMember("ManagementForm")
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("forms")
+                .getMember("models")
+                .getMember(["ModelForm", "BaseModelForm"])
+        }
+      }
+
+      /** Gets a reference to the `django.forms.forms.BaseForm` class or any subclass. */
+      API::Node subclassRef() { result = any(ModeledSubclass subclass).getASubclass*() }
+    }
+
+    /**
+     * Provides models for the `django.forms.fields.Field` class and subclasses. This is
+     * also available under the more commonly used alias `django.forms.Field`.
+     *
+     * See https://docs.djangoproject.com/en/3.1/ref/forms/fields/
+     */
+    module Field {
+      /**
+       * An `API::Node` for references to `django.forms.fields.Field` or any subclass
+       * that has explicitly been modeled in the CodeQL libraries.
+       */
+      abstract class ModeledSubclass extends API::Node {
+        override string toString() { result = this.(API::Node).toString() }
+      }
+
+      /** A Django field subclass in the `django` package. */
+      private class DjangoFieldSubclassesInDjango extends ModeledSubclass {
+        DjangoFieldSubclassesInDjango() {
+          exists(string moduleName, string className |
+            // canonical definition
+            this =
+              API::moduleImport("django")
+                  .getMember("forms")
+                  .getMember(moduleName)
+                  .getMember(className)
+            or
+            // aliases from `django.forms`
+            this = API::moduleImport("django").getMember("forms").getMember(className)
+          |
+            moduleName = "fields" and
+            className in [
+                "Field",
+                // Known subclasses
+                "BooleanField", "IntegerField", "CharField", "SlugField", "DateTimeField",
+                "EmailField", "DateField", "TimeField", "DurationField", "DecimalField",
+                "FloatField", "GenericIPAddressField", "UUIDField", "JSONField", "FilePathField",
+                "NullBooleanField", "URLField", "TypedChoiceField", "FileField", "ImageField",
+                "RegexField", "ChoiceField", "MultipleChoiceField", "ComboField", "MultiValueField",
+                "SplitDateTimeField", "TypedMultipleChoiceField", "BaseTemporalField"
+              ]
+            or
+            // Known subclasses from `django.forms.models`
+            moduleName = "models" and
+            className in ["ModelChoiceField", "ModelMultipleChoiceField", "InlineForeignKeyField"]
+          )
+          or
+          // other Field subclasses defined in Django
+          this =
+            API::moduleImport("django")
+                .getMember("contrib")
+                .getMember("auth")
+                .getMember("forms")
+                .getMember(["ReadOnlyPasswordHashField", "UsernameField"])
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("contrib")
+                .getMember("gis")
+                .getMember("forms")
+                .getMember("fields")
+                .getMember([
+                    "GeometryCollectionField", "GeometryField", "LineStringField",
+                    "MultiLineStringField", "MultiPointField", "MultiPolygonField", "PointField",
+                    "PolygonField"
+                  ])
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("contrib")
+                .getMember("postgres")
+                .getMember("forms")
+                .getMember("array")
+                .getMember(["SimpleArrayField", "SplitArrayField"])
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("contrib")
+                .getMember("postgres")
+                .getMember("forms")
+                .getMember("hstore")
+                .getMember("HStoreField")
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("contrib")
+                .getMember("postgres")
+                .getMember("forms")
+                .getMember("ranges")
+                .getMember([
+                    "BaseRangeField", "DateRangeField", "DateTimeRangeField", "DecimalRangeField",
+                    "IntegerRangeField"
+                  ])
+          or
+          this =
+            API::moduleImport("django")
+                .getMember("forms")
+                .getMember("models")
+                .getMember(["InlineForeignKeyField", "ModelChoiceField", "ModelMultipleChoiceField"])
+        }
+      }
+
+      /** Gets a reference to the `django.forms.fields.Field` class or any subclass. */
+      API::Node subclassRef() { result = any(ModeledSubclass subclass).getASubclass*() }
+    }
+  }
+}
+
+/**
+ * Provides models for the `django` PyPI package (that we are not quite ready to publicly expose yet).
+ * See https://www.djangoproject.com/.
+ */
+private module PrivateDjango {
   // ---------------------------------------------------------------------------
   // django
   // ---------------------------------------------------------------------------
@@ -1511,71 +1788,6 @@ private module Django {
     }
 
     // -------------------------------------------------------------------------
-    // django.views
-    // -------------------------------------------------------------------------
-    /** Gets a reference to the `django.views` module. */
-    DataFlow::Node views() { result = django_attr("views") }
-
-    /** Provides models for the `django.views` module */
-    module views {
-      /**
-       * Provides models for the `django.views.generic.View` class and subclasses.
-       *
-       * See
-       *  - https://docs.djangoproject.com/en/3.1/topics/class-based-views/
-       *  - https://docs.djangoproject.com/en/3.1/ref/class-based-views/
-       */
-      module View {
-        /**
-         * Get a references to: the `django.views.generic.View` class, or any subclass
-         * that has explicitly been modeled in the CodeQL libraries.
-         */
-        API::Node modeledSubclassRef() {
-          exists(string moduleName, string className |
-            // canonical definition
-            result =
-              API::moduleImport("django")
-                  .getMember("views")
-                  .getMember("generic")
-                  .getMember(moduleName)
-                  .getMember(className)
-            or
-            // alias from `django.view.generic`
-            result =
-              API::moduleImport("django")
-                  .getMember("view")
-                  .getMember("generic")
-                  .getMember(className)
-          |
-            moduleName = "base" and
-            className in ["RedirectView", "TemplateView", "View"]
-            or
-            moduleName = "dates" and
-            className in [
-                "ArchiveIndexView", "DateDetailView", "DayArchiveView", "MonthArchiveView",
-                "TodayArchiveView", "WeekArchiveView", "YearArchiveView"
-              ]
-            or
-            moduleName = "detail" and
-            className = "DetailView"
-            or
-            moduleName = "edit" and
-            className in ["CreateView", "DeleteView", "FormView", "UpdateView"]
-            or
-            moduleName = "list" and
-            className = "ListView"
-          )
-          or
-          // `django.views.View` alias
-          result = API::moduleImport("django").getMember("views").getMember("View")
-        }
-
-        /** Gets a reference to the `django.views.generic.View` class or any subclass. */
-        API::Node subclassRef() { result = modeledSubclassRef().getASubclass*() }
-      }
-    }
-
-    // -------------------------------------------------------------------------
     // django.shortcuts
     // -------------------------------------------------------------------------
     /** Gets a reference to the `django.shortcuts` module. */
@@ -1629,197 +1841,6 @@ private module Django {
        * See https://docs.djangoproject.com/en/3.1/topics/http/shortcuts/#redirect
        */
       DataFlow::Node redirect() { result = shortcuts_attr("redirect") }
-    }
-  }
-
-  /** Provides models for django forms (defined in the `django.forms` module) */
-  module Forms {
-    /**
-     * Provides models for the `django.forms.forms.BaseForm` class and subclasses. This
-     * is usually used by the `django.forms.forms.Form` class, which is also available
-     * under the more commonly used alias `django.forms.Form`.
-     *
-     * See https://docs.djangoproject.com/en/3.1/ref/forms/api/
-     */
-    module Form {
-      /**
-       * Get a references to: the `django.forms.forms.BaseForm` class, or any subclass
-       * that has explicitly been modeled in the CodeQL libraries.
-       */
-      API::Node modeledSubclassRef() {
-        // canonical definition
-        result =
-          API::moduleImport("django")
-              .getMember("forms")
-              .getMember("forms")
-              .getMember(["BaseForm", "Form"])
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("forms")
-              .getMember("models")
-              .getMember(["BaseModelForm", "ModelForm"])
-        or
-        // aliases from `django.forms`
-        result =
-          API::moduleImport("django")
-              .getMember("forms")
-              .getMember(["BaseForm", "Form", "BaseModelForm", "ModelForm"])
-        or
-        // other Form subclasses defined in Django
-        result =
-          API::moduleImport("django")
-              .getMember("contrib")
-              .getMember("admin")
-              .getMember("forms")
-              .getMember(["AdminAuthenticationForm", "AdminPasswordChangeForm"])
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("contrib")
-              .getMember("admin")
-              .getMember("helpers")
-              .getMember("ActionForm")
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("contrib")
-              .getMember("admin")
-              .getMember("views")
-              .getMember("main")
-              .getMember("ChangeListSearchForm")
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("contrib")
-              .getMember("auth")
-              .getMember("forms")
-              .getMember([
-                  "PasswordResetForm", "UserChangeForm", "SetPasswordForm",
-                  "AdminPasswordChangeForm", "PasswordChangeForm", "AuthenticationForm",
-                  "UserCreationForm"
-                ])
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("contrib")
-              .getMember("flatpages")
-              .getMember("forms")
-              .getMember("FlatpageForm")
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("forms")
-              .getMember("formsets")
-              .getMember("ManagementForm")
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("forms")
-              .getMember("models")
-              .getMember(["ModelForm", "BaseModelForm"])
-      }
-
-      /** Gets a reference to the `django.forms.forms.BaseForm` class or any subclass. */
-      API::Node subclassRef() { result = modeledSubclassRef().getASubclass*() }
-    }
-
-    /**
-     * Provides models for the `django.forms.fields.Field` class and subclasses. This is
-     * also available under the more commonly used alias `django.forms.Field`.
-     *
-     * See https://docs.djangoproject.com/en/3.1/ref/forms/fields/
-     */
-    module Field {
-      /**
-       * Get a references to: the `django.forms.fields.Field` class, or any subclass
-       * that has explicitly been modeled in the CodeQL libraries.
-       */
-      API::Node modeledSubclassRef() {
-        exists(string moduleName, string className |
-          // canonical definition
-          result =
-            API::moduleImport("django")
-                .getMember("forms")
-                .getMember(moduleName)
-                .getMember(className)
-          or
-          // alias from `django.forms`
-          result = API::moduleImport("django").getMember("forms").getMember(className)
-        |
-          moduleName = "fields" and
-          className in [
-              "Field",
-              // Known subclasses
-              "BooleanField", "IntegerField", "CharField", "SlugField", "DateTimeField",
-              "EmailField", "DateField", "TimeField", "DurationField", "DecimalField", "FloatField",
-              "GenericIPAddressField", "UUIDField", "JSONField", "FilePathField",
-              "NullBooleanField", "URLField", "TypedChoiceField", "FileField", "ImageField",
-              "RegexField", "ChoiceField", "MultipleChoiceField", "ComboField", "MultiValueField",
-              "SplitDateTimeField", "TypedMultipleChoiceField", "BaseTemporalField"
-            ]
-          or
-          // Known subclasses from `django.forms.models`
-          moduleName = "models" and
-          className in ["ModelChoiceField", "ModelMultipleChoiceField", "InlineForeignKeyField"]
-        )
-        or
-        // other Field subclasses defined in Django
-        result =
-          API::moduleImport("django")
-              .getMember("contrib")
-              .getMember("auth")
-              .getMember("forms")
-              .getMember(["ReadOnlyPasswordHashField", "UsernameField"])
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("contrib")
-              .getMember("gis")
-              .getMember("forms")
-              .getMember("fields")
-              .getMember([
-                  "GeometryCollectionField", "GeometryField", "LineStringField",
-                  "MultiLineStringField", "MultiPointField", "MultiPolygonField", "PointField",
-                  "PolygonField"
-                ])
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("contrib")
-              .getMember("postgres")
-              .getMember("forms")
-              .getMember("array")
-              .getMember(["SimpleArrayField", "SplitArrayField"])
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("contrib")
-              .getMember("postgres")
-              .getMember("forms")
-              .getMember("hstore")
-              .getMember("HStoreField")
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("contrib")
-              .getMember("postgres")
-              .getMember("forms")
-              .getMember("ranges")
-              .getMember([
-                  "BaseRangeField", "DateRangeField", "DateTimeRangeField", "DecimalRangeField",
-                  "IntegerRangeField"
-                ])
-        or
-        result =
-          API::moduleImport("django")
-              .getMember("forms")
-              .getMember("models")
-              .getMember(["InlineForeignKeyField", "ModelChoiceField", "ModelMultipleChoiceField"])
-      }
-
-      /** Gets a reference to the `django.forms.fields.Field` class or any subclass. */
-      API::Node subclassRef() { result = modeledSubclassRef().getASubclass*() }
     }
   }
 
@@ -2039,7 +2060,7 @@ private module Django {
    */
   class DjangoViewClassFromSuperClass extends DjangoViewClass {
     DjangoViewClassFromSuperClass() {
-      this.getABase() = django::views::View::subclassRef().getAUse().asExpr()
+      this.getABase() = Django::Views::View::subclassRef().getAUse().asExpr()
     }
   }
 

--- a/python/ql/src/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/semmle/python/frameworks/Django.qll
@@ -11,6 +11,7 @@ private import semmle.python.Concepts
 private import semmle.python.ApiGraphs
 private import semmle.python.frameworks.PEP249
 private import semmle.python.regex
+private import semmle.python.frameworks.internal.AutomatedModeling
 
 /**
  * Provides models for the `django` PyPI package.
@@ -75,6 +76,8 @@ module Django {
           or
           // `django.views.View` alias
           this = API::moduleImport("django").getMember("views").getMember("View")
+          or
+          this = automatedModeledClass("Django::Views::View", _)
         }
       }
 
@@ -123,58 +126,7 @@ module Django {
                 .getMember("forms")
                 .getMember(["BaseForm", "Form", "BaseModelForm", "ModelForm"])
           or
-          // other Form subclasses defined in Django
-          this =
-            API::moduleImport("django")
-                .getMember("contrib")
-                .getMember("admin")
-                .getMember("forms")
-                .getMember(["AdminAuthenticationForm", "AdminPasswordChangeForm"])
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("contrib")
-                .getMember("admin")
-                .getMember("helpers")
-                .getMember("ActionForm")
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("contrib")
-                .getMember("admin")
-                .getMember("views")
-                .getMember("main")
-                .getMember("ChangeListSearchForm")
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("contrib")
-                .getMember("auth")
-                .getMember("forms")
-                .getMember([
-                    "PasswordResetForm", "UserChangeForm", "SetPasswordForm",
-                    "AdminPasswordChangeForm", "PasswordChangeForm", "AuthenticationForm",
-                    "UserCreationForm"
-                  ])
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("contrib")
-                .getMember("flatpages")
-                .getMember("forms")
-                .getMember("FlatpageForm")
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("forms")
-                .getMember("formsets")
-                .getMember("ManagementForm")
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("forms")
-                .getMember("models")
-                .getMember(["ModelForm", "BaseModelForm"])
+          this = automatedModeledClass("Django::Forms::Form", _)
         }
       }
 
@@ -228,58 +180,7 @@ module Django {
             className in ["ModelChoiceField", "ModelMultipleChoiceField", "InlineForeignKeyField"]
           )
           or
-          // other Field subclasses defined in Django
-          this =
-            API::moduleImport("django")
-                .getMember("contrib")
-                .getMember("auth")
-                .getMember("forms")
-                .getMember(["ReadOnlyPasswordHashField", "UsernameField"])
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("contrib")
-                .getMember("gis")
-                .getMember("forms")
-                .getMember("fields")
-                .getMember([
-                    "GeometryCollectionField", "GeometryField", "LineStringField",
-                    "MultiLineStringField", "MultiPointField", "MultiPolygonField", "PointField",
-                    "PolygonField"
-                  ])
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("contrib")
-                .getMember("postgres")
-                .getMember("forms")
-                .getMember("array")
-                .getMember(["SimpleArrayField", "SplitArrayField"])
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("contrib")
-                .getMember("postgres")
-                .getMember("forms")
-                .getMember("hstore")
-                .getMember("HStoreField")
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("contrib")
-                .getMember("postgres")
-                .getMember("forms")
-                .getMember("ranges")
-                .getMember([
-                    "BaseRangeField", "DateRangeField", "DateTimeRangeField", "DecimalRangeField",
-                    "IntegerRangeField"
-                  ])
-          or
-          this =
-            API::moduleImport("django")
-                .getMember("forms")
-                .getMember("models")
-                .getMember(["InlineForeignKeyField", "ModelChoiceField", "ModelMultipleChoiceField"])
+          this = automatedModeledClass("Django::Forms::Field", _)
         }
       }
 

--- a/python/ql/src/semmle/python/frameworks/internal/AutomatedModeling.qll
+++ b/python/ql/src/semmle/python/frameworks/internal/AutomatedModeling.qll
@@ -1,0 +1,1901 @@
+/**
+ * INTERNAL: Do not use.
+ *
+ * Provides results from semi-automated modeling of PyPI packages.
+ */
+
+// Instructions:
+// This needs to be automated better, but for this prototype, here are some rough instructions:
+// 1) run `FindNewModels.ql` against a new CodeQL DB
+// 2) do some magic formatting commands yourself
+// 3) paste the data into the `automatedModeledClassData` predicate
+private import python
+private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.ApiGraphs
+private import semmle.python.frameworks.Django
+
+bindingset[fullyQaulified]
+string fullyQualifiedToAPIGraphPath(string fullyQaulified) {
+  result = "moduleImport(\"" + fullyQaulified.replaceAll(".", "\").getMember(\"") + "\")"
+}
+
+API::Node automatedModeledClass(string spec, string qualifier) {
+  automatedModeledClassData(spec, qualifier) and
+  result.getPath() = fullyQualifiedToAPIGraphPath(qualifier)
+}
+
+// -- Specs --
+bindingset[this]
+abstract class FindSubclassesSpec extends string {
+  abstract API::Node getAlreadyModeledClass();
+}
+
+class DjangoViewSubclass extends FindSubclassesSpec {
+  DjangoViewSubclass() { this = "Django::Views::View" }
+
+  override API::Node getAlreadyModeledClass() {
+    result = any(Django::Views::View::ModeledSubclass subclass)
+  }
+}
+
+class DjangoFormSubclass extends FindSubclassesSpec {
+  DjangoFormSubclass() { this = "Django::Forms::Form" }
+
+  override API::Node getAlreadyModeledClass() {
+    result = any(Django::Forms::Form::ModeledSubclass subclass)
+  }
+}
+
+class DjangoFieldSubclass extends FindSubclassesSpec {
+  DjangoFieldSubclass() { this = "Django::Forms::Field" }
+
+  override API::Node getAlreadyModeledClass() {
+    result = any(Django::Forms::Field::ModeledSubclass subclass)
+  }
+}
+
+// -- actual data -- (this should live in a CSV file in the future) -- probably one _per_ PyPI package / project
+predicate automatedModeledClassData(string spec, string qualifier) {
+  // from `django` PyPI package analyzed on 2021-03-29
+  (
+    spec = "Django::Forms::Form" and
+    qualifier = "django.contrib.admin.views.main.ChangeListSearchForm"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.admindocs.views.BaseAdminDocsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "django.contrib.admin.views.autocomplete.AutocompleteJsonView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.dates.BaseDateListView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.dates.BaseArchiveIndexView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.dates.BaseYearArchiveView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.dates.BaseMonthArchiveView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.dates.BaseWeekArchiveView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.dates.BaseDayArchiveView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.dates.BaseTodayArchiveView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.dates.BaseDateDetailView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.detail.BaseDetailView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.edit.ProcessFormView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.edit.BaseFormView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.edit.BaseCreateView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.edit.BaseUpdateView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.edit.BaseDeleteView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.i18n.JavaScriptCatalog"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.i18n.JSONCatalog"
+    or
+    spec = "Django::Views::View" and qualifier = "django.views.generic.list.BaseListView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.auth.views.LoginView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.auth.views.LogoutView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.auth.views.PasswordResetView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.auth.views.PasswordResetDoneView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "django.contrib.auth.views.PasswordResetConfirmView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "django.contrib.auth.views.PasswordResetCompleteView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.auth.views.PasswordChangeView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.auth.views.PasswordChangeDoneView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.admindocs.views.BookmarkletsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "django.contrib.admindocs.views.TemplateTagIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "django.contrib.admindocs.views.TemplateFilterIndexView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.admindocs.views.ViewIndexView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.admindocs.views.ViewDetailView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.admindocs.views.ModelIndexView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.admindocs.views.ModelDetailView"
+    or
+    spec = "Django::Views::View" and qualifier = "django.contrib.admindocs.views.TemplateDetailView"
+    or
+    spec = "Django::Forms::Field" and
+    qualifier = "django.contrib.postgres.forms.array.SimpleArrayField"
+    or
+    spec = "Django::Forms::Field" and
+    qualifier = "django.contrib.postgres.forms.array.SplitArrayField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "django.contrib.gis.forms.fields.GeometryField"
+    or
+    spec = "Django::Forms::Field" and
+    qualifier = "django.contrib.gis.forms.fields.GeometryCollectionField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "django.contrib.gis.forms.fields.PointField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "django.contrib.gis.forms.fields.MultiPointField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "django.contrib.gis.forms.fields.LineStringField"
+    or
+    spec = "Django::Forms::Field" and
+    qualifier = "django.contrib.gis.forms.fields.MultiLineStringField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "django.contrib.gis.forms.fields.PolygonField"
+    or
+    spec = "Django::Forms::Field" and
+    qualifier = "django.contrib.gis.forms.fields.MultiPolygonField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "django.contrib.auth.forms.UsernameField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "django.contrib.postgres.forms.hstore.HStoreField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "django.forms.models.InlineForeignKeyField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "django.forms.models.ModelChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "django.forms.models.ModelMultipleChoiceField"
+    or
+    spec = "Django::Forms::Field" and
+    qualifier = "django.contrib.postgres.forms.ranges.BaseRangeField"
+    or
+    spec = "Django::Forms::Field" and
+    qualifier = "django.contrib.postgres.forms.ranges.IntegerRangeField"
+    or
+    spec = "Django::Forms::Field" and
+    qualifier = "django.contrib.postgres.forms.ranges.DecimalRangeField"
+    or
+    spec = "Django::Forms::Field" and
+    qualifier = "django.contrib.postgres.forms.ranges.DateRangeField"
+  )
+  or
+  // from `horizon` PyPI package analyzed on 2021-03-29
+  // see https://github.com/openstack/horizon/blob/master/setup.cfg#L32-L34
+  (
+    spec = "Django::Forms::Form" and qualifier = "horizon.workflows.base.Action"
+    or
+    spec = "Django::Forms::Form" and qualifier = "horizon.workflows.base.MembershipAction"
+    or
+    spec = "Django::Forms::Form" and qualifier = "horizon.forms.base.SelfHandlingForm"
+    or
+    spec = "Django::Forms::Form" and qualifier = "horizon.forms.base.DateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.instances.workflows.create_instance.SelectProjectUserAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.instances.workflows.create_instance.SetInstanceDetailsAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.instances.workflows.create_instance.SetAccessControlsAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.instances.workflows.create_instance.CustomizeAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.instances.workflows.create_instance.SetNetworkAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.instances.workflows.create_instance.SetNetworkPortsAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.instances.workflows.create_instance.SetAdvancedAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.floating_ips.forms.FloatingIpAllocate"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.api_access.forms.RecreateCredentials"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.images.images.forms.CreateParent"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.images.images.forms.CreateImageForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.groups.forms.CreateGroupForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.groups.forms.UpdateGroupForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.forms.PasswordMixin"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.forms.BaseUserForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.forms.CreateUserForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.images.images.forms.UpdateImageForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.forms.UpdateUserForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.forms.ChangePasswordForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.security_groups.forms.GroupBase"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.security_groups.forms.CreateGroup"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.security_groups.forms.UpdateGroup"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.security_groups.forms.AddRule"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_groups.forms.RemoveVolsForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_groups.forms.DeleteForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.snapshots.forms.UpdateStatus"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.forms.CreateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.identity.application_credentials.forms.CreateApplicationCredentialForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.forms.UpdateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.identity.application_credentials.forms.CreateSuccessfulForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.forms.CreateVolumeType"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.forms.CreateQosSpec"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.forms.CreateVolumeTypeEncryption"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.forms.UpdateVolumeTypeEncryption"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.forms.ManageQosSpecAssociation"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.forms.EditQosSpecConsumer"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.forms.EditVolumeType"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.forms.EditTypeAccessForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.roles.forms.CreateRoleForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.aggregates.forms.UpdateAggregateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.roles.forms.UpdateRoleForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.group_types.specs.forms.CreateSpec"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.group_types.forms.CreateGroupType"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.group_types.specs.forms.EditSpec"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.group_types.forms.EditGroupType"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.networks.ports.extensions.allowed_address_pairs.forms.AddAllowedAddressPairForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.extras.forms.CreateExtraSpec"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.metadata_defs.forms.CreateNamespaceForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.extras.forms.EditExtraSpec"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.metadata_defs.forms.ManageResourceTypesForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.metadata_defs.forms.UpdateNamespaceForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.forms.RebuildInstanceForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.forms.DecryptPasswordInstanceForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.forms.AttachVolume"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.identity.identity_providers.protocols.forms.AddProtocolForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.forms.DetachVolume"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.forms.AttachInterface"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.forms.DetachInterface"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.hypervisors.compute.forms.EvacuateHostForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.forms.Disassociate"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.hypervisors.compute.forms.DisableServiceForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.hypervisors.compute.forms.MigrateHostForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.forms.RescueInstanceForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.backups.forms.UpdateStatus"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.backups.forms.AdminRestoreBackupForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.agents.forms.AddDHCPAgent"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.backups.forms.CreateBackupForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.backups.forms.RestoreBackupForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.forms.NTCreateRouterForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.forms.CreateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.routers.forms.CreateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.routers.forms.UpdateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.mappings.forms.CreateMappingForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.mappings.forms.UpdateMappingForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.identity_providers.forms.RegisterIdPForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.identity_providers.forms.UpdateIdPForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.forms.AttachForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.forms.CreateSnapshotForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.forms.UpdateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.forms.RemoveVolsForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.forms.CreateTransferForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.forms.DeleteForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.forms.AcceptTransferForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.forms.CreateSnapshotForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.forms.ShowTransferForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.forms.UpdateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.forms.CloneGroupForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.forms.UploadToImageForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.forms.ExtendForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.forms.RetypeForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.key_pairs.forms.ImportKeypair"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.settings.user.forms.UserSettingsForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.settings.password.forms.PasswordForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.floating_ips.forms.AdminFloatingIpAllocate"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.instances.forms.LiveMigrateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.instances.forms.RescueInstanceForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.rbac_policies.forms.CreatePolicyForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.rbac_policies.forms.UpdatePolicyForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.forms.CreateNetwork"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.snapshots.forms.UpdateForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.forms.UpdateNetwork"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.forms.UpdateNetwork"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.vg_snapshots.forms.CreateGroupForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.networks.ports.extensions.allowed_address_pairs.forms.AddAllowedAddressPairForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.images.forms.AdminCreateImageForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.images.forms.AdminUpdateImageForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volumes.forms.ManageVolume"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volumes.forms.UnmanageVolume"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volumes.forms.MigrateVolume"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volumes.forms.UpdateStatus"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.images.snapshots.forms.CreateSnapshot"
+    or
+    spec = "Django::Forms::Form" and qualifier = "openstack_auth.forms.Login"
+    or
+    spec = "Django::Forms::Form" and qualifier = "openstack_auth.forms.Password"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.routers.extensions.extraroutes.forms.AddRouterRoute"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.volume_types.qos_specs.forms.CreateKeyValuePair"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.qos_specs.forms.EditKeyValuePair"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.ports.forms.AddInterface"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.ports.forms.SetGatewayForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.api.rest.glance.UploadObjectForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.instances.workflows.resize_instance.SetFlavorChoiceAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.networks.ports.sg_base.BaseSecurityGroupsAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.api.rest.swift.UploadObjectForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "horizon.test.unit.forms.test_fields.ChoiceFieldForm"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "horizon.test.unit.forms.test_fields.ThemableChoiceFieldForm"
+    or
+    spec = "Django::Forms::Form" and qualifier = "horizon.test.unit.forms.test_forms.FormForTesting"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "horizon.test.unit.workflows.test_workflows.ActionOne"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "horizon.test.unit.workflows.test_workflows.ActionTwo"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "horizon.test.unit.workflows.test_workflows.ActionThree"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "horizon.test.unit.workflows.test_workflows.ActionFour"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "horizon.test.unit.workflows.test_workflows.AdminAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "horizon.test.unit.workflows.test_workflows.DisabledAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "horizon.test.unit.workflows.test_workflows.AdminForbiddenAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.instances.workflows.update_instance.UpdateInstanceSecurityGroupsAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.instances.workflows.update_instance.UpdateInstanceInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.defaults.workflows.UpdateDefaultComputeQuotasAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.defaults.workflows.UpdateDefaultVolumeQuotasAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.ports.workflows.CreatePortInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.ports.workflows.UpdatePortInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.networks.ports.workflows.CreatePortSecurityGroupAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.networks.ports.workflows.CreatePortInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.domains.workflows.CreateDomainInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.domains.workflows.UpdateDomainUsersAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.networks.ports.workflows.UpdatePortInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.domains.workflows.UpdateDomainGroupsAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.networks.ports.workflows.UpdatePortSecurityGroupAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.domains.workflows.UpdateDomainInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.networks.subnets.workflows.CreateSubnetInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.networks.subnets.workflows.UpdateSubnetInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.networks.subnets.workflows.UpdateSubnetDetailAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.workflows.CreateNetworkInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.workflows.CreateSubnetInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.workflows.CreateSubnetDetailAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.workflows.AddGroupInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.volume_groups.workflows.AddVolumeTypesToGroupAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.volume_groups.workflows.AddVolumesToGroupAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.project.floating_ips.workflows.AssociateIPAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.workflows.CommonQuotaAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.aggregates.workflows.SetAggregateInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.aggregates.workflows.AddHostsToAggregateAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.workflows.ComputeQuotaAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.workflows.VolumeQuotaAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.aggregates.workflows.ManageAggregateHostsAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.workflows.NetworkQuotaAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.workflows.CreateProjectInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.identity.projects.workflows.UpdateProjectMembersAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.identity.projects.workflows.UpdateProjectGroupsAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.workflows.UpdateProjectInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.workflows.CreateNetworkInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.flavors.workflows.CreateFlavorInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier = "openstack_dashboard.dashboards.admin.flavors.workflows.FlavorAccessAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.networks.subnets.workflows.CreateSubnetInfoAction"
+    or
+    spec = "Django::Forms::Form" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.networks.subnets.workflows.UpdateSubnetInfoAction"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.test.test_panels.plugin_panel.views.TestBannerView"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.cinder.Volumes"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.cinder.Volume"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.cinder.VolumeTypes"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.cinder.VolumeMetadata"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.cinder.VolumeType"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.cinder.VolumeSnapshots"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.cinder.VolumeSnapshotMetadata"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.cinder.VolumeTypeMetadata"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.cinder.Extensions"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.cinder.QoSSpecs"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.cinder.TenantAbsoluteLimits"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.cinder.Services"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.cinder.DefaultQuotaSets"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.cinder.QuotaSets"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.cinder.AvailabilityZones"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.config.Settings"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.config.Timezones"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.glance.Version"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.glance.Image"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.glance.ImageProperties"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.glance.Images"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.glance.MetadefsNamespaces"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.glance.MetadefsResourceTypesList"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Version"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Users"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.User"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Roles"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Role"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.keystone.DefaultDomain"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Domains"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Domain"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Projects"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Project"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.ProjectRole"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.keystone.ServiceCatalog"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.UserSession"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Services"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Groups"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.keystone.Group"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.network.SecurityGroups"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.network.FloatingIP"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.network.FloatingIPs"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.network.FloatingIPPools"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.neutron.Networks"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.neutron.Subnets"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.neutron.Ports"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.neutron.Trunk"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.neutron.Trunks"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.neutron.Services"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.neutron.Extensions"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.neutron.DefaultQuotaSets"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.neutron.QuotasSets"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.neutron.QoSPolicies"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.neutron.QoSPolicy"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Snapshots"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Features"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Keypairs"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Keypair"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Services"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.nova.AvailabilityZones"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Limits"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.ServerActions"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.SecurityGroups"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Volumes"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.nova.RemoteConsoleInfo"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.ConsoleOutput"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Servers"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Server"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.ServerGroups"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.ServerGroup"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.ServerMetadata"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Flavors"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.Flavor"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.nova.FlavorExtraSpecs"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.nova.AggregateExtraSpecs"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.nova.DefaultQuotaSets"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.api.rest.nova.EditableQuotaSets"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.nova.QuotaSets"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.policy.Policy"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.swift.Info"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.swift.Policies"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.swift.Containers"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.swift.Container"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.swift.Objects"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.swift.Object"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.swift.ObjectMetadata"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.api.rest.swift.ObjectCopy"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.test.unit.tabs.test_tabs.TabWithTableView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.unit.tables.test_tables.SingleTableView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.unit.tables.test_tables.APIFilterTableView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.unit.tables.test_tables.SingleTableViewWithPermissions"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.unit.tables.test_tables.MultiTableView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.test.unit.test_views.PageWithNoTitle"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.test.unit.test_views.PageWithTitle"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.test.unit.test_views.PageWithTitleData"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.test.unit.test_views.FormWithTitle"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.test.unit.test_views.ViewWithTitle"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.test.unit.test_views.ViewWithTransTitle"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.unit.workflows.test_workflows.WorkflowViewForTesting"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.unit.workflows.test_workflows.FullscreenWorkflowView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.images.images.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.images.images.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.images.images.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.NTAddInterfaceView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.NTCreateRouterView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.NTCreateNetworkView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.NTLaunchInstanceView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.NTCreateSubnetView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.InstanceView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.RouterView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.NetworkView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.RouterDetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.NetworkDetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.NetworkTopologyView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.JSONView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.containers.views.NgIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volumes.views.VolumesView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volumes.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volumes.views.ManageVolumeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volumes.views.UnmanageVolumeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volumes.views.MigrateVolumeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volumes.views.UpdateStatusView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.rbac_policies.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.rbac_policies.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.rbac_policies.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.rbac_policies.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.identity_providers.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.identity_providers.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.identity_providers.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.identity_providers.views.RegisterView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.snapshots.views.SnapshotsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.snapshots.views.UpdateStatusView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.snapshots.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.routers.ports.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.backups.views.BackupsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.backups.views.CreateBackupView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.backups.views.BackupDetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.backups.views.RestoreBackupView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.views.ProjectUsageView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.views.CreateProjectView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.views.UpdateProjectView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.views.UpdateQuotasView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.projects.views.DetailProjectView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.contrib.developer.theme_preview.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.VolumesView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.ExtendView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.CreateSnapshotView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.UploadToImageView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.CreateTransferView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.AcceptTransferView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.ShowTransferView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.EditAttachmentsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.RetypeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.EncryptionDetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volumes.views.DownloadTransferCreds"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.test.test_panels.another_panel.views.IndexView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.tables.views.MultiTableView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.tables.views.DataTableView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.tables.views.MixedDataTableView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_groups.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_groups.views.RemoveVolumesView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_groups.views.DeleteView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_groups.views.ManageView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_groups.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.flavors.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.flavors.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.flavors.views.UpdateView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.conf.panel_template.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.test.test_panels.second_panel.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.roles.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.roles.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.roles.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.floating_ips.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.floating_ips.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.floating_ips.views.AllocateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.qos_specs.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.volume_types.qos_specs.views.CreateKeyValuePairView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.volume_types.qos_specs.views.EditKeyValuePairView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.routers.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.routers.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.routers.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.routers.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.routers.views.L3AgentView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.test_dashboards.cats.tigers.views.IndexView"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.views.ExtensibleHeaderView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.security_groups.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.security_groups.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.security_groups.views.AddRuleView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.security_groups.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.security_groups.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.overview.views.GlobalOverview"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.api_access.views.CredentialsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.api_access.views.RecreateCredentialsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.api_access.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.hypervisors.compute.views.EvacuateHostView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.hypervisors.compute.views.DisableServiceView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.hypervisors.compute.views.MigrateHostView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.aggregates.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.aggregates.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.aggregates.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.aggregates.views.ManageHostsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.identity.identity_providers.protocols.views.AddProtocolView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.networks.ports.extensions.allowed_address_pairs.views.AddAllowedAddressPair"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.mappings.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.mappings.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.mappings.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.key_pairs.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.key_pairs.views.ImportView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.key_pairs.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.images.snapshots.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.group_types.views.GroupTypesView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.group_types.views.CreateGroupTypeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.group_types.views.EditGroupTypeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.test.test_panels.plugin_panel.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.settings.user.views.UserSettingsView"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.usage.views.UsageView"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.usage.views.ProjectUsageView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.views.VolumeTypesView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.views.CreateVolumeTypeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.volume_types.views.VolumeTypeEncryptionDetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.volume_types.views.CreateVolumeTypeEncryptionView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.views.EditVolumeTypeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.volume_types.views.UpdateVolumeTypeEncryptionView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.views.CreateQosSpecView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.views.EditQosSpecConsumerView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.volume_types.views.ManageQosSpecAssociationView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.views.EditAccessView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.application_credentials.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.application_credentials.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.identity.application_credentials.views.CreateSuccessfulView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.application_credentials.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.contrib.developer.profiler.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.contrib.developer.profiler.views.Traces"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.contrib.developer.profiler.views.Trace"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.test_dashboards.cats.kittens.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.views.RemoveVolumesView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.views.DeleteView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.views.ManageView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.views.CreateSnapshotView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.views.CloneGroupView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.volume_groups.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.backups.views.AdminBackupsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.backups.views.UpdateStatusView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.backups.views.AdminBackupDetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.backups.views.AdminRestoreBackupView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.images.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.test.test_panels.nonloading_panel.views.IndexView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.views.HorizonTemplateView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.views.HorizonFormView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.views.APIView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.images.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.images.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.images.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.group_types.specs.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.group_types.specs.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.group_types.specs.views.EditView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.domains.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.hypervisors.views.AdminIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.hypervisors.views.AdminDetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.domains.views.CreateDomainView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.domains.views.UpdateDomainView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.contrib.developer.form_builder.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.test_dashboards.dogs.puppies.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.test_dashboards.dogs.puppies.views.TwoTabsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.agents.views.AddView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.views.ChangePasswordView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.snapshots.views.SnapshotsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.snapshots.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.snapshots.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.overview.views.ProjectOverview"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.overview.views.WarningView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.project.routers.extensions.extraroutes.views.AddRouterRouteView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.vg_snapshots.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.vg_snapshots.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.vg_snapshots.views.CreateGroupView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.floating_ips.views.AssociateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.floating_ips.views.AllocateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.floating_ips.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.ngflavors.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier =
+      "openstack_dashboard.dashboards.admin.networks.ports.extensions.allowed_address_pairs.views.AddAllowedAddressPair"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.groups.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.groups.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.groups.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.groups.views.ManageMembersView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.groups.views.NonMembersView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.extras.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.extras.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.LaunchInstanceView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.volume_types.extras.views.EditView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.SerialConsoleView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.ports.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.ports.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.RebuildView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.DecryptPasswordView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.ports.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.DisassociateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.ResizeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.AttachInterfaceView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.info.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.AttachVolumeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.settings.password.views.PasswordView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.DetachVolumeView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.defaults.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.defaults.views.UpdateDefaultQuotasView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.DetachInterfaceView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.UpdatePortView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.vg_snapshots.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.instances.views.RescueView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.vg_snapshots.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.ports.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.ports.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.ports.views.UpdateView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.tabs.views.TabView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.tabs.views.TabbedTableView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.ports.views.AddInterfaceView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.ports.views.SetGatewayView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.routers.ports.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.subnets.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.subnets.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.subnets.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.subnets.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.subnets.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.networks.subnets.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.instances.views.AdminUpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.instances.views.AdminIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.instances.views.LiveMigrateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.instances.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.instances.views.RescueView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.workflows.views.WorkflowView"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_auth.views.PasswordView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.images.views.IndexView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.browsers.views.ResourceBrowserView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.browsers.views.AngularIndexView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.browsers.views.AngularDetailsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.metadata_defs.views.AdminIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.metadata_defs.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.metadata_defs.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.metadata_defs.views.DetailView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.metadata_defs.views.ManageResourceTypes"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.forms.views.ModalFormView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.views.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.views.CreateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.views.UpdateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.networks.views.DetailView"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.fields.IPField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.fields.MultiIPField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.fields.MACAddressField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.fields.ThemableChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.fields.DynamicChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.fields.ThemableDynamicChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.fields.DynamicTypedChoiceField"
+    or
+    spec = "Django::Forms::Field" and
+    qualifier = "horizon.forms.fields.ThemableDynamicTypedChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.fields.ExternalFileField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.DynamicChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.DynamicTypedChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.ExternalFileField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.IPField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.MACAddressField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.MultiIPField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.ThemableChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.ThemableDynamicChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.ThemableDynamicTypedChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.Field"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.FileField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.BooleanField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.IntegerField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.ChoiceField"
+    or
+    spec = "Django::Forms::Field" and qualifier = "horizon.forms.CharField"
+    or
+    spec = "Django::Forms::Form" and qualifier = "horizon.workflows.Action"
+    or
+    spec = "Django::Forms::Form" and qualifier = "horizon.workflows.MembershipAction"
+    or
+    spec = "Django::Forms::Form" and qualifier = "horizon.forms.DateForm"
+    or
+    spec = "Django::Forms::Form" and qualifier = "horizon.forms.SelfHandlingForm"
+    or
+    spec = "Django::Forms::Form" and qualifier = "openstack_auth.views.Login"
+    or
+    spec = "Django::Forms::Form" and qualifier = "horizon.forms.BaseForm"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.workflows.WorkflowView"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.usage.ProjectUsageView"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.usage.UsageView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.tabs.TabbedTableView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.tabs.TabView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.forms.ModalFormView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.browsers.ResourceBrowserView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.tables.DataTableView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.tables.MixedDataTableView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.tables.MultiTableView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.site_urls.TemplateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.contrib.developer.resource_browser.urls.AngularIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.images.images.urls.AngularIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.users.urls.AngularIndexView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.test.urls.TemplateView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.images.urls.AngularIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.test_dashboards.dogs.puppies.urls.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.test_dashboards.dogs.puppies.urls.TwoTabsView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.trunks.urls.AngularIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.test_dashboards.cats.tigers.urls.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.groups.urls.AngularIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.images.urls.AngularIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.trunks.urls.AngularIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "horizon.test.test_dashboards.cats.kittens.urls.IndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.admin.flavors.urls.AngularIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.identity.roles.urls.AngularIndexView"
+    or
+    spec = "Django::Views::View" and
+    qualifier = "openstack_dashboard.dashboards.project.network_topology.views.View"
+    or
+    spec = "Django::Views::View" and qualifier = "openstack_dashboard.views.TemplateView"
+    or
+    spec = "Django::Views::View" and qualifier = "horizon.browsers.views.MultiTableView"
+  )
+}

--- a/python/ql/src/semmle/python/frameworks/internal/FindNewModels.ql
+++ b/python/ql/src/semmle/python/frameworks/internal/FindNewModels.ql
@@ -1,0 +1,147 @@
+import python
+private import semmle.python.ApiGraphs
+private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.filters.Tests
+private import semmle.python.frameworks.Django
+private import semmle.python.frameworks.internal.AutomatedModeling
+
+API::Node newOrExistingModeling(FindSubclassesSpec spec) {
+  result = spec.getAlreadyModeledClass()
+  or
+  exists(string newSubclassName |
+    newModel(spec, newSubclassName, _, _, _) and
+    result.getPath() = fullyQualifiedToAPIGraphPath(newSubclassName)
+  )
+}
+
+bindingset[fullyQualifiedName]
+predicate alreadyModeled(FindSubclassesSpec spec, string fullyQualifiedName) {
+  fullyQualifiedToAPIGraphPath(fullyQualifiedName) = spec.getAlreadyModeledClass().getPath()
+  or
+  automatedModeledClassData(spec.(string), fullyQualifiedName)
+}
+
+predicate isNonTestProjectCode(AstNode ast) {
+  not ast.getScope*() instanceof TestScope and
+  not ast.getLocation().getFile().getRelativePath().matches("tests/%") and
+  exists(ast.getLocation().getFile().getRelativePath())
+}
+
+predicate hasAllStatement(Module mod) {
+  exists(AssignStmt a, GlobalVariable all |
+    a.defines(all) and
+    a.getScope() = mod and
+    all.getId() = "__all__"
+  )
+}
+
+/**
+ * Holds if `newAliasFullyQualified` describes new alias originating from the import
+ * `from <module> import <member> [as <new-name>]`, where `<module>.<member>` belongs to
+ * `spec`.
+ * So if this import happened in module `foo.bar`, `newAliasFullyQualified` would be
+ * `foo.bar.<member>` (or `foo.bar.<new-name>`).
+ *
+ * Note that this predicate currently respects `__all__` in sort of a backwards fashion.
+ * - if `__all__` is defined in module `foo.bar`, we only allow new aliases where the member name is also in `__all__`. (this doesn't map 100% to the semantics of imports though)
+ * - If `__all__` is not defined we don't impose any limitations.
+ *
+ * Also note that we don't currently consider deleting module-attributes at all, so in the code snippet below, we would consider that `my_module.foo` is a
+ * reference to `django.foo`, although `my_module.foo` isn't even available at runtime. (there currently also isn't any code to discover that `my_module.bar`
+ * is an alias to `django.foo`)
+ * ```py
+ * # module my_module
+ * from django import foo
+ * bar = foo
+ * del foo
+ * ```
+ */
+predicate newDirectAlias(
+  FindSubclassesSpec spec, string newAliasFullyQualified, ImportMember importMember, Module mod,
+  Location loc
+) {
+  importMember = newOrExistingModeling(spec).getAUse().asExpr() and
+  importMember.getScope() = mod and
+  loc = importMember.getLocation() and
+  (
+    mod.isPackageInit() and
+    newAliasFullyQualified = mod.getPackageName() + "." + importMember.getName()
+    or
+    not mod.isPackageInit() and
+    newAliasFullyQualified = mod.getName() + "." + importMember.getName()
+  ) and
+  (
+    not hasAllStatement(mod)
+    or
+    mod.declaredInAll(importMember.getName())
+  ) and
+  not alreadyModeled(spec, newAliasFullyQualified) and
+  isNonTestProjectCode(importMember)
+}
+
+/** same as `newDirectAlias` predicate, but handling `from <module> import *`, considering all `<member>`, where `<module>.<member>` belongs to `spec`. */
+predicate newImportStar(
+  FindSubclassesSpec spec, string newAliasFullyQualified, ImportStar importStar, Module mod,
+  API::Node relevantClass, string relevantName, Location loc
+) {
+  relevantClass = newOrExistingModeling(spec) and
+  loc = importStar.getLocation() and
+  importStar.getScope() = mod and
+  // WHAT A HACK :D :D
+  relevantClass.getPath() =
+    relevantClass.getAPredecessor().getPath() + ".getMember(\"" + relevantName + "\")" and
+  relevantClass.getAPredecessor().getAUse().asExpr() = importStar.getModule() and
+  (
+    mod.isPackageInit() and
+    newAliasFullyQualified = mod.getPackageName() + "." + relevantName
+    or
+    not mod.isPackageInit() and
+    newAliasFullyQualified = mod.getName() + "." + relevantName
+  ) and
+  (
+    not hasAllStatement(mod)
+    or
+    mod.declaredInAll(relevantName)
+  ) and
+  not alreadyModeled(spec, newAliasFullyQualified) and
+  isNonTestProjectCode(importStar)
+}
+
+/** Holds if `classExpr` defines a new subclass that belongs to `spec`, which has the fully qualified name `newSubclassQualified`. */
+predicate newSubclass(
+  FindSubclassesSpec spec, string newSubclassQualified, ClassExpr classExpr, Module mod,
+  Location loc
+) {
+  classExpr = newOrExistingModeling(spec).getASubclass*().getAUse().asExpr() and
+  classExpr.getScope() = mod and
+  newSubclassQualified = mod.getName() + "." + classExpr.getName() and
+  loc = classExpr.getLocation() and
+  not alreadyModeled(spec, newSubclassQualified) and
+  isNonTestProjectCode(classExpr)
+}
+
+/**
+ * Holds if `newModelFullyQualified` describes either a new subclass, or a new alias, belonging to `spec` that we should include in our automated modeling.
+ * This new element is defined by `ast`, which is defined at `loc` in the module `mod`.
+ */
+query predicate newModel(
+  FindSubclassesSpec spec, string newModelFullyQualified, AstNode ast, Module mod, Location loc
+) {
+  (
+    newSubclass(spec, newModelFullyQualified, ast, mod, loc)
+    or
+    newDirectAlias(spec, newModelFullyQualified, ast, mod, loc)
+    or
+    newImportStar(spec, newModelFullyQualified, ast, mod, _, _, loc)
+  )
+}
+// inherint problem with API graphs is that there doesn't need to exist a result for all
+// the stuff we have already modeled... as an example, the following query has no
+// results when evaluated against Django
+//
+// select API::moduleImport("django")
+//       .getMember("contrib")
+//       .getMember("admin")
+//       .getMember("views")
+//       .getMember("main")
+//       .getMember("ChangeListSearchForm")


### PR DESCRIPTION
First 4 commits is just refactoring to enable a nice setup. The real meat of this PR is the last commit, where I introduce a prototype enabling some form of (semi) automated modeling of PyPI packages. (and this PR includes some more in-depth modeling of `django`, as well as modeling of the `horizon` PyPI package)

### Why?

To capture an interesting security result (CVE), we need to understand that some of the classes provided by the `horizon` PyPI package are Django Form classes. For our long term goal of not installing external dependencies, this means we need to have some modeling of `horizon` in our CodeQL libraries. However, writing such models by hand is quite time consuming (and a pain). 

The obvious idea is to write a CodeQL query to capture these details, and then just include the results in our standard analysis. This is what this PR does, and although it is some quickly hacked together prototype code, it is **useful** enough that it now allows me to flag this CVE without installing any external dependencies.

### What can it do right now? (and rough sketch of how it works)

Let me start by calling out that this is some hacky prototype code I made, so I'm not very committed to the way the code works (and I'm very open to change it drastically), but I'm really excited about the idea!

#### New subclasses

For this prototype, I focused on Django classes (forms/views/fields), and added support for finding new definitions or aliases of such subclasses. The initial version just had support for new definitions, so for the following code, we would record that `mypkg.foo.foo.MyForm` is also a Django Form subclass. 

```py
# mypkg/foo/foo.py
import django.forms 
class MyForm(django.forms.Form):
    pass
```

In the current prototype I use some nasty string manipulation to convert that into an API node, by constructing the string `moduleImport("mypkg").getMember("foo").getMember("foo").getMember("MyForm")`, and then using something along the lines of `any(API::Node node | where node.getPath() = fullyQualifiedToAPIGraphPath("mypkg.foo.foo.MyForm")`

#### Direct aliases

Although the above did introduce quite a lot of new subclasses, it wasn't quite enough to solve my problem, since the `horizon` package provides some easy aliases (just like `django.forms.Form` is an alias for the class defined at `django.forms.forms.Form`). So I added some basic understanding that in the code below, `mypkg.foo.MyForm` would also be a reference to a Django Form subclass.

```py
# mypkg/foo/__init__
from mypkg.foo import MyForm
```

#### `import *`

and that was not quite enough, so I also added basic support for handling `import *`, such that for the code below, `mypkg.baz.Form` and `mypkg.baz.MyForm` (among others) would be considered references to a Django Form subclass.

```py
# mypkg/baz.py
from django.forms import *
from mypkg.foo import *
```

### Excitement 

<details>
<summary>GIF</summary>

![excited](https://media.giphy.com/media/xTiN0CNHgoRf1Ha7CM/giphy.gif)

</details>

I'm quite excited about what this prototype does! I'm not very committed to the way it does things, and I'm open to rewriting everything and doing it in a completely different way. I **am** very committed to the idea, and I would like to be able to use this as soon as possible. I think we should keep it internal use only for a good while, so we can change any details we want, and iterate on how much detail should be captured. 

For example, we might want to capture the class hierarchy instead of just capturing that "this class is a subclass of <foo>". But for now, I think it's more important to be able to start to use this, then iteratively improve it as we need, instead of waiting to design the perfect solution.

### What now?

Although I'm very excited about this, I think we better agree as a team that this is actually useful to do!

If we agree that it is, we need to figure out how we want a first iteration of this to look like. I'd very much like to involve `@max-schaefer` in this discussion, since what I've done here is pretty much what he was working on for the initial version of API graphs in JavaScript. I personally don't know anything about how the JS setup worked, so it might turn out that Max has a much better way of doing things that we should adopt... we'll see.