### PR TITLE
Add stepFlow from ClientReponse to error callback response

### DIFF
--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -412,6 +412,10 @@ private class PromiseTaintStep extends TaintTracking::SharedTaintStep {
       pred = thn.getReceiver() and
       succ = thn.getCallback(0).getParameter(0)
       or
+      thn.getReceiver() instanceof ClientRequest::Range and
+      pred = thn.getReceiver() and
+      succ = thn.getCallback(1).getParameter(0).getAPropertyRead("response")
+      or
       // from `v` to `p.then(x => return v)`
       pred = thn.getCallback([0 .. 1]).getAReturn() and
       succ = thn


### PR DESCRIPTION
Hello!

I want to add stepFlow for Promise from ClientRequest error callback to err.response property read.

Code Snippet:
```
import axios, {AxiosError} from 'axios';
import {apiUrl} from 'myconfig';

export default async function apiEndpoint(req: Request, res: Response) {

    axios({
        method: 'GET',
        url: `${apiUrl}`
    }).then(
        x => res.send(x.data),
        (err: AxiosError) => {
            if ('response' in err && err.response) {
                res.status(err.response.status).send(err.response.data);
            } else {
                res.status(502).send();
            }
        }
    );
}
```

It's my first commit to the core of standart library. I hope you can guide me how make this taint enchantment better.