### PR TITLE
JS: add global replacements using inverted char classes as a sanitizer for DOM based XSS

### DIFF
--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -1078,6 +1078,12 @@ module RegExp {
       not cls.isInverted() and
       cls.getAChild().(RegExpCharacterClassEscape).getValue().isUppercase()
     )
+    or
+    // an unlimited number of wildcards, is also a wildcard.
+    exists(InfiniteRepetitionQuantifier q |
+      term = q and
+      isWildcardLike(q.getAChild())
+    )
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -192,6 +192,19 @@ class RegExpQuantifier extends RegExpTerm, @regexp_quantifier {
 }
 
 /**
+ * A regular expression term that permits unlimited repetitions.
+ */
+class InfiniteRepetitionQuantifier extends RegExpQuantifier {
+  InfiniteRepetitionQuantifier() {
+    this instanceof RegExpPlus
+    or
+    this instanceof RegExpStar
+    or
+    this instanceof RegExpRange and not exists(this.(RegExpRange).getUpperBound())
+  }
+}
+
+/**
  * An escaped regular expression term, that is, a regular expression
  * term starting with a backslash.
  *

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -37,10 +37,8 @@ module Shared {
       (
         RegExp::alwaysMatchesMetaCharacter(getRegExp().getRoot(), ["<", "'", "\""])
         or
-        // or it's a global inverted char class.
-        getRegExp().getRoot().(RegExpCharacterClass).isInverted()
-        or
-        getRegExp().getRoot().(RegExpQuantifier).getAChild().(RegExpCharacterClass).isInverted()
+        // or it's like a wild-card.
+        RegExp::isWildcardLike(getRegExp().getRoot())
       )
     }
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -34,7 +34,14 @@ module Shared {
   class MetacharEscapeSanitizer extends Sanitizer, StringReplaceCall {
     MetacharEscapeSanitizer() {
       isGlobal() and
-      RegExp::alwaysMatchesMetaCharacter(getRegExp().getRoot(), ["<", "'", "\""])
+      (
+        RegExp::alwaysMatchesMetaCharacter(getRegExp().getRoot(), ["<", "'", "\""])
+        or
+        // or it's a global inverted char class.
+        getRegExp().getRoot().(RegExpCharacterClass).isInverted()
+        or
+        getRegExp().getRoot().(RegExpQuantifier).getAChild().(RegExpCharacterClass).isInverted()
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/security/performance/ReDoSUtil.qll
+++ b/javascript/ql/src/semmle/javascript/security/performance/ReDoSUtil.qll
@@ -54,19 +54,6 @@ private predicate isReDoSCandidate(State state, string pump) {
 }
 
 /**
- * A regular expression term that permits unlimited repetitions.
- */
-class InfiniteRepetitionQuantifier extends RegExpQuantifier {
-  InfiniteRepetitionQuantifier() {
-    this instanceof RegExpPlus
-    or
-    this instanceof RegExpStar
-    or
-    this instanceof RegExpRange and not exists(this.(RegExpRange).getUpperBound())
-  }
-}
-
-/**
  * Gets the char after `c` (from a simplified ASCII table).
  */
 private string nextChar(string c) { exists(int code | code = ascii(c) | code + 1 = ascii(result)) }

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
@@ -85,4 +85,8 @@
 
 	$("#id").html(anser.ansiToHtml(text)); // NOT OK
 	$("#id").html(new anser().process(text)); // NOT OK
+	
+	$("section h1").each(function(){
+		$("nav ul").append("<a href='#" + $(this).text().toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,'') + "'>Section</a>"); // OK
+	});
 })();


### PR DESCRIPTION
Fixes an FP I noticed in an internal project. 

[An evaluation was uneventful](https://github.com/dsp-testing/erik-krogh-dca/tree/run/domFP-default-xss/reports). 

I don't think this requires a change-note, but let me know if you think this change needs one. 