### PR TITLE
JS: Use the new non-extending-subtypes syntax

### DIFF
--- a/javascript/ql/lib/semmle/javascript/Base64.qll
+++ b/javascript/ql/lib/semmle/javascript/Base64.qll
@@ -6,14 +6,12 @@ import javascript
 
 module Base64 {
   /** A call to a base64 encoder. */
-  class Encode extends DataFlow::Node {
-    Encode() { this instanceof Encode::Range }
-
+  class Encode extends DataFlow::Node instanceof Encode::Range {
     /** Gets the input passed to the encoder. */
-    DataFlow::Node getInput() { result = this.(Encode::Range).getInput() }
+    DataFlow::Node getInput() { result = super.getInput() }
 
     /** Gets the base64-encoded output of the encoder. */
-    DataFlow::Node getOutput() { result = this.(Encode::Range).getOutput() }
+    DataFlow::Node getOutput() { result = super.getOutput() }
   }
 
   module Encode {
@@ -32,14 +30,12 @@ module Base64 {
   }
 
   /** A call to a base64 decoder. */
-  class Decode extends DataFlow::Node {
-    Decode() { this instanceof Decode::Range }
-
+  class Decode extends DataFlow::Node instanceof Decode::Range {
     /** Gets the base64-encoded input passed to the decoder. */
-    DataFlow::Node getInput() { result = this.(Decode::Range).getInput() }
+    DataFlow::Node getInput() { result = super.getInput() }
 
     /** Gets the output of the decoder. */
-    DataFlow::Node getOutput() { result = this.(Decode::Range).getOutput() }
+    DataFlow::Node getOutput() { result = super.getOutput() }
   }
 
   module Decode {

--- a/javascript/ql/lib/semmle/javascript/Base64.qll
+++ b/javascript/ql/lib/semmle/javascript/Base64.qll
@@ -7,15 +7,13 @@ import javascript
 module Base64 {
   /** A call to a base64 encoder. */
   class Encode extends DataFlow::Node {
-    Encode::Range encode;
-
-    Encode() { this = encode }
+    Encode() { this instanceof Encode::Range }
 
     /** Gets the input passed to the encoder. */
-    DataFlow::Node getInput() { result = encode.getInput() }
+    DataFlow::Node getInput() { result = this.(Encode::Range).getInput() }
 
     /** Gets the base64-encoded output of the encoder. */
-    DataFlow::Node getOutput() { result = encode.getOutput() }
+    DataFlow::Node getOutput() { result = this.(Encode::Range).getOutput() }
   }
 
   module Encode {
@@ -35,15 +33,13 @@ module Base64 {
 
   /** A call to a base64 decoder. */
   class Decode extends DataFlow::Node {
-    Decode::Range encode;
-
-    Decode() { this = encode }
+    Decode() { this instanceof Decode::Range }
 
     /** Gets the base64-encoded input passed to the decoder. */
-    DataFlow::Node getInput() { result = encode.getInput() }
+    DataFlow::Node getInput() { result = this.(Decode::Range).getInput() }
 
     /** Gets the output of the decoder. */
-    DataFlow::Node getOutput() { result = encode.getOutput() }
+    DataFlow::Node getOutput() { result = this.(Decode::Range).getOutput() }
   }
 
   module Decode {

--- a/javascript/ql/lib/semmle/javascript/Closure.qll
+++ b/javascript/ql/lib/semmle/javascript/Closure.qll
@@ -9,14 +9,14 @@ module Closure {
    * A reference to a Closure namespace.
    */
   class ClosureNamespaceRef extends DataFlow::Node {
-    ClosureNamespaceRef::Range range;
-
-    ClosureNamespaceRef() { this = range }
+    ClosureNamespaceRef() { this instanceof ClosureNamespaceRef::Range }
 
     /**
      * Gets the namespace being referenced.
      */
-    string getClosureNamespace() { result = range.getClosureNamespace() }
+    string getClosureNamespace() {
+      result = this.(ClosureNamespaceRef::Range).getClosureNamespace()
+    }
   }
 
   module ClosureNamespaceRef {
@@ -37,7 +37,7 @@ module Closure {
    * A data flow node that returns the value of a closure namespace.
    */
   class ClosureNamespaceAccess extends ClosureNamespaceRef {
-    override ClosureNamespaceAccess::Range range;
+    ClosureNamespaceAccess() { this instanceof ClosureNamespaceAccess::Range }
   }
 
   module ClosureNamespaceAccess {
@@ -81,7 +81,7 @@ module Closure {
    * A top-level call to `goog.provide`.
    */
   class ClosureProvideCall extends ClosureNamespaceRef, DataFlow::MethodCallNode {
-    override DefaultClosureProvideCall range;
+    ClosureProvideCall() { this instanceof DefaultClosureProvideCall }
   }
 
   /**
@@ -95,7 +95,7 @@ module Closure {
    * A call to `goog.require`.
    */
   class ClosureRequireCall extends ClosureNamespaceAccess, DataFlow::MethodCallNode {
-    override DefaultClosureRequireCall range;
+    ClosureRequireCall() { this instanceof DefaultClosureRequireCall }
   }
 
   /**
@@ -112,7 +112,7 @@ module Closure {
    * A top-level call to `goog.module` or `goog.declareModuleId`.
    */
   class ClosureModuleDeclaration extends ClosureNamespaceRef, DataFlow::MethodCallNode {
-    override DefaultClosureModuleDeclaration range;
+    ClosureModuleDeclaration() { this instanceof DefaultClosureModuleDeclaration }
   }
 
   private GlobalVariable googVariable() { variables(result, "goog", any(GlobalScope sc)) }

--- a/javascript/ql/lib/semmle/javascript/Closure.qll
+++ b/javascript/ql/lib/semmle/javascript/Closure.qll
@@ -8,15 +8,11 @@ module Closure {
   /**
    * A reference to a Closure namespace.
    */
-  class ClosureNamespaceRef extends DataFlow::Node {
-    ClosureNamespaceRef() { this instanceof ClosureNamespaceRef::Range }
-
+  class ClosureNamespaceRef extends DataFlow::Node instanceof ClosureNamespaceRef::Range {
     /**
      * Gets the namespace being referenced.
      */
-    string getClosureNamespace() {
-      result = this.(ClosureNamespaceRef::Range).getClosureNamespace()
-    }
+    string getClosureNamespace() { result = super.getClosureNamespace() }
   }
 
   module ClosureNamespaceRef {
@@ -36,8 +32,7 @@ module Closure {
   /**
    * A data flow node that returns the value of a closure namespace.
    */
-  class ClosureNamespaceAccess extends ClosureNamespaceRef {
-    ClosureNamespaceAccess() { this instanceof ClosureNamespaceAccess::Range }
+  class ClosureNamespaceAccess extends ClosureNamespaceRef instanceof ClosureNamespaceAccess::Range {
   }
 
   module ClosureNamespaceAccess {

--- a/javascript/ql/lib/semmle/javascript/InclusionTests.qll
+++ b/javascript/ql/lib/semmle/javascript/InclusionTests.qll
@@ -17,15 +17,13 @@ private import javascript
  * ```
  */
 class InclusionTest extends DataFlow::Node {
-  InclusionTest::Range range;
-
-  InclusionTest() { this = range }
+  InclusionTest() { this instanceof InclusionTest::Range }
 
   /** Gets the `A` in `A.includes(B)`. */
-  DataFlow::Node getContainerNode() { result = range.getContainerNode() }
+  DataFlow::Node getContainerNode() { result = this.(InclusionTest::Range).getContainerNode() }
 
   /** Gets the `B` in `A.includes(B)`. */
-  DataFlow::Node getContainedNode() { result = range.getContainedNode() }
+  DataFlow::Node getContainedNode() { result = this.(InclusionTest::Range).getContainedNode() }
 
   /**
    * Gets the polarity of the check.
@@ -33,7 +31,7 @@ class InclusionTest extends DataFlow::Node {
    * If the polarity is `false` the check returns `true` if the container does not contain
    * the given element.
    */
-  boolean getPolarity() { result = range.getPolarity() }
+  boolean getPolarity() { result = this.(InclusionTest::Range).getPolarity() }
 }
 
 module InclusionTest {

--- a/javascript/ql/lib/semmle/javascript/InclusionTests.qll
+++ b/javascript/ql/lib/semmle/javascript/InclusionTests.qll
@@ -16,14 +16,12 @@ private import javascript
  * ~A.indexOf(B)
  * ```
  */
-class InclusionTest extends DataFlow::Node {
-  InclusionTest() { this instanceof InclusionTest::Range }
-
+class InclusionTest extends DataFlow::Node instanceof InclusionTest::Range {
   /** Gets the `A` in `A.includes(B)`. */
-  DataFlow::Node getContainerNode() { result = this.(InclusionTest::Range).getContainerNode() }
+  DataFlow::Node getContainerNode() { result = super.getContainerNode() }
 
   /** Gets the `B` in `A.includes(B)`. */
-  DataFlow::Node getContainedNode() { result = this.(InclusionTest::Range).getContainedNode() }
+  DataFlow::Node getContainedNode() { result = super.getContainedNode() }
 
   /**
    * Gets the polarity of the check.
@@ -31,7 +29,7 @@ class InclusionTest extends DataFlow::Node {
    * If the polarity is `false` the check returns `true` if the container does not contain
    * the given element.
    */
-  boolean getPolarity() { result = this.(InclusionTest::Range).getPolarity() }
+  boolean getPolarity() { result = super.getPolarity() }
 }
 
 module InclusionTest {

--- a/javascript/ql/lib/semmle/javascript/MembershipCandidates.qll
+++ b/javascript/ql/lib/semmle/javascript/MembershipCandidates.qll
@@ -9,25 +9,23 @@ import javascript
  *
  * Additional candidates can be added by subclassing `MembershipCandidate::Range`
  */
-class MembershipCandidate extends DataFlow::Node {
-  MembershipCandidate() { this instanceof MembershipCandidate::Range }
-
+class MembershipCandidate extends DataFlow::Node instanceof MembershipCandidate::Range {
   /**
    * Gets the expression that performs the membership test, if any.
    */
-  DataFlow::Node getTest() { result = this.(MembershipCandidate::Range).getTest() }
+  DataFlow::Node getTest() { result = super.getTest() }
 
   /**
    * Gets a string that this candidate is tested against, if
    * it can be determined.
    */
-  string getAMemberString() { result = this.(MembershipCandidate::Range).getAMemberString() }
+  string getAMemberString() { result = super.getAMemberString() }
 
   /**
    * Gets a node that this candidate is tested against, if
    * it can be determined.
    */
-  DataFlow::Node getAMemberNode() { result = this.(MembershipCandidate::Range).getAMemberNode() }
+  DataFlow::Node getAMemberNode() { result = super.getAMemberNode() }
 
   /**
    * Gets the polarity of the test.
@@ -35,7 +33,7 @@ class MembershipCandidate extends DataFlow::Node {
    * If the polarity is `false` the test returns `true` if the
    * collection does not contain this candidate.
    */
-  boolean getTestPolarity() { result = this.(MembershipCandidate::Range).getTestPolarity() }
+  boolean getTestPolarity() { result = super.getTestPolarity() }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/MembershipCandidates.qll
+++ b/javascript/ql/lib/semmle/javascript/MembershipCandidates.qll
@@ -10,26 +10,24 @@ import javascript
  * Additional candidates can be added by subclassing `MembershipCandidate::Range`
  */
 class MembershipCandidate extends DataFlow::Node {
-  MembershipCandidate::Range range;
-
-  MembershipCandidate() { this = range }
+  MembershipCandidate() { this instanceof MembershipCandidate::Range }
 
   /**
    * Gets the expression that performs the membership test, if any.
    */
-  DataFlow::Node getTest() { result = range.getTest() }
+  DataFlow::Node getTest() { result = this.(MembershipCandidate::Range).getTest() }
 
   /**
    * Gets a string that this candidate is tested against, if
    * it can be determined.
    */
-  string getAMemberString() { result = range.getAMemberString() }
+  string getAMemberString() { result = this.(MembershipCandidate::Range).getAMemberString() }
 
   /**
    * Gets a node that this candidate is tested against, if
    * it can be determined.
    */
-  DataFlow::Node getAMemberNode() { result = range.getAMemberNode() }
+  DataFlow::Node getAMemberNode() { result = this.(MembershipCandidate::Range).getAMemberNode() }
 
   /**
    * Gets the polarity of the test.
@@ -37,7 +35,7 @@ class MembershipCandidate extends DataFlow::Node {
    * If the polarity is `false` the test returns `true` if the
    * collection does not contain this candidate.
    */
-  boolean getTestPolarity() { result = range.getTestPolarity() }
+  boolean getTestPolarity() { result = this.(MembershipCandidate::Range).getTestPolarity() }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/StringOps.qll
+++ b/javascript/ql/lib/semmle/javascript/StringOps.qll
@@ -9,19 +9,17 @@ module StringOps {
    * A expression that is equivalent to `A.startsWith(B)` or `!A.startsWith(B)`.
    */
   class StartsWith extends DataFlow::Node {
-    StartsWith::Range range;
-
-    StartsWith() { range = this }
+    StartsWith() { this instanceof StartsWith::Range }
 
     /**
      * Gets the `A` in `A.startsWith(B)`.
      */
-    DataFlow::Node getBaseString() { result = range.getBaseString() }
+    DataFlow::Node getBaseString() { result = this.(StartsWith::Range).getBaseString() }
 
     /**
      * Gets the `B` in `A.startsWith(B)`.
      */
-    DataFlow::Node getSubstring() { result = range.getSubstring() }
+    DataFlow::Node getSubstring() { result = this.(StartsWith::Range).getSubstring() }
 
     /**
      * Gets the polarity of the check.
@@ -29,7 +27,7 @@ module StringOps {
      * If the polarity is `false` the check returns `true` if the string does not start
      * with the given substring.
      */
-    boolean getPolarity() { result = range.getPolarity() }
+    boolean getPolarity() { result = this.(StartsWith::Range).getPolarity() }
   }
 
   module StartsWith {
@@ -238,19 +236,17 @@ module StringOps {
    * An expression that is equivalent to `A.endsWith(B)` or `!A.endsWith(B)`.
    */
   class EndsWith extends DataFlow::Node {
-    EndsWith::Range range;
-
-    EndsWith() { this = range }
+    EndsWith() { this instanceof EndsWith::Range }
 
     /**
      * Gets the `A` in `A.startsWith(B)`.
      */
-    DataFlow::Node getBaseString() { result = range.getBaseString() }
+    DataFlow::Node getBaseString() { result = this.(EndsWith::Range).getBaseString() }
 
     /**
      * Gets the `B` in `A.startsWith(B)`.
      */
-    DataFlow::Node getSubstring() { result = range.getSubstring() }
+    DataFlow::Node getSubstring() { result = this.(EndsWith::Range).getSubstring() }
 
     /**
      * Gets the polarity if the check.
@@ -258,7 +254,7 @@ module StringOps {
      * If the polarity is `false` the check returns `true` if the string does not end
      * with the given substring.
      */
-    boolean getPolarity() { result = range.getPolarity() }
+    boolean getPolarity() { result = this.(EndsWith::Range).getPolarity() }
   }
 
   module EndsWith {
@@ -663,9 +659,7 @@ module StringOps {
    * ```
    */
   class RegExpTest extends DataFlow::Node {
-    RegExpTest::Range range;
-
-    RegExpTest() { this = range }
+    RegExpTest() { this instanceof RegExpTest::Range }
 
     /**
      * Gets the AST of the regular expression used in the test, if it can be seen locally.
@@ -673,7 +667,7 @@ module StringOps {
     RegExpTerm getRegExp() {
       result = getRegExpOperand().getALocalSource().(DataFlow::RegExpCreationNode).getRoot()
       or
-      result = range.getRegExpOperand(true).asExpr().(StringLiteral).asRegExp()
+      result = this.(RegExpTest::Range).getRegExpOperand(true).asExpr().(StringLiteral).asRegExp()
     }
 
     /**
@@ -681,12 +675,12 @@ module StringOps {
      *
      * In some cases this represents a string value being coerced to a RegExp object.
      */
-    DataFlow::Node getRegExpOperand() { result = range.getRegExpOperand(_) }
+    DataFlow::Node getRegExpOperand() { result = this.(RegExpTest::Range).getRegExpOperand(_) }
 
     /**
      * Gets the data flow node corresponding to the string being tested against the regular expression.
      */
-    DataFlow::Node getStringOperand() { result = range.getStringOperand() }
+    DataFlow::Node getStringOperand() { result = this.(RegExpTest::Range).getStringOperand() }
 
     /**
      * Gets the return value indicating that the string matched the regular expression.
@@ -694,7 +688,7 @@ module StringOps {
      * For example, for `regexp.exec(str) == null`, the polarity is `false`, and for
      * `regexp.exec(str) != null` the polarity is `true`.
      */
-    boolean getPolarity() { result = range.getPolarity() }
+    boolean getPolarity() { result = this.(RegExpTest::Range).getPolarity() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/StringOps.qll
+++ b/javascript/ql/lib/semmle/javascript/StringOps.qll
@@ -8,18 +8,16 @@ module StringOps {
   /**
    * A expression that is equivalent to `A.startsWith(B)` or `!A.startsWith(B)`.
    */
-  class StartsWith extends DataFlow::Node {
-    StartsWith() { this instanceof StartsWith::Range }
-
+  class StartsWith extends DataFlow::Node instanceof StartsWith::Range {
     /**
      * Gets the `A` in `A.startsWith(B)`.
      */
-    DataFlow::Node getBaseString() { result = this.(StartsWith::Range).getBaseString() }
+    DataFlow::Node getBaseString() { result = super.getBaseString() }
 
     /**
      * Gets the `B` in `A.startsWith(B)`.
      */
-    DataFlow::Node getSubstring() { result = this.(StartsWith::Range).getSubstring() }
+    DataFlow::Node getSubstring() { result = super.getSubstring() }
 
     /**
      * Gets the polarity of the check.
@@ -27,7 +25,7 @@ module StringOps {
      * If the polarity is `false` the check returns `true` if the string does not start
      * with the given substring.
      */
-    boolean getPolarity() { result = this.(StartsWith::Range).getPolarity() }
+    boolean getPolarity() { result = super.getPolarity() }
   }
 
   module StartsWith {
@@ -235,18 +233,16 @@ module StringOps {
   /**
    * An expression that is equivalent to `A.endsWith(B)` or `!A.endsWith(B)`.
    */
-  class EndsWith extends DataFlow::Node {
-    EndsWith() { this instanceof EndsWith::Range }
-
+  class EndsWith extends DataFlow::Node instanceof EndsWith::Range {
     /**
      * Gets the `A` in `A.startsWith(B)`.
      */
-    DataFlow::Node getBaseString() { result = this.(EndsWith::Range).getBaseString() }
+    DataFlow::Node getBaseString() { result = super.getBaseString() }
 
     /**
      * Gets the `B` in `A.startsWith(B)`.
      */
-    DataFlow::Node getSubstring() { result = this.(EndsWith::Range).getSubstring() }
+    DataFlow::Node getSubstring() { result = super.getSubstring() }
 
     /**
      * Gets the polarity if the check.
@@ -254,7 +250,7 @@ module StringOps {
      * If the polarity is `false` the check returns `true` if the string does not end
      * with the given substring.
      */
-    boolean getPolarity() { result = this.(EndsWith::Range).getPolarity() }
+    boolean getPolarity() { result = super.getPolarity() }
   }
 
   module EndsWith {
@@ -658,16 +654,14 @@ module StringOps {
    * if (!match) { ... } // <--- 'match' is the RegExpTest
    * ```
    */
-  class RegExpTest extends DataFlow::Node {
-    RegExpTest() { this instanceof RegExpTest::Range }
-
+  class RegExpTest extends DataFlow::Node instanceof RegExpTest::Range {
     /**
      * Gets the AST of the regular expression used in the test, if it can be seen locally.
      */
     RegExpTerm getRegExp() {
       result = getRegExpOperand().getALocalSource().(DataFlow::RegExpCreationNode).getRoot()
       or
-      result = this.(RegExpTest::Range).getRegExpOperand(true).asExpr().(StringLiteral).asRegExp()
+      result = super.getRegExpOperand(true).asExpr().(StringLiteral).asRegExp()
     }
 
     /**
@@ -675,12 +669,12 @@ module StringOps {
      *
      * In some cases this represents a string value being coerced to a RegExp object.
      */
-    DataFlow::Node getRegExpOperand() { result = this.(RegExpTest::Range).getRegExpOperand(_) }
+    DataFlow::Node getRegExpOperand() { result = super.getRegExpOperand(_) }
 
     /**
      * Gets the data flow node corresponding to the string being tested against the regular expression.
      */
-    DataFlow::Node getStringOperand() { result = this.(RegExpTest::Range).getStringOperand() }
+    DataFlow::Node getStringOperand() { result = super.getStringOperand() }
 
     /**
      * Gets the return value indicating that the string matched the regular expression.
@@ -688,7 +682,7 @@ module StringOps {
      * For example, for `regexp.exec(str) == null`, the polarity is `false`, and for
      * `regexp.exec(str) != null` the polarity is `true`.
      */
-    boolean getPolarity() { result = this.(RegExpTest::Range).getPolarity() }
+    boolean getPolarity() { result = super.getPolarity() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -702,11 +702,9 @@ class ArrayCreationNode extends DataFlow::ValueNode, DataFlow::SourceNode {
  * define(["fs"], function(fs) { ... }); // AMD module
  * ```
  */
-class ModuleImportNode extends DataFlow::SourceNode {
-  ModuleImportNode() { this instanceof ModuleImportNode::Range }
-
+class ModuleImportNode extends DataFlow::SourceNode instanceof ModuleImportNode::Range {
   /** Gets the path of the imported module. */
-  string getPath() { result = this.(ModuleImportNode::Range).getPath() }
+  string getPath() { result = super.getPath() }
 }
 
 module ModuleImportNode {
@@ -842,23 +840,21 @@ module MemberKind {
  *
  * Additional patterns can be recognized as class nodes, by extending `DataFlow::ClassNode::Range`.
  */
-class ClassNode extends DataFlow::SourceNode {
-  ClassNode() { this instanceof ClassNode::Range }
-
+class ClassNode extends DataFlow::SourceNode instanceof ClassNode::Range {
   /**
    * Gets the unqualified name of the class, if it has one or one can be determined from the context.
    */
-  string getName() { result = this.(ClassNode::Range).getName() }
+  string getName() { result = super.getName() }
 
   /**
    * Gets a description of the class.
    */
-  string describe() { result = this.(ClassNode::Range).describe() }
+  string describe() { result = super.describe() }
 
   /**
    * Gets the constructor function of this class.
    */
-  FunctionNode getConstructor() { result = this.(ClassNode::Range).getConstructor() }
+  FunctionNode getConstructor() { result = super.getConstructor() }
 
   /**
    * Gets an instance method declared in this class, with the given name, if any.
@@ -866,7 +862,7 @@ class ClassNode extends DataFlow::SourceNode {
    * Does not include methods from superclasses.
    */
   FunctionNode getInstanceMethod(string name) {
-    result = this.(ClassNode::Range).getInstanceMember(name, MemberKind::method())
+    result = super.getInstanceMember(name, MemberKind::method())
   }
 
   /**
@@ -876,9 +872,7 @@ class ClassNode extends DataFlow::SourceNode {
    *
    * Does not include methods from superclasses.
    */
-  FunctionNode getAnInstanceMethod() {
-    result = this.(ClassNode::Range).getAnInstanceMember(MemberKind::method())
-  }
+  FunctionNode getAnInstanceMethod() { result = super.getAnInstanceMember(MemberKind::method()) }
 
   /**
    * Gets the instance method, getter, or setter with the given name and kind.
@@ -886,7 +880,7 @@ class ClassNode extends DataFlow::SourceNode {
    * Does not include members from superclasses.
    */
   FunctionNode getInstanceMember(string name, MemberKind kind) {
-    result = this.(ClassNode::Range).getInstanceMember(name, kind)
+    result = super.getInstanceMember(name, kind)
   }
 
   /**
@@ -894,35 +888,31 @@ class ClassNode extends DataFlow::SourceNode {
    *
    * Does not include members from superclasses.
    */
-  FunctionNode getAnInstanceMember(MemberKind kind) {
-    result = this.(ClassNode::Range).getAnInstanceMember(kind)
-  }
+  FunctionNode getAnInstanceMember(MemberKind kind) { result = super.getAnInstanceMember(kind) }
 
   /**
    * Gets an instance method, getter, or setter declared in this class.
    *
    * Does not include members from superclasses.
    */
-  FunctionNode getAnInstanceMember() { result = this.(ClassNode::Range).getAnInstanceMember(_) }
+  FunctionNode getAnInstanceMember() { result = super.getAnInstanceMember(_) }
 
   /**
    * Gets the static method declared in this class with the given name.
    */
-  FunctionNode getStaticMethod(string name) {
-    result = this.(ClassNode::Range).getStaticMethod(name)
-  }
+  FunctionNode getStaticMethod(string name) { result = super.getStaticMethod(name) }
 
   /**
    * Gets a static method declared in this class.
    *
    * The constructor is not considered a static method.
    */
-  FunctionNode getAStaticMethod() { result = this.(ClassNode::Range).getAStaticMethod() }
+  FunctionNode getAStaticMethod() { result = super.getAStaticMethod() }
 
   /**
    * Gets a dataflow node that refers to the superclass of this class.
    */
-  DataFlow::Node getASuperClassNode() { result = this.(ClassNode::Range).getASuperClassNode() }
+  DataFlow::Node getASuperClassNode() { result = super.getASuperClassNode() }
 
   /**
    * Gets a direct super class of this class.
@@ -1068,13 +1058,13 @@ class ClassNode extends DataFlow::SourceNode {
    * Gets the type annotation for the field `fieldName`, if any.
    */
   TypeAnnotation getFieldTypeAnnotation(string fieldName) {
-    result = this.(ClassNode::Range).getFieldTypeAnnotation(fieldName)
+    result = super.getFieldTypeAnnotation(fieldName)
   }
 
   /**
    * Gets a decorator applied to this class.
    */
-  DataFlow::Node getADecorator() { result = this.(ClassNode::Range).getADecorator() }
+  DataFlow::Node getADecorator() { result = super.getADecorator() }
 }
 
 module ClassNode {
@@ -1360,9 +1350,7 @@ module ClassNode {
  * _.partial(fn, x, y, z)
  * ```
  */
-class PartialInvokeNode extends DataFlow::Node {
-  PartialInvokeNode() { this instanceof PartialInvokeNode::Range }
-
+class PartialInvokeNode extends DataFlow::Node instanceof PartialInvokeNode::Range {
   /** Gets a node holding a callback invoked by this partial invocation node. */
   DataFlow::Node getACallbackNode() {
     isPartialArgument(result, _, _)
@@ -1374,26 +1362,26 @@ class PartialInvokeNode extends DataFlow::Node {
    * Holds if `argument` is passed as argument `index` to the function in `callback`.
    */
   predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
-    this.(PartialInvokeNode::Range).isPartialArgument(callback, argument, index)
+    super.isPartialArgument(callback, argument, index)
   }
 
   /**
    * Gets a node referring to a bound version of `callback` with `boundArgs` arguments bound.
    */
   DataFlow::SourceNode getBoundFunction(DataFlow::Node callback, int boundArgs) {
-    result = this.(PartialInvokeNode::Range).getBoundFunction(callback, boundArgs)
+    result = super.getBoundFunction(callback, boundArgs)
   }
 
   /**
    * Gets the node holding the receiver to be passed to the bound function, if specified.
    */
-  DataFlow::Node getBoundReceiver() { result = this.(PartialInvokeNode::Range).getBoundReceiver(_) }
+  DataFlow::Node getBoundReceiver() { result = super.getBoundReceiver(_) }
 
   /**
    * Gets the node holding the receiver to be passed to the bound function, if specified.
    */
   DataFlow::Node getBoundReceiver(DataFlow::Node callback) {
-    result = this.(PartialInvokeNode::Range).getBoundReceiver(callback)
+    result = super.getBoundReceiver(callback)
   }
 }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -703,12 +703,10 @@ class ArrayCreationNode extends DataFlow::ValueNode, DataFlow::SourceNode {
  * ```
  */
 class ModuleImportNode extends DataFlow::SourceNode {
-  ModuleImportNode::Range range;
-
-  ModuleImportNode() { this = range }
+  ModuleImportNode() { this instanceof ModuleImportNode::Range }
 
   /** Gets the path of the imported module. */
-  string getPath() { result = range.getPath() }
+  string getPath() { result = this.(ModuleImportNode::Range).getPath() }
 }
 
 module ModuleImportNode {
@@ -845,24 +843,22 @@ module MemberKind {
  * Additional patterns can be recognized as class nodes, by extending `DataFlow::ClassNode::Range`.
  */
 class ClassNode extends DataFlow::SourceNode {
-  ClassNode::Range impl;
-
-  ClassNode() { this = impl }
+  ClassNode() { this instanceof ClassNode::Range }
 
   /**
    * Gets the unqualified name of the class, if it has one or one can be determined from the context.
    */
-  string getName() { result = impl.getName() }
+  string getName() { result = this.(ClassNode::Range).getName() }
 
   /**
    * Gets a description of the class.
    */
-  string describe() { result = impl.describe() }
+  string describe() { result = this.(ClassNode::Range).describe() }
 
   /**
    * Gets the constructor function of this class.
    */
-  FunctionNode getConstructor() { result = impl.getConstructor() }
+  FunctionNode getConstructor() { result = this.(ClassNode::Range).getConstructor() }
 
   /**
    * Gets an instance method declared in this class, with the given name, if any.
@@ -870,7 +866,7 @@ class ClassNode extends DataFlow::SourceNode {
    * Does not include methods from superclasses.
    */
   FunctionNode getInstanceMethod(string name) {
-    result = impl.getInstanceMember(name, MemberKind::method())
+    result = this.(ClassNode::Range).getInstanceMember(name, MemberKind::method())
   }
 
   /**
@@ -880,7 +876,9 @@ class ClassNode extends DataFlow::SourceNode {
    *
    * Does not include methods from superclasses.
    */
-  FunctionNode getAnInstanceMethod() { result = impl.getAnInstanceMember(MemberKind::method()) }
+  FunctionNode getAnInstanceMethod() {
+    result = this.(ClassNode::Range).getAnInstanceMember(MemberKind::method())
+  }
 
   /**
    * Gets the instance method, getter, or setter with the given name and kind.
@@ -888,7 +886,7 @@ class ClassNode extends DataFlow::SourceNode {
    * Does not include members from superclasses.
    */
   FunctionNode getInstanceMember(string name, MemberKind kind) {
-    result = impl.getInstanceMember(name, kind)
+    result = this.(ClassNode::Range).getInstanceMember(name, kind)
   }
 
   /**
@@ -896,31 +894,35 @@ class ClassNode extends DataFlow::SourceNode {
    *
    * Does not include members from superclasses.
    */
-  FunctionNode getAnInstanceMember(MemberKind kind) { result = impl.getAnInstanceMember(kind) }
+  FunctionNode getAnInstanceMember(MemberKind kind) {
+    result = this.(ClassNode::Range).getAnInstanceMember(kind)
+  }
 
   /**
    * Gets an instance method, getter, or setter declared in this class.
    *
    * Does not include members from superclasses.
    */
-  FunctionNode getAnInstanceMember() { result = impl.getAnInstanceMember(_) }
+  FunctionNode getAnInstanceMember() { result = this.(ClassNode::Range).getAnInstanceMember(_) }
 
   /**
    * Gets the static method declared in this class with the given name.
    */
-  FunctionNode getStaticMethod(string name) { result = impl.getStaticMethod(name) }
+  FunctionNode getStaticMethod(string name) {
+    result = this.(ClassNode::Range).getStaticMethod(name)
+  }
 
   /**
    * Gets a static method declared in this class.
    *
    * The constructor is not considered a static method.
    */
-  FunctionNode getAStaticMethod() { result = impl.getAStaticMethod() }
+  FunctionNode getAStaticMethod() { result = this.(ClassNode::Range).getAStaticMethod() }
 
   /**
    * Gets a dataflow node that refers to the superclass of this class.
    */
-  DataFlow::Node getASuperClassNode() { result = impl.getASuperClassNode() }
+  DataFlow::Node getASuperClassNode() { result = this.(ClassNode::Range).getASuperClassNode() }
 
   /**
    * Gets a direct super class of this class.
@@ -1066,13 +1068,13 @@ class ClassNode extends DataFlow::SourceNode {
    * Gets the type annotation for the field `fieldName`, if any.
    */
   TypeAnnotation getFieldTypeAnnotation(string fieldName) {
-    result = impl.getFieldTypeAnnotation(fieldName)
+    result = this.(ClassNode::Range).getFieldTypeAnnotation(fieldName)
   }
 
   /**
    * Gets a decorator applied to this class.
    */
-  DataFlow::Node getADecorator() { result = impl.getADecorator() }
+  DataFlow::Node getADecorator() { result = this.(ClassNode::Range).getADecorator() }
 }
 
 module ClassNode {
@@ -1359,9 +1361,7 @@ module ClassNode {
  * ```
  */
 class PartialInvokeNode extends DataFlow::Node {
-  PartialInvokeNode::Range range;
-
-  PartialInvokeNode() { this = range }
+  PartialInvokeNode() { this instanceof PartialInvokeNode::Range }
 
   /** Gets a node holding a callback invoked by this partial invocation node. */
   DataFlow::Node getACallbackNode() {
@@ -1374,26 +1374,26 @@ class PartialInvokeNode extends DataFlow::Node {
    * Holds if `argument` is passed as argument `index` to the function in `callback`.
    */
   predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
-    range.isPartialArgument(callback, argument, index)
+    this.(PartialInvokeNode::Range).isPartialArgument(callback, argument, index)
   }
 
   /**
    * Gets a node referring to a bound version of `callback` with `boundArgs` arguments bound.
    */
   DataFlow::SourceNode getBoundFunction(DataFlow::Node callback, int boundArgs) {
-    result = range.getBoundFunction(callback, boundArgs)
+    result = this.(PartialInvokeNode::Range).getBoundFunction(callback, boundArgs)
   }
 
   /**
    * Gets the node holding the receiver to be passed to the bound function, if specified.
    */
-  DataFlow::Node getBoundReceiver() { result = range.getBoundReceiver(_) }
+  DataFlow::Node getBoundReceiver() { result = this.(PartialInvokeNode::Range).getBoundReceiver(_) }
 
   /**
    * Gets the node holding the receiver to be passed to the bound function, if specified.
    */
   DataFlow::Node getBoundReceiver(DataFlow::Node callback) {
-    result = range.getBoundReceiver(callback)
+    result = this.(PartialInvokeNode::Range).getBoundReceiver(callback)
   }
 }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Cheerio.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Cheerio.qll
@@ -33,9 +33,7 @@ module Cheerio {
    * with an interface similar to that of a jQuery object.
    */
   class CheerioObjectCreation extends DataFlow::SourceNode {
-    CheerioObjectCreation::Range range;
-
-    CheerioObjectCreation() { this = range }
+    CheerioObjectCreation() { this instanceof CheerioObjectCreation::Range }
   }
 
   module CheerioObjectCreation {

--- a/javascript/ql/lib/semmle/javascript/frameworks/Cheerio.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Cheerio.qll
@@ -32,8 +32,7 @@ module Cheerio {
    * Creation of `cheerio` object, a collection of virtual DOM elements
    * with an interface similar to that of a jQuery object.
    */
-  class CheerioObjectCreation extends DataFlow::SourceNode {
-    CheerioObjectCreation() { this instanceof CheerioObjectCreation::Range }
+  class CheerioObjectCreation extends DataFlow::SourceNode instanceof CheerioObjectCreation::Range {
   }
 
   module CheerioObjectCreation {

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -19,24 +19,22 @@ import javascript
  * predicates.
  */
 class ClientRequest extends DataFlow::InvokeNode {
-  ClientRequest::Range self;
-
-  ClientRequest() { this = self }
+  ClientRequest() { this instanceof ClientRequest::Range }
 
   /**
    * Gets the URL of the request.
    */
-  DataFlow::Node getUrl() { result = self.getUrl() }
+  DataFlow::Node getUrl() { result = this.(ClientRequest::Range).getUrl() }
 
   /**
    * Gets the host of the request.
    */
-  DataFlow::Node getHost() { result = self.getHost() }
+  DataFlow::Node getHost() { result = this.(ClientRequest::Range).getHost() }
 
   /**
    * Gets a node that contributes to the data-part this request.
    */
-  DataFlow::Node getADataNode() { result = self.getADataNode() }
+  DataFlow::Node getADataNode() { result = this.(ClientRequest::Range).getADataNode() }
 
   /**
    * Gets a data flow node that refers to some representation of the response, possibly
@@ -60,7 +58,7 @@ class ClientRequest extends DataFlow::InvokeNode {
    * - Any value provided by custom implementations of `ClientRequest::Range`.
    */
   DataFlow::Node getAResponseDataNode(string responseType, boolean promise) {
-    result = self.getAResponseDataNode(responseType, promise)
+    result = this.(ClientRequest::Range).getAResponseDataNode(responseType, promise)
   }
 
   /**
@@ -72,7 +70,7 @@ class ClientRequest extends DataFlow::InvokeNode {
   /**
    * Gets a data-flow node that determines where in the file-system the result of the request should be saved.
    */
-  DataFlow::Node getASavePath() { result = self.getASavePath() }
+  DataFlow::Node getASavePath() { result = this.(ClientRequest::Range).getASavePath() }
 }
 
 deprecated class CustomClientRequest = ClientRequest::Range;

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -18,23 +18,21 @@ import javascript
  * To model additional APIs, extend `ClientRequest::Range` and implement its abstract member
  * predicates.
  */
-class ClientRequest extends DataFlow::InvokeNode {
-  ClientRequest() { this instanceof ClientRequest::Range }
-
+class ClientRequest extends DataFlow::InvokeNode instanceof ClientRequest::Range {
   /**
    * Gets the URL of the request.
    */
-  DataFlow::Node getUrl() { result = this.(ClientRequest::Range).getUrl() }
+  DataFlow::Node getUrl() { result = super.getUrl() }
 
   /**
    * Gets the host of the request.
    */
-  DataFlow::Node getHost() { result = this.(ClientRequest::Range).getHost() }
+  DataFlow::Node getHost() { result = super.getHost() }
 
   /**
    * Gets a node that contributes to the data-part this request.
    */
-  DataFlow::Node getADataNode() { result = this.(ClientRequest::Range).getADataNode() }
+  DataFlow::Node getADataNode() { result = super.getADataNode() }
 
   /**
    * Gets a data flow node that refers to some representation of the response, possibly
@@ -58,7 +56,7 @@ class ClientRequest extends DataFlow::InvokeNode {
    * - Any value provided by custom implementations of `ClientRequest::Range`.
    */
   DataFlow::Node getAResponseDataNode(string responseType, boolean promise) {
-    result = this.(ClientRequest::Range).getAResponseDataNode(responseType, promise)
+    result = super.getAResponseDataNode(responseType, promise)
   }
 
   /**
@@ -70,7 +68,7 @@ class ClientRequest extends DataFlow::InvokeNode {
   /**
    * Gets a data-flow node that determines where in the file-system the result of the request should be saved.
    */
-  DataFlow::Node getASavePath() { result = this.(ClientRequest::Range).getASavePath() }
+  DataFlow::Node getASavePath() { result = super.getASavePath() }
 }
 
 deprecated class CustomClientRequest = ClientRequest::Range;

--- a/javascript/ql/lib/semmle/javascript/frameworks/ComposedFunctions.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ComposedFunctions.qll
@@ -9,9 +9,7 @@ import javascript
  * series of functions `f, g, h, ...`.
  */
 class FunctionCompositionCall extends DataFlow::CallNode {
-  FunctionCompositionCall::Range range;
-
-  FunctionCompositionCall() { this = range }
+  FunctionCompositionCall() { this instanceof FunctionCompositionCall::Range }
 
   /**
    * Gets the `i`th function in the composition `f(g(h(...)))`, counting from left to right.
@@ -19,7 +17,9 @@ class FunctionCompositionCall extends DataFlow::CallNode {
    * Note that this is the opposite of the order in which the function are invoked,
    * that is, `g` occurs later than `f` in `f(g(...))` but is invoked before `f`.
    */
-  DataFlow::Node getOperandNode(int i) { result = range.getOperandNode(i) }
+  DataFlow::Node getOperandNode(int i) {
+    result = this.(FunctionCompositionCall::Range).getOperandNode(i)
+  }
 
   /** Gets a node holding one of the functions to be composed. */
   final DataFlow::Node getAnOperandNode() { result = getOperandNode(_) }
@@ -38,7 +38,7 @@ class FunctionCompositionCall extends DataFlow::CallNode {
   final DataFlow::FunctionNode getAnOperandFunction() { result = getOperandFunction(_) }
 
   /** Gets the number of functions being composed. */
-  int getNumOperand() { result = range.getNumOperand() }
+  int getNumOperand() { result = this.(FunctionCompositionCall::Range).getNumOperand() }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/ComposedFunctions.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ComposedFunctions.qll
@@ -8,18 +8,14 @@ import javascript
  * A call to a function that constructs a function composition `f(g(h(...)))` from a
  * series of functions `f, g, h, ...`.
  */
-class FunctionCompositionCall extends DataFlow::CallNode {
-  FunctionCompositionCall() { this instanceof FunctionCompositionCall::Range }
-
+class FunctionCompositionCall extends DataFlow::CallNode instanceof FunctionCompositionCall::Range {
   /**
    * Gets the `i`th function in the composition `f(g(h(...)))`, counting from left to right.
    *
    * Note that this is the opposite of the order in which the function are invoked,
    * that is, `g` occurs later than `f` in `f(g(...))` but is invoked before `f`.
    */
-  DataFlow::Node getOperandNode(int i) {
-    result = this.(FunctionCompositionCall::Range).getOperandNode(i)
-  }
+  DataFlow::Node getOperandNode(int i) { result = super.getOperandNode(i) }
 
   /** Gets a node holding one of the functions to be composed. */
   final DataFlow::Node getAnOperandNode() { result = getOperandNode(_) }
@@ -38,7 +34,7 @@ class FunctionCompositionCall extends DataFlow::CallNode {
   final DataFlow::FunctionNode getAnOperandFunction() { result = getOperandFunction(_) }
 
   /** Gets the number of functions being composed. */
-  int getNumOperand() { result = this.(FunctionCompositionCall::Range).getNumOperand() }
+  int getNumOperand() { result = super.getNumOperand() }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Electron.qll
@@ -182,7 +182,7 @@ module Electron {
    * A Node.js-style HTTP or HTTPS request made using an Electron module.
    */
   class ElectronClientRequest extends NodeJSLib::NodeJSClientRequest {
-    override ElectronClientRequest::Range self;
+    ElectronClientRequest() { this instanceof ElectronClientRequest::Range }
   }
 
   module ElectronClientRequest {

--- a/javascript/ql/lib/semmle/javascript/frameworks/EventEmitter.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/EventEmitter.qll
@@ -69,39 +69,41 @@ module EventEmitter {
  * Extend EventEmitter::Range to mark something as being an EventEmitter.
  */
 class EventEmitter extends DataFlow::Node {
-  EventEmitter::Range range;
-
-  EventEmitter() { this = range }
+  EventEmitter() { this instanceof EventEmitter::Range }
 }
 
 /**
  * A registration of an event handler on an EventEmitter.
  */
 class EventRegistration extends DataFlow::Node {
-  EventRegistration::Range range;
-
-  EventRegistration() { this = range }
+  EventRegistration() { this instanceof EventRegistration::Range }
 
   /** Gets the EventEmitter that the event handler is registered on. */
-  final EventEmitter getEmitter() { result = range.getEmitter() }
+  final EventEmitter getEmitter() { result = this.(EventRegistration::Range).getEmitter() }
 
   /** Gets the name of the channel if possible. */
-  string getChannel() { result = range.getChannel() }
+  string getChannel() { result = this.(EventRegistration::Range).getChannel() }
 
   /** Gets the `i`th parameter in the event handler. */
-  DataFlow::Node getReceivedItem(int i) { result = range.getReceivedItem(i) }
+  DataFlow::Node getReceivedItem(int i) {
+    result = this.(EventRegistration::Range).getReceivedItem(i)
+  }
 
   /**
    * Gets a value that is returned by the event handler.
    * The default implementation is that no value can be returned.
    */
-  DataFlow::Node getAReturnedValue() { result = range.getAReturnedValue() }
+  DataFlow::Node getAReturnedValue() {
+    result = this.(EventRegistration::Range).getAReturnedValue()
+  }
 
   /**
    * Get a dispatch that this event handler can return a value to.
    * The default implementation is that there exists no such dispatch.
    */
-  EventDispatch getAReturnDispatch() { result = range.getAReturnDispatch() }
+  EventDispatch getAReturnDispatch() {
+    result = this.(EventRegistration::Range).getAReturnDispatch()
+  }
 }
 
 module EventRegistration {
@@ -141,25 +143,23 @@ module EventRegistration {
  * A dispatch of an event on an EventEmitter.
  */
 class EventDispatch extends DataFlow::Node {
-  EventDispatch::Range range;
-
-  EventDispatch() { this = range }
+  EventDispatch() { this instanceof EventDispatch::Range }
 
   /** Gets the emitter that the event dispatch happens on. */
-  EventEmitter getEmitter() { result = range.getEmitter() }
+  EventEmitter getEmitter() { result = this.(EventDispatch::Range).getEmitter() }
 
   /** Gets the name of the channel if possible. */
-  string getChannel() { result = range.getChannel() }
+  string getChannel() { result = this.(EventDispatch::Range).getChannel() }
 
   /** Gets the `i`th argument that is send to the event handler. */
-  DataFlow::Node getSentItem(int i) { result = range.getSentItem(i) }
+  DataFlow::Node getSentItem(int i) { result = this.(EventDispatch::Range).getSentItem(i) }
 
   /**
    * Get an EventRegistration that this event dispatch can send an event to.
    * The default implementation is that the emitters of the dispatch and registration have to be equal.
    * Channels are by default ignored.
    */
-  EventRegistration getAReceiver() { result = range.getAReceiver() }
+  EventRegistration getAReceiver() { result = this.(EventDispatch::Range).getAReceiver() }
 }
 
 module EventDispatch {

--- a/javascript/ql/lib/semmle/javascript/frameworks/EventEmitter.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/EventEmitter.qll
@@ -68,42 +68,32 @@ module EventEmitter {
  * An EventEmitter instance that implements the EventEmitter API.
  * Extend EventEmitter::Range to mark something as being an EventEmitter.
  */
-class EventEmitter extends DataFlow::Node {
-  EventEmitter() { this instanceof EventEmitter::Range }
-}
+class EventEmitter extends DataFlow::Node instanceof EventEmitter::Range { }
 
 /**
  * A registration of an event handler on an EventEmitter.
  */
-class EventRegistration extends DataFlow::Node {
-  EventRegistration() { this instanceof EventRegistration::Range }
-
+class EventRegistration extends DataFlow::Node instanceof EventRegistration::Range {
   /** Gets the EventEmitter that the event handler is registered on. */
-  final EventEmitter getEmitter() { result = this.(EventRegistration::Range).getEmitter() }
+  final EventEmitter getEmitter() { result = super.getEmitter() }
 
   /** Gets the name of the channel if possible. */
-  string getChannel() { result = this.(EventRegistration::Range).getChannel() }
+  string getChannel() { result = super.getChannel() }
 
   /** Gets the `i`th parameter in the event handler. */
-  DataFlow::Node getReceivedItem(int i) {
-    result = this.(EventRegistration::Range).getReceivedItem(i)
-  }
+  DataFlow::Node getReceivedItem(int i) { result = super.getReceivedItem(i) }
 
   /**
    * Gets a value that is returned by the event handler.
    * The default implementation is that no value can be returned.
    */
-  DataFlow::Node getAReturnedValue() {
-    result = this.(EventRegistration::Range).getAReturnedValue()
-  }
+  DataFlow::Node getAReturnedValue() { result = super.getAReturnedValue() }
 
   /**
    * Get a dispatch that this event handler can return a value to.
    * The default implementation is that there exists no such dispatch.
    */
-  EventDispatch getAReturnDispatch() {
-    result = this.(EventRegistration::Range).getAReturnDispatch()
-  }
+  EventDispatch getAReturnDispatch() { result = super.getAReturnDispatch() }
 }
 
 module EventRegistration {
@@ -142,24 +132,22 @@ module EventRegistration {
 /**
  * A dispatch of an event on an EventEmitter.
  */
-class EventDispatch extends DataFlow::Node {
-  EventDispatch() { this instanceof EventDispatch::Range }
-
+class EventDispatch extends DataFlow::Node instanceof EventDispatch::Range {
   /** Gets the emitter that the event dispatch happens on. */
-  EventEmitter getEmitter() { result = this.(EventDispatch::Range).getEmitter() }
+  EventEmitter getEmitter() { result = super.getEmitter() }
 
   /** Gets the name of the channel if possible. */
-  string getChannel() { result = this.(EventDispatch::Range).getChannel() }
+  string getChannel() { result = super.getChannel() }
 
   /** Gets the `i`th argument that is send to the event handler. */
-  DataFlow::Node getSentItem(int i) { result = this.(EventDispatch::Range).getSentItem(i) }
+  DataFlow::Node getSentItem(int i) { result = super.getSentItem(i) }
 
   /**
    * Get an EventRegistration that this event dispatch can send an event to.
    * The default implementation is that the emitters of the dispatch and registration have to be equal.
    * Channels are by default ignored.
    */
-  EventRegistration getAReceiver() { result = this.(EventDispatch::Range).getAReceiver() }
+  EventRegistration getAReceiver() { result = super.getAReceiver() }
 }
 
 module EventDispatch {

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -541,15 +541,13 @@ module HTTP {
    * An object that contains one or more potential route handlers.
    */
   class RouteHandlerCandidateContainer extends DataFlow::Node {
-    RouteHandlerCandidateContainer::Range self;
-
-    RouteHandlerCandidateContainer() { this = self }
+    RouteHandlerCandidateContainer() { this instanceof RouteHandlerCandidateContainer::Range }
 
     /**
      * Gets the route handler in this container that is accessed at `access`.
      */
     DataFlow::SourceNode getRouteHandler(DataFlow::SourceNode access) {
-      result = self.getRouteHandler(access)
+      result = this.(RouteHandlerCandidateContainer::Range).getRouteHandler(access)
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -540,14 +540,12 @@ module HTTP {
   /**
    * An object that contains one or more potential route handlers.
    */
-  class RouteHandlerCandidateContainer extends DataFlow::Node {
-    RouteHandlerCandidateContainer() { this instanceof RouteHandlerCandidateContainer::Range }
-
+  class RouteHandlerCandidateContainer extends DataFlow::Node instanceof RouteHandlerCandidateContainer::Range {
     /**
      * Gets the route handler in this container that is accessed at `access`.
      */
     DataFlow::SourceNode getRouteHandler(DataFlow::SourceNode access) {
-      result = this.(RouteHandlerCandidateContainer::Range).getRouteHandler(access)
+      result = super.getRouteHandler(access)
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -826,7 +826,7 @@ module NodeJSLib {
    * for example `http.request(url)`.
    */
   class NodeJSClientRequest extends ClientRequest {
-    override NodeJSClientRequest::Range self;
+    NodeJSClientRequest() { this instanceof NodeJSClientRequest::Range }
   }
 
   module NodeJSClientRequest {

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -825,9 +825,7 @@ module NodeJSLib {
    * A data flow node that is an HTTP or HTTPS client request made by a Node.js application,
    * for example `http.request(url)`.
    */
-  class NodeJSClientRequest extends ClientRequest {
-    NodeJSClientRequest() { this instanceof NodeJSClientRequest::Range }
-  }
+  class NodeJSClientRequest extends ClientRequest instanceof NodeJSClientRequest::Range { }
 
   module NodeJSClientRequest {
     /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/PropertyProjection.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/PropertyProjection.qll
@@ -14,18 +14,16 @@ import javascript
  * To model additional APIs, extend `PropertyProjection::Range` and implement its abstract member
  * predicates.
  */
-class PropertyProjection extends DataFlow::CallNode {
-  PropertyProjection() { this instanceof PropertyProjection::Range }
-
+class PropertyProjection extends DataFlow::CallNode instanceof PropertyProjection::Range {
   /**
    * Gets the argument for the object to project properties from, such as `o` in `_.get(o, 'a.b')`.
    */
-  DataFlow::Node getObject() { result = this.(PropertyProjection::Range).getObject() }
+  DataFlow::Node getObject() { result = super.getObject() }
 
   /**
    * Gets an argument that selects the properties to project, such as `'a.b'` in `_.get(o, 'a.b')`.
    */
-  DataFlow::Node getASelector() { result = this.(PropertyProjection::Range).getASelector() }
+  DataFlow::Node getASelector() { result = super.getASelector() }
 
   /**
    * Holds if this call returns the value of a single projected property, as opposed to an object that can contain multiple projected properties.
@@ -34,7 +32,7 @@ class PropertyProjection extends DataFlow::CallNode {
    * - This predicate holds for `_.get({a: 'b'}, 'a')`, which returns `'b'`,
    * - This predicate does not hold for `_.pick({a: 'b', c: 'd'}}, 'a')`, which returns `{a: 'b'}`,
    */
-  predicate isSingletonProjection() { this.(PropertyProjection::Range).isSingletonProjection() }
+  predicate isSingletonProjection() { super.isSingletonProjection() }
 }
 
 module PropertyProjection {

--- a/javascript/ql/lib/semmle/javascript/frameworks/PropertyProjection.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/PropertyProjection.qll
@@ -15,19 +15,17 @@ import javascript
  * predicates.
  */
 class PropertyProjection extends DataFlow::CallNode {
-  PropertyProjection::Range self;
-
-  PropertyProjection() { this = self }
+  PropertyProjection() { this instanceof PropertyProjection::Range }
 
   /**
    * Gets the argument for the object to project properties from, such as `o` in `_.get(o, 'a.b')`.
    */
-  DataFlow::Node getObject() { result = self.getObject() }
+  DataFlow::Node getObject() { result = this.(PropertyProjection::Range).getObject() }
 
   /**
    * Gets an argument that selects the properties to project, such as `'a.b'` in `_.get(o, 'a.b')`.
    */
-  DataFlow::Node getASelector() { result = self.getASelector() }
+  DataFlow::Node getASelector() { result = this.(PropertyProjection::Range).getASelector() }
 
   /**
    * Holds if this call returns the value of a single projected property, as opposed to an object that can contain multiple projected properties.
@@ -36,7 +34,7 @@ class PropertyProjection extends DataFlow::CallNode {
    * - This predicate holds for `_.get({a: 'b'}, 'a')`, which returns `'b'`,
    * - This predicate does not hold for `_.pick({a: 'b', c: 'd'}}, 'a')`, which returns `{a: 'b'}`,
    */
-  predicate isSingletonProjection() { self.isSingletonProjection() }
+  predicate isSingletonProjection() { this.(PropertyProjection::Range).isSingletonProjection() }
 }
 
 module PropertyProjection {

--- a/javascript/ql/lib/semmle/javascript/frameworks/Redux.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Redux.qll
@@ -57,9 +57,7 @@ module Redux {
    * Creation of a redux store, usually via a call to `createStore`.
    */
   class StoreCreation extends DataFlow::SourceNode {
-    StoreCreation::Range range;
-
-    StoreCreation() { this = range }
+    StoreCreation() { this instanceof StoreCreation::Range }
 
     /** Gets a reference to the store. */
     DataFlow::SourceNode ref() { result = asApiNode().getAUse() }
@@ -68,7 +66,7 @@ module Redux {
     API::Node asApiNode() { result.getAnImmediateUse() = this }
 
     /** Gets the data flow node holding the root reducer for this store. */
-    DataFlow::Node getReducerArg() { result = range.getReducerArg() }
+    DataFlow::Node getReducerArg() { result = this.(StoreCreation::Range).getReducerArg() }
 
     /** Gets a data flow node referring to the root reducer. */
     DataFlow::SourceNode getAReducerSource() { result = getReducerArg().(ReducerArg).getASource() }
@@ -424,12 +422,10 @@ module Redux {
    * at some point. We model all action creators as if they dispatch the action they create.
    */
   class ActionCreator extends DataFlow::SourceNode {
-    ActionCreator::Range range;
-
-    ActionCreator() { this = range }
+    ActionCreator() { this instanceof ActionCreator::Range }
 
     /** Gets the `type` property of actions created by this action creator, if it is known. */
-    string getTypeTag() { result = range.getTypeTag() }
+    string getTypeTag() { result = this.(ActionCreator::Range).getTypeTag() }
 
     /**
      * Gets the middleware function that transforms arguments passed to this function into the
@@ -442,7 +438,7 @@ module Redux {
      * the action payload. Otherwise, the return value is the payload itself.
      */
     DataFlow::FunctionNode getMiddlewareFunction(boolean async) {
-      result = range.getMiddlewareFunction(async)
+      result = this.(ActionCreator::Range).getMiddlewareFunction(async)
     }
 
     /** Gets a data flow node referring to this action creator. */

--- a/javascript/ql/lib/semmle/javascript/frameworks/Redux.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Redux.qll
@@ -56,9 +56,7 @@ module Redux {
   /**
    * Creation of a redux store, usually via a call to `createStore`.
    */
-  class StoreCreation extends DataFlow::SourceNode {
-    StoreCreation() { this instanceof StoreCreation::Range }
-
+  class StoreCreation extends DataFlow::SourceNode instanceof StoreCreation::Range {
     /** Gets a reference to the store. */
     DataFlow::SourceNode ref() { result = asApiNode().getAUse() }
 
@@ -66,7 +64,7 @@ module Redux {
     API::Node asApiNode() { result.getAnImmediateUse() = this }
 
     /** Gets the data flow node holding the root reducer for this store. */
-    DataFlow::Node getReducerArg() { result = this.(StoreCreation::Range).getReducerArg() }
+    DataFlow::Node getReducerArg() { result = super.getReducerArg() }
 
     /** Gets a data flow node referring to the root reducer. */
     DataFlow::SourceNode getAReducerSource() { result = getReducerArg().(ReducerArg).getASource() }
@@ -421,11 +419,9 @@ module Redux {
    * Some action creators dispatch the action to a store, while for others, the value is returned and it is simply assumed to be dispatched
    * at some point. We model all action creators as if they dispatch the action they create.
    */
-  class ActionCreator extends DataFlow::SourceNode {
-    ActionCreator() { this instanceof ActionCreator::Range }
-
+  class ActionCreator extends DataFlow::SourceNode instanceof ActionCreator::Range {
     /** Gets the `type` property of actions created by this action creator, if it is known. */
-    string getTypeTag() { result = this.(ActionCreator::Range).getTypeTag() }
+    string getTypeTag() { result = super.getTypeTag() }
 
     /**
      * Gets the middleware function that transforms arguments passed to this function into the
@@ -438,7 +434,7 @@ module Redux {
      * the action payload. Otherwise, the return value is the payload itself.
      */
     DataFlow::FunctionNode getMiddlewareFunction(boolean async) {
-      result = this.(ActionCreator::Range).getMiddlewareFunction(async)
+      result = super.getMiddlewareFunction(async)
     }
 
     /** Gets a data flow node referring to this action creator. */

--- a/javascript/ql/lib/semmle/javascript/frameworks/ShellJS.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ShellJS.qll
@@ -15,12 +15,10 @@ module ShellJS {
 
   /** A member of the `shelljs` library. */
   class Member extends DataFlow::SourceNode {
-    Member::Range range;
-
-    Member() { this = range }
+    Member() { this instanceof Member::Range }
 
     /** Gets the name of `shelljs` member being referenced, such as `cat` in `shelljs.cat`. */
-    string getName() { result = range.getName() }
+    string getName() { result = this.(Member::Range).getName() }
   }
 
   module Member {

--- a/javascript/ql/lib/semmle/javascript/frameworks/ShellJS.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ShellJS.qll
@@ -14,11 +14,9 @@ module ShellJS {
   }
 
   /** A member of the `shelljs` library. */
-  class Member extends DataFlow::SourceNode {
-    Member() { this instanceof Member::Range }
-
+  class Member extends DataFlow::SourceNode instanceof Member::Range {
     /** Gets the name of `shelljs` member being referenced, such as `cat` in `shelljs.cat`. */
-    string getName() { result = this.(Member::Range).getName() }
+    string getName() { result = super.getName() }
   }
 
   module Member {


### PR DESCRIPTION
I grepped through the JavaScript QL for `::Range`, and first I converted them all to the casting-based `::Range` pattern, and next to the new syntax.  
I think I got most, but I might have missed some. 

[Evaluation looks fine.](https://github.com/github/codeql-dca-main/tree/run/erik-krogh/casting-nightly-security/reports)   
(No noticeable performance change, no change in results). 

/cc @ginsbach 