### PR TITLE
JS: fix bad join order in Xss.qll

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -211,7 +211,7 @@ module DomBasedXss {
       exists(JQuery::MethodCall call |
         call.interpretsArgumentAsHtml(this) and
         call.interpretsArgumentAsSelector(this) and
-        analyze().getAType() = TTString()
+        pragma[only_bind_out](analyze()).getAType() = TTString()
       )
     }
 


### PR DESCRIPTION
I was looking for a performance regression in VSCode.   
I'm quite sure I haven't found it yet, but I found this thing.  

This is how the tuple counts looked before: 
```
[2021-04-19 13:07:24] (3s) Tuple counts for Xss::DomBasedXss::JQueryHtmlOrSelectorArgument#f/1@a9a054:
                      14883760 ~4%     {2} r1 = SCAN TypeInference::AnalyzedNode::getAType_dispred#ff@staged_ext OUTPUT In.1, In.0 'this'
                      1579031  ~6%     {1} r2 = JOIN r1 WITH construct<TypeTag,4>@dom#InferredTypes::TTString#0#f ON FIRST 1 OUTPUT Lhs.1 'this'
                      30       ~2%     {2} r3 = JOIN r2 WITH jQuery::JQuery::MethodCall::interpretsArgumentAsHtml_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'this'
                      30       ~0%     {1} r4 = JOIN r3 WITH jQuery::JQuery::MethodCall::interpretsArgumentAsSelector_dispred#ff ON FIRST 2 OUTPUT Lhs.1 'this'
``` 

And with this change the max number of tuples is `30`. 

[Evaluation looks good](https://github.com/dsp-testing/erik-krogh-dca/tree/run/xssFix-nightly-xss/reports). (internal link, was partially done when I checked). 