### PR TITLE
C++: Add barriers to `cpp/uncontrolled-allocation-size`

### DIFF
--- a/cpp/change-notes/2021-05-14-uncontrolled-allocation-size.md
+++ b/cpp/change-notes/2021-05-14-uncontrolled-allocation-size.md
@@ -1,0 +1,2 @@
+lgtm
+* The "Tainted allocation size" query (cpp/uncontrolled-allocation-size) has been improved to produce fewer false positives.

--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -42,6 +42,12 @@ class TaintedAllocationSizeConfiguration extends TaintTrackingConfiguration {
       e instanceof AssignArithmeticOperation
     ) and
     not convertedExprMightOverflow(e)
+    or
+    // Subtracting two pointers is either well-defined (and the result will likely be small), or
+    // terribly undefined and dangerous. Here, we assume that the programmer has ensured that the
+    // result is well-defined (i.e., the two pointers point to the same object), and thus the result
+    // will likely be small.
+    e = any(PointerDiffExpr diff).getAnOperand()
   }
 }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -27,24 +27,6 @@ edges
 | test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... |
 | test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... |
 | test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... |
-| test.cpp:75:25:75:29 | start | test.cpp:79:18:79:28 | ... - ... |
-| test.cpp:75:25:75:29 | start | test.cpp:79:18:79:28 | ... - ... |
-| test.cpp:75:38:75:40 | end | test.cpp:79:18:79:28 | ... - ... |
-| test.cpp:75:38:75:40 | end | test.cpp:79:18:79:28 | ... - ... |
-| test.cpp:97:18:97:23 | buffer | test.cpp:100:4:100:15 | buffer |
-| test.cpp:97:18:97:23 | buffer | test.cpp:100:17:100:22 | buffer indirection |
-| test.cpp:97:18:97:23 | buffer | test.cpp:101:4:101:15 | ... + ... |
-| test.cpp:97:18:97:23 | buffer | test.cpp:101:4:101:15 | buffer |
-| test.cpp:97:18:97:23 | fread output argument | test.cpp:100:4:100:15 | buffer |
-| test.cpp:97:18:97:23 | fread output argument | test.cpp:100:17:100:22 | buffer indirection |
-| test.cpp:97:18:97:23 | fread output argument | test.cpp:101:4:101:15 | ... + ... |
-| test.cpp:97:18:97:23 | fread output argument | test.cpp:101:4:101:15 | buffer |
-| test.cpp:100:4:100:15 | buffer | test.cpp:100:17:100:22 | processData1 output argument |
-| test.cpp:100:17:100:22 | buffer indirection | test.cpp:100:17:100:22 | processData1 output argument |
-| test.cpp:100:17:100:22 | processData1 output argument | test.cpp:101:4:101:15 | ... + ... |
-| test.cpp:100:17:100:22 | processData1 output argument | test.cpp:101:4:101:15 | buffer |
-| test.cpp:101:4:101:15 | ... + ... | test.cpp:75:38:75:40 | end |
-| test.cpp:101:4:101:15 | buffer | test.cpp:75:25:75:29 | start |
 | test.cpp:123:18:123:23 | call to getenv | test.cpp:127:24:127:41 | ... * ... |
 | test.cpp:123:18:123:23 | call to getenv | test.cpp:127:24:127:41 | ... * ... |
 | test.cpp:123:18:123:31 | (const char *)... | test.cpp:127:24:127:41 | ... * ... |
@@ -87,12 +69,6 @@ edges
 | test.cpp:295:18:295:21 | Chi | test.cpp:298:10:298:27 | ... * ... |
 | test.cpp:295:18:295:21 | Chi | test.cpp:298:10:298:27 | ... * ... |
 | test.cpp:295:18:295:21 | get_size output argument [array content] | test.cpp:295:18:295:21 | Chi |
-| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | (size_t)... |
-| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | (size_t)... |
-| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | offset |
-| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | offset |
-| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | offset |
-| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | offset |
 nodes
 | test.cpp:39:21:39:24 | argv | semmle.label | argv |
 | test.cpp:39:21:39:24 | argv | semmle.label | argv |
@@ -118,21 +94,6 @@ nodes
 | test.cpp:52:35:52:60 | ... * ... | semmle.label | ... * ... |
 | test.cpp:52:35:52:60 | ... * ... | semmle.label | ... * ... |
 | test.cpp:52:35:52:60 | ... * ... | semmle.label | ... * ... |
-| test.cpp:64:25:64:30 | *buffer | semmle.label | *buffer |
-| test.cpp:64:25:64:30 | *buffer | semmle.label | *buffer |
-| test.cpp:64:25:64:30 | buffer | semmle.label | buffer |
-| test.cpp:75:25:75:29 | start | semmle.label | start |
-| test.cpp:75:38:75:40 | end | semmle.label | end |
-| test.cpp:79:18:79:28 | ... - ... | semmle.label | ... - ... |
-| test.cpp:79:18:79:28 | ... - ... | semmle.label | ... - ... |
-| test.cpp:79:18:79:28 | ... - ... | semmle.label | ... - ... |
-| test.cpp:97:18:97:23 | buffer | semmle.label | buffer |
-| test.cpp:97:18:97:23 | fread output argument | semmle.label | fread output argument |
-| test.cpp:100:4:100:15 | buffer | semmle.label | buffer |
-| test.cpp:100:17:100:22 | buffer indirection | semmle.label | buffer indirection |
-| test.cpp:100:17:100:22 | processData1 output argument | semmle.label | processData1 output argument |
-| test.cpp:101:4:101:15 | ... + ... | semmle.label | ... + ... |
-| test.cpp:101:4:101:15 | buffer | semmle.label | buffer |
 | test.cpp:123:18:123:23 | call to getenv | semmle.label | call to getenv |
 | test.cpp:123:18:123:31 | (const char *)... | semmle.label | (const char *)... |
 | test.cpp:127:24:127:41 | ... * ... | semmle.label | ... * ... |
@@ -185,13 +146,6 @@ nodes
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:321:15:321:20 | call to getenv | semmle.label | call to getenv |
-| test.cpp:321:15:321:20 | call to getenv | semmle.label | call to getenv |
-| test.cpp:324:9:324:14 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:324:9:324:14 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:324:9:324:14 | offset | semmle.label | offset |
-| test.cpp:324:9:324:14 | offset | semmle.label | offset |
-| test.cpp:324:9:324:14 | offset | semmle.label | offset |
 #select
 | test.cpp:42:31:42:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:43:31:43:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
@@ -199,7 +153,6 @@ nodes
 | test.cpp:48:25:48:30 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:49:17:49:30 | new[] | test.cpp:39:21:39:24 | argv | test.cpp:49:26:49:29 | size | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:52:21:52:27 | call to realloc | test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
-| test.cpp:79:9:79:29 | new[] | test.cpp:97:18:97:23 | buffer | test.cpp:79:18:79:28 | ... - ... | This allocation size is derived from $@ and might overflow | test.cpp:97:18:97:23 | buffer | user input (fread) |
 | test.cpp:127:17:127:22 | call to malloc | test.cpp:123:18:123:23 | call to getenv | test.cpp:127:24:127:41 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:123:18:123:23 | call to getenv | user input (getenv) |
 | test.cpp:134:3:134:8 | call to malloc | test.cpp:132:19:132:24 | call to getenv | test.cpp:134:10:134:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:132:19:132:24 | call to getenv | user input (getenv) |
 | test.cpp:215:14:215:19 | call to malloc | test.cpp:227:24:227:29 | call to getenv | test.cpp:215:21:215:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:227:24:227:29 | call to getenv | user input (getenv) |
@@ -209,4 +162,3 @@ nodes
 | test.cpp:253:4:253:9 | call to malloc | test.cpp:249:20:249:25 | call to getenv | test.cpp:253:11:253:29 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:249:20:249:25 | call to getenv | user input (getenv) |
 | test.cpp:281:4:281:9 | call to malloc | test.cpp:241:18:241:23 | call to getenv | test.cpp:281:11:281:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:241:18:241:23 | call to getenv | user input (getenv) |
 | test.cpp:298:3:298:8 | call to malloc | test.cpp:241:18:241:23 | call to getenv | test.cpp:298:10:298:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:241:18:241:23 | call to getenv | user input (getenv) |
-| test.cpp:324:2:324:7 | call to malloc | test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | offset | This allocation size is derived from $@ and might overflow | test.cpp:321:15:321:20 | call to getenv | user input (getenv) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -53,10 +53,6 @@ edges
 | test.cpp:132:19:132:24 | call to getenv | test.cpp:134:10:134:27 | ... * ... |
 | test.cpp:132:19:132:32 | (const char *)... | test.cpp:134:10:134:27 | ... * ... |
 | test.cpp:132:19:132:32 | (const char *)... | test.cpp:134:10:134:27 | ... * ... |
-| test.cpp:138:19:138:24 | call to getenv | test.cpp:142:11:142:28 | ... * ... |
-| test.cpp:138:19:138:24 | call to getenv | test.cpp:142:11:142:28 | ... * ... |
-| test.cpp:138:19:138:32 | (const char *)... | test.cpp:142:11:142:28 | ... * ... |
-| test.cpp:138:19:138:32 | (const char *)... | test.cpp:142:11:142:28 | ... * ... |
 | test.cpp:201:9:201:42 | Store | test.cpp:231:9:231:24 | call to get_tainted_size |
 | test.cpp:201:9:201:42 | Store | test.cpp:231:9:231:24 | call to get_tainted_size |
 | test.cpp:201:14:201:19 | call to getenv | test.cpp:201:9:201:42 | Store |
@@ -91,14 +87,6 @@ edges
 | test.cpp:295:18:295:21 | Chi | test.cpp:298:10:298:27 | ... * ... |
 | test.cpp:295:18:295:21 | Chi | test.cpp:298:10:298:27 | ... * ... |
 | test.cpp:295:18:295:21 | get_size output argument [array content] | test.cpp:295:18:295:21 | Chi |
-| test.cpp:301:19:301:24 | call to getenv | test.cpp:305:11:305:28 | ... * ... |
-| test.cpp:301:19:301:24 | call to getenv | test.cpp:305:11:305:28 | ... * ... |
-| test.cpp:301:19:301:32 | (const char *)... | test.cpp:305:11:305:28 | ... * ... |
-| test.cpp:301:19:301:32 | (const char *)... | test.cpp:305:11:305:28 | ... * ... |
-| test.cpp:309:19:309:24 | call to getenv | test.cpp:314:10:314:27 | ... * ... |
-| test.cpp:309:19:309:24 | call to getenv | test.cpp:314:10:314:27 | ... * ... |
-| test.cpp:309:19:309:32 | (const char *)... | test.cpp:314:10:314:27 | ... * ... |
-| test.cpp:309:19:309:32 | (const char *)... | test.cpp:314:10:314:27 | ... * ... |
 nodes
 | test.cpp:39:21:39:24 | argv | semmle.label | argv |
 | test.cpp:39:21:39:24 | argv | semmle.label | argv |
@@ -149,11 +137,6 @@ nodes
 | test.cpp:134:10:134:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:134:10:134:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:134:10:134:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:138:19:138:24 | call to getenv | semmle.label | call to getenv |
-| test.cpp:138:19:138:32 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:142:11:142:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:142:11:142:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:142:11:142:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:201:9:201:42 | Store | semmle.label | Store |
 | test.cpp:201:14:201:19 | call to getenv | semmle.label | call to getenv |
 | test.cpp:201:14:201:27 | (const char *)... | semmle.label | (const char *)... |
@@ -196,16 +179,6 @@ nodes
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:301:19:301:24 | call to getenv | semmle.label | call to getenv |
-| test.cpp:301:19:301:32 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:305:11:305:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:305:11:305:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:305:11:305:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:309:19:309:24 | call to getenv | semmle.label | call to getenv |
-| test.cpp:309:19:309:32 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:314:10:314:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:314:10:314:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:314:10:314:27 | ... * ... | semmle.label | ... * ... |
 #select
 | test.cpp:42:31:42:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:43:31:43:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
@@ -216,7 +189,6 @@ nodes
 | test.cpp:79:9:79:29 | new[] | test.cpp:97:18:97:23 | buffer | test.cpp:79:18:79:28 | ... - ... | This allocation size is derived from $@ and might overflow | test.cpp:97:18:97:23 | buffer | user input (fread) |
 | test.cpp:127:17:127:22 | call to malloc | test.cpp:123:18:123:23 | call to getenv | test.cpp:127:24:127:41 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:123:18:123:23 | call to getenv | user input (getenv) |
 | test.cpp:134:3:134:8 | call to malloc | test.cpp:132:19:132:24 | call to getenv | test.cpp:134:10:134:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:132:19:132:24 | call to getenv | user input (getenv) |
-| test.cpp:142:4:142:9 | call to malloc | test.cpp:138:19:138:24 | call to getenv | test.cpp:142:11:142:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:138:19:138:24 | call to getenv | user input (getenv) |
 | test.cpp:215:14:215:19 | call to malloc | test.cpp:227:24:227:29 | call to getenv | test.cpp:215:21:215:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:227:24:227:29 | call to getenv | user input (getenv) |
 | test.cpp:221:14:221:19 | call to malloc | test.cpp:227:24:227:29 | call to getenv | test.cpp:221:21:221:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:227:24:227:29 | call to getenv | user input (getenv) |
 | test.cpp:229:2:229:7 | call to malloc | test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | local_size | This allocation size is derived from $@ and might overflow | test.cpp:227:24:227:29 | call to getenv | user input (getenv) |
@@ -224,5 +196,3 @@ nodes
 | test.cpp:253:4:253:9 | call to malloc | test.cpp:249:20:249:25 | call to getenv | test.cpp:253:11:253:29 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:249:20:249:25 | call to getenv | user input (getenv) |
 | test.cpp:281:4:281:9 | call to malloc | test.cpp:241:18:241:23 | call to getenv | test.cpp:281:11:281:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:241:18:241:23 | call to getenv | user input (getenv) |
 | test.cpp:298:3:298:8 | call to malloc | test.cpp:241:18:241:23 | call to getenv | test.cpp:298:10:298:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:241:18:241:23 | call to getenv | user input (getenv) |
-| test.cpp:305:4:305:9 | call to malloc | test.cpp:301:19:301:24 | call to getenv | test.cpp:305:11:305:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:301:19:301:24 | call to getenv | user input (getenv) |
-| test.cpp:314:3:314:8 | call to malloc | test.cpp:309:19:309:24 | call to getenv | test.cpp:314:10:314:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:309:19:309:24 | call to getenv | user input (getenv) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -1,164 +1,174 @@
 edges
-| test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | (size_t)... |
-| test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | (size_t)... |
-| test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted |
-| test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted |
-| test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted |
-| test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted |
-| test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:45:38:45:63 | ... + ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:45:38:45:63 | ... + ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:45:38:45:63 | ... + ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:45:38:45:63 | ... + ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | (size_t)... |
-| test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | (size_t)... |
-| test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size |
-| test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size |
-| test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size |
-| test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size |
-| test.cpp:39:21:39:24 | argv | test.cpp:49:26:49:29 | size |
-| test.cpp:39:21:39:24 | argv | test.cpp:49:26:49:29 | size |
-| test.cpp:39:21:39:24 | argv | test.cpp:49:26:49:29 | size |
-| test.cpp:39:21:39:24 | argv | test.cpp:49:26:49:29 | size |
-| test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... |
-| test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... |
-| test.cpp:123:18:123:23 | call to getenv | test.cpp:127:24:127:41 | ... * ... |
-| test.cpp:123:18:123:23 | call to getenv | test.cpp:127:24:127:41 | ... * ... |
-| test.cpp:123:18:123:31 | (const char *)... | test.cpp:127:24:127:41 | ... * ... |
-| test.cpp:123:18:123:31 | (const char *)... | test.cpp:127:24:127:41 | ... * ... |
-| test.cpp:132:19:132:24 | call to getenv | test.cpp:134:10:134:27 | ... * ... |
-| test.cpp:132:19:132:24 | call to getenv | test.cpp:134:10:134:27 | ... * ... |
-| test.cpp:132:19:132:32 | (const char *)... | test.cpp:134:10:134:27 | ... * ... |
-| test.cpp:132:19:132:32 | (const char *)... | test.cpp:134:10:134:27 | ... * ... |
-| test.cpp:201:9:201:42 | Store | test.cpp:231:9:231:24 | call to get_tainted_size |
-| test.cpp:201:9:201:42 | Store | test.cpp:231:9:231:24 | call to get_tainted_size |
-| test.cpp:201:14:201:19 | call to getenv | test.cpp:201:9:201:42 | Store |
-| test.cpp:201:14:201:27 | (const char *)... | test.cpp:201:9:201:42 | Store |
-| test.cpp:214:23:214:23 | s | test.cpp:215:21:215:21 | s |
-| test.cpp:214:23:214:23 | s | test.cpp:215:21:215:21 | s |
-| test.cpp:220:21:220:21 | s | test.cpp:221:21:221:21 | s |
-| test.cpp:220:21:220:21 | s | test.cpp:221:21:221:21 | s |
-| test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | (size_t)... |
-| test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | local_size |
-| test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | local_size |
-| test.cpp:227:24:227:29 | call to getenv | test.cpp:235:2:235:9 | local_size |
-| test.cpp:227:24:227:29 | call to getenv | test.cpp:237:2:237:8 | local_size |
-| test.cpp:227:24:227:37 | (const char *)... | test.cpp:229:9:229:18 | (size_t)... |
-| test.cpp:227:24:227:37 | (const char *)... | test.cpp:229:9:229:18 | local_size |
-| test.cpp:227:24:227:37 | (const char *)... | test.cpp:229:9:229:18 | local_size |
-| test.cpp:227:24:227:37 | (const char *)... | test.cpp:235:2:235:9 | local_size |
-| test.cpp:227:24:227:37 | (const char *)... | test.cpp:237:2:237:8 | local_size |
-| test.cpp:235:2:235:9 | local_size | test.cpp:214:23:214:23 | s |
-| test.cpp:237:2:237:8 | local_size | test.cpp:220:21:220:21 | s |
-| test.cpp:241:2:241:32 | Chi [array content] | test.cpp:279:17:279:20 | get_size output argument [array content] |
-| test.cpp:241:2:241:32 | Chi [array content] | test.cpp:295:18:295:21 | get_size output argument [array content] |
-| test.cpp:241:18:241:23 | call to getenv | test.cpp:241:2:241:32 | Chi [array content] |
-| test.cpp:241:18:241:31 | (const char *)... | test.cpp:241:2:241:32 | Chi [array content] |
-| test.cpp:249:20:249:25 | call to getenv | test.cpp:253:11:253:29 | ... * ... |
-| test.cpp:249:20:249:25 | call to getenv | test.cpp:253:11:253:29 | ... * ... |
-| test.cpp:249:20:249:33 | (const char *)... | test.cpp:253:11:253:29 | ... * ... |
-| test.cpp:249:20:249:33 | (const char *)... | test.cpp:253:11:253:29 | ... * ... |
-| test.cpp:279:17:279:20 | Chi | test.cpp:281:11:281:28 | ... * ... |
-| test.cpp:279:17:279:20 | Chi | test.cpp:281:11:281:28 | ... * ... |
-| test.cpp:279:17:279:20 | get_size output argument [array content] | test.cpp:279:17:279:20 | Chi |
-| test.cpp:295:18:295:21 | Chi | test.cpp:298:10:298:27 | ... * ... |
-| test.cpp:295:18:295:21 | Chi | test.cpp:298:10:298:27 | ... * ... |
-| test.cpp:295:18:295:21 | get_size output argument [array content] | test.cpp:295:18:295:21 | Chi |
+| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | (size_t)... |
+| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | (size_t)... |
+| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
+| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
+| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
+| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
+| test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | (size_t)... |
+| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | (size_t)... |
+| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
+| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
+| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
+| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
+| test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
+| test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
+| test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
+| test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
+| test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
+| test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
+| test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
+| test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
+| test.cpp:124:18:124:31 | (const char *)... | test.cpp:128:24:128:41 | ... * ... |
+| test.cpp:124:18:124:31 | (const char *)... | test.cpp:128:24:128:41 | ... * ... |
+| test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... |
+| test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... |
+| test.cpp:133:19:133:32 | (const char *)... | test.cpp:135:10:135:27 | ... * ... |
+| test.cpp:133:19:133:32 | (const char *)... | test.cpp:135:10:135:27 | ... * ... |
+| test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... |
+| test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... |
+| test.cpp:148:20:148:33 | (const char *)... | test.cpp:152:11:152:28 | ... * ... |
+| test.cpp:148:20:148:33 | (const char *)... | test.cpp:152:11:152:28 | ... * ... |
+| test.cpp:211:9:211:42 | Store | test.cpp:241:9:241:24 | call to get_tainted_size |
+| test.cpp:211:9:211:42 | Store | test.cpp:241:9:241:24 | call to get_tainted_size |
+| test.cpp:211:14:211:19 | call to getenv | test.cpp:211:9:211:42 | Store |
+| test.cpp:211:14:211:27 | (const char *)... | test.cpp:211:9:211:42 | Store |
+| test.cpp:224:23:224:23 | s | test.cpp:225:21:225:21 | s |
+| test.cpp:224:23:224:23 | s | test.cpp:225:21:225:21 | s |
+| test.cpp:230:21:230:21 | s | test.cpp:231:21:231:21 | s |
+| test.cpp:230:21:230:21 | s | test.cpp:231:21:231:21 | s |
+| test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | (size_t)... |
+| test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size |
+| test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size |
+| test.cpp:237:24:237:29 | call to getenv | test.cpp:245:2:245:9 | local_size |
+| test.cpp:237:24:237:29 | call to getenv | test.cpp:247:2:247:8 | local_size |
+| test.cpp:237:24:237:37 | (const char *)... | test.cpp:239:9:239:18 | (size_t)... |
+| test.cpp:237:24:237:37 | (const char *)... | test.cpp:239:9:239:18 | local_size |
+| test.cpp:237:24:237:37 | (const char *)... | test.cpp:239:9:239:18 | local_size |
+| test.cpp:237:24:237:37 | (const char *)... | test.cpp:245:2:245:9 | local_size |
+| test.cpp:237:24:237:37 | (const char *)... | test.cpp:247:2:247:8 | local_size |
+| test.cpp:245:2:245:9 | local_size | test.cpp:224:23:224:23 | s |
+| test.cpp:247:2:247:8 | local_size | test.cpp:230:21:230:21 | s |
+| test.cpp:251:2:251:32 | Chi [array content] | test.cpp:289:17:289:20 | get_size output argument [array content] |
+| test.cpp:251:2:251:32 | Chi [array content] | test.cpp:305:18:305:21 | get_size output argument [array content] |
+| test.cpp:251:18:251:23 | call to getenv | test.cpp:251:2:251:32 | Chi [array content] |
+| test.cpp:251:18:251:31 | (const char *)... | test.cpp:251:2:251:32 | Chi [array content] |
+| test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... |
+| test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... |
+| test.cpp:259:20:259:33 | (const char *)... | test.cpp:263:11:263:29 | ... * ... |
+| test.cpp:259:20:259:33 | (const char *)... | test.cpp:263:11:263:29 | ... * ... |
+| test.cpp:289:17:289:20 | Chi | test.cpp:291:11:291:28 | ... * ... |
+| test.cpp:289:17:289:20 | Chi | test.cpp:291:11:291:28 | ... * ... |
+| test.cpp:289:17:289:20 | get_size output argument [array content] | test.cpp:289:17:289:20 | Chi |
+| test.cpp:305:18:305:21 | Chi | test.cpp:308:10:308:27 | ... * ... |
+| test.cpp:305:18:305:21 | Chi | test.cpp:308:10:308:27 | ... * ... |
+| test.cpp:305:18:305:21 | get_size output argument [array content] | test.cpp:305:18:305:21 | Chi |
 nodes
-| test.cpp:39:21:39:24 | argv | semmle.label | argv |
-| test.cpp:39:21:39:24 | argv | semmle.label | argv |
-| test.cpp:42:38:42:44 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:42:38:42:44 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:42:38:42:44 | tainted | semmle.label | tainted |
-| test.cpp:42:38:42:44 | tainted | semmle.label | tainted |
-| test.cpp:42:38:42:44 | tainted | semmle.label | tainted |
-| test.cpp:43:38:43:63 | ... * ... | semmle.label | ... * ... |
-| test.cpp:43:38:43:63 | ... * ... | semmle.label | ... * ... |
-| test.cpp:43:38:43:63 | ... * ... | semmle.label | ... * ... |
-| test.cpp:45:38:45:63 | ... + ... | semmle.label | ... + ... |
-| test.cpp:45:38:45:63 | ... + ... | semmle.label | ... + ... |
-| test.cpp:45:38:45:63 | ... + ... | semmle.label | ... + ... |
-| test.cpp:48:32:48:35 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:48:32:48:35 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:48:32:48:35 | size | semmle.label | size |
-| test.cpp:48:32:48:35 | size | semmle.label | size |
-| test.cpp:48:32:48:35 | size | semmle.label | size |
-| test.cpp:49:26:49:29 | size | semmle.label | size |
-| test.cpp:49:26:49:29 | size | semmle.label | size |
-| test.cpp:49:26:49:29 | size | semmle.label | size |
-| test.cpp:52:35:52:60 | ... * ... | semmle.label | ... * ... |
-| test.cpp:52:35:52:60 | ... * ... | semmle.label | ... * ... |
-| test.cpp:52:35:52:60 | ... * ... | semmle.label | ... * ... |
-| test.cpp:123:18:123:23 | call to getenv | semmle.label | call to getenv |
-| test.cpp:123:18:123:31 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:127:24:127:41 | ... * ... | semmle.label | ... * ... |
-| test.cpp:127:24:127:41 | ... * ... | semmle.label | ... * ... |
-| test.cpp:127:24:127:41 | ... * ... | semmle.label | ... * ... |
-| test.cpp:132:19:132:24 | call to getenv | semmle.label | call to getenv |
-| test.cpp:132:19:132:32 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:134:10:134:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:134:10:134:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:134:10:134:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:201:9:201:42 | Store | semmle.label | Store |
-| test.cpp:201:14:201:19 | call to getenv | semmle.label | call to getenv |
-| test.cpp:201:14:201:27 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:214:23:214:23 | s | semmle.label | s |
-| test.cpp:215:21:215:21 | s | semmle.label | s |
-| test.cpp:215:21:215:21 | s | semmle.label | s |
-| test.cpp:215:21:215:21 | s | semmle.label | s |
-| test.cpp:220:21:220:21 | s | semmle.label | s |
-| test.cpp:221:21:221:21 | s | semmle.label | s |
-| test.cpp:221:21:221:21 | s | semmle.label | s |
-| test.cpp:221:21:221:21 | s | semmle.label | s |
-| test.cpp:227:24:227:29 | call to getenv | semmle.label | call to getenv |
-| test.cpp:227:24:227:37 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:229:9:229:18 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:229:9:229:18 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:229:9:229:18 | local_size | semmle.label | local_size |
-| test.cpp:229:9:229:18 | local_size | semmle.label | local_size |
-| test.cpp:229:9:229:18 | local_size | semmle.label | local_size |
-| test.cpp:231:9:231:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
-| test.cpp:231:9:231:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
-| test.cpp:231:9:231:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
-| test.cpp:235:2:235:9 | local_size | semmle.label | local_size |
-| test.cpp:237:2:237:8 | local_size | semmle.label | local_size |
-| test.cpp:241:2:241:32 | Chi [array content] | semmle.label | Chi [array content] |
-| test.cpp:241:2:241:32 | ChiPartial | semmle.label | ChiPartial |
-| test.cpp:241:18:241:23 | call to getenv | semmle.label | call to getenv |
-| test.cpp:241:18:241:31 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:249:20:249:25 | call to getenv | semmle.label | call to getenv |
-| test.cpp:249:20:249:33 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:253:11:253:29 | ... * ... | semmle.label | ... * ... |
-| test.cpp:253:11:253:29 | ... * ... | semmle.label | ... * ... |
-| test.cpp:253:11:253:29 | ... * ... | semmle.label | ... * ... |
-| test.cpp:279:17:279:20 | Chi | semmle.label | Chi |
-| test.cpp:279:17:279:20 | get_size output argument [array content] | semmle.label | get_size output argument [array content] |
-| test.cpp:281:11:281:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:281:11:281:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:281:11:281:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:295:18:295:21 | Chi | semmle.label | Chi |
-| test.cpp:295:18:295:21 | get_size output argument [array content] | semmle.label | get_size output argument [array content] |
-| test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
+| test.cpp:40:21:40:24 | argv | semmle.label | argv |
+| test.cpp:40:21:40:24 | argv | semmle.label | argv |
+| test.cpp:43:38:43:44 | (size_t)... | semmle.label | (size_t)... |
+| test.cpp:43:38:43:44 | (size_t)... | semmle.label | (size_t)... |
+| test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
+| test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
+| test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
+| test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
+| test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
+| test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
+| test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
+| test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
+| test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
+| test.cpp:49:32:49:35 | (size_t)... | semmle.label | (size_t)... |
+| test.cpp:49:32:49:35 | (size_t)... | semmle.label | (size_t)... |
+| test.cpp:49:32:49:35 | size | semmle.label | size |
+| test.cpp:49:32:49:35 | size | semmle.label | size |
+| test.cpp:49:32:49:35 | size | semmle.label | size |
+| test.cpp:50:26:50:29 | size | semmle.label | size |
+| test.cpp:50:26:50:29 | size | semmle.label | size |
+| test.cpp:50:26:50:29 | size | semmle.label | size |
+| test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
+| test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
+| test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
+| test.cpp:124:18:124:23 | call to getenv | semmle.label | call to getenv |
+| test.cpp:124:18:124:31 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
+| test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
+| test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
+| test.cpp:133:19:133:24 | call to getenv | semmle.label | call to getenv |
+| test.cpp:133:19:133:32 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
+| test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
+| test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
+| test.cpp:148:20:148:25 | call to getenv | semmle.label | call to getenv |
+| test.cpp:148:20:148:33 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:211:9:211:42 | Store | semmle.label | Store |
+| test.cpp:211:14:211:19 | call to getenv | semmle.label | call to getenv |
+| test.cpp:211:14:211:27 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:224:23:224:23 | s | semmle.label | s |
+| test.cpp:225:21:225:21 | s | semmle.label | s |
+| test.cpp:225:21:225:21 | s | semmle.label | s |
+| test.cpp:225:21:225:21 | s | semmle.label | s |
+| test.cpp:230:21:230:21 | s | semmle.label | s |
+| test.cpp:231:21:231:21 | s | semmle.label | s |
+| test.cpp:231:21:231:21 | s | semmle.label | s |
+| test.cpp:231:21:231:21 | s | semmle.label | s |
+| test.cpp:237:24:237:29 | call to getenv | semmle.label | call to getenv |
+| test.cpp:237:24:237:37 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:239:9:239:18 | (size_t)... | semmle.label | (size_t)... |
+| test.cpp:239:9:239:18 | (size_t)... | semmle.label | (size_t)... |
+| test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
+| test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
+| test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
+| test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
+| test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
+| test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
+| test.cpp:245:2:245:9 | local_size | semmle.label | local_size |
+| test.cpp:247:2:247:8 | local_size | semmle.label | local_size |
+| test.cpp:251:2:251:32 | Chi [array content] | semmle.label | Chi [array content] |
+| test.cpp:251:2:251:32 | ChiPartial | semmle.label | ChiPartial |
+| test.cpp:251:18:251:23 | call to getenv | semmle.label | call to getenv |
+| test.cpp:251:18:251:31 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:259:20:259:25 | call to getenv | semmle.label | call to getenv |
+| test.cpp:259:20:259:33 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
+| test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
+| test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
+| test.cpp:289:17:289:20 | Chi | semmle.label | Chi |
+| test.cpp:289:17:289:20 | get_size output argument [array content] | semmle.label | get_size output argument [array content] |
+| test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:305:18:305:21 | Chi | semmle.label | Chi |
+| test.cpp:305:18:305:21 | get_size output argument [array content] | semmle.label | get_size output argument [array content] |
+| test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
+| test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
+| test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
 #select
-| test.cpp:42:31:42:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
-| test.cpp:43:31:43:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
-| test.cpp:45:31:45:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:45:38:45:63 | ... + ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
-| test.cpp:48:25:48:30 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
-| test.cpp:49:17:49:30 | new[] | test.cpp:39:21:39:24 | argv | test.cpp:49:26:49:29 | size | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
-| test.cpp:52:21:52:27 | call to realloc | test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
-| test.cpp:127:17:127:22 | call to malloc | test.cpp:123:18:123:23 | call to getenv | test.cpp:127:24:127:41 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:123:18:123:23 | call to getenv | user input (getenv) |
-| test.cpp:134:3:134:8 | call to malloc | test.cpp:132:19:132:24 | call to getenv | test.cpp:134:10:134:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:132:19:132:24 | call to getenv | user input (getenv) |
-| test.cpp:215:14:215:19 | call to malloc | test.cpp:227:24:227:29 | call to getenv | test.cpp:215:21:215:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:227:24:227:29 | call to getenv | user input (getenv) |
-| test.cpp:221:14:221:19 | call to malloc | test.cpp:227:24:227:29 | call to getenv | test.cpp:221:21:221:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:227:24:227:29 | call to getenv | user input (getenv) |
-| test.cpp:229:2:229:7 | call to malloc | test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | local_size | This allocation size is derived from $@ and might overflow | test.cpp:227:24:227:29 | call to getenv | user input (getenv) |
-| test.cpp:231:2:231:7 | call to malloc | test.cpp:201:14:201:19 | call to getenv | test.cpp:231:9:231:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow | test.cpp:201:14:201:19 | call to getenv | user input (getenv) |
-| test.cpp:253:4:253:9 | call to malloc | test.cpp:249:20:249:25 | call to getenv | test.cpp:253:11:253:29 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:249:20:249:25 | call to getenv | user input (getenv) |
-| test.cpp:281:4:281:9 | call to malloc | test.cpp:241:18:241:23 | call to getenv | test.cpp:281:11:281:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:241:18:241:23 | call to getenv | user input (getenv) |
-| test.cpp:298:3:298:8 | call to malloc | test.cpp:241:18:241:23 | call to getenv | test.cpp:298:10:298:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:241:18:241:23 | call to getenv | user input (getenv) |
+| test.cpp:43:31:43:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
+| test.cpp:44:31:44:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
+| test.cpp:46:31:46:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
+| test.cpp:49:25:49:30 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
+| test.cpp:50:17:50:30 | new[] | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
+| test.cpp:53:21:53:27 | call to realloc | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
+| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:124:18:124:23 | call to getenv | user input (getenv) |
+| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:133:19:133:24 | call to getenv | user input (getenv) |
+| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:148:20:148:25 | call to getenv | user input (getenv) |
+| test.cpp:225:14:225:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:225:21:225:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (getenv) |
+| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (getenv) |
+| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (getenv) |
+| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:19 | call to getenv | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow | test.cpp:211:14:211:19 | call to getenv | user input (getenv) |
+| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:259:20:259:25 | call to getenv | user input (getenv) |
+| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:251:18:251:23 | call to getenv | user input (getenv) |
+| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:251:18:251:23 | call to getenv | user input (getenv) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -87,6 +87,12 @@ edges
 | test.cpp:295:18:295:21 | Chi | test.cpp:298:10:298:27 | ... * ... |
 | test.cpp:295:18:295:21 | Chi | test.cpp:298:10:298:27 | ... * ... |
 | test.cpp:295:18:295:21 | get_size output argument [array content] | test.cpp:295:18:295:21 | Chi |
+| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | (size_t)... |
+| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | (size_t)... |
+| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | offset |
+| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | offset |
+| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | offset |
+| test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | offset |
 nodes
 | test.cpp:39:21:39:24 | argv | semmle.label | argv |
 | test.cpp:39:21:39:24 | argv | semmle.label | argv |
@@ -179,6 +185,13 @@ nodes
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
+| test.cpp:321:15:321:20 | call to getenv | semmle.label | call to getenv |
+| test.cpp:321:15:321:20 | call to getenv | semmle.label | call to getenv |
+| test.cpp:324:9:324:14 | (size_t)... | semmle.label | (size_t)... |
+| test.cpp:324:9:324:14 | (size_t)... | semmle.label | (size_t)... |
+| test.cpp:324:9:324:14 | offset | semmle.label | offset |
+| test.cpp:324:9:324:14 | offset | semmle.label | offset |
+| test.cpp:324:9:324:14 | offset | semmle.label | offset |
 #select
 | test.cpp:42:31:42:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:43:31:43:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
@@ -196,3 +209,4 @@ nodes
 | test.cpp:253:4:253:9 | call to malloc | test.cpp:249:20:249:25 | call to getenv | test.cpp:253:11:253:29 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:249:20:249:25 | call to getenv | user input (getenv) |
 | test.cpp:281:4:281:9 | call to malloc | test.cpp:241:18:241:23 | call to getenv | test.cpp:281:11:281:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:241:18:241:23 | call to getenv | user input (getenv) |
 | test.cpp:298:3:298:8 | call to malloc | test.cpp:241:18:241:23 | call to getenv | test.cpp:298:10:298:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:241:18:241:23 | call to getenv | user input (getenv) |
+| test.cpp:324:2:324:7 | call to malloc | test.cpp:321:15:321:20 | call to getenv | test.cpp:324:9:324:14 | offset | This allocation size is derived from $@ and might overflow | test.cpp:321:15:321:20 | call to getenv | user input (getenv) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
@@ -76,7 +76,7 @@ void processData2(char *start, char *end)
 {
 	char *copy;
 
-	copy = new char[end - start]; // GOOD [FALSE POSITIVE]
+	copy = new char[end - start]; // GOOD
 
 	// ...
 
@@ -321,5 +321,5 @@ void ptr_diff_case() {
 	char* user = getenv("USER");
 	char* admin_begin_pos = strstr(user, "ADMIN");
 	int offset = admin_begin_pos ? user - admin_begin_pos : 0; 
-	malloc(offset); // GOOD [FALSE POSITIVE]
+	malloc(offset); // GOOD
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
@@ -139,7 +139,7 @@ void more_bounded_tests() {
 
 		if (size > 0)
 		{
-			malloc(size * sizeof(int)); // BAD
+			malloc(size * sizeof(int)); // GOOD (overflow not possible)
 		}
 	}
 
@@ -302,7 +302,7 @@ void equality_cases() {
 
 		if ((size == 50) || (size == 100))
 		{
-			malloc(size * sizeof(int)); // GOOD [FALSE POSITIVE]
+			malloc(size * sizeof(int)); // GOOD
 		}
 	}
 	{
@@ -311,6 +311,6 @@ void equality_cases() {
 		if (size != 50 && size != 100)
 			return;
 
-		malloc(size * sizeof(int)); // GOOD [FALSE POSITIVE]
+		malloc(size * sizeof(int)); // GOOD
 	}
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
@@ -7,6 +7,7 @@ void *malloc(size_t size);
 void *realloc(void *ptr, size_t size);
 void free(void *ptr);
 int atoi(const char *nptr);
+long atol(const char *nptr);
 struct MyStruct
 {
 	char data[256];
@@ -140,6 +141,15 @@ void more_bounded_tests() {
 		if (size > 0)
 		{
 			malloc(size * sizeof(int)); // GOOD (overflow not possible)
+		}
+	}
+
+	{
+		long size = atol(getenv("USER"));
+
+		if (size > 0)
+		{
+			malloc(size * sizeof(int)); // BAD
 		}
 	}
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
@@ -314,3 +314,12 @@ void equality_cases() {
 		malloc(size * sizeof(int)); // GOOD
 	}
 }
+
+char * strstr(char *, const char *);
+
+void ptr_diff_case() {
+	char* user = getenv("USER");
+	char* admin_begin_pos = strstr(user, "ADMIN");
+	int offset = admin_begin_pos ? user - admin_begin_pos : 0; 
+	malloc(offset); // GOOD [FALSE POSITIVE]
+}


### PR DESCRIPTION
(Part of https://github.com/github/codeql-c-team/issues/272.)

This PR adds two barriers to `cpp/uncontrolled-allocation-size`:

- The first barrier (added in 5031b73f3509e4d1c1ce21586dd1262502177670) blocks flow out of arithmetic operations that we can prove won't overflow. This removes false positives in a couple of LGTM projects. When I compare [5031b73](https://lgtm.com/query/4264381093598795328/) to [main](https://lgtm.com/query/6134533116057054671/) we get:

| Project | Alerts with main | Alerts with 5031b73 |
|--------|--------|--------|
| openssl/openssl | 8 | 7 |
| gpac/gpac | 2 | 0 |
| libretro/RetroArch | 2 | 1 |
| axiomatic-systems/Bento4 | 1 | 0 |
| systemd/systemd | 11 | 9 | 
| rizinorg/cutter | 33 | 25 | 
| radareorg/radare2 | 29 | 22 | 
| haiku/haiku | 14 | 12 | 
| kernel.org/pub/scm/network/iproute2/iproute2-next | 3 | 1 | 
| Chia-Network/chiapos | 1 | 0 | 
| ArtifexSoftware/ghostpdl | 3 | 1 | 

- The second barrier (added in 2d0a56128d8f10acade04f99c73493671186d298) blocks flow out of `PointerDiffExpr`. This is quite a common cause of false positives for this query. When I compare [5031b73](https://lgtm.com/query/4264381093598795328/) to [2d0a561](https://lgtm.com/query/6799893794923674095/)) we get:

| Project | Alerts with 5031b73 | Alerts with 2d0a561 |
|--------|--------|--------|
vim/vim | 1 | 0
openssl/openssl | 7 | 0
git/git | 1 | 0
lxc/lxc | 1 | 0
alibaba/AliSQL | 1 | 0
apache/trafficserver | 2 | 1
stellar/stellar-core | 3 | 0
systemd/systemd | 9 | 6
nmap/nmap | 1 | 0
cfengine/core | 2 | 1
rizinorg/cutter | 25 | 24
haiku/haiku | 12 | 10
horms/openvswitch | 1 | 0
trini/u-boot | 1 | 0
FreeRADIUS/freeradius-server | 1 | 0
ArtifexSoftware/ghostpdl | 1 | 0

This change doesn't seem to affect SAMATE.