### PR TITLE
Python: Use API graphs in Werkzeug

### DIFF
--- a/python/change-notes/2021-04-13-werkzeug-api-graphs.md
+++ b/python/change-notes/2021-04-13-werkzeug-api-graphs.md
@@ -1,0 +1,5 @@
+lgtm,codescanning
+* The Werkzeug model has been changed to use API graphs. When defining new models for classes based
+  on the `MultiDict` and `FileStorage` classes in `werkzeug.datastructures`, the relevant extension
+  points are now the two `InstanceSourceApiNode` classes in the `semmle.python.frameworks.Werkzeug`
+  module, instead of `InstanceSource`. The latter classes have now been deprecated.

--- a/python/ql/src/semmle/python/frameworks/Flask.qll
+++ b/python/ql/src/semmle/python/frameworks/Flask.qll
@@ -401,13 +401,15 @@ module Flask {
     }
   }
 
-  private class RequestAttrMultiDict extends Werkzeug::werkzeug::datastructures::MultiDict::InstanceSource {
+  private class RequestAttrMultiDict extends Werkzeug::werkzeug::datastructures::MultiDict::InstanceSourceApiNode {
     string attr_name;
 
     RequestAttrMultiDict() {
       attr_name in ["args", "values", "form", "files"] and
-      this = request().getMember(attr_name).getAnImmediateUse()
+      this = request().getMember(attr_name)
     }
+
+    override string toString() { result = this.(API::Node).toString() }
   }
 
   private class RequestAttrFiles extends RequestAttrMultiDict {

--- a/python/ql/src/semmle/python/frameworks/Werkzeug.qll
+++ b/python/ql/src/semmle/python/frameworks/Werkzeug.qll
@@ -5,6 +5,7 @@
 private import python
 private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.dataflow.new.TaintTracking
+private import semmle.python.ApiGraphs
 
 /**
  * Provides models for the `Werkzeug` PyPI package.
@@ -23,6 +24,9 @@ module Werkzeug {
        * See https://werkzeug.palletsprojects.com/en/1.0.x/datastructures/#werkzeug.datastructures.MultiDict.
        */
       module MultiDict {
+        /** DEPRECATED. Use `InstanceSourceApiNode` instead. */
+        abstract deprecated class InstanceSource extends DataFlow::Node { }
+
         /**
          * A source of instances of `werkzeug.datastructures.MultiDict`, extend this class to model new instances.
          *
@@ -32,37 +36,16 @@ module Werkzeug {
          *
          * Use the predicate `MultiDict::instance()` to get references to instances of `werkzeug.datastructures.MultiDict`.
          */
-        abstract class InstanceSource extends DataFlow::Node { }
-
-        /** Gets a reference to an instance of `werkzeug.datastructures.MultiDict`. */
-        private DataFlow::Node instance(DataFlow::TypeTracker t) {
-          t.start() and
-          result instanceof InstanceSource
-          or
-          exists(DataFlow::TypeTracker t2 | result = instance(t2).track(t2, t))
-        }
-
-        /** Gets a reference to an instance of `werkzeug.datastructures.MultiDict`. */
-        DataFlow::Node instance() { result = instance(DataFlow::TypeTracker::end()) }
+        abstract class InstanceSourceApiNode extends API::Node { }
 
         /**
          * Gets a reference to the `getlist` method on an instance of `werkzeug.datastructures.MultiDict`.
          *
          * See https://werkzeug.palletsprojects.com/en/1.0.x/datastructures/#werkzeug.datastructures.Headers.getlist
          */
-        private DataFlow::Node getlist(DataFlow::TypeTracker t) {
-          t.startInAttr("getlist") and
-          result = instance()
-          or
-          exists(DataFlow::TypeTracker t2 | result = getlist(t2).track(t2, t))
+        DataFlow::Node getlist() {
+          result = any(InstanceSourceApiNode a).getMember("getlist").getAUse()
         }
-
-        /**
-         * Gets a reference to the `getlist` method on an instance of `werkzeug.datastructures.MultiDict`.
-         *
-         * See https://werkzeug.palletsprojects.com/en/1.0.x/datastructures/#werkzeug.datastructures.Headers.getlist
-         */
-        DataFlow::Node getlist() { result = getlist(DataFlow::TypeTracker::end()) }
       }
 
       /**
@@ -71,6 +54,9 @@ module Werkzeug {
        * See https://werkzeug.palletsprojects.com/en/1.0.x/datastructures/#werkzeug.datastructures.FileStorage.
        */
       module FileStorage {
+        /** DEPRECATED. Use `InstanceSourceApiNode` instead. */
+        abstract deprecated class InstanceSource extends DataFlow::Node { }
+
         /**
          * A source of instances of `werkzeug.datastructures.FileStorage`, extend this class to model new instances.
          *
@@ -80,18 +66,10 @@ module Werkzeug {
          *
          * Use the predicate `FileStorage::instance()` to get references to instances of `werkzeug.datastructures.FileStorage`.
          */
-        abstract class InstanceSource extends DataFlow::Node { }
+        abstract class InstanceSourceApiNode extends API::Node { }
 
         /** Gets a reference to an instance of `werkzeug.datastructures.FileStorage`. */
-        private DataFlow::Node instance(DataFlow::TypeTracker t) {
-          t.start() and
-          result instanceof InstanceSource
-          or
-          exists(DataFlow::TypeTracker t2 | result = instance(t2).track(t2, t))
-        }
-
-        /** Gets a reference to an instance of `werkzeug.datastructures.FileStorage`. */
-        DataFlow::Node instance() { result = instance(DataFlow::TypeTracker::end()) }
+        DataFlow::Node instance() { result = any(InstanceSourceApiNode a).getAUse() }
       }
     }
   }


### PR DESCRIPTION
Deprecates the old `InstanceSource` classes, as these were non-private.