### PR TITLE
JS: Improve XMLParsers

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -924,7 +924,7 @@ private module Label {
       result = member(pn) and
       // only consider properties with alphanumeric(-ish) names, excluding special properties
       // and properties whose names look like they are meant to be internal
-      pn.regexpMatch("(?!prototype$|__)[a-zA-Z_$][\\w\\-.$]*")
+      pn.regexpMatch("(?!prototype$|__)[\\w_$][\\w\\-.$]*")
     )
     or
     not exists(pr.getPropertyName()) and

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -166,3 +166,7 @@ typeInferenceMismatch
 | xml.js:23:18:23:25 | source() | xml.js:20:14:20:17 | attr |
 | xml.js:26:27:26:34 | source() | xml.js:26:10:26:39 | convert ... (), {}) |
 | xml.js:34:18:34:25 | source() | xml.js:31:18:31:21 | name |
+| xml.js:41:15:41:22 | source() | xml.js:44:10:44:22 | gchild.text() |
+| xml.js:41:15:41:22 | source() | xml.js:49:10:49:34 | child.a ... value() |
+| xml.js:41:15:41:22 | source() | xml.js:52:10:52:34 | child2. ... .name() |
+| xml.js:41:15:41:22 | source() | xml.js:58:12:58:14 | str |

--- a/javascript/ql/test/library-tests/TaintTracking/xml.js
+++ b/javascript/ql/test/library-tests/TaintTracking/xml.js
@@ -35,3 +35,26 @@
     parser.end();
 
 })();
+
+(function () {
+    var libxml = require("libxmljs");
+    var xml = source();
+    var xmlDoc = libxml.parseXmlString(xml);
+    var gchild = xmlDoc.get('//grandchild');
+    sink(gchild.text()); // NOT OK
+
+    var children = xmlDoc.root().childNodes();
+    var child = children[0];
+
+    sink(child.attr('foo').value()); // NOT OK
+
+    var child2 = xmlDoc.root().child()
+    sink(child2.attr('foo').name()); // NOT OK
+
+    const SaxPushParser = libxml.SaxPushParser;
+    var parser = new SaxPushParser();
+    parser.push(xml);
+    parser.on('characters', function (str) {
+      sink(str); // NOT OK
+    })    
+});


### PR DESCRIPTION
Inspired by CVE-2020-7750

I've refactored the libraries to use `API::Node` more, and added models for the return values from more XML-parsing libraries. 

[A simple evaluation looks OK](https://github.com/dsp-testing/erik-krogh-dca/issues/71). 