### PR TITLE
JS: add "uid" (and friends) as maybe being sensitive account info

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/internal/SensitiveDataHeuristics.qll
+++ b/javascript/ql/src/semmle/javascript/security/internal/SensitiveDataHeuristics.qll
@@ -59,7 +59,7 @@ module HeuristicNames {
   string maybeAccountInfo() {
     result = "(?is).*acc(ou)?nt.*" or
     result = "(?is).*(puid|username|userid).*" or
-    result = "(?is).*(u|^|_|[a-z(?=U)])(uid).*"
+    result = "(?s).*([uU]|^|_|[a-z](?=U))([uU][iI][dD]).*"
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/internal/SensitiveDataHeuristics.qll
+++ b/javascript/ql/src/semmle/javascript/security/internal/SensitiveDataHeuristics.qll
@@ -58,7 +58,8 @@ module HeuristicNames {
    */
   string maybeAccountInfo() {
     result = "(?is).*acc(ou)?nt.*" or
-    result = "(?is).*(puid|username|userid).*"
+    result = "(?is).*(puid|username|userid).*" or
+    result = "(?is).*(u|^|_|[a-z(?=U)])(uid).*"
   }
 
   /**

--- a/javascript/ql/test/query-tests/Security/CWE-338/InsecureRandomness.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-338/InsecureRandomness.expected
@@ -86,6 +86,12 @@ nodes
 | tst.js:118:34:118:46 | Math.random() |
 | tst.js:118:34:118:46 | Math.random() |
 | tst.js:118:34:118:62 | Math.ra ... 000_000 |
+| tst.js:120:16:120:28 | Math.random() |
+| tst.js:120:16:120:28 | Math.random() |
+| tst.js:120:16:120:28 | Math.random() |
+| tst.js:121:18:121:30 | Math.random() |
+| tst.js:121:18:121:30 | Math.random() |
+| tst.js:121:18:121:30 | Math.random() |
 edges
 | tst.js:2:20:2:32 | Math.random() | tst.js:2:20:2:32 | Math.random() |
 | tst.js:6:31:6:43 | Math.random() | tst.js:6:20:6:43 | "prefix ... andom() |
@@ -150,6 +156,8 @@ edges
 | tst.js:118:34:118:46 | Math.random() | tst.js:118:34:118:62 | Math.ra ... 000_000 |
 | tst.js:118:34:118:62 | Math.ra ... 000_000 | tst.js:118:23:118:63 | Math.fl ... 00_000) |
 | tst.js:118:34:118:62 | Math.ra ... 000_000 | tst.js:118:23:118:63 | Math.fl ... 00_000) |
+| tst.js:120:16:120:28 | Math.random() | tst.js:120:16:120:28 | Math.random() |
+| tst.js:121:18:121:30 | Math.random() | tst.js:121:18:121:30 | Math.random() |
 #select
 | tst.js:2:20:2:32 | Math.random() | tst.js:2:20:2:32 | Math.random() | tst.js:2:20:2:32 | Math.random() | Cryptographically insecure $@ in a security context. | tst.js:2:20:2:32 | Math.random() | random value |
 | tst.js:6:20:6:43 | "prefix ... andom() | tst.js:6:31:6:43 | Math.random() | tst.js:6:20:6:43 | "prefix ... andom() | Cryptographically insecure $@ in a security context. | tst.js:6:31:6:43 | Math.random() | random value |
@@ -171,3 +179,5 @@ edges
 | tst.js:116:22:116:62 | Math.fl ... 00_000) | tst.js:116:33:116:45 | Math.random() | tst.js:116:22:116:62 | Math.fl ... 00_000) | Cryptographically insecure $@ in a security context. | tst.js:116:33:116:45 | Math.random() | random value |
 | tst.js:117:15:117:55 | Math.fl ... 00_000) | tst.js:117:26:117:38 | Math.random() | tst.js:117:15:117:55 | Math.fl ... 00_000) | Cryptographically insecure $@ in a security context. | tst.js:117:26:117:38 | Math.random() | random value |
 | tst.js:118:23:118:63 | Math.fl ... 00_000) | tst.js:118:34:118:46 | Math.random() | tst.js:118:23:118:63 | Math.fl ... 00_000) | Cryptographically insecure $@ in a security context. | tst.js:118:34:118:46 | Math.random() | random value |
+| tst.js:120:16:120:28 | Math.random() | tst.js:120:16:120:28 | Math.random() | tst.js:120:16:120:28 | Math.random() | Cryptographically insecure $@ in a security context. | tst.js:120:16:120:28 | Math.random() | random value |
+| tst.js:121:18:121:30 | Math.random() | tst.js:121:18:121:30 | Math.random() | tst.js:121:18:121:30 | Math.random() | Cryptographically insecure $@ in a security context. | tst.js:121:18:121:30 | Math.random() | random value |

--- a/javascript/ql/test/query-tests/Security/CWE-338/InsecureRandomness.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-338/InsecureRandomness.expected
@@ -66,6 +66,26 @@ nodes
 | tst.js:95:33:95:45 | Math.random() |
 | tst.js:95:33:95:45 | Math.random() |
 | tst.js:95:33:95:45 | Math.random() |
+| tst.js:115:16:115:56 | Math.fl ... 00_000) |
+| tst.js:115:16:115:56 | Math.fl ... 00_000) |
+| tst.js:115:27:115:39 | Math.random() |
+| tst.js:115:27:115:39 | Math.random() |
+| tst.js:115:27:115:55 | Math.ra ... 000_000 |
+| tst.js:116:22:116:62 | Math.fl ... 00_000) |
+| tst.js:116:22:116:62 | Math.fl ... 00_000) |
+| tst.js:116:33:116:45 | Math.random() |
+| tst.js:116:33:116:45 | Math.random() |
+| tst.js:116:33:116:61 | Math.ra ... 000_000 |
+| tst.js:117:15:117:55 | Math.fl ... 00_000) |
+| tst.js:117:15:117:55 | Math.fl ... 00_000) |
+| tst.js:117:26:117:38 | Math.random() |
+| tst.js:117:26:117:38 | Math.random() |
+| tst.js:117:26:117:54 | Math.ra ... 000_000 |
+| tst.js:118:23:118:63 | Math.fl ... 00_000) |
+| tst.js:118:23:118:63 | Math.fl ... 00_000) |
+| tst.js:118:34:118:46 | Math.random() |
+| tst.js:118:34:118:46 | Math.random() |
+| tst.js:118:34:118:62 | Math.ra ... 000_000 |
 edges
 | tst.js:2:20:2:32 | Math.random() | tst.js:2:20:2:32 | Math.random() |
 | tst.js:6:31:6:43 | Math.random() | tst.js:6:20:6:43 | "prefix ... andom() |
@@ -114,6 +134,22 @@ edges
 | tst.js:84:19:84:31 | Math.random() | tst.js:84:19:84:31 | Math.random() |
 | tst.js:90:32:90:44 | Math.random() | tst.js:90:32:90:44 | Math.random() |
 | tst.js:95:33:95:45 | Math.random() | tst.js:95:33:95:45 | Math.random() |
+| tst.js:115:27:115:39 | Math.random() | tst.js:115:27:115:55 | Math.ra ... 000_000 |
+| tst.js:115:27:115:39 | Math.random() | tst.js:115:27:115:55 | Math.ra ... 000_000 |
+| tst.js:115:27:115:55 | Math.ra ... 000_000 | tst.js:115:16:115:56 | Math.fl ... 00_000) |
+| tst.js:115:27:115:55 | Math.ra ... 000_000 | tst.js:115:16:115:56 | Math.fl ... 00_000) |
+| tst.js:116:33:116:45 | Math.random() | tst.js:116:33:116:61 | Math.ra ... 000_000 |
+| tst.js:116:33:116:45 | Math.random() | tst.js:116:33:116:61 | Math.ra ... 000_000 |
+| tst.js:116:33:116:61 | Math.ra ... 000_000 | tst.js:116:22:116:62 | Math.fl ... 00_000) |
+| tst.js:116:33:116:61 | Math.ra ... 000_000 | tst.js:116:22:116:62 | Math.fl ... 00_000) |
+| tst.js:117:26:117:38 | Math.random() | tst.js:117:26:117:54 | Math.ra ... 000_000 |
+| tst.js:117:26:117:38 | Math.random() | tst.js:117:26:117:54 | Math.ra ... 000_000 |
+| tst.js:117:26:117:54 | Math.ra ... 000_000 | tst.js:117:15:117:55 | Math.fl ... 00_000) |
+| tst.js:117:26:117:54 | Math.ra ... 000_000 | tst.js:117:15:117:55 | Math.fl ... 00_000) |
+| tst.js:118:34:118:46 | Math.random() | tst.js:118:34:118:62 | Math.ra ... 000_000 |
+| tst.js:118:34:118:46 | Math.random() | tst.js:118:34:118:62 | Math.ra ... 000_000 |
+| tst.js:118:34:118:62 | Math.ra ... 000_000 | tst.js:118:23:118:63 | Math.fl ... 00_000) |
+| tst.js:118:34:118:62 | Math.ra ... 000_000 | tst.js:118:23:118:63 | Math.fl ... 00_000) |
 #select
 | tst.js:2:20:2:32 | Math.random() | tst.js:2:20:2:32 | Math.random() | tst.js:2:20:2:32 | Math.random() | Cryptographically insecure $@ in a security context. | tst.js:2:20:2:32 | Math.random() | random value |
 | tst.js:6:20:6:43 | "prefix ... andom() | tst.js:6:31:6:43 | Math.random() | tst.js:6:20:6:43 | "prefix ... andom() | Cryptographically insecure $@ in a security context. | tst.js:6:31:6:43 | Math.random() | random value |
@@ -131,3 +167,7 @@ edges
 | tst.js:84:19:84:31 | Math.random() | tst.js:84:19:84:31 | Math.random() | tst.js:84:19:84:31 | Math.random() | Cryptographically insecure $@ in a security context. | tst.js:84:19:84:31 | Math.random() | random value |
 | tst.js:90:32:90:44 | Math.random() | tst.js:90:32:90:44 | Math.random() | tst.js:90:32:90:44 | Math.random() | Cryptographically insecure $@ in a security context. | tst.js:90:32:90:44 | Math.random() | random value |
 | tst.js:95:33:95:45 | Math.random() | tst.js:95:33:95:45 | Math.random() | tst.js:95:33:95:45 | Math.random() | Cryptographically insecure $@ in a security context. | tst.js:95:33:95:45 | Math.random() | random value |
+| tst.js:115:16:115:56 | Math.fl ... 00_000) | tst.js:115:27:115:39 | Math.random() | tst.js:115:16:115:56 | Math.fl ... 00_000) | Cryptographically insecure $@ in a security context. | tst.js:115:27:115:39 | Math.random() | random value |
+| tst.js:116:22:116:62 | Math.fl ... 00_000) | tst.js:116:33:116:45 | Math.random() | tst.js:116:22:116:62 | Math.fl ... 00_000) | Cryptographically insecure $@ in a security context. | tst.js:116:33:116:45 | Math.random() | random value |
+| tst.js:117:15:117:55 | Math.fl ... 00_000) | tst.js:117:26:117:38 | Math.random() | tst.js:117:15:117:55 | Math.fl ... 00_000) | Cryptographically insecure $@ in a security context. | tst.js:117:26:117:38 | Math.random() | random value |
+| tst.js:118:23:118:63 | Math.fl ... 00_000) | tst.js:118:34:118:46 | Math.random() | tst.js:118:23:118:63 | Math.fl ... 00_000) | Cryptographically insecure $@ in a security context. | tst.js:118:34:118:46 | Math.random() | random value |

--- a/javascript/ql/test/query-tests/Security/CWE-338/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-338/tst.js
@@ -116,4 +116,7 @@ function uid() {
     var sessionUid = Math.floor(Math.random() * 4_000_000_000); // NOT OK
     var uid = Math.floor(Math.random() * 4_000_000_000); // NOT OK
     var my_nice_uid = Math.floor(Math.random() * 4_000_000_000); // NOT OK
+    var liquid = Math.random(); // OK
+    var UUID = Math.random(); // NOT OK
+    var MY_UID = Math.random(); // NOK OK
 }

--- a/javascript/ql/test/query-tests/Security/CWE-338/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-338/tst.js
@@ -110,3 +110,10 @@ function f18() {
     };
     var secret = genRandom(); // OK - Math.random() is only a fallback.
 })();
+
+function uid() {
+    var uuid = Math.floor(Math.random() * 4_000_000_000); // NOT OK
+    var sessionUid = Math.floor(Math.random() * 4_000_000_000); // NOT OK
+    var uid = Math.floor(Math.random() * 4_000_000_000); // NOT OK
+    var my_nice_uid = Math.floor(Math.random() * 4_000_000_000); // NOT OK
+}

--- a/python/ql/src/semmle/python/security/internal/SensitiveDataHeuristics.qll
+++ b/python/ql/src/semmle/python/security/internal/SensitiveDataHeuristics.qll
@@ -59,7 +59,7 @@ module HeuristicNames {
   string maybeAccountInfo() {
     result = "(?is).*acc(ou)?nt.*" or
     result = "(?is).*(puid|username|userid).*" or
-    result = "(?is).*(u|^|_|[a-z(?=U)])(uid).*"
+    result = "(?s).*([uU]|^|_|[a-z](?=U))([uU][iI][dD]).*"
   }
 
   /**

--- a/python/ql/src/semmle/python/security/internal/SensitiveDataHeuristics.qll
+++ b/python/ql/src/semmle/python/security/internal/SensitiveDataHeuristics.qll
@@ -58,7 +58,8 @@ module HeuristicNames {
    */
   string maybeAccountInfo() {
     result = "(?is).*acc(ou)?nt.*" or
-    result = "(?is).*(puid|username|userid).*"
+    result = "(?is).*(puid|username|userid).*" or
+    result = "(?is).*(u|^|_|[a-z(?=U)])(uid).*"
   }
 
   /**


### PR DESCRIPTION
TP/TN for CVE-2020-7660

[An LGTM showing which variables are now treated as sensitive](https://lgtm.com/query/7759044802537800320/) reveals some FPs. 
(Like [this `getUid` method in bootstrap](https://github.com/twbs/bootstrap/blob/58b1be927f43c779377e478df2d119f2ddf956ca/js/src/util/index.js#L29-L35)).   
But generally I think the new results look good. 

[An evaluation](https://github.com/dsp-testing/erik-krogh-dca/tree/run/uid-nightly-insecureRandom/reports) shows some noisy performance. And about the same amount of FPs as the above LGTM run. 