### PR TITLE
C++: Make exprMightOverflowPositively sound for unanalyzable expressions

### DIFF
--- a/cpp/change-notes/2021-26-04-more-sound-expr-might-overflow.md
+++ b/cpp/change-notes/2021-26-04-more-sound-expr-might-overflow.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The `exprMightOverflowPositively` and `exprMightOverflowNegatively` predicates from the `SimpleRangeAnalysis` library now recognize more expressions that might overflow.

--- a/cpp/ql/src/Security/CWE/CWE-190/IntegerOverflowTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/IntegerOverflowTainted.ql
@@ -28,6 +28,7 @@ predicate outOfBoundsExpr(Expr expr, string kind) {
 
 from Expr use, Expr origin, string kind
 where
+  not use.getUnspecifiedType() instanceof PointerType and
   outOfBoundsExpr(use, kind) and
   tainted(origin, use) and
   origin != use and

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -1618,6 +1618,18 @@ private module SimpleRangeAnalysisCached {
   }
 
   /**
+   * Holds if `e` is an expression where the concept of overflow makes sense.
+   * This predicate is used to filter out some of the unanalyzable expressions
+   * from `exprMightOverflowPositively` and `exprMightOverflowNegatively`.
+   */
+  pragma[inline]
+  private predicate exprThatCanOverflow(Expr e) {
+    e instanceof UnaryArithmeticOperation or
+    e instanceof BinaryArithmeticOperation or
+    e instanceof LShiftExpr
+  }
+
+  /**
    * Holds if the expression might overflow negatively. This predicate
    * does not consider the possibility that the expression might overflow
    * due to a conversion.
@@ -1631,8 +1643,10 @@ private module SimpleRangeAnalysisCached {
     // detecting whether it might overflow.
     getLowerBoundsImpl(expr.(PostfixDecrExpr)) = exprMinVal(expr)
     or
-    // Expressions we cannot analyze could potentially overflow
-    not analyzableExpr(expr)
+    // We can't conclude that any unanalyzable expression might overflow. This
+    // is because there are many expressions that the range analysis doesn't
+    // handle, but where the concept of overflow doesn't make sense.
+    exprThatCanOverflow(expr) and not analyzableExpr(expr)
   }
 
   /**
@@ -1661,8 +1675,10 @@ private module SimpleRangeAnalysisCached {
     // detecting whether it might overflow.
     getUpperBoundsImpl(expr.(PostfixIncrExpr)) = exprMaxVal(expr)
     or
-    // Expressions we cannot analyze could potentially overflow
-    not analyzableExpr(expr)
+    // We can't conclude that any unanalyzable expression might overflow. This
+    // is because there are many expressions that the range analysis doesn't
+    // handle, but where the concept of overflow doesn't make sense.
+    exprThatCanOverflow(expr) and not analyzableExpr(expr)
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -1630,6 +1630,9 @@ private module SimpleRangeAnalysisCached {
     // bound of `x`, so the standard logic (above) does not work for
     // detecting whether it might overflow.
     getLowerBoundsImpl(expr.(PostfixDecrExpr)) = exprMinVal(expr)
+    or
+    // Expressions we cannot analyze could potentially overflow
+    not analyzableExpr(expr)
   }
 
   /**
@@ -1657,6 +1660,9 @@ private module SimpleRangeAnalysisCached {
     // bound of `x`, so the standard logic (above) does not work for
     // detecting whether it might overflow.
     getUpperBoundsImpl(expr.(PostfixIncrExpr)) = exprMaxVal(expr)
+    or
+    // Expressions we cannot analyze could potentially overflow
+    not analyzableExpr(expr)
   }
 
   /**

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/IntegerOverflowTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/IntegerOverflowTainted.expected
@@ -12,6 +12,5 @@
 | test6.cpp:16:15:16:15 | s | $@ flows to here and is used in an expression which might overflow. | test6.cpp:39:23:39:24 | & ... | User-provided value |
 | test6.cpp:30:16:30:16 | s | $@ flows to here and is used in an expression which might overflow. | test6.cpp:39:23:39:24 | & ... | User-provided value |
 | test.c:14:15:14:35 | ... * ... | $@ flows to here and is used in an expression which might overflow. | test.c:11:29:11:32 | argv | User-provided value |
-| test.c:25:5:25:9 | ... ++ | $@ flows to here and is used in an expression which might overflow. | test.c:23:15:23:18 | argv | User-provided value |
 | test.c:44:7:44:12 | ... -- | $@ flows to here and is used in an expression which might overflow negatively. | test.c:41:17:41:20 | argv | User-provided value |
 | test.c:54:7:54:12 | ... -- | $@ flows to here and is used in an expression which might overflow negatively. | test.c:51:17:51:20 | argv | User-provided value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/IntegerOverflowTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/IntegerOverflowTainted.expected
@@ -12,5 +12,6 @@
 | test6.cpp:16:15:16:15 | s | $@ flows to here and is used in an expression which might overflow. | test6.cpp:39:23:39:24 | & ... | User-provided value |
 | test6.cpp:30:16:30:16 | s | $@ flows to here and is used in an expression which might overflow. | test6.cpp:39:23:39:24 | & ... | User-provided value |
 | test.c:14:15:14:35 | ... * ... | $@ flows to here and is used in an expression which might overflow. | test.c:11:29:11:32 | argv | User-provided value |
+| test.c:25:5:25:9 | ... ++ | $@ flows to here and is used in an expression which might overflow. | test.c:23:15:23:18 | argv | User-provided value |
 | test.c:44:7:44:12 | ... -- | $@ flows to here and is used in an expression which might overflow negatively. | test.c:41:17:41:20 | argv | User-provided value |
 | test.c:54:7:54:12 | ... -- | $@ flows to here and is used in an expression which might overflow negatively. | test.c:51:17:51:20 | argv | User-provided value |


### PR DESCRIPTION
(and similarly for the `exprMightOverflowNegatively` predicate.)

This hopefully means that expressions that do not satisfy these predicates will never overflow/underflow.

This _might_ Break Everything. But let's wait and see what CPP-differences says: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1917/