### PR TITLE
[Java] Support local taint tracking through JDK Collections lambdas

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -48,6 +48,8 @@ predicate localTaintStep(DataFlow::Node src, DataFlow::Node sink) {
 predicate localAdditionalTaintStep(DataFlow::Node src, DataFlow::Node sink) {
   localAdditionalTaintExprStep(src.asExpr(), sink.asExpr())
   or
+  localAdditionalTaintExprToParameterStep(src.asExpr(), sink.asParameter())
+  or
   localAdditionalTaintUpdateStep(src.asExpr(),
     sink.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr())
   or
@@ -118,6 +120,15 @@ private predicate localAdditionalTaintExprStep(Expr src, Expr sink) {
   serializationStep(src, sink)
   or
   formatStep(src, sink)
+}
+
+/**
+ * Holds if taint can flow in one local step from `src` to functional argument `sink`
+ * excluding local data flow steps. That is, `src`, and `sink` are likely to represent
+ * different objects.
+ */
+private predicate localAdditionalTaintExprToParameterStep(Expr src, Parameter sink) {
+  containerToParameterStep(src, sink)
 }
 
 /**

--- a/java/ql/src/semmle/code/java/dispatch/ObjFlow.qll
+++ b/java/ql/src/semmle/code/java/dispatch/ObjFlow.qll
@@ -129,6 +129,8 @@ private predicate step(Node n1, Node n2) {
   or
   containerStep(n1.asExpr(), n2.asExpr())
   or
+  containerToParameterStep(n1.asExpr(), n2.asParameter())
+  or
   exists(Field v |
     containerStep(n1.asExpr(), v.getAnAccess()) and
     n2.asExpr() = v.getAnAccess()

--- a/java/ql/test/library-tests/dataflow/collections/Test.java
+++ b/java/ql/test/library-tests/dataflow/collections/Test.java
@@ -25,5 +25,21 @@ public class Test {
     Iterator<String> it = m.values().iterator();
     String x5 = it.next();
     sink(x5); // Flow
+
+    it.forEachRemaining(x6 -> {
+      sink(x6); // Flow
+    });
+
+    m.forEach((key, value) -> {
+      sink(key); // Flow
+      sink(value); // Flow
+    });
+
+    m.entrySet().forEach(entry -> {
+      String x7 = entry.getKey();
+      sink(x7); // No flow
+      String x8 = entry.getValue();
+      sink(x8); // Flow
+    });
   }
 }

--- a/java/ql/test/library-tests/dataflow/collections/flow.expected
+++ b/java/ql/test/library-tests/dataflow/collections/flow.expected
@@ -132,3 +132,7 @@
 | Test.java:13:18:13:24 | tainted | Test.java:18:10:18:11 | x3 |
 | Test.java:13:18:13:24 | tainted | Test.java:22:12:22:13 | x4 |
 | Test.java:13:18:13:24 | tainted | Test.java:27:10:27:11 | x5 |
+| Test.java:13:18:13:24 | tainted | Test.java:30:12:30:13 | x6 |
+| Test.java:13:18:13:24 | tainted | Test.java:34:12:34:14 | key |
+| Test.java:13:18:13:24 | tainted | Test.java:35:12:35:16 | value |
+| Test.java:13:18:13:24 | tainted | Test.java:42:12:42:13 | x8 |


### PR DESCRIPTION
Adds support for local taint tracking through common simple JDK collections functional APIs like `forEach` and `forEachRemaining`.