### PR TITLE
C#: Speedup `DispatchMethodOrAccessorCall::getAViableOverrider()`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dispatch/Dispatch.qll
@@ -233,71 +233,61 @@ private module Internal {
   }
 
   pragma[noinline]
-  private predicate hasOverrider(OverridableCallable oc, ValueOrRefType t) {
-    exists(oc.getAnOverrider(t))
+  private predicate hasOverrider(OverridableCallable oc, Gvn::GvnType t) {
+    exists(oc.getAnOverrider(any(ValueOrRefType t0 | Gvn::getGlobalValueNumber(t0) = t)))
   }
 
   pragma[noinline]
-  private predicate hasCallable(OverridableCallable source, ValueOrRefType t, OverridableCallable c) {
+  private predicate hasCallable(OverridableCallable source, Gvn::GvnType t, OverridableCallable c) {
     c.getUnboundDeclaration() = source and
-    t.hasCallable(c) and
+    any(ValueOrRefType t0 | Gvn::getGlobalValueNumber(t0) = t).hasCallable(c) and
     hasOverrider(c, t) and
-    hasQualifierTypeOverridden0(t, _) and
-    hasQualifierTypeOverridden1(source, _)
-  }
-
-  pragma[noinline]
-  private Unification::ConstrainedTypeParameter getAConstrainedTypeParameterQualifierType(
-    DispatchMethodOrAccessorCall call
-  ) {
-    result = getAPossibleType(call.getQualifier(), false)
-  }
-
-  pragma[noinline]
-  private predicate constrainedTypeParameterQualifierTypeSubsumes(
-    ValueOrRefType t, Unification::ConstrainedTypeParameter tp
-  ) {
-    tp = getAConstrainedTypeParameterQualifierType(_) and
-    tp.subsumes(t)
-  }
-
-  pragma[noinline]
-  private predicate hasQualifierTypeOverridden0(ValueOrRefType t, DispatchMethodOrAccessorCall call) {
-    hasOverrider(_, t) and
-    (
-      exists(Type t0, Type t1 |
-        t0 = getAPossibleType(call.getQualifier(), false) and
-        t1 = [t0, t0.(Unification::UnconstrainedTypeParameter).getAnUltimatelySuppliedType()]
-      |
-        t = t1
-        or
-        Unification::subsumes(t1, t)
-      )
-      or
-      constrainedTypeParameterQualifierTypeSubsumes(t,
-        getAConstrainedTypeParameterQualifierType(call))
-    )
-  }
-
-  pragma[noinline]
-  private predicate hasQualifierTypeOverridden1(
-    OverridableCallable c, DispatchMethodOrAccessorCall call
-  ) {
-    exists(OverridableCallable target | call.getAStaticTarget() = target |
-      c = target.getUnboundDeclaration()
-      or
-      c = target.getAnUltimateImplementor().getUnboundDeclaration()
-    )
+    source = any(DispatchMethodOrAccessorCall call).getAStaticTargetExt()
   }
 
   abstract private class DispatchMethodOrAccessorCall extends DispatchCallImpl {
+    pragma[noinline]
+    OverridableCallable getAStaticTargetExt() {
+      exists(OverridableCallable target | this.getAStaticTarget() = target |
+        result = target.getUnboundDeclaration()
+        or
+        result = target.getAnUltimateImplementor().getUnboundDeclaration()
+      )
+    }
+
     pragma[nomagic]
     predicate hasQualifierTypeInherited(Type t) { t = getAPossibleType(this.getQualifier(), _) }
 
+    pragma[noinline]
+    private predicate hasSubsumedQualifierType(Gvn::GvnType t) {
+      hasOverrider(_, t) and
+      exists(Type t0 |
+        t0 = getAPossibleType(this.getQualifier(), false) and
+        not t0 instanceof TypeParameter
+      |
+        t = Gvn::getGlobalValueNumber(t0)
+        or
+        Gvn::subsumes(Gvn::getGlobalValueNumber(t0), t)
+      )
+    }
+
+    pragma[noinline]
+    private predicate hasConstrainedTypeParameterQualifierType(
+      Unification::ConstrainedTypeParameter tp
+    ) {
+      tp = getAPossibleType(this.getQualifier(), false)
+    }
+
+    pragma[noinline]
+    private predicate hasUnconstrainedTypeParameterQualifierType() {
+      getAPossibleType(this.getQualifier(), false) instanceof
+        Unification::UnconstrainedTypeParameter
+    }
+
     pragma[nomagic]
-    predicate hasQualifierTypeOverridden(ValueOrRefType t, OverridableCallable c) {
-      hasQualifierTypeOverridden0(t, this) and
-      hasCallable(any(OverridableCallable oc | hasQualifierTypeOverridden1(oc, this)), t, c)
+    predicate hasSubsumedQualifierTypeOverridden(Gvn::GvnType t, OverridableCallable c) {
+      this.hasSubsumedQualifierType(t) and
+      hasCallable(any(OverridableCallable oc | oc = this.getAStaticTargetExt()), t, c)
     }
 
     /**
@@ -357,12 +347,33 @@ private module Internal {
     }
 
     pragma[nomagic]
-    private Callable getASubsumedStaticTarget0(Type t) {
+    private predicate contextArgHasConstrainedTypeParameterType(
+      DispatchCall ctx, Unification::ConstrainedTypeParameter tp
+    ) {
+      this.contextArgHasType(ctx, tp, false)
+    }
+
+    pragma[nomagic]
+    private predicate contextArgHasUnconstrainedTypeParameterType(DispatchCall ctx) {
+      this.contextArgHasType(ctx, any(Unification::UnconstrainedTypeParameter t), false)
+    }
+
+    pragma[nomagic]
+    private predicate contextArgHasNonTypeParameterType(DispatchCall ctx, Gvn::GvnType t) {
+      exists(Type t0 |
+        this.contextArgHasType(ctx, t0, false) and
+        not t0 instanceof TypeParameter and
+        t = Gvn::getGlobalValueNumber(t0)
+      )
+    }
+
+    pragma[nomagic]
+    private Callable getASubsumedStaticTarget0(Gvn::GvnType t) {
       exists(Callable staticTarget, Type declType |
         staticTarget = this.getAStaticTarget() and
         declType = staticTarget.getDeclaringType() and
         result = staticTarget.getUnboundDeclaration() and
-        Unification::subsumes(declType, t)
+        Gvn::subsumes(Gvn::getGlobalValueNumber(declType), t)
       )
     }
 
@@ -375,7 +386,8 @@ private module Internal {
     private Callable getASubsumedStaticTarget() {
       result = this.getAStaticTarget()
       or
-      result.getUnboundDeclaration() = this.getASubsumedStaticTarget0(result.getDeclaringType())
+      result.getUnboundDeclaration() =
+        this.getASubsumedStaticTarget0(Gvn::getGlobalValueNumber(result.getDeclaringType()))
     }
 
     /**
@@ -426,6 +438,12 @@ private module Internal {
       )
     }
 
+    pragma[noinline]
+    NonConstructedOverridableCallable getAViableOverrider0() {
+      getAPossibleType(this.getQualifier(), false) instanceof TypeParameter and
+      result.getAConstructingCallableOrSelf() = this.getAStaticTargetExt()
+    }
+
     /**
      * Gets a callable that is defined in a subtype of the qualifier type of this
      * call, and which overrides a static target of this call.
@@ -468,8 +486,21 @@ private module Internal {
      */
     private RuntimeCallable getAViableOverrider() {
       exists(ValueOrRefType t, NonConstructedOverridableCallable c |
-        this.hasQualifierTypeOverridden(t, c.getAConstructingCallableOrSelf()) and
+        this.hasSubsumedQualifierTypeOverridden(Gvn::getGlobalValueNumber(t),
+          c.getAConstructingCallableOrSelf()) and
         result = c.getAnOverrider(t)
+      )
+      or
+      exists(NonConstructedOverridableCallable c |
+        c = this.getAViableOverrider0() and
+        result = c.getAnOverrider(_)
+      |
+        this.hasUnconstrainedTypeParameterQualifierType()
+        or
+        exists(Unification::ConstrainedTypeParameter tp |
+          this.hasConstrainedTypeParameterQualifierType(tp) and
+          tp.subsumes(result.getDeclaringType())
+        )
       )
     }
 
@@ -510,36 +541,40 @@ private module Internal {
     }
 
     pragma[nomagic]
-    private RuntimeCallable getAViableOverriderInCallContext0(
-      NonConstructedOverridableCallable c, ValueOrRefType t
-    ) {
-      result = this.getAViableOverrider() and
-      this.contextArgHasType(_, _, false) and
-      result = c.getAnOverrider(t)
+    private RuntimeCallable getAViableOverriderInCallContext0(Gvn::GvnType t) {
+      exists(NonConstructedOverridableCallable c |
+        result = this.getAViableOverrider() and
+        this.contextArgHasType(_, _, false) and
+        result = c.getAnOverrider(any(Type t0 | t = Gvn::getGlobalValueNumber(t0))) and
+        this.getAStaticTarget() = c.getAConstructingCallableOrSelf()
+      )
     }
 
     pragma[nomagic]
-    private RuntimeCallable getAViableOverriderInCallContext1(
-      NonConstructedOverridableCallable c, DispatchCall ctx
-    ) {
-      exists(ValueOrRefType t |
-        result = this.getAViableOverriderInCallContext0(c, t) and
-        exists(Type t0, Type t1 |
-          this.contextArgHasType(ctx, t0, false) and
-          t1 = [t0, t0.(Unification::UnconstrainedTypeParameter).getAnUltimatelySuppliedType()]
-        |
-          t = t1
-          or
-          Unification::subsumes(t1, t)
-        )
+    private predicate contextArgHasSubsumedType(DispatchCall ctx, Gvn::GvnType t) {
+      hasOverrider(_, t) and
+      exists(Gvn::GvnType t0 | this.contextArgHasNonTypeParameterType(ctx, t0) |
+        t = t0
+        or
+        Gvn::subsumes(t0, t)
       )
     }
 
     pragma[nomagic]
     private RuntimeCallable getAViableOverriderInCallContext(DispatchCall ctx) {
-      exists(NonConstructedOverridableCallable c |
-        result = this.getAViableOverriderInCallContext1(c, ctx) and
-        this.getAStaticTarget() = c.getAConstructingCallableOrSelf()
+      exists(Gvn::GvnType t |
+        result = this.getAViableOverriderInCallContext0(t) and
+        this.contextArgHasSubsumedType(ctx, t)
+      )
+      or
+      result = this.getAViableOverrider() and
+      (
+        this.contextArgHasUnconstrainedTypeParameterType(ctx)
+        or
+        exists(Unification::ConstrainedTypeParameter tp |
+          this.contextArgHasConstrainedTypeParameterType(ctx, tp) and
+          tp.subsumes(result.getDeclaringType())
+        )
       )
     }
 


### PR DESCRIPTION
In addition to improved performance, the analysis no longer applies a closed-world assumption to type parameters. That is, if the type of a receiver is a type parameter, then the call may target any method of a compatible receiver type, not just the types that may instantiate the type parameter.


<details>
  <summary>Before (`dotnet/efcore`)</summary>
  
```
[2021-04-15 17:11:50] (400s) Clause timing report:
[2021-04-15 17:11:50] (400s) 
[2021-04-15 17:11:50] 
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::hasQualifierTypeOverridden#fff ............................................................................................. 33.1s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::hasQualifierTypeOverridden0#ff ........................................................................................................................... 29.2s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMember_dispred#fb ................................................................................................................................... 9.4s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMethod_dispred#ff ................................................................................................................................... 7s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::constrainedTypeParameterQualifierTypeSubsumes#ff ......................................................................................................... 6s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableInherited_dispred#ff ............................................................................................. 5.6s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited0#fff .................................................................................................................. 5.5s (37 evaluations with max 2.2s in OverridableCallable::OverridableCallable::getInherited0#fff/3@i3#9715bw)
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasCallable_dispred#ff_10#join_rhs ..................................................................................................................... 5.5s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMember_dispred#fb_10#join_rhs ....................................................................................................................... 5.1s
	GetADynamicTarget copy.ql-25:project#Dispatch::Internal::hasQualifierTypeOverridden0#ff ................................................................................................................... 3.3s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::isRelevantReflectionOrDynamicQualifierType#f ............................................................................................................. 3.1s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::isDeclaringSubType#ff .............................................................................................................. 2.6s (37 evaluations with max 1.1s in OverridableCallable::OverridableCallable::isDeclaringSubType#ff/2@i4#957d3w)
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited#fff ................................................................................................................... 2.3s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getAnOverrider#2#fff#join_rhs ...................................................................................................... 2.1s
	GetADynamicTarget copy.ql-25:Element::Element::fromLibrary_dispred#b ...................................................................................................................................... 1.5s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasCallable_dispred#ff ................................................................................................................................. 1.5s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::getADynamicTargetCandidateInstanceMethod#ff .............................................................................................................. 1.4s
	GetADynamicTarget copy.ql-25:boundedFastTC(OverridableCallable::OverridableCallable::getAnOverrider_dispred#ff_10#higher_order_body,Member::Declaration::getDeclaringType_dispred#ff_0#higher_order_body) . 1.4s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getASubsumedStaticTarget0#fff .............................................................................................. 1.2s
	GetADynamicTarget copy.ql-25:ExprOrStmtParent::Cached::bestLocation#ff_10#join_rhs ........................................................................................................................ 1.2s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::isDeclaringSubType#ff_10#join_rhs .................................................................................................. 1.2s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited#fff_201#join_rhs ...................................................................................................... 982ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getASubsumedStaticTarget0#fff_120#join_rhs ................................................................................. 968ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getASubsumedStaticTarget#ff ................................................................................................ 963ms
	GetADynamicTarget copy.ql-25:Element::NamedElement::getName_dispred#ff .................................................................................................................................... 853ms (3 evaluations with max 335ms in Element::NamedElement::getName_dispred#ff/2@i3#5d941w)
	GetADynamicTarget copy.ql-25:Conversion::implicitConversion#ff ............................................................................................................................................ 836ms
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited_dispred#fff ........................................................................................................... 832ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::hasCallable#fff .......................................................................................................................................... 830ms
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getAnOverrider#2#fff ............................................................................................................... 782ms (71 evaluations with max 263ms in OverridableCallable::OverridableCallable::getAnOverrider#2#fff/3@i5#1999aw)
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::typeMayBeImprecise#f ................................................................................................................. 671ms
	GetADynamicTarget copy.ql-25:Element::NamedElement::getQualifiedName#ff ................................................................................................................................... 655ms (27 evaluations with max 226ms in Element::NamedElement::getQualifiedName#ff/2@i10#463b0w)
	GetADynamicTarget copy.ql-25:Conversion::Cached::implicitConversionRestricted#ff_10#join_rhs .............................................................................................................. 643ms
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getAnOverrider_dispred#2#fff ....................................................................................................... 559ms (71 evaluations with max 203ms in OverridableCallable::OverridableCallable::getAnOverrider_dispred#2#fff/3@i2#1999ax)
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::Source::getType_dispred#fff .......................................................................................................... 525ms
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited1_dispred#fff .......................................................................................................... 508ms
	GetADynamicTarget copy.ql-25:Generics::TypeParameter::getASuppliedType_dispred#ff ......................................................................................................................... 492ms
	GetADynamicTarget copy.ql-25:Member::Modifiable::getAModifier_dispred#ff .................................................................................................................................. 485ms (3 evaluations with max 256ms in Member::Modifiable::getAModifier_dispred#ff/2@i2#8c2a2w)
	GetADynamicTarget copy.ql-25:boundedFastTC(Type::ValueOrRefType::getBaseClass_dispred#ff_10#join_rhs,Type::ValueOrRefType::hasMember_dispred#fb#higher_order_body) ........................................ 463ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverrider_dispred#ff ............................................................................................. 408ms
	GetADynamicTarget copy.ql-25:Declaration::Declaration::getUnboundDeclaration_dispred#ff ................................................................................................................... 396ms (5 evaluations with max 175ms in Declaration::Declaration::getUnboundDeclaration_dispred#ff/2@i4#a04aaw)
	GetADynamicTarget copy.ql-25:Steps::Steps::isOverriderParameter#fff ....................................................................................................................................... 394ms
	GetADynamicTarget copy.ql-25:Steps::Steps::getArgumentForOverridderParameter#fff .......................................................................................................................... 389ms
	GetADynamicTarget copy.ql-25:Member::Virtualizable::isOverridableOrImplementable_dispred#f#shared ......................................................................................................... 385ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverriderInCallContext0#ffff ..................................................................................... 385ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableInheritedInCallContext1#ffff ..................................................................................... 378ms
	GetADynamicTarget copy.ql-25:Element::Element::getAChild_dispred#ff_10#join_rhs ........................................................................................................................... 377ms
	GetADynamicTarget copy.ql-25:Variable::Parameter::getDeclaringType_dispred#ff ............................................................................................................................. 377ms (6 evaluations with max 183ms in Variable::Parameter::getDeclaringType_dispred#ff/2@i2#057d1y)
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getAnImplementorSubType#fff ........................................................................................................ 363ms (10 evaluations with max 170ms in OverridableCallable::OverridableCallable::getAnImplementorSubType#fff/3@i3#6b791w)
	GetADynamicTarget copy.ql-25:Member::Declaration::getDeclaringType_dispred#ff ............................................................................................................................. 362ms (6 evaluations with max 176ms in Member::Declaration::getDeclaringType_dispred#ff/2@i3#057d1z)
	GetADynamicTarget copy.ql-25:boundedFastTC(Member::Virtualizable::getAnOverrider_dispred#ff_10#higher_order_body,Steps::Steps::isOverriderParameter#fff#higher_order_body) ................................ 356ms
```
</details>


<details>
  <summary>After (`dotnet/efcore`)</summary>

```
[2021-04-16 11:25:00] (342s) Clause timing report:
[2021-04-16 11:25:00] (342s) 
[2021-04-16 11:25:00] 
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMember_dispred#fb ................................................................................................................................... 9s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMethod_dispred#ff ................................................................................................................................... 7.2s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasCallable_dispred#ff_10#join_rhs ..................................................................................................................... 5.2s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMember_dispred#fb_10#join_rhs ....................................................................................................................... 5.1s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited0#fff .................................................................................................................. 5.1s (37 evaluations with max 2.1s in OverridableCallable::OverridableCallable::getInherited0#fff/3@i3#9715bw)
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableInherited_dispred#ff ............................................................................................. 4.8s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::isRelevantReflectionOrDynamicQualifierType#f ............................................................................................................. 2.9s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::isDeclaringSubType#ff .............................................................................................................. 2.6s (37 evaluations with max 1.1s in OverridableCallable::OverridableCallable::isDeclaringSubType#ff/2@i3#957d3w)
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited#fff ................................................................................................................... 2.2s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getAnOverrider#2#fff#join_rhs ...................................................................................................... 1.9s
	GetADynamicTarget copy.ql-25:Element::Element::fromLibrary_dispred#b ...................................................................................................................................... 1.6s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasCallable_dispred#ff ................................................................................................................................. 1.5s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::getADynamicTargetCandidateInstanceMethod#ff .............................................................................................................. 1.5s
	GetADynamicTarget copy.ql-25:ExprOrStmtParent::Cached::bestLocation#ff_10#join_rhs ........................................................................................................................ 1.4s
	GetADynamicTarget copy.ql-25:boundedFastTC(OverridableCallable::OverridableCallable::getAnOverrider_dispred#ff_10#higher_order_body,Member::Declaration::getDeclaringType_dispred#ff_0#higher_order_body) . 1.4s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::hasSubsumedQualifierType#ff ................................................................................................ 1.1s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::isDeclaringSubType#ff_10#join_rhs .................................................................................................. 1.1s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getASubsumedStaticTarget#ff ................................................................................................ 1.1s
	GetADynamicTarget copy.ql-25:Conversion::implicitConversion#ff ............................................................................................................................................ 1s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited#fff_201#join_rhs ...................................................................................................... 955ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::typeMayBeImprecise#f ................................................................................................................. 942ms
	GetADynamicTarget copy.ql-25:Element::NamedElement::getName_dispred#ff .................................................................................................................................... 883ms (3 evaluations with max 313ms in Element::NamedElement::getName_dispred#ff/2@i2#5d941w)
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited_dispred#fff ........................................................................................................... 796ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverrider_dispred#ff ............................................................................................. 735ms
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getAnOverrider#2#fff ............................................................................................................... 723ms (71 evaluations with max 219ms in OverridableCallable::OverridableCallable::getAnOverrider#2#fff/3@i5#1999aw)
	GetADynamicTarget copy.ql-25:Dispatch::Internal::hasCallable#fff .......................................................................................................................................... 712ms
	GetADynamicTarget copy.ql-25:Conversion::Cached::implicitConversionRestricted#ff_10#join_rhs .............................................................................................................. 704ms
	GetADynamicTarget copy.ql-25:Element::NamedElement::getQualifiedName#ff ................................................................................................................................... 662ms (27 evaluations with max 256ms in Element::NamedElement::getQualifiedName#ff/2@i10#463b0w)
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getAnOverrider_dispred#2#fff ....................................................................................................... 612ms (71 evaluations with max 220ms in OverridableCallable::OverridableCallable::getAnOverrider_dispred#2#fff/3@i2#1999ax)
	GetADynamicTarget copy.ql-25:boundedFastTC(Type::ValueOrRefType::getBaseClass_dispred#ff_10#join_rhs,Type::ValueOrRefType::hasMember_dispred#fb#higher_order_body) ........................................ 511ms
	GetADynamicTarget copy.ql-25:Member::Modifiable::getAModifier_dispred#ff .................................................................................................................................. 508ms (3 evaluations with max 260ms in Member::Modifiable::getAModifier_dispred#ff/2@i2#8c2a2w)
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited1_dispred#fff .......................................................................................................... 485ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::Source::getType_dispred#fff .......................................................................................................... 476ms
	GetADynamicTarget copy.ql-25:Generics::TypeParameter::getASuppliedType_dispred#ff ......................................................................................................................... 475ms
	GetADynamicTarget copy.ql-25:Assignable::Assignable::getAnAssignedValue_dispred#bf ........................................................................................................................ 474ms
	GetADynamicTarget copy.ql-25:Variable::Parameter::getDeclaringType_dispred#ff ............................................................................................................................. 447ms (6 evaluations with max 200ms in Variable::Parameter::getDeclaringType_dispred#ff/2@i2#057d1y)
	GetADynamicTarget copy.ql-25:Member::Declaration::getDeclaringType_dispred#ff ............................................................................................................................. 444ms (6 evaluations with max 242ms in Member::Declaration::getDeclaringType_dispred#ff/2@i3#057d1z)
	GetADynamicTarget copy.ql-25:Member::Virtualizable::isOverridableOrImplementable_dispred#f#shared ......................................................................................................... 396ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getASubsumedStaticTarget0#fff .............................................................................................. 380ms
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getAnImplementorSubType#fff ........................................................................................................ 380ms (10 evaluations with max 187ms in OverridableCallable::OverridableCallable::getAnImplementorSubType#fff/3@i3#6b791w)
	GetADynamicTarget copy.ql-25:Declaration::Declaration::getUnboundDeclaration_dispred#ff ................................................................................................................... 376ms (5 evaluations with max 192ms in Declaration::Declaration::getUnboundDeclaration_dispred#ff/2@i4#a04aaw)
	GetADynamicTarget copy.ql-25:Steps::Steps::isOverriderParameter#fff ....................................................................................................................................... 373ms
	GetADynamicTarget copy.ql-25:Steps::Steps::getArgumentForOverridderParameter#fff .......................................................................................................................... 369ms
	GetADynamicTarget copy.ql-25:ExprOrStmtParent::ExprOrStmtParent::getChildExpr_dispred#fff_120#join_rhs .................................................................................................... 368ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableInheritedInCallContext1#ffff ..................................................................................... 355ms
	GetADynamicTarget copy.ql-25:Expr::Expr::getType_dispred#ff_10#join_rhs ................................................................................................................................... 347ms
	GetADynamicTarget copy.ql-25:#Declaration::Declaration::getDeclaringType_dispred#bfPlus ................................................................................................................... 343ms (7 evaluations with max 168ms in #Declaration::Declaration::getDeclaringType_dispred#bfPlus/2@i1#3d706w)
	GetADynamicTarget copy.ql-25:m#Assignable::nameOfChild#fb ................................................................................................................................................. 342ms (36 evaluations with max 147ms in m#Assignable::nameOfChild#fb/1@i3#77fbaw)
	GetADynamicTarget copy.ql-25:boundedFastTC(Member::Virtualizable::getAnOverrider_dispred#ff_10#higher_order_body,Steps::Steps::isOverriderParameter#fff#higher_order_body) ................................ 339ms
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getASubsumedStaticTarget0#fff_120#join_rhs ................................................................................. 338ms
```
</details>

<details>
  <summary>Before (`mono/mono`)</summary>
  
```
[2021-04-15 17:22:35] (605s) Clause timing report:
[2021-04-15 17:22:35] (605s) 
[2021-04-15 17:22:35] 
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverriderInCallContext1#ffff ..................................................................................... 16.7s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::hasQualifierTypeOverridden0#ff ........................................................................................................................... 14.6s
	GetADynamicTarget copy.ql-25:SsaImplCommon::SsaDefReaches::varBlockReaches#2#fff .......................................................................................................................... 5.2s (1703 evaluations with max 407ms in SsaImplCommon::SsaDefReaches::varBlockReaches#2#fff/3@i4#6b5b2w)
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverriderInCallContext0#ffff ..................................................................................... 4.9s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::hasQualifierTypeOverridden#fff ............................................................................................. 4s
	GetADynamicTarget copy.ql-25:SsaImplCommon::ssaDefReachesEndOfBlock#3#fff ................................................................................................................................. 3.6s (1704 evaluations with max 480ms in SsaImplCommon::ssaDefReachesEndOfBlock#3#fff/3@i2#2d8f2w)
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getASubsumedStaticTarget0#fff .............................................................................................. 3.3s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableInherited_dispred#ff ............................................................................................. 3.1s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableInheritedInCallContext0#fff_120#join_rhs ......................................................................... 2.7s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getASubsumedStaticTarget0#fff_120#join_rhs ................................................................................. 2.7s
	GetADynamicTarget copy.ql-25:Steps::Steps::stepOpen#ff .................................................................................................................................................... 2.4s
	GetADynamicTarget copy.ql-25:ExprOrStmtParent::Cached::bestLocation#ff_10#join_rhs ........................................................................................................................ 2.3s
	GetADynamicTarget copy.ql-25:Steps::Steps::flowIn#fff ..................................................................................................................................................... 2.2s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverrider_dispred#ff ............................................................................................. 1.8s
	GetADynamicTarget copy.ql-25:SsaImplCommon::Liveness::liveAtExit#3#ff ..................................................................................................................................... 1.8s (3405 evaluations with max 215ms in SsaImplCommon::Liveness::liveAtExit#3#ff/2@i4#22d04w)
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMember_dispred#fb ................................................................................................................................... 1.8s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getASubsumedStaticTarget#ff ................................................................................................ 1.7s
	GetADynamicTarget copy.ql-25:project#Steps::Steps::getArgumentForOverridderParameter#fff .................................................................................................................. 1.7s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMethod_dispred#ff ................................................................................................................................... 1.6s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::mayBenefitFromCallContext_dispred#fff#count_range .......................................................................... 1.6s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::Sink::getAPred#ff .................................................................................................................... 1.6s
	GetADynamicTarget copy.ql-25:Element::Element::fromLibrary_dispred#b ...................................................................................................................................... 1.5s
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited0#fff .................................................................................................................. 1.5s (12 evaluations with max 679ms in OverridableCallable::OverridableCallable::getInherited0#fff/3@i3#9715bw)
	GetADynamicTarget copy.ql-25:#Dispatch::Internal::SimpleTypeDataFlow::stepExpr#ffPlus#swapped ............................................................................................................. 1.5s
	GetADynamicTarget copy.ql-25:File::Container::getBaseName_dispred#ff ...................................................................................................................................... 1.5s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getADynamicTarget#ff ....................................................................................................... 1.5s
	GetADynamicTarget copy.ql-25:Expr::Expr::getType_dispred#ff ............................................................................................................................................... 1.4s (3 evaluations with max 1s in Expr::Expr::getType_dispred#ff/2@i1#835aaw)
	GetADynamicTarget copy.ql-25:expr_parent_12#join_rhs ...................................................................................................................................................... 1.4s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::Cached::getADynamicTarget#ff_10#join_rhs ................................................................................................................. 1.4s
	GetADynamicTarget copy.ql-25:ExprOrStmtParent::ExprOrStmtParent::getChildExpr_dispred#fff_10#join_rhs ..................................................................................................... 1.4s
	GetADynamicTarget copy.ql-25:m#Assignable::nameOfChild#fb ................................................................................................................................................. 1.4s (21 evaluations with max 609ms in m#Assignable::nameOfChild#fb/1@i3#77fbaw)
	GetADynamicTarget copy.ql-25:Steps::Steps::getArgumentForOverridderParameter#fff .......................................................................................................................... 1.4s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverrider_dispred#ff_10#join_rhs ................................................................................. 1.3s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverriderInCallContext0#ffff_0213#join_rhs ....................................................................... 1.3s
	GetADynamicTarget copy.ql-25:boundedFastTC(OverridableCallable::OverridableCallable::getAnOverrider_dispred#ff_10#higher_order_body,Member::Declaration::getDeclaringType_dispred#ff_0#higher_order_body) . 1.3s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::Source::getType_dispred#fff .......................................................................................................... 1.2s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableInheritedInCallContext0#fff ...................................................................................... 1.2s
	GetADynamicTarget copy.ql-25:SsaImplCommon::lastRefRedef#2#ffff ........................................................................................................................................... 1.2s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasCallable_dispred#ff_10#join_rhs ..................................................................................................................... 1.2s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMember_dispred#fb_10#join_rhs ....................................................................................................................... 1.2s
	GetADynamicTarget copy.ql-25:Steps::Steps::getARead#ff .................................................................................................................................................... 1.2s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::Sink::getAPred#ff_10#join_rhs ........................................................................................................ 1.2s
	GetADynamicTarget copy.ql-25:expr_parent_120#join_rhs ..................................................................................................................................................... 1.2s
	GetADynamicTarget copy.ql-25:ExprOrStmtParent::ExprOrStmtParent::getChildExpr_dispred#fff_120#join_rhs .................................................................................................... 1.2s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::stepExpr#ff .......................................................................................................................... 1.2s
	GetADynamicTarget copy.ql-25:SsaImplCommon::Liveness::liveAtEntry#3#ff .................................................................................................................................... 1.1s (3405 evaluations with max 101ms in SsaImplCommon::Liveness::liveAtEntry#3#ff/2@i1#22d04x)
	GetADynamicTarget copy.ql-25:expressions_20#join_rhs ...................................................................................................................................................... 1.1s
	GetADynamicTarget copy.ql-25:Expr::Expr::getType_dispred#ff_10#join_rhs ................................................................................................................................... 1.1s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::getASourceType#fff ................................................................................................................... 1.1s
	GetADynamicTarget copy.ql-25:SsaImplCommon::SsaDefReaches::varBlockReaches#2#fff_120#join_rhs ............................................................................................................. 952ms
```
</details>


<details>
  <summary>After (`mono/mono`)</summary>

```
[2021-04-16 10:57:49] (649s) Clause timing report:
[2021-04-16 10:57:49] (649s) 
[2021-04-16 10:57:49] 
	GetADynamicTarget copy.ql-25:SsaImplCommon::SsaDefReaches::varBlockReaches#2#fff .......................................................................................................................... 5.7s (1703 evaluations with max 385ms in SsaImplCommon::SsaDefReaches::varBlockReaches#2#fff/3@i4#6b5b2w)
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverriderInCallContext#fff ....................................................................................... 4.5s
	GetADynamicTarget copy.ql-25:SsaImplCommon::ssaDefReachesEndOfBlock#3#fff ................................................................................................................................. 4s (1704 evaluations with max 480ms in SsaImplCommon::ssaDefReachesEndOfBlock#3#fff/3@i1#2d8f2w)
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableInherited_dispred#ff ............................................................................................. 3.8s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableInheritedInCallContext0#fff_120#join_rhs ......................................................................... 3.3s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverrider_dispred#ff ............................................................................................. 3.2s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::hasSubsumedQualifierType#ff ................................................................................................ 2.9s
	GetADynamicTarget copy.ql-25:Steps::Steps::stepOpen#ff .................................................................................................................................................... 2.9s
	GetADynamicTarget copy.ql-25:Steps::Steps::flowIn#fff ..................................................................................................................................................... 2.7s
	GetADynamicTarget copy.ql-25:ExprOrStmtParent::Cached::bestLocation#ff_10#join_rhs ........................................................................................................................ 2.6s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableOverriderInCallContext0#fff ...................................................................................... 2.2s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMember_dispred#fb ................................................................................................................................... 2.2s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::contextArgHasSubsumedType#fff .............................................................................................. 2.2s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getASubsumedStaticTarget#ff ................................................................................................ 2.1s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::mayBenefitFromCallContext_dispred#fff#count_range .......................................................................... 2.1s
	GetADynamicTarget copy.ql-25:SsaImplCommon::Liveness::liveAtExit#3#ff ..................................................................................................................................... 2.1s (3405 evaluations with max 224ms in SsaImplCommon::Liveness::liveAtExit#3#ff/2@i4#22d04w)
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::Sink::getAPred#ff .................................................................................................................... 1.9s
	GetADynamicTarget copy.ql-25:project#Steps::Steps::getArgumentForOverridderParameter#fff .................................................................................................................. 1.9s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getADynamicTarget#ff ....................................................................................................... 1.9s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::Cached::getADynamicTarget#ff_10#join_rhs ................................................................................................................. 1.8s
	GetADynamicTarget copy.ql-25:#Dispatch::Internal::SimpleTypeDataFlow::stepExpr#ffPlus#swapped ............................................................................................................. 1.8s
	GetADynamicTarget copy.ql-25:Element::Element::fromLibrary_dispred#b ...................................................................................................................................... 1.8s
	GetADynamicTarget copy.ql-25:expr_parent_12#join_rhs ...................................................................................................................................................... 1.8s
	GetADynamicTarget copy.ql-25:Expr::Expr::getType_dispred#ff ............................................................................................................................................... 1.7s (3 evaluations with max 1.3s in Expr::Expr::getType_dispred#ff/2@i1#835aaw)
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMethod_dispred#ff ................................................................................................................................... 1.7s
	GetADynamicTarget copy.ql-25:File::Container::getBaseName_dispred#ff ...................................................................................................................................... 1.7s
	GetADynamicTarget copy.ql-25:ExprOrStmtParent::ExprOrStmtParent::getChildExpr_dispred#fff_10#join_rhs ..................................................................................................... 1.7s
	GetADynamicTarget copy.ql-25:m#Assignable::nameOfChild#fb ................................................................................................................................................. 1.7s (21 evaluations with max 736ms in m#Assignable::nameOfChild#fb/1@i3#77fbaw)
	GetADynamicTarget copy.ql-25:OverridableCallable::OverridableCallable::getInherited0#fff .................................................................................................................. 1.7s (12 evaluations with max 825ms in OverridableCallable::OverridableCallable::getInherited0#fff/3@i3#9715bw)
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAViableInheritedInCallContext0#fff ...................................................................................... 1.6s
	GetADynamicTarget copy.ql-25:Steps::Steps::getArgumentForOverridderParameter#fff .......................................................................................................................... 1.6s
	GetADynamicTarget copy.ql-25:ExprOrStmtParent::ExprOrStmtParent::getChildExpr_dispred#fff_120#join_rhs .................................................................................................... 1.5s
	GetADynamicTarget copy.ql-25:boundedFastTC(OverridableCallable::OverridableCallable::getAnOverrider_dispred#ff_10#higher_order_body,Member::Declaration::getDeclaringType_dispred#ff_0#higher_order_body) . 1.5s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasCallable_dispred#ff_10#join_rhs ..................................................................................................................... 1.5s
	GetADynamicTarget copy.ql-25:Expr::Expr::getType_dispred#ff_10#join_rhs ................................................................................................................................... 1.4s
	GetADynamicTarget copy.ql-25:SsaImplCommon::lastRefRedef#2#ffff ........................................................................................................................................... 1.4s
	GetADynamicTarget copy.ql-25:expr_parent_120#join_rhs ..................................................................................................................................................... 1.4s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::Source::getType_dispred#fff .......................................................................................................... 1.4s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::Sink::getAPred#ff_10#join_rhs ........................................................................................................ 1.4s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::stepExpr#ff .......................................................................................................................... 1.4s
	GetADynamicTarget copy.ql-25:Type::ValueOrRefType::hasMember_dispred#fb_10#join_rhs ....................................................................................................................... 1.3s
	GetADynamicTarget copy.ql-25:expressions_20#join_rhs ...................................................................................................................................................... 1.3s
	GetADynamicTarget copy.ql-25:Steps::Steps::getARead#ff .................................................................................................................................................... 1.3s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::SimpleTypeDataFlow::getASourceType#fff ................................................................................................................... 1.3s
	GetADynamicTarget copy.ql-25:Dispatch::Internal::DispatchMethodOrAccessorCall::getAStaticTargetExt#ff ..................................................................................................... 1.3s
	GetADynamicTarget copy.ql-25:SsaImplCommon::Liveness::liveAtEntry#3#ff .................................................................................................................................... 1.2s (3405 evaluations with max 119ms in SsaImplCommon::Liveness::liveAtEntry#3#ff/2@i1#22d04x)
	GetADynamicTarget copy.ql-25:Element::Element::getAChild_dispred#ff_10#join_rhs ........................................................................................................................... 1.1s
	GetADynamicTarget copy.ql-25:Location::Location::getFile_dispred#ff ....................................................................................................................................... 1.1s
	GetADynamicTarget copy.ql-25:Assignable::nameOfChild#fb#join_rhs .......................................................................................................................................... 1.1s
	GetADynamicTarget copy.ql-25:SsaImplCommon::SsaDefReaches::varBlockReaches#2#fff_120#join_rhs ............................................................................................................. 1.1s
```
</details>

~https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1004/~
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1008/