### PR TITLE
Java: Denial of Service due to decoding of untrusted input

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-404/DecodeDos.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-404/DecodeDos.ql
@@ -1,0 +1,37 @@
+/**
+ * @name Denial Of Service due to decoding of untrusted input
+ * @description During the process of decoding of an untrusted input, `Exception`s can be thrown.
+ *              When these are not caught, they can lead to application crash causing a denial of service.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/decode
+ * @tags security
+ *       external/cwe/cwe-918
+ */
+
+import java
+import semmle.code.java.dataflow.FlowSources
+import DataFlow::PathGraph
+
+private class DecodeSink extends DataFlow::Node {
+  DecodeSink() {
+    exists(MethodAccess ma | ma.getMethod().hasQualifiedName(_, _, "decode") |
+      ma.getArgument(_) = this.asExpr() and
+      not exists(TryStmt ts | ma.getAnEnclosingStmt() = ts)
+    )
+  }
+}
+
+class DecodeDosConfiguration extends TaintTracking::Configuration {
+  DecodeDosConfiguration() { this = "DoS due to decode of untrusted input" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof DecodeSink }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, DecodeDosConfiguration conf
+where conf.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Potential server side request forgery due to $@.",
+  source.getNode(), "a user-provided value"


### PR DESCRIPTION
Decoding of variables can throw exceptions. When these exceptions are not caught, these can cause the application to crash leading to a denial of service. 

Best example of this vulnerability is [CVE-2020-13933](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13933) which occurred in Apache Shiro fixed by https://github.com/apache/shiro/commit/fdddd7cb982d9be69ea6b74bbe183fa47a22e5ee. In this case, the decoding of untrusted cookie values could lead to a `RuntimeException` to be thown causing the application to crash and hence, effect a denial of service.