### PR TITLE
JS: support all ClientRequests in js/disabling-certificate-validation

### DIFF
--- a/javascript/change-notes/2021-04-12-disabling-certificate-validation.md
+++ b/javascript/change-notes/2021-04-12-disabling-certificate-validation.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The query "Disabling certificate validation" (`js/disabling-certificate-validation`) has been improved to recognize many more request libraries.

--- a/javascript/ql/src/Security/CWE-295/DisablingCertificateValidation.ql
+++ b/javascript/ql/src/Security/CWE-295/DisablingCertificateValidation.ql
@@ -16,7 +16,7 @@ import javascript
  */
 DataFlow::ObjectLiteralNode tlsOptions() {
   exists(DataFlow::InvokeNode invk | result.flowsTo(invk.getAnArgument()) |
-    invk instanceof NodeJSLib::NodeJSClientRequest
+    invk instanceof ClientRequest
     or
     invk = DataFlow::moduleMember("https", "Agent").getAnInstantiation()
     or

--- a/javascript/ql/test/query-tests/Security/CWE-295/DisablingCertificateValidation.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-295/DisablingCertificateValidation.expected
@@ -1,3 +1,4 @@
+| tst2.js:8:5:8:29 | rejectU ... : false | Disabling certificate validation is strongly discouraged. |
 | tst.js:15:3:15:27 | rejectU ... : false | Disabling certificate validation is strongly discouraged. |
 | tst.js:18:1:18:40 | process ... HORIZED | Disabling certificate validation is strongly discouraged. |
 | tst.js:21:3:21:27 | rejectU ... : false | Disabling certificate validation is strongly discouraged. |

--- a/javascript/ql/test/query-tests/Security/CWE-295/tst2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-295/tst2.js
@@ -1,0 +1,24 @@
+const request = require('request');
+
+let requestOptions = {
+    headers: {
+        "content-type": "application/json",
+        "accept": "application/json"
+    },
+    rejectUnauthorized: false,
+    requestCert: true,
+    agent: false
+}
+
+module.exports.post = (url, requestBody, apiContext) => {
+    Object.assign(requestOptions, {
+        body: JSON.stringify(requestBody),
+        headers : Object.assign(requestOptions.headers, apiContext)
+    })
+
+    return request.post(url, requestOptions).then((res) => {
+        return Promise.resolve(res.body);
+    }).catch((err) => {
+        return Promise.resolve(err);
+    })
+}


### PR DESCRIPTION
Previously the query didn't recognize libraries such as `node-request`.   

But the only change required to support those libraries is updating the query to recognize all our existing `ClientRequest` models. 