### PR TITLE
JS: add `array.filter()` as a taint-step

### DIFF
--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -36,6 +36,11 @@ module ArrayTaintTracking {
       succ = call
     )
     or
+    // `array.filter` keeps the taint
+    call.(DataFlow::MethodCallNode).getMethodName() = "filter" and
+    pred = call.getReceiver() and
+    succ = call
+    or
     // `array.reduce` with tainted value in callback
     call.(DataFlow::MethodCallNode).getMethodName() = "reduce" and
     pred = call.getArgument(0).(DataFlow::FunctionNode).getAReturn() and // Require the argument to be a closure to avoid spurious call/return flow

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -36,10 +36,13 @@ module ArrayTaintTracking {
       succ = call
     )
     or
-    // `array.filter` keeps the taint
+    // `array.filter(x => x)` keeps the taint
     call.(DataFlow::MethodCallNode).getMethodName() = "filter" and
     pred = call.getReceiver() and
-    succ = call
+    succ = call and
+    exists(DataFlow::FunctionNode callback | callback = call.getArgument(0).getAFunctionValue() |
+      callback.getParameter(0).getALocalUse() = callback.getAReturn()
+    )
     or
     // `array.reduce` with tainted value in callback
     call.(DataFlow::MethodCallNode).getMethodName() = "reduce" and

--- a/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.expected
@@ -39,6 +39,11 @@ nodes
 | RegExpInjection.js:47:22:47:26 | input |
 | RegExpInjection.js:50:46:50:50 | input |
 | RegExpInjection.js:50:46:50:50 | input |
+| RegExpInjection.js:54:14:54:16 | key |
+| RegExpInjection.js:54:14:54:27 | key.split(".") |
+| RegExpInjection.js:54:14:54:42 | key.spl ... x => x) |
+| RegExpInjection.js:54:14:54:52 | key.spl ... in("-") |
+| RegExpInjection.js:54:14:54:52 | key.spl ... in("-") |
 | tst.js:1:46:1:46 | e |
 | tst.js:1:46:1:46 | e |
 | tst.js:2:9:2:21 | data |
@@ -53,6 +58,7 @@ edges
 | RegExpInjection.js:5:7:5:28 | key | RegExpInjection.js:19:19:19:21 | key |
 | RegExpInjection.js:5:7:5:28 | key | RegExpInjection.js:21:19:21:21 | key |
 | RegExpInjection.js:5:7:5:28 | key | RegExpInjection.js:33:12:33:14 | key |
+| RegExpInjection.js:5:7:5:28 | key | RegExpInjection.js:54:14:54:16 | key |
 | RegExpInjection.js:5:13:5:28 | req.param("key") | RegExpInjection.js:5:7:5:28 | key |
 | RegExpInjection.js:5:13:5:28 | req.param("key") | RegExpInjection.js:5:7:5:28 | key |
 | RegExpInjection.js:5:31:5:56 | input | RegExpInjection.js:40:19:40:23 | input |
@@ -89,6 +95,10 @@ edges
 | RegExpInjection.js:29:21:29:21 | s | RegExpInjection.js:31:23:31:23 | s |
 | RegExpInjection.js:33:12:33:14 | key | RegExpInjection.js:29:21:29:21 | s |
 | RegExpInjection.js:34:12:34:19 | getKey() | RegExpInjection.js:29:21:29:21 | s |
+| RegExpInjection.js:54:14:54:16 | key | RegExpInjection.js:54:14:54:27 | key.split(".") |
+| RegExpInjection.js:54:14:54:27 | key.split(".") | RegExpInjection.js:54:14:54:42 | key.spl ... x => x) |
+| RegExpInjection.js:54:14:54:42 | key.spl ... x => x) | RegExpInjection.js:54:14:54:52 | key.spl ... in("-") |
+| RegExpInjection.js:54:14:54:42 | key.spl ... x => x) | RegExpInjection.js:54:14:54:52 | key.spl ... in("-") |
 | tst.js:1:46:1:46 | e | tst.js:2:16:2:16 | e |
 | tst.js:1:46:1:46 | e | tst.js:2:16:2:16 | e |
 | tst.js:2:9:2:21 | data | tst.js:3:21:3:24 | data |
@@ -111,4 +121,5 @@ edges
 | RegExpInjection.js:46:23:46:27 | input | RegExpInjection.js:5:39:5:56 | req.param("input") | RegExpInjection.js:46:23:46:27 | input | This regular expression is constructed from a $@. | RegExpInjection.js:5:39:5:56 | req.param("input") | user-provided value |
 | RegExpInjection.js:47:22:47:26 | input | RegExpInjection.js:5:39:5:56 | req.param("input") | RegExpInjection.js:47:22:47:26 | input | This regular expression is constructed from a $@. | RegExpInjection.js:5:39:5:56 | req.param("input") | user-provided value |
 | RegExpInjection.js:50:46:50:50 | input | RegExpInjection.js:5:39:5:56 | req.param("input") | RegExpInjection.js:50:46:50:50 | input | This regular expression is constructed from a $@. | RegExpInjection.js:5:39:5:56 | req.param("input") | user-provided value |
+| RegExpInjection.js:54:14:54:52 | key.spl ... in("-") | RegExpInjection.js:5:13:5:28 | req.param("key") | RegExpInjection.js:54:14:54:52 | key.spl ... in("-") | This regular expression is constructed from a $@. | RegExpInjection.js:5:13:5:28 | req.param("key") | user-provided value |
 | tst.js:3:16:3:35 | "^"+ data.name + "$" | tst.js:1:46:1:46 | e | tst.js:3:16:3:35 | "^"+ data.name + "$" | This regular expression is constructed from a $@. | tst.js:1:46:1:46 | e | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.js
+++ b/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.js
@@ -51,6 +51,7 @@ app.get('/findKey', function(req, res) {
   URI(`${protocol}://${host}${path}`).search(input).href(); // OK
   unknown.search(input).unknown; // OK
 
+  new RegExp(key.split(".").filter(x => x).join("-")); // NOT OK
 });
 
 import * as Search from './search';


### PR DESCRIPTION
Adds a taint step for CVE-2018-7560
I'll run a larger evaluation to check for FPs. 

If we don't consider the callback function to the `.filter` call, then we get a few new results, about half of which are FPs. 
([evaluation](https://github.com/dsp-testing/erik-krogh-dca/tree/run/filterStep-default-security-extended/reports)).  

Adding the requirement that we only consider the identity-like functions, makes it more precise: [evaluation](https://github.com/dsp-testing/erik-krogh-dca/tree/run/390ee3a6b8fe4816e2583cf0a11cdbd94d41bc75-default-security-extended/reports).  
One new TP. 