### PR TITLE
Python: Use API graphs in `Stdlib.qll`

### DIFF
--- a/python/ql/src/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/src/semmle/python/frameworks/Stdlib.qll
@@ -341,10 +341,8 @@ private module Stdlib {
   // ---------------------------------------------------------------------------
   // pickle
   // ---------------------------------------------------------------------------
-  private string pickleModuleName() { result in ["pickle", "cPickle", "_pickle"] }
-
   /** Gets a reference to the `pickle` module. */
-  deprecated DataFlow::Node pickle() {
+  DataFlow::Node pickle() {
     result = API::moduleImport(["pickle", "cPickle", "_pickle"]).getAUse()
   }
 
@@ -578,7 +576,7 @@ private module Stdlib {
   // json
   // ---------------------------------------------------------------------------
   /** Gets a reference to the `json` module. */
-  API::Node json() { result = API::moduleImport("node") }
+  API::Node json() { result = API::moduleImport("json") }
 
   /**
    * Gets a reference to the attribute `attr_name` of the `json` module.


### PR DESCRIPTION
Eliminates _almost_ all of the bespoke type trackers found here. The
ones that remain do not fit easily inside the framework of API graphs
(at least, not yet), and I did not see any easy ways to clean them up.
They have, however, been rewritten to use `LocalSourceNode` internally,
which was the primary goal of this exercise.

I'm sure we could also clean up many of the inner modules given the more
lean presentation we have now, but this can wait for a different PR.

--- 
No change note required. This only affects internal stuff.