### PR TITLE
Java: Fix QLDoc for `Container.toString()`

### DIFF
--- a/java/ql/src/semmle/code/FileSystem.qll
+++ b/java/ql/src/semmle/code/FileSystem.qll
@@ -148,8 +148,8 @@ class Container extends @container, Top {
   /**
    * Gets a textual representation of this container.
    *
-   * The default implementation returns the absolute path to the container, but subclasses may
-   * may override to provide a different result. To get the absolute path for any `Container`, call
+   * The default implementation gets the absolute path to the container, but subclasses may override
+   * to provide a different result. To get the absolute path of any `Container`, call
    * `Container.getAbsolutePath()` directly.
    */
   override string toString() { result = getAbsolutePath() }

--- a/java/ql/src/semmle/code/FileSystem.qll
+++ b/java/ql/src/semmle/code/FileSystem.qll
@@ -146,9 +146,11 @@ class Container extends @container, Top {
   }
 
   /**
-   * Gets a textual representation of the path of this container.
+   * Gets a textual representation of this container.
    *
-   * This is the absolute path of the container.
+   * The default implementation returns the absolute path to the container, but subclasses may
+   * may override to provide a different result. To get the absolute path for any `Container`, call
+   * `Container.getAbsolutePath()` directly.
    */
   override string toString() { result = getAbsolutePath() }
 }


### PR DESCRIPTION
Fixes #5828

The QLDoc was just too specific about the default implementation. I've improved the wording.