### PR TITLE
JS: allow parameters that end with "Command" in js/shell-command-constructed-from-input

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
@@ -53,7 +53,12 @@ module UnsafeShellCommandConstruction {
   class ExternalInputSource extends Source, DataFlow::ParameterNode {
     ExternalInputSource() {
       this = Exports::getALibraryInputParameter() and
-      not this.getName() = ["cmd", "command"] // looks to be on purpose.
+      not (
+        // looks to be on purpose.
+        this.getName() = ["cmd", "command"]
+        or
+        this.getName().regexpMatch(".*(Cmd|Command)$") // ends with "Cmd" or "Command"
+      )
     }
   }
 

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
@@ -484,3 +484,8 @@ module.exports.splitConcat = function (name) {
 	let cmd = 'echo';
 	cp.exec(cmd + args);
 }
+
+module.exports.myCommand = function (myCommand) {
+	let cmd = `cd ${cwd} ; ${myCommand}`; // OK - the parameter name suggests that it is purposely a shell command.
+	cp.exec(cmd);
+}


### PR DESCRIPTION
Fixes [this FP](https://lgtm.com/query/5038770107216011085/). 