### PR TITLE
Python: Limit absolute imports

### DIFF
--- a/python/ql/src/semmle/python/Module.qll
+++ b/python/ql/src/semmle/python/Module.qll
@@ -212,8 +212,15 @@ private string moduleNameFromBase(Container file) {
 private predicate transitively_imported_from_entry_point(File file) {
   file.getExtension().matches("%py%") and
   exists(File importer |
+    // Only consider files that are in the source archive
+    exists(importer.getRelativePath()) and
     importer.getParent() = file.getParent() and
-    exists(ImportExpr i | i.getLocation().getFile() = importer and i.getName() = file.getStem())
+    exists(ImportExpr i |
+      i.getLocation().getFile() = importer and
+      i.getName() = file.getStem() and
+      // Disregard relative imports
+      i.getLevel() = 0
+    )
   |
     importer.isPossibleEntryPoint() or transitively_imported_from_entry_point(importer)
   )


### PR DESCRIPTION
Limits the behaviour of github/codeql#5614 in two ways:

First, we only consider files that are contained in the source archive.
This prevents unnecessary computation involving files in e.g. the
standard library.

Secondly, we ignore any relative imports (e.g. `from .foo import ...`),
as these only work inside packages anyway.

This fixes an observed performance regression on projects that include
`google-cloud-sdk` as part of their source code.

As with #5614, I don't think a change note is required.