### PR TITLE
Add lines-of-code tags

### DIFF
--- a/cpp/ql/src/Summary/LinesOfCode.ql
+++ b/cpp/ql/src/Summary/LinesOfCode.ql
@@ -4,6 +4,7 @@
  * @description The total number of lines of C/C++ code across all files, including system headers, libraries, and auto-generated files. This is a useful metric of the size of a database. For all files that were seen during the build, this query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
+ *       lines-of-code
  */
 
 import cpp

--- a/csharp/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/csharp/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -4,6 +4,7 @@
  * @description The total number of lines of code across all files. This is a useful metric of the size of a database. For all files that were seen during the build, this query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
+ *       lines-of-code
  */
 
 import csharp

--- a/java/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/java/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -6,6 +6,7 @@
  *              or comments.
  * @kind metric
  * @tags summary
+ *       lines-of-code
  */
 
 import java

--- a/javascript/ql/src/Summary/LinesOfCode.ql
+++ b/javascript/ql/src/Summary/LinesOfCode.ql
@@ -4,6 +4,7 @@
  * @description The total number of lines of JavaScript or TypeScript code across all files checked into the repository, except in `node_modules`. This is a useful metric of the size of a database. For all files that were seen during extraction, this query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
+ *       lines-of-code
  */
 
 import javascript

--- a/python/ql/src/Summary/LinesOfCode.ql
+++ b/python/ql/src/Summary/LinesOfCode.ql
@@ -5,6 +5,7 @@
  *   database. This query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
+ *       lines-of-code
  * @id py/summary/lines-of-code
  */
 


### PR DESCRIPTION
This is a proposed method for advertising which queries are measuring
the lines of code in a project in a more robust manner than inspecting
the rule id.

Note that the python "LinesOfUserCode" query should _not_ have this
property, as otherwise the results of the two queries will be summed.

@henrymercer @adityasharad 