### PR TITLE
JS: Join-order improvements preparing for new SmartInliner

### DIFF
--- a/javascript/ql/src/semmle/javascript/JSDoc.qll
+++ b/javascript/ql/src/semmle/javascript/JSDoc.qll
@@ -144,7 +144,7 @@ class JSDocParamTag extends JSDocTag {
   /** Gets the parameter this tag refers to, if it can be determined. */
   Variable getDocumentedParameter() {
     exists(Parameterized parm | parm.getDocumentation() = getParent() |
-      result = parm.getParameterVariable(getName())
+      result = pragma[only_bind_out](parm).getParameterVariable(getName())
     )
   }
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -96,6 +96,7 @@ module DataFlow {
     predicate accessesGlobal(string g) { globalVarRef(g).flowsTo(this) }
 
     /** Holds if this node may evaluate to the string `s`, possibly through local data flow. */
+    pragma[nomagic]
     predicate mayHaveStringValue(string s) {
       getAPredecessor().mayHaveStringValue(s)
       or

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -688,8 +688,7 @@ module Express {
     override RouteHandler getRouteHandler() { result = rh }
 
     override Expr getNameExpr() {
-      exists(DataFlow::PropWrite write |
-        getAHeaderSource().flowsTo(write.getBase()) and
+      exists(DataFlow::PropWrite write | getAHeaderSource().getAPropertyWrite() = write |
         result = write.getPropertyNameExpr()
       )
     }

--- a/javascript/ql/src/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Fastify.qll
@@ -283,8 +283,7 @@ module Fastify {
     override RouteHandler getRouteHandler() { result = rh }
 
     override Expr getNameExpr() {
-      exists(DataFlow::PropWrite write |
-        this.getAHeaderSource().flowsTo(write.getBase()) and
+      exists(DataFlow::PropWrite write | getAHeaderSource().getAPropertyWrite() = write |
         result = write.getPropertyNameExpr()
       )
     }


### PR DESCRIPTION
Unblocks the new inliner.   

## Evaluations: 
### old cli + old QL vs. new cli + new QL:  
Should confirm that things are good when the new CLI goes live.   
I ran [default/TaintedPath.ql](https://github.com/dsp-testing/erik-krogh-dca/tree/run/inliner-5/reports), [nightly/security](https://github.com/dsp-testing/erik-krogh-dca/tree/run/inliner-6/reports), and [default/lgtm-full](https://github.com/dsp-testing/erik-krogh-dca/tree/run/inliner-esbens-suggested-run/reports).  
All look fine. 

### old cli + old QL vs. old cli + new QL:  

Should confirm that the new QL will also perform well with the old CLI.   
[nightly/security](https://github.com/dsp-testing/erik-krogh-dca/tree/run/inliner-7/reports) looks fine. 