### PR TITLE
C++: Fix false positive in return stack allocated memory (second attempt)

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -13,6 +13,7 @@
 
 import cpp
 import semmle.code.cpp.dataflow.EscapesTree
+import semmle.code.cpp.models.interfaces.PointerWrapper
 import semmle.code.cpp.dataflow.DataFlow
 
 /**
@@ -38,6 +39,10 @@ predicate hasNontrivialConversion(Expr e) {
     or
     e instanceof ParenthesisExpr
   )
+  or
+  // A smart pointer can be stack-allocated while the data it points to is heap-allocated.
+  // So we exclude such "conversions" from this predicate.
+  e = any(PointerWrapper wrapper).getAnUnwrapperFunction().getACallToThisFunction()
   or
   hasNontrivialConversion(e.getConversion())
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
@@ -6,3 +6,4 @@
 | test.cpp:112:2:112:12 | return ... | May return stack-allocated memory from $@. | test.cpp:112:9:112:11 | arr | arr |
 | test.cpp:119:2:119:19 | return ... | May return stack-allocated memory from $@. | test.cpp:119:11:119:13 | arr | arr |
 | test.cpp:171:3:171:24 | return ... | May return stack-allocated memory from $@. | test.cpp:170:35:170:41 | myLocal | myLocal |
+| test.cpp:217:3:217:13 | return ... | May return stack-allocated memory from $@. | test.cpp:216:14:216:17 | port | port |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
@@ -6,4 +6,3 @@
 | test.cpp:112:2:112:12 | return ... | May return stack-allocated memory from $@. | test.cpp:112:9:112:11 | arr | arr |
 | test.cpp:119:2:119:19 | return ... | May return stack-allocated memory from $@. | test.cpp:119:11:119:13 | arr | arr |
 | test.cpp:171:3:171:24 | return ... | May return stack-allocated memory from $@. | test.cpp:170:35:170:41 | myLocal | myLocal |
-| test.cpp:217:3:217:13 | return ... | May return stack-allocated memory from $@. | test.cpp:216:14:216:17 | port | port |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
@@ -214,5 +214,5 @@ auto make_read_port()
 {
   auto port = std::shared_ptr<int>(new int);
   auto ptr = port.get();
-  return ptr; // GOOD [FALSE POSITIVE]
+  return ptr; // GOOD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
@@ -189,3 +189,30 @@ int *&conversionInFlow() {
   int *&pRef = p; // has conversion in the middle of data flow
   return pRef; // BAD [NOT DETECTED]
 }
+
+namespace std {
+	template<typename T>
+	class shared_ptr {
+	public:
+		shared_ptr() noexcept;
+		explicit shared_ptr(T*);
+		shared_ptr(const shared_ptr&) noexcept;
+		template<class U> shared_ptr(const shared_ptr<U>&) noexcept;
+		template<class U> shared_ptr(shared_ptr<U>&&) noexcept;
+
+		shared_ptr<T>& operator=(const shared_ptr<T>&) noexcept;
+		shared_ptr<T>& operator=(shared_ptr<T>&&) noexcept;
+
+		T& operator*() const noexcept;
+		T* operator->() const noexcept;
+
+		T* get() const noexcept;
+	};
+}
+
+auto make_read_port()
+{
+  auto port = std::shared_ptr<int>(new int);
+  auto ptr = port.get();
+  return ptr; // GOOD [FALSE POSITIVE]
+}


### PR DESCRIPTION
This is my second attempt at fixing the false positive report in https://github.com/github/codeql/issues/5709.

https://github.com/github/codeql/pull/5724 tried to solve it by changing `variableAddressEscapesTree`, but that turned out to have unintended consequences. Instead, this PR does the naive thing and excludes the problematic dataflow steps from that query altogether.

I don't like this solution very much. The real problem is the fact that https://github.com/github/codeql/pull/5607 adds conflation between the smart pointer and the raw pointer in dataflow (instead of taintflow), but at least this removes one place where this problem has an observable effect.