### PR TITLE
JS: add taint-step for markdown-it when the HTML flag is set

### DIFF
--- a/javascript/change-notes/2021-04-15-markdownit.md
+++ b/javascript/change-notes/2021-04-15-markdownit.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* The security queries now track taint through markdown-it.
+  Affected packages are
+    [markdown-it](https://npmjs.com/package/markdown-it)

--- a/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
@@ -118,3 +118,20 @@ private class SnarkdownStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A taint step for the `markdown-it` library.
+ */
+private class MarkdownItStep extends TaintTracking::SharedTaintStep {
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode renderer, API::CallNode call |
+      renderer = API::moduleImport("markdown-it").getACall() and
+      renderer.getParameter(0).getMember("html").getARhs().asExpr().(BooleanLiteral).getValue() =
+        "true" and
+      call = renderer.getReturn().getMember(["render", "renderInline"]).getACall()
+    |
+      succ = call and
+      pred = call.getArgument(0)
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
@@ -139,7 +139,7 @@ private module MarkdownIt {
     exists(API::CallNode call |
       call = markdownIt().getMember(["use", "set", "configure", "enable", "disable"]).getACall() and
       result = call.getReturn() and
-      not call.getParameter(0).getARhs().getALocalSource() =
+      not call.getParameter(0).getAValueReachingRhs() =
         DataFlow::moduleImport("markdown-it-sanitizer")
     )
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
@@ -120,17 +120,41 @@ private class SnarkdownStep extends TaintTracking::SharedTaintStep {
 }
 
 /**
- * A taint step for the `markdown-it` library.
+ * Classes and predicates for modelling taint steps the `markdown-it` library.
  */
-private class MarkdownItStep extends TaintTracking::SharedTaintStep {
-  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(API::CallNode renderer, API::CallNode call |
-      renderer = API::moduleImport("markdown-it").getACall() and
-      renderer.getParameter(0).getMember("html").getARhs().mayHaveBooleanValue(true) and
-      call = renderer.getReturn().getMember(["render", "renderInline"]).getACall()
+private module MarkdownIt {
+  /**
+   * The creation of a parser from `markdown-it`.
+   */
+  private API::Node markdownIt() {
+    exists(API::InvokeNode call |
+      call = API::moduleImport("markdown-it").getAnInvocation()
+      or
+      call = API::moduleImport("markdown-it").getMember("Markdown").getAnInvocation()
     |
-      succ = call and
-      pred = call.getArgument(0)
+      call.getParameter(0).getMember("html").getARhs().mayHaveBooleanValue(true) and
+      result = call.getReturn()
     )
+    or
+    exists(API::CallNode call |
+      call = markdownIt().getMember(["use", "set", "configure", "enable", "disable"]).getACall() and
+      result = call.getReturn() and
+      not call.getParameter(0).getARhs().getALocalSource() =
+        DataFlow::moduleImport("markdown-it-sanitizer")
+    )
+  }
+
+  /**
+   * A taint step for the `markdown-it` library.
+   */
+  private class MarkdownItStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(API::CallNode call |
+        call = markdownIt().getMember(["render", "renderInline"]).getACall()
+      |
+        succ = call and
+        pred = call.getArgument(0)
+      )
+    }
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Markdown.qll
@@ -126,8 +126,7 @@ private class MarkdownItStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(API::CallNode renderer, API::CallNode call |
       renderer = API::moduleImport("markdown-it").getACall() and
-      renderer.getParameter(0).getMember("html").getARhs().asExpr().(BooleanLiteral).getValue() =
-        "true" and
+      renderer.getParameter(0).getMember("html").getARhs().mayHaveBooleanValue(true) and
       call = renderer.getReturn().getMember(["render", "renderInline"]).getACall()
     |
       succ = call and

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -66,6 +66,13 @@ nodes
 | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
 | ReflectedXss.js:85:23:85:30 | req.body |
 | ReflectedXss.js:85:23:85:30 | req.body |
+| ReflectedXss.js:94:12:94:19 | req.body |
+| ReflectedXss.js:94:12:94:19 | req.body |
+| ReflectedXss.js:94:12:94:19 | req.body |
+| ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
+| ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
+| ReflectedXss.js:95:30:95:37 | req.body |
+| ReflectedXss.js:95:30:95:37 | req.body |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id |
@@ -212,6 +219,11 @@ edges
 | ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
 | ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
 | ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
+| ReflectedXss.js:94:12:94:19 | req.body | ReflectedXss.js:94:12:94:19 | req.body |
+| ReflectedXss.js:95:30:95:37 | req.body | ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
+| ReflectedXss.js:95:30:95:37 | req.body | ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
+| ReflectedXss.js:95:30:95:37 | req.body | ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
+| ReflectedXss.js:95:30:95:37 | req.body | ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
@@ -307,6 +319,8 @@ edges
 | ReflectedXss.js:83:12:83:19 | req.body | ReflectedXss.js:83:12:83:19 | req.body | ReflectedXss.js:83:12:83:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:83:12:83:19 | req.body | user-provided value |
 | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) | ReflectedXss.js:84:22:84:29 | req.body | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:84:22:84:29 | req.body | user-provided value |
 | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) | ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:85:23:85:30 | req.body | user-provided value |
+| ReflectedXss.js:94:12:94:19 | req.body | ReflectedXss.js:94:12:94:19 | req.body | ReflectedXss.js:94:12:94:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:94:12:94:19 | req.body | user-provided value |
+| ReflectedXss.js:95:12:95:38 | markdow ... q.body) | ReflectedXss.js:95:30:95:37 | req.body | ReflectedXss.js:95:12:95:38 | markdow ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:95:30:95:37 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -66,13 +66,21 @@ nodes
 | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
 | ReflectedXss.js:85:23:85:30 | req.body |
 | ReflectedXss.js:85:23:85:30 | req.body |
-| ReflectedXss.js:94:12:94:19 | req.body |
-| ReflectedXss.js:94:12:94:19 | req.body |
-| ReflectedXss.js:94:12:94:19 | req.body |
-| ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
-| ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
-| ReflectedXss.js:95:30:95:37 | req.body |
-| ReflectedXss.js:95:30:95:37 | req.body |
+| ReflectedXss.js:97:12:97:19 | req.body |
+| ReflectedXss.js:97:12:97:19 | req.body |
+| ReflectedXss.js:97:12:97:19 | req.body |
+| ReflectedXss.js:98:12:98:38 | markdow ... q.body) |
+| ReflectedXss.js:98:12:98:38 | markdow ... q.body) |
+| ReflectedXss.js:98:30:98:37 | req.body |
+| ReflectedXss.js:98:30:98:37 | req.body |
+| ReflectedXss.js:100:12:100:39 | markdow ... q.body) |
+| ReflectedXss.js:100:12:100:39 | markdow ... q.body) |
+| ReflectedXss.js:100:31:100:38 | req.body |
+| ReflectedXss.js:100:31:100:38 | req.body |
+| ReflectedXss.js:103:12:103:84 | markdow ... q.body) |
+| ReflectedXss.js:103:12:103:84 | markdow ... q.body) |
+| ReflectedXss.js:103:76:103:83 | req.body |
+| ReflectedXss.js:103:76:103:83 | req.body |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id |
@@ -219,11 +227,19 @@ edges
 | ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
 | ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
 | ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) |
-| ReflectedXss.js:94:12:94:19 | req.body | ReflectedXss.js:94:12:94:19 | req.body |
-| ReflectedXss.js:95:30:95:37 | req.body | ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
-| ReflectedXss.js:95:30:95:37 | req.body | ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
-| ReflectedXss.js:95:30:95:37 | req.body | ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
-| ReflectedXss.js:95:30:95:37 | req.body | ReflectedXss.js:95:12:95:38 | markdow ... q.body) |
+| ReflectedXss.js:97:12:97:19 | req.body | ReflectedXss.js:97:12:97:19 | req.body |
+| ReflectedXss.js:98:30:98:37 | req.body | ReflectedXss.js:98:12:98:38 | markdow ... q.body) |
+| ReflectedXss.js:98:30:98:37 | req.body | ReflectedXss.js:98:12:98:38 | markdow ... q.body) |
+| ReflectedXss.js:98:30:98:37 | req.body | ReflectedXss.js:98:12:98:38 | markdow ... q.body) |
+| ReflectedXss.js:98:30:98:37 | req.body | ReflectedXss.js:98:12:98:38 | markdow ... q.body) |
+| ReflectedXss.js:100:31:100:38 | req.body | ReflectedXss.js:100:12:100:39 | markdow ... q.body) |
+| ReflectedXss.js:100:31:100:38 | req.body | ReflectedXss.js:100:12:100:39 | markdow ... q.body) |
+| ReflectedXss.js:100:31:100:38 | req.body | ReflectedXss.js:100:12:100:39 | markdow ... q.body) |
+| ReflectedXss.js:100:31:100:38 | req.body | ReflectedXss.js:100:12:100:39 | markdow ... q.body) |
+| ReflectedXss.js:103:76:103:83 | req.body | ReflectedXss.js:103:12:103:84 | markdow ... q.body) |
+| ReflectedXss.js:103:76:103:83 | req.body | ReflectedXss.js:103:12:103:84 | markdow ... q.body) |
+| ReflectedXss.js:103:76:103:83 | req.body | ReflectedXss.js:103:12:103:84 | markdow ... q.body) |
+| ReflectedXss.js:103:76:103:83 | req.body | ReflectedXss.js:103:12:103:84 | markdow ... q.body) |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
 | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id |
@@ -319,8 +335,10 @@ edges
 | ReflectedXss.js:83:12:83:19 | req.body | ReflectedXss.js:83:12:83:19 | req.body | ReflectedXss.js:83:12:83:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:83:12:83:19 | req.body | user-provided value |
 | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) | ReflectedXss.js:84:22:84:29 | req.body | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:84:22:84:29 | req.body | user-provided value |
 | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) | ReflectedXss.js:85:23:85:30 | req.body | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:85:23:85:30 | req.body | user-provided value |
-| ReflectedXss.js:94:12:94:19 | req.body | ReflectedXss.js:94:12:94:19 | req.body | ReflectedXss.js:94:12:94:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:94:12:94:19 | req.body | user-provided value |
-| ReflectedXss.js:95:12:95:38 | markdow ... q.body) | ReflectedXss.js:95:30:95:37 | req.body | ReflectedXss.js:95:12:95:38 | markdow ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:95:30:95:37 | req.body | user-provided value |
+| ReflectedXss.js:97:12:97:19 | req.body | ReflectedXss.js:97:12:97:19 | req.body | ReflectedXss.js:97:12:97:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:97:12:97:19 | req.body | user-provided value |
+| ReflectedXss.js:98:12:98:38 | markdow ... q.body) | ReflectedXss.js:98:30:98:37 | req.body | ReflectedXss.js:98:12:98:38 | markdow ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:98:30:98:37 | req.body | user-provided value |
+| ReflectedXss.js:100:12:100:39 | markdow ... q.body) | ReflectedXss.js:100:31:100:38 | req.body | ReflectedXss.js:100:12:100:39 | markdow ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:100:31:100:38 | req.body | user-provided value |
+| ReflectedXss.js:103:12:103:84 | markdow ... q.body) | ReflectedXss.js:103:76:103:83 | req.body | ReflectedXss.js:103:12:103:84 | markdow ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:103:76:103:83 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
@@ -90,8 +90,15 @@ const markdownIt = require('markdown-it')({
 });
 const markdownIt2 = require('markdown-it')({});
 
+const markdownIt3 = require('markdown-it')({html: true})
+  .use(require('markdown-it-highlightjs'));
+
 app.get('/user/:id', function (req, res) {
   res.send(req.body); // NOT OK
   res.send(markdownIt.render(req.body)); // NOT OK
   res.send(markdownIt2.render(req.body)); // OK - no html
+  res.send(markdownIt3.render(req.body)); // NOT OK
+
+  res.send(markdownIt.use(require('markdown-it-sanitizer')).render(req.body)); // OK - HTML is sanitized. 
+  res.send(markdownIt.use(require('markdown-it-abbr')).use(unknown).render(req.body)); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.js
@@ -84,3 +84,14 @@ app.get('/user/:id', function (req, res) {
   res.send(snarkdown(req.body)); // NOT OK
   res.send(snarkdown2(req.body)); // NOT OK
 });
+
+const markdownIt = require('markdown-it')({
+  html: true
+});
+const markdownIt2 = require('markdown-it')({});
+
+app.get('/user/:id', function (req, res) {
+  res.send(req.body); // NOT OK
+  res.send(markdownIt.render(req.body)); // NOT OK
+  res.send(markdownIt2.render(req.body)); // OK - no html
+});

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
@@ -14,8 +14,10 @@
 | ReflectedXss.js:83:12:83:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:83:12:83:19 | req.body | user-provided value |
 | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:84:22:84:29 | req.body | user-provided value |
 | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:85:23:85:30 | req.body | user-provided value |
-| ReflectedXss.js:94:12:94:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:94:12:94:19 | req.body | user-provided value |
-| ReflectedXss.js:95:12:95:38 | markdow ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:95:30:95:37 | req.body | user-provided value |
+| ReflectedXss.js:97:12:97:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:97:12:97:19 | req.body | user-provided value |
+| ReflectedXss.js:98:12:98:38 | markdow ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:98:30:98:37 | req.body | user-provided value |
+| ReflectedXss.js:100:12:100:39 | markdow ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:100:31:100:38 | req.body | user-provided value |
+| ReflectedXss.js:103:12:103:84 | markdow ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:103:76:103:83 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
@@ -14,6 +14,8 @@
 | ReflectedXss.js:83:12:83:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:83:12:83:19 | req.body | user-provided value |
 | ReflectedXss.js:84:12:84:30 | snarkdown(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:84:22:84:29 | req.body | user-provided value |
 | ReflectedXss.js:85:12:85:31 | snarkdown2(req.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:85:23:85:30 | req.body | user-provided value |
+| ReflectedXss.js:94:12:94:19 | req.body | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:94:12:94:19 | req.body | user-provided value |
+| ReflectedXss.js:95:12:95:38 | markdow ... q.body) | Cross-site scripting vulnerability due to $@. | ReflectedXss.js:95:30:95:37 | req.body | user-provided value |
 | ReflectedXssContentTypes.js:10:14:10:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:10:24:10:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:20:14:20:36 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:20:24:20:36 | req.params.id | user-provided value |
 | ReflectedXssContentTypes.js:39:13:39:35 | "FOO: " ... rams.id | Cross-site scripting vulnerability due to $@. | ReflectedXssContentTypes.js:39:23:39:35 | req.params.id | user-provided value |


### PR DESCRIPTION
Adds a taint-step for CVE-2020-27224