### PR TITLE
Update code scanning selectors to include summary metrics and `@kind alert` aliases

### DIFF
--- a/misc/suite-helpers/code-scanning-selectors.yml
+++ b/misc/suite-helpers/code-scanning-selectors.yml
@@ -3,6 +3,8 @@
     kind:
     - problem
     - path-problem
+    - alert
+    - path-alert
     precision:
     - high
     - very-high

--- a/misc/suite-helpers/code-scanning-selectors.yml
+++ b/misc/suite-helpers/code-scanning-selectors.yml
@@ -13,8 +13,12 @@
     - warning
     tags contain:
     - security
+- include:
+    kind:
+    - metric
+    tags contain:
+    - summary
 - exclude:
     deprecated: //
 - exclude:
     query path: /^experimental\/.*/
-


### PR DESCRIPTION
This PR updates the code scanning selectors to:

1. Include summary metrics like the lines of code that were analyzed.
2. Include queries using the `@kind alert` and `@kind path-alert` aliases for `@kind problem` and `@kind path-problem`.  (None of these exist yet.)