### PR TITLE
JS: More robust hasUnderlyingType

### DIFF
--- a/javascript/ql/src/semmle/javascript/TypeScript.qll
+++ b/javascript/ql/src/semmle/javascript/TypeScript.qll
@@ -725,7 +725,7 @@ class TypeAccess extends @typeaccess, TypeExpr, TypeRef {
       spec.getImportedName() = exportedName and
       this = spec.getLocal().(TypeDecl).getLocalTypeName().getAnAccess()
       or
-      spec instanceof ImportNamespaceSpecifier and
+      (spec instanceof ImportNamespaceSpecifier or spec instanceof ImportDefaultSpecifier) and
       this =
         spec.getLocal().(LocalNamespaceDecl).getLocalNamespaceName().getAMemberAccess(exportedName)
     )

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -239,7 +239,6 @@ module DataFlow {
     private TypeAnnotation getFallbackTypeAnnotation() {
       exists(BindingPattern pattern |
         this = valueNode(pattern) and
-        not ast_node_type(pattern, _) and
         result = pattern.getTypeAnnotation()
       )
       or

--- a/javascript/ql/test/library-tests/TypeScript/HasUnderlyingType/HasUnderlyingType.expected
+++ b/javascript/ql/test/library-tests/TypeScript/HasUnderlyingType/HasUnderlyingType.expected
@@ -1,2 +1,6 @@
+underlyingTypeNode
+| foo | Bar | foo.ts:3:1:5:1 | use (instance (member Bar (member exports (module foo)))) |
+| foo | Bar | foo.ts:3:12:3:12 | use (instance (member Bar (member exports (module foo)))) |
+#select
 | tst.ts:8:14:8:16 | arg | Base in global scope |
 | tst.ts:8:14:8:16 | arg | Sub in global scope |

--- a/javascript/ql/test/library-tests/TypeScript/HasUnderlyingType/HasUnderlyingType.ql
+++ b/javascript/ql/test/library-tests/TypeScript/HasUnderlyingType/HasUnderlyingType.ql
@@ -3,3 +3,7 @@ import javascript
 from Expr e, TypeName typeName
 where e.getType().hasUnderlyingTypeName(typeName)
 select e, typeName
+
+query API::Node underlyingTypeNode(string mod, string name) {
+  result = API::Node::ofType(mod, name)
+}

--- a/javascript/ql/test/library-tests/TypeScript/HasUnderlyingType/foo.ts
+++ b/javascript/ql/test/library-tests/TypeScript/HasUnderlyingType/foo.ts
@@ -1,0 +1,5 @@
+import foo from "foo";
+
+function f(x: foo.Bar) {
+  return x;
+}


### PR DESCRIPTION
Improves `SourceNode.hasUnderlyingType` and thereby `API::Node::ofType`:
- Handles types of form `foo.Bar` where `foo` refers to a default-imported name.
- Does not give up if a static type exists, as the static type might be less precise when `.d.ts` files are missing (as they usually are).

@max-schaefer 