### PR TITLE
Make ExecTainted easier to extend

### DIFF
--- a/java/ql/src/semmle/code/java/JDK.qll
+++ b/java/ql/src/semmle/code/java/JDK.qll
@@ -180,21 +180,34 @@ class TypeFile extends Class {
 /**
  * Any of the methods named `command` on class `java.lang.ProcessBuilder`.
  */
-class MethodProcessBuilderCommand extends ExecMethod {
+class ProcessBuilderConstructor extends Constructor, ExecCallable {
+  ProcessBuilderConstructor() { this.getDeclaringType() instanceof TypeProcessBuilder }
+
+  override int getAnExecutedArgument() { result = 0 }
+}
+
+/**
+ * Any of the methods named `command` on class `java.lang.ProcessBuilder`.
+ */
+class MethodProcessBuilderCommand extends Method, ExecCallable {
   MethodProcessBuilderCommand() {
     hasName("command") and
     getDeclaringType() instanceof TypeProcessBuilder
   }
+
+  override int getAnExecutedArgument() { result = 0 }
 }
 
 /**
  * Any method named `exec` on class `java.lang.Runtime`.
  */
-class MethodRuntimeExec extends ExecMethod {
+class MethodRuntimeExec extends Method, ExecCallable {
   MethodRuntimeExec() {
     hasName("exec") and
     getDeclaringType() instanceof TypeRuntime
   }
+
+  override int getAnExecutedArgument() { result = 0 }
 }
 
 /**

--- a/java/ql/src/semmle/code/java/JDK.qll
+++ b/java/ql/src/semmle/code/java/JDK.qll
@@ -3,6 +3,7 @@
  */
 
 import Member
+import semmle.code.java.security.ExternalProcess
 
 // --- Standard types ---
 /** The class `java.lang.Object`. */
@@ -179,7 +180,7 @@ class TypeFile extends Class {
 /**
  * Any of the methods named `command` on class `java.lang.ProcessBuilder`.
  */
-class MethodProcessBuilderCommand extends Method {
+class MethodProcessBuilderCommand extends ExecMethod {
   MethodProcessBuilderCommand() {
     hasName("command") and
     getDeclaringType() instanceof TypeProcessBuilder
@@ -189,7 +190,7 @@ class MethodProcessBuilderCommand extends Method {
 /**
  * Any method named `exec` on class `java.lang.Runtime`.
  */
-class MethodRuntimeExec extends Method {
+class MethodRuntimeExec extends ExecMethod {
   MethodRuntimeExec() {
     hasName("exec") and
     getDeclaringType() instanceof TypeRuntime

--- a/java/ql/src/semmle/code/java/JDK.qll
+++ b/java/ql/src/semmle/code/java/JDK.qll
@@ -178,7 +178,7 @@ class TypeFile extends Class {
 
 // --- Standard methods ---
 /**
- * Any of the methods named `command` on class `java.lang.ProcessBuilder`.
+ * Any constructor of class `java.lang.ProcessBuilder`.
  */
 class ProcessBuilderConstructor extends Constructor, ExecCallable {
   ProcessBuilderConstructor() { this.getDeclaringType() instanceof TypeProcessBuilder }

--- a/java/ql/src/semmle/code/java/frameworks/apache/Exec.qll
+++ b/java/ql/src/semmle/code/java/frameworks/apache/Exec.qll
@@ -6,16 +6,20 @@ library class TypeCommandLine extends Class {
   TypeCommandLine() { hasQualifiedName("org.apache.commons.exec", "CommandLine") }
 }
 
-library class MethodCommandLineParse extends ExecMethod {
+library class MethodCommandLineParse extends Method, ExecCallable {
   MethodCommandLineParse() {
     getDeclaringType() instanceof TypeCommandLine and
     hasName("parse")
   }
+
+  override int getAnExecutedArgument() { result = 0 }
 }
 
-library class MethodCommandLineAddArguments extends ExecMethod {
+library class MethodCommandLineAddArguments extends Method, ExecCallable {
   MethodCommandLineAddArguments() {
     getDeclaringType() instanceof TypeCommandLine and
     hasName("addArguments")
   }
+
+  override int getAnExecutedArgument() { result = 0 }
 }

--- a/java/ql/src/semmle/code/java/frameworks/apache/Exec.qll
+++ b/java/ql/src/semmle/code/java/frameworks/apache/Exec.qll
@@ -1,18 +1,19 @@
 /* Definitions related to the Apache Commons Exec library. */
 import semmle.code.java.Type
+import semmle.code.java.security.ExternalProcess
 
 library class TypeCommandLine extends Class {
   TypeCommandLine() { hasQualifiedName("org.apache.commons.exec", "CommandLine") }
 }
 
-library class MethodCommandLineParse extends Method {
+library class MethodCommandLineParse extends ExecMethod {
   MethodCommandLineParse() {
     getDeclaringType() instanceof TypeCommandLine and
     hasName("parse")
   }
 }
 
-library class MethodCommandLineAddArguments extends Method {
+library class MethodCommandLineAddArguments extends ExecMethod {
   MethodCommandLineAddArguments() {
     getDeclaringType() instanceof TypeCommandLine and
     hasName("addArguments")

--- a/java/ql/src/semmle/code/java/frameworks/apache/Exec.qll
+++ b/java/ql/src/semmle/code/java/frameworks/apache/Exec.qll
@@ -2,11 +2,13 @@
 import semmle.code.java.Type
 import semmle.code.java.security.ExternalProcess
 
-library class TypeCommandLine extends Class {
+/** The class `org.apache.commons.exec.CommandLine`. */
+private class TypeCommandLine extends Class {
   TypeCommandLine() { hasQualifiedName("org.apache.commons.exec", "CommandLine") }
 }
 
-library class MethodCommandLineParse extends Method, ExecCallable {
+/** The `parse()` method of the class `org.apache.commons.exec.CommandLine`. */
+private class MethodCommandLineParse extends Method, ExecCallable {
   MethodCommandLineParse() {
     getDeclaringType() instanceof TypeCommandLine and
     hasName("parse")
@@ -15,7 +17,8 @@ library class MethodCommandLineParse extends Method, ExecCallable {
   override int getAnExecutedArgument() { result = 0 }
 }
 
-library class MethodCommandLineAddArguments extends Method, ExecCallable {
+/** The `addArguments()` method of the class `org.apache.commons.exec.CommandLine`. */
+private class MethodCommandLineAddArguments extends Method, ExecCallable {
   MethodCommandLineAddArguments() {
     getDeclaringType() instanceof TypeCommandLine and
     hasName("addArguments")

--- a/java/ql/src/semmle/code/java/security/ExternalProcess.qll
+++ b/java/ql/src/semmle/code/java/security/ExternalProcess.qll
@@ -4,9 +4,12 @@ import semmle.code.java.JDK
 import semmle.code.java.frameworks.apache.Exec
 
 /**
- * A method that executes a command.
+ * A callable that executes a command.
  */
 abstract class ExecCallable extends Callable {
+  /**
+   * Gets the index of an argument that will be part of the command that is executed.
+   */
   abstract int getAnExecutedArgument();
 }
 

--- a/java/ql/src/semmle/code/java/security/ExternalProcess.qll
+++ b/java/ql/src/semmle/code/java/security/ExternalProcess.qll
@@ -18,7 +18,7 @@ abstract class ExecCallable extends Callable {
 class ArgumentToExec extends Expr {
   ArgumentToExec() {
     exists(Call execCall, ExecCallable execCallable, int i |
-      execCall.getArgument(i) = this and
+      execCall.getArgument(pragma[only_bind_into](i)) = this and
       execCallable = execCall.getCallee() and
       i = execCallable.getAnExecutedArgument()
     )

--- a/java/ql/src/semmle/code/java/security/ExternalProcess.qll
+++ b/java/ql/src/semmle/code/java/security/ExternalProcess.qll
@@ -6,7 +6,9 @@ import semmle.code.java.frameworks.apache.Exec
 /**
  * A method that executes a command.
  */
-abstract class ExecMethod extends Method { }
+abstract class ExecCallable extends Callable {
+  abstract int getAnExecutedArgument();
+}
 
 /**
  * An expression used as an argument to a call that executes an external command. For calls to
@@ -15,15 +17,10 @@ abstract class ExecMethod extends Method { }
  */
 class ArgumentToExec extends Expr {
   ArgumentToExec() {
-    exists(MethodAccess execCall, ExecMethod method |
-      execCall.getArgument(0) = this and
-      method = execCall.getMethod()
-    )
-    or
-    exists(ConstructorCall expr, Constructor cons |
-      expr.getConstructor() = cons and
-      cons.getDeclaringType().hasQualifiedName("java.lang", "ProcessBuilder") and
-      expr.getArgument(0) = this
+    exists(Call execCall, ExecCallable execCallable, int i |
+      execCall.getArgument(i) = this and
+      execCallable = execCall.getCallee() and
+      i = execCallable.getAnExecutedArgument()
     )
   }
 }

--- a/java/ql/src/semmle/code/java/security/ExternalProcess.qll
+++ b/java/ql/src/semmle/code/java/security/ExternalProcess.qll
@@ -1,7 +1,10 @@
 /* Definitions related to external processes. */
 import semmle.code.java.Member
-import semmle.code.java.JDK
-import semmle.code.java.frameworks.apache.Exec
+
+private module Instances {
+  private import semmle.code.java.JDK
+  private import semmle.code.java.frameworks.apache.Exec
+}
 
 /**
  * A callable that executes a command.

--- a/java/ql/src/semmle/code/java/security/ExternalProcess.qll
+++ b/java/ql/src/semmle/code/java/security/ExternalProcess.qll
@@ -4,21 +4,20 @@ import semmle.code.java.JDK
 import semmle.code.java.frameworks.apache.Exec
 
 /**
+ * A method that executes a command.
+ */
+abstract class ExecMethod extends Method { }
+
+/**
  * An expression used as an argument to a call that executes an external command. For calls to
  * varargs method calls, this only includes the first argument, which will be the command
  * to be executed.
  */
 class ArgumentToExec extends Expr {
   ArgumentToExec() {
-    exists(MethodAccess execCall, Method method |
+    exists(MethodAccess execCall, ExecMethod method |
       execCall.getArgument(0) = this and
-      method = execCall.getMethod() and
-      (
-        method instanceof MethodRuntimeExec or
-        method instanceof MethodProcessBuilderCommand or
-        method instanceof MethodCommandLineParse or
-        method instanceof MethodCommandLineAddArguments
-      )
+      method = execCall.getMethod()
     )
     or
     exists(ConstructorCall expr, Constructor cons |


### PR DESCRIPTION
No change in behaviour - this is just a refactoring. To add a method that executes a command, you can now define a class
extending ExecMethod.