### PR TITLE
Python: Use API graphs in Fabric model

### DIFF
--- a/python/ql/src/semmle/python/frameworks/Fabric.qll
+++ b/python/ql/src/semmle/python/frameworks/Fabric.qll
@@ -11,6 +11,7 @@ private import python
 private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.dataflow.new.RemoteFlowSources
 private import semmle.python.Concepts
+private import semmle.python.ApiGraphs
 
 /**
  * Provides classes modeling security-relevant aspects of the `fabric` PyPI package, for
@@ -20,54 +21,13 @@ private import semmle.python.Concepts
  */
 private module FabricV1 {
   /** Gets a reference to the `fabric` module. */
-  private DataFlow::Node fabric(DataFlow::TypeTracker t) {
-    t.start() and
-    result = DataFlow::importNode("fabric")
-    or
-    exists(DataFlow::TypeTracker t2 | result = fabric(t2).track(t2, t))
-  }
-
-  /** Gets a reference to the `fabric` module. */
-  DataFlow::Node fabric() { result = fabric(DataFlow::TypeTracker::end()) }
+  API::Node fabric() { result = API::moduleImport("fabric") }
 
   /**
    * Gets a reference to the attribute `attr_name` of the `fabric` module.
    * WARNING: Only holds for a few predefined attributes.
    */
-  private DataFlow::Node fabric_attr(DataFlow::TypeTracker t, string attr_name) {
-    attr_name in ["api"] and
-    (
-      t.start() and
-      result = DataFlow::importNode("fabric" + "." + attr_name)
-      or
-      t.startInAttr(attr_name) and
-      result = fabric()
-    )
-    or
-    // Due to bad performance when using normal setup with `fabric_attr(t2, attr_name).track(t2, t)`
-    // we have inlined that code and forced a join
-    exists(DataFlow::TypeTracker t2 |
-      exists(DataFlow::StepSummary summary |
-        fabric_attr_first_join(t2, attr_name, result, summary) and
-        t = t2.append(summary)
-      )
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fabric_attr_first_join(
-    DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res, DataFlow::StepSummary summary
-  ) {
-    DataFlow::StepSummary::step(fabric_attr(t2, attr_name), res, summary)
-  }
-
-  /**
-   * Gets a reference to the attribute `attr_name` of the `fabric` module.
-   * WARNING: Only holds for a few predefined attributes.
-   */
-  private DataFlow::Node fabric_attr(string attr_name) {
-    result = fabric_attr(DataFlow::TypeTracker::end(), attr_name)
-  }
+  private API::Node fabric_attr(string attr_name) { result = fabric().getMember(attr_name) }
 
   /** Provides models for the `fabric` module. */
   module fabric {
@@ -75,7 +35,7 @@ private module FabricV1 {
     // fabric.api
     // -------------------------------------------------------------------------
     /** Gets a reference to the `fabric.api` module. */
-    DataFlow::Node api() { result = fabric_attr("api") }
+    API::Node api() { result = fabric_attr("api") }
 
     /** Provides models for the `fabric.api` module */
     module api {
@@ -83,41 +43,7 @@ private module FabricV1 {
        * Gets a reference to the attribute `attr_name` of the `fabric.api` module.
        * WARNING: Only holds for a few predefined attributes.
        */
-      private DataFlow::Node api_attr(DataFlow::TypeTracker t, string attr_name) {
-        attr_name in ["run", "local", "sudo"] and
-        (
-          t.start() and
-          result = DataFlow::importNode("fabric.api" + "." + attr_name)
-          or
-          t.startInAttr(attr_name) and
-          result = api()
-        )
-        or
-        // Due to bad performance when using normal setup with `api_attr(t2, attr_name).track(t2, t)`
-        // we have inlined that code and forced a join
-        exists(DataFlow::TypeTracker t2 |
-          exists(DataFlow::StepSummary summary |
-            api_attr_first_join(t2, attr_name, result, summary) and
-            t = t2.append(summary)
-          )
-        )
-      }
-
-      pragma[nomagic]
-      private predicate api_attr_first_join(
-        DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res,
-        DataFlow::StepSummary summary
-      ) {
-        DataFlow::StepSummary::step(api_attr(t2, attr_name), res, summary)
-      }
-
-      /**
-       * Gets a reference to the attribute `attr_name` of the `fabric.api` module.
-       * WARNING: Only holds for a few predefined attributes.
-       */
-      private DataFlow::Node api_attr(string attr_name) {
-        result = api_attr(DataFlow::TypeTracker::end(), attr_name)
-      }
+      private API::Node api_attr(string attr_name) { result = api().getMember(attr_name) }
 
       /**
        * A call to either
@@ -130,12 +56,8 @@ private module FabricV1 {
        * - https://docs.fabfile.org/en/1.14/api/core/operations.html#fabric.operations.sudo
        */
       private class FabricApiLocalRunSudoCall extends SystemCommandExecution::Range,
-        DataFlow::CfgNode {
-        override CallNode node;
-
-        FabricApiLocalRunSudoCall() {
-          node.getFunction() = api_attr(["local", "run", "sudo"]).asCfgNode()
-        }
+        DataFlow::CallCfgNode {
+        FabricApiLocalRunSudoCall() { this = api_attr(["local", "run", "sudo"]).getACall() }
 
         override DataFlow::Node getCommand() {
           result.asCfgNode() = [node.getArg(0), node.getArgByName("command")]
@@ -153,61 +75,13 @@ private module FabricV1 {
  */
 private module FabricV2 {
   /** Gets a reference to the `fabric` module. */
-  private DataFlow::Node fabric(DataFlow::TypeTracker t) {
-    t.start() and
-    result = DataFlow::importNode("fabric")
-    or
-    exists(DataFlow::TypeTracker t2 | result = fabric(t2).track(t2, t))
-  }
-
-  /** Gets a reference to the `fabric` module. */
-  DataFlow::Node fabric() { result = fabric(DataFlow::TypeTracker::end()) }
+  API::Node fabric() { result = API::moduleImport("fabric") }
 
   /**
    * Gets a reference to the attribute `attr_name` of the `fabric` module.
    * WARNING: Only holds for a few predefined attributes.
    */
-  private DataFlow::Node fabric_attr(DataFlow::TypeTracker t, string attr_name) {
-    attr_name in [
-        // connection.py
-        "connection", "Connection",
-        // group.py
-        "group", "SerialGroup", "ThreadingGroup",
-        // tasks.py
-        "tasks", "task"
-      ] and
-    (
-      t.start() and
-      result = DataFlow::importNode("fabric" + "." + attr_name)
-      or
-      t.startInAttr(attr_name) and
-      result = fabric()
-    )
-    or
-    // Due to bad performance when using normal setup with `fabric_attr(t2, attr_name).track(t2, t)`
-    // we have inlined that code and forced a join
-    exists(DataFlow::TypeTracker t2 |
-      exists(DataFlow::StepSummary summary |
-        fabric_attr_first_join(t2, attr_name, result, summary) and
-        t = t2.append(summary)
-      )
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fabric_attr_first_join(
-    DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res, DataFlow::StepSummary summary
-  ) {
-    DataFlow::StepSummary::step(fabric_attr(t2, attr_name), res, summary)
-  }
-
-  /**
-   * Gets a reference to the attribute `attr_name` of the `fabric` module.
-   * WARNING: Only holds for a few predefined attributes.
-   */
-  private DataFlow::Node fabric_attr(string attr_name) {
-    result = fabric_attr(DataFlow::TypeTracker::end(), attr_name)
-  }
+  private API::Node fabric_attr(string attr_name) { result = fabric().getMember(attr_name) }
 
   /** Provides models for the `fabric` module. */
   module fabric {
@@ -215,7 +89,7 @@ private module FabricV2 {
     // fabric.connection
     // -------------------------------------------------------------------------
     /** Gets a reference to the `fabric.connection` module. */
-    DataFlow::Node connection() { result = fabric_attr("connection") }
+    API::Node connection() { result = fabric_attr("connection") }
 
     /** Provides models for the `fabric.connection` module */
     module connection {
@@ -223,40 +97,8 @@ private module FabricV2 {
        * Gets a reference to the attribute `attr_name` of the `fabric.connection` module.
        * WARNING: Only holds for a few predefined attributes.
        */
-      private DataFlow::Node connection_attr(DataFlow::TypeTracker t, string attr_name) {
-        attr_name in ["Connection"] and
-        (
-          t.start() and
-          result = DataFlow::importNode("fabric.connection" + "." + attr_name)
-          or
-          t.startInAttr(attr_name) and
-          result = connection()
-        )
-        or
-        // Due to bad performance when using normal setup with `connection_attr(t2, attr_name).track(t2, t)`
-        // we have inlined that code and forced a join
-        exists(DataFlow::TypeTracker t2 |
-          exists(DataFlow::StepSummary summary |
-            connection_attr_first_join(t2, attr_name, result, summary) and
-            t = t2.append(summary)
-          )
-        )
-      }
-
-      pragma[nomagic]
-      private predicate connection_attr_first_join(
-        DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res,
-        DataFlow::StepSummary summary
-      ) {
-        DataFlow::StepSummary::step(connection_attr(t2, attr_name), res, summary)
-      }
-
-      /**
-       * Gets a reference to the attribute `attr_name` of the `fabric.connection` module.
-       * WARNING: Only holds for a few predefined attributes.
-       */
-      private DataFlow::Node connection_attr(string attr_name) {
-        result = connection_attr(DataFlow::TypeTracker::end(), attr_name)
+      private API::Node connection_attr(string attr_name) {
+        result = connection().getMember(attr_name)
       }
 
       /**
@@ -266,19 +108,9 @@ private module FabricV2 {
        */
       module Connection {
         /** Gets a reference to the `fabric.connection.Connection` class. */
-        private DataFlow::Node classRef(DataFlow::TypeTracker t) {
-          t.start() and
-          result = connection_attr("Connection")
-          or
-          // handle `fabric.Connection` alias
-          t.start() and
-          result = fabric_attr("Connection")
-          or
-          exists(DataFlow::TypeTracker t2 | result = classRef(t2).track(t2, t))
+        API::Node classRef() {
+          result in [fabric_attr("Connection"), connection_attr("Connection")]
         }
-
-        /** Gets a reference to the `fabric.connection.Connection` class. */
-        DataFlow::Node classRef() { result = classRef(DataFlow::TypeTracker::end()) }
 
         /**
          * A source of instances of `fabric.connection.Connection`, extend this class to model new instances.
@@ -289,16 +121,14 @@ private module FabricV2 {
          *
          * Use the predicate `Connection::instance()` to get references to instances of `fabric.connection.Connection`.
          */
-        abstract class InstanceSource extends DataFlow::Node { }
+        abstract class InstanceSource extends DataFlow::LocalSourceNode { }
 
-        private class ClassInstantiation extends InstanceSource, DataFlow::CfgNode {
-          override CallNode node;
-
-          ClassInstantiation() { node.getFunction() = classRef().asCfgNode() }
+        private class ClassInstantiation extends InstanceSource, DataFlow::CallCfgNode {
+          ClassInstantiation() { this = classRef().getACall() }
         }
 
         /** Gets a reference to an instance of `fabric.connection.Connection`. */
-        private DataFlow::Node instance(DataFlow::TypeTracker t) {
+        private DataFlow::LocalSourceNode instance(DataFlow::TypeTracker t) {
           t.start() and
           result instanceof InstanceSource
           or
@@ -306,7 +136,7 @@ private module FabricV2 {
         }
 
         /** Gets a reference to an instance of `fabric.connection.Connection`. */
-        DataFlow::Node instance() { result = instance(DataFlow::TypeTracker::end()) }
+        DataFlow::Node instance() { instance(DataFlow::TypeTracker::end()).flowsTo(result) }
 
         /**
          * Gets a reference to either `run`, `sudo`, or `local` method on a
@@ -317,7 +147,7 @@ private module FabricV2 {
          * - https://docs.fabfile.org/en/2.5/api/connection.html#fabric.connection.Connection.sudo
          * - https://docs.fabfile.org/en/2.5/api/connection.html#fabric.connection.Connection.local
          */
-        private DataFlow::Node instanceRunMethods(DataFlow::TypeTracker t) {
+        private DataFlow::LocalSourceNode instanceRunMethods(DataFlow::TypeTracker t) {
           t.startInAttr(["run", "sudo", "local"]) and
           result = instance()
           or
@@ -334,7 +164,7 @@ private module FabricV2 {
          * - https://docs.fabfile.org/en/2.5/api/connection.html#fabric.connection.Connection.local
          */
         DataFlow::Node instanceRunMethods() {
-          result = instanceRunMethods(DataFlow::TypeTracker::end())
+          instanceRunMethods(DataFlow::TypeTracker::end()).flowsTo(result)
         }
       }
     }
@@ -347,11 +177,9 @@ private module FabricV2 {
      * - https://docs.fabfile.org/en/2.5/api/connection.html#fabric.connection.Connection.local
      */
     private class FabricConnectionRunSudoLocalCall extends SystemCommandExecution::Range,
-      DataFlow::CfgNode {
-      override CallNode node;
-
+      DataFlow::CallCfgNode {
       FabricConnectionRunSudoLocalCall() {
-        node.getFunction() = fabric::connection::Connection::instanceRunMethods().asCfgNode()
+        this.getFunction() = fabric::connection::Connection::instanceRunMethods()
       }
 
       override DataFlow::Node getCommand() {
@@ -363,34 +191,19 @@ private module FabricV2 {
     // fabric.tasks
     // -------------------------------------------------------------------------
     /** Gets a reference to the `fabric.tasks` module. */
-    DataFlow::Node tasks() { result = fabric_attr("tasks") }
+    API::Node tasks() { result = fabric_attr("tasks") }
 
     /** Provides models for the `fabric.tasks` module */
     module tasks {
       /** Gets a reference to the `fabric.tasks.task` decorator. */
-      private DataFlow::Node task(DataFlow::TypeTracker t) {
-        t.start() and
-        result = DataFlow::importNode("fabric.tasks.task")
-        or
-        t.startInAttr("task") and
-        result = tasks()
-        or
-        // Handle `fabric.task` alias
-        t.startInAttr("task") and
-        result = fabric()
-        or
-        exists(DataFlow::TypeTracker t2 | result = task(t2).track(t2, t))
-      }
-
-      /** Gets a reference to the `fabric.tasks.task` decorator. */
-      DataFlow::Node task() { result = task(DataFlow::TypeTracker::end()) }
+      API::Node task() { result in [tasks().getMember("task"), fabric().getMember("task")] }
     }
 
     class FabricTaskFirstParamConnectionInstance extends fabric::connection::Connection::InstanceSource,
       DataFlow::ParameterNode {
       FabricTaskFirstParamConnectionInstance() {
         exists(Function func |
-          func.getADecorator() = fabric::tasks::task().asExpr() and
+          func.getADecorator() = fabric::tasks::task().getAUse().asExpr() and
           this.getParameter() = func.getArg(0)
         )
       }
@@ -400,7 +213,7 @@ private module FabricV2 {
     // fabric.group
     // -------------------------------------------------------------------------
     /** Gets a reference to the `fabric.group` module. */
-    DataFlow::Node group() { result = fabric_attr("group") }
+    API::Node group() { result = fabric_attr("group") }
 
     /** Provides models for the `fabric.group` module */
     module group {
@@ -408,41 +221,7 @@ private module FabricV2 {
        * Gets a reference to the attribute `attr_name` of the `fabric.group` module.
        * WARNING: Only holds for a few predefined attributes.
        */
-      private DataFlow::Node group_attr(DataFlow::TypeTracker t, string attr_name) {
-        attr_name in ["SerialGroup", "ThreadingGroup"] and
-        (
-          t.start() and
-          result = DataFlow::importNode("fabric.group" + "." + attr_name)
-          or
-          t.startInAttr(attr_name) and
-          result = group()
-        )
-        or
-        // Due to bad performance when using normal setup with `group_attr(t2, attr_name).track(t2, t)`
-        // we have inlined that code and forced a join
-        exists(DataFlow::TypeTracker t2 |
-          exists(DataFlow::StepSummary summary |
-            group_attr_first_join(t2, attr_name, result, summary) and
-            t = t2.append(summary)
-          )
-        )
-      }
-
-      pragma[nomagic]
-      private predicate group_attr_first_join(
-        DataFlow::TypeTracker t2, string attr_name, DataFlow::Node res,
-        DataFlow::StepSummary summary
-      ) {
-        DataFlow::StepSummary::step(group_attr(t2, attr_name), res, summary)
-      }
-
-      /**
-       * Gets a reference to the attribute `attr_name` of the `fabric.group` module.
-       * WARNING: Only holds for a few predefined attributes.
-       */
-      private DataFlow::Node group_attr(string attr_name) {
-        result = group_attr(DataFlow::TypeTracker::end(), attr_name)
-      }
+      private API::Node group_attr(string attr_name) { result = group().getMember(attr_name) }
 
       /**
        * Provides models for the `fabric.group.Group` class and its subclasses.
@@ -465,41 +244,20 @@ private module FabricV2 {
          *
          * Use `Group::subclassInstance()` predicate to get references to an instance of a subclass of `fabric.group.Group`.
          */
-        abstract class SubclassInstanceSource extends DataFlow::Node { }
-
-        /** Gets a reference to an instance of a subclass of `fabric.group.Group`. */
-        private DataFlow::Node subclassInstance(DataFlow::TypeTracker t) {
-          t.start() and
-          result instanceof SubclassInstanceSource
-          or
-          exists(DataFlow::TypeTracker t2 | result = subclassInstance(t2).track(t2, t))
+        abstract class ModeledSubclass extends API::Node {
+          /** Gets a string representation of this element. */
+          override string toString() { result = this.(API::Node).toString() }
         }
 
         /** Gets a reference to an instance of a subclass of `fabric.group.Group`. */
-        DataFlow::Node subclassInstance() {
-          result = subclassInstance(DataFlow::TypeTracker::end())
-        }
+        API::Node subclassInstance() { result = any(ModeledSubclass m).getASubclass*().getReturn() }
 
         /**
          * Gets a reference to the `run` method on an instance of a subclass of `fabric.group.Group`.
          *
          * See https://docs.fabfile.org/en/2.5/api/group.html#fabric.group.Group.run
          */
-        private DataFlow::Node subclassInstanceRunMethod(DataFlow::TypeTracker t) {
-          t.startInAttr("run") and
-          result = subclassInstance()
-          or
-          exists(DataFlow::TypeTracker t2 | result = subclassInstanceRunMethod(t2).track(t2, t))
-        }
-
-        /**
-         * Gets a reference to the `run` method on an instance of a subclass of `fabric.group.Group`.
-         *
-         * See https://docs.fabfile.org/en/2.5/api/group.html#fabric.group.Group.run
-         */
-        DataFlow::Node subclassInstanceRunMethod() {
-          result = subclassInstanceRunMethod(DataFlow::TypeTracker::end())
-        }
+        API::Node subclassInstanceRunMethod() { result = subclassInstance().getMember("run") }
       }
 
       /**
@@ -507,12 +265,8 @@ private module FabricV2 {
        *
        * See https://docs.fabfile.org/en/2.5/api/group.html#fabric.group.Group.run
        */
-      private class FabricGroupRunCall extends SystemCommandExecution::Range, DataFlow::CfgNode {
-        override CallNode node;
-
-        FabricGroupRunCall() {
-          node.getFunction() = fabric::group::Group::subclassInstanceRunMethod().asCfgNode()
-        }
+      private class FabricGroupRunCall extends SystemCommandExecution::Range, DataFlow::CallCfgNode {
+        FabricGroupRunCall() { this = fabric::group::Group::subclassInstanceRunMethod().getACall() }
 
         override DataFlow::Node getCommand() {
           result.asCfgNode() = [node.getArg(0), node.getArgByName("command")]
@@ -525,25 +279,8 @@ private module FabricV2 {
        * See https://docs.fabfile.org/en/2.5/api/group.html#fabric.group.SerialGroup.
        */
       module SerialGroup {
-        /** Gets a reference to the `fabric.group.SerialGroup` class. */
-        private DataFlow::Node classRef(DataFlow::TypeTracker t) {
-          t.start() and
-          result = group_attr("SerialGroup")
-          or
-          // Handle `fabric.SerialGroup` alias
-          t.start() and
-          result = fabric_attr("SerialGroup")
-          or
-          exists(DataFlow::TypeTracker t2 | result = classRef(t2).track(t2, t))
-        }
-
-        /** Gets a reference to the `fabric.group.SerialGroup` class. */
-        private DataFlow::Node classRef() { result = classRef(DataFlow::TypeTracker::end()) }
-
-        private class ClassInstantiation extends Group::SubclassInstanceSource, DataFlow::CfgNode {
-          override CallNode node;
-
-          ClassInstantiation() { node.getFunction() = classRef().asCfgNode() }
+        private class ClassInstantiation extends Group::ModeledSubclass {
+          ClassInstantiation() { this in [group_attr("SerialGroup"), fabric_attr("SerialGroup")] }
         }
       }
 
@@ -553,25 +290,10 @@ private module FabricV2 {
        * See https://docs.fabfile.org/en/2.5/api/group.html#fabric.group.ThreadingGroup.
        */
       module ThreadingGroup {
-        /** Gets a reference to the `fabric.group.ThreadingGroup` class. */
-        private DataFlow::Node classRef(DataFlow::TypeTracker t) {
-          t.start() and
-          result = group_attr("ThreadingGroup")
-          or
-          // Handle `fabric.ThreadingGroup` alias
-          t.start() and
-          result = fabric_attr("ThreadingGroup")
-          or
-          exists(DataFlow::TypeTracker t2 | result = classRef(t2).track(t2, t))
-        }
-
-        /** Gets a reference to the `fabric.group.ThreadingGroup` class. */
-        DataFlow::Node classRef() { result = classRef(DataFlow::TypeTracker::end()) }
-
-        private class ClassInstantiation extends Group::SubclassInstanceSource, DataFlow::CfgNode {
-          override CallNode node;
-
-          ClassInstantiation() { node.getFunction() = classRef().asCfgNode() }
+        private class ClassInstantiation extends Group::ModeledSubclass {
+          ClassInstantiation() {
+            this in [group_attr("ThreadingGroup"), fabric_attr("ThreadingGroup")]
+          }
         }
       }
     }

--- a/python/ql/src/semmle/python/frameworks/Fabric.qll
+++ b/python/ql/src/semmle/python/frameworks/Fabric.qll
@@ -83,7 +83,9 @@ private module FabricV2 {
       module Connection {
         /** Gets a reference to the `fabric.connection.Connection` class. */
         API::Node classRef() {
-          result in [fabric().getMember("Connection"), connection().getMember("Connection")]
+          result = fabric().getMember("Connection")
+          or
+          result = connection().getMember("Connection")
         }
 
         /**
@@ -110,7 +112,7 @@ private module FabricV2 {
         }
 
         /** Gets a reference to an instance of `fabric.connection.Connection`. */
-        DataFlow::LocalSourceNode instance() { result = instance(DataFlow::TypeTracker::end()) }
+        DataFlow::Node instance() { instance(DataFlow::TypeTracker::end()).flowsTo(result) }
 
         /**
          * Gets a reference to either `run`, `sudo`, or `local` method on a
@@ -249,7 +251,9 @@ private module FabricV2 {
       module SerialGroup {
         private class ClassInstantiation extends Group::ModeledSubclass {
           ClassInstantiation() {
-            this in [group().getMember("SerialGroup"), fabric().getMember("SerialGroup")]
+            this = group().getMember("SerialGroup")
+            or
+            this = fabric().getMember("SerialGroup")
           }
         }
       }
@@ -262,7 +266,9 @@ private module FabricV2 {
       module ThreadingGroup {
         private class ClassInstantiation extends Group::ModeledSubclass {
           ClassInstantiation() {
-            this in [group().getMember("ThreadingGroup"), fabric().getMember("ThreadingGroup")]
+            this = group().getMember("ThreadingGroup")
+            or
+            this = fabric().getMember("ThreadingGroup")
           }
         }
       }

--- a/python/ql/src/semmle/python/frameworks/Fabric.qll
+++ b/python/ql/src/semmle/python/frameworks/Fabric.qll
@@ -23,28 +23,16 @@ private module FabricV1 {
   /** Gets a reference to the `fabric` module. */
   API::Node fabric() { result = API::moduleImport("fabric") }
 
-  /**
-   * Gets a reference to the attribute `attr_name` of the `fabric` module.
-   * WARNING: Only holds for a few predefined attributes.
-   */
-  private API::Node fabric_attr(string attr_name) { result = fabric().getMember(attr_name) }
-
   /** Provides models for the `fabric` module. */
   module fabric {
     // -------------------------------------------------------------------------
     // fabric.api
     // -------------------------------------------------------------------------
     /** Gets a reference to the `fabric.api` module. */
-    API::Node api() { result = fabric_attr("api") }
+    API::Node api() { result = fabric().getMember("api") }
 
     /** Provides models for the `fabric.api` module */
     module api {
-      /**
-       * Gets a reference to the attribute `attr_name` of the `fabric.api` module.
-       * WARNING: Only holds for a few predefined attributes.
-       */
-      private API::Node api_attr(string attr_name) { result = api().getMember(attr_name) }
-
       /**
        * A call to either
        * - `fabric.api.local`
@@ -57,7 +45,7 @@ private module FabricV1 {
        */
       private class FabricApiLocalRunSudoCall extends SystemCommandExecution::Range,
         DataFlow::CallCfgNode {
-        FabricApiLocalRunSudoCall() { this = api_attr(["local", "run", "sudo"]).getACall() }
+        FabricApiLocalRunSudoCall() { this = api().getMember(["local", "run", "sudo"]).getACall() }
 
         override DataFlow::Node getCommand() {
           result.asCfgNode() = [node.getArg(0), node.getArgByName("command")]
@@ -77,30 +65,16 @@ private module FabricV2 {
   /** Gets a reference to the `fabric` module. */
   API::Node fabric() { result = API::moduleImport("fabric") }
 
-  /**
-   * Gets a reference to the attribute `attr_name` of the `fabric` module.
-   * WARNING: Only holds for a few predefined attributes.
-   */
-  private API::Node fabric_attr(string attr_name) { result = fabric().getMember(attr_name) }
-
   /** Provides models for the `fabric` module. */
   module fabric {
     // -------------------------------------------------------------------------
     // fabric.connection
     // -------------------------------------------------------------------------
     /** Gets a reference to the `fabric.connection` module. */
-    API::Node connection() { result = fabric_attr("connection") }
+    API::Node connection() { result = fabric().getMember("connection") }
 
     /** Provides models for the `fabric.connection` module */
     module connection {
-      /**
-       * Gets a reference to the attribute `attr_name` of the `fabric.connection` module.
-       * WARNING: Only holds for a few predefined attributes.
-       */
-      private API::Node connection_attr(string attr_name) {
-        result = connection().getMember(attr_name)
-      }
-
       /**
        * Provides models for the `fabric.connection.Connection` class
        *
@@ -109,7 +83,7 @@ private module FabricV2 {
       module Connection {
         /** Gets a reference to the `fabric.connection.Connection` class. */
         API::Node classRef() {
-          result in [fabric_attr("Connection"), connection_attr("Connection")]
+          result in [fabric().getMember("Connection"), connection().getMember("Connection")]
         }
 
         /**
@@ -136,7 +110,7 @@ private module FabricV2 {
         }
 
         /** Gets a reference to an instance of `fabric.connection.Connection`. */
-        DataFlow::Node instance() { instance(DataFlow::TypeTracker::end()).flowsTo(result) }
+        DataFlow::LocalSourceNode instance() { result = instance(DataFlow::TypeTracker::end()) }
 
         /**
          * Gets a reference to either `run`, `sudo`, or `local` method on a
@@ -191,7 +165,7 @@ private module FabricV2 {
     // fabric.tasks
     // -------------------------------------------------------------------------
     /** Gets a reference to the `fabric.tasks` module. */
-    API::Node tasks() { result = fabric_attr("tasks") }
+    API::Node tasks() { result = fabric().getMember("tasks") }
 
     /** Provides models for the `fabric.tasks` module */
     module tasks {
@@ -213,16 +187,10 @@ private module FabricV2 {
     // fabric.group
     // -------------------------------------------------------------------------
     /** Gets a reference to the `fabric.group` module. */
-    API::Node group() { result = fabric_attr("group") }
+    API::Node group() { result = fabric().getMember("group") }
 
     /** Provides models for the `fabric.group` module */
     module group {
-      /**
-       * Gets a reference to the attribute `attr_name` of the `fabric.group` module.
-       * WARNING: Only holds for a few predefined attributes.
-       */
-      private API::Node group_attr(string attr_name) { result = group().getMember(attr_name) }
-
       /**
        * Provides models for the `fabric.group.Group` class and its subclasses.
        *
@@ -280,7 +248,9 @@ private module FabricV2 {
        */
       module SerialGroup {
         private class ClassInstantiation extends Group::ModeledSubclass {
-          ClassInstantiation() { this in [group_attr("SerialGroup"), fabric_attr("SerialGroup")] }
+          ClassInstantiation() {
+            this in [group().getMember("SerialGroup"), fabric().getMember("SerialGroup")]
+          }
         }
       }
 
@@ -292,7 +262,7 @@ private module FabricV2 {
       module ThreadingGroup {
         private class ClassInstantiation extends Group::ModeledSubclass {
           ClassInstantiation() {
-            this in [group_attr("ThreadingGroup"), fabric_attr("ThreadingGroup")]
+            this in [group().getMember("ThreadingGroup"), fabric().getMember("ThreadingGroup")]
           }
         }
       }


### PR DESCRIPTION
Because of the modelling of decorators, I wasn't able to get rid of all of the bespoke type trackers, but the ones that remain have been converted to use `LocalSourceNode` instead.

(And we should be able to get rid of them once we add defs to the API graph.)

No change note required -- behaviour should be unchanged.