### PR TITLE
Actions: Change staleness calculation

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -15,16 +15,16 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Comment or remove the `stale` label in order to avoid having this issue closed in 7 days.'
+        stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Comment or remove the `Stale` label in order to avoid having this issue closed in 7 days.'
         close-issue-message: 'This issue was closed because it has been inactive for 7 days.'
         days-before-stale: 14
         days-before-close: 7
-        only-labels: question
-        
+        only-labels: awaiting-response
+
         # do not mark PRs as stale
         days-before-pr-stale: -1
         days-before-pr-close: -1
-        
+
         # Uncomment for dry-run
         # debug-only: true
         # operations-per-run: 1000


### PR DESCRIPTION
Calculate staleness on issues that have the `awaiting-response` label. Leave all other issues untouched.