### PR TITLE
Fix all dead qhelp links

### DIFF
--- a/cpp/ql/src/Best Practices/Magic Constants/MagicConstantsNumbers.qhelp
+++ b/cpp/ql/src/Best Practices/Magic Constants/MagicConstantsNumbers.qhelp
@@ -39,7 +39,7 @@ then replace all the relevant occurrences in the code.</p>
 </li>
 <li>
   Mats Henricson and Erik Nyquist, <i>Industrial Strength C++</i>, published by Prentice Hall PTR (1997). 
-  Chapter 5: Object Life Cycle, Rec 5.4 (<a href="http://mongers.org/industrial-c++/">PDF</a>).
+  Chapter 5: Object Life Cycle, Rec 5.4 (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">PDF</a>).
 </li>
 <li>
   <a href="https://www.securecoding.cert.org/confluence/display/c/DCL06-C.+Use+meaningful+symbolic+constants+to+represent+literal+values">DCL06-C. Use meaningful symbolic constants to represent literal values</a>

--- a/cpp/ql/src/Best Practices/Magic Constants/MagicConstantsString.qhelp
+++ b/cpp/ql/src/Best Practices/Magic Constants/MagicConstantsString.qhelp
@@ -38,7 +38,7 @@ constant.</p>
 </li>
 <li>
   Mats Henricson and Erik Nyquist, <i>Industrial Strength C++</i>, published by Prentice Hall PTR (1997). 
-  Chapter 5: Object Life Cycle, Rec 5.4 (<a href="http://mongers.org/industrial-c++/">PDF</a>).
+  Chapter 5: Object Life Cycle, Rec 5.4 (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">PDF</a>).
 </li>
 <li>
   <a href="https://www.securecoding.cert.org/confluence/display/c/DCL06-C.+Use+meaningful+symbolic+constants+to+represent+literal+values">DCL06-C. Use meaningful symbolic constants to represent literal values</a>

--- a/cpp/ql/src/Best Practices/SloppyGlobal.qhelp
+++ b/cpp/ql/src/Best Practices/SloppyGlobal.qhelp
@@ -21,7 +21,7 @@ Review the purpose of the each global variable flagged by this rule and update e
 
 <li>
   Mats Henricson and Erik Nyquist, <i>Industrial Strength C++</i>, published by Prentice Hall PTR (1997). 
-  Chapter 1: Naming, Rec 1.1 (<a href="http://mongers.org/industrial-c++/">PDF</a>).
+  Chapter 1: Naming, Rec 1.1 (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">PDF</a>).
 </li>
 <li>
   <a href="http://www.learncpp.com/cpp-tutorial/42-global-variables/">Global variables</a>.

--- a/cpp/ql/src/Best Practices/UseOfGoto.qhelp
+++ b/cpp/ql/src/Best Practices/UseOfGoto.qhelp
@@ -45,7 +45,7 @@ this rule.
 </li>
 <li>
   Mats Henricson and Erik Nyquist, <i>Industrial Strength C++</i>, Rule 4.6. Prentice Hall PTR, 1997.
-  (<a href="http://mongers.org/industrial-c++/">PDF</a>).
+  (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">PDF</a>).
 </li>
 <li>
   cplusplus.com: <a href="http://www.cplusplus.com/doc/tutorial/control/">Control Structures</a>.

--- a/cpp/ql/src/Critical/ReturnValueIgnored.qhelp
+++ b/cpp/ql/src/Critical/ReturnValueIgnored.qhelp
@@ -32,7 +32,7 @@ Check the return value of functions that return status information.
 <references>
 
 <li>
-  M. Henricson and E. Nyquist, <i>Industrial Strength C++</i>, Chapter 12: Error handling. Prentice Hall PTR, 1997 (<a href="http://mongers.org/industrial-c++/">available online</a>).
+  M. Henricson and E. Nyquist, <i>Industrial Strength C++</i>, Chapter 12: Error handling. Prentice Hall PTR, 1997 (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">available online</a>).
 </li>
 <li>
   The CERT C Secure Coding Standard: <a href="https://www.securecoding.cert.org/confluence/display/perl/EXP32-PL.+Do+not+ignore+function+return+values">EXP32-PL. Do not ignore function return values</a>.

--- a/cpp/ql/src/Likely Bugs/Likely Typos/MissingEnumCaseInSwitch.qhelp
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/MissingEnumCaseInSwitch.qhelp
@@ -26,7 +26,7 @@ indication that there may be cases unhandled by the <code>switch</code> statemen
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/cpp/switch-statement-cpp">switch statement (C++)</a>
 </li>
 <li>
-  M. Henricson and E. Nyquist, <i>Industrial Strength C++</i>, Chapter 4: Control Flow, Rec 4.5. Prentice Hall PTR, 1997 (<a href="http://mongers.org/industrial-c++/">available online</a>).
+  M. Henricson and E. Nyquist, <i>Industrial Strength C++</i>, Chapter 4: Control Flow, Rec 4.5. Prentice Hall PTR, 1997 (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">available online</a>).
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/FTransitiveIncludes.qhelp
+++ b/cpp/ql/src/Metrics/Files/FTransitiveIncludes.qhelp
@@ -29,7 +29,7 @@ build time: the more included files, the longer the compilation time.</p>
   <a href="http://www.drdobbs.com/cpp/decoupling-c-header-files/212701130">Decoupling C Header Files</a>
 </li>
 <li>
-  <a href="https://wiki.hsr.ch/Prog3/files/overload72-FINAL_DesigningHeaderFiles.pdf">C++ Best Practice -
+  <a href="https://accu.org/journals/overload/14/72/griffiths_1995/">C++ Best Practice -
 Designing Header Files</a>
 </li>
 

--- a/cpp/ql/src/Metrics/Files/FTransitiveSourceIncludes.qhelp
+++ b/cpp/ql/src/Metrics/Files/FTransitiveSourceIncludes.qhelp
@@ -35,7 +35,7 @@ they are contributing to unnecessarily long build times and creating artificial 
   <a href="http://www.drdobbs.com/cpp/decoupling-c-header-files/212701130">Decoupling C Header Files</a>
 </li>
 <li>
-  <a href="https://wiki.hsr.ch/Prog3/files/overload72-FINAL_DesigningHeaderFiles.pdf">C++ Best Practice -
+  <a href="https://accu.org/journals/overload/14/72/griffiths_1995/">C++ Best Practice -
 Designing Header Files</a>
 </li>
 </references>

--- a/cpp/ql/src/jsf/4.24 Control Flow Structures/AV Rule 189.qhelp
+++ b/cpp/ql/src/jsf/4.24 Control Flow Structures/AV Rule 189.qhelp
@@ -33,7 +33,7 @@ the break statement only exits from one level of the loop.</p>
 </li>
 <li>
   Mats Henricson and Erik Nyquist, <i>Industrial Strength C++</i>, published by Prentice Hall PTR (1997). 
-  Chapter 4: Control Flow, Rule 4.6 (<a href="http://mongers.org/industrial-c++/">PDF</a>).
+  Chapter 4: Control Flow, Rule 4.6 (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">PDF</a>).
 </li>
 <li>
   <a href="http://www.cplusplus.com/doc/tutorial/control/">www.cplusplus.com Control Structures</a>

--- a/cpp/ql/src/jsf/4.24 Control Flow Structures/AV Rule 201.qhelp
+++ b/cpp/ql/src/jsf/4.24 Control Flow Structures/AV Rule 201.qhelp
@@ -39,7 +39,7 @@ loop if the loop requires more complicated variable iteration.
 </li>
 <li>
   Mats Henricson and Erik Nyquist, <i>Industrial Strength C++</i>, published by Prentice Hall PTR (1997). 
-  Chapter 4: Control Flow, Rule 4.1 (<a href="http://mongers.org/industrial-c++/">PDF</a>).
+  Chapter 4: Control Flow, Rule 4.1 (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">PDF</a>).
 </li>
 
 

--- a/csharp/ql/src/Language Abuse/ForeachCapture.qhelp
+++ b/csharp/ql/src/Language Abuse/ForeachCapture.qhelp
@@ -29,7 +29,7 @@ However on older compilers, the actual output is <code>10 10 10 10 10 10 10 10 1
 
 <references>
 
-  <li>Eric Lippert's Blog: <a href="http://blogs.msdn.com/b/ericlippert/archive/2009/11/12/closing-over-the-loop-variable-considered-harmful.aspx">Closing over the loop variable considered harmful</a>.</li>
+  <li>Eric Lippert's Blog: <a href="https://docs.microsoft.com/en-gb/archive/blogs/ericlippert/closing-over-the-loop-variable-considered-harmful">Closing over the loop variable considered harmful</a>.</li>
 
 </references>
 

--- a/csharp/ql/src/Likely Bugs/MishandlingJapaneseEra.qhelp
+++ b/csharp/ql/src/Likely Bugs/MishandlingJapaneseEra.qhelp
@@ -27,7 +27,7 @@
     <a href="https://blogs.msdn.microsoft.com/shawnste/2018/04/12/the-japanese-calendars-y2k-moment/">The Japanese Calendar's Y2K Moment</a>.
   </li>
   <li>
-    <a href="https://docs.microsoft.com/en-us/windows/desktop/Intl/era-handling-for-the-japanese-calendar/">Era Handling for the Japanese Calendar</a>.
+    <a href="https://docs.microsoft.com/en-us/windows/win32/intl/era-handling-for-the-japanese-calendar">Era Handling for the Japanese Calendar</a>.
   </li>
   <li>
    <a href="https://simple.wikipedia.org/wiki/List_of_Japanese_eras">List of Japanese Eras (Wikipedia)</a>

--- a/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.qhelp
+++ b/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.qhelp
@@ -25,7 +25,7 @@ really be compared using <code>i == j</code>.</p>
 <references>
 
   <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.object.referenceequals.aspx">Object.ReferenceEquals Method</a>.</li>
-  <li>The Way I See It: <a href="https://web.archive.org/web/20190919103548/https://blogs.msdn.microsoft.com/vijaysk/2008/03/18/object-referenceequalsvaluevar-valuevar-will-always-return-false/">Object.ReferenceEquals(ValueVar, ValueVar) will always return false.</a></li>
+  <li>The Way I See It: <a href="https://docs.microsoft.com/en-us/archive/blogs/vijaysk/object-referenceequalsvaluevar-valuevar-will-always-return-false">Object.ReferenceEquals(ValueVar, ValueVar) will always return false.</a></li>
 
 
 </references>

--- a/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.qhelp
+++ b/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.qhelp
@@ -25,7 +25,7 @@ really be compared using <code>i == j</code>.</p>
 <references>
 
   <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.object.referenceequals.aspx">Object.ReferenceEquals Method</a>.</li>
-  <li>The Way I See It: <a href="http://blogs.msdn.com/b/vijaysk/archive/2008/03/19/object-referenceequals-valuevar-valuevar-will-always-return-false.aspx">Object.ReferenceEquals(ValueVar, ValueVar) will always return false.</a></li>
+  <li>The Way I See It: <a href="https://web.archive.org/web/20190919103548/https://blogs.msdn.microsoft.com/vijaysk/2008/03/18/object-referenceequalsvaluevar-valuevar-will-always-return-false/">Object.ReferenceEquals(ValueVar, ValueVar) will always return false.</a></li>
 
 
 </references>

--- a/csharp/ql/src/Metrics/Files/FNumberOfTests.qhelp
+++ b/csharp/ql/src/Metrics/Files/FNumberOfTests.qhelp
@@ -53,7 +53,7 @@
   Microsoft Visual Studio Unit Testing Framework: documentation at <a href="https://msdn.microsoft.com/en-us/library/microsoft.visualstudio.testtools.unittesting.aspx">MSDN</a>.
 </li>
 <li>
-  xUnit.net: official website at <a href="https://xunit.github.io/">https://xunit.github.io/</a>.
+  xUnit.net: official website at <a href="https://xunit.net/">https://xunit.net/</a>.
 </li>
 
 </references>

--- a/csharp/ql/src/Security Features/CWE-011/ASPNetDebug.qhelp
+++ b/csharp/ql/src/Security Features/CWE-011/ASPNetDebug.qhelp
@@ -42,7 +42,7 @@ To fix this problem, the 'debug' flag should be set to <code>false</code>, or re
 
 <li>
 MSDN:
-<a href="https://blogs.msdn.microsoft.com/prashant_upadhyay/2011/07/14/why-debugfalse-in-asp-net-applications-in-production-environment/">Why debug=false in ASP.NET applications in production environment</a>.
+<a href="https://web.archive.org/web/20190919105353/https://blogs.msdn.microsoft.com/prashant_upadhyay/2011/07/14/why-debugfalse-in-asp-net-applications-in-production-environment/">Why debug=false in ASP.NET applications in production environment</a>.
 </li>
 <li>
 MSDN:

--- a/csharp/ql/src/Security Features/CWE-209/ExceptionInformationExposure.qhelp
+++ b/csharp/ql/src/Security Features/CWE-209/ExceptionInformationExposure.qhelp
@@ -36,7 +36,4 @@ use the error log, but remote users will not see the information.</p>
 <sample src="ExceptionInformationExposure.cs" />
 </example>
 
-<references>
-<li>OWASP: <a href="https://www.owasp.org/index.php/Information_Leak_(information_disclosure)">Information Leak</a>.</li>
-</references>
 </qhelp>

--- a/java/ql/src/Likely Bugs/Concurrency/StartInConstructor.qhelp
+++ b/java/ql/src/Likely Bugs/Concurrency/StartInConstructor.qhelp
@@ -41,7 +41,7 @@ initialized. This results in the program outputting "hello my friend".</p>
 
 <li>
   IBM developerWorks:
-  <a href="http://www.ibm.com/developerworks/java/library/j-jtp0618/index.html#4">Don't start threads from within constructors</a>.
+  <a href="https://web.archive.org/web/20200417101823/http://www.ibm.com/developerworks/java/library/j-jtp0618/index.html#4">Don't start threads from within constructors</a>.
 </li>
 
 

--- a/java/ql/src/Likely Bugs/Frameworks/Swing/ThreadSafety.qhelp
+++ b/java/ql/src/Likely Bugs/Frameworks/Swing/ThreadSafety.qhelp
@@ -94,7 +94,7 @@ D. Flanagan, <em>Java Foundation Classes in a Nutshell</em>, p.28. O'Reilly, 199
 </li>
 <li>
 Java Developer's Journal:
-<a href="http://www2.sys-con.com/itsg/virtualcd/java/archives/0605/ford/index.html">Building Thread-Safe GUIs with Swing</a>.
+<a href="http://www.comscigate.com/JDJ/archives/0605/ford/index.html">Building Thread-Safe GUIs with Swing</a>.
 </li>
 <li>
 The Java Tutorials:

--- a/java/ql/src/Likely Bugs/Likely Typos/StringBufferCharInit.qhelp
+++ b/java/ql/src/Likely Bugs/Likely Typos/StringBufferCharInit.qhelp
@@ -41,7 +41,7 @@ J. Bloch and N. Gafter, <em>Java Puzzlers: Traps, Pitfalls, and Corner Cases</em
 Addison-Wesley, 2005.
 </li>
 <li>
-NetBeans IDE: <a href="http://wiki.netbeans.org/Java_Hints">Java Hints</a>
+NetBeans IDE: <a href="https://web.archive.org/web/20210117160808/http://wiki.netbeans.org/Java_Hints">Java Hints</a>
 </li>
 <li>
 PMD: <a href="https://pmd.github.io/latest/pmd_rules_java_errorprone.html#stringbufferinstantiationwithchar">Rule StringBufferInstantiationWithChar</a>

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.qhelp
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.qhelp
@@ -51,7 +51,7 @@ In this case, the inner expression needs to be assigned to a local variable and 
 
 
 <li>
-  IBM developerWorks: <a href="https://www.ibm.com/developerworks/java/library/j-jtp03216/index.html">Java theory and practice: Good housekeeping practices</a>. 
+  IBM developerWorks: <a href="https://web.archive.org/web/20201109041839/http://www.ibm.com/developerworks/java/library/j-jtp03216/index.html">Java theory and practice: Good housekeeping practices</a>.
 </li>
 <li>
   The Java Tutorials: <a href="https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html">The try-with-resources Statement</a>.

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseSql.qhelp
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseSql.qhelp
@@ -40,7 +40,7 @@ by the code that created it or by a server shutdown procedure, as appropriate.</
 
 
 <li>
-  IBM developerWorks: <a href="https://www.ibm.com/developerworks/java/library/j-jtp03216/index.html">Java theory and practice: Good housekeeping practices</a>.
+  IBM developerWorks: <a href="https://web.archive.org/web/20201109041839/http://www.ibm.com/developerworks/java/library/j-jtp03216/index.html">Java theory and practice: Good housekeeping practices</a>.
 </li>
 <li>
   The Java Tutorials: <a href="https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html">The try-with-resources Statement</a>.

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.qhelp
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.qhelp
@@ -50,7 +50,7 @@ In this case, the inner expression needs to be assigned to a local variable and 
 
 
 <li>
-  IBM developerWorks: <a href="https://www.ibm.com/developerworks/java/library/j-jtp03216/index.html">Java theory and practice: Good housekeeping practices</a>. 
+  IBM developerWorks: <a href="https://web.archive.org/web/20201109041839/http://www.ibm.com/developerworks/java/library/j-jtp03216/index.html">Java theory and practice: Good housekeeping practices</a>.
 </li>
 <li>
   The Java Tutorials: <a href="https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html">The try-with-resources Statement</a>.

--- a/java/ql/src/Metrics/RefTypes/TEfferentCoupling.qhelp
+++ b/java/ql/src/Metrics/RefTypes/TEfferentCoupling.qhelp
@@ -51,7 +51,7 @@ so the general technique is quite widely applicable.
 
 
 <li>
-IBM developerWorks: <a href="http://www.ibm.com/developerworks/library/j-eaed6/">Evolutionary architecture and emergent design: Emergent design through metrics</a>.
+IBM developerWorks: <a href="https://web.archive.org/web/20190919085934/https://www.ibm.com/developerworks/library/j-eaed6/">Evolutionary architecture and emergent design: Emergent design through metrics</a>.
 </li>
 <li>
 R. Martin, <em>Agile Software Development: Principles, Patterns and Practices</em>. Pearson, 2011.

--- a/java/ql/src/Metrics/RefTypes/TEfferentSourceCoupling.qhelp
+++ b/java/ql/src/Metrics/RefTypes/TEfferentSourceCoupling.qhelp
@@ -81,7 +81,7 @@ so the general technique is quite widely applicable.
 
 
 <li>
-A. Glover. <a href="http://7thgen.info/wiki/Code_Quality_For_Software_Architects">Code quality for software architects</a>. Published online, 2006.
+A. Glover. <a href="https://web.archive.org/web/20190919093358/http://7thgen.info/wiki/Code_Quality_For_Software_Architects">Code quality for software architects</a>. Published online, 2006.
 </li>
 <li>
 R. Martin. <em>Agile Software Development: Principles, Patterns and Practices</em>. Pearson, 2011.

--- a/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
+++ b/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
@@ -69,7 +69,7 @@ Or How I Learned to Start Worrying and Hate Java Object Deserialization</a>.
 </li>
 <li>
 Alvaro Muñoz &amp; Christian Schneider, RSAConference 2016:
-<a href="https://www.rsaconference.com/writable/presentations/file_upload/asd-f03-serial-killer-silently-pwning-your-java-endpoints.pdf">Serial Killer: Silently Pwning Your Java Endpoints</a>.
+<a href="https://speakerdeck.com/pwntester/serial-killer-silently-pwning-your-java-endpoints">Serial Killer: Silently Pwning Your Java Endpoints</a>.
 </li>
 <li>
 SnakeYaml documentation on deserialization:

--- a/java/ql/src/Security/CWE/CWE-611/XXE.qhelp
+++ b/java/ql/src/Security/CWE/CWE-611/XXE.qhelp
@@ -56,11 +56,11 @@ OWASP guidance on parsing xml files:
 </li>
 <li>
 Paper by Timothy Morgen:
-<a href="https://www.vsecurity.com//download/publications/XMLDTDEntityAttacks.pdf">XML Schema, DTD, and Entity Attacks</a>
+<a href="https://research.nccgroup.com/2014/05/19/xml-schema-dtd-and-entity-attacks-a-compendium-of-known-techniques/">XML Schema, DTD, and Entity Attacks</a>
 </li>
 <li>
 Out-of-band data retrieval: Timur Yunusov &amp; Alexey Osipov, Black hat EU 2013:
-<a href="https://media.blackhat.com/eu-13/briefings/Osipov/bh-eu-13-XML-data-osipov-slides.pdf">XML Out-Of-Band Data Retrieval</a>.
+<a href="https://www.slideshare.net/qqlan/bh-ready-v4">XML Out-Of-Band Data Retrieval</a>.
 </li>
 <li>
 Denial of service attack (Billion laughs):

--- a/java/ql/src/Violations of Best Practice/Dead Code/FinalizerNullsFields.qhelp
+++ b/java/ql/src/Violations of Best Practice/Dead Code/FinalizerNullsFields.qhelp
@@ -77,7 +77,7 @@ severely affect performance, and you should avoid defining <code>finalize</code>
 </li>
 <li>
   IBM developerWorks:
-  <a href="https://www.ibm.com/developerworks/java/library/j-jtp01274/index.html#3.2">Java theory and practice: Explicit nulling</a>.
+  <a href="https://web.archive.org/web/20201111184342/https://www.ibm.com/developerworks/java/library/j-jtp01274/index.html#3.2">Java theory and practice: Explicit nulling</a>.
 </li>
 <li>
   Oracle Technology Network:

--- a/java/ql/src/Violations of Best Practice/legacy/ParameterAssignment.qhelp
+++ b/java/ql/src/Violations of Best Practice/legacy/ParameterAssignment.qhelp
@@ -41,7 +41,7 @@ Help - Eclipse Platform:
 </li>
 <li>
 Java Basics:
-<a href="http://www.leepoint.net/JavaBasics/methods/methods-22-local-variables.html">Methods 4 - Local variables</a>.
+<a href="https://web.archive.org/web/20200223080939/http://leepoint.net/JavaBasics/methods/methods-22-local-variables.html">Methods 4 - Local variables</a>.
 </li>
 
 

--- a/javascript/externs/es/es2016.js
+++ b/javascript/externs/es/es2016.js
@@ -4,7 +4,7 @@
 
 /**
  * @fileoverview Definitions for ECMAScript 2016.
- * @see http://www.ecma-international.org/ecma-262/7.0/
+ * @see https://262.ecma-international.org/7.0/
  * @externs
  */
 

--- a/javascript/externs/es/es6.js
+++ b/javascript/externs/es/es6.js
@@ -210,7 +210,7 @@ String.prototype.repeat = function(count) {};
 /**
  * @constructor
  * @extends {Array<string>}
- * @see http://www.ecma-international.org/ecma-262/6.0/#sec-gettemplateobject
+ * @see https://262.ecma-international.org/6.0/#sec-gettemplateobject
  */
 var ITemplateArray = function() {};
 
@@ -1228,7 +1228,7 @@ Array.prototype.entries;
  * @return {T|undefined}
  * @this {IArrayLike<T>|string}
  * @template T,S
- * @see http://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.find
+ * @see https://262.ecma-international.org/6.0/#sec-array.prototype.find
  */
 Array.prototype.find = function(predicate, opt_this) {};
 
@@ -1239,7 +1239,7 @@ Array.prototype.find = function(predicate, opt_this) {};
  * @return {number}
  * @this {IArrayLike<T>|string}
  * @template T,S
- * @see http://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.findindex
+ * @see https://262.ecma-international.org/6.0/#sec-array.prototype.findindex
  */
 Array.prototype.findIndex = function(predicate, opt_this) {};
 
@@ -1251,7 +1251,7 @@ Array.prototype.findIndex = function(predicate, opt_this) {};
  * @return {!IArrayLike<T>}
  * @this {!IArrayLike<T>|string}
  * @template T
- * @see http://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.fill
+ * @see https://262.ecma-international.org/6.0/#sec-array.prototype.fill
  */
 Array.prototype.fill = function(value, opt_begin, opt_end) {};
 
@@ -1260,7 +1260,7 @@ Array.prototype.fill = function(value, opt_begin, opt_end) {};
  * @param {number} target
  * @param {number} start
  * @param {number=} opt_end
- * @see http://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.copywithin
+ * @see https://262.ecma-international.org/6.0/#sec-array.prototype.copywithin
  * @template T
  * @return {!IArrayLike<T>}
  */
@@ -1281,7 +1281,7 @@ Array.prototype.includes = function(searchElement, opt_fromIndex) {};
 /**
  * @param {!Object} obj
  * @return {!Array<symbol>}
- * @see http://www.ecma-international.org/ecma-262/6.0/#sec-object.getownpropertysymbols
+ * @see https://262.ecma-international.org/6.0/#sec-object.getownpropertysymbols
  */
 Object.getOwnPropertySymbols = function(obj) {};
 
@@ -1290,7 +1290,7 @@ Object.getOwnPropertySymbols = function(obj) {};
  * @param {!Object} obj
  * @param {?} proto
  * @return {!Object}
- * @see http://www.ecma-international.org/ecma-262/6.0/#sec-object.setprototypeof
+ * @see https://262.ecma-international.org/6.0/#sec-object.setprototypeof
  */
 Object.setPrototypeOf = function(obj, proto) {};
 

--- a/javascript/ql/src/Declarations/SuspiciousMethodNameDeclaration.qhelp
+++ b/javascript/ql/src/Declarations/SuspiciousMethodNameDeclaration.qhelp
@@ -48,8 +48,8 @@ in the first place.
 </example>
 <references>
 
-<li>TypeScript specification: <a href="https://github.com/microsoft/TypeScript/blob/master/doc/spec.md#3.8.9">Constructor Type Literals</a>.</li>
-<li>TypeScript specification: <a href="https://github.com/microsoft/TypeScript/blob/master/doc/spec.md#8.3.1">Constructor Parameters</a>.</li>
+<li>TypeScript specification: <a href="https://github.com/microsoft/TypeScript/blob/30cb20434a6b117e007a4959b2a7c16489f86069/doc/spec-ARCHIVED.md#3.8.9">Constructor Type Literals</a>.</li>
+<li>TypeScript specification: <a href="https://github.com/microsoft/TypeScript/blob/30cb20434a6b117e007a4959b2a7c16489f86069/doc/spec-ARCHIVED.md#8.3.1">Constructor Parameters</a>.</li>
 
 </references>
 </qhelp>

--- a/javascript/ql/src/Declarations/UnreachableMethodOverloads.qhelp
+++ b/javascript/ql/src/Declarations/UnreachableMethodOverloads.qhelp
@@ -61,7 +61,7 @@
 </example>
 <references>
 
-<li>TypeScript specification: <a href="https://github.com/microsoft/TypeScript/blob/7be7cba050799bc11c9411babd31f44c9ec087f0/doc/spec.md#4.15.1">Overload Resolution</a></li>
+<li>TypeScript specification: <a href="https://github.com/microsoft/TypeScript/blob/30cb20434a6b117e007a4959b2a7c16489f86069/doc/spec-ARCHIVED.md#4.15.1">Overload Resolution</a></li>
 
 </references>
 </qhelp>

--- a/javascript/ql/src/LanguageFeatures/PropertyWriteOnPrimitive.qhelp
+++ b/javascript/ql/src/LanguageFeatures/PropertyWriteOnPrimitive.qhelp
@@ -58,7 +58,7 @@ for (var i=s.length; i%8; ++i)
 </example>
 
 <references>
-<li>Ecma International, <a href="http://www.ecma-international.org/ecma-262/7.0/#prod-AssignmentExpression">ECMAScript 2016 Language Specification, Section 12.15: Assignment Operators</a>.</li>
-<li>Ecma International, <a href="http://www.ecma-international.org/ecma-262/7.0/#sec-object.defineproperty">ECMAScript 2016 Language Specification, Section 19.1.2.4: Object.defineProperty</a>.</li>
+<li>Ecma International, <a href="https://262.ecma-international.org/7.0/#prod-AssignmentExpression">ECMAScript 2016 Language Specification, Section 12.15: Assignment Operators</a>.</li>
+<li>Ecma International, <a href="https://262.ecma-international.org/7.0/#sec-object.defineproperty">ECMAScript 2016 Language Specification, Section 19.1.2.4: Object.defineProperty</a>.</li>
 </references>
 </qhelp>

--- a/javascript/ql/src/NodeJS/CyclicImport.qhelp
+++ b/javascript/ql/src/NodeJS/CyclicImport.qhelp
@@ -39,7 +39,7 @@ so that it no longer depends on <code>a.js</code>:
 <references>
 
 
-<li>Brad Harris: <a href="http://selfcontained.us/2012/05/08/node-js-circular-dependencies/">node.js and circular dependencies</a>.</li>
+<li>Brad Harris: <a href="https://web.archive.org/web/20200203213815/http://selfcontained.us/2012/05/08/node-js-circular-dependencies/">node.js and circular dependencies</a>.</li>
 <li>Node.js Manual: <a href="http://nodejs.org/api/modules.html#modules_cycles">Modules</a>.</li>
 
 

--- a/javascript/ql/src/NodeJS/UnusedDependency.qhelp
+++ b/javascript/ql/src/NodeJS/UnusedDependency.qhelp
@@ -66,7 +66,7 @@ Since this dependency is only used during development, it should instead be list
 <references>
 
 
-<li>NPM Manual: <a href="https://www.npmjs.org/doc/files/package.json.html">package.json</a>.</li>
+<li>NPM Manual: <a href="https://docs.npmjs.com/cli/v7/configuring-npm/package-json">package.json</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.qhelp
+++ b/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.qhelp
@@ -76,7 +76,7 @@
 		</li>
 		<li>
 			OWASP:
-			<a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet">XSS
+			<a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS
 			(Cross Site Scripting) Prevention Cheat Sheet</a>.
 		</li>
 		<li>

--- a/javascript/ql/src/Security/CWE-400/RemotePropertyInjection.qhelp
+++ b/javascript/ql/src/Security/CWE-400/RemotePropertyInjection.qhelp
@@ -73,14 +73,14 @@
 	<li>Prototype pollution attacks:
 		<a href="https://github.com/electron/electron/pull/9287">electron</a>,
 		<a href="https://hackerone.com/reports/310443">lodash</a>,
-		<a href="https://nodesecurity.io/advisories/566">hoek</a>.
+		<a href="https://npmjs.com/advisories/566">hoek</a>.
 	</li>
 	<li> Penetration testing report:
 		<a href="http://seclists.org/pen-test/2009/Mar/67">
 			header name injection attack</a>
 	</li>
 	<li> npm blog post:
-		<a href="https://blog.liftsecurity.io/2015/01/14/the-dangers-of-square-bracket-notation#lift-security">
+		<a href="https://github.com/nodesecurity/eslint-plugin-security/blob/3c7522ca1be800353513282867a1034c795d9eb4/docs/the-dangers-of-square-bracket-notation.md">
 			dangers of square bracket notation</a>
 	</li>
 </references>

--- a/javascript/ql/src/Security/CWE-611/Xxe.qhelp
+++ b/javascript/ql/src/Security/CWE-611/Xxe.qhelp
@@ -34,7 +34,7 @@ To guard against XXE attacks, the <code>noent</code> option should be omitted or
 internal entities such as <code>&amp;amp;</code> or <code>&amp;gt;</code>. If desired, these
 entities can be expanded in a separate step using utility functions provided by libraries such
 as <a href="http://underscorejs.org/#unescape">underscore</a>,
-<a href="https://lodash.com/docs/latest#unescape">lodash</a> or
+<a href="https://lodash.com/docs/4.17.15#unescape">lodash</a> or
 <a href="https://github.com/mathiasbynens/he">he</a>.
 </p>
 <sample src="examples/XxeGood.js"/>
@@ -47,11 +47,11 @@ OWASP:
 </li>
 <li>
 Timothy Morgen:
-<a href="https://www.vsecurity.com//download/publications/XMLDTDEntityAttacks.pdf">XML Schema, DTD, and Entity Attacks</a>.
+<a href="https://research.nccgroup.com/2014/05/19/xml-schema-dtd-and-entity-attacks-a-compendium-of-known-techniques/">XML Schema, DTD, and Entity Attacks</a>.
 </li>
 <li>
 Timur Yunusov, Alexey Osipov:
-<a href="https://media.blackhat.com/eu-13/briefings/Osipov/bh-eu-13-XML-data-osipov-slides.pdf">XML Out-Of-Band Data Retrieval</a>.
+<a href="https://www.slideshare.net/qqlan/bh-ready-v4">XML Out-Of-Band Data Retrieval</a>.
 </li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-829/InsecureDownload.qhelp
+++ b/javascript/ql/src/Security/CWE-829/InsecureDownload.qhelp
@@ -33,6 +33,6 @@
 	</example>
 
 	<references>
-		<li>OWASP: <a href="https://owasp.org/www-community/attacks/Man-in-the-middle_attack">Man-in-the-middle attack</a>.</li>
+		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Man-in-the-middle_attack">Man-in-the-middle attack</a></li>
 	</references>
 </qhelp>

--- a/python/ql/src/Classes/ShouldBeContextManager.qhelp
+++ b/python/ql/src/Classes/ShouldBeContextManager.qhelp
@@ -31,7 +31,7 @@ updated to use a context manager.</p>
 </example>
 <references>
 
-<li>Effbot: <a href="http://effbot.org/zone/python-with-statement.htm">Python with statement</a>.</li>
+<li>Effbot: <a href="https://web.archive.org/web/20201012110738/http://effbot.org/zone/python-with-statement.htm">Python with statement</a>.</li>
 <li>Python Standard Library: <a href="http://docs.python.org/library/stdtypes.html#context-manager-types">Context manager
 </a>.</li>
 <li>Python Language Reference: <a href="http://docs.python.org/2.7/reference/datamodel.html#with-statement-context-managers">

--- a/python/ql/src/Functions/ModificationOfParameterWithDefault.qhelp
+++ b/python/ql/src/Functions/ModificationOfParameterWithDefault.qhelp
@@ -36,7 +36,7 @@ function with a default of <code>default=None</code>, check if the parameter is
 </example>
 <references>
 
-  <li>Effbot: <a href="http://effbot.org/zone/default-values.htm">Default Parameter Values in Python</a>.</li>
+  <li>Effbot: <a href="https://web.archive.org/web/20201112004749/http://effbot.org/zone/default-values.htm">Default Parameter Values in Python</a>.</li>
   <li>Python Language Reference: <a href="http://docs.python.org/2/reference/compound_stmts.html#function-definitions">Function definitions</a>.</li>
 
 

--- a/python/ql/src/Imports/CyclicImport.qhelp
+++ b/python/ql/src/Imports/CyclicImport.qhelp
@@ -29,7 +29,7 @@ import that.
 
 <li>Python Language  Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
 <li>Python: <a href="http://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
-<li> Effbot: <a href="http://effbot.org/zone/import-confusion.htm">Import Confusion</a>.</li>
+<li> Effbot: <a href="https://web.archive.org/web/20200917011425/https://effbot.org/zone/import-confusion.htm">Import Confusion</a>.</li>
 
 
 </references>

--- a/python/ql/src/Imports/ModuleLevelCyclicImport.qhelp
+++ b/python/ql/src/Imports/ModuleLevelCyclicImport.qhelp
@@ -33,7 +33,7 @@ import that.
 
 <li>Python Language  Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
 <li>Python: <a href="http://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
-<li> Effbot: <a href="http://effbot.org/zone/import-confusion.htm">Import Confusion</a>.</li>
+<li> Effbot: <a href="https://web.archive.org/web/20200917011425/https://effbot.org/zone/import-confusion.htm">Import Confusion</a>.</li>
 
 
 </references>

--- a/python/ql/src/Metrics/ClassEfferentCoupling.qhelp
+++ b/python/ql/src/Metrics/ClassEfferentCoupling.qhelp
@@ -49,7 +49,7 @@ so the general technique is quite widely applicable.
 
 
 <li>
-IBM developerWorks: <a href="http://www.ibm.com/developerworks/library/j-eaed6/">Evolutionary architecture and emergent design: Emergent design through metrics</a>.
+IBM developerWorks: <a href="https://web.archive.org/web/20190919085934/https://www.ibm.com/developerworks/library/j-eaed6/">Evolutionary architecture and emergent design: Emergent design through metrics</a>.
 </li>
 <li>
 R. Martin, <em>Agile Software Development: Principles, Patterns and Practices</em>. Pearson, 2011.

--- a/python/ql/src/Metrics/ModuleEfferentCoupling.qhelp
+++ b/python/ql/src/Metrics/ModuleEfferentCoupling.qhelp
@@ -29,7 +29,7 @@ You can reduce efferent coupling by splitting up a module so that each part depe
 
 
 <li>
-IBM developerWorks: <a href="http://www.ibm.com/developerworks/library/j-eaed6/">Evolutionary architecture and emergent design: Emergent design through metrics</a>.
+IBM developerWorks: <a href="https://web.archive.org/web/20190919085934/https://www.ibm.com/developerworks/library/j-eaed6/">Evolutionary architecture and emergent design: Emergent design through metrics</a>.
 </li>
 <li>
 R. Martin, <em>Agile Software Development: Principles, Patterns and Practices</em>. Pearson, 2011.

--- a/python/ql/src/Variables/ShadowGlobal.qhelp
+++ b/python/ql/src/Variables/ShadowGlobal.qhelp
@@ -26,9 +26,8 @@ variable should be renamed to make the code easier to interpret.</p>
 </example>
 <references>
 
-<li>J. Lusth, <i>The Art and Craft of Programming - Python Edition</i>, Section: Scope. University of Alabama, 2012. (<a href="http://troll.cs.ua.edu/ACP-PY/index_13.html">Published online</a>).</li>
-<li>New Mexico Tech Computer Center: <a href="http://infohost.nmt.edu/tcc/help/pubs/python/web/global-statement.html">The global
-statement: Declare access to a global name</a>.</li>
+<li>J. Lusth, <i>The Art and Craft of Programming - Python Edition</i>, Section: Scope. University of Alabama, 2012. (<a href="https://web.archive.org/web/20190919091129/http://troll.cs.ua.edu/ACP-PY/index_13.html">Published online</a>).</li>
+<li>Python Language Reference: <a href="http://docs.python.org/reference/simple_stmts.html#the-global-statement">The global statement</a>.</li>
 
 
 

--- a/python/ql/src/external/MostlyDuplicateClass.qhelp
+++ b/python/ql/src/external/MostlyDuplicateClass.qhelp
@@ -25,7 +25,7 @@ duplicate classes.</p>
 </recommendation>
 <references>
 
-  <li>E. Juergens, F. Deissenboeck, B. Hummel and S. Wagner, <em>Do Code Clones Matter?</em>, 2009. (<a href="http://www4.in.tum.de/~juergens/publications/ICSE2009_RP_0110_juergens.pdf">available online</a>).</li>
+  <li>E. Juergens, F. Deissenboeck, B. Hummel and S. Wagner, <em>Do Code Clones Matter?</em>, 2009. (<a href="https://wwwbroy.in.tum.de/~juergens/publications/ICSE2009_RP_0110_juergens.pdf">available online</a>).</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/external/MostlyDuplicateFile.qhelp
+++ b/python/ql/src/external/MostlyDuplicateFile.qhelp
@@ -25,7 +25,7 @@ importing that module into the original module.</p>
 </recommendation>
 <references>
 
-  <li>E. Juergens, F. Deissenboeck, B. Hummel and S. Wagner, <em>Do Code Clones Matter?</em>, 2009. (<a href="http://www4.in.tum.de/~juergens/publications/ICSE2009_RP_0110_juergens.pdf">available online</a>).</li>
+  <li>E. Juergens, F. Deissenboeck, B. Hummel and S. Wagner, <em>Do Code Clones Matter?</em>, 2009. (<a href="https://wwwbroy.in.tum.de/~juergens/publications/ICSE2009_RP_0110_juergens.pdf">available online</a>).</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/external/MostlySimilarFile.qhelp
+++ b/python/ql/src/external/MostlySimilarFile.qhelp
@@ -19,7 +19,7 @@ of the shared code into its own module and import that module into the original.
 </recommendation>
 <references>
 
-  <li>E. Juergens, F. Deissenboeck, B. Hummel and S. Wagner, <em>Do Code Clones Matter?</em>, 2009. (<a href="http://www4.in.tum.de/~juergens/publications/ICSE2009_RP_0110_juergens.pdf">available online</a>).</li>
+  <li>E. Juergens, F. Deissenboeck, B. Hummel and S. Wagner, <em>Do Code Clones Matter?</em>, 2009. (<a href="https://wwwbroy.in.tum.de/~juergens/publications/ICSE2009_RP_0110_juergens.pdf">available online</a>).</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/external/SimilarFunction.qhelp
+++ b/python/ql/src/external/SimilarFunction.qhelp
@@ -25,7 +25,7 @@ almost all of their lines are the same, then consider extracting the same lines 
 </recommendation>
 <references>
 
-  <li>E. Juergens, F. Deissenboeck, B. Hummel and S. Wagner, <em>Do Code Clones Matter?</em>, 2009. (<a href="http://www4.in.tum.de/~juergens/publications/ICSE2009_RP_0110_juergens.pdf">available online</a>).</li>
+  <li>E. Juergens, F. Deissenboeck, B. Hummel and S. Wagner, <em>Do Code Clones Matter?</em>, 2009. (<a href="https://wwwbroy.in.tum.de/~juergens/publications/ICSE2009_RP_0110_juergens.pdf">available online</a>).</li>
 
 </references>
 </qhelp>


### PR DESCRIPTION
For those documents with no obvious new home I've pointed the links to the Internet Archive.