### PR TITLE
Java: Override getAPrimaryQlClass() for more classes

### DIFF
--- a/java/ql/src/semmle/code/FileSystem.qll
+++ b/java/ql/src/semmle/code/FileSystem.qll
@@ -159,6 +159,8 @@ class Folder extends Container, @folder {
 
   /** Gets the URL of this folder. */
   override string getURL() { result = "folder://" + getAbsolutePath() }
+
+  override string getAPrimaryQlClass() { result = "Folder" }
 }
 
 /**
@@ -171,6 +173,8 @@ class File extends Container, @file {
 
   /** Gets the URL of this file. */
   override string getURL() { result = "file://" + this.getAbsolutePath() + ":0:0:0:0" }
+
+  override string getAPrimaryQlClass() { result = "File" }
 }
 
 /**
@@ -204,4 +208,6 @@ class JarFile extends File {
   string getManifestEntryAttribute(string entry, string key) {
     jarManifestEntries(this, entry, key, result)
   }
+
+  override string getAPrimaryQlClass() { result = "JarFile" }
 }

--- a/java/ql/src/semmle/code/java/Exception.qll
+++ b/java/ql/src/semmle/code/java/Exception.qll
@@ -27,4 +27,6 @@ class Exception extends Element, @exception {
   override predicate hasName(string name) { this.getType().hasName(name) }
 
   override string toString() { result = this.getType().toString() }
+
+  override string getAPrimaryQlClass() { result = "Exception" }
 }

--- a/java/ql/src/semmle/code/java/Modifier.qll
+++ b/java/ql/src/semmle/code/java/Modifier.qll
@@ -8,6 +8,8 @@ import Element
 class Modifier extends Element, @modifier {
   /** Gets the element to which this modifier applies. */
   Element getElement() { hasModifier(result, this) }
+
+  override string getAPrimaryQlClass() { result = "Modifier" }
 }
 
 /** An element of the Java syntax tree that may have a modifier. */

--- a/java/ql/src/semmle/code/java/Package.qll
+++ b/java/ql/src/semmle/code/java/Package.qll
@@ -29,4 +29,6 @@ class Package extends Element, Annotatable, @package {
    * since packages do not have locations.
    */
   string getURL() { result = "file://:0:0:0:0" }
+
+  override string getAPrimaryQlClass() { result = "Package" }
 }

--- a/java/ql/src/semmle/code/java/Variable.qll
+++ b/java/ql/src/semmle/code/java/Variable.qll
@@ -53,6 +53,8 @@ class LocalVariableDecl extends @localvar, LocalScopeVariable {
 
   /** Gets the initializer expression of this local variable declaration. */
   override Expr getInitializer() { result = getDeclExpr().getInit() }
+
+  override string getAPrimaryQlClass() { result = "LocalVariableDecl" }
 }
 
 /** A formal parameter of a callable. */

--- a/java/ql/src/semmle/code/xml/XML.qll
+++ b/java/ql/src/semmle/code/xml/XML.qll
@@ -149,6 +149,8 @@ class XMLFile extends XMLParent, File {
 
   /** Gets a DTD associated with this XML file. */
   XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
+
+  override string getAPrimaryQlClass() { result = "XMLFile" }
 }
 
 /**

--- a/java/ql/src/semmle/code/xml/XML.qll
+++ b/java/ql/src/semmle/code/xml/XML.qll
@@ -149,8 +149,6 @@ class XMLFile extends XMLParent, File {
 
   /** Gets a DTD associated with this XML file. */
   XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
-
-  override string getAPrimaryQlClass() { result = "XMLFile" }
 }
 
 /**


### PR DESCRIPTION
Note that I have not run all CodeQL tests, only the `PrintAst` ones, so I hope this does not cause any test failures.