### PR TITLE
Code Scanning selectors: Include diagnostic queries

### DIFF
--- a/misc/suite-helpers/code-scanning-selectors.yml
+++ b/misc/suite-helpers/code-scanning-selectors.yml
@@ -15,6 +15,9 @@
     - security
 - include:
     kind:
+    - diagnostic
+- include:
+    kind:
     - metric
     tags contain:
     - summary


### PR DESCRIPTION
This PR updates the code scanning selectors to include diagnostic queries like extractor error messages.  This will mean we start analyzing these queries on Code Scanning by default.