### PR TITLE
Add security-severity tags

### DIFF
--- a/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-120
  *       external/cwe/cwe-125
+ *       security-severity/8.1
  */
 
 import cpp

--- a/cpp/ql/src/Critical/InconsistentNullnessTesting.ql
+++ b/cpp/ql/src/Critical/InconsistentNullnessTesting.ql
@@ -7,6 +7,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-476
+ *       security-severity/7.5
  */
 
 import cpp

--- a/cpp/ql/src/Critical/MemoryMayNotBeFreed.ql
+++ b/cpp/ql/src/Critical/MemoryMayNotBeFreed.ql
@@ -7,6 +7,7 @@
  * @tags efficiency
  *       security
  *       external/cwe/cwe-401
+ *       security-severity/7.5
  */
 
 import MemoryFreed

--- a/cpp/ql/src/Critical/MemoryNeverFreed.ql
+++ b/cpp/ql/src/Critical/MemoryNeverFreed.ql
@@ -7,6 +7,7 @@
  * @tags efficiency
  *       security
  *       external/cwe/cwe-401
+ *       security-severity/7.5
  */
 
 import MemoryFreed

--- a/cpp/ql/src/Critical/MissingNullTest.ql
+++ b/cpp/ql/src/Critical/MissingNullTest.ql
@@ -7,6 +7,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-476
+ *       security-severity/7.5
  */
 
 import cpp

--- a/cpp/ql/src/Critical/NewFreeMismatch.ql
+++ b/cpp/ql/src/Critical/NewFreeMismatch.ql
@@ -8,6 +8,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-401
+ *       security-severity/7.5
  */
 
 import NewDelete

--- a/cpp/ql/src/Critical/OverflowCalculated.ql
+++ b/cpp/ql/src/Critical/OverflowCalculated.ql
@@ -8,6 +8,7 @@
  *       security
  *       external/cwe/cwe-131
  *       external/cwe/cwe-120
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/Critical/OverflowDestination.ql
+++ b/cpp/ql/src/Critical/OverflowDestination.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-119
  *       external/cwe/cwe-131
+ *       security-severity/8.8
  */
 
 import cpp

--- a/cpp/ql/src/Critical/OverflowStatic.ql
+++ b/cpp/ql/src/Critical/OverflowStatic.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-119
  *       external/cwe/cwe-131
+ *       security-severity/8.8
  */
 
 import cpp

--- a/cpp/ql/src/Critical/SizeCheck.ql
+++ b/cpp/ql/src/Critical/SizeCheck.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-131
  *       external/cwe/cwe-122
+ *       security-severity/8.1
  */
 
 import cpp

--- a/cpp/ql/src/Critical/SizeCheck2.ql
+++ b/cpp/ql/src/Critical/SizeCheck2.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-131
  *       external/cwe/cwe-122
+ *       security-severity/8.1
  */
 
 import cpp

--- a/cpp/ql/src/Critical/UseAfterFree.ql
+++ b/cpp/ql/src/Critical/UseAfterFree.ql
@@ -7,6 +7,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-416
+ *       security-severity/8.8
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Arithmetic/BadAdditionOverflowCheck.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/BadAdditionOverflowCheck.ql
@@ -13,6 +13,7 @@
  *       security
  *       external/cwe/cwe-190
  *       external/cwe/cwe-192
+ *       security-severity/8.1
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -14,6 +14,7 @@
  *       external/cwe/cwe-192
  *       external/cwe/cwe-197
  *       external/cwe/cwe-681
+ *       security-severity/8.1
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
@@ -12,6 +12,7 @@
  *       security
  *       external/cwe/cwe-119
  *       external/cwe/cwe-843
+ *       security-severity/8.8
  * @id cpp/upcast-array-pointer-arithmetic
  */
 

--- a/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
+++ b/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
@@ -12,6 +12,7 @@
  *       correctness
  *       security
  *       external/cwe/cwe-134
+ *       security-severity/9.8
  */
 
 import semmle.code.cpp.dataflow.TaintTracking

--- a/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.ql
@@ -9,6 +9,7 @@
  *       correctness
  *       security
  *       external/cwe/cwe-770
+ *       security-severity/7.5
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Memory Management/ImproperNullTermination.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ImproperNullTermination.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe/cwe-170
  *       external/cwe/cwe-665
+ *       security-severity/7.8
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Memory Management/StrncpyFlippedArgs.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/StrncpyFlippedArgs.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-676
  *       external/cwe/cwe-119
  *       external/cwe/cwe-251
+ *       security-severity/8.8
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToStrncat.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToStrncat.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-676
  *       external/cwe/cwe-119
  *       external/cwe/cwe-251
+ *       security-severity/8.8
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-665
  *       external/cwe/cwe-457
+ *       security-severity/7.8
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Memory Management/UnsafeUseOfStrcat.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UnsafeUseOfStrcat.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-676
  *       external/cwe/cwe-120
  *       external/cwe/cwe-251
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-020/CountUntrustedDataToExternalAPI.ql
+++ b/cpp/ql/src/Security/CWE/CWE-020/CountUntrustedDataToExternalAPI.ql
@@ -6,6 +6,7 @@
  * @id cpp/count-untrusted-data-external-api
  * @kind table
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-020/IRCountUntrustedDataToExternalAPI.ql
+++ b/cpp/ql/src/Security/CWE/CWE-020/IRCountUntrustedDataToExternalAPI.ql
@@ -6,6 +6,7 @@
  * @id cpp/count-untrusted-data-external-api-ir
  * @kind table
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-020/IRUntrustedDataToExternalAPI.ql
+++ b/cpp/ql/src/Security/CWE/CWE-020/IRUntrustedDataToExternalAPI.ql
@@ -6,6 +6,7 @@
  * @precision low
  * @problem.severity error
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/cpp/ql/src/Security/CWE/CWE-020/UntrustedDataToExternalAPI.ql
@@ -6,6 +6,7 @@
  * @precision low
  * @problem.severity error
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-022/TaintedPath.ql
+++ b/cpp/ql/src/Security/CWE/CWE-022/TaintedPath.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-023
  *       external/cwe/cwe-036
  *       external/cwe/cwe-073
+ *       security-severity/8.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-079/CgiXss.ql
+++ b/cpp/ql/src/Security/CWE/CWE-079/CgiXss.ql
@@ -8,6 +8,7 @@
  * @id cpp/cgi-xss
  * @tags security
  *       external/cwe/cwe-079
+ *       security-severity/6.1
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-089/SqlTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-089/SqlTainted.ql
@@ -9,6 +9,7 @@
  * @id cpp/sql-injection
  * @tags security
  *       external/cwe/cwe-089
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-114/UncontrolledProcessOperation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-114/UncontrolledProcessOperation.ql
@@ -9,6 +9,7 @@
  * @id cpp/uncontrolled-process-operation
  * @tags security
  *       external/cwe/cwe-114
+ *       security-severity/8.2
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-119/OverflowBuffer.ql
+++ b/cpp/ql/src/Security/CWE/CWE-119/OverflowBuffer.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-121
  *       external/cwe/cwe-122
  *       external/cwe/cwe-126
+ *       security-severity/8.8
  */
 
 import semmle.code.cpp.security.BufferWrite

--- a/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-120
  *       external/cwe/cwe-787
  *       external/cwe/cwe-805
+ *       security-severity/9.1
  */
 
 import semmle.code.cpp.security.BufferWrite

--- a/cpp/ql/src/Security/CWE/CWE-120/OverrunWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/OverrunWrite.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-120
  *       external/cwe/cwe-787
  *       external/cwe/cwe-805
+ *       security-severity/9.1
  */
 
 import semmle.code.cpp.security.BufferWrite

--- a/cpp/ql/src/Security/CWE/CWE-120/OverrunWriteFloat.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/OverrunWriteFloat.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-120
  *       external/cwe/cwe-787
  *       external/cwe/cwe-805
+ *       security-severity/9.1
  */
 
 import semmle.code.cpp.security.BufferWrite

--- a/cpp/ql/src/Security/CWE/CWE-120/UnboundedWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/UnboundedWrite.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-120
  *       external/cwe/cwe-787
  *       external/cwe/cwe-805
+ *       security-severity/9.1
  */
 
 import semmle.code.cpp.security.BufferWrite

--- a/cpp/ql/src/Security/CWE/CWE-121/UnterminatedVarargsCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-121/UnterminatedVarargsCall.ql
@@ -10,6 +10,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-121
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
@@ -8,6 +8,7 @@
  * @problem.severity warning
  * @tags security
  *       external/cwe/cwe-129
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.ql
+++ b/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-131
  *       external/cwe/cwe-120
  *       external/cwe/cwe-122
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatString.ql
+++ b/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatString.ql
@@ -10,6 +10,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-134
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatStringThroughGlobalVar.ql
+++ b/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatStringThroughGlobalVar.ql
@@ -10,6 +10,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-134
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @tags security
  *       external/cwe/cwe-170
+ *       security-severity/5.5
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-190
  *       external/cwe/cwe-191
+ *       security-severity/8.1
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-190
  *       external/cwe/cwe-191
+ *       security-severity/8.1
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticWithExtremeValues.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticWithExtremeValues.ql
@@ -11,6 +11,7 @@
  *       reliability
  *       external/cwe/cwe-190
  *       external/cwe/cwe-191
+ *       security-severity/8.1
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-190
  *       external/cwe/cwe-197
  *       external/cwe/cwe-835
+ *       security-severity/7.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-190/IntegerOverflowTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/IntegerOverflowTainted.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-190
  *       external/cwe/cwe-197
  *       external/cwe/cwe-681
+ *       security-severity/8.1
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -9,6 +9,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-190
+ *       security-severity/8.1
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero.ql
+++ b/cpp/ql/src/Security/CWE/CWE-191/UnsignedDifferenceExpressionComparedZero.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       correctness
  *       external/cwe/cwe-191
+ *       security-severity/8.2
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-290/AuthenticationBypass.ql
+++ b/cpp/ql/src/Security/CWE/CWE-290/AuthenticationBypass.ql
@@ -9,6 +9,7 @@
  * @id cpp/user-controlled-bypass
  * @tags security
  *       external/cwe/cwe-290
+ *       security-severity/7.7
  */
 
 import semmle.code.cpp.security.TaintTracking

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
@@ -8,6 +8,7 @@
  * @id cpp/cleartext-storage-buffer
  * @tags security
  *       external/cwe/cwe-312
+ *       security-severity/7.5
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.ql
+++ b/cpp/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.ql
@@ -8,6 +8,7 @@
  * @id cpp/weak-cryptographic-algorithm
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-327/OpenSslHeartbleed.ql
+++ b/cpp/ql/src/Security/CWE/CWE-327/OpenSslHeartbleed.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-327
  *       external/cwe/cwe-788
+ *       security-severity/7.5
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-367/TOCTOUFilesystemRace.ql
+++ b/cpp/ql/src/Security/CWE/CWE-367/TOCTOUFilesystemRace.ql
@@ -9,6 +9,7 @@
  * @id cpp/toctou-race-condition
  * @tags security
  *       external/cwe/cwe-367
+ *       security-severity/7.0
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-428
  *       external/microsoft/C6277
+ *       security-severity/7.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-704
  *       external/microsoft/c/c6276
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-732/DoNotCreateWorldWritable.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/DoNotCreateWorldWritable.ql
@@ -7,6 +7,7 @@
  * @id cpp/world-writable-file-creation
  * @tags security
  *       external/cwe/cwe-732
+ *       security-severity/7.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-732/UnsafeDaclSecurityDescriptor.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/UnsafeDaclSecurityDescriptor.ql
@@ -11,6 +11,7 @@
  * @tags security
  *       external/cwe/cwe-732
  *       external/microsoft/C6248
+ *       security-severity/7.8
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-835/InfiniteLoopWithUnsatisfiableExitCondition.ql
+++ b/cpp/ql/src/Security/CWE/CWE-835/InfiniteLoopWithUnsatisfiableExitCondition.ql
@@ -8,6 +8,7 @@
  * @problem.severity warning
  * @tags security
  *       external/cwe/cwe-835
+ *       security-severity/7.5
  */
 
 import cpp

--- a/cpp/ql/src/experimental/Likely Bugs/RedundantNullCheckParam.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/RedundantNullCheckParam.ql
@@ -9,6 +9,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-476
+ *       security-severity/7.5
  */
 
 import cpp

--- a/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
@@ -10,6 +10,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import cpp

--- a/cpp/ql/src/experimental/Security/CWE/CWE-120/MemoryUnsafeFunctionScan.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-120/MemoryUnsafeFunctionScan.ql
@@ -7,6 +7,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-120
+ *       security-severity/9.8
  */
 
 import cpp

--- a/cpp/ql/src/experimental/Security/CWE/CWE-190/AllocMultiplicationOverflow.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-190/AllocMultiplicationOverflow.ql
@@ -8,6 +8,7 @@
  *       correctness
  *       external/cwe/cwe-190
  *       external/cwe/cwe-128
+ *       security-severity/8.1
  * @id cpp/multiplication-overflow-in-alloc
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-273/PrivilegeDroppingOutoforder.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-273/PrivilegeDroppingOutoforder.ql
@@ -9,6 +9,7 @@
  * @id cpp/drop-linux-privileges-outoforder
  * @tags security
  *       external/cwe/cwe-273
+ *       security-severity/9.8
  * @precision medium
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-401/MemoryLeakOnFailedCallToRealloc.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-401/MemoryLeakOnFailedCallToRealloc.ql
@@ -9,6 +9,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-401
+ *       security-severity/7.5
  */
 
 import cpp

--- a/csharp/ql/src/Configuration/EmptyPasswordInConfigurationFile.ql
+++ b/csharp/ql/src/Configuration/EmptyPasswordInConfigurationFile.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe/cwe-258
  *       external/cwe/cwe-862
+ *       security-severity/8.1
  */
 
 import csharp

--- a/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
+++ b/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
@@ -9,6 +9,7 @@
  *       external/cwe/cwe-13
  *       external/cwe/cwe-256
  *       external/cwe/cwe-313
+ *       security-severity/6.5
  */
 
 import csharp

--- a/csharp/ql/src/Input Validation/UseOfFileUpload.ql
+++ b/csharp/ql/src/Input Validation/UseOfFileUpload.ql
@@ -9,6 +9,7 @@
  *       maintainability
  *       frameworks/asp.net
  *       external/cwe/cwe-434
+ *       security-severity/8.8
  */
 
 import csharp

--- a/csharp/ql/src/Likely Bugs/ThreadUnsafeICryptoTransform.ql
+++ b/csharp/ql/src/Likely Bugs/ThreadUnsafeICryptoTransform.ql
@@ -10,6 +10,7 @@
  * @tags concurrency
  *       security
  *       external/cwe/cwe-362
+ *       security-severity/7.0
  */
 
 import csharp

--- a/csharp/ql/src/Likely Bugs/ThreadUnsafeICryptoTransformLambda.ql
+++ b/csharp/ql/src/Likely Bugs/ThreadUnsafeICryptoTransformLambda.ql
@@ -11,6 +11,7 @@
  * @tags concurrency
  *       security
  *       external/cwe/cwe-362
+ *       security-severity/7.0
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       frameworks/asp.net
  *       external/cwe/cwe-16
+ *       security-severity/7.1
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetPagesValidateRequest.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetPagesValidateRequest.ql
@@ -7,6 +7,7 @@
  * @tags security
  *       frameworks/asp.net
  *       external/cwe/cwe-16
+ *       security-severity/7.1
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetRequestValidationMode.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetRequestValidationMode.ql
@@ -8,6 +8,7 @@
  * @problem.severity warning
  * @tags security
  *       external/cwe/cwe-016
+ *       security-severity/7.1
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
+++ b/csharp/ql/src/Security Features/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
@@ -6,6 +6,7 @@
  * @id csharp/count-untrusted-data-external-api
  * @kind table
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-020/RuntimeChecksBypass.ql
+++ b/csharp/ql/src/Security Features/CWE-020/RuntimeChecksBypass.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @tags security
  *       external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import semmle.code.csharp.serialization.Serialization

--- a/csharp/ql/src/Security Features/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/csharp/ql/src/Security Features/CWE-020/UntrustedDataToExternalAPI.ql
@@ -6,6 +6,7 @@
  * @precision low
  * @problem.severity error
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-022/TaintedPath.ql
+++ b/csharp/ql/src/Security Features/CWE-022/TaintedPath.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-036
  *       external/cwe/cwe-073
  *       external/cwe/cwe-099
+ *       security-severity/8.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-022/ZipSlip.ql
+++ b/csharp/ql/src/Security Features/CWE-022/ZipSlip.ql
@@ -9,6 +9,7 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-022
+ *       security-severity/8.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-078/CommandInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-078/CommandInjection.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-078/StoredCommandInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-078/StoredCommandInjection.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-079/StoredXSS.ql
+++ b/csharp/ql/src/Security Features/CWE-079/StoredXSS.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-079/XSS.ql
+++ b/csharp/ql/src/Security Features/CWE-079/XSS.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-089/SecondOrderSqlInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-089/SecondOrderSqlInjection.ql
@@ -8,6 +8,7 @@
  * @id cs/second-order-sql-injection
  * @tags security
  *       external/cwe/cwe-089
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-089/SqlInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-089/SqlInjection.ql
@@ -8,6 +8,7 @@
  * @id cs/sql-injection
  * @tags security
  *       external/cwe/cwe-089
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-091/XMLInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-091/XMLInjection.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-091
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-094/CodeInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-094/CodeInjection.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-094
  *       external/cwe/cwe-095
  *       external/cwe/cwe-096
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-112/MissingXMLValidation.ql
+++ b/csharp/ql/src/Security Features/CWE-112/MissingXMLValidation.ql
@@ -8,6 +8,7 @@
  * @id cs/xml/missing-validation
  * @tags security
  *       external/cwe/cwe-112
+ *       security-severity/4.3
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-114/AssemblyPathInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-114/AssemblyPathInjection.ql
@@ -9,6 +9,7 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-114
+ *       security-severity/8.2
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-117/LogForging.ql
+++ b/csharp/ql/src/Security Features/CWE-117/LogForging.ql
@@ -8,6 +8,7 @@
  * @id cs/log-forging
  * @tags security
  *       external/cwe/cwe-117
+ *       security-severity/5.3
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-119/LocalUnvalidatedArithmetic.ql
+++ b/csharp/ql/src/Security Features/CWE-119/LocalUnvalidatedArithmetic.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-120
  *       external/cwe/cwe-122
  *       external/cwe/cwe-788
+ *       security-severity/8.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-134/UncontrolledFormatString.ql
+++ b/csharp/ql/src/Security Features/CWE-134/UncontrolledFormatString.ql
@@ -8,6 +8,7 @@
  * @id cs/uncontrolled-format-string
  * @tags security
  *       external/cwe/cwe-134
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-201/ExposureInTransmittedData.ql
+++ b/csharp/ql/src/Security Features/CWE-201/ExposureInTransmittedData.ql
@@ -7,6 +7,7 @@
  * @id cs/sensitive-data-transmission
  * @tags security
  *       external/cwe/cwe-201
+ *       security-severity/4.3
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-209/ExceptionInformationExposure.ql
+++ b/csharp/ql/src/Security Features/CWE-209/ExceptionInformationExposure.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-209
  *       external/cwe/cwe-497
+ *       security-severity/5.3
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-248/MissingASPNETGlobalErrorHandler.ql
+++ b/csharp/ql/src/Security Features/CWE-248/MissingASPNETGlobalErrorHandler.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-12
  *       external/cwe/cwe-248
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-312/CleartextStorage.ql
+++ b/csharp/ql/src/Security Features/CWE-312/CleartextStorage.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-312
  *       external/cwe/cwe-315
  *       external/cwe/cwe-359
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-327/DontInstallRootCert.ql
+++ b/csharp/ql/src/Security Features/CWE-327/DontInstallRootCert.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
+++ b/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-352/MissingAntiForgeryTokenValidation.ql
+++ b/csharp/ql/src/Security Features/CWE-352/MissingAntiForgeryTokenValidation.ql
@@ -8,6 +8,7 @@
  * @id cs/web/missing-token-validation
  * @tags security
  *       external/cwe/cwe-352
+ *       security-severity/8.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-384/AbandonSession.ql
+++ b/csharp/ql/src/Security Features/CWE-384/AbandonSession.ql
@@ -9,6 +9,7 @@
  * @id cs/session-reuse
  * @tags security
  *       external/cwe/cwe-384
+ *       security-severity/8.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-451/MissingXFrameOptions.ql
+++ b/csharp/ql/src/Security Features/CWE-451/MissingXFrameOptions.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-451
  *       external/cwe/cwe-829
+ *       security-severity/8.1
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-502/DeserializedDelegate.ql
+++ b/csharp/ql/src/Security Features/CWE-502/DeserializedDelegate.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-502
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-502/UnsafeDeserialization.ql
+++ b/csharp/ql/src/Security Features/CWE-502/UnsafeDeserialization.ql
@@ -8,6 +8,7 @@
  * @precision low
  * @tags security
  *       external/cwe/cwe-502
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-502/UnsafeDeserializationUntrustedInput.ql
+++ b/csharp/ql/src/Security Features/CWE-502/UnsafeDeserializationUntrustedInput.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-502
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-601/UrlRedirect.ql
+++ b/csharp/ql/src/Security Features/CWE-601/UrlRedirect.ql
@@ -8,6 +8,7 @@
  * @id cs/web/unvalidated-url-redirection
  * @tags security
  *       external/cwe/cwe-601
+ *       security-severity/6.1
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-611/UntrustedDataInsecureXml.ql
+++ b/csharp/ql/src/Security Features/CWE-611/UntrustedDataInsecureXml.ql
@@ -9,6 +9,7 @@
  *       external/cwe/cwe-611
  *       external/cwe/cwe-827
  *       external/cwe/cwe-776
+ *       security-severity/8.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-611/UseXmlSecureResolver.ql
+++ b/csharp/ql/src/Security Features/CWE-611/UseXmlSecureResolver.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-611
  *       external/cwe/cwe-827
  *       external/cwe/cwe-776
+ *       security-severity/8.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-614/RequireSSL.ql
+++ b/csharp/ql/src/Security Features/CWE-614/RequireSSL.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-319
  *       external/cwe/cwe-614
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-730/ReDoS.ql
+++ b/csharp/ql/src/Security Features/CWE-730/ReDoS.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-730
  *       external/cwe/cwe-400
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-730/RegexInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-730/RegexInjection.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-730
  *       external/cwe/cwe-400
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-798/HardcodedConnectionString.ql
+++ b/csharp/ql/src/Security Features/CWE-798/HardcodedConnectionString.ql
@@ -9,6 +9,7 @@
  *       external/cwe/cwe-259
  *       external/cwe/cwe-321
  *       external/cwe/cwe-798
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-798/HardcodedCredentials.ql
+++ b/csharp/ql/src/Security Features/CWE-798/HardcodedCredentials.ql
@@ -9,6 +9,7 @@
  *       external/cwe/cwe-259
  *       external/cwe/cwe-321
  *       external/cwe/cwe-798
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-807/ConditionalBypass.ql
+++ b/csharp/ql/src/Security Features/CWE-807/ConditionalBypass.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-807
  *       external/cwe/cwe-247
  *       external/cwe/cwe-350
+ *       security-severity/5.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-838/InappropriateEncoding.ql
+++ b/csharp/ql/src/Security Features/CWE-838/InappropriateEncoding.ql
@@ -8,6 +8,7 @@
  * @id cs/inappropriate-encoding
  * @tags security
  *       external/cwe/cwe-838
+ *       security-severity/4.3
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CookieWithOverlyBroadDomain.ql
+++ b/csharp/ql/src/Security Features/CookieWithOverlyBroadDomain.ql
@@ -7,6 +7,7 @@
  * @id cs/web/broad-cookie-domain
  * @tags security
  *       external/cwe/cwe-287
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CookieWithOverlyBroadPath.ql
+++ b/csharp/ql/src/Security Features/CookieWithOverlyBroadPath.ql
@@ -7,6 +7,7 @@
  * @id cs/web/broad-cookie-path
  * @tags security
  *       external/cwe/cwe-287
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/Encryption using ECB.ql
+++ b/csharp/ql/src/Security Features/Encryption using ECB.ql
@@ -7,6 +7,7 @@
  * @id cs/ecb-encryption
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/InadequateRSAPadding.ql
+++ b/csharp/ql/src/Security Features/InadequateRSAPadding.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe/cwe-327
  *       external/cwe/cwe-780
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/InsecureRandomness.ql
+++ b/csharp/ql/src/Security Features/InsecureRandomness.ql
@@ -9,6 +9,7 @@
  * @id cs/insecure-randomness
  * @tags security
  *       external/cwe/cwe-338
+ *       security-severity/9.8
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/InsufficientKeySize.ql
+++ b/csharp/ql/src/Security Features/InsufficientKeySize.ql
@@ -7,6 +7,7 @@
  * @id cs/insufficient-key-size
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/WeakEncryption.ql
+++ b/csharp/ql/src/Security Features/WeakEncryption.ql
@@ -7,6 +7,7 @@
  * @id cs/weak-encryption
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import csharp

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClient.ql
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClient.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-023
  *       external/cwe/cwe-036
  *       external/cwe/cwe-073
+ *       security-severity/9.8
  */
 
 import csharp

--- a/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
@@ -13,6 +13,7 @@
  *       external/cwe/cwe-192
  *       external/cwe/cwe-197
  *       external/cwe/cwe-681
+ *       security-severity/8.1
  */
 
 import semmle.code.java.arithmetic.Overflow

--- a/java/ql/src/Security/CWE/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
+++ b/java/ql/src/Security/CWE/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
@@ -6,6 +6,7 @@
  * @id java/count-untrusted-data-external-api
  * @kind table
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/java/ql/src/Security/CWE/CWE-020/UntrustedDataToExternalAPI.ql
@@ -6,6 +6,7 @@
  * @precision low
  * @problem.severity error
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-022/TaintedPath.ql
+++ b/java/ql/src/Security/CWE/CWE-022/TaintedPath.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-023
  *       external/cwe/cwe-036
  *       external/cwe/cwe-073
+ *       security-severity/8.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-022/TaintedPathLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-022/TaintedPathLocal.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-023
  *       external/cwe/cwe-036
  *       external/cwe/cwe-073
+ *       security-severity/8.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-022/ZipSlip.ql
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlip.ql
@@ -9,6 +9,7 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-022
+ *       security-severity/8.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-078/ExecRelative.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecRelative.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import semmle.code.java.Expr

--- a/java/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-078/ExecTaintedLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecTaintedLocal.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import semmle.code.java.Expr

--- a/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-079/XSS.ql
+++ b/java/ql/src/Security/CWE/CWE-079/XSS.ql
@@ -8,6 +8,7 @@
  * @id java/xss
  * @tags security
  *       external/cwe/cwe-079
+ *       security-severity/6.1
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-079/XSSLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-079/XSSLocal.ql
@@ -8,6 +8,7 @@
  * @id java/xss-local
  * @tags security
  *       external/cwe/cwe-079
+ *       security-severity/6.1
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-089
  *       external/cwe/cwe-564
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-089/SqlTaintedLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlTaintedLocal.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-089
  *       external/cwe/cwe-564
+ *       security-severity/9.8
  */
 
 import semmle.code.java.Expr

--- a/java/ql/src/Security/CWE/CWE-089/SqlUnescaped.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlUnescaped.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-089
  *       external/cwe/cwe-564
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
+++ b/java/ql/src/Security/CWE/CWE-094/InsecureBeanValidation.ql
@@ -7,6 +7,7 @@
  * @id java/insecure-bean-validation
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayConstruction.ql
+++ b/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayConstruction.ql
@@ -7,6 +7,7 @@
  * @id java/improper-validation-of-array-construction
  * @tags security
  *       external/cwe/cwe-129
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayConstructionCodeSpecified.ql
+++ b/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayConstructionCodeSpecified.ql
@@ -8,6 +8,7 @@
  * @id java/improper-validation-of-array-construction-code-specified
  * @tags security
  *       external/cwe/cwe-129
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayConstructionLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayConstructionLocal.ql
@@ -8,6 +8,7 @@
  * @id java/improper-validation-of-array-construction-local
  * @tags security
  *       external/cwe/cwe-129
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayIndex.ql
+++ b/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayIndex.ql
@@ -7,6 +7,7 @@
  * @id java/improper-validation-of-array-index
  * @tags security
  *       external/cwe/cwe-129
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayIndexCodeSpecified.ql
+++ b/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayIndexCodeSpecified.ql
@@ -8,6 +8,7 @@
  * @id java/improper-validation-of-array-index-code-specified
  * @tags security
  *       external/cwe/cwe-129
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayIndexLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayIndexLocal.ql
@@ -8,6 +8,7 @@
  * @id java/improper-validation-of-array-index-local
  * @tags security
  *       external/cwe/cwe-129
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-134/ExternallyControlledFormatString.ql
+++ b/java/ql/src/Security/CWE/CWE-134/ExternallyControlledFormatString.ql
@@ -7,6 +7,7 @@
  * @id java/tainted-format-string
  * @tags security
  *       external/cwe/cwe-134
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-134/ExternallyControlledFormatStringLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-134/ExternallyControlledFormatStringLocal.ql
@@ -7,6 +7,7 @@
  * @id java/tainted-format-string-local
  * @tags security
  *       external/cwe/cwe-134
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-190
  *       external/cwe/cwe-191
+ *       security-severity/8.1
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-190/ArithmeticTaintedLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-190/ArithmeticTaintedLocal.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-190
  *       external/cwe/cwe-191
+ *       security-severity/8.1
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/java/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-190
  *       external/cwe/cwe-191
+ *       security-severity/8.1
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-190/ArithmeticWithExtremeValues.ql
+++ b/java/ql/src/Security/CWE/CWE-190/ArithmeticWithExtremeValues.ql
@@ -10,6 +10,7 @@
  *       reliability
  *       external/cwe/cwe-190
  *       external/cwe/cwe-191
+ *       security-severity/8.1
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
+++ b/java/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-190
  *       external/cwe/cwe-197
+ *       security-severity/8.1
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-209/StackTraceExposure.ql
+++ b/java/ql/src/Security/CWE/CWE-209/StackTraceExposure.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-209
  *       external/cwe/cwe-497
+ *       security-severity/5.3
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-312/CleartextStorageClass.ql
+++ b/java/ql/src/Security/CWE/CWE-312/CleartextStorageClass.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe/cwe-499
  *       external/cwe/cwe-312
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-319/HttpsUrls.ql
+++ b/java/ql/src/Security/CWE/CWE-319/HttpsUrls.ql
@@ -7,6 +7,7 @@
  * @id java/non-https-url
  * @tags security
  *       external/cwe/cwe-319
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-319/UseSSL.ql
+++ b/java/ql/src/Security/CWE/CWE-319/UseSSL.ql
@@ -7,6 +7,7 @@
  * @id java/non-ssl-connection
  * @tags security
  *       external/cwe/cwe-319
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-319/UseSSLSocketFactories.ql
+++ b/java/ql/src/Security/CWE/CWE-319/UseSSLSocketFactories.ql
@@ -8,6 +8,7 @@
  * @id java/non-ssl-socket-factory
  * @tags security
  *       external/cwe/cwe-319
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.ql
+++ b/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.ql
@@ -7,6 +7,7 @@
  * @id java/weak-cryptographic-algorithm
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
+++ b/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
@@ -7,6 +7,7 @@
  * @id java/potentially-weak-cryptographic-algorithm
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-338/JHipsterGeneratedPRNG.ql
+++ b/java/ql/src/Security/CWE/CWE-338/JHipsterGeneratedPRNG.ql
@@ -7,6 +7,7 @@
  * @id java/jhipster-prng
  * @tags security
  *       external/cwe/cwe-338
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
@@ -8,6 +8,7 @@
  * @id java/spring-disabled-csrf-protection
  * @tags security
  *       external/cwe/cwe-352
+ *       security-severity/8.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-367/TOCTOURace.ql
+++ b/java/ql/src/Security/CWE/CWE-367/TOCTOURace.ql
@@ -8,6 +8,7 @@
  * @id java/toctou-race-condition
  * @tags security
  *       external/cwe/cwe-367
+ *       security-severity/7.0
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.ql
+++ b/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.ql
@@ -8,6 +8,7 @@
  * @id java/unsafe-deserialization
  * @tags security
  *       external/cwe/cwe-502
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-601/UrlRedirect.ql
+++ b/java/ql/src/Security/CWE/CWE-601/UrlRedirect.ql
@@ -8,6 +8,7 @@
  * @id java/unvalidated-url-redirection
  * @tags security
  *       external/cwe/cwe-601
+ *       security-severity/6.1
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-601/UrlRedirectLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-601/UrlRedirectLocal.ql
@@ -8,6 +8,7 @@
  * @id java/unvalidated-url-redirection-local
  * @tags security
  *       external/cwe/cwe-601
+ *       security-severity/6.1
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/java/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-611
  *       external/cwe/cwe-776
  *       external/cwe/cwe-827
+ *       security-severity/8.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-681/NumericCastTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-681/NumericCastTainted.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-197
  *       external/cwe/cwe-681
+ *       security-severity/9.0
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-681/NumericCastTaintedLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-681/NumericCastTaintedLocal.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-197
  *       external/cwe/cwe-681
+ *       security-severity/9.0
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-732/ReadingFromWorldWritableFile.ql
+++ b/java/ql/src/Security/CWE/CWE-732/ReadingFromWorldWritableFile.ql
@@ -8,6 +8,7 @@
  * @id java/world-writable-file-read
  * @tags security
  *       external/cwe/cwe-732
+ *       security-severity/7.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsApiCall.ql
+++ b/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsApiCall.ql
@@ -7,6 +7,7 @@
  * @id java/hardcoded-credential-api-call
  * @tags security
  *       external/cwe/cwe-798
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsComparison.ql
+++ b/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsComparison.ql
@@ -7,6 +7,7 @@
  * @id java/hardcoded-credential-comparison
  * @tags security
  *       external/cwe/cwe-798
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsSourceCall.ql
+++ b/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsSourceCall.ql
@@ -7,6 +7,7 @@
  * @id java/hardcoded-credential-sensitive-call
  * @tags security
  *       external/cwe/cwe-798
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-798/HardcodedPasswordField.ql
+++ b/java/ql/src/Security/CWE/CWE-798/HardcodedPasswordField.ql
@@ -7,6 +7,7 @@
  * @id java/hardcoded-password-field
  * @tags security
  *       external/cwe/cwe-798
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-807/ConditionalBypass.ql
+++ b/java/ql/src/Security/CWE/CWE-807/ConditionalBypass.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-807
  *       external/cwe/cwe-290
+ *       security-severity/7.7
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-807/TaintedPermissionsCheck.ql
+++ b/java/ql/src/Security/CWE/CWE-807/TaintedPermissionsCheck.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-807
  *       external/cwe/cwe-290
+ *       security-severity/7.7
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql
+++ b/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-319
  *       external/cwe/cwe-494
  *       external/cwe/cwe-829
+ *       security-severity/8.8
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-835/InfiniteLoop.ql
+++ b/java/ql/src/Security/CWE/CWE-835/InfiniteLoop.ql
@@ -9,6 +9,7 @@
  * @id java/unreachable-exit-in-loop
  * @tags security
  *       external/cwe/cwe-835
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-016/InsecureSpringActuatorConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-016/InsecureSpringActuatorConfig.ql
@@ -6,6 +6,7 @@
  * @id java/insecure-spring-actuator-config
  * @tags security
  *       external/cwe-016
+ *       security-severity/7.1
  */
 
 /*

--- a/java/ql/src/experimental/Security/CWE/CWE-016/SpringBootActuators.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-016/SpringBootActuators.ql
@@ -8,6 +8,7 @@
  * @id java/spring-boot-exposed-actuators
  * @tags security
  *       external/cwe/cwe-16
+ *       security-severity/7.1
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjection.ql
@@ -8,6 +8,7 @@
  * @id java/jndi-injection
  * @tags security
  *       external/cwe/cwe-074
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-074/XsltInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-074/XsltInjection.ql
@@ -8,6 +8,7 @@
  * @id java/xslt-injection
  * @tags security
  *       external/cwe/cwe-074
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-094/GroovyInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/GroovyInjection.ql
@@ -8,6 +8,7 @@
  * @id java/groovy-injection
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-094/InsecureDexLoading.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/InsecureDexLoading.ql
@@ -8,6 +8,7 @@
  * @id java/android-insecure-dex-loading
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.ql
@@ -8,6 +8,7 @@
  * @id java/javaee-expression-injection
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JexlInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JexlInjection.ql
@@ -8,6 +8,7 @@
  * @id java/jexl-expression-injection
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjection.ql
@@ -8,6 +8,7 @@
  * @id java/mvel-expression-injection
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-094/ScriptEngine.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/ScriptEngine.ql
@@ -7,6 +7,7 @@
  * @id java/unsafe-eval
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-094/SpelInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/SpelInjection.ql
@@ -8,6 +8,7 @@
  * @id java/spel-expression-injection
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-094/SpringImplicitViewManipulation.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/SpringImplicitViewManipulation.ql
@@ -7,6 +7,7 @@
  * @id java/spring-view-manipulation-implicit
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-094/SpringViewManipulation.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/SpringViewManipulation.ql
@@ -7,6 +7,7 @@
  * @id java/spring-view-manipulation
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.ql
@@ -8,6 +8,7 @@
  * @id java/log-injection
  * @tags security
  *       external/cwe/cwe-117
+ *       security-severity/5.3
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
@@ -10,6 +10,7 @@
  * @id java/unsafe-cert-trust
  * @tags security
  *       external/cwe-273
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-295/JxBrowserWithoutCertValidation.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/JxBrowserWithoutCertValidation.ql
@@ -9,6 +9,7 @@
  * @id java/jxbrowser/disabled-certificate-validation
  * @tags security
  *       external/cwe/cwe-295
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-299/DisabledRevocationChecking.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-299/DisabledRevocationChecking.ql
@@ -8,6 +8,7 @@
  * @id java/disabled-certificate-revocation-checking
  * @tags security
  *       external/cwe/cwe-299
+ *       security-severity/6.4
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-312/CleartextStorageSharedPrefs.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-312/CleartextStorageSharedPrefs.ql
@@ -9,6 +9,7 @@
  * @id java/android/cleartext-storage-shared-prefs
  * @tags security
  *       external/cwe/cwe-312
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
@@ -7,6 +7,7 @@
  * @id java/insufficient-key-size
  * @tags security
  *       external/cwe/cwe-326
+ *       security-severity/8.4
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.ql
@@ -8,6 +8,7 @@
  * @id java/unsafe-tls-version
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-346/UnvalidatedCors.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-346/UnvalidatedCors.ql
@@ -7,6 +7,7 @@
  * @id java/unvalidated-cors-origin-set
  * @tags security
  *       external/cwe/cwe-346
+ *       security-severity/7.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjection.ql
@@ -8,6 +8,7 @@
  * @id java/jsonp-injection
  * @tags security
  *       external/cwe/cwe-352
+ *       security-severity/8.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeSpringExporterInConfigurationClass.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeSpringExporterInConfigurationClass.ql
@@ -9,6 +9,7 @@
  * @id java/unsafe-deserialization-spring-exporter-in-configuration-class
  * @tags security
  *       external/cwe/cwe-502
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeSpringExporterInXMLConfiguration.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeSpringExporterInXMLConfiguration.ql
@@ -9,6 +9,7 @@
  * @id java/unsafe-deserialization-spring-exporter-in-xml-configuration
  * @tags security
  *       external/cwe/cwe-502
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-522/InsecureBasicAuth.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-522/InsecureBasicAuth.ql
@@ -11,6 +11,7 @@
  * @tags security
  *       external/cwe-522
  *       external/cwe-319
+ *       security-severity/7.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-522/InsecureLdapAuth.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-522/InsecureLdapAuth.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe-522
  *       external/cwe-319
+ *       security-severity/7.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-532/SensitiveInfoLog.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-532/SensitiveInfoLog.ql
@@ -8,6 +8,7 @@
  * @id java/sensitiveinfo-in-logfile
  * @tags security
  *       external/cwe-532
+ *       security-severity/6.5
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-555/CredentialsInPropertiesFile.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-555/CredentialsInPropertiesFile.ql
@@ -7,6 +7,7 @@
  *       external/cwe/cwe-555
  *       external/cwe/cwe-256
  *       external/cwe/cwe-260
+ *       security-severity/6.5
  */
 
 /*

--- a/java/ql/src/experimental/Security/CWE/CWE-555/PasswordInConfigurationFile.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-555/PasswordInConfigurationFile.ql
@@ -9,6 +9,7 @@
  *       external/cwe/cwe-555
  *       external/cwe/cwe-256
  *       external/cwe/cwe-260
+ *       security-severity/6.5
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-749/UnsafeAndroidAccess.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-749/UnsafeAndroidAccess.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-749
  *       external/cwe/cwe-079
+ *       security-severity/6.1
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-755/NFEAndroidDoS.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-755/NFEAndroidDoS.ql
@@ -10,6 +10,7 @@
  * @id java/android/nfe-local-android-dos
  * @tags security
  *       external/cwe/cwe-755
+ *       security-severity/7.5
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-759/HashWithoutSalt.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-759/HashWithoutSalt.ql
@@ -7,6 +7,7 @@
  * @id java/hash-without-salt
  * @tags security
  *       external/cwe-759
+ *       security-severity/7.2
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-917/OgnlInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-917/OgnlInjection.ql
@@ -8,6 +8,7 @@
  * @id java/ognl-injection
  * @tags security
  *       external/cwe/cwe-917
+ *       security-severity/9.8
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-918/RequestForgery.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-918/RequestForgery.ql
@@ -8,6 +8,7 @@
  * @id java/ssrf
  * @tags security
  *       external/cwe/cwe-918
+ *       security-severity/8.2
  */
 
 import java

--- a/javascript/ql/src/AngularJS/InsecureUrlWhitelist.ql
+++ b/javascript/ql/src/AngularJS/InsecureUrlWhitelist.ql
@@ -9,6 +9,7 @@
  *       frameworks/angularjs
  *       external/cwe/cwe-183
  *       external/cwe/cwe-625
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/DOM/TargetBlank.ql
+++ b/javascript/ql/src/DOM/TargetBlank.ql
@@ -9,6 +9,7 @@
  *       security
  *       external/cwe/cwe-200
  *       external/cwe/cwe-1022
+ *       security-severity/6.8
  * @precision very-high
  */
 

--- a/javascript/ql/src/Electron/EnablingNodeIntegration.ql
+++ b/javascript/ql/src/Electron/EnablingNodeIntegration.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       frameworks/electron
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Performance/PolynomialReDoS.ql
+++ b/javascript/ql/src/Performance/PolynomialReDoS.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-730
  *       external/cwe/cwe-400
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Performance/ReDoS.ql
+++ b/javascript/ql/src/Performance/ReDoS.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-730
  *       external/cwe/cwe-400
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/RegExp/IdentityReplacement.ql
+++ b/javascript/ql/src/RegExp/IdentityReplacement.ql
@@ -8,6 +8,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-116
+ *       security-severity/7.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
+++ b/javascript/ql/src/Security/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
@@ -6,6 +6,7 @@
  * @id js/count-untrusted-data-external-api
  * @kind table
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-020/IncompleteHostnameRegExp.ql
+++ b/javascript/ql/src/Security/CWE-020/IncompleteHostnameRegExp.ql
@@ -8,6 +8,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-020
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-020/IncompleteUrlSchemeCheck.ql
+++ b/javascript/ql/src/Security/CWE-020/IncompleteUrlSchemeCheck.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       correctness
  *       external/cwe/cwe-020
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.ql
+++ b/javascript/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.ql
@@ -8,6 +8,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-020
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
+++ b/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       correctness
  *       external/cwe/cwe-020
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-020/MissingRegExpAnchor.ql
+++ b/javascript/ql/src/Security/CWE-020/MissingRegExpAnchor.ql
@@ -8,6 +8,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-020
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/javascript/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
@@ -6,6 +6,7 @@
  * @precision low
  * @problem.severity error
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-020/UselessRegExpCharacterEscape.ql
+++ b/javascript/ql/src/Security/CWE-020/UselessRegExpCharacterEscape.ql
@@ -10,6 +10,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-020
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-022/TaintedPath.ql
+++ b/javascript/ql/src/Security/CWE-022/TaintedPath.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-036
  *       external/cwe/cwe-073
  *       external/cwe/cwe-099
+ *       security-severity/8.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-022/ZipSlip.ql
+++ b/javascript/ql/src/Security/CWE-022/ZipSlip.ql
@@ -9,6 +9,7 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-022
+ *       security-severity/8.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-073/TemplateObjectInjection.ql
+++ b/javascript/ql/src/Security/CWE-073/TemplateObjectInjection.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe/cwe-073
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-078/CommandInjection.ql
+++ b/javascript/ql/src/Security/CWE-078/CommandInjection.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-078/IndirectCommandInjection.ql
+++ b/javascript/ql/src/Security/CWE-078/IndirectCommandInjection.ql
@@ -11,6 +11,7 @@
  *       security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-078/ShellCommandInjectionFromEnvironment.ql
+++ b/javascript/ql/src/Security/CWE-078/ShellCommandInjectionFromEnvironment.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-078/UnsafeShellCommandConstruction.ql
+++ b/javascript/ql/src/Security/CWE-078/UnsafeShellCommandConstruction.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-079/ExceptionXss.ql
+++ b/javascript/ql/src/Security/CWE-079/ExceptionXss.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-079/ReflectedXss.ql
+++ b/javascript/ql/src/Security/CWE-079/ReflectedXss.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-079/StoredXss.ql
+++ b/javascript/ql/src/Security/CWE-079/StoredXss.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.ql
+++ b/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.ql
@@ -9,6 +9,7 @@
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
  *       frameworks/jquery
+ *       security-severity/6.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-079/Xss.ql
+++ b/javascript/ql/src/Security/CWE-079/Xss.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-079/XssThroughDom.ql
+++ b/javascript/ql/src/Security/CWE-079/XssThroughDom.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-089/SqlInjection.ql
+++ b/javascript/ql/src/Security/CWE-089/SqlInjection.ql
@@ -8,6 +8,7 @@
  * @id js/sql-injection
  * @tags security
  *       external/cwe/cwe-089
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-094/CodeInjection.ql
+++ b/javascript/ql/src/Security/CWE-094/CodeInjection.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-094
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.ql
+++ b/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.ql
@@ -9,6 +9,7 @@
  *       external/cwe/cwe-094
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-094/UnsafeDynamicMethodAccess.ql
+++ b/javascript/ql/src/Security/CWE-094/UnsafeDynamicMethodAccess.ql
@@ -7,6 +7,7 @@
  * @id js/unsafe-dynamic-method-access
  * @tags security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -11,6 +11,7 @@
  *       security
  *       external/cwe/cwe-116
  *       external/cwe/cwe-020
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.ql
+++ b/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
  *       external/cwe/cwe-020
+ *       security-severity/6.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-116/IncompleteMultiCharacterSanitization.ql
+++ b/javascript/ql/src/Security/CWE-116/IncompleteMultiCharacterSanitization.ql
@@ -9,6 +9,7 @@
  *       security
  *       external/cwe/cwe-116
  *       external/cwe/cwe-020
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql
+++ b/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-116
  *       external/cwe/cwe-020
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-116/UnsafeHtmlExpansion.ql
+++ b/javascript/ql/src/Security/CWE-116/UnsafeHtmlExpansion.ql
@@ -10,6 +10,7 @@
  *       security
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-117/LogInjection.ql
+++ b/javascript/ql/src/Security/CWE-117/LogInjection.ql
@@ -8,6 +8,7 @@
  * @id js/log-injection
  * @tags security
  *       external/cwe/cwe-117
+ *       security-severity/5.3
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-134/TaintedFormatString.ql
+++ b/javascript/ql/src/Security/CWE-134/TaintedFormatString.ql
@@ -7,6 +7,7 @@
  * @id js/tainted-format-string
  * @tags security
  *       external/cwe/cwe-134
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-200/FileAccessToHttp.ql
+++ b/javascript/ql/src/Security/CWE-200/FileAccessToHttp.ql
@@ -7,6 +7,7 @@
  * @id js/file-access-to-http
  * @tags security
  *       external/cwe/cwe-200
+ *       security-severity/6.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
+++ b/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
@@ -7,6 +7,7 @@
  * @id js/exposure-of-private-files
  * @tags security
  *       external/cwe/cwe-200
+ *       security-severity/6.8
  * @precision high
  */
 

--- a/javascript/ql/src/Security/CWE-201/PostMessageStar.ql
+++ b/javascript/ql/src/Security/CWE-201/PostMessageStar.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-201
  *       external/cwe/cwe-359
+ *       security-severity/4.3
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-209/StackTraceExposure.ql
+++ b/javascript/ql/src/Security/CWE-209/StackTraceExposure.ql
@@ -9,6 +9,7 @@
  * @id js/stack-trace-exposure
  * @tags security
  *       external/cwe/cwe-209
+ *       security-severity/5.3
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-295/DisablingCertificateValidation.ql
+++ b/javascript/ql/src/Security/CWE-295/DisablingCertificateValidation.ql
@@ -7,6 +7,7 @@
  * @id js/disabling-certificate-validation
  * @tags security
  *       external/cwe-295
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-312/BuildArtifactLeak.ql
+++ b/javascript/ql/src/Security/CWE-312/BuildArtifactLeak.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-312
  *       external/cwe/cwe-315
  *       external/cwe/cwe-359
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-312/CleartextLogging.ql
+++ b/javascript/ql/src/Security/CWE-312/CleartextLogging.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-312
  *       external/cwe/cwe-315
  *       external/cwe/cwe-359
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-312/CleartextStorage.ql
+++ b/javascript/ql/src/Security/CWE-312/CleartextStorage.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-312
  *       external/cwe/cwe-315
  *       external/cwe/cwe-359
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
+++ b/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
@@ -9,6 +9,7 @@
  *       external/cwe/cwe-256
  *       external/cwe/cwe-260
  *       external/cwe/cwe-313
+ *       security-severity/6.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-327/BadRandomness.ql
+++ b/javascript/ql/src/Security/CWE-327/BadRandomness.ql
@@ -8,6 +8,7 @@
  * @id js/biased-cryptographic-random
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
+++ b/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
@@ -7,6 +7,7 @@
  * @id js/weak-cryptographic-algorithm
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-338/InsecureRandomness.ql
+++ b/javascript/ql/src/Security/CWE-338/InsecureRandomness.ql
@@ -9,6 +9,7 @@
  * @id js/insecure-randomness
  * @tags security
  *       external/cwe/cwe-338
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-346/CorsMisconfigurationForCredentials.ql
+++ b/javascript/ql/src/Security/CWE-346/CorsMisconfigurationForCredentials.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe/cwe-346
  *       external/cwe/cwe-639
+ *       security-severity/7.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -8,6 +8,7 @@
  * @id js/missing-token-validation
  * @tags security
  *       external/cwe/cwe-352
+ *       security-severity/8.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-400/DeepObjectResourceExhaustion.ql
+++ b/javascript/ql/src/Security/CWE-400/DeepObjectResourceExhaustion.ql
@@ -7,6 +7,7 @@
  * @id js/resource-exhaustion-from-deep-object-traversal
  * @tags security
  *       external/cwe/cwe-400
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-400/RemotePropertyInjection.ql
+++ b/javascript/ql/src/Security/CWE-400/RemotePropertyInjection.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-250
  *       external/cwe/cwe-400
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-451/MissingXFrameOptions.ql
+++ b/javascript/ql/src/Security/CWE-451/MissingXFrameOptions.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-451
  *       external/cwe/cwe-829
+ *       security-severity/8.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-502/UnsafeDeserialization.ql
+++ b/javascript/ql/src/Security/CWE-502/UnsafeDeserialization.ql
@@ -8,6 +8,7 @@
  * @id js/unsafe-deserialization
  * @tags security
  *       external/cwe/cwe-502
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-506/HardcodedDataInterpretedAsCode.ql
+++ b/javascript/ql/src/Security/CWE-506/HardcodedDataInterpretedAsCode.ql
@@ -9,6 +9,7 @@
  * @id js/hardcoded-data-interpreted-as-code
  * @tags security
  *       external/cwe/cwe-506
+ *       security-severity/9.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-601/ClientSideUrlRedirect.ql
+++ b/javascript/ql/src/Security/CWE-601/ClientSideUrlRedirect.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
  *       external/cwe/cwe-601
+ *       security-severity/6.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-601/ServerSideUrlRedirect.ql
+++ b/javascript/ql/src/Security/CWE-601/ServerSideUrlRedirect.ql
@@ -7,6 +7,7 @@
  * @id js/server-side-unvalidated-url-redirection
  * @tags security
  *       external/cwe/cwe-601
+ *       security-severity/6.1
  * @precision high
  */
 

--- a/javascript/ql/src/Security/CWE-611/Xxe.ql
+++ b/javascript/ql/src/Security/CWE-611/Xxe.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-611
  *       external/cwe/cwe-827
+ *       security-severity/8.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.ql
+++ b/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.ql
@@ -8,6 +8,7 @@
  * @id js/host-header-forgery-in-email-generation
  * @tags security
  *       external/cwe/cwe-640
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-730/RegExpInjection.ql
+++ b/javascript/ql/src/Security/CWE-730/RegExpInjection.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-730
  *       external/cwe/cwe-400
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-754/UnvalidatedDynamicMethodCall.ql
+++ b/javascript/ql/src/Security/CWE-754/UnvalidatedDynamicMethodCall.ql
@@ -8,6 +8,7 @@
  * @id js/unvalidated-dynamic-method-call
  * @tags security
  *       external/cwe/cwe-754
+ *       security-severity/7.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-770/MissingRateLimiting.ql
+++ b/javascript/ql/src/Security/CWE-770/MissingRateLimiting.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-770
  *       external/cwe/cwe-307
  *       external/cwe/cwe-400
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-776/XmlBomb.ql
+++ b/javascript/ql/src/Security/CWE-776/XmlBomb.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-776
  *       external/cwe/cwe-400
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-259
  *       external/cwe/cwe-321
  *       external/cwe/cwe-798
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-807/ConditionalBypass.ql
+++ b/javascript/ql/src/Security/CWE-807/ConditionalBypass.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe/cwe-807
  *       external/cwe/cwe-290
+ *       security-severity/7.7
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-807/DifferentKindsComparisonBypass.ql
+++ b/javascript/ql/src/Security/CWE-807/DifferentKindsComparisonBypass.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe/cwe-807
  *       external/cwe/cwe-290
+ *       security-severity/7.7
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-829/InsecureDownload.ql
+++ b/javascript/ql/src/Security/CWE-829/InsecureDownload.ql
@@ -8,6 +8,7 @@
  * @id js/insecure-download
  * @tags security
  *       external/cwe/cwe-829
+ *       security-severity/8.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-834/LoopBoundInjection.ql
+++ b/javascript/ql/src/Security/CWE-834/LoopBoundInjection.ql
@@ -7,6 +7,7 @@
  * @id js/loop-bound-injection
  * @tags security
  *       external/cwe/cwe-834
+ *       security-severity/7.5
  * @precision high
  */
 

--- a/javascript/ql/src/Security/CWE-843/TypeConfusionThroughParameterTampering.ql
+++ b/javascript/ql/src/Security/CWE-843/TypeConfusionThroughParameterTampering.ql
@@ -7,6 +7,7 @@
  * @id js/type-confusion-through-parameter-tampering
  * @tags security
  *       external/cwe/cwe-843
+ *       security-severity/8.8
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-912/HttpToFileAccess.ql
+++ b/javascript/ql/src/Security/CWE-912/HttpToFileAccess.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe/cwe-912
  *       external/cwe/cwe-434
+ *       security-severity/9.1
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-915/PrototypePollutingAssignment.ql
+++ b/javascript/ql/src/Security/CWE-915/PrototypePollutingAssignment.ql
@@ -13,6 +13,7 @@
  *       external/cwe/cwe-094
  *       external/cwe/cwe-400
  *       external/cwe/cwe-915
+ *       security-severity/7.2
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-915/PrototypePollutingFunction.ql
+++ b/javascript/ql/src/Security/CWE-915/PrototypePollutingFunction.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-094
  *       external/cwe/cwe-400
  *       external/cwe/cwe-915
+ *       security-severity/7.2
  */
 
 import javascript
@@ -207,8 +208,10 @@ class UnsafePropLabel extends FlowLabel {
  *   for (var key in src)
  *     if (...)
  *       merge(dst[key], src[key])
+ *       security-severity/7.2
  *     else
  *       dst[key] = src[key]
+ *       security-severity/7.2
  * }
  * ```
  *

--- a/javascript/ql/src/Security/CWE-915/PrototypePollutingMergeCall.ql
+++ b/javascript/ql/src/Security/CWE-915/PrototypePollutingMergeCall.ql
@@ -13,6 +13,7 @@
  *       external/cwe/cwe-094
  *       external/cwe/cwe-400
  *       external/cwe/cwe-915
+ *       security-severity/7.2
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-916/InsufficientPasswordHash.ql
+++ b/javascript/ql/src/Security/CWE-916/InsufficientPasswordHash.ql
@@ -7,6 +7,7 @@
  * @id js/insufficient-password-hash
  * @tags security
  *       external/cwe/cwe-916
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-918/RequestForgery.ql
+++ b/javascript/ql/src/Security/CWE-918/RequestForgery.ql
@@ -7,6 +7,7 @@
  * @id js/request-forgery
  * @tags security
  *       external/cwe/cwe-918
+ *       security-severity/8.2
  */
 
 import javascript

--- a/javascript/ql/src/experimental/Security/CWE-020/PostMessageNoOriginCheck.ql
+++ b/javascript/ql/src/experimental/Security/CWE-020/PostMessageNoOriginCheck.ql
@@ -9,6 +9,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-020
+ *       security-severity/8.6
  */
 
 import javascript

--- a/javascript/ql/src/experimental/Security/CWE-094/ExpressionInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-094/ExpressionInjection.ql
@@ -9,6 +9,7 @@
  * @tags actions
  *       security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/experimental/Security/CWE-094/UntrustedCheckout.ql
+++ b/javascript/ql/src/experimental/Security/CWE-094/UntrustedCheckout.ql
@@ -10,6 +10,7 @@
  * @tags actions
  *       security
  *       external/cwe/cwe-094
+ *       security-severity/9.8
  */
 
 import javascript

--- a/javascript/ql/src/experimental/Security/CWE-347/JWTMissingSecretOrPublicKeyVerification.ql
+++ b/javascript/ql/src/experimental/Security/CWE-347/JWTMissingSecretOrPublicKeyVerification.ql
@@ -7,6 +7,7 @@
  * @id js/jwt-missing-verification
  * @tags security
  *       external/cwe/cwe-347
+ *       security-severity/7.8
  */
 
 import javascript

--- a/javascript/ql/src/experimental/Security/CWE-770/ResourceExhaustion.ql
+++ b/javascript/ql/src/experimental/Security/CWE-770/ResourceExhaustion.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-770
+ *       security-severity/7.5
  */
 
 import javascript

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.ql
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import javascript

--- a/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIsUsedWithUntrustedData.ql
+++ b/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIsUsedWithUntrustedData.ql
@@ -6,6 +6,7 @@
  * @id python/count-untrusted-data-external-api
  * @kind table
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import python

--- a/python/ql/src/Security/CWE-020-ExternalAPIs/UntrustedDataToExternalAPI.ql
+++ b/python/ql/src/Security/CWE-020-ExternalAPIs/UntrustedDataToExternalAPI.ql
@@ -6,6 +6,7 @@
  * @precision low
  * @problem.severity error
  * @tags security external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import python

--- a/python/ql/src/Security/CWE-020/IncompleteHostnameRegExp.ql
+++ b/python/ql/src/Security/CWE-020/IncompleteHostnameRegExp.ql
@@ -8,6 +8,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import python

--- a/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.ql
+++ b/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.ql
@@ -8,6 +8,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-20
+ *       security-severity/8.6
  */
 
 import python

--- a/python/ql/src/Security/CWE-022/PathInjection.ql
+++ b/python/ql/src/Security/CWE-022/PathInjection.ql
@@ -14,6 +14,7 @@
  *       external/cwe/cwe-036
  *       external/cwe/cwe-073
  *       external/cwe/cwe-099
+ *       security-severity/8.8
  */
 
 import python

--- a/python/ql/src/Security/CWE-022/TarSlip.ql
+++ b/python/ql/src/Security/CWE-022/TarSlip.ql
@@ -9,6 +9,7 @@
  * @precision medium
  * @tags security
  *       external/cwe/cwe-022
+ *       security-severity/8.8
  */
 
 import python

--- a/python/ql/src/Security/CWE-078/CommandInjection.ql
+++ b/python/ql/src/Security/CWE-078/CommandInjection.ql
@@ -12,6 +12,7 @@
  *       external/owasp/owasp-a1
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       security-severity/9.8
  */
 
 import python

--- a/python/ql/src/Security/CWE-079/Jinja2WithoutEscaping.ql
+++ b/python/ql/src/Security/CWE-079/Jinja2WithoutEscaping.ql
@@ -8,6 +8,7 @@
  * @id py/jinja2/autoescape-false
  * @tags security
  *       external/cwe/cwe-079
+ *       security-severity/6.1
  */
 
 import python

--- a/python/ql/src/Security/CWE-079/ReflectedXss.ql
+++ b/python/ql/src/Security/CWE-079/ReflectedXss.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
+ *       security-severity/6.1
  */
 
 import python

--- a/python/ql/src/Security/CWE-089/SqlInjection.ql
+++ b/python/ql/src/Security/CWE-089/SqlInjection.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-089
  *       external/owasp/owasp-a1
+ *       security-severity/9.8
  */
 
 import python

--- a/python/ql/src/Security/CWE-094/CodeInjection.ql
+++ b/python/ql/src/Security/CWE-094/CodeInjection.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-094
  *       external/cwe/cwe-095
  *       external/cwe/cwe-116
+ *       security-severity/9.8
  */
 
 import python

--- a/python/ql/src/Security/CWE-209/StackTraceExposure.ql
+++ b/python/ql/src/Security/CWE-209/StackTraceExposure.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       external/cwe/cwe-209
  *       external/cwe/cwe-497
+ *       security-severity/5.3
  */
 
 import python

--- a/python/ql/src/Security/CWE-295/MissingHostKeyValidation.ql
+++ b/python/ql/src/Security/CWE-295/MissingHostKeyValidation.ql
@@ -7,6 +7,7 @@
  * @id py/paramiko-missing-host-key-validation
  * @tags security
  *       external/cwe/cwe-295
+ *       security-severity/7.5
  */
 
 import python

--- a/python/ql/src/Security/CWE-295/RequestWithoutValidation.ql
+++ b/python/ql/src/Security/CWE-295/RequestWithoutValidation.ql
@@ -7,6 +7,7 @@
  * @id py/request-without-cert-validation
  * @tags security
  *       external/cwe/cwe-295
+ *       security-severity/7.5
  */
 
 import python

--- a/python/ql/src/Security/CWE-312/CleartextLogging.ql
+++ b/python/ql/src/Security/CWE-312/CleartextLogging.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-312
  *       external/cwe/cwe-315
  *       external/cwe/cwe-359
+ *       security-severity/7.5
  */
 
 import python

--- a/python/ql/src/Security/CWE-312/CleartextStorage.ql
+++ b/python/ql/src/Security/CWE-312/CleartextStorage.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-312
  *       external/cwe/cwe-315
  *       external/cwe/cwe-359
+ *       security-severity/7.5
  */
 
 import python

--- a/python/ql/src/Security/CWE-326/WeakCryptoKey.ql
+++ b/python/ql/src/Security/CWE-326/WeakCryptoKey.ql
@@ -7,6 +7,7 @@
  * @id py/weak-crypto-key
  * @tags security
  *       external/cwe/cwe-326
+ *       security-severity/8.4
  */
 
 import python

--- a/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
+++ b/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
@@ -7,6 +7,7 @@
  * @id py/weak-cryptographic-algorithm
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import python

--- a/python/ql/src/Security/CWE-327/InsecureDefaultProtocol.ql
+++ b/python/ql/src/Security/CWE-327/InsecureDefaultProtocol.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 // Connections are generally created based on a context which controls the range of acceptable

--- a/python/ql/src/Security/CWE-327/InsecureProtocol.ql
+++ b/python/ql/src/Security/CWE-327/InsecureProtocol.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-327
+ *       security-severity/7.5
  */
 
 import python

--- a/python/ql/src/Security/CWE-377/InsecureTemporaryFile.ql
+++ b/python/ql/src/Security/CWE-377/InsecureTemporaryFile.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @tags external/cwe/cwe-377
  *       security
+ *       security-severity/7.0
  */
 
 import python

--- a/python/ql/src/Security/CWE-502/UnsafeDeserialization.ql
+++ b/python/ql/src/Security/CWE-502/UnsafeDeserialization.ql
@@ -9,6 +9,7 @@
  * @tags external/cwe/cwe-502
  *       security
  *       serialization
+ *       security-severity/9.8
  */
 
 import python

--- a/python/ql/src/Security/CWE-601/UrlRedirect.ql
+++ b/python/ql/src/Security/CWE-601/UrlRedirect.ql
@@ -8,6 +8,7 @@
  * @id py/url-redirection
  * @tags security
  *       external/cwe/cwe-601
+ *       security-severity/6.1
  * @precision high
  */
 

--- a/python/ql/src/Security/CWE-732/WeakFilePermissions.ql
+++ b/python/ql/src/Security/CWE-732/WeakFilePermissions.ql
@@ -8,6 +8,7 @@
  * @precision medium
  * @tags external/cwe/cwe-732
  *       security
+ *       security-severity/7.8
  */
 
 import python

--- a/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -9,6 +9,7 @@
  *       external/cwe/cwe-259
  *       external/cwe/cwe-321
  *       external/cwe/cwe-798
+ *       security-severity/9.8
  */
 
 import python

--- a/python/ql/src/experimental/Security/CWE-074/TemplateInjection.ql
+++ b/python/ql/src/experimental/Security/CWE-074/TemplateInjection.ql
@@ -7,6 +7,7 @@
  * @id py/template-injection
  * @tags security
  *       external/cwe/cwe-074
+ *       security-severity/9.8
  */
 
 import python


### PR DESCRIPTION
Adds security-severity scores to queries. A number of queries could not be tagged since they did not have any CWEs. These queries are:

	1. python/ql/src/Security/CVE-2018-1281/BindToAllInterfaces.ql
	2. python/ql/src/Statements/ExecUsed.ql
	3. python/ql/src/Expressions/UseofInput.ql
	4. python/ql/src/Functions/ModificationOfParameterWithDefault.ql
	5. cpp/ql/src/Critical/LargeParameter.ql
	6. cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.ql 
	7. cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.ql
	8. cpp/ql/src/Likely Bugs/Memory Management/PointerOverflow.ql
	9. cpp/ql/src/Likely Bugs/Arithmetic/SignedOverflowCheck.ql cpp/ql/src/Likely Bugs/Format/SnprintfOverflow.ql
	10. cpp/ql/src/Likely Bugs/OO/UnsafeUseOfThis.ql
	11. cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
	12. cpp/ql/src/Likely Bugs/Protocols/UseOfDeprecatedHardcodedProtocol.ql
	13. csharp/ql/src/Input Validation/ValueShadowing.ql
	14. csharp/ql/src/Input Validation/ValueShadowingServerVariable.ql
	15. csharp/ql/src/Security Features/CWE-321/HardcodedSymmetricEncryptionKey.ql
	16. csharp/ql/src/Security Features/CWE-321/HardcodedEncryptionKey.ql
	17. javascript/ql/src/AngularJS/DisablingSce.ql
	18. javascript/ql/src/AngularJS/DoubleCompilation.ql
	19. javascript/ql/src/Security/CWE-078/UselessUseOfCat.ql
	20. javascript/ql/src/Electron/AllowRunningInsecureContent.ql
	21. javascript/ql/src/Electron/DisablingWebSecurity.ql

Other queries that are tagged as "security", or are in tests, example, or experimental.

Some of the security queries have only CWEs with no CVEs. They are:

	1. python/ql/src/experimental/Security/CWE-091/Xslt.ql
	2. python/ql/src/experimental/Security/CWE-643/xpath.ql
	3. python/ql/src/Security/CWE-215/FlaskDebug.ql 
	4. java/ql/src/experimental/Security/CWE/CWE-600/UncaughtServletException.ql
	5. java/ql/src/experimental/Security/CWE/CWE-652/XQueryInjection.ql
	6. java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
	7. java/ql/src/experimental/Security/CWE/CWE-927/SensitiveBroadcast.ql
	8. java/ql/src/experimental/Security/CWE/CWE-598/SensitiveGetQuery.ql
	9. java/ql/src/experimental/Security/CWE/CWE-489/devMode.ql
	10. java/ql/src/experimental/Security/CWE/CWE-489/WebComponentMain.ql
	11. java/ql/src/experimental/Security/CWE/CWE-489/EJBMain.ql
	12. java/ql/src/experimental/Security/CWE/CWE-036/OpenStream.ql
	13. java/ql/src/experimental/Security/CWE/CWE-939/IncorrectURLVerification.ql
	14. java/ql/src/experimental/Security/CWE/CWE-1004/InsecureTomcatConfig.ql
	15. java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
	16. java/ql/src/experimental/Security/CWE/CWE-643/XPathInjection.ql
	17. java/ql/src/Security/CWE/CWE-1104/MavenPomDependsOnBintray.ql
	18. ./java/ql/src/Security/CWE/CWE-113/ResponseSplittingLocal.ql
	19. ./java/ql/src/Security/CWE/CWE-113/NettyResponseSplitting.ql
	20. ./java/ql/src/Security/CWE/CWE-113/ResponseSplitting.ql
	21. ./java/ql/src/Security/CWE/CWE-614/InsecureCookie.ql
	22. ./java/ql/src/Security/CWE/CWE-421/SocketAuthRace.ql
	23. ./java/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
	24. ./java/ql/src/Security/CWE/CWE-090/LdapInjection.ql
	25. ./java/ql/src/Security/CWE/CWE-833/LockOrderInconsistency.ql
	26. ./java/ql/src/Security/CWE/CWE-312/CleartextStorageCookie.ql
	27. ./java/ql/src/Security/CWE/CWE-312/CleartextStorageProperties.ql
	28. ./java/ql/src/Frameworks/JavaEE/EJB/EjbFileIO.ql
	29. ./java/ql/src/Frameworks/JavaEE/EJB/EjbSecurityConfiguration.ql
	30. ./java/ql/src/Frameworks/JavaEE/EJB/EjbReflection.ql
	31. ./java/ql/src/Frameworks/JavaEE/EJB/EjbContainerInterference.ql
	32. ./java/ql/src/Frameworks/JavaEE/EJB/EjbSetSocketOrUrlFactory.ql
	33. ./java/ql/src/Frameworks/JavaEE/EJB/EjbNative.ql
	34. ./java/ql/src/Frameworks/JavaEE/EJB/EjbSerialization.ql
	35. ./java/ql/src/Likely Bugs/Concurrency/UnreleasedLock.ql 
	36. ./cpp/ql/src/experimental/Security/CWE/CWE-691/InsufficientControlFlowManagementWhenUsingBitOperations.ql 
	37. ./cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql 
	38. ./cpp/ql/src/experimental/Security/CWE/CWE-788/AccessOfMemoryLocationAfterEndOfBufferUsingStrncat.ql 
	39. ./cpp/ql/src/experimental/Security/CWE/CWE-788/AccessOfMemoryLocationAfterEndOfBufferUsingStrlen.ql
	40. ./cpp/ql/src/experimental/Security/CWE/CWE-359/PrivateCleartextWrite.ql 
	41. ./cpp/ql/src/experimental/Security/CWE/CWE-783/OperatorPrecedenceLogicErrorWhenUseBoolType.ql 
	42. ./cpp/ql/src/Security/CWE/CWE-457/ConditionallyUninitializedVariable.ql 
	43. ./cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql 
	44. ./cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql 
	45. ./cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql 
	46. ./cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
	47. ./cpp/ql/src/Security/CWE/CWE-807/TaintedCondition.ql 
	48. ./cpp/ql/src/Security/CWE/CWE-253/HResultBooleanConversion.ql 
	49. ./cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
	50. ./cpp/ql/src/Security/CWE/CWE-676/DangerousUseOfCin.ql 
	51. ./cpp/ql/src/Security/CWE/CWE-676/DangerousFunctionOverflow.ql
	52. ./cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql 
	53. ./cpp/ql/src/Security/CWE/CWE-497/ExposedSystemData.ql
	54. ./cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
	55. ./cpp/ql/src/Security/CWE/CWE-764/TwiceLocked.ql
	56. ./cpp/ql/src/Security/CWE/CWE-764/LockOrderCycle.ql
	57. ./cpp/ql/src/Security/CWE/CWE-764/UnreleasedLock.ql 
	58. ./cpp/ql/src/Security/CWE/CWE-014/MemsetMayBeDeleted.ql
	59. ./cpp/ql/src/Critical/DescriptorNeverClosed.ql
	60. ./cpp/ql/src/Critical/LateNegativeTest.ql
	61. ./cpp/ql/src/Critical/InitialisationNotRun.ql
	62. ./cpp/ql/src/Critical/FileMayNotBeClosed.ql
	63. ./cpp/ql/src/Critical/DescriptorMayNotBeClosed.ql
	64. ./cpp/ql/src/Critical/ReturnStackAllocatedObject.ql
	65. ./cpp/ql/src/Critical/GlobalUseBeforeInit.ql
	66. ./cpp/ql/src/Critical/FileNeverClosed.ql
	67. cpp/ql/src/Critical/MissingNegativityTest.ql
	68. cpp/ql/src/Likely Bugs/Likely Typos/IncorrectNotOperatorUsage.ql
	69. cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
	70. cpp/ql/src/Likely Bugs/Memory Management/SuspiciousSizeof.ql
	71. cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToMemset.ql
	72. cpp/ql/src/Likely Bugs/Format/WrongNumberOfFormatArguments.ql
	73. cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql 
	74. cpp/ql/src/Likely Bugs/OO/SelfAssignmentCheck.ql
	75. csharp/ql/src/Bad Practices/UseOfHtmlInputHidden.ql
	76. csharp/ql/src/Bad Practices/LeftoverDebugCode.ql
	77. csharp/ql/src/Security Features/PersistentCookie.ql
	78. csharp/ql/src/Security Features/CWE-548/ASPNetDirectoryListing.ql
	79. csharp/ql/src/Security Features/CWE-359/ExposureOfPrivateInformation.ql 
	80. csharp/ql/src/Security Features/CWE-011/ASPNetDebug.ql
	81. csharp/ql/src/Security Features/CWE-099/ResourceInjection.ql
	82. csharp/ql/src/Security Features/CWE-090/StoredLDAPInjection.ql
	83. csharp/ql/src/Security Features/CWE-090/LDAPInjection.ql
	84. csharp/ql/src/Security Features/CWE-643/XPathInjection.ql
	85. csharp/ql/src/Security Features/CWE-643/StoredXPathInjection.ql
	86. csharp/ql/src/Security Features/HeaderCheckingDisabled.ql
	87. javascript/ql/src/experimental/Security/CWE-614/InsecureCookie.ql
	88. javascript/ql/src/experimental/Security/CWE-090/LdapInjection.ql
	89. javascript/ql/src/Security/CWE-730/ServerCrash.ql
	90. javascript/ql/src/Security/CWE-643/XpathInjection.ql

Adding more years reduces the number of missing scores, but not entirely

* With 2020: 90 scores missing
* 2019-2020: 78 scores missing
* 2018-2020: 74 scores missing
* 2017-2020: 74 scores missing
* 2016-2020: 70 scores missing

The solution to these 90 queries would be to identify further CWEs for the query to be tagged by. However, this is a manual step.