### PR TITLE
Java: Avoid comparing result of toString()

### DIFF
--- a/java/ql/src/Likely Bugs/Concurrency/NotifyWithoutSynch.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/NotifyWithoutSynch.ql
@@ -85,6 +85,8 @@ predicate synchronizedVarAccess(VarAccess x) {
     s.getAChild*() = x.getEnclosingStmt() and
     s.getExpr() = y and
     y.getVariable() = x.getVariable() and
+    // TODO: Properly compare whether access is on same variable; toString() can
+    // be ambiguous
     y.toString() = x.toString()
   )
 }

--- a/java/ql/src/semmle/code/java/PrintAst.qll
+++ b/java/ql/src/semmle/code/java/PrintAst.qll
@@ -97,7 +97,7 @@ private string getQlClass(Top el) {
 private predicate locationSortKeys(Element ast, string file, int line, int column) {
   exists(Location loc |
     loc = ast.getLocation() and
-    file = loc.getFile().toString() and
+    file = loc.getFile().getAbsolutePath() and
     line = loc.getStartLine() and
     column = loc.getStartColumn()
   )

--- a/java/ql/test/library-tests/dispatch/viableCallable.ql
+++ b/java/ql/test/library-tests/dispatch/viableCallable.ql
@@ -3,7 +3,7 @@ import semmle.code.java.dispatch.VirtualDispatch
 
 from MethodAccess ma, Method m
 where
-  ma.getFile().toString().matches("ViableCallable%") and
+  ma.getFile().getAbsolutePath().matches("ViableCallable%") and
   ma.getMethod().getSourceDeclaration().fromSource() and
   m = viableImpl(ma)
 select ma, m.toString(), m.getDeclaringType().getLocation().getStartLine(),

--- a/java/ql/test/library-tests/structure/EnclosingCallables.ql
+++ b/java/ql/test/library-tests/structure/EnclosingCallables.ql
@@ -7,5 +7,5 @@ string printableEnclosingCallable(Expr e) {
 }
 
 from Expr e
-where e.getFile().toString() = "A"
+where e.getFile().getAbsolutePath() = "A"
 select e, printableEnclosingCallable(e)

--- a/java/ql/test/library-tests/structure/EnclosingStatements.ql
+++ b/java/ql/test/library-tests/structure/EnclosingStatements.ql
@@ -7,5 +7,5 @@ string printableEnclosingStmt(Expr e) {
 }
 
 from Expr e
-where e.getFile().toString() = "A"
+where e.getFile().getAbsolutePath() = "A"
 select e, printableEnclosingStmt(e)

--- a/java/ql/test/library-tests/structure/HasObjectMethod.ql
+++ b/java/ql/test/library-tests/structure/HasObjectMethod.ql
@@ -9,5 +9,5 @@ where
   inheritor.hasMethod(method, declarer) and
   inheritor.fromSource() and
   declarer.hasName("Object") and
-  inheritor.getFile().toString() = "Inherit"
+  inheritor.getFile().getAbsolutePath() = "Inherit"
 select inheritor.toString(), method.toString(), declarer.toString()

--- a/java/ql/test/library-tests/structure/InSameTopLevelType.ql
+++ b/java/ql/test/library-tests/structure/InSameTopLevelType.ql
@@ -10,5 +10,5 @@ where
   e.fromSource() and
   f.fromSource() and
   e.getName() < f.getName() and
-  e.getFile().toString() = "A"
+  e.getFile().getAbsolutePath() = "A"
 select e, f

--- a/java/ql/test/library-tests/structure/IsInType.ql
+++ b/java/ql/test/library-tests/structure/IsInType.ql
@@ -5,5 +5,5 @@
 import default
 
 from Element e, RefType t
-where t.hasChildElement*(e) and e.fromSource() and e.getFile().toString() = "A"
+where t.hasChildElement*(e) and e.fromSource() and e.getFile().getAbsolutePath() = "A"
 select e, t

--- a/java/ql/test/library-tests/structure/IsTopLevelType.ql
+++ b/java/ql/test/library-tests/structure/IsTopLevelType.ql
@@ -5,5 +5,5 @@
 import default
 
 from TopLevelType tp
-where tp.fromSource() and tp.getFile().toString() = "A"
+where tp.fromSource() and tp.getFile().getAbsolutePath() = "A"
 select tp, tp.getPackage()

--- a/java/ql/test/library-tests/structure/OuterType.ql
+++ b/java/ql/test/library-tests/structure/OuterType.ql
@@ -5,5 +5,5 @@
 import default
 
 from TopLevelType t
-where t.fromSource() and t.getFile().toString() = "A"
+where t.fromSource() and t.getFile().getAbsolutePath() = "A"
 select t

--- a/java/ql/test/library-tests/structure/TypeIsInPackage.ql
+++ b/java/ql/test/library-tests/structure/TypeIsInPackage.ql
@@ -5,5 +5,5 @@
 import default
 
 from RefType tp
-where tp.fromSource() and tp.getFile().toString() = "A"
+where tp.fromSource() and tp.getFile().getAbsolutePath() = "A"
 select tp, tp.getPackage()


### PR DESCRIPTION
Replace usage of `toString()` in queries and instead use proper predicate instead.

Note that there are still a few cases where `Type.toString()` is used (also for PrintAst); would it be better to use `getName()` there?