### PR TITLE
C++: Fix duplicate names in experimental queries

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-788/AccessOfMemoryLocationAfterEndOfBufferUsingStrlen.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-788/AccessOfMemoryLocationAfterEndOfBufferUsingStrlen.ql
@@ -3,7 +3,7 @@
  * @description The expression `buffer [strlen (buffer)] = 0` is potentially dangerous, if the variable `buffer` does not have a terminal zero, then access beyond the bounds of the allocated memory is possible, which will lead to undefined behavior.
  *              If terminal zero is present, then the specified expression is meaningless.
  * @kind problem
- * @id cpp/access-memory-location-after-end-buffer
+ * @id cpp/access-memory-location-after-end-buffer-strlen
  * @problem.severity warning
  * @precision medium
  * @tags correctness

--- a/cpp/ql/src/experimental/Security/CWE/CWE-788/AccessOfMemoryLocationAfterEndOfBufferUsingStrncat.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-788/AccessOfMemoryLocationAfterEndOfBufferUsingStrncat.ql
@@ -2,7 +2,7 @@
  * @name Access Of Memory Location After The End Of A Buffer Using Strncat
  * @description Calls of the form `strncat(dest, source, sizeof (dest) - strlen (dest))` set the third argument to one more than possible. So when `dest` is full, the expression `sizeof(dest) - strlen (dest)` will be equal to one, and not zero as the programmer might think. Making a call of this type may result in a zero byte being written just outside the `dest` buffer.
  * @kind problem
- * @id cpp/access-memory-location-after-end-buffer
+ * @id cpp/access-memory-location-after-end-buffer-strncat
  * @problem.severity warning
  * @precision medium
  * @tags correctness


### PR DESCRIPTION
These names should probably be improved if we pull these queries out of experimental.