### PR TITLE
C#: Various data-flow performance tweaks

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/Caching.qll
+++ b/csharp/ql/src/semmle/code/csharp/Caching.qll
@@ -49,6 +49,7 @@ module Stages {
 
   cached
   module DataFlowStage {
+    private import semmle.code.csharp.dataflow.internal.DataFlowDispatch
     private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
     private import semmle.code.csharp.dataflow.internal.DataFlowImplCommon
     private import semmle.code.csharp.dataflow.internal.TaintTrackingPrivate
@@ -77,6 +78,8 @@ module Stages {
       exists(any(OutNode n).getCall(_))
       or
       exists(CallContext cc)
+      or
+      exists(any(DataFlowCall c).getEnclosingCallable())
       or
       forceCachingInSameStageRev()
     }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -4,6 +4,7 @@ private import dotnet
 private import DataFlowPublic
 private import DataFlowPrivate
 private import FlowSummaryImpl as FlowSummaryImpl
+private import semmle.code.csharp.Caching
 private import semmle.code.csharp.dataflow.FlowSummary
 private import semmle.code.csharp.dispatch.Dispatch
 private import semmle.code.csharp.frameworks.system.Collections
@@ -69,8 +70,6 @@ private predicate transitiveCapturedCallTarget(ControlFlow::Nodes::ElementNode c
 
 cached
 private module Cached {
-  private import semmle.code.csharp.Caching
-
   cached
   newtype TReturnKind =
     TNormalReturnKind() { Stages::DataFlowStage::forceCachingInSameStage() } or
@@ -247,6 +246,7 @@ abstract class DataFlowCall extends TDataFlowCall {
   abstract DataFlow::Node getNode();
 
   /** Gets the enclosing callable of this call. */
+  cached
   abstract DataFlowCallable getEnclosingCallable();
 
   /** Gets the underlying expression, if any. */
@@ -280,7 +280,10 @@ class NonDelegateDataFlowCall extends DataFlowCall, TNonDelegateCall {
 
   override DataFlow::ExprNode getNode() { result.getControlFlowNode() = cfn }
 
-  override DataFlowCallable getEnclosingCallable() { result = cfn.getEnclosingCallable() }
+  override DataFlowCallable getEnclosingCallable() {
+    Stages::DataFlowStage::forceCachingInSameStage() and
+    result = cfn.getEnclosingCallable()
+  }
 
   override string toString() { result = cfn.toString() }
 


### PR DESCRIPTION
- Cache `DataFlowCall::getEnclosingCallable()`.
- Cache `ParameterNode`.
- Cache `ArgumentNode`.
- Force proper join-orders for uses of `getNodeType()`.
- Inline `localFlow` to prevent calculating full TC.

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1021/