### PR TITLE
C#: Add missing `StringBuilder` flow summaries

### DIFF
--- a/csharp/change-notes/2021-04-26-string-builder-summaries.md
+++ b/csharp/change-notes/2021-04-26-string-builder-summaries.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Data-flow modelling of `StringBuilder` objects has been improved.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -807,17 +807,29 @@ class SystemTextStringBuilderFlow extends LibraryTypeDataFlow, SystemTextStringB
       sinkAp = AccessPath::empty() and
       preservesValue = false
       or
-      exists(int i, Type t |
-        name.regexpMatch("Append(Format|Line)?") and
-        t = m.getParameter(i).getType() and
-        source = TCallableFlowSourceArg(i) and
+      name.regexpMatch("Append(Format|Line|Join)?") and
+      preservesValue = true and
+      (
+        exists(int i, Type t |
+          t = m.getParameter(i).getType() and
+          source = TCallableFlowSourceArg(i) and
+          sink = TCallableFlowSinkQualifier() and
+          sinkAp = AccessPath::element()
+        |
+          (
+            t instanceof StringType or
+            t instanceof ObjectType
+          ) and
+          sourceAp = AccessPath::empty()
+          or
+          isCollectionType(t) and
+          sourceAp = AccessPath::element()
+        )
+        or
+        source = TCallableFlowSourceQualifier() and
         sourceAp = AccessPath::empty() and
-        sink = [TCallableFlowSinkQualifier().(TCallableFlowSink), TCallableFlowSinkReturn()] and
-        sinkAp = AccessPath::element() and
-        preservesValue = true
-      |
-        t instanceof StringType or
-        t instanceof ObjectType
+        sink = TCallableFlowSinkReturn() and
+        sinkAp = AccessPath::empty()
       )
     )
   }

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.expected
@@ -2211,54 +2211,83 @@
 | System.Text.RegularExpressions.MatchCollection.get_Item(int) | element of argument -1 -> return (normal) | true |
 | System.Text.RegularExpressions.MatchCollection.set_Item(int, Match) | argument 1 -> element of argument -1 | true |
 | System.Text.RegularExpressions.MatchCollection.set_Item(int, object) | argument 1 -> element of argument -1 | true |
+| System.Text.StringBuilder.Append(Char[]) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(Char[]) | element of argument 0 -> element of argument -1 | true |
+| System.Text.StringBuilder.Append(Char[], int, int) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(Char[], int, int) | element of argument 0 -> element of argument -1 | true |
+| System.Text.StringBuilder.Append(ReadOnlyMemory<Char>) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(ReadOnlySpan<Char>) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(StringBuilder) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(StringBuilder, int, int) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(bool) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(byte) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(char) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(char*, int) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(char, int) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(decimal) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(double) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(float) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(int) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(long) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.Append(object) | argument 0 -> element of argument -1 | true |
-| System.Text.StringBuilder.Append(object) | argument 0 -> element of return (normal) | true |
+| System.Text.StringBuilder.Append(object) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(sbyte) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(short) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.Append(string) | argument 0 -> element of argument -1 | true |
-| System.Text.StringBuilder.Append(string) | argument 0 -> element of return (normal) | true |
+| System.Text.StringBuilder.Append(string) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.Append(string, int, int) | argument 0 -> element of argument -1 | true |
-| System.Text.StringBuilder.Append(string, int, int) | argument 0 -> element of return (normal) | true |
+| System.Text.StringBuilder.Append(string, int, int) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(uint) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(ulong) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.Append(ushort) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object) | argument 1 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object) | argument 1 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object) | argument 2 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object) | argument 2 -> element of return (normal) | true |
+| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object) | argument 1 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object) | argument 1 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object) | argument 2 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object) | argument 2 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object) | argument 3 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object) | argument 3 -> element of return (normal) | true |
+| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object, object) | argument 1 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object, object) | argument 1 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object, object) | argument 2 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object, object) | argument 2 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object, object) | argument 3 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object, object) | argument 3 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object, object) | argument 4 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object, object) | argument 4 -> element of return (normal) | true |
+| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, object, object, object) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(IFormatProvider, string, params Object[]) | argument 1 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, params Object[]) | argument 1 -> element of return (normal) | true |
+| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, params Object[]) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.AppendFormat(IFormatProvider, string, params Object[]) | element of argument 2 -> element of argument -1 | true |
 | System.Text.StringBuilder.AppendFormat(string, object) | argument 0 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(string, object) | argument 0 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(string, object) | argument 1 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(string, object) | argument 1 -> element of return (normal) | true |
+| System.Text.StringBuilder.AppendFormat(string, object) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(string, object, object) | argument 0 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(string, object, object) | argument 0 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(string, object, object) | argument 1 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(string, object, object) | argument 1 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(string, object, object) | argument 2 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(string, object, object) | argument 2 -> element of return (normal) | true |
+| System.Text.StringBuilder.AppendFormat(string, object, object) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(string, object, object, object) | argument 0 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(string, object, object, object) | argument 0 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(string, object, object, object) | argument 1 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(string, object, object, object) | argument 1 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(string, object, object, object) | argument 2 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(string, object, object, object) | argument 2 -> element of return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(string, object, object, object) | argument 3 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(string, object, object, object) | argument 3 -> element of return (normal) | true |
+| System.Text.StringBuilder.AppendFormat(string, object, object, object) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.AppendFormat(string, params Object[]) | argument 0 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendFormat(string, params Object[]) | argument 0 -> element of return (normal) | true |
+| System.Text.StringBuilder.AppendFormat(string, params Object[]) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.AppendFormat(string, params Object[]) | element of argument 1 -> element of argument -1 | true |
+| System.Text.StringBuilder.AppendJoin(char, params Object[]) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.AppendJoin(char, params Object[]) | element of argument 1 -> element of argument -1 | true |
+| System.Text.StringBuilder.AppendJoin(char, params String[]) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.AppendJoin(char, params String[]) | element of argument 1 -> element of argument -1 | true |
+| System.Text.StringBuilder.AppendJoin(string, params Object[]) | argument 0 -> element of argument -1 | true |
+| System.Text.StringBuilder.AppendJoin(string, params Object[]) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.AppendJoin(string, params Object[]) | element of argument 1 -> element of argument -1 | true |
+| System.Text.StringBuilder.AppendJoin(string, params String[]) | argument 0 -> element of argument -1 | true |
+| System.Text.StringBuilder.AppendJoin(string, params String[]) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.AppendJoin(string, params String[]) | element of argument 1 -> element of argument -1 | true |
+| System.Text.StringBuilder.AppendJoin<T>(char, IEnumerable<T>) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.AppendJoin<T>(char, IEnumerable<T>) | element of argument 1 -> element of argument -1 | true |
+| System.Text.StringBuilder.AppendJoin<T>(string, IEnumerable<T>) | argument 0 -> element of argument -1 | true |
+| System.Text.StringBuilder.AppendJoin<T>(string, IEnumerable<T>) | argument -1 -> return (normal) | true |
+| System.Text.StringBuilder.AppendJoin<T>(string, IEnumerable<T>) | element of argument 1 -> element of argument -1 | true |
+| System.Text.StringBuilder.AppendLine() | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.AppendLine(string) | argument 0 -> element of argument -1 | true |
-| System.Text.StringBuilder.AppendLine(string) | argument 0 -> element of return (normal) | true |
+| System.Text.StringBuilder.AppendLine(string) | argument -1 -> return (normal) | true |
 | System.Text.StringBuilder.StringBuilder(string) | argument 0 -> element of return (normal) | true |
 | System.Text.StringBuilder.StringBuilder(string, int) | argument 0 -> element of return (normal) | true |
 | System.Text.StringBuilder.StringBuilder(string, int, int, int) | argument 0 -> element of return (normal) | true |

--- a/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -310,6 +310,7 @@
 | LocalDataFlow.cs:234:13:234:42 | SSA def(sink36) | LocalDataFlow.cs:235:9:235:14 | access to local variable sink36 |
 | LocalDataFlow.cs:234:22:234:42 | object creation of type StringBuilder | LocalDataFlow.cs:234:13:234:42 | SSA def(sink36) |
 | LocalDataFlow.cs:235:9:235:14 | [post] access to local variable sink36 | LocalDataFlow.cs:236:15:236:20 | access to local variable sink36 |
+| LocalDataFlow.cs:235:9:235:14 | access to local variable sink36 | LocalDataFlow.cs:235:9:235:33 | call to method AppendLine |
 | LocalDataFlow.cs:235:9:235:14 | access to local variable sink36 | LocalDataFlow.cs:236:15:236:20 | access to local variable sink36 |
 | LocalDataFlow.cs:239:13:239:51 | SSA def(nonSink10) | LocalDataFlow.cs:240:15:240:23 | access to local variable nonSink10 |
 | LocalDataFlow.cs:239:25:239:51 | object creation of type StringBuilder | LocalDataFlow.cs:239:13:239:51 | SSA def(nonSink10) |
@@ -322,6 +323,7 @@
 | LocalDataFlow.cs:242:15:242:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:243:30:243:37 | access to local variable nonSink0 |
 | LocalDataFlow.cs:242:15:242:22 | access to local variable nonSink0 | LocalDataFlow.cs:243:30:243:37 | access to local variable nonSink0 |
 | LocalDataFlow.cs:243:9:243:17 | [post] access to local variable nonSink10 | LocalDataFlow.cs:244:15:244:23 | access to local variable nonSink10 |
+| LocalDataFlow.cs:243:9:243:17 | access to local variable nonSink10 | LocalDataFlow.cs:243:9:243:38 | call to method AppendLine |
 | LocalDataFlow.cs:243:9:243:17 | access to local variable nonSink10 | LocalDataFlow.cs:244:15:244:23 | access to local variable nonSink10 |
 | LocalDataFlow.cs:247:13:247:52 | SSA def(taintedDataContract) | LocalDataFlow.cs:248:22:248:40 | access to local variable taintedDataContract |
 | LocalDataFlow.cs:247:13:247:52 | SSA qualifier def(taintedDataContract.AList) | LocalDataFlow.cs:250:22:250:46 | access to property AList |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
@@ -400,9 +400,9 @@
 | LocalDataFlow.cs:234:22:234:42 | object creation of type StringBuilder | LocalDataFlow.cs:234:13:234:42 | SSA def(sink36) |
 | LocalDataFlow.cs:234:40:234:41 | "" | LocalDataFlow.cs:234:22:234:42 | object creation of type StringBuilder |
 | LocalDataFlow.cs:235:9:235:14 | [post] access to local variable sink36 | LocalDataFlow.cs:236:15:236:20 | access to local variable sink36 |
+| LocalDataFlow.cs:235:9:235:14 | access to local variable sink36 | LocalDataFlow.cs:235:9:235:33 | call to method AppendLine |
 | LocalDataFlow.cs:235:9:235:14 | access to local variable sink36 | LocalDataFlow.cs:236:15:236:20 | access to local variable sink36 |
 | LocalDataFlow.cs:235:27:235:32 | access to local variable sink35 | LocalDataFlow.cs:235:9:235:14 | [post] access to local variable sink36 |
-| LocalDataFlow.cs:235:27:235:32 | access to local variable sink35 | LocalDataFlow.cs:235:9:235:33 | call to method AppendLine |
 | LocalDataFlow.cs:239:13:239:51 | SSA def(nonSink10) | LocalDataFlow.cs:240:15:240:23 | access to local variable nonSink10 |
 | LocalDataFlow.cs:239:25:239:51 | object creation of type StringBuilder | LocalDataFlow.cs:239:13:239:51 | SSA def(nonSink10) |
 | LocalDataFlow.cs:239:43:239:50 | access to local variable nonSink0 | LocalDataFlow.cs:239:25:239:51 | object creation of type StringBuilder |
@@ -416,9 +416,9 @@
 | LocalDataFlow.cs:242:15:242:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:243:30:243:37 | access to local variable nonSink0 |
 | LocalDataFlow.cs:242:15:242:22 | access to local variable nonSink0 | LocalDataFlow.cs:243:30:243:37 | access to local variable nonSink0 |
 | LocalDataFlow.cs:243:9:243:17 | [post] access to local variable nonSink10 | LocalDataFlow.cs:244:15:244:23 | access to local variable nonSink10 |
+| LocalDataFlow.cs:243:9:243:17 | access to local variable nonSink10 | LocalDataFlow.cs:243:9:243:38 | call to method AppendLine |
 | LocalDataFlow.cs:243:9:243:17 | access to local variable nonSink10 | LocalDataFlow.cs:244:15:244:23 | access to local variable nonSink10 |
 | LocalDataFlow.cs:243:30:243:37 | access to local variable nonSink0 | LocalDataFlow.cs:243:9:243:17 | [post] access to local variable nonSink10 |
-| LocalDataFlow.cs:243:30:243:37 | access to local variable nonSink0 | LocalDataFlow.cs:243:9:243:38 | call to method AppendLine |
 | LocalDataFlow.cs:247:13:247:52 | SSA def(taintedDataContract) | LocalDataFlow.cs:248:22:248:40 | access to local variable taintedDataContract |
 | LocalDataFlow.cs:247:13:247:52 | SSA qualifier def(taintedDataContract.AList) | LocalDataFlow.cs:250:22:250:46 | access to property AList |
 | LocalDataFlow.cs:247:13:247:52 | SSA qualifier def(taintedDataContract.AString) | LocalDataFlow.cs:248:22:248:48 | access to property AString |


### PR DESCRIPTION
This PR
- adds missing flow summaries for `StringBuilder::AppendJoin`,
- adjusts existing summaries for `params` arguments to read from the elements of the array, rather than the array itself, and
- adds missing flow from qualifiers to return for all append method calls (i.e., fluent interface).

The second change results in 6 new (TP) stored-XXS results on WebGoat.net.

The third change means that flow from append arguments to returns can be removed, now that the shared implementation [has support for fluent interfaces](https://github.com/github/codeql/pull/5743).



https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1034/