### PR TITLE
Fix inconsistency in the find-the-thief exercise

### DIFF
--- a/docs/codeql/writing-codeql-queries/find-the-thief.rst
+++ b/docs/codeql/writing-codeql-queries/find-the-thief.rst
@@ -39,11 +39,13 @@ You start asking some creative questions and making notes of the answers so you 
 +------+--------------------------------------------------------------------+--------+
 | (7)  | Is the thief taller than 180cm and shorter than 190cm?             | no     |
 +------+--------------------------------------------------------------------+--------+
-| (8)  | Is the thief the tallest person in the village?                    | no     |
+| (8)  | Is the thief the oldest person in the village?                     | no     |
 +------+--------------------------------------------------------------------+--------+
-| (9)  | Is the thief shorter than the average villager?                    | yes    |
+| (9)  | Is the thief the tallest person in the village?                    | no     |
 +------+--------------------------------------------------------------------+--------+
-| (10) | Is the thief the oldest person in the eastern part of the village? | yes    |
+| (10) | Is the thief shorter than the average villager?                    | yes    |
++------+--------------------------------------------------------------------+--------+
+| (11) | Is the thief the oldest person in the eastern part of the village? | yes    |
 +------+--------------------------------------------------------------------+--------+
 
 There is too much information to search through by hand, so you decide to use your newly acquired QL skills to help you with your investigation...


### PR DESCRIPTION
The find-the-thief exercise is inconsistent.  The first part lists 10 answered questions about the thief, but later discussion silently adds a new question as question 8, so there are a total of 11 answered questions.

This commit updates the first list of answered questions so that it matches later discussions and the sample solution.