### PR TITLE
Revert "Revert "C++: Work around extractor issue CPP-383""

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/CFG.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/CFG.qll
@@ -1307,7 +1307,8 @@ private predicate conditionJumps(Expr test, boolean truth, Node n2, Pos p2) {
   )
 }
 
-// Factored out for performance. See QL-796.
+// Pulled out for performance. See
+// https://github.com/github/codeql-coreql-team/issues/1044.
 private predicate normalGroupMemberBaseCase(Node memberNode, Pos memberPos, Node atNode) {
   memberNode = atNode and
   memberPos.isAt() and

--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
@@ -118,7 +118,7 @@ private predicate isFunction(Element el) {
 
 /**
  * Holds if `fc` is a `FunctionCall` with no return value for `getTarget`. This
- * can happen due to extractor issue CPP-383.
+ * can happen in case of rare database inconsistencies.
  */
 pragma[noopt]
 private predicate callHasNoTarget(@funbindexpr fc) {

--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
@@ -128,7 +128,8 @@ private predicate callHasNoTarget(@funbindexpr fc) {
   )
 }
 
-// This base case is pulled out to work around QL-796
+// Pulled out for performance. See
+// https://github.com/github/codeql-coreql-team/issues/1044.
 private predicate potentiallyReturningFunctionCall_base(FunctionCall fc) {
   fc.isVirtual()
   or

--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
@@ -104,9 +104,42 @@ private predicate loopConditionAlwaysUponEntry(ControlFlowNode loop, Expr condit
   )
 }
 
+/**
+ * This relation is the same as the `el instanceof Function`, only obfuscated
+ * so the optimizer will not understand that any `FunctionCall.getTarget()`
+ * should be in this relation.
+ */
+pragma[noinline]
+private predicate isFunction(Element el) {
+  el instanceof Function
+  or
+  el.(Expr).getParent() = el
+}
+
+/**
+ * Holds if `fc` is a `FunctionCall` with no return value for `getTarget`. This
+ * can happen due to extractor issue CPP-383.
+ */
+pragma[noopt]
+private predicate callHasNoTarget(@funbindexpr fc) {
+  exists(Function f |
+    funbind(fc, f) and
+    not isFunction(f)
+  )
+}
+
+// This base case is pulled out to work around QL-796
+private predicate potentiallyReturningFunctionCall_base(FunctionCall fc) {
+  fc.isVirtual()
+  or
+  callHasNoTarget(fc)
+}
+
 /** A function call that *may* return; if in doubt, we assume it may. */
 private predicate potentiallyReturningFunctionCall(FunctionCall fc) {
-  potentiallyReturningFunction(fc.getTarget()) or fc.isVirtual()
+  potentiallyReturningFunctionCall_base(fc)
+  or
+  potentiallyReturningFunction(fc.getTarget())
 }
 
 /** A function that *may* return; if in doubt, we assume it may. */

--- a/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
@@ -1271,7 +1271,8 @@ private predicate convparents(Expr child, int idx, Element parent) {
   )
 }
 
-// Pulled out for performance. See QL-796.
+// Pulled out for performance. See
+// https://github.com/github/codeql-coreql-team/issues/1044.
 private predicate hasNoConversions(Expr e) { not e.hasConversion() }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -42,7 +42,8 @@ IRTempVariable getIRTempVariable(Locatable ast, TempVariableTag tag) {
  */
 predicate isIRConstant(Expr expr) { exists(expr.getValue()) }
 
-// Pulled out to work around QL-796
+// Pulled out for performance. See
+// https://github.com/github/codeql-coreql-team/issues/1044.
 private predicate isOrphan(Expr expr) { not exists(getRealParent(expr)) }
 
 /**

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/TranslatedElement.qll
@@ -57,7 +57,8 @@ private Element getRealParent(Expr expr) { result = expr.getParent() }
  */
 predicate isIRConstant(Expr expr) { exists(expr.getValue()) }
 
-// Pulled out to work around QL-796
+// Pulled out for performance. See
+// https://github.com/github/codeql-coreql-team/issues/1044.
 private predicate isOrphan(Expr expr) { not exists(getRealParent(expr)) }
 
 /**


### PR DESCRIPTION
**Revert the revert** of the workaround for CFG issues when a `FunctionCall` has a `getTarget` that does not exist. While we've fixed the main cause of the problem, it can apparently still happen in rare cases as a result of extractor crashes.

This reverts commit ee5eaef5e48ba3802fb118c56bd9aae0ef2ac805.

Cc @lcartey.