### PR TITLE
C++: Reorder getInstructionOpcode

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -297,7 +297,8 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets the opcode that specifies the operation performed by this instruction.
    */
-  final Opcode getOpcode() { result = Construction::getInstructionOpcode(this) }
+  pragma[inline]
+  final Opcode getOpcode() { Construction::getInstructionOpcode(result, this) }
 
   /**
    * Gets all direct uses of the result of this instruction. The result can be

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -339,14 +339,14 @@ private module Cached {
   }
 
   cached
-  Opcode getInstructionOpcode(Instruction instr) {
-    result = getOldInstruction(instr).getOpcode()
+  predicate getInstructionOpcode(Opcode opcode, Instruction instr) {
+    opcode = getOldInstruction(instr).getOpcode()
     or
-    instr = phiInstruction(_, _) and result instanceof Opcode::Phi
+    instr = phiInstruction(_, _) and opcode instanceof Opcode::Phi
     or
-    instr = chiInstruction(_) and result instanceof Opcode::Chi
+    instr = chiInstruction(_) and opcode instanceof Opcode::Chi
     or
-    instr = unreachedInstruction(_) and result instanceof Opcode::Unreached
+    instr = unreachedInstruction(_) and opcode instanceof Opcode::Unreached
   }
 
   cached

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -338,6 +338,12 @@ private module Cached {
     instr = unreachedInstruction(_) and result = Language::getVoidType()
   }
 
+  /**
+   * Holds if `opcode` is the opcode that specifies the operation performed by `instr`.
+   *
+   * The parameters are ordered such that they produce a clean join (with no need for reordering)
+   * in the characteristic predicates of the `Instruction` subclasses.
+   */
   cached
   predicate getInstructionOpcode(Opcode opcode, Instruction instr) {
     opcode = getOldInstruction(instr).getOpcode()

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -297,7 +297,8 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets the opcode that specifies the operation performed by this instruction.
    */
-  final Opcode getOpcode() { result = Construction::getInstructionOpcode(this) }
+  pragma[inline]
+  final Opcode getOpcode() { Construction::getInstructionOpcode(result, this) }
 
   /**
    * Gets all direct uses of the result of this instruction. The result can be

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -360,8 +360,8 @@ CppType getInstructionResultType(TStageInstruction instr) {
   getInstructionTranslatedElement(instr).hasInstruction(_, getInstructionTag(instr), result)
 }
 
-Opcode getInstructionOpcode(TStageInstruction instr) {
-  getInstructionTranslatedElement(instr).hasInstruction(result, getInstructionTag(instr), _)
+predicate getInstructionOpcode(Opcode opcode, TStageInstruction instr) {
+  getInstructionTranslatedElement(instr).hasInstruction(opcode, getInstructionTag(instr), _)
 }
 
 IRFunctionBase getInstructionEnclosingIRFunction(TStageInstruction instr) {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -297,7 +297,8 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets the opcode that specifies the operation performed by this instruction.
    */
-  final Opcode getOpcode() { result = Construction::getInstructionOpcode(this) }
+  pragma[inline]
+  final Opcode getOpcode() { Construction::getInstructionOpcode(result, this) }
 
   /**
    * Gets all direct uses of the result of this instruction. The result can be

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -339,14 +339,14 @@ private module Cached {
   }
 
   cached
-  Opcode getInstructionOpcode(Instruction instr) {
-    result = getOldInstruction(instr).getOpcode()
+  predicate getInstructionOpcode(Opcode opcode, Instruction instr) {
+    opcode = getOldInstruction(instr).getOpcode()
     or
-    instr = phiInstruction(_, _) and result instanceof Opcode::Phi
+    instr = phiInstruction(_, _) and opcode instanceof Opcode::Phi
     or
-    instr = chiInstruction(_) and result instanceof Opcode::Chi
+    instr = chiInstruction(_) and opcode instanceof Opcode::Chi
     or
-    instr = unreachedInstruction(_) and result instanceof Opcode::Unreached
+    instr = unreachedInstruction(_) and opcode instanceof Opcode::Unreached
   }
 
   cached

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -338,6 +338,12 @@ private module Cached {
     instr = unreachedInstruction(_) and result = Language::getVoidType()
   }
 
+  /**
+   * Holds if `opcode` is the opcode that specifies the operation performed by `instr`.
+   *
+   * The parameters are ordered such that they produce a clean join (with no need for reordering)
+   * in the characteristic predicates of the `Instruction` subclasses.
+   */
   cached
   predicate getInstructionOpcode(Opcode opcode, Instruction instr) {
     opcode = getOldInstruction(instr).getOpcode()

--- a/csharp/ql/src/experimental/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/Instruction.qll
@@ -297,7 +297,8 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets the opcode that specifies the operation performed by this instruction.
    */
-  final Opcode getOpcode() { result = Construction::getInstructionOpcode(this) }
+  pragma[inline]
+  final Opcode getOpcode() { Construction::getInstructionOpcode(result, this) }
 
   /**
    * Gets all direct uses of the result of this instruction. The result can be

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/IRConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/IRConstruction.qll
@@ -165,10 +165,10 @@ import Cached
 cached
 private module Cached {
   cached
-  Opcode getInstructionOpcode(TRawInstruction instr) {
+  predicate getInstructionOpcode(Opcode opcode, TRawInstruction instr) {
     exists(TranslatedElement element, InstructionTag tag |
       instructionOrigin(instr, element, tag) and
-      element.hasInstruction(result, tag, _)
+      element.hasInstruction(opcode, tag, _)
     )
   }
 

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/Instruction.qll
@@ -297,7 +297,8 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets the opcode that specifies the operation performed by this instruction.
    */
-  final Opcode getOpcode() { result = Construction::getInstructionOpcode(this) }
+  pragma[inline]
+  final Opcode getOpcode() { Construction::getInstructionOpcode(result, this) }
 
   /**
    * Gets all direct uses of the result of this instruction. The result can be

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -339,14 +339,14 @@ private module Cached {
   }
 
   cached
-  Opcode getInstructionOpcode(Instruction instr) {
-    result = getOldInstruction(instr).getOpcode()
+  predicate getInstructionOpcode(Opcode opcode, Instruction instr) {
+    opcode = getOldInstruction(instr).getOpcode()
     or
-    instr = phiInstruction(_, _) and result instanceof Opcode::Phi
+    instr = phiInstruction(_, _) and opcode instanceof Opcode::Phi
     or
-    instr = chiInstruction(_) and result instanceof Opcode::Chi
+    instr = chiInstruction(_) and opcode instanceof Opcode::Chi
     or
-    instr = unreachedInstruction(_) and result instanceof Opcode::Unreached
+    instr = unreachedInstruction(_) and opcode instanceof Opcode::Unreached
   }
 
   cached

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -338,6 +338,12 @@ private module Cached {
     instr = unreachedInstruction(_) and result = Language::getVoidType()
   }
 
+  /**
+   * Holds if `opcode` is the opcode that specifies the operation performed by `instr`.
+   *
+   * The parameters are ordered such that they produce a clean join (with no need for reordering)
+   * in the characteristic predicates of the `Instruction` subclasses.
+   */
   cached
   predicate getInstructionOpcode(Opcode opcode, Instruction instr) {
     opcode = getOldInstruction(instr).getOpcode()


### PR DESCRIPTION
On `main` we get lots of reordering in the charpreds in `Instruction.qll` such as the following:
```
Tuple counts for Instruction::CallInstruction#class#3#f/1@ed64f2:
  17604888 ~2%     {2} r1 = SCAN SSAConstruction::Cached::getInstructionOpcode#2#ff@staged_ext OUTPUT In.1, In.0 'this'
  576776   ~2%     {1} r2 = JOIN r1 WITH construct<TOpcode,51>@dom#Opcode::TCall#0#f ON FIRST 1 OUTPUT Lhs.1 'this'
  return r2
```

with this PR these charpreds simplify to:
```
Tuple counts for Instruction::CallInstruction#class#f/1@3c2d81:
  586586   ~6%     {1} r1 = JOIN construct<TOpcode,51>@dom#Opcode::TCall#0#f WITH IRConstruction::getInstructionOpcode#ff ON FIRST 1 OUTPUT Rhs.1 'this'
  return r1
```

CPP-differences: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1991/