### PR TITLE
Python: Limit set of globals that may be built-ins

### DIFF
--- a/python/ql/src/Expressions/UseofInput.ql
+++ b/python/ql/src/Expressions/UseofInput.ql
@@ -16,6 +16,7 @@ import semmle.python.ApiGraphs
 
 from DataFlow::CallCfgNode call
 where
+  major_version() = 2 and
   call = API::builtin("input").getACall() and
   call != API::builtin("raw_input").getACall()
 select call, "The unsafe built-in function 'input' is used in Python 2."

--- a/python/ql/src/Expressions/UseofInput.ql
+++ b/python/ql/src/Expressions/UseofInput.ql
@@ -11,11 +11,11 @@
  */
 
 import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.ApiGraphs
 
-from CallNode call, Context context, ControlFlowNode func
+from DataFlow::CallCfgNode call
 where
-  context.getAVersion().includes(2, _) and
-  call.getFunction() = func and
-  func.pointsTo(context, Value::named("input"), _) and
-  not func.pointsTo(context, Value::named("raw_input"), _)
+  call = API::builtin("input").getACall() and
+  call != API::builtin("raw_input").getACall()
 select call, "The unsafe built-in function 'input' is used in Python 2."

--- a/python/ql/src/semmle/python/ApiGraphs.qll
+++ b/python/ql/src/semmle/python/ApiGraphs.qll
@@ -349,10 +349,10 @@ module API {
       )
     }
 
-    private import semmle.python.types.Builtins as Builtins
-
-    /** Returns the names of known built-ins. */
-    private string builtin_name() {
+    /** Gets the name of a known built-in. */
+    private string getBuiltInName() {
+      // These lists were created by inspecting the `builtins` and `__builtin__` modules in
+      // Python 2 and 3 respectively, using the `dir` built-in.
       // Built-in functions and exceptions shared between Python 2 and 3
       result in [
           "abs", "all", "any", "bin", "bool", "bytearray", "callable", "chr", "classmethod",
@@ -381,7 +381,6 @@ module API {
       result in ["False", "True", "None", "NotImplemented", "Ellipsis", "__debug__"]
       or
       // Python 3 only
-      major_version() = 3 and
       result in [
           "ascii", "breakpoint", "bytes", "exec",
           // Exceptions
@@ -393,7 +392,6 @@ module API {
         ]
       or
       // Python 2 only
-      major_version() = 2 and
       result in [
           "basestring", "cmp", "execfile", "file", "long", "raw_input", "reduce", "reload",
           "unichr", "unicode", "xrange"
@@ -425,7 +423,7 @@ module API {
         not exists(LocalVariable v | n.defines(v)) and
         n.isStore() and
         name = n.getId() and
-        name = builtin_name() and
+        name = getBuiltInName() and
         m = n.getEnclosingModule()
       )
     }
@@ -438,7 +436,7 @@ module API {
       n.isGlobal() and
       n.isLoad() and
       name = n.getId() and
-      name = builtin_name() and
+      name = getBuiltInName() and
       m = n.getEnclosingModule()
     }
 

--- a/python/ql/src/semmle/python/ApiGraphs.qll
+++ b/python/ql/src/semmle/python/ApiGraphs.qll
@@ -372,7 +372,9 @@ module API {
           "RuntimeWarning", "StandardError", "StopIteration", "SyntaxError", "SyntaxWarning",
           "SystemError", "SystemExit", "TabError", "TypeError", "UnboundLocalError",
           "UnicodeDecodeError", "UnicodeEncodeError", "UnicodeError", "UnicodeTranslateError",
-          "UnicodeWarning", "UserWarning", "ValueError", "Warning", "ZeroDivisionError"
+          "UnicodeWarning", "UserWarning", "ValueError", "Warning", "ZeroDivisionError",
+          // Added for compatibility
+          "exec"
         ]
       or
       // Built-in constants shared between Python 2 and 3

--- a/python/ql/src/semmle/python/ApiGraphs.qll
+++ b/python/ql/src/semmle/python/ApiGraphs.qll
@@ -422,7 +422,7 @@ module API {
      */
     private predicate possible_builtin_defined_in_module(string name, Module m) {
       exists(NameNode n |
-        n.isGlobal() and
+        not exists(LocalVariable v | n.defines(v)) and
         n.isStore() and
         name = n.getId() and
         name = builtin_name() and

--- a/python/ql/src/semmle/python/ApiGraphs.qll
+++ b/python/ql/src/semmle/python/ApiGraphs.qll
@@ -352,7 +352,7 @@ module API {
     /** Gets the name of a known built-in. */
     private string getBuiltInName() {
       // These lists were created by inspecting the `builtins` and `__builtin__` modules in
-      // Python 2 and 3 respectively, using the `dir` built-in.
+      // Python 3 and 2 respectively, using the `dir` built-in.
       // Built-in functions and exceptions shared between Python 2 and 3
       result in [
           "abs", "all", "any", "bin", "bool", "bytearray", "callable", "chr", "classmethod",

--- a/python/ql/src/semmle/python/ApiGraphs.qll
+++ b/python/ql/src/semmle/python/ApiGraphs.qll
@@ -353,7 +353,7 @@ module API {
 
     /** Returns the names of known built-ins. */
     private string builtin_name() {
-      // Built-in functions shared between Python 2.7.6 and 3.9.5
+      // Built-in functions and exceptions shared between Python 2 and 3
       result in [
           "abs", "all", "any", "bin", "bool", "bytearray", "callable", "chr", "classmethod",
           "compile", "complex", "delattr", "dict", "dir", "divmod", "enumerate", "eval", "filter",
@@ -361,17 +361,36 @@ module API {
           "id", "input", "int", "isinstance", "issubclass", "iter", "len", "list", "locals", "map",
           "max", "memoryview", "min", "next", "object", "oct", "open", "ord", "pow", "print",
           "property", "range", "repr", "reversed", "round", "set", "setattr", "slice", "sorted",
-          "staticmethod", "str", "sum", "super", "tuple", "type", "vars", "zip", "__import__"
+          "staticmethod", "str", "sum", "super", "tuple", "type", "vars", "zip", "__import__",
+          // Exceptions
+          "ArithmeticError", "AssertionError", "AttributeError", "BaseException", "BufferError",
+          "BytesWarning", "DeprecationWarning", "EOFError", "EnvironmentError", "Exception",
+          "FloatingPointError", "FutureWarning", "GeneratorExit", "IOError", "ImportError",
+          "ImportWarning", "IndentationError", "IndexError", "KeyError", "KeyboardInterrupt",
+          "LookupError", "MemoryError", "NameError", "NotImplemented", "NotImplementedError",
+          "OSError", "OverflowError", "PendingDeprecationWarning", "ReferenceError", "RuntimeError",
+          "RuntimeWarning", "StandardError", "StopIteration", "SyntaxError", "SyntaxWarning",
+          "SystemError", "SystemExit", "TabError", "TypeError", "UnboundLocalError",
+          "UnicodeDecodeError", "UnicodeEncodeError", "UnicodeError", "UnicodeTranslateError",
+          "UnicodeWarning", "UserWarning", "ValueError", "Warning", "ZeroDivisionError"
         ]
       or
-      // Built-in constants shared between Python 2.7.6 and 3.9.5
+      // Built-in constants shared between Python 2 and 3
       result in ["False", "True", "None", "NotImplemented", "Ellipsis", "__debug__"]
       or
-      // Python 3.9.5 only
+      // Python 3 only
       major_version() = 3 and
-      result in ["ascii", "breakpoint", "bytes", "exec"]
+      result in [
+          "ascii", "breakpoint", "bytes", "exec",
+          // Exceptions
+          "BlockingIOError", "BrokenPipeError", "ChildProcessError", "ConnectionAbortedError",
+          "ConnectionError", "ConnectionRefusedError", "ConnectionResetError", "FileExistsError",
+          "FileNotFoundError", "InterruptedError", "IsADirectoryError", "ModuleNotFoundError",
+          "NotADirectoryError", "PermissionError", "ProcessLookupError", "RecursionError",
+          "ResourceWarning", "StopAsyncIteration", "TimeoutError"
+        ]
       or
-      // Python 2.7.6 only
+      // Python 2 only
       major_version() = 2 and
       result in [
           "basestring", "cmp", "execfile", "file", "long", "raw_input", "reduce", "reload",

--- a/python/ql/test/experimental/dataflow/ApiGraphs/test.py
+++ b/python/ql/test/experimental/dataflow/ApiGraphs/test.py
@@ -122,14 +122,18 @@ def redefine_print():
     print = my_print
     print("these words")
 
-def local_redefine_range():
-    range = 5
-    return range
+def local_redefine_chr():
+    chr = 5
+    return chr
 
-def global_redefine_range():
-    global range
-    range = 6
-    return range #$ SPURIOUS: use=moduleImport("builtins").getMember("range")
+def global_redefine_chr():
+    global chr
+    chr = 6
+    return chr
+
+def what_is_chr_now():
+    # If global_redefine_chr has been run, then the following is _not_ a reference to the built-in chr
+    return chr(123) #$ MISSING: use=moduleImport("builtins").getMember("chr").getReturn()
 
 def obscured_print():
     p = print #$ use=moduleImport("builtins").getMember("print")


### PR DESCRIPTION
I am very tempted to leave out the constants, or at the very least
`False`, `True`, and `None`, as these have _many_ occurrences in the
average codebase, and are not terribly useful at the API-graph level.

If we really do want to capture "nodes that refer to such and such
constant", then I think a better solution would be to create classes
extending `DataFlow::Node` to facilitate this.

---
No change note required -- this only gets rid of junk that should never have been there in the first place.

As an added bonus, I've also ported the `py/use-of-input` query to use API graphs.

I'm not entirely convinced that this way of handling shadowing of built-ins is the best possible. One might make the argument, for instance, that if something redefines `print`, say, then it's likely a function that acts as a drop-in replacement for `print` (and therefore also of interest when looking for instances of the `print` built-in). With that in mind, it may be better to keep the redefined built-ins, and perhaps allow for some other way of checking if they may have been redefined.