### PR TITLE
C#: First try `pwsh` and then `powershell` when calling `dotnet-install.ps1`

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -981,7 +981,7 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         {
             actions.RunProcess["cmd.exe /C dotnet --list-sdks"] = 0;
             actions.RunProcessOut["cmd.exe /C dotnet --list-sdks"] = "2.1.3 [C:\\Program Files\\dotnet\\sdks]\n2.1.4 [C:\\Program Files\\dotnet\\sdks]";
-            actions.RunProcess[@"cmd.exe /C powershell -NoProfile -ExecutionPolicy unrestricted -file C:\Project\install-dotnet.ps1 -Version 2.1.3 -InstallDir C:\Project\.dotnet"] = 0;
+            actions.RunProcess[@"cmd.exe /C pwsh -NoProfile -ExecutionPolicy unrestricted -file C:\Project\install-dotnet.ps1 -Version 2.1.3 -InstallDir C:\Project\.dotnet"] = 0;
             actions.RunProcess[@"cmd.exe /C del C:\Project\install-dotnet.ps1"] = 0;
             actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet --info"] = 0;
             actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet clean C:\Project\test.csproj"] = 0;
@@ -1006,6 +1006,39 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
 
             var autobuilder = CreateAutoBuilder(true, dotnetVersion: "2.1.3");
             TestAutobuilderScript(autobuilder, 0, 7);
+        }
+
+        [Fact]
+        public void TestDotnetVersionWindowsNoPwsh()
+        {
+            actions.RunProcess["cmd.exe /C dotnet --list-sdks"] = 0;
+            actions.RunProcessOut["cmd.exe /C dotnet --list-sdks"] = "2.1.3 [C:\\Program Files\\dotnet\\sdks]\n2.1.4 [C:\\Program Files\\dotnet\\sdks]";
+            actions.RunProcess[@"cmd.exe /C pwsh -NoProfile -ExecutionPolicy unrestricted -file C:\Project\install-dotnet.ps1 -Version 2.1.3 -InstallDir C:\Project\.dotnet"] = 1;
+            actions.RunProcess[@"cmd.exe /C powershell -NoProfile -ExecutionPolicy unrestricted -file C:\Project\install-dotnet.ps1 -Version 2.1.3 -InstallDir C:\Project\.dotnet"] = 0;
+            actions.RunProcess[@"cmd.exe /C del C:\Project\install-dotnet.ps1"] = 0;
+            actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet --info"] = 0;
+            actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet clean C:\Project\test.csproj"] = 0;
+            actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet restore C:\Project\test.csproj"] = 0;
+            actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\.dotnet\dotnet build --no-incremental C:\Project\test.csproj"] = 0;
+            actions.FileExists["csharp.log"] = true;
+            actions.FileExists[@"C:\Project\test.csproj"] = true;
+            actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
+            actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
+            actions.GetEnvironmentVariable["PATH"] = "/bin:/usr/bin";
+            actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.cs\ntest.csproj";
+            actions.EnumerateDirectories[@"C:\Project"] = "";
+            var xml = new XmlDocument();
+            xml.LoadXml(@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>");
+            actions.LoadXml[@"C:\Project\test.csproj"] = xml;
+
+            var autobuilder = CreateAutoBuilder(true, dotnetVersion: "2.1.3");
+            TestAutobuilderScript(autobuilder, 0, 8);
         }
 
         [Fact]

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -981,8 +981,39 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         {
             actions.RunProcess["cmd.exe /C dotnet --list-sdks"] = 0;
             actions.RunProcessOut["cmd.exe /C dotnet --list-sdks"] = "2.1.3 [C:\\Program Files\\dotnet\\sdks]\n2.1.4 [C:\\Program Files\\dotnet\\sdks]";
-            actions.RunProcess[@"cmd.exe /C pwsh -NoProfile -ExecutionPolicy unrestricted -file C:\Project\install-dotnet.ps1 -Version 2.1.3 -InstallDir C:\Project\.dotnet"] = 0;
-            actions.RunProcess[@"cmd.exe /C del C:\Project\install-dotnet.ps1"] = 0;
+            actions.RunProcess[@"cmd.exe /C pwsh -NoProfile -ExecutionPolicy unrestricted -Command ""[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version 2.1.3 -InstallDir C:\Project\.dotnet"""] = 0;
+            actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet --info"] = 0;
+            actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet clean C:\Project\test.csproj"] = 0;
+            actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet restore C:\Project\test.csproj"] = 0;
+            actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\.dotnet\dotnet build --no-incremental C:\Project\test.csproj"] = 0;
+            actions.FileExists["csharp.log"] = true;
+            actions.FileExists[@"C:\Project\test.csproj"] = true;
+            actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
+            actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
+            actions.GetEnvironmentVariable["PATH"] = "/bin:/usr/bin";
+            actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.cs\ntest.csproj";
+            actions.EnumerateDirectories[@"C:\Project"] = "";
+            var xml = new XmlDocument();
+            xml.LoadXml(@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>");
+            actions.LoadXml[@"C:\Project\test.csproj"] = xml;
+
+            var autobuilder = CreateAutoBuilder(true, dotnetVersion: "2.1.3");
+            TestAutobuilderScript(autobuilder, 0, 6);
+        }
+
+        [Fact]
+        public void TestDotnetVersionWindowsNoPwsh()
+        {
+            actions.RunProcess["cmd.exe /C dotnet --list-sdks"] = 0;
+            actions.RunProcessOut["cmd.exe /C dotnet --list-sdks"] = "2.1.3 [C:\\Program Files\\dotnet\\sdks]\n2.1.4 [C:\\Program Files\\dotnet\\sdks]";
+            actions.RunProcess[@"cmd.exe /C pwsh -NoProfile -ExecutionPolicy unrestricted -Command ""[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version 2.1.3 -InstallDir C:\Project\.dotnet"""] = 1;
+            actions.RunProcess[@"cmd.exe /C powershell -NoProfile -ExecutionPolicy unrestricted -Command ""[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version 2.1.3 -InstallDir C:\Project\.dotnet"""] = 0;
             actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet --info"] = 0;
             actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet clean C:\Project\test.csproj"] = 0;
             actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet restore C:\Project\test.csproj"] = 0;
@@ -1006,39 +1037,6 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
 
             var autobuilder = CreateAutoBuilder(true, dotnetVersion: "2.1.3");
             TestAutobuilderScript(autobuilder, 0, 7);
-        }
-
-        [Fact]
-        public void TestDotnetVersionWindowsNoPwsh()
-        {
-            actions.RunProcess["cmd.exe /C dotnet --list-sdks"] = 0;
-            actions.RunProcessOut["cmd.exe /C dotnet --list-sdks"] = "2.1.3 [C:\\Program Files\\dotnet\\sdks]\n2.1.4 [C:\\Program Files\\dotnet\\sdks]";
-            actions.RunProcess[@"cmd.exe /C pwsh -NoProfile -ExecutionPolicy unrestricted -file C:\Project\install-dotnet.ps1 -Version 2.1.3 -InstallDir C:\Project\.dotnet"] = 1;
-            actions.RunProcess[@"cmd.exe /C powershell -NoProfile -ExecutionPolicy unrestricted -file C:\Project\install-dotnet.ps1 -Version 2.1.3 -InstallDir C:\Project\.dotnet"] = 0;
-            actions.RunProcess[@"cmd.exe /C del C:\Project\install-dotnet.ps1"] = 0;
-            actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet --info"] = 0;
-            actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet clean C:\Project\test.csproj"] = 0;
-            actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet restore C:\Project\test.csproj"] = 0;
-            actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\.dotnet\dotnet build --no-incremental C:\Project\test.csproj"] = 0;
-            actions.FileExists["csharp.log"] = true;
-            actions.FileExists[@"C:\Project\test.csproj"] = true;
-            actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
-            actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
-            actions.GetEnvironmentVariable["PATH"] = "/bin:/usr/bin";
-            actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.cs\ntest.csproj";
-            actions.EnumerateDirectories[@"C:\Project"] = "";
-            var xml = new XmlDocument();
-            xml.LoadXml(@"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-</Project>");
-            actions.LoadXml[@"C:\Project\test.csproj"] = xml;
-
-            var autobuilder = CreateAutoBuilder(true, dotnetVersion: "2.1.3");
-            TestAutobuilderScript(autobuilder, 0, 8);
         }
 
         [Fact]

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -179,35 +179,8 @@ namespace Semmle.Autobuild.CSharp
 
                     if (builder.Actions.IsWindows())
                     {
-                        var psScript = @"param([string]$Version, [string]$InstallDir)
 
-add-type @""
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy
-{
-    public bool CheckValidationResult(ServicePoint srvPoint, X509Certificate certificate, WebRequest request, int certificateProblem)
-    {
-        return true;
-    }
-}
-""@
-$AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
-[System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
-[System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-$Script = Invoke-WebRequest -useb 'https://dot.net/v1/dotnet-install.ps1'
-
-$arguments = @{
-  Channel = 'release'
-  Version = $Version
-  InstallDir = $InstallDir
-}
-
-$ScriptBlock = [scriptblock]::create("".{$($Script)} $(&{$args} @arguments)"")
-
-Invoke-Command -ScriptBlock $ScriptBlock";
-                        var psScriptFile = builder.Actions.PathCombine(builder.Options.RootDirectory, "install-dotnet.ps1");
-                        builder.Actions.WriteAllText(psScriptFile, psScript);
+                        var psCommand = $"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version {version} -InstallDir {path}";
 
                         BuildScript GetInstall(string pwsh) =>
                             new CommandBuilder(builder.Actions).
@@ -215,19 +188,11 @@ Invoke-Command -ScriptBlock $ScriptBlock";
                             Argument("-NoProfile").
                             Argument("-ExecutionPolicy").
                             Argument("unrestricted").
-                            Argument("-file").
-                            Argument(psScriptFile).
-                            Argument("-Version").
-                            Argument(version).
-                            Argument("-InstallDir").
-                            Argument(path).
+                            Argument("-Command").
+                            Argument("\"" + psCommand + "\"").
                             Script;
 
-                        var removeScript = new CommandBuilder(builder.Actions).
-                            RunCommand("del").
-                            Argument(psScriptFile);
-
-                        return (GetInstall("pwsh") | GetInstall("powershell")) & BuildScript.Try(removeScript.Script);
+                        return GetInstall("pwsh") | GetInstall("powershell");
                     }
                     else
                     {

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -209,8 +209,9 @@ Invoke-Command -ScriptBlock $ScriptBlock";
                         var psScriptFile = builder.Actions.PathCombine(builder.Options.RootDirectory, "install-dotnet.ps1");
                         builder.Actions.WriteAllText(psScriptFile, psScript);
 
-                        var install = new CommandBuilder(builder.Actions).
-                            RunCommand("powershell").
+                        BuildScript GetInstall(string pwsh) =>
+                            new CommandBuilder(builder.Actions).
+                            RunCommand(pwsh).
                             Argument("-NoProfile").
                             Argument("-ExecutionPolicy").
                             Argument("unrestricted").
@@ -219,13 +220,14 @@ Invoke-Command -ScriptBlock $ScriptBlock";
                             Argument("-Version").
                             Argument(version).
                             Argument("-InstallDir").
-                            Argument(path);
+                            Argument(path).
+                            Script;
 
                         var removeScript = new CommandBuilder(builder.Actions).
                             RunCommand("del").
                             Argument(psScriptFile);
 
-                        return install.Script & BuildScript.Try(removeScript.Script);
+                        return (GetInstall("pwsh") | GetInstall("powershell")) & BuildScript.Try(removeScript.Script);
                     }
                     else
                     {


### PR DESCRIPTION
I also simplified the logic following the section [Obtain script and install .NET CLI one-liner examples](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script).