### PR TITLE
Python: Disallow `PostUpdateNode` as `LocalSourceNode`

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/LocalSources.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/LocalSources.qll
@@ -26,7 +26,8 @@ class LocalSourceNode extends Node {
   cached
   LocalSourceNode() {
     not comes_from_cfgnode(this) and
-    not this instanceof ModuleVariableNode
+    not this instanceof ModuleVariableNode and
+    not this instanceof PostUpdateNode
     or
     this = any(ModuleVariableNode mvn).getARead()
   }

--- a/python/ql/src/semmle/python/dataflow/new/internal/LocalSources.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/LocalSources.qll
@@ -27,7 +27,9 @@ class LocalSourceNode extends Node {
   LocalSourceNode() {
     not comes_from_cfgnode(this) and
     not this instanceof ModuleVariableNode and
-    not this instanceof PostUpdateNode
+    not this.(PostUpdateNode).getPreUpdateNode() in [
+        syntheticPostUpdateNode::storePreUpdateNode(), syntheticPostUpdateNode::readPreUpdateNode()
+      ]
     or
     this = any(ModuleVariableNode mvn).getARead()
   }


### PR DESCRIPTION
Previously, in cases like

```python
def foo(x):
    x.bar()
    x.baz()
    x.quux()
```

we would have flow from the first `x` to each use _and_ flow from the
post-update node for each method call to each subsequent use, and all
of these would be `LocalSourceNode`s. For large functions with the above
pattern, this would lead to a quadratic blowup in `hasLocalSource`.

With this commit, only the first of these will count as a
`LocalSourceNode`, and the blowup disappears.

--- 
Evaluation needed. I don't think a change note is necessary (but I'm willing to be convinced otherwise).
