### PR TITLE
C#: Always pass `/p:UseSharedCompilation=false` to `dotnet build` in auto builder

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -415,7 +415,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.RunProcess["cmd.exe /C dotnet --info"] = 0;
             actions.RunProcess[@"cmd.exe /C dotnet clean C:\Project\test.csproj"] = 0;
             actions.RunProcess[@"cmd.exe /C dotnet restore C:\Project\test.csproj"] = 0;
-            actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto dotnet build --no-incremental C:\Project\test.csproj"] = 0;
+            actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto dotnet build --no-incremental /p:UseSharedCompilation=false C:\Project\test.csproj"] = 0;
             actions.FileExists["csharp.log"] = true;
             actions.FileExists[@"C:\Project\test.csproj"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -439,9 +439,6 @@ namespace Semmle.Autobuild.CSharp.Tests
         [Fact]
         public void TestLinuxCSharpAutoBuilder()
         {
-            actions.RunProcess["dotnet --list-runtimes"] = 0;
-            actions.RunProcessOut["dotnet --list-runtimes"] = @"Microsoft.AspNetCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
-Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]";
             actions.RunProcess["dotnet --info"] = 0;
             actions.RunProcess[@"dotnet clean C:\Project/test.csproj"] = 0;
             actions.RunProcess[@"dotnet restore C:\Project/test.csproj"] = 0;
@@ -463,7 +460,7 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             actions.LoadXml[@"C:\Project/test.csproj"] = xml;
 
             var autobuilder = CreateAutoBuilder(false);
-            TestAutobuilderScript(autobuilder, 0, 5);
+            TestAutobuilderScript(autobuilder, 0, 4);
         }
 
         [Fact]
@@ -603,8 +600,6 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         [Fact]
         public void TestLinuxBuildCommand()
         {
-            actions.RunProcess["dotnet --list-runtimes"] = 1;
-            actions.RunProcessOut["dotnet --list-runtimes"] = "";
             actions.RunProcess[@"C:\odasa/tools/odasa index --auto ""./build.sh --skip-tests"""] = 0;
             actions.FileExists["csharp.log"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -615,7 +610,7 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             SkipVsWhere();
 
             var autobuilder = CreateAutoBuilder(false, buildCommand: "./build.sh --skip-tests");
-            TestAutobuilderScript(autobuilder, 0, 2);
+            TestAutobuilderScript(autobuilder, 0, 1);
         }
 
         [Fact]
@@ -626,14 +621,12 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             actions.RunProcess[@"/bin/chmod u+x C:\Project/build/build.sh"] = 0;
-            actions.RunProcess["dotnet --list-runtimes"] = 1;
-            actions.RunProcessOut["dotnet --list-runtimes"] = "";
             actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/build/build.sh"] = 0;
             actions.RunProcessWorkingDirectory[@"C:\odasa/tools/odasa index --auto C:\Project/build/build.sh"] = @"C:\Project/build";
             actions.FileExists["csharp.log"] = true;
 
             var autobuilder = CreateAutoBuilder(false);
-            TestAutobuilderScript(autobuilder, 0, 3);
+            TestAutobuilderScript(autobuilder, 0, 2);
         }
 
         [Fact]
@@ -645,14 +638,12 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
 
             actions.RunProcess[@"/bin/chmod u+x C:\Project/build.sh"] = 0;
-            actions.RunProcess["dotnet --list-runtimes"] = 1;
-            actions.RunProcessOut["dotnet --list-runtimes"] = "";
             actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/build.sh"] = 0;
             actions.RunProcessWorkingDirectory[@"C:\odasa/tools/odasa index --auto C:\Project/build.sh"] = @"C:\Project";
             actions.FileExists["csharp.log"] = false;
 
             var autobuilder = CreateAutoBuilder(false);
-            TestAutobuilderScript(autobuilder, 1, 3);
+            TestAutobuilderScript(autobuilder, 1, 2);
         }
 
         [Fact]
@@ -664,14 +655,12 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
 
             actions.RunProcess[@"/bin/chmod u+x C:\Project/build.sh"] = 0;
-            actions.RunProcess["dotnet --list-runtimes"] = 1;
-            actions.RunProcessOut["dotnet --list-runtimes"] = "";
             actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/build.sh"] = 5;
             actions.RunProcessWorkingDirectory[@"C:\odasa/tools/odasa index --auto C:\Project/build.sh"] = @"C:\Project";
             actions.FileExists["csharp.log"] = true;
 
             var autobuilder = CreateAutoBuilder(false);
-            TestAutobuilderScript(autobuilder, 1, 3);
+            TestAutobuilderScript(autobuilder, 1, 2);
         }
 
         [Fact]
@@ -872,9 +861,6 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         [Fact]
         public void TestSkipNugetDotnet()
         {
-            actions.RunProcess["dotnet --list-runtimes"] = 0;
-            actions.RunProcessOut["dotnet --list-runtimes"] = @"Microsoft.AspNetCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
-Microsoft.NETCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]";
             actions.RunProcess["dotnet --info"] = 0;
             actions.RunProcess[@"dotnet clean C:\Project/test.csproj"] = 0;
             actions.RunProcess[@"dotnet restore C:\Project/test.csproj"] = 0;
@@ -896,7 +882,7 @@ Microsoft.NETCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             actions.LoadXml[@"C:\Project/test.csproj"] = xml;
 
             var autobuilder = CreateAutoBuilder(false, dotnetArguments: "--no-restore");  // nugetRestore=false does not work for now.
-            TestAutobuilderScript(autobuilder, 0, 5);
+            TestAutobuilderScript(autobuilder, 0, 4);
         }
 
         [Fact]
@@ -907,13 +893,10 @@ Microsoft.NETCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             actions.RunProcess[@"chmod u+x dotnet-install.sh"] = 0;
             actions.RunProcess[@"./dotnet-install.sh --channel release --version 2.1.3 --install-dir C:\Project/.dotnet"] = 0;
             actions.RunProcess[@"rm dotnet-install.sh"] = 0;
-            actions.RunProcess[@"C:\Project/.dotnet/dotnet --list-runtimes"] = 0;
-            actions.RunProcessOut[@"C:\Project/.dotnet/dotnet --list-runtimes"] = @"Microsoft.AspNetCore.App 3.0.0 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
-Microsoft.NETCore.App 3.0.0 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]";
             actions.RunProcess[@"C:\Project/.dotnet/dotnet --info"] = 0;
             actions.RunProcess[@"C:\Project/.dotnet/dotnet clean C:\Project/test.csproj"] = 0;
             actions.RunProcess[@"C:\Project/.dotnet/dotnet restore C:\Project/test.csproj"] = 0;
-            actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/.dotnet/dotnet build --no-incremental C:\Project/test.csproj"] = 0;
+            actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/.dotnet/dotnet build --no-incremental /p:UseSharedCompilation=false C:\Project/test.csproj"] = 0;
             actions.FileExists["csharp.log"] = true;
             actions.FileExists["test.csproj"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
@@ -933,7 +916,7 @@ Microsoft.NETCore.App 3.0.0 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             actions.DownloadFiles.Add(("https://dot.net/v1/dotnet-install.sh", "dotnet-install.sh"));
 
             var autobuilder = CreateAutoBuilder(false, dotnetVersion: "2.1.3");
-            TestAutobuilderScript(autobuilder, 0, 9);
+            TestAutobuilderScript(autobuilder, 0, 8);
         }
 
         [Fact]
@@ -945,11 +928,6 @@ Microsoft.NETCore.App 3.0.0 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             actions.RunProcess[@"chmod u+x dotnet-install.sh"] = 0;
             actions.RunProcess[@"./dotnet-install.sh --channel release --version 2.1.3 --install-dir C:\Project/.dotnet"] = 0;
             actions.RunProcess[@"rm dotnet-install.sh"] = 0;
-            actions.RunProcess[@"C:\Project/.dotnet/dotnet --list-runtimes"] = 0;
-            actions.RunProcessOut[@"C:\Project/.dotnet/dotnet --list-runtimes"] = @"Microsoft.AspNetCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
-Microsoft.AspNetCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
-Microsoft.NETCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
-Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]";
             actions.RunProcess[@"C:\Project/.dotnet/dotnet --info"] = 0;
             actions.RunProcess[@"C:\Project/.dotnet/dotnet clean C:\Project/test.csproj"] = 0;
             actions.RunProcess[@"C:\Project/.dotnet/dotnet restore C:\Project/test.csproj"] = 0;
@@ -973,7 +951,7 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             actions.DownloadFiles.Add(("https://dot.net/v1/dotnet-install.sh", "dotnet-install.sh"));
 
             var autobuilder = CreateAutoBuilder(false, dotnetVersion: "2.1.3");
-            TestAutobuilderScript(autobuilder, 0, 9);
+            TestAutobuilderScript(autobuilder, 0, 8);
         }
 
         private void TestDotnetVersionWindows(Action action, int commandsRun)
@@ -984,7 +962,7 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet --info"] = 0;
             actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet clean C:\Project\test.csproj"] = 0;
             actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet restore C:\Project\test.csproj"] = 0;
-            actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\.dotnet\dotnet build --no-incremental C:\Project\test.csproj"] = 0;
+            actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\.dotnet\dotnet build --no-incremental /p:UseSharedCompilation=false C:\Project\test.csproj"] = 0;
             actions.FileExists["csharp.log"] = true;
             actions.FileExists[@"C:\Project\test.csproj"] = true;
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -36,7 +36,7 @@ namespace Semmle.Autobuild.CSharp
                 builder.Log(Severity.Info, "Attempting to build using .NET Core");
             }
 
-            return WithDotNet(builder, (dotNetPath, environment, compatibleClr) =>
+            return WithDotNet(builder, (dotNetPath, environment) =>
                 {
                     var ret = GetInfoCommand(builder.Actions, dotNetPath, environment);
                     foreach (var projectOrSolution in builder.ProjectsOrSolutionsToBuild)
@@ -49,7 +49,7 @@ namespace Semmle.Autobuild.CSharp
                         restoreCommand.QuoteArgument(projectOrSolution.FullPath);
                         var restore = restoreCommand.Script;
 
-                        var build = GetBuildScript(builder, dotNetPath, environment, compatibleClr, projectOrSolution.FullPath);
+                        var build = GetBuildScript(builder, dotNetPath, environment, projectOrSolution.FullPath);
 
                         ret &= BuildScript.Try(clean) & BuildScript.Try(restore) & build;
                     }
@@ -57,7 +57,7 @@ namespace Semmle.Autobuild.CSharp
                 });
         }
 
-        private static BuildScript WithDotNet(Autobuilder builder, Func<string?, IDictionary<string, string>?, bool, BuildScript> f)
+        private static BuildScript WithDotNet(Autobuilder builder, Func<string?, IDictionary<string, string>?, BuildScript> f)
         {
             var installDir = builder.Actions.PathCombine(builder.Options.RootDirectory, ".dotnet");
             var installScript = DownloadDotNet(builder, installDir);
@@ -81,35 +81,10 @@ namespace Semmle.Autobuild.CSharp
                     env = null;
                 }
 
-                // The CLR tracer is always compatible on Windows
-                if (builder.Actions.IsWindows())
-                    return f(installDir, env, true);
-
-                // The CLR tracer is only compatible on .NET Core >= 3 on Linux and macOS (see
-                // https://github.com/dotnet/coreclr/issues/19622)
-                return BuildScript.Bind(GetInstalledRuntimesScript(builder.Actions, installDir, env), (runtimes, runtimesRet) =>
-                {
-                    var compatibleClr = false;
-                    if (runtimesRet == 0)
-                    {
-                        var minimumVersion = new Version(3, 0);
-                        var regex = new Regex(@"Microsoft\.NETCore\.App (\d\.\d\.\d)");
-                        compatibleClr = runtimes
-                            .Select(runtime => regex.Match(runtime))
-                            .Where(m => m.Success)
-                            .Select(m => m.Groups[1].Value)
-                            .Any(m => Version.TryParse(m, out var v) && v >= minimumVersion);
-                    }
-
-                    if (!compatibleClr)
-                    {
-                        if (env is null)
-                            env = new Dictionary<string, string>();
-                        env.Add("UseSharedCompilation", "false");
-                    }
-
-                    return f(installDir, env, compatibleClr);
-                });
+                if (env is null)
+                    env = new Dictionary<string, string>();
+                env.Add("UseSharedCompilation", "false");
+                return f(installDir, env);
             });
         }
 
@@ -122,7 +97,7 @@ namespace Semmle.Autobuild.CSharp
         /// are needed).
         /// </summary>
         public static BuildScript WithDotNet(Autobuilder builder, Func<IDictionary<string, string>?, BuildScript> f)
-            => WithDotNet(builder, (_1, env, _2) => f(env));
+            => WithDotNet(builder, (_1, env) => f(env));
 
         /// <summary>
         /// Returns a script for downloading relevant versions of the
@@ -259,14 +234,6 @@ namespace Semmle.Autobuild.CSharp
             return restore;
         }
 
-        private static BuildScript GetInstalledRuntimesScript(IBuildActions actions, string? dotNetPath, IDictionary<string, string>? environment)
-        {
-            var listSdks = new CommandBuilder(actions, environment: environment, silent: true).
-                RunCommand(DotNetCommand(actions, dotNetPath)).
-                Argument("--list-runtimes");
-            return listSdks.Script;
-        }
-
         /// <summary>
         /// Gets the `dotnet build` script.
         ///
@@ -276,17 +243,14 @@ namespace Semmle.Autobuild.CSharp
         /// hence the need for CLR tracing), by adding a
         /// `/p:UseSharedCompilation=false` argument.
         /// </summary>
-        private static BuildScript GetBuildScript(Autobuilder builder, string? dotNetPath, IDictionary<string, string>? environment, bool compatibleClr, string projOrSln)
+        private static BuildScript GetBuildScript(Autobuilder builder, string? dotNetPath, IDictionary<string, string>? environment, string projOrSln)
         {
             var build = new CommandBuilder(builder.Actions, null, environment);
             var script = builder.MaybeIndex(build, DotNetCommand(builder.Actions, dotNetPath)).
                 Argument("build").
                 Argument("--no-incremental");
 
-            return compatibleClr ?
-                script.Argument(builder.Options.DotNetArguments).
-                    QuoteArgument(projOrSln).
-                    Script :
+            return
                 script.Argument("/p:UseSharedCompilation=false").
                     Argument(builder.Options.DotNetArguments).
                     QuoteArgument(projOrSln).

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -236,12 +236,6 @@ namespace Semmle.Autobuild.CSharp
 
         /// <summary>
         /// Gets the `dotnet build` script.
-        ///
-        /// The CLR tracer only works on .NET Core >= 3 on Linux and macOS (see
-        /// https://github.com/dotnet/coreclr/issues/19622), so in case we are
-        /// running on an older .NET Core, we disable shared compilation (and
-        /// hence the need for CLR tracing), by adding a
-        /// `/p:UseSharedCompilation=false` argument.
         /// </summary>
         private static BuildScript GetBuildScript(Autobuilder builder, string? dotNetPath, IDictionary<string, string>? environment, string projOrSln)
         {


### PR DESCRIPTION
Until we have a proper (tracer based) fix for this, we may as well disable shared compilation when invoking `dotnet build` from the auto builder.