### PR TITLE
Java: split extractor diagnostics query into two

### DIFF
--- a/java/ql/src/Diagnostics/DiagnosticsReporting.qll
+++ b/java/ql/src/Diagnostics/DiagnosticsReporting.qll
@@ -51,11 +51,25 @@ private predicate unknownErrors(@diagnostic d, string msg, int sev) {
 
 /**
  * Holds if an extraction error or warning occurred that should be reported to end users,
- * with the error message `msg` and SARIF severity `sev`.
+ * with the message `msg` and SARIF severity `sev`.
  */
 predicate reportableDiagnostics(@diagnostic d, string msg, int sev) {
-  knownWarnings(d, msg, sev) or knownErrors(d, msg, sev) or unknownErrors(d, msg, sev)
+  reportableWarnings(d, msg, sev) or reportableErrors(d, msg, sev)
 }
+
+/**
+ * Holds if an extraction error occurred that should be reported to end users,
+ * with the message `msg` and SARIF severity `sev`.
+ */
+predicate reportableErrors(@diagnostic d, string msg, int sev) {
+  knownErrors(d, msg, sev) or unknownErrors(d, msg, sev)
+}
+
+/**
+ * Holds if an extraction warning occurred that should be reported to end users,
+ * with the message `msg` and SARIF severity `sev`.
+ */
+predicate reportableWarnings(@diagnostic d, string msg, int sev) { knownWarnings(d, msg, sev) }
 
 /**
  * Holds if compilation unit `f` is a source file that has

--- a/java/ql/src/Diagnostics/ExtractionErrors.ql
+++ b/java/ql/src/Diagnostics/ExtractionErrors.ql
@@ -9,5 +9,5 @@ import java
 import DiagnosticsReporting
 
 from string msg, int sev
-where reportableDiagnostics(_, msg, sev)
+where reportableErrors(_, msg, sev)
 select msg, sev

--- a/java/ql/src/Diagnostics/ExtractionWarnings.ql
+++ b/java/ql/src/Diagnostics/ExtractionWarnings.ql
@@ -1,0 +1,13 @@
+/**
+ * @name Extraction warnings
+ * @description A list of extraction warnings for files in the source code directory.
+ * @kind diagnostic
+ * @id java/diagnostics/extraction-warnings
+ */
+
+import java
+import DiagnosticsReporting
+
+from string msg, int sev
+where reportableWarnings(_, msg, sev)
+select msg, sev


### PR DESCRIPTION
Warnings are now reported by the query `java/diagnostics/extraction-warnings` and errors continue to be reported by `java/diagnostics/extraction-errors`. Previously, both were included in the latter.