### PR TITLE
Python: Add missing builtins to `API::builtin`

### DIFF
--- a/python/ql/src/semmle/python/ApiGraphs.qll
+++ b/python/ql/src/semmle/python/ApiGraphs.qll
@@ -363,7 +363,7 @@ module API {
           n.isGlobal() and
           n.isLoad() and
           name = n.getId() and
-          name = any(Builtins::Builtin b).getName()
+          name in [any(Builtins::Builtin b).getName(), "None", "True", "False"]
         )
     }
 


### PR DESCRIPTION
We were missing out on `None`, `True`, and `False` as these do not
appear as actual attributes of the `builtins` module in Python 3
(because they are elevated to the status of keywords there).

The simple solution, then, is to just always include them directly.

---
cf. #3878 where `API::builtin("None")` would come in handy.

This is a minor bugfix, and so I don't think a change note is required.