### PR TITLE
Actions: Add workflow for marking stale questions

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -25,6 +25,6 @@ jobs:
         days-before-pr-stale: -1
         days-before-pr-close: -1
         
-        # Dry-run only. remove this when we are ready to actually change issues
-        debug-only: true
-        operations-per-run: 1000
+        # Uncomment for dry-run
+        # debug-only: true
+        # operations-per-run: 1000

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,30 @@
+name: Mark stale issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    if: github.repository == 'github/codeql'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Comment or remove the `stale` label in order to avoid having this issue closed in 7 days.'
+        close-issue-message: 'This issue was closed because it has been inactive for 7 days.'
+        days-before-stale: 14
+        days-before-close: 7
+        only-labels: question
+        
+        # do not mark PRs as stale
+        days-before-pr-stale: -1
+        days-before-pr-close: -1
+        
+        # Dry-run only. remove this when we are ready to actually change issues
+        debug-only: true
+        operations-per-run: 1000


### PR DESCRIPTION
This PR adds a workflow for marking and closing issues as stale. Issues must be labeled as _question_. PRs are never marked as stale.