### PR TITLE
CPP: fix semi-unused variables in WrongInDetectingAndHandlingMemoryAllocationErrors.q

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-570/WrongInDetectingAndHandlingMemoryAllocationErrors.ql
@@ -53,20 +53,27 @@ class WrongCheckErrorOperatorNew extends FunctionCall {
    * Holds if results call `operator new` check in `operator if`.
    */
   predicate isExistsIfCondition() {
-    exists(IfCompareWithZero ifc, AssignExpr aex, Initializer it |
+    exists(IfCompareWithZero ifc |
       // call `operator new` directly from the condition of `operator if`.
       this = ifc.getCondition().getAChild*()
       or
-      // check results call `operator new` with variable appropriation
       postDominates(ifc, this) and
-      aex.getAChild() = exp and
-      ifc.getCondition().getAChild().(VariableAccess).getTarget() =
-        aex.getLValue().(VariableAccess).getTarget()
-      or
-      // check results call `operator new` with declaration variable
-      postDominates(ifc, this) and
-      exp = it.getExpr() and
-      it.getDeclaration() = ifc.getCondition().getAChild().(VariableAccess).getTarget()
+      exists(Variable v |
+        v = ifc.getCondition().getAChild().(VariableAccess).getTarget() and
+        (
+          exists(AssignExpr aex |
+            // check results call `operator new` with variable appropriation
+            aex.getAChild() = exp and
+            v = aex.getLValue().(VariableAccess).getTarget()
+          )
+          or
+          exists(Initializer it |
+            // check results call `operator new` with declaration variable
+            exp = it.getExpr() and
+            it.getDeclaration() = v
+          )
+        )
+      )
     )
   }
 


### PR DESCRIPTION
The fact that `aex` and `it` were each used in just one disjunct of the exists() body caused the optimizer to generate perfectly horrible code, including a pointless cartesian product between them that caused the evaluation to blow up.

Fix it such that each variable is logically scoped. That makes the compiler much happier.

(And is also semantically more correct. The query doesn't _really_ want only to produce results if there's an initializer somwhere in the program).