### PR TITLE
JS: add support for error values in an axios client request

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -184,6 +184,11 @@ module API {
     Node getPromised() { result = getASuccessor(Label::promised()) }
 
     /**
+     * Gets a node representing the error wrapped in the `Promise` object represented by this node.
+     */
+    Node getPromisedError() { result = getASuccessor(Label::promisedError()) }
+
+    /**
      * Gets a string representation of the lexicographically least among all shortest access paths
      * from the root to this node.
      */
@@ -468,6 +473,9 @@ module API {
           or
           lbl = Label::promised() and
           PromiseFlow::storeStep(rhs, pred, Promises::valueProp())
+          or
+          lbl = Label::promisedError() and
+          PromiseFlow::storeStep(rhs, pred, Promises::errorProp())
         )
         or
         exists(DataFlow::ClassNode cls, string name |
@@ -480,6 +488,12 @@ module API {
           base = MkAsyncFuncResult(f) and
           lbl = Label::promised() and
           rhs = f.getAReturn()
+        )
+        or
+        exists(DataFlow::FunctionNode f |
+          base = MkAsyncFuncResult(f) and
+          lbl = Label::promisedError() and
+          rhs = f.getExceptionalReturn()
         )
         or
         exists(int i |
@@ -559,6 +573,9 @@ module API {
           or
           lbl = Label::promised() and
           PromiseFlow::loadStep(pred, ref, Promises::valueProp())
+          or
+          lbl = Label::promisedError() and
+          PromiseFlow::loadStep(pred, ref, Promises::errorProp())
         )
         or
         exists(DataFlow::Node def, DataFlow::FunctionNode fn |
@@ -962,6 +979,9 @@ private module Label {
 
   /** Gets the `promised` edge label connecting a promise to its contained value. */
   string promised() { result = "promised" }
+
+  /** Gets the `promisedError` edge label connecting a promise to its rejected value. */
+  string promisedError() { result = "promisedError" }
 }
 
 private class NodeModuleSourcesNodes extends DataFlow::SourceNode::Range {

--- a/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
@@ -242,7 +242,7 @@ module ClientRequest {
       method = "request" and
       result = getOptionArgument(0, "data")
       or
-      method = ["post", "put", "put"] and
+      method = ["post", "put"] and
       result = [getArgument(1), getOptionArgument(2, "data")]
       or
       result = getOptionArgument([0 .. 2], ["headers", "params"])

--- a/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
@@ -206,19 +206,14 @@ module ClientRequest {
   /**
    * A model of a URL request made using the `axios` library.
    */
-  class AxiosUrlRequest extends ClientRequest::Range {
+  class AxiosUrlRequest extends ClientRequest::Range, API::CallNode {
     string method;
 
     AxiosUrlRequest() {
-      exists(string moduleName, DataFlow::SourceNode callee | this = callee.getACall() |
-        moduleName = "axios" and
-        (
-          callee = DataFlow::moduleImport(moduleName) and method = "request"
-          or
-          callee = DataFlow::moduleMember(moduleName, method) and
-          (method = httpMethodName() or method = "request")
-        )
-      )
+      this = API::moduleImport("axios").getACall() and method = "request"
+      or
+      this = API::moduleImport("axios").getMember(method).getACall() and
+      method = [httpMethodName(), "request"]
     }
 
     private int getOptionsArgIndex() {
@@ -247,12 +242,10 @@ module ClientRequest {
       method = "request" and
       result = getOptionArgument(0, "data")
       or
-      (method = "post" or method = "put" or method = "put") and
-      (result = getArgument(1) or result = getOptionArgument(2, "data"))
+      method = ["post", "put", "put"] and
+      result = [getArgument(1), getOptionArgument(2, "data")]
       or
-      exists(string name | name = "headers" or name = "params" |
-        result = getOptionArgument([0 .. 2], name)
-      )
+      result = getOptionArgument([0 .. 2], ["headers", "params"])
     }
 
     /** Gets the response type from the options passed in. */

--- a/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
@@ -271,8 +271,7 @@ module ClientRequest {
       or
       responseType = getResponseType() and
       promise = false and
-      result =
-        getReturn().getPromisedError().getMember("response").getMember("data").getAnImmediateUse()
+      result = getReturn().getPromisedError().getMember("response").getAnImmediateUse()
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
@@ -268,6 +268,11 @@ module ClientRequest {
       responseType = getResponseType() and
       promise = true and
       result = this
+      or
+      responseType = getResponseType() and
+      promise = false and
+      result =
+        getReturn().getPromisedError().getMember("response").getMember("data").getAnImmediateUse()
     }
   }
 

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -87,6 +87,7 @@ test_ClientRequest
 | tst.js:271:3:271:61 | proxy.w ... 080' }) |
 | tst.js:274:1:283:2 | httpPro ... true\\n}) |
 | tst.js:286:20:286:55 | new Web ... :8080') |
+| tst.js:296:5:299:6 | axios({ ... \\n    }) |
 test_getADataNode
 | tst.js:53:5:53:23 | axios({data: data}) | tst.js:53:18:53:21 | data |
 | tst.js:57:5:57:39 | axios.p ... data2}) | tst.js:57:19:57:23 | data1 |
@@ -227,6 +228,8 @@ test_getUrl
 | tst.js:271:3:271:61 | proxy.w ... 080' }) | tst.js:271:33:271:58 | 'http:/ ... m:8080' |
 | tst.js:274:1:283:2 | httpPro ... true\\n}) | tst.js:275:13:281:5 | {\\n      ... ,\\n    } |
 | tst.js:286:20:286:55 | new Web ... :8080') | tst.js:286:34:286:54 | 'ws://l ... t:8080' |
+| tst.js:296:5:299:6 | axios({ ... \\n    }) | tst.js:296:11:299:5 | {\\n      ... ,\\n    } |
+| tst.js:296:5:299:6 | axios({ ... \\n    }) | tst.js:298:14:298:44 | "http:/ ... -axios" |
 test_getAResponseDataNode
 | tst.js:19:5:19:23 | requestPromise(url) | tst.js:19:5:19:23 | requestPromise(url) | text | true |
 | tst.js:21:5:21:23 | superagent.get(url) | tst.js:21:5:21:23 | superagent.get(url) | stream | true |
@@ -294,3 +297,5 @@ test_getAResponseDataNode
 | tst.js:235:5:237:6 | needle. ... \\n    }) | tst.js:235:67:235:70 | resp | fetch.response | false |
 | tst.js:235:5:237:6 | needle. ... \\n    }) | tst.js:235:73:235:76 | body | json | false |
 | tst.js:286:20:286:55 | new Web ... :8080') | tst.js:291:44:291:53 | event.data | json | false |
+| tst.js:296:5:299:6 | axios({ ... \\n    }) | tst.js:296:5:299:6 | axios({ ... \\n    }) | json | true |
+| tst.js:296:5:299:6 | axios({ ... \\n    }) | tst.js:303:26:303:42 | err.response.data | json | false |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -298,4 +298,6 @@ test_getAResponseDataNode
 | tst.js:235:5:237:6 | needle. ... \\n    }) | tst.js:235:73:235:76 | body | json | false |
 | tst.js:286:20:286:55 | new Web ... :8080') | tst.js:291:44:291:53 | event.data | json | false |
 | tst.js:296:5:299:6 | axios({ ... \\n    }) | tst.js:296:5:299:6 | axios({ ... \\n    }) | json | true |
-| tst.js:296:5:299:6 | axios({ ... \\n    }) | tst.js:303:26:303:42 | err.response.data | json | false |
+| tst.js:296:5:299:6 | axios({ ... \\n    }) | tst.js:302:28:302:39 | err.response | json | false |
+| tst.js:296:5:299:6 | axios({ ... \\n    }) | tst.js:303:26:303:37 | err.response | json | false |
+| tst.js:296:5:299:6 | axios({ ... \\n    }) | tst.js:304:27:304:38 | err.response | json | false |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -291,3 +291,16 @@ function webSocket() {
         console.log("Data from server: " + event.data);
     });
 }
+
+function moreAxios() {
+    axios({
+        method: 'GET',
+        url: "http://example.org/more-axios",
+    }).then(
+        x => res.send(x.data),
+        (err) => {
+            const status = err.response.status;
+            const data = err.response.data;
+        }
+    );
+}

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -301,6 +301,7 @@ function moreAxios() {
         (err) => {
             const status = err.response.status;
             const data = err.response.data;
+            const agent = err.response.headers.useragent;
         }
     );
 }


### PR DESCRIPTION
An alternative solution to https://github.com/github/codeql/pull/5856 

Also required adding support for rejected promise values to API-graphs, so I'll run a decently sized evaluation. 
[Evaluation (internal link)](https://github.com/dsp-testing/erik-krogh-dca/tree/run/apiGraphs-added-rejected-promise/reports). 