### PR TITLE
Java: Fix id in experimental JsonpInjection.ql query

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjection.ql
@@ -5,7 +5,7 @@
  * @kind path-problem
  * @problem.severity error
  * @precision high
- * @id java/JSONP-Injection
+ * @id java/jsonp-injection
  * @tags security
  *       external/cwe/cwe-352
  */


### PR DESCRIPTION
The invalid `@id` broke PR checks here: https://github.com/github/codeql/pull/5703 (see https://github.slack.com/archives/CPSEA0G22/p1618602834224600 for the follow-up discussion)