### PR TITLE
Use only_bind_out to force a good join order.

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dispatch/Dispatch.qll
@@ -387,7 +387,8 @@ private module Internal {
       result = this.getAStaticTarget()
       or
       result.getUnboundDeclaration() =
-        this.getASubsumedStaticTarget0(Gvn::getGlobalValueNumber(result.getDeclaringType()))
+        this.getASubsumedStaticTarget0(pragma[only_bind_out](Gvn::getGlobalValueNumber(result
+                .getDeclaringType())))
     }
 
     /**


### PR DESCRIPTION
This predicate changes to a bad join order with slight changes in the optimiser. By adding a `pragma` here we make it so that we avoid using `Gvn::getGlobalValueNumber` backwards where possible.This makes it easier to make future optimiser changes which don't break this predicate.