### PR TITLE
JS: Simplify JSON API

### DIFF
--- a/javascript/ql/src/Declarations/UnusedVariable.ql
+++ b/javascript/ql/src/Declarations/UnusedVariable.ql
@@ -65,8 +65,8 @@ predicate isReactForJSX(UnusedLocal v) {
       v.getName() =
         tsconfig
             .getPropValue("compilerOptions")
-            .(JSONObject)
-            .getPropStringValue(["jsxFactory", "jsxFragmentFactory"])
+            .getPropValue(["jsxFactory", "jsxFragmentFactory"])
+            .getStringValue()
     )
   )
 }

--- a/javascript/ql/src/semmle/javascript/JSON.qll
+++ b/javascript/ql/src/semmle/javascript/JSON.qll
@@ -41,6 +41,21 @@ class JSONValue extends @json_value, Locatable {
     )
   }
 
+  /** If this is an object, gets the value of property `name`. */
+  JSONValue getPropValue(string name) { json_properties(this, name, result) }
+
+  /** If this is an array, gets the value of the `i`th element. */
+  JSONValue getElementValue(int i) { result = this.(JSONArray).getChild(i) }
+
+  /** If this is a string constant, gets the value of the string. */
+  string getStringValue() { result = this.(JSONString).getValue() }
+
+  /** If this is an integer constant, gets its numeric value. */
+  int getIntValue() { result = this.(JSONNumber).getValue().toInt() }
+
+  /** If this is a boolean constant, gets its boolean value. */
+  boolean getBooleanValue() { result.toString() = this.(JSONBoolean).getValue() }
+
   override string getAPrimaryQlClass() { result = "JSONValue" }
 }
 
@@ -129,13 +144,10 @@ class JSONString extends @json_string, JSONPrimitiveValue {
  * ```
  */
 class JSONArray extends @json_array, JSONValue {
-  /** Gets the value of the `i`th element of this array. */
-  JSONValue getElementValue(int i) { result = getChild(i) }
+  override string getAPrimaryQlClass() { result = "JSONArray" }
 
   /** Gets the string value of the `i`th element of this array. */
-  string getElementStringValue(int i) { result = getElementValue(i).(JSONString).getValue() }
-
-  override string getAPrimaryQlClass() { result = "JSONArray" }
+  string getElementStringValue(int i) { result = getElementValue(i).getStringValue() }
 }
 
 /**
@@ -148,13 +160,10 @@ class JSONArray extends @json_array, JSONValue {
  * ```
  */
 class JSONObject extends @json_object, JSONValue {
-  /** Gets the value of property `name` of this object. */
-  JSONValue getPropValue(string name) { json_properties(this, name, result) }
+  override string getAPrimaryQlClass() { result = "JSONObject" }
 
   /** Gets the string value of property `name` of this object. */
-  string getPropStringValue(string name) { result = getPropValue(name).(JSONString).getValue() }
-
-  override string getAPrimaryQlClass() { result = "JSONObject" }
+  string getPropStringValue(string name) { result = getPropValue(name).getStringValue() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/NPM.qll
+++ b/javascript/ql/src/semmle/javascript/NPM.qll
@@ -41,7 +41,7 @@ class PackageJSON extends JSONObject {
 
   /** Gets information for a contributor to this package. */
   ContributorInfo getAContributor() {
-    result = getPropValue("contributors").(JSONArray).getElementValue(_)
+    result = getPropValue("contributors").getElementValue(_)
   }
 
   /** Gets the array of files for this package. */
@@ -57,13 +57,13 @@ class PackageJSON extends JSONObject {
   string getBin(string cmd) {
     cmd = getPackageName() and result = getPropStringValue("bin")
     or
-    result = getPropValue("bin").(JSONObject).getPropStringValue(cmd)
+    result = getPropValue("bin").getPropValue(cmd).getStringValue()
   }
 
   /** Gets a manual page for this package. */
   string getAManFile() {
     result = getPropStringValue("man") or
-    result = getPropValue("man").(JSONArray).getElementStringValue(_)
+    result = getPropValue("man").getElementValue(_).getStringValue()
   }
 
   /** Gets information about the directories of this package. */
@@ -191,12 +191,12 @@ class BugTrackerInfo extends JSONValue {
 
   /** Gets the bug tracker URL. */
   string getUrl() {
-    result = this.(JSONObject).getPropStringValue("url") or
-    result = this.(JSONString).getValue()
+    result = this.getPropValue("url").getStringValue() or
+    result = this.getStringValue()
   }
 
   /** Gets the bug reporting email address. */
-  string getEmail() { result = this.(JSONObject).getPropStringValue("email") }
+  string getEmail() { result = this.getPropValue("email").getStringValue() }
 }
 
 /**
@@ -206,7 +206,7 @@ class ContributorInfo extends JSONValue {
   ContributorInfo() {
     exists(PackageJSON pkg |
       this = pkg.getPropValue("author") or
-      this = pkg.getPropValue("contributors").(JSONArray).getElementValue(_)
+      this = pkg.getPropValue("contributors").getElementValue(_)
     ) and
     (this instanceof JSONObject or this instanceof JSONString)
   }
@@ -217,24 +217,24 @@ class ContributorInfo extends JSONValue {
    * homepage URL.
    */
   private string parseInfo(int group) {
-    result = this.(JSONString).getValue().regexpCapture("(.*?)(?: <(.*?)>)?(?: \\((.*)?\\))", group)
+    result = this.getStringValue().regexpCapture("(.*?)(?: <(.*?)>)?(?: \\((.*)?\\))", group)
   }
 
   /** Gets the contributor's name. */
   string getName() {
-    result = this.(JSONObject).getPropStringValue("name") or
+    result = this.getPropValue("name").getStringValue() or
     result = parseInfo(1)
   }
 
   /** Gets the contributor's email address. */
   string getEmail() {
-    result = this.(JSONObject).getPropStringValue("email") or
+    result = this.getPropValue("email").getStringValue() or
     result = parseInfo(2)
   }
 
   /** Gets the contributor's homepage URL. */
   string getUrl() {
-    result = this.(JSONObject).getPropStringValue("url") or
+    result = this.getPropValue("url").getStringValue() or
     result = parseInfo(3)
   }
 }

--- a/javascript/ql/src/semmle/javascript/NPM.qll
+++ b/javascript/ql/src/semmle/javascript/NPM.qll
@@ -40,9 +40,7 @@ class PackageJSON extends JSONObject {
   ContributorInfo getAuthor() { result = getPropValue("author") }
 
   /** Gets information for a contributor to this package. */
-  ContributorInfo getAContributor() {
-    result = getPropValue("contributors").getElementValue(_)
-  }
+  ContributorInfo getAContributor() { result = getPropValue("contributors").getElementValue(_) }
 
   /** Gets the array of files for this package. */
   JSONArray getFiles() { result = getPropValue("files") }

--- a/javascript/ql/src/semmle/javascript/Paths.qll
+++ b/javascript/ql/src/semmle/javascript/Paths.qll
@@ -233,11 +233,7 @@ private module TypeScriptOutDir {
     tsconfig.getFile().getBaseName().regexpMatch("tsconfig.*\\.json") and
     tsconfig.isTopLevel() and
     tsconfig.getFile().getParentContainer() = parent and
-    result =
-      tsconfig
-          .getPropValue("compilerOptions")
-          .getPropValue("outDir")
-          .getStringValue()
+    result = tsconfig.getPropValue("compilerOptions").getPropValue("outDir").getStringValue()
   }
 
   /**
@@ -279,10 +275,7 @@ private module TypeScriptOutDir {
   pragma[inline]
   private string getARootDirFromInclude(JSONObject tsconfig) {
     result =
-      getRootFolderFromPath(tsconfig
-            .getPropValue("include")
-            .getElementValue(_)
-            .getStringValue())
+      getRootFolderFromPath(tsconfig.getPropValue("include").getElementValue(_).getStringValue())
   }
 
   /**
@@ -290,11 +283,7 @@ private module TypeScriptOutDir {
    */
   pragma[inline]
   private string getRootDir(JSONObject tsconfig) {
-    result =
-      tsconfig
-          .getPropValue("compilerOptions")
-          .getPropValue("rootDir")
-          .getStringValue()
+    result = tsconfig.getPropValue("compilerOptions").getPropValue("rootDir").getStringValue()
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/Paths.qll
+++ b/javascript/ql/src/semmle/javascript/Paths.qll
@@ -236,10 +236,8 @@ private module TypeScriptOutDir {
     result =
       tsconfig
           .getPropValue("compilerOptions")
-          .(JSONObject)
           .getPropValue("outDir")
-          .(JSONString)
-          .getValue()
+          .getStringValue()
   }
 
   /**
@@ -283,10 +281,8 @@ private module TypeScriptOutDir {
     result =
       getRootFolderFromPath(tsconfig
             .getPropValue("include")
-            .(JSONArray)
             .getElementValue(_)
-            .(JSONString)
-            .getValue())
+            .getStringValue())
   }
 
   /**
@@ -297,10 +293,8 @@ private module TypeScriptOutDir {
     result =
       tsconfig
           .getPropValue("compilerOptions")
-          .(JSONObject)
           .getPropValue("rootDir")
-          .(JSONString)
-          .getValue()
+          .getStringValue()
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
@@ -24,9 +24,9 @@ module Babel {
         plugins = getPropValue("plugins") and
         result = plugins.getElementValue(_)
       |
-        result.(JSONString).getValue() = pluginName
+        result.getStringValue() = pluginName
         or
-        result.(JSONArray).getElementStringValue(0) = pluginName
+        result.getElementValue(0).getStringValue() = pluginName
       )
     }
 
@@ -67,7 +67,7 @@ module Babel {
     JSONValue getOptions() { result = this.(JSONArray).getElementValue(1) }
 
     /** Gets a named option from the option object, if present. */
-    JSONValue getOption(string name) { result = getOptions().(JSONObject).getPropValue(name) }
+    JSONValue getOption(string name) { result = getOptions().getPropValue(name) }
 
     /** Holds if this plugin applies to `tl`. */
     predicate appliesTo(TopLevel tl) { cfg.appliesTo(tl) }
@@ -186,7 +186,7 @@ module Babel {
     TransformReactJsxConfig() { pluginName = "transform-react-jsx" }
 
     /** Gets the name of the variable used to create JSX elements. */
-    string getJsxFactoryVariableName() { result = getOption("pragma").(JSONString).getValue() }
+    string getJsxFactoryVariableName() { result = getOption("pragma").getStringValue() }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
@@ -108,7 +108,7 @@ private class RemoteFlowSourceAccessPath extends JSONString {
     exists(JSONObject specs |
       specs.isTopLevel() and
       this.getFile().getBaseName() = "codeql-javascript-remote-flow-sources.json" and
-      this = specs.getPropValue(sourceType).(JSONArray).getElementValue(_) and
+      this = specs.getPropValue(sourceType).getElementValue(_) and
       this.getValue().regexpMatch("window(\\.\\w+)+")
     )
   }


### PR DESCRIPTION
Previously you had to downcast a `JSONValue` to be able to do anything useful with it. This was quite verbose, especially when inspecting nested properties.

Now the accessors `getPropValue`, `getElementValue`, `getStringValue`, `getIntValue` and `getBooleanValue` are available on `JSONValue` itself.