### PR TITLE
Consider boxed booleans to avoid false positives for XXE.ql

### DIFF
--- a/java/change-notes/2021-05-12-xxe-fp-fix.md
+++ b/java/change-notes/2021-05-12-xxe-fp-fix.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The query "Resolving XML external entity in user-controlled data" (`java/xxe`) has been improved to report fewer false positives when a Builder / Factory (e.g. an `XMLInputFactory`) is configured safely by using a boxed boolean as second argument to one or more of its configuration methods.

--- a/java/ql/src/semmle/code/java/security/XmlParsers.qll
+++ b/java/ql/src/semmle/code/java/security/XmlParsers.qll
@@ -36,7 +36,10 @@ abstract class ParserConfig extends MethodAccess {
    */
   predicate disables(Expr e) {
     this.getArgument(0) = e and
-    this.getArgument(1).(BooleanLiteral).getBooleanValue() = false
+    (
+      this.getArgument(1).(BooleanLiteral).getBooleanValue() = false or
+      this.getArgument(1).(FieldAccess).getField().hasQualifiedName("java.lang", "Boolean", "FALSE")
+    )
   }
 
   /**
@@ -44,7 +47,10 @@ abstract class ParserConfig extends MethodAccess {
    */
   predicate enables(Expr e) {
     this.getArgument(0) = e and
-    this.getArgument(1).(BooleanLiteral).getBooleanValue() = true
+    (
+      this.getArgument(1).(BooleanLiteral).getBooleanValue() = true or
+      this.getArgument(1).(FieldAccess).getField().hasQualifiedName("java.lang", "Boolean", "TRUE")
+    )
   }
 }
 


### PR DESCRIPTION
The XXE.ql query erroneously flags the last line in

```java
XMLInputFactory factory = XMLInputFactory.newFactory();
factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
factory.setProperty("javax.xml.stream.isSupportingExternalEntities", Boolean.FALSE);
factory.createXMLStreamReader(sock.getInputStream());    // false positive
```

The solution, as proposed in this PR, is to consider the boolean value of boxed booleans as second argument of `setProperty()`.

@aschackmull     // as discussed in https://github.com/github/codeql-java-team/issues/120