### PR TITLE
JS: recognize more library input

### DIFF
--- a/javascript/ql/src/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/src/semmle/javascript/PackageExports.qll
@@ -67,7 +67,8 @@ private DataFlow::Node getAValueExportedByPackage() {
   exists(ImmediatelyInvokedFunctionExpr func, DataFlow::ParameterNode prev, int i |
     prev.getName() = "factory" and
     func.getParameter(i) = prev.getParameter() and
-    result = func.getInvocation().getArgument(i).flow().getAFunctionValue().getAReturn()
+    result = func.getInvocation().getArgument(i).flow().getAFunctionValue().getAReturn() and
+    DataFlow::globalVarRef("define").getACall().getArgument(1) = prev.getALocalUse()
   )
   or
   // the exported value is a call to a unique callee

--- a/javascript/ql/src/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/src/semmle/javascript/PackageExports.qll
@@ -18,7 +18,6 @@ DataFlow::ParameterNode getALibraryInputParameter() {
 
 /**
  * Gets a value exported by the main module from a named `package.json` file.
- * The value is either directly the `module.exports` value, a nested property of `module.exports`, or a method on an exported class.
  */
 private DataFlow::Node getAValueExportedByPackage() {
   result =

--- a/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialBackTracking.expected
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialBackTracking.expected
@@ -30,6 +30,7 @@
 | lib/closure.js:4:6:4:7 | u* | Strings with many repetitions of 'u' can start matching anywhere after the start of the preceeding u*o |
 | lib/lib.js:1:15:1:16 | a* | Strings with many repetitions of 'a' can start matching anywhere after the start of the preceeding a*b |
 | lib/lib.js:8:3:8:4 | f* | Strings with many repetitions of 'f' can start matching anywhere after the start of the preceeding f*g |
+| lib/sublib/factory.js:13:14:13:15 | f* | Strings with many repetitions of 'f' can start matching anywhere after the start of the preceeding f*g |
 | polynomial-redos.js:7:24:7:26 | \\s+ | Strings with many repetitions of ' ' can start matching anywhere after the start of the preceeding \\s+$ |
 | polynomial-redos.js:8:17:8:18 |  * | Strings with many repetitions of ' ' can start matching anywhere after the start of the preceeding  *, * |
 | polynomial-redos.js:9:19:9:21 | \\s* | Strings with many repetitions of ' ' can start matching anywhere after the start of the preceeding \\s*\\n\\s* |

--- a/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialReDoS.expected
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/PolynomialReDoS.expected
@@ -11,6 +11,10 @@ nodes
 | lib/lib.js:7:19:7:22 | name |
 | lib/lib.js:8:13:8:16 | name |
 | lib/lib.js:8:13:8:16 | name |
+| lib/sublib/factory.js:12:26:12:29 | name |
+| lib/sublib/factory.js:12:26:12:29 | name |
+| lib/sublib/factory.js:13:24:13:27 | name |
+| lib/sublib/factory.js:13:24:13:27 | name |
 | polynomial-redos.js:5:6:5:32 | tainted |
 | polynomial-redos.js:5:16:5:32 | req.query.tainted |
 | polynomial-redos.js:5:16:5:32 | req.query.tainted |
@@ -166,6 +170,10 @@ edges
 | lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name |
 | lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name |
 | lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name |
+| lib/sublib/factory.js:12:26:12:29 | name | lib/sublib/factory.js:13:24:13:27 | name |
+| lib/sublib/factory.js:12:26:12:29 | name | lib/sublib/factory.js:13:24:13:27 | name |
+| lib/sublib/factory.js:12:26:12:29 | name | lib/sublib/factory.js:13:24:13:27 | name |
+| lib/sublib/factory.js:12:26:12:29 | name | lib/sublib/factory.js:13:24:13:27 | name |
 | polynomial-redos.js:5:6:5:32 | tainted | polynomial-redos.js:7:2:7:8 | tainted |
 | polynomial-redos.js:5:6:5:32 | tainted | polynomial-redos.js:7:2:7:8 | tainted |
 | polynomial-redos.js:5:6:5:32 | tainted | polynomial-redos.js:8:2:8:8 | tainted |
@@ -307,6 +315,7 @@ edges
 | lib/closure.js:4:5:4:17 | /u*o/.test(x) | lib/closure.js:3:21:3:21 | x | lib/closure.js:4:16:4:16 | x | This $@ that depends on $@ may run slow on strings with many repetitions of 'u'. | lib/closure.js:4:6:4:7 | u* | regular expression | lib/closure.js:3:21:3:21 | x | library input |
 | lib/lib.js:4:2:4:18 | regexp.test(name) | lib/lib.js:3:28:3:31 | name | lib/lib.js:4:14:4:17 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'a'. | lib/lib.js:1:15:1:16 | a* | regular expression | lib/lib.js:3:28:3:31 | name | library input |
 | lib/lib.js:8:2:8:17 | /f*g/.test(name) | lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'f'. | lib/lib.js:8:3:8:4 | f* | regular expression | lib/lib.js:7:19:7:22 | name | library input |
+| lib/sublib/factory.js:13:13:13:28 | /f*g/.test(name) | lib/sublib/factory.js:12:26:12:29 | name | lib/sublib/factory.js:13:24:13:27 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'f'. | lib/sublib/factory.js:13:14:13:15 | f* | regular expression | lib/sublib/factory.js:12:26:12:29 | name | library input |
 | polynomial-redos.js:7:2:7:34 | tainted ... /g, '') | polynomial-redos.js:5:16:5:32 | req.query.tainted | polynomial-redos.js:7:2:7:8 | tainted | This $@ that depends on $@ may run slow on strings with many repetitions of ' '. | polynomial-redos.js:7:24:7:26 | \\s+ | regular expression | polynomial-redos.js:5:16:5:32 | req.query.tainted | a user-provided value |
 | polynomial-redos.js:8:2:8:23 | tainted ...  *, */) | polynomial-redos.js:5:16:5:32 | req.query.tainted | polynomial-redos.js:8:2:8:8 | tainted | This $@ that depends on $@ may run slow on strings with many repetitions of ' '. | polynomial-redos.js:8:17:8:18 |  * | regular expression | polynomial-redos.js:5:16:5:32 | req.query.tainted | a user-provided value |
 | polynomial-redos.js:9:2:9:34 | tainted ... g, ' ') | polynomial-redos.js:5:16:5:32 | req.query.tainted | polynomial-redos.js:9:2:9:8 | tainted | This $@ that depends on $@ may run slow on strings with many repetitions of ' '. | polynomial-redos.js:9:19:9:21 | \\s* | regular expression | polynomial-redos.js:5:16:5:32 | req.query.tainted | a user-provided value |

--- a/javascript/ql/test/query-tests/Performance/ReDoS/lib/sublib/factory.js
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/lib/sublib/factory.js
@@ -1,0 +1,17 @@
+
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define('my-sub-library', factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
+    } else {
+        root.mySubLibrary = factory();
+    }
+}(this, function () {
+    function create() {
+        return function (name) {
+            /f*g/.test(name); // NOT OK
+        }
+    }
+    return create()
+}));

--- a/javascript/ql/test/query-tests/Performance/ReDoS/lib/sublib/package.json
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/lib/sublib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "my-sub-lib",
+  "version": "0.0.7",
+  "main": "./my-file.js"
+}

--- a/javascript/ql/test/query-tests/Performance/ReDoS/lib/sublib/package.json
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/lib/sublib/package.json
@@ -1,5 +1,5 @@
 {
   "name": "my-sub-lib",
   "version": "0.0.7",
-  "main": "./my-file.js"
+  "main": "./factory.js"
 }


### PR DESCRIPTION
Recognizes a library-input source for CVE-2017-0931 and CVE-2017-1001004. 

[Evaluation looks good](https://github.com/dsp-testing/erik-krogh-dca/tree/run/moreLib-nightly-libInput-3/reports).  
No change in performance, and a few new poly-redos TPs. 