### PR TITLE
C++: Fix false positive in `cpp/comparison-with-wider-type`

### DIFF
--- a/cpp/change-notes/2021-10-05-comparison-with-wider-type.md
+++ b/cpp/change-notes/2021-10-05-comparison-with-wider-type.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The 'Comparison with wider type' (cpp/comparison-with-wider-type) query has been improved to produce fewer false positives.

--- a/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
@@ -49,6 +49,9 @@ where
   small = rel.getLesserOperand() and
   large = rel.getGreaterOperand() and
   rel = l.getCondition().getAChild*() and
+  forall(Expr conv | conv = large.getConversion*() |
+    upperBound(conv).log2() > getComparisonSize(small) * 8
+  ) and
   upperBound(large.getFullyConverted()).log2() > getComparisonSize(small) * 8 and
   // Ignore cases where the smaller type is int or larger
   // These are still bugs, but you should need a very large string or array to

--- a/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
@@ -52,7 +52,6 @@ where
   forall(Expr conv | conv = large.getConversion*() |
     upperBound(conv).log2() > getComparisonSize(small) * 8
   ) and
-  upperBound(large.getFullyConverted()).log2() > getComparisonSize(small) * 8 and
   // Ignore cases where the smaller type is int or larger
   // These are still bugs, but you should need a very large string or array to
   // trigger them. We will want to disable this for some applications, but it's

--- a/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
@@ -49,7 +49,7 @@ where
   small = rel.getLesserOperand() and
   large = rel.getGreaterOperand() and
   rel = l.getCondition().getAChild*() and
-  upperBound(large).log2() > getComparisonSize(small) * 8 and
+  upperBound(large.getFullyConverted()).log2() > getComparisonSize(small) * 8 and
   // Ignore cases where the smaller type is int or larger
   // These are still bugs, but you should need a very large string or array to
   // trigger them. We will want to disable this for some applications, but it's

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/ComparisonWithWiderType.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/ComparisonWithWiderType.expected
@@ -1,4 +1,3 @@
-| test3.cpp:6:8:6:71 | ... < ... | Comparison between $@ of type unsigned char and $@ of wider type int. | test3.cpp:5:34:5:38 | small | small | test3.cpp:6:42:6:70 | ... - ... | ... - ... |
 | test.c:4:14:4:18 | ... < ... | Comparison between $@ of type char and $@ of wider type int. | test.c:3:7:3:7 | c | c | test.c:2:17:2:17 | x | x |
 | test.c:9:14:9:18 | ... > ... | Comparison between $@ of type char and $@ of wider type int. | test.c:8:7:8:7 | c | c | test.c:7:17:7:17 | x | x |
 | test.c:14:14:14:18 | ... < ... | Comparison between $@ of type short and $@ of wider type int. | test.c:13:8:13:8 | s | s | test.c:12:17:12:17 | x | x |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/ComparisonWithWiderType.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/ComparisonWithWiderType.expected
@@ -1,4 +1,3 @@
-| test3.cpp:2:8:2:53 | ... < ... | Comparison between $@ of type unsigned char and $@ of wider type unsigned int. | test3.cpp:1:36:1:40 | small | small | test3.cpp:2:43:2:52 | ... - ... | ... - ... |
 | test.c:4:14:4:18 | ... < ... | Comparison between $@ of type char and $@ of wider type int. | test.c:3:7:3:7 | c | c | test.c:2:17:2:17 | x | x |
 | test.c:9:14:9:18 | ... > ... | Comparison between $@ of type char and $@ of wider type int. | test.c:8:7:8:7 | c | c | test.c:7:17:7:17 | x | x |
 | test.c:14:14:14:18 | ... < ... | Comparison between $@ of type short and $@ of wider type int. | test.c:13:8:13:8 | s | s | test.c:12:17:12:17 | x | x |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/ComparisonWithWiderType.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/ComparisonWithWiderType.expected
@@ -1,3 +1,4 @@
+| test3.cpp:2:8:2:53 | ... < ... | Comparison between $@ of type unsigned char and $@ of wider type unsigned int. | test3.cpp:1:36:1:40 | small | small | test3.cpp:2:43:2:52 | ... - ... | ... - ... |
 | test.c:4:14:4:18 | ... < ... | Comparison between $@ of type char and $@ of wider type int. | test.c:3:7:3:7 | c | c | test.c:2:17:2:17 | x | x |
 | test.c:9:14:9:18 | ... > ... | Comparison between $@ of type char and $@ of wider type int. | test.c:8:7:8:7 | c | c | test.c:7:17:7:17 | x | x |
 | test.c:14:14:14:18 | ... < ... | Comparison between $@ of type short and $@ of wider type int. | test.c:13:8:13:8 | s | s | test.c:12:17:12:17 | x | x |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/ComparisonWithWiderType.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/ComparisonWithWiderType.expected
@@ -1,3 +1,4 @@
+| test3.cpp:6:8:6:71 | ... < ... | Comparison between $@ of type unsigned char and $@ of wider type int. | test3.cpp:5:34:5:38 | small | small | test3.cpp:6:42:6:70 | ... - ... | ... - ... |
 | test.c:4:14:4:18 | ... < ... | Comparison between $@ of type char and $@ of wider type int. | test.c:3:7:3:7 | c | c | test.c:2:17:2:17 | x | x |
 | test.c:9:14:9:18 | ... > ... | Comparison between $@ of type char and $@ of wider type int. | test.c:8:7:8:7 | c | c | test.c:7:17:7:17 | x | x |
 | test.c:14:14:14:18 | ... < ... | Comparison between $@ of type short and $@ of wider type int. | test.c:13:8:13:8 | s | s | test.c:12:17:12:17 | x | x |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/test3.cpp
@@ -1,3 +1,3 @@
 void test_issue_5850(unsigned char small, unsigned int large1) {
-	for(; small < static_cast<unsigned char>(large1 - 1); small++) { } // GOOD [FALSE POSITIVE]
+	for(; small < static_cast<unsigned char>(large1 - 1); small++) { } // GOOD
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/test3.cpp
@@ -1,0 +1,3 @@
+void test_issue_5850(unsigned char small, unsigned int large1) {
+	for(; small < static_cast<unsigned char>(large1 - 1); small++) { } // GOOD [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/test3.cpp
@@ -3,5 +3,5 @@ void test_issue_5850(unsigned char small, unsigned int large1) {
 }
 
 void test_widening(unsigned char small, char large) {
-	for(; small < static_cast<unsigned int>(static_cast<short>(large) - 1); small++) { } // GOOD [FALSE POSITIVE]
+	for(; small < static_cast<unsigned int>(static_cast<short>(large) - 1); small++) { } // GOOD
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ComparisonWithWiderType/test3.cpp
@@ -1,3 +1,7 @@
 void test_issue_5850(unsigned char small, unsigned int large1) {
 	for(; small < static_cast<unsigned char>(large1 - 1); small++) { } // GOOD
 }
+
+void test_widening(unsigned char small, char large) {
+	for(; small < static_cast<unsigned int>(static_cast<short>(large) - 1); small++) { } // GOOD [FALSE POSITIVE]
+}


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/5850.

Prior to this PR, we ignored the conversions on the large expression when computing range analysis.