### PR TITLE
Java: Add StmtParent as superclass of SwitchExpr

### DIFF
--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1280,7 +1280,7 @@ class ConditionalExpr extends Expr, @conditionalexpr {
 /**
  * A `switch` expression.
  */
-class SwitchExpr extends Expr, @switchexpr {
+class SwitchExpr extends Expr, StmtParent, @switchexpr {
   /** Gets an immediate child statement of this `switch` expression. */
   Stmt getAStmt() { result.getParent() = this }
 


### PR DESCRIPTION
Database type `@stmtparent` already [includes `@switchexpr`](https://codeql.github.com/codeql-standard-libraries/java/type.@stmtparent.html), this change merely changes the class `SwitchExpr` to also accordingly extend `StmtParent`.