### PR TITLE
C++: Detect more uses of `abs`

### DIFF
--- a/cpp/change-notes/2021-03-11-overflow-abs.md
+++ b/cpp/change-notes/2021-03-11-overflow-abs.md
@@ -1,0 +1,2 @@
+lgtm
+* The `cpp/tainted-arithmetic`, `cpp/arithmetic-with-extreme-values`, and `cpp/uncontrolled-arithmetic` queries now recognize more functions as returning the absolute value of their input. As a result, they produce fewer false positives.

--- a/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
@@ -12,7 +12,7 @@ import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
  * Holds if the value of `use` is guarded using `abs`.
  */
 predicate guardedAbs(Operation e, Expr use) {
-  exists(FunctionCall fc | fc.getTarget().getName() = "abs" |
+  exists(FunctionCall fc | fc.getTarget().getName() = ["abs", "labs", "llabs", "imaxabs"] |
     fc.getArgument(0).getAChild*() = use and
     guardedLesser(e, fc)
   )

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
@@ -3,6 +3,10 @@
 | test5.cpp:17:6:17:18 | call to getTaintedInt | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
 | test5.cpp:19:6:19:6 | y | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
 | test5.cpp:19:6:19:6 | y | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
+| test5.cpp:30:17:30:23 | tainted | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
+| test5.cpp:30:17:30:23 | tainted | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
+| test5.cpp:30:27:30:33 | tainted | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
+| test5.cpp:30:27:30:33 | tainted | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
 | test.c:14:15:14:28 | maxConnections | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:11:29:11:32 | argv | User-provided value |
 | test.c:14:15:14:28 | maxConnections | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:11:29:11:32 | argv | User-provided value |
 | test.c:44:7:44:10 | len2 | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:41:17:41:20 | argv | User-provided value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
@@ -3,10 +3,6 @@
 | test5.cpp:17:6:17:18 | call to getTaintedInt | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
 | test5.cpp:19:6:19:6 | y | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
 | test5.cpp:19:6:19:6 | y | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
-| test5.cpp:30:17:30:23 | tainted | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
-| test5.cpp:30:17:30:23 | tainted | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
-| test5.cpp:30:27:30:33 | tainted | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
-| test5.cpp:30:27:30:33 | tainted | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
 | test.c:14:15:14:28 | maxConnections | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:11:29:11:32 | argv | User-provided value |
 | test.c:14:15:14:28 | maxConnections | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:11:29:11:32 | argv | User-provided value |
 | test.c:44:7:44:10 | len2 | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:41:17:41:20 | argv | User-provided value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/test5.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/test5.cpp
@@ -30,3 +30,13 @@ void useTaintedIntWithGuard() {
 		int product = tainted * tainted; // GOOD: can't underflow/overflow
 	}
 }
+
+#define INTMAX_MIN (-0x7fffffffffffffff - 1)
+
+void useTaintedIntWithGuardIntMaxMin() {
+	intmax_t tainted = getTaintedInt();
+
+	if(imaxabs(tainted) <= INTMAX_MIN) {
+		int product = tainted * tainted; // BAD: imaxabs(INTMAX_MIN) == INTMAX_MIN [NOT DETECTED]
+	}
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/test5.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/test5.cpp
@@ -27,6 +27,6 @@ void useTaintedIntWithGuard() {
 	int tainted = getTaintedInt();
 
 	if(imaxabs(tainted) <= 100) {
-		int product = tainted * tainted; // GOOD: can't underflow/overflow [FALSE POSITIVE]
+		int product = tainted * tainted; // GOOD: can't underflow/overflow
 	}
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/test5.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/test5.cpp
@@ -18,3 +18,15 @@ void useTaintedInt()
 	y = getTaintedInt();
 	y = y * 1024; // BAD: arithmetic on a tainted value
 }
+
+typedef long long int intmax_t;
+
+intmax_t imaxabs(intmax_t j);
+
+void useTaintedIntWithGuard() {
+	int tainted = getTaintedInt();
+
+	if(imaxabs(tainted) <= 100) {
+		int product = tainted * tainted; // GOOD: can't underflow/overflow [FALSE POSITIVE]
+	}
+}


### PR DESCRIPTION
(Part of https://github.com/github/codeql-c-team/issues/272.)

The `semmle.code.cpp.security.Overflow` library recognizes uses of `abs` in relational comparisons, but it _only_ recognized `abs`. This doesn't match well with SAMATE, which apparently tends to use `imaxabs` for `CWE-190`.

This PR adds a couple more `abs`-like functions to the list. Locally, these are the changes I see for the queries that import `semmle.code.cpp.security.Overflow`:

| Query | TP/FP on `main` | TP/FP on this PR |
|--------|--------|--------|
| ArithmeticTainted.ql | 3472/228 | 3468/0 |
| ArithmeticUncontrolled.ql | 2177/232 | 2173/0 |
| ArithmeticWithExtremeValues.ql | 1714/114 | 1712/0 | 