### PR TITLE
C++: Add nomagic to getUnspecifiedType

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Type.qll
+++ b/cpp/ql/src/semmle/code/cpp/Type.qll
@@ -101,6 +101,7 @@ class Type extends Locatable, @type {
    *
    * For example, starting with `const i64* const` in the context of `typedef long long i64;`, this predicate will return `long long*`.
    */
+  pragma[nomagic]
   Type getUnspecifiedType() { unspecifiedtype(underlyingElement(this), unresolveElement(result)) }
 
   /**


### PR DESCRIPTION
When testing `cpp/signed-overflow-check` on `Wireshark` with `main` I found this bad RA:
```
Tuple counts for Type::Type::getUnspecifiedType_dispred#fb/2@494c52:
  187500    ~0%           {2} r1 = SCAN unspecifiedtype OUTPUT In.1, In.0 'this'
  1853      ~0%           {2} r2 = JOIN r1 WITH Type::IntegralType::isSigned_dispred#f ON FIRST 1 OUTPUT Lhs.1 'this', Rhs.0
  1853      ~1%           {3} r3 = JOIN r2 WITH ResolveClass::Cached::isType#f@staged_ext ON FIRST 1 OUTPUT 25, Lhs.1 'result', Lhs.0 'this'
  116123804 ~4%           {3} r4 = JOIN r3 WITH exprs_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'result', Lhs.2 'this'
  62449806  ~3329555%     {2} r5 = JOIN r4 WITH SimpleRangeAnalysis::SimpleRangeAnalysisCached::exprMightOverflowPositively#f@staged_ext ON FIRST 1 OUTPUT Lhs.2 'this', Lhs.1 'result'
                          return r5
Registering Type::Type::getUnspecifiedType_dispred#fb/2@494c52 + [] with content 111a4f97qukntsl3ng257gcl4joic
>>> Created relation Type::Type::getUnspecifiedType_dispred#fb/2@494c52 with 1853 rows.
...
Starting to evaluate predicate Expr::Expr::getUnspecifiedType_dispred#bb/2@83d91b
Tuple counts for Expr::Expr::getUnspecifiedType_dispred#bb/2@83d91b:
  33702    ~4%     {2} r1 = JOIN Expr::Expr::getUnspecifiedType_dispred#bb#shared WITH Expr::Expr::getType_dispred#ff@staged_ext ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'this'
  20856    ~2%     {2} r2 = JOIN r1 WITH Type::Type::getUnspecifiedType_dispred#fb ON FIRST 1 OUTPUT Rhs.1 'result', Lhs.1 'this'
  20856    ~0%     {2} r3 = JOIN r2 WITH Type::IntegralType::isSigned_dispred#f ON FIRST 1 OUTPUT Lhs.1 'this', Lhs.0 'result'
                    return r3
```

and with this PR:
```
Starting to evaluate predicate Expr::Expr::getUnspecifiedType_dispred#bb/2@80d431
Tuple counts for Expr::Expr::getUnspecifiedType_dispred#bb/2@80d431:
  33702    ~4%     {2} r1 = JOIN Expr::Expr::getUnspecifiedType_dispred#bb#shared WITH Expr::Expr::getType_dispred#ff@staged_ext ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'this'
  33702    ~4%     {2} r2 = JOIN r1 WITH Type::Type::getUnspecifiedType#ff ON FIRST 1 OUTPUT Rhs.1 'result', Lhs.1 'this'
  20856    ~0%     {2} r3 = JOIN r2 WITH Type::IntegralType::isSigned_dispred#f ON FIRST 1 OUTPUT Lhs.1 'this', Lhs.0 'result'
                    return r3
```

CPP-differences: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1978/