### PR TITLE
C++: Use range analysis in Overflow.qll

### DIFF
--- a/cpp/change-notes/2021-04-13-arithmetic-queries.md
+++ b/cpp/change-notes/2021-04-13-arithmetic-queries.md
@@ -1,0 +1,2 @@
+lgtm
+* The queries cpp/tainted-arithmetic, cpp/uncontrolled-arithmetic, and cpp/arithmetic-with-extreme-values have been improved to produce fewer false positives.

--- a/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
@@ -5,6 +5,7 @@
 
 import cpp
 import semmle.code.cpp.controlflow.Dominance
+import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 
 /**
  * Holds if the value of `use` is guarded using `abs`.
@@ -94,9 +95,10 @@ predicate guardedGreater(Operation e, Expr use) {
 VariableAccess varUse(LocalScopeVariable v) { result = v.getAnAccess() }
 
 /**
- * Holds if `e` is not guarded against overflow by `use`.
+ * Holds if `e` potentially overflows and `use` is an operand of `e` that is not guarded.
  */
 predicate missingGuardAgainstOverflow(Operation e, VariableAccess use) {
+  convertedExprMightOverflow(e) and
   use = e.getAnOperand() and
   exists(LocalScopeVariable v | use.getTarget() = v |
     // overflow possible if large
@@ -115,9 +117,10 @@ predicate missingGuardAgainstOverflow(Operation e, VariableAccess use) {
 }
 
 /**
- * Holds if `e` is not guarded against underflow by `use`.
+ * Holds if `e` potentially underflows and `use` is an operand of `e` that is not guarded.
  */
 predicate missingGuardAgainstUnderflow(Operation e, VariableAccess use) {
+  convertedExprMightOverflowNegatively(e) and
   use = e.getAnOperand() and
   exists(LocalScopeVariable v | use.getTarget() = v |
     // underflow possible if use is left operand and small

--- a/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
@@ -98,7 +98,7 @@ VariableAccess varUse(LocalScopeVariable v) { result = v.getAnAccess() }
  * Holds if `e` potentially overflows and `use` is an operand of `e` that is not guarded.
  */
 predicate missingGuardAgainstOverflow(Operation e, VariableAccess use) {
-  convertedExprMightOverflow(e) and
+  convertedExprMightOverflowPositively(e) and
   use = e.getAnOperand() and
   exists(LocalScopeVariable v | use.getTarget() = v |
     // overflow possible if large

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/extreme/ArithmeticWithExtremeValues.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/extreme/ArithmeticWithExtremeValues.expected
@@ -3,6 +3,4 @@
 | test.c:50:3:50:5 | sc3 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:49:9:49:16 | 127 | Extreme value |
 | test.c:59:3:59:5 | sc6 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:58:9:58:16 | 127 | Extreme value |
 | test.c:63:3:63:5 | sc8 | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:62:9:62:16 | - ... | Extreme value |
-| test.c:75:3:75:5 | sc1 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:74:9:74:16 | 127 | Extreme value |
-| test.c:76:3:76:5 | sc1 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:74:9:74:16 | 127 | Extreme value |
 | test.c:124:9:124:9 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:118:17:118:23 | 2147483647 | Extreme value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/extreme/ArithmeticWithExtremeValues.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/extreme/ArithmeticWithExtremeValues.expected
@@ -3,4 +3,5 @@
 | test.c:50:3:50:5 | sc3 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:49:9:49:16 | 127 | Extreme value |
 | test.c:59:3:59:5 | sc6 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:58:9:58:16 | 127 | Extreme value |
 | test.c:63:3:63:5 | sc8 | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:62:9:62:16 | - ... | Extreme value |
+| test.c:75:3:75:5 | sc1 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:74:9:74:16 | 127 | Extreme value |
 | test.c:124:9:124:9 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:118:17:118:23 | 2147483647 | Extreme value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/extreme/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/extreme/test.c
@@ -72,8 +72,8 @@ void test_negatives() {
   signed char sc1, sc2, sc3, sc4, sc5, sc6, sc7, sc8;
 
   sc1 = CHAR_MAX;
-  sc1 += 0; // GOOD [FALSE POSITIVE]
-  sc1 += -1; // GOOD [FALSE POSITIVE]
+  sc1 += 0; // GOOD
+  sc1 += -1; // GOOD
   sc2 = CHAR_MIN;
   sc2 += -1; // BAD [NOT DETECTED]
   sc3 = CHAR_MIN;

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/extreme/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/extreme/test.c
@@ -72,7 +72,7 @@ void test_negatives() {
   signed char sc1, sc2, sc3, sc4, sc5, sc6, sc7, sc8;
 
   sc1 = CHAR_MAX;
-  sc1 += 0; // GOOD
+  sc1 += 0; // GOOD [FALSE POSITIVE]
   sc1 += -1; // GOOD
   sc2 = CHAR_MIN;
   sc2 += -1; // BAD [NOT DETECTED]

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
@@ -1,8 +1,5 @@
 | test2.cpp:14:11:14:11 | v | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test2.cpp:25:22:25:23 | & ... | User-provided value |
 | test2.cpp:14:11:14:11 | v | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test2.cpp:25:22:25:23 | & ... | User-provided value |
-| test3.c:15:10:15:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test3.c:11:15:11:18 | argv | User-provided value |
-| test3.c:15:14:15:14 | y | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test3.c:11:15:11:18 | argv | User-provided value |
-| test3.c:15:18:15:18 | z | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test3.c:11:15:11:18 | argv | User-provided value |
 | test5.cpp:17:6:17:18 | call to getTaintedInt | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
 | test5.cpp:19:6:19:6 | y | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
 | test5.cpp:19:6:19:6 | y | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test5.cpp:9:7:9:9 | buf | User-provided value |


### PR DESCRIPTION
(Part of https://github.com/github/codeql-c-analysis-team/issues/272.)

Three of the queries in `Security/CEW/CWE-190` use the `semmle.code.cpp.security.Overflow` library to detect missing overflow/underflow guards. However, that library doesn't use the range analysis library to rule out non-interesting operations. This seems like low-hanging fruit.

This PR adds range analysis to this library. This should improve the false-positivity rate of the queries:
- `cpp/tainted-arithmetic`
- `cpp/uncontrolled-arithmetic`
- `cpp/arithmetic-with-extreme-values`