### PR TITLE
C#: Add `Customizations.qll`

### DIFF
--- a/csharp/change-notes/2021-04-14-customizations.md
+++ b/csharp/change-notes/2021-04-14-customizations.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* A new library, `Customizations.qll`, has been added, which allows for global customizations that affect all queries.

--- a/csharp/ql/src/Customizations.qll
+++ b/csharp/ql/src/Customizations.qll
@@ -1,0 +1,12 @@
+/**
+ * Contains customizations to the standard library.
+ *
+ * This module is imported by `csharp.qll`, so any customizations defined here automatically
+ * apply to all queries.
+ *
+ * Typical examples of customizations include adding new subclasses of abstract classes such as
+ * the `RemoteFlowSource` and `SummarizedCallable` classes associated with the security queries
+ * to model frameworks that are not covered by the standard library.
+ */
+
+import csharp

--- a/csharp/ql/src/csharp.qll
+++ b/csharp/ql/src/csharp.qll
@@ -2,6 +2,7 @@
  * The default C# QL library.
  */
 
+import Customizations
 import semmle.code.csharp.Attribute
 import semmle.code.csharp.Callable
 import semmle.code.csharp.Comments


### PR DESCRIPTION
Even though I am not super happy with the approach, this seems to be the only way to allow for global customizations at the moment.