### PR TITLE
Add heuristic query identifying probable SQL injection sinks

### DIFF
--- a/java/ql/src/experimental/heuristics/SqlSink.ql
+++ b/java/ql/src/experimental/heuristics/SqlSink.ql
@@ -1,0 +1,90 @@
+import java
+import semmle.code.java.security.QueryInjection
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.dataflow.ExternalFlow
+
+class PublicCallable extends Callable {
+  PublicCallable() { this.isPublic() and this.getDeclaringType().isPublic() }
+}
+
+class PublicArgumentToSqlInjectionSinkConfiguration extends DataFlow::Configuration {
+  PublicArgumentToSqlInjectionSinkConfiguration() {
+    this = "PublicArgumentToSqlInjectionSinkConfiguration"
+  }
+
+  override predicate isSource(DataFlow::Node node) {
+    node.asParameter() = any(PublicCallable c).getAParameter() and
+    node.getType() instanceof TypeString
+  }
+
+  override predicate isSink(DataFlow::Node node) { node instanceof SqlInjectionSink }
+}
+
+class PublicArgumentToSqlInjectionSinkTaintConfiguration extends TaintTracking::Configuration {
+  PublicArgumentToSqlInjectionSinkTaintConfiguration() {
+    this = "PublicArgumentToSqlInjectionSinkTaintConfiguration"
+  }
+
+  override predicate isSource(DataFlow::Node node) {
+    node.asParameter() = any(PublicCallable c).getAParameter() and
+    node.getType() instanceof TypeString
+  }
+
+  override predicate isSink(DataFlow::Node node) { node instanceof SqlInjectionSink }
+}
+
+Callable getASqlInjectionVulnerableParameterValueFlow(int paramIdx) {
+  exists(PublicArgumentToSqlInjectionSinkConfiguration config, DataFlow::ParameterNode source |
+    config.hasFlow(source, _) and
+    source.isParameterOf(result, paramIdx)
+  )
+}
+
+Callable getASqlInjectionVulnerableParameterTaintFlow(int paramIdx) {
+  exists(PublicArgumentToSqlInjectionSinkTaintConfiguration config, DataFlow::ParameterNode source |
+    config.hasFlow(source, _) and
+    source.isParameterOf(result, paramIdx)
+  )
+}
+
+PublicCallable getASqlInjectionVulnerableParameterNameBasedGuess(int paramIdx) {
+  exists(Parameter p |
+    p.getName() = "sql" and
+    p = result.getParameter(paramIdx)
+  )
+}
+
+query PublicCallable getASqlInjectionVulnerableParameter(int paramIdx, string reason) {
+  result = getASqlInjectionVulnerableParameterValueFlow(paramIdx) and
+  reason = "valueFlowToKnownSink"
+  or
+  result = getASqlInjectionVulnerableParameterTaintFlow(paramIdx) and
+  not result = getASqlInjectionVulnerableParameterValueFlow(paramIdx) and
+  reason = "taintFlowToKnownSink"
+  or
+  result = getASqlInjectionVulnerableParameterNameBasedGuess(paramIdx) and
+  not result = getASqlInjectionVulnerableParameterValueFlow(paramIdx) and
+  not result = getASqlInjectionVulnerableParameterTaintFlow(paramIdx) and
+  reason = "nameBasedGuess"
+}
+
+predicate hasOverloads(PublicCallable c) {
+  exists(PublicCallable other |
+    other.getDeclaringType() = c.getDeclaringType() and
+    other.getName() = c.getName() and
+    other != c
+  )
+}
+
+string signatureIfNeeded(PublicCallable c) {
+  if hasOverloads(c) then result = paramsString(c) else result = ""
+}
+
+query string getASqlInjectionVulnerableParameterSpecification() {
+  exists(PublicCallable c, int paramIdx |
+    c = getASqlInjectionVulnerableParameter(paramIdx, _) and
+    result =
+      c.getDeclaringType().getPackage() + ";" + c.getDeclaringType().getName() + ";" + "false;" +
+        c.getName() + ";" + signatureIfNeeded(c) + ";;" + "Argument[" + paramIdx + "];" + "sql"
+  )
+}

--- a/java/ql/src/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/src/semmle/code/java/dataflow/ExternalFlow.qll
@@ -560,9 +560,7 @@ private string paramsStringPart(Callable c, int i) {
   i = 2 * c.getNumberOfParameters() and result = ")"
 }
 
-private string paramsString(Callable c) {
-  result = concat(int i | | paramsStringPart(c, i) order by i)
-}
+string paramsString(Callable c) { result = concat(int i | | paramsStringPart(c, i) order by i) }
 
 private Element interpretElement0(
   string namespace, string type, boolean subtypes, string name, string signature

--- a/java/ql/src/semmle/code/java/security/QueryInjection.qll
+++ b/java/ql/src/semmle/code/java/security/QueryInjection.qll
@@ -28,7 +28,7 @@ class AdditionalQueryInjectionTaintStep extends Unit {
 }
 
 /** A sink for SQL injection vulnerabilities. */
-private class SqlInjectionSink extends QueryInjectionSink {
+class SqlInjectionSink extends QueryInjectionSink {
   SqlInjectionSink() {
     this.asExpr() instanceof SqlExpr
     or


### PR DESCRIPTION
How about this for a start on heuristic queries? I checked out 5-6 Java SQL-database-interaction libraries and couldn't beat @yo-h's suggested heuristic, "string-typed parameter named 'sql'".

It suggests I should add these SQL sinks for https://github.com/zsoltherpai/fluent-jdbc:

```
org.codejargon.fluentjdbc.api.query;Query;false;batch;;;Argument[0];sql
org.codejargon.fluentjdbc.api.query;Query;false;update;;;Argument[0];sql
org.codejargon.fluentjdbc.api.query;Query;false;select;;;Argument[0];sql
org.codejargon.fluentjdbc.api.query;SqlErrorHandler;false;handle;;;Argument[1];sql
org.codejargon.fluentjdbc.internal.query;QueryInternal;false;batch;;;Argument[0];sql
org.codejargon.fluentjdbc.internal.query;QueryInternal;false;update;;;Argument[0];sql
org.codejargon.fluentjdbc.internal.query;QueryInternal;false;select;;;Argument[0];sql
org.codejargon.fluentjdbc.internal.query;DefaultSqlHandler;false;handle;;;Argument[1];sql
org.codejargon.fluentjdbc.internal.query.namedparameter;NamedTransformedSqlFactory;false;create;;;Argument[0];sql
org.codejargon.fluentjdbc.internal.query;SqlAndParams;false;SqlAndParams;;;Argument[0];sql
org.codejargon.fluentjdbc.internal.query.namedparameter;NamedParameterUtils;false;parseSqlStatement;;;Argument[0];sql org.codejargon.fluentjdbc.internal.query.namedparameter;NamedTransformedSql;false;forSqlAndParams;;;Argument[0];sql
```

That seems reasonable to me -- I could add `internal` as a package name heuristic, but I'm inclined not to because this is for expert users who might prefer breadth over potentially-surprising negative heuristics.
