### PR TITLE
C++: Do not inline `Dominance::hasMultiScopeNode`

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/Dominance.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/Dominance.qll
@@ -14,6 +14,7 @@ import cpp
  * In rare cases, the same node is used in multiple control-flow scopes. This
  * confuses the dominance analysis, so this predicate is used to exclude them.
  */
+pragma[noinline]
 private predicate hasMultiScopeNode(Function f) {
   exists(ControlFlowNode node |
     node.getControlFlowScope() = f and


### PR DESCRIPTION
Before:
```
[2021-04-28 15:02:24] (59s) Tuple counts for Dominance::functionEntry#f#antijoin_rhs/2@ade525:
                      14483550  ~0%       {2} r1 = SCAN ControlFlowGraph::ControlFlowNode::getControlFlowScope_dispred#ff OUTPUT In.1, In.0
                      421467581 ~0%       {3} r2 = JOIN r1 WITH function_entry_point ON FIRST 1 OUTPUT Lhs.1, Rhs.0, Rhs.1 'arg1'
                      421467581 ~0%       {4} r3 = JOIN r2 WITH ControlFlowGraph::ControlFlowNode::getControlFlowScope_dispred#ff ON FIRST 1 OUTPUT Lhs.1 'arg0', Lhs.2 'arg1', Lhs.0, Rhs.1
                      0         ~0%       {4} r4 = SELECT r3 ON In.0 'arg0' != In.3
                      0         ~0%       {2} r5 = SCAN r4 OUTPUT In.0 'arg0', In.1 'arg1'
                                          return r5
[2021-04-28 15:02:24] (59s) Registering Dominance::functionEntry#f#antijoin_rhs/2@ade525 + [] with content 0094a86d5et7ij5027jn41idnru35
[2021-04-28 15:02:24] (59s)  >>> Created relation Dominance::functionEntry#f#antijoin_rhs/2@ade525 with 0 rows.
[2021-04-28 15:02:24] (59s) Found relation function_entry_point/2@ce22d5 + [] in the query-local cache as 15ed2c28o2rd17hre6ies37vj2q47
[2021-04-28 15:02:24] (59s) Starting to evaluate predicate Dominance::functionEntry#f/1@c84b39
[2021-04-28 15:02:24] (59s) Tuple counts for Dominance::functionEntry#f/1@c84b39:
                      23019 ~7%     {2} r1 = function_entry_point AND NOT Dominance::functionEntry#f#antijoin_rhs(Lhs.0, Lhs.1 'entry')
                      23019 ~4%     {1} r2 = SCAN r1 OUTPUT In.1 'entry'
                                    return r2
```

After:
```
[2021-04-28 15:06:20] (14s) Tuple counts for Dominance::hasMultiScopeNode#b/1@c0d630:
                      23019    ~18%     {1} r1 = SCAN function_entry_point OUTPUT In.0 'f'
                      19099    ~0%      {1} r2 = STREAM DEDUP r1
                      14474325 ~1%      {2} r3 = JOIN r2 WITH ControlFlowGraph::ControlFlowNode::getControlFlowScope_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'f'
                      14474325 ~0%      {3} r4 = JOIN r3 WITH ControlFlowGraph::ControlFlowNode::getControlFlowScope_dispred#ff ON FIRST 1 OUTPUT Lhs.1 'f', Lhs.0, Rhs.1
                      0        ~0%      {3} r5 = SELECT r4 ON In.0 'f' != In.2
                      0        ~0%      {1} r6 = SCAN r5 OUTPUT In.0 'f'
                                        return r6
[2021-04-28 15:06:20] (14s) Registering Dominance::hasMultiScopeNode#b/1@c0d630 + [] with content 00738c354g24o2r9o9oippfammbt0
[2021-04-28 15:06:20] (14s)  >>> Created relation Dominance::hasMultiScopeNode#b/1@c0d630 with 0 rows.
[2021-04-28 15:06:20] (14s) Found relation function_entry_point/2@ce22d5 + [] in the query-local cache as 15ed2c28o2rd17hre6ies37vj2q47
[2021-04-28 15:06:20] (14s) Starting to evaluate predicate Dominance::functionEntry#f/1@1d0685
[2021-04-28 15:06:20] (14s) Tuple counts for Dominance::functionEntry#f/1@1d0685:
                      23019 ~7%     {2} r1 = function_entry_point AND NOT Dominance::hasMultiScopeNode#b(Lhs.0)
                      23019 ~4%     {1} r2 = SCAN r1 OUTPUT In.1 'entry'
                                    return r2
```

https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1956/