### PR TITLE
C#: Extract implicit constructor initializer calls

### DIFF
--- a/csharp/change-notes/2021-05-03-implicit-constructor-init.md
+++ b/csharp/change-notes/2021-05-03-implicit-constructor-init.md
@@ -1,0 +1,14 @@
+lgtm,codescanning
+* Implicit base constructor calls are now extracted. For example, in
+  ```csharp
+    class Base
+    {
+        public Base() { }
+    }
+
+    class Sub : Base
+    {
+        public Sub() { }
+    }
+  ```
+  there is an implicit call to the `Base` constructor from the `Sub` constructor.

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
@@ -41,7 +41,38 @@ namespace Semmle.Extraction.CSharp.Entities
             var initializer = syntax?.Initializer;
 
             if (initializer is null)
+            {
+                if (Symbol.MethodKind is MethodKind.Constructor)
+                {
+                    var baseType = Symbol.ContainingType.BaseType;
+                    if (baseType is null)
+                    {
+                        Context.ModelError(Symbol, "Unable to resolve base type in implicit constructor initializer");
+                        return;
+                    }
+
+                    var baseConstructor = baseType.InstanceConstructors.FirstOrDefault(c => c.Arity is 0);
+
+                    if (baseConstructor is null)
+                    {
+                        Context.ModelError(Symbol, "Unable to resolve implicit constructor initializer call");
+                        return;
+                    }
+
+                    var baseConstructorTarget = Create(Context, baseConstructor);
+                    var info = new ExpressionInfo(Context,
+                        AnnotatedTypeSymbol.CreateNotAnnotated(baseType),
+                        Location,
+                        Kinds.ExprKind.CONSTRUCTOR_INIT,
+                        this,
+                        -1,
+                        isCompilerGenerated: true,
+                        null);
+
+                    trapFile.expr_call(new Expression(info), baseConstructorTarget);
+                }
                 return;
+            }
 
             ITypeSymbol initializerType;
             var symbolInfo = Context.GetSymbolInfo(initializer);

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
@@ -244,18 +244,10 @@ module InitializerSplitting {
    * Holds if `c` is a non-static constructor that performs the initialization
    * of member `m`.
    */
-  predicate constructorInitializes(Constructor c, InitializedInstanceMember m) {
+  predicate constructorInitializes(InstanceConstructor c, InitializedInstanceMember m) {
     c.isUnboundDeclaration() and
-    not c.isStatic() and
-    c.getDeclaringType().hasMember(m) and
-    (
-      not c.hasInitializer()
-      or
-      // Members belonging to the base class are initialized via calls to the
-      // base constructor
-      c.getInitializer().isBase() and
-      m.getDeclaringType() = c.getDeclaringType()
-    )
+    c.getDeclaringType().getAMember() = m and
+    not c.getInitializer().isThis()
   }
 
   /**

--- a/csharp/ql/test/experimental/ir/ir/raw_ir.expected
+++ b/csharp/ql/test/experimental/ir/ir/raw_ir.expected
@@ -285,29 +285,37 @@ collections.cs:
 constructor_init.cs:
 #    5| System.Void BaseClass..ctor()
 #    5|   Block 0
-#    5|     v5_1(Void)             = EnterFunction     : 
-#    5|     mu5_2(<unknown>)       = AliasedDefinition : 
-#    5|     r5_3(glval<BaseClass>) = InitializeThis    : 
-#    6|     v6_1(Void)             = NoOp              : 
-#    5|     v5_4(Void)             = ReturnVoid        : 
-#    5|     v5_5(Void)             = AliasedUse        : ~m?
-#    5|     v5_6(Void)             = ExitFunction      : 
+#    5|     v5_1(Void)             = EnterFunction               : 
+#    5|     mu5_2(<unknown>)       = AliasedDefinition           : 
+#    5|     r5_3(glval<BaseClass>) = InitializeThis              : 
+#    5|     r5_4(glval<Object>)    = Convert[BaseClass : Object] : r5_3
+#    5|     r5_5(<funcaddr>)       = FunctionAddress[Object]     : 
+#    5|     v5_6(Void)             = Call[Object]                : func:r5_5, this:r5_4
+#    5|     mu5_7(<unknown>)       = ^CallSideEffect             : ~m?
+#    6|     v6_1(Void)             = NoOp                        : 
+#    5|     v5_8(Void)             = ReturnVoid                  : 
+#    5|     v5_9(Void)             = AliasedUse                  : ~m?
+#    5|     v5_10(Void)            = ExitFunction                : 
 
 #    9| System.Void BaseClass..ctor(System.Int32)
 #    9|   Block 0
-#    9|     v9_1(Void)             = EnterFunction          : 
-#    9|     mu9_2(<unknown>)       = AliasedDefinition      : 
-#    9|     r9_3(glval<BaseClass>) = InitializeThis         : 
-#    9|     r9_4(glval<Int32>)     = VariableAddress[i]     : 
-#    9|     mu9_5(Int32)           = InitializeParameter[i] : &:r9_4
-#   11|     r11_1(glval<Int32>)    = VariableAddress[i]     : 
-#   11|     r11_2(Int32)           = Load[i]                : &:r11_1, ~m?
-#   11|     r11_3(BaseClass)       = CopyValue              : r9_3
-#   11|     r11_4(glval<Int32>)    = FieldAddress[num]      : r11_3
-#   11|     mu11_5(Int32)          = Store[?]               : &:r11_4, r11_2
-#    9|     v9_6(Void)             = ReturnVoid             : 
-#    9|     v9_7(Void)             = AliasedUse             : ~m?
-#    9|     v9_8(Void)             = ExitFunction           : 
+#    9|     v9_1(Void)             = EnterFunction               : 
+#    9|     mu9_2(<unknown>)       = AliasedDefinition           : 
+#    9|     r9_3(glval<BaseClass>) = InitializeThis              : 
+#    9|     r9_4(glval<Int32>)     = VariableAddress[i]          : 
+#    9|     mu9_5(Int32)           = InitializeParameter[i]      : &:r9_4
+#    9|     r9_6(glval<Object>)    = Convert[BaseClass : Object] : r9_3
+#    9|     r9_7(<funcaddr>)       = FunctionAddress[Object]     : 
+#    9|     v9_8(Void)             = Call[Object]                : func:r9_7, this:r9_6
+#    9|     mu9_9(<unknown>)       = ^CallSideEffect             : ~m?
+#   11|     r11_1(glval<Int32>)    = VariableAddress[i]          : 
+#   11|     r11_2(Int32)           = Load[i]                     : &:r11_1, ~m?
+#   11|     r11_3(BaseClass)       = CopyValue                   : r9_3
+#   11|     r11_4(glval<Int32>)    = FieldAddress[num]           : r11_3
+#   11|     mu11_5(Int32)          = Store[?]                    : &:r11_4, r11_2
+#    9|     v9_10(Void)            = ReturnVoid                  : 
+#    9|     v9_11(Void)            = AliasedUse                  : ~m?
+#    9|     v9_12(Void)            = ExitFunction                : 
 
 #   17| System.Void DerivedClass..ctor()
 #   17|   Block 0
@@ -469,20 +477,24 @@ delegates.cs:
 events.cs:
 #    8| System.Void Events..ctor()
 #    8|   Block 0
-#    8|     v8_1(Void)          = EnterFunction          : 
-#    8|     mu8_2(<unknown>)    = AliasedDefinition      : 
-#    8|     r8_3(glval<Events>) = InitializeThis         : 
-#   10|     r10_1(MyDel)        = NewObj                 : 
-#   10|     r10_2(<funcaddr>)   = FunctionAddress[MyDel] : 
-#   10|     r10_3(glval<MyDel>) = FunctionAddress[Fun]   : 
-#   10|     v10_4(Void)         = Call[MyDel]            : func:r10_2, this:r10_1, 0:r10_3
-#   10|     mu10_5(<unknown>)   = ^CallSideEffect        : ~m?
-#   10|     r10_6(Events)       = CopyValue              : r8_3
-#   10|     r10_7(glval<MyDel>) = FieldAddress[Inst]     : r10_6
-#   10|     mu10_8(MyDel)       = Store[?]               : &:r10_7, r10_1
-#    8|     v8_4(Void)          = ReturnVoid             : 
-#    8|     v8_5(Void)          = AliasedUse             : ~m?
-#    8|     v8_6(Void)          = ExitFunction           : 
+#    8|     v8_1(Void)          = EnterFunction            : 
+#    8|     mu8_2(<unknown>)    = AliasedDefinition        : 
+#    8|     r8_3(glval<Events>) = InitializeThis           : 
+#    8|     r8_4(glval<Object>) = Convert[Events : Object] : r8_3
+#    8|     r8_5(<funcaddr>)    = FunctionAddress[Object]  : 
+#    8|     v8_6(Void)          = Call[Object]             : func:r8_5, this:r8_4
+#    8|     mu8_7(<unknown>)    = ^CallSideEffect          : ~m?
+#   10|     r10_1(MyDel)        = NewObj                   : 
+#   10|     r10_2(<funcaddr>)   = FunctionAddress[MyDel]   : 
+#   10|     r10_3(glval<MyDel>) = FunctionAddress[Fun]     : 
+#   10|     v10_4(Void)         = Call[MyDel]              : func:r10_2, this:r10_1, 0:r10_3
+#   10|     mu10_5(<unknown>)   = ^CallSideEffect          : ~m?
+#   10|     r10_6(Events)       = CopyValue                : r8_3
+#   10|     r10_7(glval<MyDel>) = FieldAddress[Inst]       : r10_6
+#   10|     mu10_8(MyDel)       = Store[?]                 : &:r10_7, r10_1
+#    8|     v8_8(Void)          = ReturnVoid               : 
+#    8|     v8_9(Void)          = AliasedUse               : ~m?
+#    8|     v8_10(Void)         = ExitFunction             : 
 
 #   13| System.Void Events.AddEvent()
 #   13|   Block 0
@@ -1237,29 +1249,37 @@ lock.cs:
 obj_creation.cs:
 #    7| System.Void ObjCreation.MyClass..ctor()
 #    7|   Block 0
-#    7|     v7_1(Void)           = EnterFunction     : 
-#    7|     mu7_2(<unknown>)     = AliasedDefinition : 
-#    7|     r7_3(glval<MyClass>) = InitializeThis    : 
-#    8|     v8_1(Void)           = NoOp              : 
-#    7|     v7_4(Void)           = ReturnVoid        : 
-#    7|     v7_5(Void)           = AliasedUse        : ~m?
-#    7|     v7_6(Void)           = ExitFunction      : 
+#    7|     v7_1(Void)           = EnterFunction             : 
+#    7|     mu7_2(<unknown>)     = AliasedDefinition         : 
+#    7|     r7_3(glval<MyClass>) = InitializeThis            : 
+#    7|     r7_4(glval<Object>)  = Convert[MyClass : Object] : r7_3
+#    7|     r7_5(<funcaddr>)     = FunctionAddress[Object]   : 
+#    7|     v7_6(Void)           = Call[Object]              : func:r7_5, this:r7_4
+#    7|     mu7_7(<unknown>)     = ^CallSideEffect           : ~m?
+#    8|     v8_1(Void)           = NoOp                      : 
+#    7|     v7_8(Void)           = ReturnVoid                : 
+#    7|     v7_9(Void)           = AliasedUse                : ~m?
+#    7|     v7_10(Void)          = ExitFunction              : 
 
 #   11| System.Void ObjCreation.MyClass..ctor(System.Int32)
 #   11|   Block 0
-#   11|     v11_1(Void)           = EnterFunction           : 
-#   11|     mu11_2(<unknown>)     = AliasedDefinition       : 
-#   11|     r11_3(glval<MyClass>) = InitializeThis          : 
-#   11|     r11_4(glval<Int32>)   = VariableAddress[_x]     : 
-#   11|     mu11_5(Int32)         = InitializeParameter[_x] : &:r11_4
-#   13|     r13_1(glval<Int32>)   = VariableAddress[_x]     : 
-#   13|     r13_2(Int32)          = Load[_x]                : &:r13_1, ~m?
-#   13|     r13_3(MyClass)        = CopyValue               : r11_3
-#   13|     r13_4(glval<Int32>)   = FieldAddress[x]         : r13_3
-#   13|     mu13_5(Int32)         = Store[?]                : &:r13_4, r13_2
-#   11|     v11_6(Void)           = ReturnVoid              : 
-#   11|     v11_7(Void)           = AliasedUse              : ~m?
-#   11|     v11_8(Void)           = ExitFunction            : 
+#   11|     v11_1(Void)           = EnterFunction             : 
+#   11|     mu11_2(<unknown>)     = AliasedDefinition         : 
+#   11|     r11_3(glval<MyClass>) = InitializeThis            : 
+#   11|     r11_4(glval<Int32>)   = VariableAddress[_x]       : 
+#   11|     mu11_5(Int32)         = InitializeParameter[_x]   : &:r11_4
+#   11|     r11_6(glval<Object>)  = Convert[MyClass : Object] : r11_3
+#   11|     r11_7(<funcaddr>)     = FunctionAddress[Object]   : 
+#   11|     v11_8(Void)           = Call[Object]              : func:r11_7, this:r11_6
+#   11|     mu11_9(<unknown>)     = ^CallSideEffect           : ~m?
+#   13|     r13_1(glval<Int32>)   = VariableAddress[_x]       : 
+#   13|     r13_2(Int32)          = Load[_x]                  : &:r13_1, ~m?
+#   13|     r13_3(MyClass)        = CopyValue                 : r11_3
+#   13|     r13_4(glval<Int32>)   = FieldAddress[x]           : r13_3
+#   13|     mu13_5(Int32)         = Store[?]                  : &:r13_4, r13_2
+#   11|     v11_10(Void)          = ReturnVoid                : 
+#   11|     v11_11(Void)          = AliasedUse                : ~m?
+#   11|     v11_12(Void)          = ExitFunction              : 
 
 #   17| System.Void ObjCreation.SomeFun(ObjCreation.MyClass)
 #   17|   Block 0
@@ -1884,13 +1904,17 @@ stmts.cs:
 using.cs:
 #    7| System.Void UsingStmt.MyDisposable..ctor()
 #    7|   Block 0
-#    7|     v7_1(Void)                = EnterFunction     : 
-#    7|     mu7_2(<unknown>)          = AliasedDefinition : 
-#    7|     r7_3(glval<MyDisposable>) = InitializeThis    : 
-#    7|     v7_4(Void)                = NoOp              : 
-#    7|     v7_5(Void)                = ReturnVoid        : 
-#    7|     v7_6(Void)                = AliasedUse        : ~m?
-#    7|     v7_7(Void)                = ExitFunction      : 
+#    7|     v7_1(Void)                = EnterFunction                  : 
+#    7|     mu7_2(<unknown>)          = AliasedDefinition              : 
+#    7|     r7_3(glval<MyDisposable>) = InitializeThis                 : 
+#    7|     r7_4(glval<Object>)       = Convert[MyDisposable : Object] : r7_3
+#    7|     r7_5(<funcaddr>)          = FunctionAddress[Object]        : 
+#    7|     v7_6(Void)                = Call[Object]                   : func:r7_5, this:r7_4
+#    7|     mu7_7(<unknown>)          = ^CallSideEffect                : ~m?
+#    7|     v7_8(Void)                = NoOp                           : 
+#    7|     v7_9(Void)                = ReturnVoid                     : 
+#    7|     v7_10(Void)               = AliasedUse                     : ~m?
+#    7|     v7_11(Void)               = ExitFunction                   : 
 
 #    8| System.Void UsingStmt.MyDisposable.DoSomething()
 #    8|   Block 0

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -674,14 +674,14 @@
 | Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | exit M6 | 2 |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | 1 |
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:39:11:39:11 | ; | 4 |
-| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | exit Initializers | 15 |
-| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | exit Initializers | 15 |
+| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | exit Initializers | 16 |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | exit Initializers | 16 |
 | Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | exit M | 22 |
 | Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... | 2 |
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | exit NoConstructor | 9 |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | exit Sub | 12 |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | exit Sub | 9 |
-| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | exit Sub | 19 |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | exit Sub | 14 |
 | Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | exit Test | 105 |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:9:13:9:28 | ... == ... | 7 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | exit M1 | 2 |
@@ -776,6 +776,7 @@
 | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 | 2 |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:18:9:18:22 | M2(...) | 2 |
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:9:18:22 | exit M2 | 4 |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationA.cs:20:12:20:13 | call to constructor Object | 1 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 | 1 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 | 1 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | exit C2 | 1 |
@@ -858,6 +859,7 @@
 | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 | 2 |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:16:9:16:31 | M2(...) | 2 |
 | MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:9:16:31 | exit M2 | 5 |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationB.cs:18:12:18:13 | call to constructor Object | 1 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 | 1 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 | 1 |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | exit C2 | 1 |
@@ -1231,7 +1233,7 @@
 | cflow.cs:127:48:127:49 | "" | cflow.cs:127:48:127:49 | "" | 1 |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field | 2 |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:62:127:64 | exit set_Prop | 8 |
-| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | exit ControlFlow | 8 |
+| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | exit ControlFlow | 9 |
 | cflow.cs:134:5:134:15 | enter ControlFlow | cflow.cs:134:5:134:15 | exit ControlFlow | 9 |
 | cflow.cs:136:12:136:22 | enter ControlFlow | cflow.cs:136:12:136:22 | exit ControlFlow | 8 |
 | cflow.cs:138:40:138:40 | enter + | cflow.cs:138:40:138:40 | exit + | 9 |
@@ -1330,7 +1332,7 @@
 | cflow.cs:284:5:284:18 | enter ControlFlowSub | cflow.cs:284:5:284:18 | exit ControlFlowSub | 5 |
 | cflow.cs:286:5:286:18 | enter ControlFlowSub | cflow.cs:286:5:286:18 | exit ControlFlowSub | 7 |
 | cflow.cs:291:12:291:12 | enter M | cflow.cs:291:12:291:12 | exit M | 6 |
-| cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | exit NegationInConstructor | 4 |
+| cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | exit NegationInConstructor | 5 |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:300:46:300:50 | ... > ... | 7 |
 | cflow.cs:300:44:300:51 | [false] !... | cflow.cs:300:44:300:51 | [false] !... | 1 |
 | cflow.cs:300:44:300:51 | [true] !... | cflow.cs:300:44:300:51 | [true] !... | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Consistency.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Consistency.expected
@@ -9,6 +9,8 @@ multipleSuccessors
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | successor | MultiImplementationA.cs:24:16:24:16 | this access |
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | successor | MultiImplementationB.cs:11:16:11:16 | this access |
 | MultiImplementationA.cs:13:16:13:20 | ... = ... | successor | MultiImplementationB.cs:22:16:22:16 | this access |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | successor | MultiImplementationA.cs:13:16:13:16 | this access |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | successor | MultiImplementationB.cs:11:16:11:16 | this access |
 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | successor | MultiImplementationA.cs:21:27:21:29 | {...} |
 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | successor | MultiImplementationB.cs:19:27:19:29 | {...} |
 | MultiImplementationA.cs:24:32:24:34 | ... = ... | successor | MultiImplementationA.cs:20:22:20:31 | {...} |
@@ -19,6 +21,8 @@ multipleSuccessors
 | MultiImplementationB.cs:11:16:11:20 | ... = ... | successor | MultiImplementationA.cs:24:16:24:16 | this access |
 | MultiImplementationB.cs:11:16:11:20 | ... = ... | successor | MultiImplementationB.cs:11:16:11:16 | this access |
 | MultiImplementationB.cs:11:16:11:20 | ... = ... | successor | MultiImplementationB.cs:22:16:22:16 | this access |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | successor | MultiImplementationA.cs:13:16:13:16 | this access |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | successor | MultiImplementationB.cs:11:16:11:16 | this access |
 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | successor | MultiImplementationA.cs:21:27:21:29 | {...} |
 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | successor | MultiImplementationB.cs:19:27:19:29 | {...} |
 | MultiImplementationB.cs:22:32:22:34 | ... = ... | successor | MultiImplementationA.cs:20:22:20:31 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -2475,10 +2475,12 @@ dominance
 | Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:9:6:9 | access to property G |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... |
-| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:8:5:8:16 | call to constructor Object | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | call to constructor Object |
 | Initializers.cs:8:5:8:16 | exit Initializers (normal) | Initializers.cs:8:5:8:16 | exit Initializers |
 | Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | exit Initializers (normal) |
-| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:10:5:10:16 | call to constructor Object | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | call to constructor Object |
 | Initializers.cs:10:5:10:16 | exit Initializers (normal) | Initializers.cs:10:5:10:16 | exit Initializers |
 | Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | exit Initializers (normal) |
 | Initializers.cs:12:10:12:10 | enter M | Initializers.cs:13:5:16:5 | {...} |
@@ -2506,16 +2508,10 @@ dominance
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:22:23:22:23 | this access |
 | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:20:11:20:23 | exit NoConstructor |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 |
-| Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 |
-| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access |
 | Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access |
 | Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... |
-| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... |
-| Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 |
 | Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 |
 | Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) |
-| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:28:13:28:13 | this access |
-| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... |
 | Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... |
 | Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 |
 | Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 |
@@ -2539,7 +2535,8 @@ dominance
 | Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub (normal) |
 | Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:31 | this access |
 | Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:35 | ... = ... |
-| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:35:9:35:11 | call to constructor NoConstructor | Initializers.cs:28:13:28:13 | this access |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | call to constructor NoConstructor |
 | Initializers.cs:35:9:35:11 | exit Sub (normal) | Initializers.cs:35:9:35:11 | exit Sub |
 | Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:29:35:38 | ...; |
 | Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:33:35:33 | access to parameter i |
@@ -2888,8 +2885,8 @@ dominance
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:21:18:21 | 0 |
 | MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | MultiImplementationA.cs:18:9:18:22 | exit M2 |
 | MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) |
-| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access |
-| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:11:16:11:16 | this access |
+| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |
+| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:24:20:29 | ...; |
 | MultiImplementationA.cs:20:24:20:24 | this access | MultiImplementationA.cs:20:28:20:28 | access to parameter i |
 | MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) |
@@ -2973,8 +2970,8 @@ dominance
 | MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | MultiImplementationB.cs:16:9:16:31 | exit M2 |
 | MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) |
 | MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:21:16:30 | throw ... |
-| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access |
-| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:11:16:11:16 | this access |
+| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |
+| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |
 | MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:30:18:33 | null |
 | MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) |
 | MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) |
@@ -3917,7 +3914,8 @@ dominance
 | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | exit set_Prop (normal) |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:72 | this access |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:80 | ... = ... |
-| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:130:5:132:5 | {...} |
+| cflow.cs:129:5:129:15 | call to constructor Object | cflow.cs:130:5:132:5 | {...} |
+| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | call to constructor Object |
 | cflow.cs:129:5:129:15 | exit ControlFlow (normal) | cflow.cs:129:5:129:15 | exit ControlFlow |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:18 | ...; |
 | cflow.cs:131:9:131:13 | this access | cflow.cs:131:17:131:17 | access to parameter s |
@@ -4278,7 +4276,8 @@ dominance
 | cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:40:291:40 | 0 |
 | cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:12:291:12 | exit M (normal) |
 | cflow.cs:291:40:291:40 | 0 | cflow.cs:291:38:291:41 | delegate call |
-| cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:52:296:54 | {...} |
+| cflow.cs:296:5:296:25 | call to constructor Object | cflow.cs:296:52:296:54 | {...} |
+| cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | call to constructor Object |
 | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | cflow.cs:296:5:296:25 | exit NegationInConstructor |
 | cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:299:5:301:5 | {...} |
@@ -6550,8 +6549,8 @@ postDominance
 | Foreach.cs:38:33:38:33 | Int32 y | Foreach.cs:38:26:38:26 | String x |
 | Foreach.cs:38:39:38:42 | access to parameter args | Foreach.cs:37:5:40:5 | {...} |
 | Foreach.cs:39:11:39:11 | ; | Foreach.cs:38:18:38:34 | (..., ...) |
-| Initializers.cs:5:9:5:9 | this access | Initializers.cs:8:5:8:16 | enter Initializers |
-| Initializers.cs:5:9:5:9 | this access | Initializers.cs:10:5:10:16 | enter Initializers |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:8:5:8:16 | call to constructor Object |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:10:5:10:16 | call to constructor Object |
 | Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:5:13:5:17 | ... + ... |
 | Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:5:13:5:17 | ... + ... |
 | Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:9:5:9 | this access |
@@ -6572,9 +6571,11 @@ postDominance
 | Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:31:6:31 | 2 |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:27 | access to field H |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:27 | access to field H |
+| Initializers.cs:8:5:8:16 | call to constructor Object | Initializers.cs:8:5:8:16 | enter Initializers |
 | Initializers.cs:8:5:8:16 | exit Initializers | Initializers.cs:8:5:8:16 | exit Initializers (normal) |
 | Initializers.cs:8:5:8:16 | exit Initializers (normal) | Initializers.cs:8:20:8:22 | {...} |
 | Initializers.cs:8:20:8:22 | {...} | Initializers.cs:6:25:6:31 | ... = ... |
+| Initializers.cs:10:5:10:16 | call to constructor Object | Initializers.cs:10:5:10:16 | enter Initializers |
 | Initializers.cs:10:5:10:16 | exit Initializers | Initializers.cs:10:5:10:16 | exit Initializers (normal) |
 | Initializers.cs:10:5:10:16 | exit Initializers (normal) | Initializers.cs:10:28:10:30 | {...} |
 | Initializers.cs:10:28:10:30 | {...} | Initializers.cs:6:25:6:31 | ... = ... |
@@ -6603,19 +6604,13 @@ postDominance
 | Initializers.cs:20:11:20:23 | exit NoConstructor | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) |
 | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:23:23:23:27 | ... = ... |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:20:11:20:23 | enter NoConstructor |
-| Initializers.cs:22:23:22:23 | this access | Initializers.cs:35:9:35:11 | enter Sub |
-| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:22:27:22:27 | 0 |
 | Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:22:27:22:27 | 0 |
 | Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:23 | this access |
-| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:23 | this access |
-| Initializers.cs:23:23:23:23 | this access | Initializers.cs:22:23:22:27 | ... = ... |
 | Initializers.cs:23:23:23:23 | this access | Initializers.cs:22:23:22:27 | ... = ... |
 | Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:23:27:23:27 | 1 |
-| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:23:27:23:27 | 1 |
 | Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:23 | this access |
-| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:23 | this access |
-| Initializers.cs:28:13:28:13 | this access | Initializers.cs:23:23:23:27 | ... = ... |
 | Initializers.cs:28:13:28:13 | this access | Initializers.cs:31:17:31:20 | call to constructor NoConstructor |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:35:9:35:11 | call to constructor NoConstructor |
 | Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:28:17:28:17 | 2 |
 | Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:28:17:28:17 | 2 |
 | Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:13 | this access |
@@ -6636,6 +6631,7 @@ postDominance
 | Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:35:33:35 | access to parameter i |
 | Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:29:33:38 | {...} |
 | Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:31 | this access |
+| Initializers.cs:35:9:35:11 | call to constructor NoConstructor | Initializers.cs:35:9:35:11 | enter Sub |
 | Initializers.cs:35:9:35:11 | exit Sub | Initializers.cs:35:9:35:11 | exit Sub (normal) |
 | Initializers.cs:35:9:35:11 | exit Sub (normal) | Initializers.cs:35:29:35:37 | ... = ... |
 | Initializers.cs:35:27:35:40 | {...} | Initializers.cs:28:13:28:17 | ... = ... |
@@ -7948,9 +7944,10 @@ postDominance
 | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:76:127:80 | access to parameter value |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:66:127:83 | {...} |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:72 | this access |
+| cflow.cs:129:5:129:15 | call to constructor Object | cflow.cs:129:5:129:15 | enter ControlFlow |
 | cflow.cs:129:5:129:15 | exit ControlFlow | cflow.cs:129:5:129:15 | exit ControlFlow (normal) |
 | cflow.cs:129:5:129:15 | exit ControlFlow (normal) | cflow.cs:131:9:131:17 | ... = ... |
-| cflow.cs:130:5:132:5 | {...} | cflow.cs:129:5:129:15 | enter ControlFlow |
+| cflow.cs:130:5:132:5 | {...} | cflow.cs:129:5:129:15 | call to constructor Object |
 | cflow.cs:131:9:131:13 | this access | cflow.cs:131:9:131:18 | ...; |
 | cflow.cs:131:9:131:17 | ... = ... | cflow.cs:131:17:131:17 | access to parameter s |
 | cflow.cs:131:9:131:18 | ...; | cflow.cs:130:5:132:5 | {...} |
@@ -8301,9 +8298,10 @@ postDominance
 | cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:12:291:12 | enter M |
 | cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:40:291:40 | 0 |
 | cflow.cs:291:40:291:40 | 0 | cflow.cs:291:38:291:38 | access to parameter f |
+| cflow.cs:296:5:296:25 | call to constructor Object | cflow.cs:296:5:296:25 | enter NegationInConstructor |
 | cflow.cs:296:5:296:25 | exit NegationInConstructor | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) |
 | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | cflow.cs:296:52:296:54 | {...} |
-| cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | enter NegationInConstructor |
+| cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | call to constructor Object |
 | cflow.cs:298:10:298:10 | exit M | cflow.cs:298:10:298:10 | exit M (normal) |
 | cflow.cs:298:10:298:10 | exit M (normal) | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor |
 | cflow.cs:299:5:301:5 | {...} | cflow.cs:298:10:298:10 | enter M |
@@ -11404,12 +11402,15 @@ blockDominance
 | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:9:18:22 | enter M2 |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access |
+| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | exit C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:22:20:31 | {...} |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:24:16:24:16 | this access |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:11:16:11:16 | this access |
+| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | exit C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:22:18:36 | {...} |
@@ -11534,12 +11535,15 @@ blockDominance
 | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:15:5:17:5 | {...} |
 | MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:9:16:31 | enter M2 |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access |
+| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | exit C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:22:20:31 | {...} |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:24:16:24:16 | this access |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:11:16:11:16 | this access |
+| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | exit C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:22:18:36 | {...} |
@@ -14983,15 +14987,18 @@ postBlockDominance
 | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:15:5:17:5 | {...} |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:9:18:22 | enter M2 |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | exit C2 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationB.cs:18:12:18:13 | exit C2 |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:13:16:13:16 | this access |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:12:20:13 | enter C2 |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:22:20:31 | {...} |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:24:16:24:16 | this access |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:11:16:11:16 | this access |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:18:12:18:13 | enter C2 |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationB.cs:22:16:22:16 | this access |
 | MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:12:21:13 | enter C2 |
@@ -15087,6 +15094,7 @@ postBlockDominance
 | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:15:5:17:5 | {...} |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:15:5:17:5 | {...} |
 | MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:9:16:31 | enter M2 |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | enter C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | enter C2 |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | exit C2 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -2675,10 +2675,12 @@ nodeEnclosing
 | Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:10:5:10:16 | Initializers |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:8:5:8:16 | Initializers |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:8:5:8:16 | call to constructor Object | Initializers.cs:8:5:8:16 | Initializers |
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | Initializers |
 | Initializers.cs:8:5:8:16 | exit Initializers | Initializers.cs:8:5:8:16 | Initializers |
 | Initializers.cs:8:5:8:16 | exit Initializers (normal) | Initializers.cs:8:5:8:16 | Initializers |
 | Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:10:5:10:16 | call to constructor Object | Initializers.cs:10:5:10:16 | Initializers |
 | Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | Initializers |
 | Initializers.cs:10:5:10:16 | exit Initializers | Initializers.cs:10:5:10:16 | Initializers |
 | Initializers.cs:10:5:10:16 | exit Initializers (normal) | Initializers.cs:10:5:10:16 | Initializers |
@@ -2709,17 +2711,11 @@ nodeEnclosing
 | Initializers.cs:20:11:20:23 | exit NoConstructor | Initializers.cs:20:11:20:23 | NoConstructor |
 | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:20:11:20:23 | NoConstructor |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:20:11:20:23 | NoConstructor |
-| Initializers.cs:22:23:22:23 | this access | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:20:11:20:23 | NoConstructor |
-| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:22:27:22:27 | 0 | Initializers.cs:20:11:20:23 | NoConstructor |
-| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:23:23:23:23 | this access | Initializers.cs:20:11:20:23 | NoConstructor |
-| Initializers.cs:23:23:23:23 | this access | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | NoConstructor |
-| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:23:27:23:27 | 1 | Initializers.cs:20:11:20:23 | NoConstructor |
-| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:28:13:28:13 | this access | Initializers.cs:31:9:31:11 | Sub |
 | Initializers.cs:28:13:28:13 | this access | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:31:9:31:11 | Sub |
@@ -2744,6 +2740,7 @@ nodeEnclosing
 | Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | Sub |
 | Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:9:33:11 | Sub |
 | Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:9:33:11 | Sub |
+| Initializers.cs:35:9:35:11 | call to constructor NoConstructor | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:35:9:35:11 | exit Sub | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:35:9:35:11 | exit Sub (normal) | Initializers.cs:35:9:35:11 | Sub |
@@ -3167,6 +3164,8 @@ nodeEnclosing
 | MultiImplementationA.cs:18:9:18:22 | exit M2 | MultiImplementationA.cs:18:9:18:22 | M2 |
 | MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | MultiImplementationA.cs:18:9:18:22 | M2 |
 | MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | M2 |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationA.cs:20:12:20:13 | C2 |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
@@ -3354,6 +3353,8 @@ nodeEnclosing
 | MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | MultiImplementationB.cs:16:9:16:31 | M2 |
 | MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:9:16:31 | M2 |
 | MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:9:16:31 | M2 |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationA.cs:20:12:20:13 | C2 |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
@@ -4436,6 +4437,7 @@ nodeEnclosing
 | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | set_Prop |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:62:127:64 | set_Prop |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:62:127:64 | set_Prop |
+| cflow.cs:129:5:129:15 | call to constructor Object | cflow.cs:129:5:129:15 | ControlFlow |
 | cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | ControlFlow |
 | cflow.cs:129:5:129:15 | exit ControlFlow | cflow.cs:129:5:129:15 | ControlFlow |
 | cflow.cs:129:5:129:15 | exit ControlFlow (normal) | cflow.cs:129:5:129:15 | ControlFlow |
@@ -4826,6 +4828,7 @@ nodeEnclosing
 | cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:12:291:12 | M |
 | cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:12:291:12 | M |
 | cflow.cs:291:40:291:40 | 0 | cflow.cs:291:12:291:12 | M |
+| cflow.cs:296:5:296:25 | call to constructor Object | cflow.cs:296:5:296:25 | NegationInConstructor |
 | cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | NegationInConstructor |
 | cflow.cs:296:5:296:25 | exit NegationInConstructor | cflow.cs:296:5:296:25 | NegationInConstructor |
 | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | cflow.cs:296:5:296:25 | NegationInConstructor |
@@ -5628,6 +5631,8 @@ blockEnclosing
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:9:18:22 | M2 |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationA.cs:20:12:20:13 | C2 |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
 | MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
@@ -5716,6 +5721,8 @@ blockEnclosing
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationA.cs:16:17:16:18 | M1 |
 | MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:14:17:14:18 | M1 |
 | MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:9:16:31 | M2 |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationA.cs:20:12:20:13 | C2 |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | C2 |
 | MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | C2 |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 | MultiImplementationA.cs:20:12:20:13 | C2 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -1687,7 +1687,9 @@
 | Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:27:6:27 | access to field H |
 | Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:27:6:27 | access to field H |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:31:6:31 | 2 |
+| Initializers.cs:8:5:8:16 | call to constructor Object | Initializers.cs:8:5:8:16 | call to constructor Object |
 | Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:20:8:22 | {...} |
+| Initializers.cs:10:5:10:16 | call to constructor Object | Initializers.cs:10:5:10:16 | call to constructor Object |
 | Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:28:10:30 | {...} |
 | Initializers.cs:13:5:16:5 | {...} | Initializers.cs:13:5:16:5 | {...} |
 | Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:14:9:14:54 | ... ...; |
@@ -1735,6 +1737,7 @@
 | Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:31:33:31 | this access |
 | Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:36 | ...; |
 | Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:35:33:35 | access to parameter i |
+| Initializers.cs:35:9:35:11 | call to constructor NoConstructor | Initializers.cs:35:9:35:11 | call to constructor NoConstructor |
 | Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:27:35:40 | {...} |
 | Initializers.cs:35:29:35:29 | access to field I | Initializers.cs:35:29:35:29 | this access |
 | Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:29:35:29 | this access |
@@ -2045,6 +2048,7 @@
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationA.cs:18:9:18:22 | M2(...) |
 | MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:21:18:21 | 0 |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:22:20:31 | {...} |
 | MultiImplementationA.cs:20:24:20:24 | access to field F | MultiImplementationA.cs:20:24:20:24 | this access |
 | MultiImplementationA.cs:20:24:20:24 | this access | MultiImplementationA.cs:20:24:20:24 | this access |
@@ -2089,6 +2093,7 @@
 | MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationB.cs:16:9:16:31 | M2(...) |
 | MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:27:16:30 | null |
 | MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:27:16:30 | null |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |
 | MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:22:18:36 | {...} |
 | MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationB.cs:18:30:18:33 | null |
 | MultiImplementationB.cs:18:30:18:33 | null | MultiImplementationB.cs:18:30:18:33 | null |
@@ -2933,6 +2938,7 @@
 | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:68:127:72 | this access |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:81 | ...; |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:76:127:80 | access to parameter value |
+| cflow.cs:129:5:129:15 | call to constructor Object | cflow.cs:129:5:129:15 | call to constructor Object |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:130:5:132:5 | {...} |
 | cflow.cs:131:9:131:13 | access to field Field | cflow.cs:131:9:131:13 | this access |
 | cflow.cs:131:9:131:13 | this access | cflow.cs:131:9:131:13 | this access |
@@ -3267,6 +3273,7 @@
 | cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:38:291:38 | access to parameter f |
 | cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:38:291:38 | access to parameter f |
 | cflow.cs:291:40:291:40 | 0 | cflow.cs:291:40:291:40 | 0 |
+| cflow.cs:296:5:296:25 | call to constructor Object | cflow.cs:296:5:296:25 | call to constructor Object |
 | cflow.cs:296:52:296:54 | {...} | cflow.cs:296:52:296:54 | {...} |
 | cflow.cs:299:5:301:5 | {...} | cflow.cs:299:5:301:5 | {...} |
 | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:300:38:300:38 | 0 |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -2325,7 +2325,9 @@
 | Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:27:6:27 | access to field H | normal |
 | Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:27:6:31 | ... + ... | normal |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:31:6:31 | 2 | normal |
+| Initializers.cs:8:5:8:16 | call to constructor Object | Initializers.cs:8:5:8:16 | call to constructor Object | normal |
 | Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:20:8:22 | {...} | normal |
+| Initializers.cs:10:5:10:16 | call to constructor Object | Initializers.cs:10:5:10:16 | call to constructor Object | normal |
 | Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:28:10:30 | {...} | normal |
 | Initializers.cs:13:5:16:5 | {...} | Initializers.cs:15:13:15:63 | Initializers[] iz = ... | normal |
 | Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:14:13:14:53 | Initializers i = ... | normal |
@@ -2373,6 +2375,7 @@
 | Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:31:33:35 | ... = ... | normal |
 | Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:35 | ... = ... | normal |
 | Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:35:33:35 | access to parameter i | normal |
+| Initializers.cs:35:9:35:11 | call to constructor NoConstructor | Initializers.cs:35:9:35:11 | call to constructor NoConstructor | normal |
 | Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:29:35:37 | ... = ... | normal |
 | Initializers.cs:35:29:35:29 | access to field I | Initializers.cs:35:29:35:29 | this access | normal |
 | Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:29:35:29 | this access | normal |
@@ -2697,6 +2700,7 @@
 | MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:18:9:18:22 | M2(...) | normal |
 | MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationA.cs:18:9:18:22 | M2(...) | normal |
 | MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:21:18:21 | 0 | normal |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationA.cs:20:12:20:13 | call to constructor Object | normal |
 | MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:24:20:28 | ... = ... | normal |
 | MultiImplementationA.cs:20:24:20:24 | access to field F | MultiImplementationA.cs:20:24:20:24 | this access | normal |
 | MultiImplementationA.cs:20:24:20:24 | this access | MultiImplementationA.cs:20:24:20:24 | this access | normal |
@@ -2741,6 +2745,7 @@
 | MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationB.cs:16:9:16:31 | M2(...) | normal |
 | MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:21:16:30 | throw ... | throw(NullReferenceException) |
 | MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:27:16:30 | null | normal |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationB.cs:18:12:18:13 | call to constructor Object | normal |
 | MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:24:18:34 | throw ...; | throw(NullReferenceException) |
 | MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationB.cs:18:24:18:34 | throw ...; | throw(NullReferenceException) |
 | MultiImplementationB.cs:18:30:18:33 | null | MultiImplementationB.cs:18:30:18:33 | null | normal |
@@ -3868,6 +3873,7 @@
 | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:68:127:80 | ... = ... | normal |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:80 | ... = ... | normal |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:76:127:80 | access to parameter value | normal |
+| cflow.cs:129:5:129:15 | call to constructor Object | cflow.cs:129:5:129:15 | call to constructor Object | normal |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:17 | ... = ... | normal |
 | cflow.cs:131:9:131:13 | access to field Field | cflow.cs:131:9:131:13 | this access | normal |
 | cflow.cs:131:9:131:13 | this access | cflow.cs:131:9:131:13 | this access | normal |
@@ -4272,6 +4278,7 @@
 | cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:38:291:38 | access to parameter f | normal |
 | cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:38:291:41 | delegate call | normal |
 | cflow.cs:291:40:291:40 | 0 | cflow.cs:291:40:291:40 | 0 | normal |
+| cflow.cs:296:5:296:25 | call to constructor Object | cflow.cs:296:5:296:25 | call to constructor Object | normal |
 | cflow.cs:296:52:296:54 | {...} | cflow.cs:296:52:296:54 | {...} | normal |
 | cflow.cs:299:5:301:5 | {...} | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | normal |
 | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -2792,10 +2792,12 @@
 | Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:9:6:9 | access to property G | semmle.label | successor |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... | semmle.label | successor |
 | Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... | semmle.label | successor |
-| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access | semmle.label | successor |
+| Initializers.cs:8:5:8:16 | call to constructor Object | Initializers.cs:5:9:5:9 | this access | semmle.label | successor |
+| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | call to constructor Object | semmle.label | successor |
 | Initializers.cs:8:5:8:16 | exit Initializers (normal) | Initializers.cs:8:5:8:16 | exit Initializers | semmle.label | successor |
 | Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | exit Initializers (normal) | semmle.label | successor |
-| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access | semmle.label | successor |
+| Initializers.cs:10:5:10:16 | call to constructor Object | Initializers.cs:5:9:5:9 | this access | semmle.label | successor |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | call to constructor Object | semmle.label | successor |
 | Initializers.cs:10:5:10:16 | exit Initializers (normal) | Initializers.cs:10:5:10:16 | exit Initializers | semmle.label | successor |
 | Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | exit Initializers (normal) | semmle.label | successor |
 | Initializers.cs:12:10:12:10 | enter M | Initializers.cs:13:5:16:5 | {...} | semmle.label | successor |
@@ -2823,16 +2825,10 @@
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:22:23:22:23 | this access | semmle.label | successor |
 | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:20:11:20:23 | exit NoConstructor | semmle.label | successor |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 | semmle.label | successor |
-| Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 | semmle.label | successor |
-| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access | semmle.label | successor |
 | Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access | semmle.label | successor |
 | Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... | semmle.label | successor |
-| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... | semmle.label | successor |
-| Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 | semmle.label | successor |
 | Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 | semmle.label | successor |
 | Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | semmle.label | successor |
-| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:28:13:28:13 | this access | semmle.label | successor |
-| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... | semmle.label | successor |
 | Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... | semmle.label | successor |
 | Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 | semmle.label | successor |
 | Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 | semmle.label | successor |
@@ -2856,7 +2852,8 @@
 | Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub (normal) | semmle.label | successor |
 | Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:31 | this access | semmle.label | successor |
 | Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:35 | ... = ... | semmle.label | successor |
-| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:22:23:22:23 | this access | semmle.label | successor |
+| Initializers.cs:35:9:35:11 | call to constructor NoConstructor | Initializers.cs:28:13:28:13 | this access | semmle.label | successor |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | call to constructor NoConstructor | semmle.label | successor |
 | Initializers.cs:35:9:35:11 | exit Sub (normal) | Initializers.cs:35:9:35:11 | exit Sub | semmle.label | successor |
 | Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:29:35:38 | ...; | semmle.label | successor |
 | Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:33:35:33 | access to parameter i | semmle.label | successor |
@@ -3253,8 +3250,10 @@
 | MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:21:18:21 | 0 | semmle.label | successor |
 | MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | MultiImplementationA.cs:18:9:18:22 | exit M2 | semmle.label | successor |
 | MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | semmle.label | successor |
-| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access | semmle.label | successor |
-| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:11:16:11:16 | this access | semmle.label | successor |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationA.cs:13:16:13:16 | this access | semmle.label | successor |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationB.cs:11:16:11:16 | this access | semmle.label | successor |
+| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object | semmle.label | successor |
+| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object | semmle.label | successor |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
 | MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
@@ -3394,8 +3393,10 @@
 | MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | MultiImplementationB.cs:16:9:16:31 | exit M2 | semmle.label | successor |
 | MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | semmle.label | exception(NullReferenceException) |
 | MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:21:16:30 | throw ... | semmle.label | successor |
-| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:13:16:13:16 | this access | semmle.label | successor |
-| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:11:16:11:16 | this access | semmle.label | successor |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationA.cs:13:16:13:16 | this access | semmle.label | successor |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationB.cs:11:16:11:16 | this access | semmle.label | successor |
+| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object | semmle.label | successor |
+| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object | semmle.label | successor |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
 | MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
@@ -4501,7 +4502,8 @@
 | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | exit set_Prop (normal) | semmle.label | successor |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:72 | this access | semmle.label | successor |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:80 | ... = ... | semmle.label | successor |
-| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:130:5:132:5 | {...} | semmle.label | successor |
+| cflow.cs:129:5:129:15 | call to constructor Object | cflow.cs:130:5:132:5 | {...} | semmle.label | successor |
+| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | call to constructor Object | semmle.label | successor |
 | cflow.cs:129:5:129:15 | exit ControlFlow (normal) | cflow.cs:129:5:129:15 | exit ControlFlow | semmle.label | successor |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:18 | ...; | semmle.label | successor |
 | cflow.cs:131:9:131:13 | this access | cflow.cs:131:17:131:17 | access to parameter s | semmle.label | successor |
@@ -4894,7 +4896,8 @@
 | cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:40:291:40 | 0 | semmle.label | successor |
 | cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:12:291:12 | exit M (normal) | semmle.label | successor |
 | cflow.cs:291:40:291:40 | 0 | cflow.cs:291:38:291:41 | delegate call | semmle.label | successor |
-| cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:52:296:54 | {...} | semmle.label | successor |
+| cflow.cs:296:5:296:25 | call to constructor Object | cflow.cs:296:52:296:54 | {...} | semmle.label | successor |
+| cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | call to constructor Object | semmle.label | successor |
 | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | cflow.cs:296:5:296:25 | exit NegationInConstructor | semmle.label | successor |
 | cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | semmle.label | successor |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:299:5:301:5 | {...} | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -1137,13 +1137,13 @@ entryPoint
 | Foreach.cs:24:10:24:11 | M4 | Foreach.cs:25:5:28:5 | {...} |
 | Foreach.cs:30:10:30:11 | M5 | Foreach.cs:31:5:34:5 | {...} |
 | Foreach.cs:36:10:36:11 | M6 | Foreach.cs:37:5:40:5 | {...} |
-| Initializers.cs:8:5:8:16 | Initializers | Initializers.cs:5:9:5:9 | this access |
-| Initializers.cs:10:5:10:16 | Initializers | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:8:5:8:16 | Initializers | Initializers.cs:8:5:8:16 | call to constructor Object |
+| Initializers.cs:10:5:10:16 | Initializers | Initializers.cs:10:5:10:16 | call to constructor Object |
 | Initializers.cs:12:10:12:10 | M | Initializers.cs:13:5:16:5 | {...} |
 | Initializers.cs:20:11:20:23 | NoConstructor | Initializers.cs:22:23:22:23 | this access |
 | Initializers.cs:31:9:31:11 | Sub | Initializers.cs:31:17:31:20 | call to constructor NoConstructor |
 | Initializers.cs:33:9:33:11 | Sub | Initializers.cs:33:22:33:25 | call to constructor Sub |
-| Initializers.cs:35:9:35:11 | Sub | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:35:9:35:11 | Sub | Initializers.cs:35:9:35:11 | call to constructor NoConstructor |
 | Initializers.cs:51:10:51:13 | Test | Initializers.cs:52:5:66:5 | {...} |
 | LoopUnrolling.cs:7:10:7:11 | M1 | LoopUnrolling.cs:8:5:13:5 | {...} |
 | LoopUnrolling.cs:15:10:15:11 | M2 | LoopUnrolling.cs:16:5:20:5 | {...} |
@@ -1173,8 +1173,8 @@ entryPoint
 | MultiImplementationA.cs:16:17:16:18 | M1 | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationA.cs:16:17:16:18 | M1 | MultiImplementationB.cs:15:5:17:5 | {...} |
 | MultiImplementationA.cs:18:9:18:22 | M2 | MultiImplementationA.cs:18:21:18:21 | 0 |
-| MultiImplementationA.cs:20:12:20:13 | C2 | MultiImplementationA.cs:13:16:13:16 | this access |
-| MultiImplementationA.cs:20:12:20:13 | C2 | MultiImplementationB.cs:11:16:11:16 | this access |
+| MultiImplementationA.cs:20:12:20:13 | C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |
+| MultiImplementationA.cs:20:12:20:13 | C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |
 | MultiImplementationA.cs:21:12:21:13 | C2 | MultiImplementationA.cs:21:24:21:24 | 0 |
 | MultiImplementationA.cs:21:12:21:13 | C2 | MultiImplementationB.cs:19:24:19:24 | 1 |
 | MultiImplementationA.cs:22:6:22:7 | ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} |
@@ -1202,8 +1202,8 @@ entryPoint
 | MultiImplementationB.cs:14:17:14:18 | M1 | MultiImplementationA.cs:17:5:19:5 | {...} |
 | MultiImplementationB.cs:14:17:14:18 | M1 | MultiImplementationB.cs:15:5:17:5 | {...} |
 | MultiImplementationB.cs:16:9:16:31 | M2 | MultiImplementationB.cs:16:27:16:30 | null |
-| MultiImplementationB.cs:18:12:18:13 | C2 | MultiImplementationA.cs:13:16:13:16 | this access |
-| MultiImplementationB.cs:18:12:18:13 | C2 | MultiImplementationB.cs:11:16:11:16 | this access |
+| MultiImplementationB.cs:18:12:18:13 | C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |
+| MultiImplementationB.cs:18:12:18:13 | C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |
 | MultiImplementationB.cs:19:12:19:13 | C2 | MultiImplementationA.cs:21:24:21:24 | 0 |
 | MultiImplementationB.cs:19:12:19:13 | C2 | MultiImplementationB.cs:19:24:19:24 | 1 |
 | MultiImplementationB.cs:20:6:20:7 | ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} |
@@ -1265,7 +1265,7 @@ entryPoint
 | cflow.cs:119:20:119:21 | M5 | cflow.cs:120:5:124:5 | {...} |
 | cflow.cs:127:19:127:21 | get_Prop | cflow.cs:127:23:127:60 | {...} |
 | cflow.cs:127:62:127:64 | set_Prop | cflow.cs:127:66:127:83 | {...} |
-| cflow.cs:129:5:129:15 | ControlFlow | cflow.cs:130:5:132:5 | {...} |
+| cflow.cs:129:5:129:15 | ControlFlow | cflow.cs:129:5:129:15 | call to constructor Object |
 | cflow.cs:134:5:134:15 | ControlFlow | cflow.cs:134:31:134:31 | access to parameter i |
 | cflow.cs:136:12:136:22 | ControlFlow | cflow.cs:136:33:136:33 | 0 |
 | cflow.cs:138:40:138:40 | + | cflow.cs:139:5:142:5 | {...} |
@@ -1285,5 +1285,5 @@ entryPoint
 | cflow.cs:284:5:284:18 | ControlFlowSub | cflow.cs:284:32:284:35 | call to constructor ControlFlowSub |
 | cflow.cs:286:5:286:18 | ControlFlowSub | cflow.cs:286:34:286:34 | access to parameter i |
 | cflow.cs:291:12:291:12 | M | cflow.cs:291:38:291:38 | access to parameter f |
-| cflow.cs:296:5:296:25 | NegationInConstructor | cflow.cs:296:52:296:54 | {...} |
+| cflow.cs:296:5:296:25 | NegationInConstructor | cflow.cs:296:5:296:25 | call to constructor Object |
 | cflow.cs:298:10:298:10 | M | cflow.cs:299:5:301:5 | {...} |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -167,7 +167,9 @@
 | Splitting.cs:32:9:32:16 | [b (line 24): false] dynamic call to method Check | normal | Splitting.cs:32:9:32:16 | [b (line 24): false] dynamic call to method Check |
 | Splitting.cs:32:9:32:16 | [b (line 24): true] dynamic call to method Check | normal | Splitting.cs:32:9:32:16 | [b (line 24): true] dynamic call to method Check |
 | Splitting.cs:34:13:34:20 | dynamic call to method Check | normal | Splitting.cs:34:13:34:20 | dynamic call to method Check |
+| This.cs:7:5:7:8 | call to constructor Object | normal | This.cs:7:5:7:8 | call to constructor Object |
 | This.cs:17:9:17:18 | object creation of type This | normal | This.cs:17:9:17:18 | object creation of type This |
+| This.cs:22:9:22:11 | call to constructor This | normal | This.cs:22:9:22:11 | call to constructor This |
 | This.cs:28:13:28:21 | object creation of type Sub | normal | This.cs:28:13:28:21 | object creation of type Sub |
 | file://:0:0:0:0 | [summary] call to collectionSelector in SelectMany | normal | file://:0:0:0:0 | [summary] read: return (normal) of argument 1 in SelectMany |
 | file://:0:0:0:0 | [summary] call to collectionSelector in SelectMany | normal | file://:0:0:0:0 | [summary] read: return (normal) of argument 1 in SelectMany |

--- a/csharp/ql/test/library-tests/expressions/ConstructorInitializers.expected
+++ b/csharp/ql/test/library-tests/expressions/ConstructorInitializers.expected
@@ -1,0 +1,8 @@
+| expressions.cs:56:9:56:13 | Class | expressions.cs:56:19:56:22 | call to constructor Class | expressions.cs:58:19:58:23 | Class |
+| expressions.cs:58:19:58:23 | Class | expressions.cs:58:19:58:23 | call to constructor Object | file://:0:0:0:0 | Object |
+| expressions.cs:132:13:132:18 | Nested | expressions.cs:132:13:132:18 | call to constructor Class | expressions.cs:56:9:56:13 | Class |
+| expressions.cs:133:13:133:18 | Nested | expressions.cs:133:29:133:32 | call to constructor Class | expressions.cs:58:19:58:23 | Class |
+| expressions.cs:249:16:249:26 | LoginDialog | expressions.cs:249:16:249:26 | call to constructor Object | file://:0:0:0:0 | Object |
+| expressions.cs:270:16:270:24 | IntVector | expressions.cs:270:16:270:24 | call to constructor Object | file://:0:0:0:0 | Object |
+| expressions.cs:310:16:310:20 | Digit | expressions.cs:310:16:310:20 | call to constructor ValueType | file://:0:0:0:0 | ValueType |
+| expressions.cs:480:20:480:22 | Num | expressions.cs:480:20:480:22 | call to constructor Object | file://:0:0:0:0 | Object |

--- a/csharp/ql/test/library-tests/expressions/ConstructorInitializers.ql
+++ b/csharp/ql/test/library-tests/expressions/ConstructorInitializers.ql
@@ -1,0 +1,21 @@
+import csharp
+
+private class ConstructorInitializerTarget extends Constructor {
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    if this.fromSource()
+    then this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    else (
+      filepath = "" and
+      startline = 0 and
+      startcolumn = 0 and
+      endline = 0 and
+      endcolumn = 0
+    )
+  }
+}
+
+from Constructor c, ConstructorInitializer i, ConstructorInitializerTarget target
+where c.getInitializer() = i and target = i.getTarget()
+select c, i, target

--- a/csharp/ql/test/library-tests/expressions/PrintAst.expected
+++ b/csharp/ql/test/library-tests/expressions/PrintAst.expected
@@ -835,7 +835,14 @@ expressions.cs:
 #  129|     21: [Class] Nested
 #-----|       3: (Base types)
 #  129|         0: [TypeMention] Class
-#  133|       4: [InstanceConstructor] Nested
+#  131|       4: [StaticConstructor] Nested
+#  131|         4: [BlockStmt] {...}
+#  132|       5: [InstanceConstructor] Nested
+#-----|         2: (Parameters)
+#  132|           0: [Parameter] b
+#  132|             -1: [TypeMention] bool
+#  132|         4: [BlockStmt] {...}
+#  133|       6: [InstanceConstructor] Nested
 #-----|         2: (Parameters)
 #  133|           0: [Parameter] i
 #  133|             -1: [TypeMention] int
@@ -844,7 +851,7 @@ expressions.cs:
 #  133|             0: [ParameterAccess] access to parameter i
 #  133|             1: [IntLiteral] 1
 #  133|         4: [BlockStmt] {...}
-#  135|       5: [Method] OtherAccesses
+#  135|       7: [Method] OtherAccesses
 #  135|         -1: [TypeMention] Void
 #  136|         4: [BlockStmt] {...}
 #  137|           0: [ExprStmt] ...;

--- a/csharp/ql/test/library-tests/expressions/expressions.cs
+++ b/csharp/ql/test/library-tests/expressions/expressions.cs
@@ -128,8 +128,8 @@ namespace Expressions
 
         class Nested : Class
         {
-
-
+            static Nested() { }
+            Nested(bool b) { }
             Nested(int i) : base(i + 1) { }
 
             void OtherAccesses()


### PR DESCRIPTION
Implicit base constructor calls are now extracted:
```csharp
class Base
{
    public Base() { }
}

class Sub : Base
{
    public Sub() { } // implicit `base()` call
}
```

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1046/