### PR TITLE
Docs: Document Go tracer support

### DIFF
--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -169,7 +169,7 @@ build steps, you may need to explicitly define each step in the command line.
    are dependencies, the appropriate dependency manager (such as `dep
    <https://golang.github.io/dep/>`__).
    
-   The Go autobuilder attempts to automatically detect Go code in a repository,
+   The Go autobuilder attempts to automatically detect code written in Go in a repository,
    and only runs build scripts in an attempt to fetch dependencies. To force
    CodeQL to limit extraction to the files compiled by your build script, set the environment variable
    `CODEQL_EXTRACTOR_GO_BUILD_TRACING=on` or use the ``--command`` option to specify a

--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -165,13 +165,14 @@ build steps, you may need to explicitly define each step in the command line.
 
 .. pull-quote:: Creating databases for Go
   
-   For Go, you should always use the CodeQL autobuilder. Install the Go
-   toolchain (version 1.11 or later) and, if there are dependencies, the
-   appropriate dependency manager (such as `dep
+   For Go, install the Go toolchain (version 1.11 or later) and, if there
+   are dependencies, the appropriate dependency manager (such as `dep
    <https://golang.github.io/dep/>`__).
    
-   Do not specify any build commands, as you will override the autobuilder
-   invocation, which will create an empty database.  
+   The Go autobuilder attempts to automatically detect Go code in a repository,
+   and only runs build scripts in an attempt to fetch dependencies. To force
+   CodeQL to use your build script, set the environment variable
+   `CODEQL_EXTRACTOR_GO_BUILD_TRACING=on` or pass a command.
 
 Specifying build commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -199,6 +200,10 @@ commands that you can specify for compiled languages.
   with .NET Core 2 or earlier, so expand the command to::
 
      codeql database create csharp-database --language=csharp --command='dotnet build /p:UseSharedCompilation=false /t:rebuild'
+
+- Go project built using a custom build script::
+
+   CODEQL_EXTRACTOR_GO_BUILD_TRACING=on codeql database create go-database --language=go --command='./scripts/build.sh'
 
 - Java project built using Gradle::
 

--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -172,7 +172,7 @@ build steps, you may need to explicitly define each step in the command line.
    The Go autobuilder attempts to automatically detect Go code in a repository,
    and only runs build scripts in an attempt to fetch dependencies. To force
    CodeQL to use your build script, set the environment variable
-   `CODEQL_EXTRACTOR_GO_BUILD_TRACING=on` or pass a command.
+   `CODEQL_EXTRACTOR_GO_BUILD_TRACING=on` or use the ``--command`` option.
 
 Specifying build commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -171,8 +171,9 @@ build steps, you may need to explicitly define each step in the command line.
    
    The Go autobuilder attempts to automatically detect Go code in a repository,
    and only runs build scripts in an attempt to fetch dependencies. To force
-   CodeQL to use your build script, set the environment variable
-   `CODEQL_EXTRACTOR_GO_BUILD_TRACING=on` or use the ``--command`` option.
+   CodeQL to limit extraction to the files compiled by your build script, set the environment variable
+   `CODEQL_EXTRACTOR_GO_BUILD_TRACING=on` or use the ``--command`` option to specify a
+   build command.
 
 Specifying build commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -203,6 +203,7 @@ commands that you can specify for compiled languages.
      codeql database create csharp-database --language=csharp --command='dotnet build /p:UseSharedCompilation=false /t:rebuild'
 
 - Go project built using the ``COEQL_EXTRACTOR_GO_BUILD_TRACING=on`` environment variable::
+
    CODEQL_EXTRACTOR_GO_BUILD_TRACING=on codeql database create go-database --language=go
 
 - Go project built using a custom build script::

--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -202,9 +202,12 @@ commands that you can specify for compiled languages.
 
      codeql database create csharp-database --language=csharp --command='dotnet build /p:UseSharedCompilation=false /t:rebuild'
 
+- Go project built using the ``COEQL_EXTRACTOR_GO_BUILD_TRACING=on`` environment variable::
+   CODEQL_EXTRACTOR_GO_BUILD_TRACING=on codeql database create go-database --language=go
+
 - Go project built using a custom build script::
 
-   CODEQL_EXTRACTOR_GO_BUILD_TRACING=on codeql database create go-database --language=go --command='./scripts/build.sh'
+   codeql database create go-database --language=go --command='./scripts/build.sh'
 
 - Java project built using Gradle::
 


### PR DESCRIPTION
This PR updates "[Creating CodeQL databases](https://codeql.github.com/docs/codeql-cli/creating-codeql-databases/#creating-databases-for-compiled-languages)" to document tracer support for Go.

The Creating databases for Go callout box is updated and a sample build command for Go is added.

More info in the internally linked issue.