### PR TITLE
C#: Fix special case of default argument value extraction

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
@@ -193,6 +193,16 @@ namespace Semmle.Extraction.CSharp.Entities
                 return Default.CreateGenerated(cx, parent, childIndex, location, parameter.Type.IsReferenceType ? ValueAsString(null) : null);
             }
 
+            if (parameter.Type.SpecialType == SpecialType.System_Object)
+            {
+                // this can happen in VB.NET
+                cx.ExtractionError($"Extracting default argument value 'object {parameter.Name} = default' instead of 'object {parameter.Name} = {defaultValue}'. The latter is not supported in C#.",
+                    null, null, severity: Util.Logging.Severity.Warning);
+
+                // we're generating a default expression:
+                return Default.CreateGenerated(cx, parent, childIndex, location, ValueAsString(null));
+            }
+
             // const literal:
             return Literal.CreateGenerated(cx, parent, childIndex, parameter.Type, defaultValue, location);
         }

--- a/csharp/ql/test/library-tests/standalone/errorrecovery/DiagnosticsAndErrors.expected
+++ b/csharp/ql/test/library-tests/standalone/errorrecovery/DiagnosticsAndErrors.expected
@@ -1,2 +1,3 @@
 compilationMessages
 extractorMessages
+| file://:0:0:0:0 | Extracting default argument value 'object RecordNumber = default' instead of 'object RecordNumber = -1'. The latter is not supported in C#. |


### PR DESCRIPTION
This PR fixes default argument value extraction in a special case found in assemblies compiled from vb.net. Vb.net allows specifying default argument values for parameters of type `object` where the value is not `null`.

[Differences job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1025/)