### PR TITLE
Add UnsafeDeserialization sinks

### DIFF
--- a/cpp/change-notes/2021-04-06-assign-where-compare-meant.md
+++ b/cpp/change-notes/2021-04-06-assign-where-compare-meant.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The 'Assignment where comparison was intended' (cpp/assign-where-compare-meant) query has been improved to flag fewer benign assignments in conditionals.

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
@@ -19,10 +19,6 @@
 | test.cpp:144:32:144:36 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:150:32:150:36 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:153:46:153:50 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:160:7:160:12 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:162:7:162:12 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:163:7:163:12 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:164:7:164:12 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:166:22:166:27 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:168:24:168:29 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:169:23:169:28 | ... = ... | Use of '=' where '==' may have been intended. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
@@ -19,3 +19,11 @@
 | test.cpp:144:32:144:36 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:150:32:150:36 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:153:46:153:50 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:160:7:160:12 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:162:7:162:12 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:163:7:163:12 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:164:7:164:12 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:166:22:166:27 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:168:24:168:29 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:169:23:169:28 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:171:7:171:12 | ... = ... | Use of '=' where '==' may have been intended. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
@@ -153,3 +153,21 @@ void f3(int x, int y) {
   if((x == 10) || ((z == z) && (x == 1)) && (y = 2)) { // BAD
   }
 }
+
+bool use(int);
+
+void f4(int x, bool b) {
+  if((x = 10) && use(x)) {} // GOOD [FALSE POSITIVE]: This is likely just a short-hand way of writing an assignment
+                            // followed by a boolean check.
+  if((x = 10) && b && use(x)) {} // GOOD [FALSE POSITIVE]: Same reason as above
+  if((x = 10) && use(x) && b) {} // GOOD [FALSE POSITIVE]: Same reason as above
+  if((x = 10) && (use(x) && b)) {} // GOOD [FALSE POSITIVE]: Same reason as above
+
+  if(use(x) && b && (x = 10)) {} // BAD: The assignment is the last thing that happens in the comparison.
+                                 // This doesn't match the usual pattern.
+  if((use(x) && b) && (x = 10)) {} // BAD: Same reason as above
+  if(use(x) && (b && (x = 10))) {} // BAD: Same reason as above
+
+  if((x = 10) || use(x)) {} // BAD: This doesn't follow the usual style of writing an assignment in
+                            // a boolean check.
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
@@ -157,11 +157,11 @@ void f3(int x, int y) {
 bool use(int);
 
 void f4(int x, bool b) {
-  if((x = 10) && use(x)) {} // GOOD [FALSE POSITIVE]: This is likely just a short-hand way of writing an assignment
+  if((x = 10) && use(x)) {} // GOOD: This is likely just a short-hand way of writing an assignment
                             // followed by a boolean check.
-  if((x = 10) && b && use(x)) {} // GOOD [FALSE POSITIVE]: Same reason as above
-  if((x = 10) && use(x) && b) {} // GOOD [FALSE POSITIVE]: Same reason as above
-  if((x = 10) && (use(x) && b)) {} // GOOD [FALSE POSITIVE]: Same reason as above
+  if((x = 10) && b && use(x)) {} // GOOD: Same reason as above
+  if((x = 10) && use(x) && b) {} // GOOD: Same reason as above
+  if((x = 10) && (use(x) && b)) {} // GOOD: Same reason as above
 
   if(use(x) && b && (x = 10)) {} // BAD: The assignment is the last thing that happens in the comparison.
                                  // This doesn't match the usual pattern.

--- a/docs/codeql/codeql-language-guides/data-flow-cheat-sheet-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/data-flow-cheat-sheet-for-javascript.rst
@@ -130,7 +130,7 @@ System and Network
     - `FileSystemWriteAccess <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/Concepts.qll/type.Concepts$FileSystemWriteAccess.html>`__ -- writing to the contents of a file
 - `PersistentReadAccess <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/Concepts.qll/type.Concepts$PersistentReadAccess.html>`__ -- reading from persistent storage, like cookies
 - `PersistentWriteAccess <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/Concepts.qll/type.Concepts$PersistentWriteAccess.html>`__ -- writing to persistent storage
-- `RemoteFlowSource <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/security/dataflow/RemoteFlowSources.qll/type.RemoteFlowSources$RemoteFlowSource.html>`__ -- source of untrusted user input
+- `RemoteFlowSource <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/security/dataflow/RemoteFlowSources.qll/type.RemoteFlowSources$Cached$RemoteFlowSource.html>`__ -- source of untrusted user input
 - `SystemCommandExecution <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/Concepts.qll/type.Concepts$SystemCommandExecution.html>`__ -- execution of a system command
 
 Files

--- a/docs/codeql/codeql-language-guides/specifying-additional-remote-flow-sources-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/specifying-additional-remote-flow-sources-for-javascript.rst
@@ -12,7 +12,7 @@ You can model potential sources of untrusted user input in your code without mak
    Specifying remote flow sources in external files is currently in beta and subject to change.
 
 As mentioned in the :doc:`Data flow cheat sheet for JavaScript <data-flow-cheat-sheet-for-javascript>`, the CodeQL libraries for JavaScript
-provide a class `RemoteFlowSource <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/security/dataflow/RemoteFlowSources.qll/type.RemoteFlowSources$RemoteFlowSource.html>`__ to represent sources of untrusted user input, sometimes also referred to as remote flow
+provide a class `RemoteFlowSource <https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/security/dataflow/RemoteFlowSources.qll/type.RemoteFlowSources$Cached$RemoteFlowSource.html>`__ to represent sources of untrusted user input, sometimes also referred to as remote flow
 sources.
 
 To model a new source of untrusted input, such as a previously unmodelled library API, you can

--- a/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
+++ b/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
@@ -14,8 +14,18 @@ may have unforeseen effects, such as the execution of arbitrary code.
 </p>
 <p>
 There are many different serialization frameworks.  This query currently
-supports Kryo, XmlDecoder, XStream, SnakeYaml, and Java IO serialization through
-<code>ObjectInputStream</code>/<code>ObjectOutputStream</code>.
+<<<<<<< HEAD
+<<<<<<< HEAD
+supports Kryo, XmlDecoder, XStream, SnakeYaml, Hessian, JsonIO, YAMLBeans, Castor, Burlap, 
+and Java IO serialization through <code>ObjectInputStream</code>/<code>ObjectOutputStream</code>.
+=======
+supports Kryo, XmlDecoder, XStream, SnakeYaml, Hessian, JsonIO, YAMLBeans, and Java 
+IO serialization through <code>ObjectInputStream</code>/<code>ObjectOutputStream</code>.
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+supports Kryo, XmlDecoder, XStream, SnakeYaml, Hessian, JsonIO, YAMLBeans, Castor, Burlap, 
+and Java IO serialization through <code>ObjectInputStream</code>/<code>ObjectOutputStream</code>.
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
 </p>
 </overview>
 
@@ -74,6 +84,22 @@ Alvaro Muñoz &amp; Christian Schneider, RSAConference 2016:
 <li>
 SnakeYaml documentation on deserialization:
 <a href="https://bitbucket.org/asomov/snakeyaml/wiki/Documentation#markdown-header-loading-yaml">SnakeYaml deserialization</a>.
+</li>
+<li>
+Hessian deserialization and related gadget chains:
+<a href="https://paper.seebug.org/1137/">Hessian deserialization</a>.
+</li>
+<li>
+Castor and Hessian java deserialization vulnerabilities:
+<a href="https://securitylab.github.com/research/hessian-java-deserialization-castor-vulnerabilities/">Castor and Hessian deserialization</a>.
+</li>
+<li>
+Remote code execution in JYaml library:
+<a href="https://www.cybersecurity-help.cz/vdb/SB2020022512">JYaml deserialization</a>.
+</li>
+<li>
+JsonIO deserialization vulnerabilities:
+<a href="https://klezvirus.github.io/Advanced-Web-Hacking/Serialisation/">JsonIO deserialization</a>.
 </li>
 </references>
 

--- a/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.ql
+++ b/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.ql
@@ -21,6 +21,48 @@ class UnsafeDeserializationConfig extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   override predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeDeserializationSink }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node prod, DataFlow::Node succ) {
+    exists(ClassInstanceExpr cie |
+      cie.getConstructor().getDeclaringType() instanceof JsonReader and
+      cie.getArgument(0) = prod.asExpr() and
+      cie = succ.asExpr() and
+      not exists(SafeJsonIo sji | sji.hasFlowToExpr(cie.getArgument(1)))
+    )
+    or
+    exists(ClassInstanceExpr cie |
+      cie.getConstructor().getDeclaringType() instanceof YamlReader and
+      cie.getArgument(0) = prod.asExpr() and
+      cie = succ.asExpr()
+    )
+    or
+    exists(ClassInstanceExpr cie |
+      cie.getConstructor().getDeclaringType() instanceof UnSafeHessianInput and
+      cie.getArgument(0) = prod.asExpr() and
+      cie = succ.asExpr()
+    )
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+    or
+    exists(ClassInstanceExpr cie |
+      cie.getConstructor().getDeclaringType() instanceof BurlapInput and
+      cie.getArgument(0) = prod.asExpr() and
+      cie = succ.asExpr()
+    )
+    or
+    exists(MethodAccess ma |
+      ma.getMethod() instanceof BurlapInputInitMethod and
+      ma.getArgument(0) = prod.asExpr() and
+      ma.getQualifier() = succ.asExpr()
+    )
+<<<<<<< HEAD
+=======
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+  }
 }
 
 from DataFlow::PathNode source, DataFlow::PathNode sink, UnsafeDeserializationConfig conf

--- a/java/ql/src/semmle/code/java/frameworks/Castor.qll
+++ b/java/ql/src/semmle/code/java/frameworks/Castor.qll
@@ -1,0 +1,26 @@
+/**
+ * Provides classes and predicates for working with the Castor framework.
+ */
+
+import java
+
+/**
+ * The class `org.exolab.castor.xml.Unmarshaller`.
+ */
+class Unmarshaller extends RefType {
+  Unmarshaller() { this.hasQualifiedName("org.exolab.castor.xml", "Unmarshaller") }
+}
+
+<<<<<<< HEAD
+/** A method with the name `unmarshal` declared in `org.exolab.castor.xml.Unmarshaller`. */
+=======
+/**
+ * A Unmarshaller unmarshal method. This is either `Unmarshaller.unmarshal`.
+ */
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+class UnmarshalMethod extends Method {
+  UnmarshalMethod() {
+    this.getDeclaringType() instanceof Unmarshaller and
+    this.getName() = "unmarshal"
+  }
+}

--- a/java/ql/src/semmle/code/java/frameworks/Hessian.qll
+++ b/java/ql/src/semmle/code/java/frameworks/Hessian.qll
@@ -1,0 +1,68 @@
+/**
+ * Provides classes and predicates for working with the Hession framework.
+ */
+
+import java
+
+/**
+ * The class `com.caucho.hessian.io.HessianInput` or `com.caucho.hessian.io.Hessian2Input`.
+ */
+class UnSafeHessianInput extends RefType {
+  UnSafeHessianInput() {
+    this.hasQualifiedName("com.caucho.hessian.io", ["HessianInput", "Hessian2Input"])
+  }
+}
+
+/**
+ * A HessianInput readObject method. This is either `HessianInput.readObject` or `Hessian2Input.readObject`.
+ */
+class UnSafeHessianInputReadObjectMethod extends Method {
+  UnSafeHessianInputReadObjectMethod() {
+    this.getDeclaringType() instanceof UnSafeHessianInput and
+    this.getName() = "readObject"
+  }
+}
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+
+/**
+ * The class `com.caucho.burlap.io.BurlapInput`.
+ */
+class BurlapInput extends RefType {
+  BurlapInput() { this.hasQualifiedName("com.caucho.burlap.io", "BurlapInput") }
+}
+
+<<<<<<< HEAD
+/** A method with the name `readObject` declared in `com.caucho.burlap.io.BurlapInput`. */
+=======
+/**
+ * A BurlapInput readObject method. This is either `BurlapInput.readObject`.
+ */
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+class BurlapInputReadObjectMethod extends Method {
+  BurlapInputReadObjectMethod() {
+    this.getDeclaringType() instanceof BurlapInput and
+    this.getName() = "readObject"
+  }
+}
+
+<<<<<<< HEAD
+/** A method with the name `init` declared in `com.caucho.burlap.io.BurlapInput`. */
+=======
+/**
+ * A BurlapInput init method. This is either `BurlapInput.init`.
+ */
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+class BurlapInputInitMethod extends Method {
+  BurlapInputInitMethod() {
+    this.getDeclaringType() instanceof BurlapInput and
+    this.getName() = "init"
+  }
+}
+<<<<<<< HEAD
+=======
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection

--- a/java/ql/src/semmle/code/java/frameworks/JYaml.qll
+++ b/java/ql/src/semmle/code/java/frameworks/JYaml.qll
@@ -1,0 +1,49 @@
+/**
+ * Provides classes and predicates for working with the JYaml framework.
+ */
+
+import java
+
+/**
+ * The class `org.ho.yaml.Yaml`.
+ */
+class JYaml extends RefType {
+  JYaml() { this.hasQualifiedName("org.ho.yaml", "Yaml") }
+}
+
+/**
+<<<<<<< HEAD
+ * A JYaml unsafe load method. This is either `YAML.load` or
+ * `YAML.loadStream` or `YAML.loadStreamOfType`.
+=======
+ * A JYaml unsafe load method. This is either `YAML.load`.
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+ */
+class JYamlUnSafeLoadMethod extends Method {
+  JYamlUnSafeLoadMethod() {
+    this.getDeclaringType() instanceof JYaml and
+    this.getName() in ["load", "loadStream", "loadStreamOfType"]
+  }
+}
+
+/**
+ * The class `org.ho.yaml.YamlConfig`.
+ */
+class JYamlConfig extends RefType {
+  JYamlConfig() { this.hasQualifiedName("org.ho.yaml", "YamlConfig") }
+}
+
+/**
+<<<<<<< HEAD
+ * A JYamlConfig unsafe load method. This is either `YamlConfig.load` or
+=======
+ * A JYamlConfig unsafe load method. This is either `YamlConfig.load` or 
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+ * `YamlConfig.loadStream` or `YamlConfig.loadStreamOfType`.
+ */
+class JYamlConfigUnSafeLoadMethod extends Method {
+  JYamlConfigUnSafeLoadMethod() {
+    this.getDeclaringType() instanceof JYamlConfig and
+    this.getName() in ["load", "loadStream", "loadStreamOfType"]
+  }
+}

--- a/java/ql/src/semmle/code/java/frameworks/JsonIo.qll
+++ b/java/ql/src/semmle/code/java/frameworks/JsonIo.qll
@@ -1,0 +1,57 @@
+/**
+ * Provides classes and predicates for working with the Json-io framework.
+ */
+
+import java
+import semmle.code.java.Maps
+
+/**
+ * The class `com.cedarsoftware.util.io.JsonReader`.
+ */
+class JsonReader extends RefType {
+  JsonReader() { this.hasQualifiedName("com.cedarsoftware.util.io", "JsonReader") }
+}
+
+<<<<<<< HEAD
+/** A method with the name `jsonToJava` declared in `com.cedarsoftware.util.io.JsonReader`. */
+=======
+/**
+ * A json-io jsonToJava method. This is either `JsonReader.jsonToJava`.
+ */
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+class JsonIoJsonToJavaMethod extends Method {
+  JsonIoJsonToJavaMethod() {
+    this.getDeclaringType() instanceof JsonReader and
+    this.getName() = "jsonToJava"
+  }
+}
+
+<<<<<<< HEAD
+/** A method with the name `readObject` declared in `com.cedarsoftware.util.io.JsonReader`. */
+=======
+/**
+ * A json-io readObject method. This is either `JsonReader.readObject`.
+ */
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+class JsonIoReadObjectMethod extends Method {
+  JsonIoReadObjectMethod() {
+    this.getDeclaringType() instanceof JsonReader and
+    this.getName() = "readObject"
+  }
+}
+
+<<<<<<< HEAD
+/**
+ * A call to `Map.put` method, set the value of the `USE_MAPS` key to `true`.
+ * 
+ */
+=======
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+class JsonIoSafeOptionalArgs extends MethodAccess {
+  JsonIoSafeOptionalArgs() {
+    this.getMethod().getDeclaringType().getASourceSupertype*() instanceof MapType and
+    this.getMethod().hasName("put") and
+    this.getArgument(0).(CompileTimeConstantExpr).getStringValue() = "USE_MAPS" and
+    this.getArgument(1).(CompileTimeConstantExpr).getBooleanValue() = true
+  }
+}

--- a/java/ql/src/semmle/code/java/frameworks/YamlBeans.qll
+++ b/java/ql/src/semmle/code/java/frameworks/YamlBeans.qll
@@ -1,0 +1,26 @@
+/**
+ * Provides classes and predicates for working with the YamlBeans framework.
+ */
+
+import java
+
+/**
+ * The class `com.esotericsoftware.yamlbeans.YamlReader`.
+ */
+class YamlReader extends RefType {
+  YamlReader() { this.hasQualifiedName("com.esotericsoftware.yamlbeans", "YamlReader") }
+}
+
+<<<<<<< HEAD
+/** A method with the name `read` declared in `com.esotericsoftware.yamlbeans.YamlReader`. */
+=======
+/**
+ * A YamlReader read method. This is either `YamlReader.read`.
+ */
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+class YamlReaderReadMethod extends Method {
+  YamlReaderReadMethod() {
+    this.getDeclaringType() instanceof YamlReader and
+    this.getName() = "read"
+  }
+}

--- a/java/ql/src/semmle/code/java/security/UnsafeDeserialization.qll
+++ b/java/ql/src/semmle/code/java/security/UnsafeDeserialization.qll
@@ -2,6 +2,18 @@ import semmle.code.java.frameworks.Kryo
 import semmle.code.java.frameworks.XStream
 import semmle.code.java.frameworks.SnakeYaml
 import semmle.code.java.frameworks.FastJson
+import semmle.code.java.frameworks.JYaml
+import semmle.code.java.frameworks.JsonIo
+import semmle.code.java.frameworks.YamlBeans
+import semmle.code.java.frameworks.Hessian
+<<<<<<< HEAD
+<<<<<<< HEAD
+import semmle.code.java.frameworks.Castor
+=======
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+import semmle.code.java.frameworks.Castor
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
 import semmle.code.java.frameworks.apache.Lang
 
 class ObjectInputStreamReadObjectMethod extends Method {
@@ -50,6 +62,29 @@ class SafeKryo extends DataFlow2::Configuration {
   }
 }
 
+class SafeJsonIo extends DataFlow2::Configuration {
+  SafeJsonIo() { this = "UnsafeDeserialization::SafeJsonIo" }
+
+  override predicate isSource(DataFlow::Node src) {
+    exists(MethodAccess ma |
+      ma instanceof JsonIoSafeOptionalArgs and
+      src.asExpr() = ma.getQualifier()
+    )
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma |
+      ma.getMethod() instanceof JsonIoJsonToJavaMethod and
+      sink.asExpr() = ma.getArgument(1)
+    )
+    or
+    exists(ClassInstanceExpr cie |
+      cie.getConstructor().getDeclaringType() instanceof JsonReader and
+      sink.asExpr() = cie.getArgument(1)
+    )
+  }
+}
+
 predicate unsafeDeserialization(MethodAccess ma, Expr sink) {
   exists(Method m | m = ma.getMethod() |
     m instanceof ObjectInputStreamReadObjectMethod and
@@ -81,6 +116,36 @@ predicate unsafeDeserialization(MethodAccess ma, Expr sink) {
     ma.getMethod() instanceof FastJsonParseMethod and
     not fastJsonLooksSafe() and
     sink = ma.getArgument(0)
+    or
+    ma.getMethod() instanceof JYamlUnSafeLoadMethod and
+    sink = ma.getArgument(0)
+    or
+    ma.getMethod() instanceof JYamlConfigUnSafeLoadMethod and
+    sink = ma.getArgument(0)
+    or
+    ma.getMethod() instanceof JsonIoJsonToJavaMethod and
+    sink = ma.getArgument(0) and
+    not exists(SafeJsonIo sji | sji.hasFlowToExpr(ma.getArgument(1)))
+    or
+    ma.getMethod() instanceof JsonIoReadObjectMethod and
+    sink = ma.getQualifier()
+    or
+    ma.getMethod() instanceof YamlReaderReadMethod and sink = ma.getQualifier()
+    or
+    ma.getMethod() instanceof UnSafeHessianInputReadObjectMethod and sink = ma.getQualifier()
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+    or
+    ma.getMethod() instanceof UnmarshalMethod and sink = ma.getAnArgument()
+    or
+    ma.getMethod() instanceof BurlapInputReadObjectMethod and sink = ma.getQualifier()
+<<<<<<< HEAD
+=======
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
   )
 }
 

--- a/java/ql/test/query-tests/security/CWE-502/C.java
+++ b/java/ql/test/query-tests/security/CWE-502/C.java
@@ -1,0 +1,123 @@
+import java.util.HashMap;
+<<<<<<< HEAD
+<<<<<<< HEAD
+import java.io.StringReader;
+=======
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+import java.io.StringReader;
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import com.cedarsoftware.util.io.JsonReader;
+import com.esotericsoftware.yamlbeans.YamlReader;
+import org.ho.yaml.Yaml;
+import org.ho.yaml.YamlConfig;
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+import org.exolab.castor.xml.Unmarshaller;
+import com.caucho.hessian.io.Hessian2Input;
+import com.caucho.hessian.io.HessianInput;
+import com.caucho.burlap.io.BurlapInput;
+<<<<<<< HEAD
+=======
+import com.caucho.hessian.io.Hessian2Input;
+import com.caucho.hessian.io.HessianInput;
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+import java.io.ByteArrayInputStream;
+
+@Controller
+public class C {
+
+	@GetMapping(value = "jyaml")
+	public void bad1(HttpServletRequest request) throws Exception {
+		String data = request.getParameter("data");
+		Yaml.load(data);  //bad
+		Yaml.loadStream(data);  //bad
+		Yaml.loadStreamOfType(data, Object.class);  //bad
+		Yaml.loadType(data, Object.class);  //good
+
+		org.ho.yaml.YamlConfig yamlConfig = new YamlConfig();
+		yamlConfig.load(data);  //bad
+		yamlConfig.loadStream(data);  //bad
+		yamlConfig.loadStreamOfType(data, Object.class);  //bad
+		yamlConfig.loadType(data, Object.class);  //good
+	}
+
+	@GetMapping(value = "jsonio")
+	public void bad2(HttpServletRequest request) {
+		String data = request.getParameter("data");
+
+		HashMap hashMap = new HashMap();
+		hashMap.put("USE_MAPS", true);
+
+		JsonReader.jsonToJava(data); //bad
+
+		JsonReader.jsonToJava(data, hashMap); //good
+
+		JsonReader jr = new JsonReader(data, null); //bad
+		jr.readObject();
+
+		JsonReader jr1 = new JsonReader(data, hashMap); //good
+		jr1.readObject();
+	}
+
+	@GetMapping(value = "yamlbeans")
+	public void bad3(HttpServletRequest request) throws Exception {
+		String data = request.getParameter("data");
+		YamlReader r = new YamlReader(data);
+		r.read(); //bad
+		r.read(Object.class); //bad
+		r.read(Object.class, Object.class); //bad
+	}
+
+        @GetMapping(value = "hessian")
+	public void bad4(HttpServletRequest request) throws Exception {
+		byte[] bytes = request.getParameter("data").getBytes();
+		ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+		HessianInput hessianInput = new HessianInput(bis);
+		hessianInput.readObject(); //bad
+		hessianInput.readObject(Object.class); //bad
+	}
+
+	@GetMapping(value = "hessian2")
+	public void bad5(HttpServletRequest request) throws Exception {
+		byte[] bytes = request.getParameter("data").getBytes();
+		ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+		Hessian2Input hessianInput = new Hessian2Input(bis);
+		hessianInput.readObject(); //bad
+		hessianInput.readObject(Object.class); //bad
+	}
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+    
+    @GetMapping(value = "castor")
+	public void bad6(HttpServletRequest request) throws Exception {
+		Unmarshaller unmarshaller = new Unmarshaller();
+		unmarshaller.unmarshal(new StringReader(request.getParameter("data"))); //bad
+	}
+
+    @GetMapping(value = "burlap")
+	public void bad7(HttpServletRequest request) throws Exception {
+		byte[] serializedData = request.getParameter("data").getBytes();
+		ByteArrayInputStream is = new ByteArrayInputStream(serializedData);
+		BurlapInput burlapInput = new BurlapInput(is);
+		burlapInput.readObject(); //bad
+
+        BurlapInput burlapInput1 = new BurlapInput();
+		burlapInput1.init(is);
+		burlapInput1.readObject(); //bad
+	}
+<<<<<<< HEAD
+=======
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+}

--- a/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
+++ b/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
@@ -1,40 +1,136 @@
 edges
+| A.java:13:31:13:51 | getInputStream(...) : InputStream | A.java:14:50:14:60 | inputStream : InputStream |
 | A.java:13:31:13:51 | getInputStream(...) : InputStream | A.java:15:12:15:13 | in |
+| A.java:14:28:14:61 | new ObjectInputStream(...) : ObjectInputStream | A.java:15:12:15:13 | in |
+| A.java:14:50:14:60 | inputStream : InputStream | A.java:14:28:14:61 | new ObjectInputStream(...) : ObjectInputStream |
+| A.java:19:31:19:51 | getInputStream(...) : InputStream | A.java:20:50:20:60 | inputStream : InputStream |
 | A.java:19:31:19:51 | getInputStream(...) : InputStream | A.java:21:12:21:13 | in |
-| A.java:25:31:25:51 | getInputStream(...) : InputStream | A.java:27:12:27:12 | d |
-| A.java:32:31:32:51 | getInputStream(...) : InputStream | A.java:34:23:34:28 | reader |
-| A.java:39:29:39:49 | getInputStream(...) : InputStream | A.java:40:28:40:32 | input |
-| A.java:39:29:39:49 | getInputStream(...) : InputStream | A.java:41:34:41:38 | input |
-| A.java:39:29:39:49 | getInputStream(...) : InputStream | A.java:42:40:42:44 | input |
+| A.java:20:28:20:61 | new ObjectInputStream(...) : ObjectInputStream | A.java:21:12:21:13 | in |
+| A.java:20:50:20:60 | inputStream : InputStream | A.java:20:28:20:61 | new ObjectInputStream(...) : ObjectInputStream |
+| A.java:25:31:25:51 | getInputStream(...) : InputStream | A.java:26:35:26:45 | inputStream : InputStream |
+| A.java:26:20:26:46 | new XMLDecoder(...) : XMLDecoder | A.java:27:12:27:12 | d |
+| A.java:26:35:26:45 | inputStream : InputStream | A.java:26:20:26:46 | new XMLDecoder(...) : XMLDecoder |
+| A.java:32:31:32:51 | getInputStream(...) : InputStream | A.java:33:43:33:53 | inputStream : InputStream |
+| A.java:33:21:33:54 | new InputStreamReader(...) : InputStreamReader | A.java:34:23:34:28 | reader |
+| A.java:33:43:33:53 | inputStream : InputStream | A.java:33:21:33:54 | new InputStreamReader(...) : InputStreamReader |
+| A.java:39:19:39:50 | new Input(...) : Input | A.java:40:28:40:32 | input |
+| A.java:39:19:39:50 | new Input(...) : Input | A.java:41:34:41:38 | input |
+| A.java:39:19:39:50 | new Input(...) : Input | A.java:42:40:42:44 | input |
+| A.java:39:29:39:49 | getInputStream(...) : InputStream | A.java:39:19:39:50 | new Input(...) : Input |
 | A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:61:26:61:30 | input |
 | A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:62:30:62:34 | input |
-| A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:63:28:63:55 | new InputStreamReader(...) |
+| A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:63:50:63:54 | input : InputStream |
 | A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:64:24:64:28 | input |
-| A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:65:24:65:51 | new InputStreamReader(...) |
+| A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:65:46:65:50 | input : InputStream |
+| A.java:63:50:63:54 | input : InputStream | A.java:63:28:63:55 | new InputStreamReader(...) |
+| A.java:65:46:65:50 | input : InputStream | A.java:65:24:65:51 | new InputStreamReader(...) |
 | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:71:26:71:30 | input |
 | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:72:30:72:34 | input |
-| A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:73:28:73:55 | new InputStreamReader(...) |
+| A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:73:50:73:54 | input : InputStream |
 | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:74:24:74:28 | input |
-| A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:75:24:75:51 | new InputStreamReader(...) |
+| A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:75:46:75:50 | input : InputStream |
+| A.java:73:50:73:54 | input : InputStream | A.java:73:28:73:55 | new InputStreamReader(...) |
+| A.java:75:46:75:50 | input : InputStream | A.java:75:24:75:51 | new InputStreamReader(...) |
 | A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:91:26:91:30 | input |
 | A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:92:30:92:34 | input |
-| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:93:28:93:55 | new InputStreamReader(...) |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:93:50:93:54 | input : InputStream |
 | A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:94:24:94:28 | input |
-| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:95:24:95:51 | new InputStreamReader(...) |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:95:46:95:50 | input : InputStream |
+| A.java:93:50:93:54 | input : InputStream | A.java:93:28:93:55 | new InputStreamReader(...) |
+| A.java:95:46:95:50 | input : InputStream | A.java:95:24:95:51 | new InputStreamReader(...) |
 | B.java:7:31:7:51 | getInputStream(...) : InputStream | B.java:8:29:8:39 | inputStream |
-| B.java:12:31:12:51 | getInputStream(...) : InputStream | B.java:15:23:15:27 | bytes |
-| B.java:19:31:19:51 | getInputStream(...) : InputStream | B.java:23:29:23:29 | s |
-| B.java:27:31:27:51 | getInputStream(...) : InputStream | B.java:31:23:31:23 | s |
+| B.java:12:31:12:51 | getInputStream(...) : InputStream | B.java:14:5:14:15 | inputStream : InputStream |
+| B.java:14:5:14:15 | inputStream : InputStream | B.java:14:22:14:26 | bytes [post update] : byte[] |
+| B.java:14:22:14:26 | bytes [post update] : byte[] | B.java:15:23:15:27 | bytes |
+| B.java:19:31:19:51 | getInputStream(...) : InputStream | B.java:21:5:21:15 | inputStream : InputStream |
+| B.java:21:5:21:15 | inputStream : InputStream | B.java:21:22:21:26 | bytes [post update] : byte[] |
+| B.java:21:22:21:26 | bytes [post update] : byte[] | B.java:23:29:23:29 | s |
+| B.java:27:31:27:51 | getInputStream(...) : InputStream | B.java:29:5:29:15 | inputStream : InputStream |
+| B.java:29:5:29:15 | inputStream : InputStream | B.java:29:22:29:26 | bytes [post update] : byte[] |
+| B.java:29:22:29:26 | bytes [post update] : byte[] | B.java:31:23:31:23 | s |
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+| C.java:21:17:21:44 | getParameter(...) : String | C.java:22:13:22:16 | data |
+| C.java:21:17:21:44 | getParameter(...) : String | C.java:23:19:23:22 | data |
+| C.java:21:17:21:44 | getParameter(...) : String | C.java:24:25:24:28 | data |
+| C.java:21:17:21:44 | getParameter(...) : String | C.java:28:19:28:22 | data |
+| C.java:21:17:21:44 | getParameter(...) : String | C.java:29:25:29:28 | data |
+| C.java:21:17:21:44 | getParameter(...) : String | C.java:30:31:30:34 | data |
+| C.java:36:17:36:44 | getParameter(...) : String | C.java:41:25:41:28 | data |
+| C.java:36:17:36:44 | getParameter(...) : String | C.java:46:3:46:4 | jr |
+| C.java:54:17:54:44 | getParameter(...) : String | C.java:56:3:56:3 | r |
+| C.java:54:17:54:44 | getParameter(...) : String | C.java:57:3:57:3 | r |
+| C.java:54:17:54:44 | getParameter(...) : String | C.java:58:3:58:3 | r |
+| C.java:63:18:63:45 | getParameter(...) : String | C.java:64:55:64:59 | bytes : byte[] |
+| C.java:63:18:63:45 | getParameter(...) : String | C.java:66:3:66:14 | hessianInput |
+| C.java:63:18:63:45 | getParameter(...) : String | C.java:67:3:67:14 | hessianInput |
+| C.java:64:30:64:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:66:3:66:14 | hessianInput |
+| C.java:64:30:64:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:67:3:67:14 | hessianInput |
+| C.java:64:55:64:59 | bytes : byte[] | C.java:64:30:64:60 | new ByteArrayInputStream(...) : ByteArrayInputStream |
+| C.java:72:18:72:45 | getParameter(...) : String | C.java:73:55:73:59 | bytes : byte[] |
+| C.java:72:18:72:45 | getParameter(...) : String | C.java:75:3:75:14 | hessianInput |
+| C.java:72:18:72:45 | getParameter(...) : String | C.java:76:3:76:14 | hessianInput |
+| C.java:73:30:73:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:75:3:75:14 | hessianInput |
+| C.java:73:30:73:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:76:3:76:14 | hessianInput |
+| C.java:73:55:73:59 | bytes : byte[] | C.java:73:30:73:60 | new ByteArrayInputStream(...) : ByteArrayInputStream |
+| C.java:82:43:82:70 | getParameter(...) : String | C.java:82:26:82:71 | new StringReader(...) |
+| C.java:87:27:87:54 | getParameter(...) : String | C.java:88:54:88:67 | serializedData : byte[] |
+| C.java:87:27:87:54 | getParameter(...) : String | C.java:90:3:90:13 | burlapInput |
+| C.java:87:27:87:54 | getParameter(...) : String | C.java:94:3:94:14 | burlapInput1 |
+| C.java:88:29:88:68 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:90:3:90:13 | burlapInput |
+| C.java:88:29:88:68 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:94:3:94:14 | burlapInput1 |
+| C.java:88:54:88:67 | serializedData : byte[] | C.java:88:29:88:68 | new ByteArrayInputStream(...) : ByteArrayInputStream |
+<<<<<<< HEAD
+=======
+| C.java:18:17:18:44 | getParameter(...) : String | C.java:19:13:19:16 | data |
+| C.java:18:17:18:44 | getParameter(...) : String | C.java:20:19:20:22 | data |
+| C.java:18:17:18:44 | getParameter(...) : String | C.java:21:25:21:28 | data |
+| C.java:18:17:18:44 | getParameter(...) : String | C.java:25:19:25:22 | data |
+| C.java:18:17:18:44 | getParameter(...) : String | C.java:26:25:26:28 | data |
+| C.java:18:17:18:44 | getParameter(...) : String | C.java:27:31:27:34 | data |
+| C.java:33:17:33:44 | getParameter(...) : String | C.java:38:25:38:28 | data |
+| C.java:33:17:33:44 | getParameter(...) : String | C.java:43:3:43:4 | jr |
+| C.java:51:17:51:44 | getParameter(...) : String | C.java:53:3:53:3 | r |
+| C.java:51:17:51:44 | getParameter(...) : String | C.java:54:3:54:3 | r |
+| C.java:51:17:51:44 | getParameter(...) : String | C.java:55:3:55:3 | r |
+| C.java:60:18:60:45 | getParameter(...) : String | C.java:61:55:61:59 | bytes : byte[] |
+| C.java:60:18:60:45 | getParameter(...) : String | C.java:63:3:63:14 | hessianInput |
+| C.java:60:18:60:45 | getParameter(...) : String | C.java:64:3:64:14 | hessianInput |
+| C.java:61:30:61:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:63:3:63:14 | hessianInput |
+| C.java:61:30:61:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:64:3:64:14 | hessianInput |
+| C.java:61:55:61:59 | bytes : byte[] | C.java:61:30:61:60 | new ByteArrayInputStream(...) : ByteArrayInputStream |
+| C.java:69:18:69:45 | getParameter(...) : String | C.java:70:55:70:59 | bytes : byte[] |
+| C.java:69:18:69:45 | getParameter(...) : String | C.java:72:3:72:14 | hessianInput |
+| C.java:69:18:69:45 | getParameter(...) : String | C.java:73:3:73:14 | hessianInput |
+| C.java:70:30:70:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:72:3:72:14 | hessianInput |
+| C.java:70:30:70:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:73:3:73:14 | hessianInput |
+| C.java:70:55:70:59 | bytes : byte[] | C.java:70:30:70:60 | new ByteArrayInputStream(...) : ByteArrayInputStream |
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
 | TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) |
+| TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | TestMessageBodyReader.java:22:40:22:51 | entityStream : InputStream |
+| TestMessageBodyReader.java:22:40:22:51 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) |
 nodes
 | A.java:13:31:13:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| A.java:14:28:14:61 | new ObjectInputStream(...) : ObjectInputStream | semmle.label | new ObjectInputStream(...) : ObjectInputStream |
+| A.java:14:50:14:60 | inputStream : InputStream | semmle.label | inputStream : InputStream |
 | A.java:15:12:15:13 | in | semmle.label | in |
 | A.java:19:31:19:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| A.java:20:28:20:61 | new ObjectInputStream(...) : ObjectInputStream | semmle.label | new ObjectInputStream(...) : ObjectInputStream |
+| A.java:20:50:20:60 | inputStream : InputStream | semmle.label | inputStream : InputStream |
 | A.java:21:12:21:13 | in | semmle.label | in |
 | A.java:25:31:25:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| A.java:26:20:26:46 | new XMLDecoder(...) : XMLDecoder | semmle.label | new XMLDecoder(...) : XMLDecoder |
+| A.java:26:35:26:45 | inputStream : InputStream | semmle.label | inputStream : InputStream |
 | A.java:27:12:27:12 | d | semmle.label | d |
 | A.java:32:31:32:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| A.java:33:21:33:54 | new InputStreamReader(...) : InputStreamReader | semmle.label | new InputStreamReader(...) : InputStreamReader |
+| A.java:33:43:33:53 | inputStream : InputStream | semmle.label | inputStream : InputStream |
 | A.java:34:23:34:28 | reader | semmle.label | reader |
+| A.java:39:19:39:50 | new Input(...) : Input | semmle.label | new Input(...) : Input |
 | A.java:39:29:39:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:40:28:40:32 | input | semmle.label | input |
 | A.java:41:34:41:38 | input | semmle.label | input |
@@ -43,30 +139,107 @@ nodes
 | A.java:61:26:61:30 | input | semmle.label | input |
 | A.java:62:30:62:34 | input | semmle.label | input |
 | A.java:63:28:63:55 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:63:50:63:54 | input : InputStream | semmle.label | input : InputStream |
 | A.java:64:24:64:28 | input | semmle.label | input |
 | A.java:65:24:65:51 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:65:46:65:50 | input : InputStream | semmle.label | input : InputStream |
 | A.java:70:25:70:45 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:71:26:71:30 | input | semmle.label | input |
 | A.java:72:30:72:34 | input | semmle.label | input |
 | A.java:73:28:73:55 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:73:50:73:54 | input : InputStream | semmle.label | input : InputStream |
 | A.java:74:24:74:28 | input | semmle.label | input |
 | A.java:75:24:75:51 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:75:46:75:50 | input : InputStream | semmle.label | input : InputStream |
 | A.java:90:25:90:45 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:91:26:91:30 | input | semmle.label | input |
 | A.java:92:30:92:34 | input | semmle.label | input |
 | A.java:93:28:93:55 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:93:50:93:54 | input : InputStream | semmle.label | input : InputStream |
 | A.java:94:24:94:28 | input | semmle.label | input |
 | A.java:95:24:95:51 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:95:46:95:50 | input : InputStream | semmle.label | input : InputStream |
 | B.java:7:31:7:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | B.java:8:29:8:39 | inputStream | semmle.label | inputStream |
 | B.java:12:31:12:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| B.java:14:5:14:15 | inputStream : InputStream | semmle.label | inputStream : InputStream |
+| B.java:14:22:14:26 | bytes [post update] : byte[] | semmle.label | bytes [post update] : byte[] |
 | B.java:15:23:15:27 | bytes | semmle.label | bytes |
 | B.java:19:31:19:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| B.java:21:5:21:15 | inputStream : InputStream | semmle.label | inputStream : InputStream |
+| B.java:21:22:21:26 | bytes [post update] : byte[] | semmle.label | bytes [post update] : byte[] |
 | B.java:23:29:23:29 | s | semmle.label | s |
 | B.java:27:31:27:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| B.java:29:5:29:15 | inputStream : InputStream | semmle.label | inputStream : InputStream |
+| B.java:29:22:29:26 | bytes [post update] : byte[] | semmle.label | bytes [post update] : byte[] |
 | B.java:31:23:31:23 | s | semmle.label | s |
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+| C.java:21:17:21:44 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:22:13:22:16 | data | semmle.label | data |
+| C.java:23:19:23:22 | data | semmle.label | data |
+| C.java:24:25:24:28 | data | semmle.label | data |
+| C.java:28:19:28:22 | data | semmle.label | data |
+| C.java:29:25:29:28 | data | semmle.label | data |
+| C.java:30:31:30:34 | data | semmle.label | data |
+| C.java:36:17:36:44 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:41:25:41:28 | data | semmle.label | data |
+| C.java:46:3:46:4 | jr | semmle.label | jr |
+| C.java:54:17:54:44 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:56:3:56:3 | r | semmle.label | r |
+| C.java:57:3:57:3 | r | semmle.label | r |
+| C.java:58:3:58:3 | r | semmle.label | r |
+| C.java:63:18:63:45 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:64:30:64:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | semmle.label | new ByteArrayInputStream(...) : ByteArrayInputStream |
+| C.java:64:55:64:59 | bytes : byte[] | semmle.label | bytes : byte[] |
+| C.java:66:3:66:14 | hessianInput | semmle.label | hessianInput |
+| C.java:67:3:67:14 | hessianInput | semmle.label | hessianInput |
+| C.java:72:18:72:45 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:73:30:73:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | semmle.label | new ByteArrayInputStream(...) : ByteArrayInputStream |
+| C.java:73:55:73:59 | bytes : byte[] | semmle.label | bytes : byte[] |
+| C.java:75:3:75:14 | hessianInput | semmle.label | hessianInput |
+| C.java:76:3:76:14 | hessianInput | semmle.label | hessianInput |
+| C.java:82:26:82:71 | new StringReader(...) | semmle.label | new StringReader(...) |
+| C.java:82:43:82:70 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:87:27:87:54 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:88:29:88:68 | new ByteArrayInputStream(...) : ByteArrayInputStream | semmle.label | new ByteArrayInputStream(...) : ByteArrayInputStream |
+| C.java:88:54:88:67 | serializedData : byte[] | semmle.label | serializedData : byte[] |
+| C.java:90:3:90:13 | burlapInput | semmle.label | burlapInput |
+| C.java:94:3:94:14 | burlapInput1 | semmle.label | burlapInput1 |
+<<<<<<< HEAD
+=======
+| C.java:18:17:18:44 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:19:13:19:16 | data | semmle.label | data |
+| C.java:20:19:20:22 | data | semmle.label | data |
+| C.java:21:25:21:28 | data | semmle.label | data |
+| C.java:25:19:25:22 | data | semmle.label | data |
+| C.java:26:25:26:28 | data | semmle.label | data |
+| C.java:27:31:27:34 | data | semmle.label | data |
+| C.java:33:17:33:44 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:38:25:38:28 | data | semmle.label | data |
+| C.java:43:3:43:4 | jr | semmle.label | jr |
+| C.java:51:17:51:44 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:53:3:53:3 | r | semmle.label | r |
+| C.java:54:3:54:3 | r | semmle.label | r |
+| C.java:55:3:55:3 | r | semmle.label | r |
+| C.java:60:18:60:45 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:61:30:61:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | semmle.label | new ByteArrayInputStream(...) : ByteArrayInputStream |
+| C.java:61:55:61:59 | bytes : byte[] | semmle.label | bytes : byte[] |
+| C.java:63:3:63:14 | hessianInput | semmle.label | hessianInput |
+| C.java:64:3:64:14 | hessianInput | semmle.label | hessianInput |
+| C.java:69:18:69:45 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| C.java:70:30:70:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | semmle.label | new ByteArrayInputStream(...) : ByteArrayInputStream |
+| C.java:70:55:70:59 | bytes : byte[] | semmle.label | bytes : byte[] |
+| C.java:72:3:72:14 | hessianInput | semmle.label | hessianInput |
+| C.java:73:3:73:14 | hessianInput | semmle.label | hessianInput |
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
 | TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | semmle.label | entityStream : InputStream |
 | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | semmle.label | new ObjectInputStream(...) |
+| TestMessageBodyReader.java:22:40:22:51 | entityStream : InputStream | semmle.label | entityStream : InputStream |
 #select
 | A.java:15:12:15:26 | readObject(...) | A.java:13:31:13:51 | getInputStream(...) : InputStream | A.java:15:12:15:13 | in | Unsafe deserialization of $@. | A.java:13:31:13:51 | getInputStream(...) | user input |
 | A.java:21:12:21:28 | readUnshared(...) | A.java:19:31:19:51 | getInputStream(...) : InputStream | A.java:21:12:21:13 | in | Unsafe deserialization of $@. | A.java:19:31:19:51 | getInputStream(...) | user input |
@@ -94,4 +267,46 @@ nodes
 | B.java:15:12:15:28 | parse(...) | B.java:12:31:12:51 | getInputStream(...) : InputStream | B.java:15:23:15:27 | bytes | Unsafe deserialization of $@. | B.java:12:31:12:51 | getInputStream(...) | user input |
 | B.java:23:12:23:30 | parseObject(...) | B.java:19:31:19:51 | getInputStream(...) : InputStream | B.java:23:29:23:29 | s | Unsafe deserialization of $@. | B.java:19:31:19:51 | getInputStream(...) | user input |
 | B.java:31:12:31:24 | parse(...) | B.java:27:31:27:51 | getInputStream(...) : InputStream | B.java:31:23:31:23 | s | Unsafe deserialization of $@. | B.java:27:31:27:51 | getInputStream(...) | user input |
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
+| C.java:22:3:22:17 | load(...) | C.java:21:17:21:44 | getParameter(...) : String | C.java:22:13:22:16 | data | Unsafe deserialization of $@. | C.java:21:17:21:44 | getParameter(...) | user input |
+| C.java:23:3:23:23 | loadStream(...) | C.java:21:17:21:44 | getParameter(...) : String | C.java:23:19:23:22 | data | Unsafe deserialization of $@. | C.java:21:17:21:44 | getParameter(...) | user input |
+| C.java:24:3:24:43 | loadStreamOfType(...) | C.java:21:17:21:44 | getParameter(...) : String | C.java:24:25:24:28 | data | Unsafe deserialization of $@. | C.java:21:17:21:44 | getParameter(...) | user input |
+| C.java:28:3:28:23 | load(...) | C.java:21:17:21:44 | getParameter(...) : String | C.java:28:19:28:22 | data | Unsafe deserialization of $@. | C.java:21:17:21:44 | getParameter(...) | user input |
+| C.java:29:3:29:29 | loadStream(...) | C.java:21:17:21:44 | getParameter(...) : String | C.java:29:25:29:28 | data | Unsafe deserialization of $@. | C.java:21:17:21:44 | getParameter(...) | user input |
+| C.java:30:3:30:49 | loadStreamOfType(...) | C.java:21:17:21:44 | getParameter(...) : String | C.java:30:31:30:34 | data | Unsafe deserialization of $@. | C.java:21:17:21:44 | getParameter(...) | user input |
+| C.java:41:3:41:29 | jsonToJava(...) | C.java:36:17:36:44 | getParameter(...) : String | C.java:41:25:41:28 | data | Unsafe deserialization of $@. | C.java:36:17:36:44 | getParameter(...) | user input |
+| C.java:46:3:46:17 | readObject(...) | C.java:36:17:36:44 | getParameter(...) : String | C.java:46:3:46:4 | jr | Unsafe deserialization of $@. | C.java:36:17:36:44 | getParameter(...) | user input |
+| C.java:56:3:56:10 | read(...) | C.java:54:17:54:44 | getParameter(...) : String | C.java:56:3:56:3 | r | Unsafe deserialization of $@. | C.java:54:17:54:44 | getParameter(...) | user input |
+| C.java:57:3:57:22 | read(...) | C.java:54:17:54:44 | getParameter(...) : String | C.java:57:3:57:3 | r | Unsafe deserialization of $@. | C.java:54:17:54:44 | getParameter(...) | user input |
+| C.java:58:3:58:36 | read(...) | C.java:54:17:54:44 | getParameter(...) : String | C.java:58:3:58:3 | r | Unsafe deserialization of $@. | C.java:54:17:54:44 | getParameter(...) | user input |
+| C.java:66:3:66:27 | readObject(...) | C.java:63:18:63:45 | getParameter(...) : String | C.java:66:3:66:14 | hessianInput | Unsafe deserialization of $@. | C.java:63:18:63:45 | getParameter(...) | user input |
+| C.java:67:3:67:39 | readObject(...) | C.java:63:18:63:45 | getParameter(...) : String | C.java:67:3:67:14 | hessianInput | Unsafe deserialization of $@. | C.java:63:18:63:45 | getParameter(...) | user input |
+| C.java:75:3:75:27 | readObject(...) | C.java:72:18:72:45 | getParameter(...) : String | C.java:75:3:75:14 | hessianInput | Unsafe deserialization of $@. | C.java:72:18:72:45 | getParameter(...) | user input |
+| C.java:76:3:76:39 | readObject(...) | C.java:72:18:72:45 | getParameter(...) : String | C.java:76:3:76:14 | hessianInput | Unsafe deserialization of $@. | C.java:72:18:72:45 | getParameter(...) | user input |
+| C.java:82:3:82:72 | unmarshal(...) | C.java:82:43:82:70 | getParameter(...) : String | C.java:82:26:82:71 | new StringReader(...) | Unsafe deserialization of $@. | C.java:82:43:82:70 | getParameter(...) | user input |
+| C.java:90:3:90:26 | readObject(...) | C.java:87:27:87:54 | getParameter(...) : String | C.java:90:3:90:13 | burlapInput | Unsafe deserialization of $@. | C.java:87:27:87:54 | getParameter(...) | user input |
+| C.java:94:3:94:27 | readObject(...) | C.java:87:27:87:54 | getParameter(...) : String | C.java:94:3:94:14 | burlapInput1 | Unsafe deserialization of $@. | C.java:87:27:87:54 | getParameter(...) | user input |
+<<<<<<< HEAD
+=======
+| C.java:19:3:19:17 | load(...) | C.java:18:17:18:44 | getParameter(...) : String | C.java:19:13:19:16 | data | Unsafe deserialization of $@. | C.java:18:17:18:44 | getParameter(...) | user input |
+| C.java:20:3:20:23 | loadStream(...) | C.java:18:17:18:44 | getParameter(...) : String | C.java:20:19:20:22 | data | Unsafe deserialization of $@. | C.java:18:17:18:44 | getParameter(...) | user input |
+| C.java:21:3:21:43 | loadStreamOfType(...) | C.java:18:17:18:44 | getParameter(...) : String | C.java:21:25:21:28 | data | Unsafe deserialization of $@. | C.java:18:17:18:44 | getParameter(...) | user input |
+| C.java:25:3:25:23 | load(...) | C.java:18:17:18:44 | getParameter(...) : String | C.java:25:19:25:22 | data | Unsafe deserialization of $@. | C.java:18:17:18:44 | getParameter(...) | user input |
+| C.java:26:3:26:29 | loadStream(...) | C.java:18:17:18:44 | getParameter(...) : String | C.java:26:25:26:28 | data | Unsafe deserialization of $@. | C.java:18:17:18:44 | getParameter(...) | user input |
+| C.java:27:3:27:49 | loadStreamOfType(...) | C.java:18:17:18:44 | getParameter(...) : String | C.java:27:31:27:34 | data | Unsafe deserialization of $@. | C.java:18:17:18:44 | getParameter(...) | user input |
+| C.java:38:3:38:29 | jsonToJava(...) | C.java:33:17:33:44 | getParameter(...) : String | C.java:38:25:38:28 | data | Unsafe deserialization of $@. | C.java:33:17:33:44 | getParameter(...) | user input |
+| C.java:43:3:43:17 | readObject(...) | C.java:33:17:33:44 | getParameter(...) : String | C.java:43:3:43:4 | jr | Unsafe deserialization of $@. | C.java:33:17:33:44 | getParameter(...) | user input |
+| C.java:53:3:53:10 | read(...) | C.java:51:17:51:44 | getParameter(...) : String | C.java:53:3:53:3 | r | Unsafe deserialization of $@. | C.java:51:17:51:44 | getParameter(...) | user input |
+| C.java:54:3:54:22 | read(...) | C.java:51:17:51:44 | getParameter(...) : String | C.java:54:3:54:3 | r | Unsafe deserialization of $@. | C.java:51:17:51:44 | getParameter(...) | user input |
+| C.java:55:3:55:36 | read(...) | C.java:51:17:51:44 | getParameter(...) : String | C.java:55:3:55:3 | r | Unsafe deserialization of $@. | C.java:51:17:51:44 | getParameter(...) | user input |
+| C.java:63:3:63:27 | readObject(...) | C.java:60:18:60:45 | getParameter(...) : String | C.java:63:3:63:14 | hessianInput | Unsafe deserialization of $@. | C.java:60:18:60:45 | getParameter(...) | user input |
+| C.java:64:3:64:39 | readObject(...) | C.java:60:18:60:45 | getParameter(...) : String | C.java:64:3:64:14 | hessianInput | Unsafe deserialization of $@. | C.java:60:18:60:45 | getParameter(...) | user input |
+| C.java:72:3:72:27 | readObject(...) | C.java:69:18:69:45 | getParameter(...) : String | C.java:72:3:72:14 | hessianInput | Unsafe deserialization of $@. | C.java:69:18:69:45 | getParameter(...) | user input |
+| C.java:73:3:73:39 | readObject(...) | C.java:69:18:69:45 | getParameter(...) : String | C.java:73:3:73:14 | hessianInput | Unsafe deserialization of $@. | C.java:69:18:69:45 | getParameter(...) | user input |
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+>>>>>>> 9e39c222ae... Increase castor and burlap detection
 | TestMessageBodyReader.java:22:18:22:65 | readObject(...) | TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | Unsafe deserialization of $@. | TestMessageBodyReader.java:20:55:20:78 | entityStream | user input |

--- a/java/ql/test/query-tests/security/CWE-502/options
+++ b/java/ql/test/query-tests/security/CWE-502/options
@@ -1,1 +1,9 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/snakeyaml-1.21:${testdir}/../../../stubs/xstream-1.4.10:${testdir}/../../../stubs/kryo-4.0.2:${testdir}/../../../stubs/jsr311-api-1.1.1:${testdir}/../../../stubs/fastjson-1.2.74
+<<<<<<< HEAD
+<<<<<<< HEAD
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/snakeyaml-1.21:${testdir}/../../../stubs/xstream-1.4.10:${testdir}/../../../stubs/kryo-4.0.2:${testdir}/../../../stubs/jsr311-api-1.1.1:${testdir}/../../../stubs/fastjson-1.2.74:${testdir}/../../../stubs/springframework-5.2.3:${testdir}/../../../stubs/servlet-api-2.4:${testdir}/../../../stubs/jyaml-1.3:${testdir}/../../../stubs/json-io-4.10.0:${testdir}/../../../stubs/yamlbeans-1.09:${testdir}/../../../stubs/hessian-4.0.38:${testdir}/../../../stubs/castor-1.4.1
+=======
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/snakeyaml-1.21:${testdir}/../../../stubs/xstream-1.4.10:${testdir}/../../../stubs/kryo-4.0.2:${testdir}/../../../stubs/jsr311-api-1.1.1:${testdir}/../../../stubs/fastjson-1.2.74:${testdir}/../../../stubs/springframework-5.2.3:${testdir}/../../../stubs/servlet-api-2.4:${testdir}/../../../stubs/jyaml-1.3:${testdir}/../../../stubs/json-io-4.10.0:${testdir}/../../../stubs/yamlbeans-1.09:${testdir}/../../../stubs/hessian-4.0.38
+>>>>>>> 6738bf5186... Add UnsafeDeserialization sink
+=======
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/snakeyaml-1.21:${testdir}/../../../stubs/xstream-1.4.10:${testdir}/../../../stubs/kryo-4.0.2:${testdir}/../../../stubs/jsr311-api-1.1.1:${testdir}/../../../stubs/fastjson-1.2.74:${testdir}/../../../stubs/springframework-5.2.3:${testdir}/../../../stubs/servlet-api-2.4:${testdir}/../../../stubs/jyaml-1.3:${testdir}/../../../stubs/json-io-4.10.0:${testdir}/../../../stubs/yamlbeans-1.09:${testdir}/../../../stubs/hessian-4.0.38:${testdir}/../../../stubs/castor-1.4.1
+>>>>>>> 9e39c222ae... Increase castor and burlap detection

--- a/java/ql/test/stubs/castor-1.4.1/org/exolab/castor/types/AnyNode.java
+++ b/java/ql/test/stubs/castor-1.4.1/org/exolab/castor/types/AnyNode.java
@@ -1,0 +1,11 @@
+package org.exolab.castor.types;
+
+import java.io.Serializable;
+
+public final class AnyNode implements Serializable {
+
+    private static final long serialVersionUID = -4104117996051705975L;
+
+    public AnyNode() { }
+}
+

--- a/java/ql/test/stubs/castor-1.4.1/org/exolab/castor/xml/EventProducer.java
+++ b/java/ql/test/stubs/castor-1.4.1/org/exolab/castor/xml/EventProducer.java
@@ -1,0 +1,12 @@
+package org.exolab.castor.xml;
+
+import org.xml.sax.DocumentHandler;
+import org.xml.sax.SAXException;
+
+/** @deprecated */
+public interface EventProducer {
+    void setDocumentHandler(DocumentHandler var1);
+
+    void start() throws SAXException;
+}
+

--- a/java/ql/test/stubs/castor-1.4.1/org/exolab/castor/xml/SAX2EventAndErrorProducer.java
+++ b/java/ql/test/stubs/castor-1.4.1/org/exolab/castor/xml/SAX2EventAndErrorProducer.java
@@ -1,0 +1,8 @@
+package org.exolab.castor.xml;
+
+import org.xml.sax.ErrorHandler;
+
+public interface SAX2EventAndErrorProducer extends SAX2EventProducer {
+    void setErrorHandler(ErrorHandler var1);
+}
+

--- a/java/ql/test/stubs/castor-1.4.1/org/exolab/castor/xml/SAX2EventProducer.java
+++ b/java/ql/test/stubs/castor-1.4.1/org/exolab/castor/xml/SAX2EventProducer.java
@@ -1,0 +1,11 @@
+package org.exolab.castor.xml;
+
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+public interface SAX2EventProducer {
+    void setContentHandler(ContentHandler var1);
+
+    void start() throws SAXException;
+}
+

--- a/java/ql/test/stubs/castor-1.4.1/org/exolab/castor/xml/Unmarshaller.java
+++ b/java/ql/test/stubs/castor-1.4.1/org/exolab/castor/xml/Unmarshaller.java
@@ -1,0 +1,74 @@
+package org.exolab.castor.xml;
+
+import java.io.Reader;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.Source;
+import org.exolab.castor.types.AnyNode;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.Parser;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+public class Unmarshaller {
+
+    public Unmarshaller() { }
+
+    public Object unmarshal(Reader reader) {
+        return null;
+    }
+
+    public Object unmarshal(EventProducer eventProducer) {
+        return null;
+    }
+
+    public Object unmarshal(SAX2EventProducer eventProducer) {
+        return null;
+    }
+
+    public Object unmarshal(AnyNode anyNode) {
+        return null;
+    }
+
+    public Object unmarshal(InputSource source) {
+        return null;
+    }
+
+    public Object unmarshal(Node node) {
+        return null;
+    }
+
+    public Object unmarshal(XMLEventReader eventReader) {
+        return null;
+    }
+
+    public Object unmarshal(XMLStreamReader streamReader) {
+        return null;
+    }
+
+    public Object unmarshal(SAX2EventAndErrorProducer eventProducer) {
+        return null;
+    }
+
+    public Object unmarshal(Source source) {
+        return null;
+    }
+
+    public static Object unmarshal(Class c, Reader reader) {
+        return null;
+    }
+
+    private static Unmarshaller createUnmarshaller(Class clazz) {
+        return null;
+    }
+
+    public static Object unmarshal(Class c, InputSource source) {
+        return null;
+    }
+
+    public static Object unmarshal(Class c, Node node) {
+        return null;
+    }
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/AbstractBurlapInput.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/AbstractBurlapInput.java
@@ -1,0 +1,9 @@
+package com.caucho.burlap.io;
+
+import com.caucho.hessian.io.AbstractHessianInput;
+
+public abstract class AbstractBurlapInput extends AbstractHessianInput {
+    public AbstractBurlapInput() {
+    }
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/AbstractHessianInput.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/AbstractHessianInput.java
@@ -1,0 +1,110 @@
+package com.caucho.hessian.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import org.w3c.dom.Node;
+
+public abstract class AbstractHessianInput {
+
+    public AbstractHessianInput() {
+    }
+
+    public void init(InputStream is) {
+    }
+
+    public abstract String getMethod();
+
+    public void setSerializerFactory(SerializerFactory ser) {
+    }
+
+    public abstract int readCall() throws IOException;
+
+    public void skipOptionalCall() throws IOException {
+    }
+
+    public abstract String readHeader() throws IOException;
+
+    public abstract String readMethod() throws IOException;
+
+    public int readMethodArgLength() throws IOException {
+        return -1;
+    }
+
+    public abstract void startCall() throws IOException;
+
+    public abstract void completeCall() throws IOException;
+
+    public abstract Object readReply(Class var1) throws Throwable;
+
+    public abstract void startReply() throws Throwable;
+
+    public void startReplyBody() throws Throwable {
+    }
+
+    public abstract void completeReply() throws IOException;
+
+    public abstract boolean readBoolean() throws IOException;
+
+    public abstract void readNull() throws IOException;
+
+    public abstract int readInt() throws IOException;
+
+    public abstract long readLong() throws IOException;
+
+    public abstract double readDouble() throws IOException;
+
+    public abstract long readUTCDate() throws IOException;
+
+    public abstract String readString() throws IOException;
+
+    public Node readNode() throws IOException {
+        return null;
+    }
+
+    public abstract Reader getReader() throws IOException;
+
+    public abstract InputStream readInputStream() throws IOException;
+
+    public boolean readToOutputStream(OutputStream os) throws IOException {
+        return true;
+    }
+
+    public abstract byte[] readBytes() throws IOException;
+
+    public abstract Object readObject(Class var1) throws IOException;
+
+    public abstract Object readObject() throws IOException;
+
+    public abstract Object readRemote() throws IOException;
+
+    public abstract Object readRef() throws IOException;
+
+    public abstract int addRef(Object var1) throws IOException;
+
+    public abstract void setRef(int var1, Object var2) throws IOException;
+
+    public void resetReferences() {
+    }
+
+    public abstract int readListStart() throws IOException;
+
+    public abstract int readLength() throws IOException;
+
+    public abstract int readMapStart() throws IOException;
+
+    public abstract String readType() throws IOException;
+
+    public abstract boolean isEnd() throws IOException;
+
+    public abstract void readEnd() throws IOException;
+
+    public abstract void readMapEnd() throws IOException;
+
+    public abstract void readListEnd() throws IOException;
+
+    public void close() throws IOException {
+    }
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/AbstractSerializerFactory.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/AbstractSerializerFactory.java
@@ -1,0 +1,11 @@
+package com.caucho.hessian.io;
+
+public abstract class AbstractSerializerFactory {
+    public AbstractSerializerFactory() {
+    }
+
+    public abstract Serializer getSerializer(Class var1) throws HessianProtocolException;
+
+    public abstract Deserializer getDeserializer(Class var1) throws HessianProtocolException;
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/BurlapInput.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/BurlapInput.java
@@ -1,0 +1,274 @@
+package com.caucho.burlap.io;
+
+import com.caucho.hessian.io.SerializerFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.TimeZone;
+import org.w3c.dom.Node;
+
+public class BurlapInput extends AbstractBurlapInput {
+
+    public BurlapInput() { }
+
+    public BurlapInput(InputStream is) { }
+
+    public void setSerializerFactory(SerializerFactory factory) { }
+
+    public SerializerFactory getSerializerFactory() {
+        return null;
+    }
+
+    public void init(InputStream is) { }
+
+    public String getMethod() {
+        return null;
+    }
+
+    public Throwable getReplyFault() {
+        return null;
+    }
+
+    public void startCall() throws IOException { }
+
+    public int readCall() throws IOException {
+        return 1;
+    }
+
+    public String readMethod() throws IOException {
+        return null;
+    }
+
+    public void completeCall() throws IOException { }
+
+    public Object readReply(Class expectedClass) throws Throwable {
+        return null;
+    }
+
+    public void startReply() throws Throwable { }
+
+    private Throwable prepareFault() throws IOException {
+        return null;
+    }
+
+    public void completeReply() throws IOException { }
+
+    public String readHeader() throws IOException {
+        return null;
+    }
+
+    public void readNull() throws IOException { }
+
+    public boolean readBoolean() throws IOException {
+        return true;
+    }
+
+    public byte readByte() throws IOException {
+        return 1;
+    }
+
+    public short readShort() throws IOException {
+        return 1;
+    }
+
+    public int readInt() throws IOException {
+        return 1;
+    }
+
+    public long readLong() throws IOException {
+        return 1L;
+    }
+
+    public float readFloat() throws IOException {
+        return 1.1F;
+    }
+
+    public double readDouble() throws IOException {
+        return 1.1;
+    }
+
+    public long readUTCDate() throws IOException {
+        return 1L;
+    }
+
+    public long readLocalDate() throws IOException {
+        return 1L;
+    }
+
+    public String readString() throws IOException {
+        return null;
+    }
+
+    public Node readNode() throws IOException {
+        return null;
+    }
+
+    public byte[] readBytes() throws IOException {
+        return null;
+    }
+
+    public int readLength() throws IOException {
+        return 1;
+    }
+
+    private HashMap readFault() throws IOException {
+        return null;
+    }
+
+    public Object readObject(Class cl) throws IOException {
+        return null;
+    }
+
+    public Object readObject() throws IOException {
+        return null;
+    }
+
+    public Object readRemote() throws IOException {
+        return null;
+    }
+
+    public Object readRef() throws IOException {
+        return null;
+    }
+
+    public int readListStart() throws IOException {
+        return 1;
+    }
+
+    public int readMapStart() throws IOException {
+        return 1;
+    }
+
+    public boolean isEnd() throws IOException {
+        return true;
+    }
+
+    public void readEnd() throws IOException { }
+
+    public void readMapEnd() throws IOException { }
+
+    public void readListEnd() throws IOException { }
+
+    public int addRef(Object ref) {
+        return 1;
+    }
+
+    public void setRef(int i, Object ref) { }
+
+    public Object resolveRemote(String type, String url) throws IOException {
+        return null;
+    }
+
+    public String readType() throws IOException {
+        return null;
+    }
+
+    private int parseInt() throws IOException {
+        return 1;
+    }
+
+    private long parseLong() throws IOException {
+        return 1L;
+    }
+
+    private double parseDouble() throws IOException {
+        return 1.1;
+    }
+
+    protected long parseDate() throws IOException {
+        return 1L;
+    }
+
+    protected long parseDate(Calendar calendar) throws IOException {
+        return 1L;
+    }
+
+    protected String parseString() throws IOException {
+        return null;
+    }
+
+    protected StringBuffer parseString(StringBuffer sbuf) throws IOException {
+        return null;
+    }
+
+    Node parseXML() throws IOException {
+        return null;
+    }
+
+    int readChar() throws IOException {
+        return 1;
+    }
+
+    protected byte[] parseBytes() throws IOException {
+        return null;
+    }
+
+    protected ByteArrayOutputStream parseBytes(ByteArrayOutputStream bos) throws IOException {
+        return null;
+    }
+
+    public void expectTag(int expectTag) throws IOException { }
+
+    protected int parseTag() throws IOException {
+        return 1;
+    }
+
+    private boolean isTagChar(int ch) {
+        return true;
+    }
+
+    protected int skipWhitespace() throws IOException {
+        return 1;
+    }
+
+    protected boolean isWhitespace(int ch) throws IOException {
+        return true;
+    }
+
+    int read(byte[] buffer, int offset, int length) throws IOException {
+        return 1;
+    }
+
+    int read() throws IOException {
+        return 1;
+    }
+
+    public Reader getReader() {
+        return null;
+    }
+
+    public InputStream readInputStream() {
+        return null;
+    }
+
+    public InputStream getInputStream() {
+        return null;
+    }
+
+    protected IOException expectBeginTag(String expect, String tag) {
+        return null;
+    }
+
+    protected IOException expectedChar(String expect, int ch) {
+        return null;
+    }
+
+    protected IOException expectedTag(String expect, int tag) {
+        return null;
+    }
+
+    protected IOException error(String message) {
+        return null;
+    }
+
+    protected static String tagName(int tag) {
+        return null;
+    }
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/Deserializer.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/Deserializer.java
@@ -1,0 +1,26 @@
+package com.caucho.hessian.io;
+
+import java.io.IOException;
+
+public interface Deserializer {
+    Class<?> getType();
+
+    boolean isReadResolve();
+
+    Object readObject(AbstractHessianInput var1) throws IOException;
+
+    Object readList(AbstractHessianInput var1, int var2) throws IOException;
+
+    Object readLengthList(AbstractHessianInput var1, int var2) throws IOException;
+
+    Object readMap(AbstractHessianInput var1) throws IOException;
+
+    Object[] createFields(int var1);
+
+    Object createField(String var1);
+
+    Object readObject(AbstractHessianInput var1, Object[] var2) throws IOException;
+
+    Object readObject(AbstractHessianInput var1, String[] var2) throws IOException;
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/HessianProtocolException.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/HessianProtocolException.java
@@ -1,0 +1,24 @@
+package com.caucho.hessian.io;
+
+import java.io.IOException;
+
+public class HessianProtocolException extends IOException {
+
+    public HessianProtocolException() {
+    }
+
+    public HessianProtocolException(String message) { }
+
+    public HessianProtocolException(String message, Throwable rootCause) { }
+
+    public HessianProtocolException(Throwable rootCause) { }
+
+    public Throwable getRootCause() {
+        return null;
+    }
+
+    public Throwable getCause() {
+        return null;
+    }
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/Serializer.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/Serializer.java
@@ -1,0 +1,8 @@
+package com.caucho.hessian.io;
+
+import java.io.IOException;
+
+public interface Serializer {
+
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/SerializerFactory.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/burlap/io/SerializerFactory.java
@@ -1,0 +1,12 @@
+package com.caucho.hessian.io;
+
+public class SerializerFactory extends AbstractSerializerFactory {
+
+   public Serializer getSerializer(Class cl) throws HessianProtocolException {
+       return null;
+   }
+
+   public Deserializer getDeserializer(Class cl) throws HessianProtocolException {
+       return null;
+   }
+}

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/hessian/io/AbstractHessianInput.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/hessian/io/AbstractHessianInput.java
@@ -1,0 +1,111 @@
+package com.caucho.hessian.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+
+public abstract class AbstractHessianInput {
+
+    public AbstractHessianInput() {
+    }
+
+    public void init(InputStream is) {
+    }
+
+    public abstract String getMethod();
+
+    public void setRemoteResolver(HessianRemoteResolver resolver) { }
+
+    public HessianRemoteResolver getRemoteResolver() {
+        return null;
+    }
+
+    public void setSerializerFactory(SerializerFactory ser) {
+    }
+
+    public abstract int readCall() throws IOException;
+
+    public void skipOptionalCall() throws IOException {
+    }
+
+    public abstract String readHeader() throws IOException;
+
+    public abstract String readMethod() throws IOException;
+
+    public int readMethodArgLength() throws IOException {
+        return -1;
+    }
+
+    public abstract void startCall() throws IOException;
+
+    public abstract void completeCall() throws IOException;
+
+    public abstract Object readReply(Class var1) throws Throwable;
+
+    public abstract void startReply() throws Throwable;
+
+    public void startReplyBody() throws Throwable {
+    }
+
+    public abstract void completeReply() throws IOException;
+
+    public abstract boolean readBoolean() throws IOException;
+
+    public abstract void readNull() throws IOException;
+
+    public abstract int readInt() throws IOException;
+
+    public abstract long readLong() throws IOException;
+
+    public abstract double readDouble() throws IOException;
+
+    public abstract long readUTCDate() throws IOException;
+
+    public abstract String readString() throws IOException;
+
+    public abstract Reader getReader() throws IOException;
+
+    public abstract InputStream readInputStream() throws IOException;
+
+    public boolean readToOutputStream(OutputStream os) throws IOException {
+        return true;
+    }
+
+    public abstract byte[] readBytes() throws IOException;
+
+    public abstract Object readObject(Class var1) throws IOException;
+
+    public abstract Object readObject() throws IOException;
+
+    public abstract Object readRemote() throws IOException;
+
+    public abstract Object readRef() throws IOException;
+
+    public abstract int addRef(Object var1) throws IOException;
+
+    public abstract void setRef(int var1, Object var2) throws IOException;
+
+    public void resetReferences() {
+    }
+
+    public abstract int readListStart() throws IOException;
+
+    public abstract int readLength() throws IOException;
+
+    public abstract int readMapStart() throws IOException;
+
+    public abstract String readType() throws IOException;
+
+    public abstract boolean isEnd() throws IOException;
+
+    public abstract void readEnd() throws IOException;
+
+    public abstract void readMapEnd() throws IOException;
+
+    public abstract void readListEnd() throws IOException;
+
+    public void close() throws IOException {
+    }
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/hessian/io/Hessian2Input.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/hessian/io/Hessian2Input.java
@@ -1,0 +1,297 @@
+package com.caucho.hessian.io;
+
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Hessian2Input extends AbstractHessianInput {
+
+    public Hessian2Input() { }
+
+    public Hessian2Input(InputStream is) { }
+
+    public String getMethod() {
+        return null;
+    }
+
+    public Throwable getReplyFault() {
+        return null;
+    }
+
+    public int readCall() throws IOException {
+        return 1;
+    }
+
+    public int readEnvelope() throws IOException {
+        return 1;
+    }
+
+    public void completeEnvelope() throws IOException { }
+
+    public String readMethod() throws IOException {
+        return null;
+    }
+
+    public int readMethodArgLength() throws IOException {
+        return 1;
+    }
+
+    public void startCall() throws IOException { }
+
+    public Object[] readArguments() throws IOException {
+        return null;
+    }
+
+    public void completeCall() throws IOException { }
+
+    public Object readReply(Class expectedClass) throws Throwable {
+        return null;
+    }
+
+    public void startReply() throws Throwable { }
+
+    private Throwable prepareFault(HashMap fault) throws IOException {
+        return null;
+    }
+
+    public void completeReply() throws IOException { }
+
+    public void completeValueReply() throws IOException { }
+
+    public String readHeader() throws IOException {
+        return null;
+    }
+
+    public int startMessage() throws IOException {
+        return 1;
+    }
+
+    public void completeMessage() throws IOException { }
+
+    public void readNull() throws IOException { }
+
+    public boolean readBoolean() throws IOException {
+        return true;
+    }
+
+    public short readShort() throws IOException {
+        return 11111;
+    }
+
+    public final int readInt() throws IOException {
+        return 1;
+    }
+
+    public long readLong() throws IOException {
+        return 1L;
+    }
+
+    public float readFloat() throws IOException {
+        return 1.1F;
+    }
+
+    public double readDouble() throws IOException {
+        return 1.1;
+    }
+
+    public long readUTCDate() throws IOException {
+        return 1L;
+    }
+
+    public int readChar() throws IOException {
+        return 1;
+    }
+
+    public int readString(char[] buffer, int offset, int length) throws IOException {
+        return 1;
+    }
+
+    public String readString() throws IOException {
+        return null;
+    }
+
+    public byte[] readBytes() throws IOException {
+        return null;
+    }
+
+    public int readByte() throws IOException {
+        return 1;
+    }
+
+    public int readBytes(byte[] buffer, int offset, int length) throws IOException {
+        return 1;
+    }
+
+    private HashMap readFault() throws IOException {
+        return null;
+    }
+
+    public Object readObject(Class cl) throws IOException {
+        return null;
+    }
+
+    public Object readObject() throws IOException {
+        return null;
+    }
+
+    private void readObjectDefinition(Class<?> cl) throws IOException { }
+
+    private Object readObjectInstance(Class<?> cl, Hessian2Input.ObjectDefinition def) throws IOException {
+        return null;
+    }
+
+    public Object readRemote() throws IOException {
+        return null;
+    }
+
+    public Object readRef() throws IOException {
+        return null;
+    }
+
+    public int readListStart() throws IOException {
+        return 1;
+    }
+
+    public int readMapStart() throws IOException {
+        return 1;
+    }
+
+    public boolean isEnd() throws IOException {
+        return true;
+    }
+
+    public void readEnd() throws IOException { }
+
+    public void readMapEnd() throws IOException { }
+
+    public void readListEnd() throws IOException { }
+
+    public int addRef(Object ref) {
+        return 1;
+    }
+
+    public void setRef(int i, Object ref) { }
+
+    public void resetReferences() { }
+
+    public void reset() { }
+
+    public void resetBuffer() { }
+
+    public Object readStreamingObject() throws IOException {
+        return null;
+    }
+
+    public Object resolveRemote(String type, String url) throws IOException {
+        return null;
+    }
+
+    public String readType() throws IOException {
+        return null;
+    }
+
+    public int readLength() throws IOException {
+        return 1;
+    }
+
+    private int parseInt() throws IOException {
+        return 1;
+    }
+
+    private long parseLong() throws IOException {
+        return 1L;
+    }
+
+    private double parseDouble() throws IOException {
+        return 1.1;
+    }
+
+    private void parseString(StringBuilder sbuf) throws IOException { }
+
+    private int parseChar() throws IOException {
+        return 1;
+    }
+
+    private boolean parseChunkLength() throws IOException {
+        return true;
+    }
+
+    private int parseUTF8Char() throws IOException {
+        return 1;
+    }
+
+    private int parseByte() throws IOException {
+        return 1;
+    }
+
+    public InputStream readInputStream() throws IOException {
+        return null;
+    }
+
+    int read(byte[] buffer, int offset, int length) throws IOException {
+        return 1;
+    }
+
+    public final int read() throws IOException {
+        return 1;
+    }
+
+    protected void unread() { }
+
+    private final boolean readBuffer() throws IOException {
+        return true;
+    }
+
+    public Reader getReader() {
+        return null;
+    }
+
+    protected IOException expect(String expect, int ch) throws IOException {
+        return null;
+    }
+
+    private String buildDebugContext(byte[] buffer, int offset, int length, int errorOffset) {
+        return null;
+    }
+
+    private void addDebugChar(StringBuilder sb, int ch) { }
+
+    protected String codeName(int ch) {
+        return null;
+    }
+
+    protected IOException error(String message) {
+        return null;
+    }
+
+    public void free() { }
+
+    public void close() throws IOException { }
+
+    static final class ObjectDefinition {
+    }
+
+    class ReadInputStream extends InputStream {
+
+        ReadInputStream() { }
+
+        public int read() throws IOException {
+            return 1;
+        }
+
+        public int read(byte[] buffer, int offset, int length) throws IOException {
+            return 1;
+        }
+
+        public void close() throws IOException { }
+    }
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/hessian/io/HessianInput.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/hessian/io/HessianInput.java
@@ -1,0 +1,229 @@
+package com.caucho.hessian.io;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+
+public class HessianInput extends AbstractHessianInput {
+
+    public HessianInput() {
+    }
+
+    public HessianInput(InputStream is) { }
+
+    public void init(InputStream is) { }
+
+    public String getMethod() {
+        return null;
+    }
+
+    public Throwable getReplyFault() {
+        return null;
+    }
+
+    public int readCall() throws IOException {
+        return 0;
+    }
+
+    public void skipOptionalCall() throws IOException { }
+
+    public String readMethod() throws IOException {
+        return null;
+    }
+
+    public void startCall() throws IOException { }
+
+    public void completeCall() throws IOException { }
+
+    public Object readReply(Class expectedClass) throws Throwable {
+        return null;
+    }
+
+    public void startReply() throws Throwable { }
+
+    public void startReplyBody() throws Throwable { }
+
+    private Throwable prepareFault() throws IOException {
+        return null;
+    }
+
+    public void completeReply() throws IOException { }
+
+    public void completeValueReply() throws IOException { }
+
+    public String readHeader() throws IOException {
+        return null;
+    }
+
+    public void readNull() throws IOException { }
+
+    public boolean readBoolean() throws IOException {
+        return true;
+    }
+
+    public short readShort() throws IOException {
+        return 11111;
+    }
+
+    public int readInt() throws IOException {
+        return 1;
+    }
+
+    public long readLong() throws IOException {
+        return 1L;
+    }
+
+    public float readFloat() throws IOException {
+        return 1.1F;
+    }
+
+    public double readDouble() throws IOException {
+        return 1.1;
+    }
+
+    public long readUTCDate() throws IOException {
+        return 1L;
+    }
+
+    public int readChar() throws IOException {
+        return 1;
+    }
+
+    public int readString(char[] buffer, int offset, int length) throws IOException {
+        return 1;
+    }
+
+    public String readString() throws IOException {
+        return null;
+    }
+
+    public byte[] readBytes() throws IOException {
+        return null;
+    }
+
+    public int readByte() throws IOException {
+        return 1;
+    }
+
+    public int readBytes(byte[] buffer, int offset, int length) throws IOException {
+        return 1;
+    }
+
+    private HashMap readFault() throws IOException {
+        return null;
+    }
+
+    public Object readObject(Class cl) throws IOException {
+        return null;
+    }
+
+    public Object readObject() throws IOException {
+        return null;
+    }
+
+    public Object readRemote() throws IOException {
+        return null;
+    }
+
+    public Object readRef() throws IOException {
+        return null;
+    }
+
+    public int readListStart() throws IOException {
+        return 1;
+    }
+
+    public int readMapStart() throws IOException {
+        return 1;
+    }
+
+    public boolean isEnd() throws IOException {
+        return true;
+    }
+
+    public void readEnd() throws IOException { }
+
+    public void readMapEnd() throws IOException { }
+
+    public void readListEnd() throws IOException { }
+
+    public int addRef(Object ref) {
+        return 1;
+    }
+
+    public void setRef(int i, Object ref) { }
+
+    public void resetReferences() { }
+
+    public Object resolveRemote(String type, String url) throws IOException {
+        return null;
+    }
+
+    public String readType() throws IOException {
+        return null;
+    }
+
+    public int readLength() throws IOException {
+        return 1;
+    }
+
+    private int parseInt() throws IOException {
+        return 1;
+    }
+
+    private long parseLong() throws IOException {
+        return 1L;
+    }
+
+    private double parseDouble() throws IOException {
+        return 1.1;
+    }
+
+    private int parseChar() throws IOException {
+        return 1;
+    }
+
+    private int parseUTF8Char() throws IOException {
+        return 1;
+    }
+
+    private int parseByte() throws IOException {
+        return 1;
+    }
+
+    public InputStream readInputStream() throws IOException {
+        return null;
+    }
+
+    int read(byte[] buffer, int offset, int length) throws IOException {
+        return 1;
+    }
+
+    final int read() throws IOException {
+        return 1;
+    }
+
+    public void close() { }
+
+    public Reader getReader() {
+        return null;
+    }
+
+    protected IOException expect(String expect, int ch) {
+        return null;
+    }
+
+    protected String codeName(int ch) {
+        return null;
+    }
+
+    protected IOException error(String message) {
+        return null;
+    }
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/hessian/io/HessianRemoteResolver.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/hessian/io/HessianRemoteResolver.java
@@ -1,0 +1,8 @@
+package com.caucho.hessian.io;
+
+import java.io.IOException;
+
+public interface HessianRemoteResolver {
+    Object lookup(String var1, String var2) throws IOException;
+}
+

--- a/java/ql/test/stubs/hessian-4.0.38/com/caucho/hessian/io/SerializerFactory.java
+++ b/java/ql/test/stubs/hessian-4.0.38/com/caucho/hessian/io/SerializerFactory.java
@@ -1,0 +1,5 @@
+package com.caucho.hessian.io;
+
+public class SerializerFactory {
+
+}

--- a/java/ql/test/stubs/json-io-4.10.0/com/cedarsoftware/util/io/JsonReader.java
+++ b/java/ql/test/stubs/json-io-4.10.0/com/cedarsoftware/util/io/JsonReader.java
@@ -1,0 +1,41 @@
+package com.cedarsoftware.util.io;
+
+import java.io.Closeable;
+import java.io.InputStream;
+import java.util.Map;
+
+public class JsonReader implements Closeable {
+
+    public static Object jsonToJava(String json) {
+        return null;
+    }
+
+    public static Object jsonToJava(String json, Map<String, Object> optionalArgs) {
+        return null;
+    }
+
+    public static Object jsonToJava(InputStream inputStream, Map<String, Object> optionalArgs) {
+        return null;
+    }
+
+    public JsonReader() { }
+
+    public JsonReader(InputStream inp) { }
+
+    public JsonReader(Map<String, Object> optionalArgs) { }
+
+    public JsonReader(InputStream inp, boolean useMaps) { }
+
+    public JsonReader(InputStream inp, Map<String, Object> optionalArgs) { }
+
+    public JsonReader(String inp, Map<String, Object> optionalArgs) { }
+
+    public JsonReader(byte[] inp, Map<String, Object> optionalArgs) { }
+
+    public Object readObject() {
+        return null;
+    }
+
+    public void close() { }
+}
+

--- a/java/ql/test/stubs/jyaml-1.3/org/ho/yaml/Yaml.java
+++ b/java/ql/test/stubs/jyaml-1.3/org/ho/yaml/Yaml.java
@@ -1,0 +1,77 @@
+package org.ho.yaml;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.Reader;
+
+public class Yaml {
+
+    public Yaml() {
+    }
+
+    public static Object load(Reader var0) {
+        return null;
+    }
+
+    public static Object load(InputStream var0) {
+        return null;
+    }
+
+    public static Object load(File var0) throws FileNotFoundException {
+        return null;
+    }
+
+    public static Object load(String var0) {
+        return null;
+    }
+
+    public static <T> T loadType(Reader var0, Class<T> var1) {
+        return null;
+    }
+
+    public static <T> T loadType(InputStream var0, Class<T> var1) throws FileNotFoundException {
+        return null;
+    }
+
+    public static <T> T loadType(File var0, Class<T> var1) throws FileNotFoundException {
+        return null;
+    }
+
+    public static <T> T loadType(String var0, Class<T> var1) {
+        return null;
+    }
+
+    public static YamlStream loadStream(Reader var0) {
+        return null;
+    }
+
+    public static YamlStream loadStream(InputStream var0) {
+        return null;
+    }
+
+    public static YamlStream loadStream(File var0) throws FileNotFoundException {
+        return null;
+    }
+
+    public static YamlStream loadStream(String var0) {
+        return null;
+    }
+
+    public static <T> YamlStream<T> loadStreamOfType(Reader var0, Class<T> var1) {
+        return null;
+    }
+
+    public static <T> YamlStream<T> loadStreamOfType(InputStream var0, Class<T> var1) {
+        return null;
+    }
+
+    public static <T> YamlStream<T> loadStreamOfType(File var0, Class<T> var1) throws FileNotFoundException {
+        return null;
+    }
+
+    public static <T> YamlStream<T> loadStreamOfType(String var0, Class<T> var1) throws FileNotFoundException {
+        return null;
+    }
+}
+

--- a/java/ql/test/stubs/jyaml-1.3/org/ho/yaml/YamlConfig.java
+++ b/java/ql/test/stubs/jyaml-1.3/org/ho/yaml/YamlConfig.java
@@ -1,0 +1,122 @@
+package org.ho.yaml;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.util.Iterator;
+
+public class YamlConfig implements YamlOperations, Cloneable {
+
+    public YamlConfig() { }
+
+    public Object load(YamlDecoder var1) {
+        return null;
+    }
+
+    public Object load(InputStream var1) {
+        return null;
+    }
+
+    public Object load(Reader var1) {
+        return null;
+    }
+
+    public Object load(File var1) throws FileNotFoundException {
+        return null;
+    }
+
+    public Object load(String var1) {
+        return null;
+    }
+
+    public <T> T loadType(YamlDecoder var1, Class<T> var2) {
+        return null;
+    }
+
+    public <T> T loadType(InputStream var1, Class<T> var2) {
+        return null;
+    }
+
+    public <T> T loadType(Reader var1, Class<T> var2) {
+        return null;
+    }
+
+    public <T> T loadType(File var1, Class<T> var2) throws FileNotFoundException {
+        return null;
+    }
+
+    public <T> T loadType(String var1, Class<T> var2) {
+        return null;
+    }
+
+    public YamlStream loadStream(YamlDecoder var1) {
+        return null;
+    }
+
+    public YamlStream loadStream(Reader var1) {
+        return null;
+    }
+
+    public YamlStream loadStream(InputStream var1) {
+        return null;
+    }
+
+    public YamlStream loadStream(File var1) throws FileNotFoundException {
+        return null;
+    }
+
+    public YamlStream loadStream(String var1) {
+        return null;
+    }
+
+    public <T> YamlStream<T> loadStreamOfType(YamlDecoder var1, Class<T> var2) {
+        return null;
+    }
+
+    public <T> YamlStream<T> loadStreamOfType(Reader var1, Class<T> var2) {
+        return null;
+    }
+
+    public <T> YamlStream<T> loadStreamOfType(InputStream var1, Class<T> var2) {
+        return null;
+    }
+
+    public <T> YamlStream<T> loadStreamOfType(File var1, Class<T> var2) throws FileNotFoundException {
+        return null;
+    }
+
+    public <T> YamlStream<T> loadStreamOfType(String var1, Class<T> var2) {
+        return null;
+    }
+
+    public void dump(Object var1, File var2) throws FileNotFoundException { }
+
+    public void dump(Object var1, File var2, boolean var3) throws FileNotFoundException { }
+
+    public String dump(Object var1) {
+        return null;
+    }
+
+    public String dump(Object var1, boolean var2) {
+        return null;
+    }
+
+    public void dump(Object var1, OutputStream var2, boolean var3) { }
+
+    public void dump(Object var1, OutputStream var2) { }
+
+    public void dumpStream(Iterator var1, File var2, boolean var3) throws FileNotFoundException { }
+
+    public void dumpStream(Iterator var1, File var2) throws FileNotFoundException { }
+
+    public String dumpStream(Iterator var1) {
+        return null;
+    }
+
+    public String dumpStream(Iterator var1, boolean var2) {
+        return null;
+    }
+}
+

--- a/java/ql/test/stubs/jyaml-1.3/org/ho/yaml/YamlDecoder.java
+++ b/java/ql/test/stubs/jyaml-1.3/org/ho/yaml/YamlDecoder.java
@@ -1,0 +1,16 @@
+package org.ho.yaml;
+
+import java.io.InputStream;
+import java.io.Reader;
+
+public class YamlDecoder {
+    
+    YamlDecoder(InputStream var1, YamlConfig var2) { }
+
+    public YamlDecoder(InputStream var1) { }
+
+    public YamlDecoder(Reader var1) { }
+
+    public YamlDecoder(Reader var1, YamlConfig var2) { }
+}
+

--- a/java/ql/test/stubs/jyaml-1.3/org/ho/yaml/YamlOperations.java
+++ b/java/ql/test/stubs/jyaml-1.3/org/ho/yaml/YamlOperations.java
@@ -1,0 +1,63 @@
+package org.ho.yaml;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.util.Iterator;
+
+public interface YamlOperations {
+    Object load(InputStream var1);
+
+    Object load(Reader var1);
+
+    Object load(File var1) throws FileNotFoundException;
+
+    Object load(String var1);
+
+    <T> T loadType(InputStream var1, Class<T> var2);
+
+    <T> T loadType(Reader var1, Class<T> var2);
+
+    <T> T loadType(File var1, Class<T> var2) throws FileNotFoundException;
+
+    <T> T loadType(String var1, Class<T> var2);
+
+    YamlStream loadStream(InputStream var1);
+
+    YamlStream loadStream(Reader var1);
+
+    YamlStream loadStream(File var1) throws FileNotFoundException;
+
+    YamlStream loadStream(String var1);
+
+    <T> YamlStream<T> loadStreamOfType(InputStream var1, Class<T> var2);
+
+    <T> YamlStream<T> loadStreamOfType(Reader var1, Class<T> var2);
+
+    <T> YamlStream<T> loadStreamOfType(File var1, Class<T> var2) throws FileNotFoundException;
+
+    <T> YamlStream<T> loadStreamOfType(String var1, Class<T> var2);
+
+    void dump(Object var1, File var2) throws FileNotFoundException;
+
+    void dump(Object var1, File var2, boolean var3) throws FileNotFoundException;
+
+    String dump(Object var1);
+
+    String dump(Object var1, boolean var2);
+
+    void dumpStream(Iterator var1, File var2) throws FileNotFoundException;
+
+    void dumpStream(Iterator var1, File var2, boolean var3) throws FileNotFoundException;
+
+    String dumpStream(Iterator var1);
+
+    String dumpStream(Iterator var1, boolean var2);
+
+    void dump(Object var1, OutputStream var2);
+
+    void dump(Object var1, OutputStream var2, boolean var3);
+}
+

--- a/java/ql/test/stubs/jyaml-1.3/org/ho/yaml/YamlStream.java
+++ b/java/ql/test/stubs/jyaml-1.3/org/ho/yaml/YamlStream.java
@@ -1,0 +1,7 @@
+package org.ho.yaml;
+
+import java.util.Iterator;
+
+public interface YamlStream<T> extends Iterable<T>, Iterator<T> {
+}
+

--- a/java/ql/test/stubs/yamlbeans-1.09/com/esotericsoftware/yamlbeans/YamlConfig.java
+++ b/java/ql/test/stubs/yamlbeans-1.09/com/esotericsoftware/yamlbeans/YamlConfig.java
@@ -1,0 +1,7 @@
+package com.esotericsoftware.yamlbeans;
+
+public class YamlConfig {
+
+    public YamlConfig() { }
+}
+

--- a/java/ql/test/stubs/yamlbeans-1.09/com/esotericsoftware/yamlbeans/YamlException.java
+++ b/java/ql/test/stubs/yamlbeans-1.09/com/esotericsoftware/yamlbeans/YamlException.java
@@ -1,0 +1,18 @@
+package com.esotericsoftware.yamlbeans;
+
+import java.io.IOException;
+
+public class YamlException extends IOException {
+    public YamlException() {
+    }
+
+    public YamlException(String message, Throwable cause) {
+    }
+
+    public YamlException(String message) {
+    }
+
+    public YamlException(Throwable cause) {
+    }
+}
+

--- a/java/ql/test/stubs/yamlbeans-1.09/com/esotericsoftware/yamlbeans/YamlReader.java
+++ b/java/ql/test/stubs/yamlbeans-1.09/com/esotericsoftware/yamlbeans/YamlReader.java
@@ -1,0 +1,28 @@
+package com.esotericsoftware.yamlbeans;
+
+
+import java.io.Reader;
+
+public class YamlReader {
+
+    public YamlReader(Reader reader) { }
+
+    public YamlReader(Reader reader, YamlConfig config) { }
+
+    public YamlReader(String yaml) { }
+
+    public YamlReader(String yaml, YamlConfig config) { }
+
+    public Object read() throws YamlException {
+        return null;
+    }
+
+    public <T> T read(Class<T> type) throws YamlException {
+        return null;
+    }
+
+    public <T> T read(Class<T> type, Class elementType) throws YamlException {
+        return null;
+    }
+}
+

--- a/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
@@ -77,6 +77,11 @@ nodes
 | tst.js:98:29:98:35 | req.url |
 | tst.js:100:19:100:25 | tainted |
 | tst.js:100:19:100:25 | tainted |
+| tst.js:108:11:108:27 | url |
+| tst.js:108:17:108:27 | request.url |
+| tst.js:108:17:108:27 | request.url |
+| tst.js:109:27:109:29 | url |
+| tst.js:109:27:109:29 | url |
 edges
 | tst.js:14:9:14:52 | tainted | tst.js:18:13:18:19 | tainted |
 | tst.js:14:9:14:52 | tainted | tst.js:18:13:18:19 | tainted |
@@ -152,6 +157,10 @@ edges
 | tst.js:98:19:98:52 | url.par ... ery.url | tst.js:98:9:98:52 | tainted |
 | tst.js:98:29:98:35 | req.url | tst.js:98:19:98:42 | url.par ... , true) |
 | tst.js:98:29:98:35 | req.url | tst.js:98:19:98:42 | url.par ... , true) |
+| tst.js:108:11:108:27 | url | tst.js:109:27:109:29 | url |
+| tst.js:108:11:108:27 | url | tst.js:109:27:109:29 | url |
+| tst.js:108:17:108:27 | request.url | tst.js:108:11:108:27 | url |
+| tst.js:108:17:108:27 | request.url | tst.js:108:11:108:27 | url |
 #select
 | tst.js:18:5:18:20 | request(tainted) | tst.js:14:29:14:35 | req.url | tst.js:18:13:18:19 | tainted | The $@ of this request depends on $@. | tst.js:18:13:18:19 | tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
 | tst.js:20:5:20:24 | request.get(tainted) | tst.js:14:29:14:35 | req.url | tst.js:20:17:20:23 | tainted | The $@ of this request depends on $@. | tst.js:20:17:20:23 | tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
@@ -173,3 +182,4 @@ edges
 | tst.js:90:5:90:33 | JSDOM.f ... ms.foo) | tst.js:90:19:90:28 | ctx.params | tst.js:90:19:90:32 | ctx.params.foo | The $@ of this request depends on $@. | tst.js:90:19:90:32 | ctx.params.foo | URL | tst.js:90:19:90:28 | ctx.params | a user-provided value |
 | tst.js:92:5:92:33 | JSDOM.f ... ms.foo) | tst.js:92:19:92:28 | ctx.params | tst.js:92:19:92:32 | ctx.params.foo | The $@ of this request depends on $@. | tst.js:92:19:92:32 | ctx.params.foo | URL | tst.js:92:19:92:28 | ctx.params | a user-provided value |
 | tst.js:100:5:100:26 | new Web ... ainted) | tst.js:98:29:98:35 | req.url | tst.js:100:19:100:25 | tainted | The $@ of this request depends on $@. | tst.js:100:19:100:25 | tainted | URL | tst.js:98:29:98:35 | req.url | a user-provided value |
+| tst.js:109:20:109:30 | new ws(url) | tst.js:108:17:108:27 | request.url | tst.js:109:27:109:29 | url | The $@ of this request depends on $@. | tst.js:109:27:109:29 | url | URL | tst.js:108:17:108:27 | request.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-918/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-918/tst.js
@@ -99,3 +99,13 @@ var server = http.createServer(async function(req, res) {
 
     new WebSocket(tainted); // NOT OK
 });
+
+
+import * as ws from 'ws';
+
+new ws.Server({ port: 8080 }).on('connection', function(socket, request) {
+  socket.on('message', function(message) {
+    const url = request.url;
+    const socket = new ws(url);
+  });
+});


### PR DESCRIPTION
In the study of Java deserialization vulnerabilities, some sinks were recorded. This pr adds these sinks to the CodeQL query.

Mainly known: `JYaml.load`, `JsonReader.jsonToJava`, `YamlReader.read`, `HessianInput.readObject`, `Hessian2Input.readObject`, `Unmarshaller.unmarshal`, `BurlapInput.readObject`. There are also some sink points not mentioned: `YamlConfig.load`,`JsonReader.readObject`.
