### PR TITLE
Java: Add synthetic fields; model Commons Lang's MutableObject type

### DIFF
--- a/java/change-notes/2021-06-18-apache-mutable.md
+++ b/java/change-notes/2021-06-18-apache-mutable.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added models for the Apache Commons Lang Mutable types. This may lead to more results from any query using data-flow analysis where a relevant path uses one of these container types.

--- a/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
+++ b/java/ql/src/semmle/code/java/frameworks/apache/Lang.qll
@@ -861,3 +861,17 @@ private class ApacheTripleModel extends SummaryModelCsv {
       ]
   }
 }
+
+/**
+ * Value-propagating models for `MutableObject`.
+ */
+private class ApacheMutableObjectModel extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "org.apache.commons.lang3.mutable;MutableObject;false;MutableObject;;;Argument[0];SyntheticField[org.apache.commons.lang3.mutable.MutableObject.value] of Argument[-1];value",
+        "org.apache.commons.lang3.mutable;MutableObject;false;setValue;;;Argument[0];SyntheticField[org.apache.commons.lang3.mutable.MutableObject.value] of Argument[-1];value",
+        "org.apache.commons.lang3.mutable;MutableObject;false;getValue;;;SyntheticField[org.apache.commons.lang3.mutable.MutableObject.value] of Argument[-1];ReturnValue;value"
+      ]
+  }
+}

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/MutableTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/MutableTest.java
@@ -1,0 +1,28 @@
+import org.apache.commons.lang3.mutable.Mutable;
+import org.apache.commons.lang3.mutable.MutableObject;
+
+class MutableTest {
+    String taint() { return "tainted"; }
+
+    void sink(Object o) {}
+
+    void test() throws Exception {
+
+      MutableObject<String> tainted = new MutableObject<>(taint());
+      MutableObject<String> taintSet = new MutableObject<>("clean");
+      MutableObject<String> taintCleared = new MutableObject<>(taint());
+      taintSet.setValue(taint());
+      taintCleared.setValue("clean");
+      Mutable<String> taintedAlias = tainted;
+      Mutable<String> taintSetAlias = taintSet;
+      Mutable<String> taintClearedAlias = taintCleared;
+
+      sink(tainted.getValue()); // $hasValueFlow
+      sink(taintedAlias.getValue()); // $hasValueFlow
+      sink(taintSet.getValue()); // $hasValueFlow
+      sink(taintSetAlias.getValue()); // $hasValueFlow
+      sink(taintCleared.getValue());
+      sink(taintClearedAlias.getValue());
+
+    }
+}

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/MutableTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/MutableTest.java
@@ -21,8 +21,10 @@ class MutableTest {
       sink(taintedAlias.getValue()); // $hasValueFlow
       sink(taintSet.getValue()); // $hasValueFlow
       sink(taintSetAlias.getValue()); // $hasValueFlow
-      sink(taintCleared.getValue());
-      sink(taintClearedAlias.getValue());
+      // These two cases don't work currently because synthetic fields are always weakly updated,
+      // so no taint clearing takes place.
+      sink(taintCleared.getValue()); // $SPURIOUS: hasValueFlow
+      sink(taintClearedAlias.getValue()); // $SPURIOUS: hasValueFlow
 
     }
 }

--- a/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/mutable/Mutable.java
+++ b/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/mutable/Mutable.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.lang3.mutable;
+
+/**
+ * Provides mutable access to a value.
+ * <p>
+ * <code>Mutable</code> is used as a generic interface to the implementations in this package.
+ * <p>
+ * A typical use case would be to enable a primitive or string to be passed to a method and allow that method to
+ * effectively change the value of the primitive/string. Another use case is to store a frequently changing primitive in
+ * a collection (for example a total in a map) without needing to create new Integer/Long wrapper objects.
+ *
+ * @param <T> the type to set and get
+ * @since 2.1
+ * @version $Id$
+ */
+public interface Mutable<T> {
+
+    /**
+     * Gets the value of this mutable.
+     *
+     * @return the stored value
+     */
+    T getValue();
+
+    /**
+     * Sets the value of this mutable.
+     *
+     * @param value
+     *            the value to store
+     * @throws NullPointerException
+     *             if the object is null and null is invalid
+     * @throws ClassCastException
+     *             if the type is invalid
+     */
+    void setValue(T value);
+
+}

--- a/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/mutable/MutableObject.java
+++ b/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/mutable/MutableObject.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.lang3.mutable;
+
+import java.io.Serializable;
+
+/**
+ * A mutable <code>Object</code> wrapper.
+ *
+ * @param <T> the type to set and get
+ * @since 2.1
+ * @version $Id$
+ */
+public class MutableObject<T> implements Mutable<T>, Serializable {
+
+    /**
+     * Constructs a new MutableObject with the default value of <code>null</code>.
+     */
+    public MutableObject() {
+        super();
+    }
+
+    /**
+     * Constructs a new MutableObject with the specified value.
+     *
+     * @param value  the initial value to store
+     */
+    public MutableObject(final T value) {
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Gets the value.
+     *
+     * @return the value, may be null
+     */
+    @Override
+    public T getValue() {
+        return null;
+    }
+
+    /**
+     * Sets the value.
+     *
+     * @param value  the value to set
+     */
+    @Override
+    public void setValue(final T value) {
+    }
+
+}


### PR DESCRIPTION
Based on https://github.com/github/codeql/pull/5772

This adds support for synthetic fields (for now, specifically in external flow specifications), then uses one to model Commons Lang's `MutableObject` type.