### PR TITLE
C++: Add ref qualifiers

### DIFF
--- a/cpp/change-notes/2021-05-20-ref-qualifiers.md
+++ b/cpp/change-notes/2021-05-20-ref-qualifiers.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* lvalue/rvalue ref qualifiers are now accessible via the new predicates on `MemberFunction`(`.isLValueRefQualified`, `.isRValueRefQualified`, and `isRefQualified`).

--- a/cpp/ql/src/semmle/code/cpp/MemberFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/MemberFunction.qll
@@ -48,6 +48,15 @@ class MemberFunction extends Function {
   /** Holds if this member is public. */
   predicate isPublic() { this.hasSpecifier("public") }
 
+  /** Holds if this declaration has the lvalue ref-qualifier */
+  predicate isLValueRefQualified() { hasSpecifier("&") }
+
+  /** Holds if this declaration has the rvalue ref-qualifier */
+  predicate isRValueRefQualified() { hasSpecifier("&&") }
+
+  /** Holds if this declaration has a ref-qualifier */
+  predicate isRefQualified() { isLValueRefQualified() or isRValueRefQualified() }
+
   /** Holds if this function overrides that function. */
   predicate overrides(MemberFunction that) {
     overrides(underlyingElement(this), unresolveElement(that))

--- a/cpp/ql/test/library-tests/clang_ms/element.expected
+++ b/cpp/ql/test/library-tests/clang_ms/element.expected
@@ -26,6 +26,8 @@
 | clang_ms.cpp:17:1:17:32 | #pragma |
 | clang_ms.cpp:18:1:18:31 | #pragma |
 | file://:0:0:0:0 |  |
+| file://:0:0:0:0 | & |
+| file://:0:0:0:0 | && |
 | file://:0:0:0:0 | (global namespace) |
 | file://:0:0:0:0 | (unnamed parameter 0) |
 | file://:0:0:0:0 | (unnamed parameter 0) |

--- a/cpp/ql/test/library-tests/conditions/elements.expected
+++ b/cpp/ql/test/library-tests/conditions/elements.expected
@@ -1,4 +1,6 @@
 | file://:0:0:0:0 |  |
+| file://:0:0:0:0 | & |
+| file://:0:0:0:0 | && |
 | file://:0:0:0:0 | (global namespace) |
 | file://:0:0:0:0 | (unnamed parameter 0) |
 | file://:0:0:0:0 | (unnamed parameter 0) |

--- a/cpp/ql/test/library-tests/templates/instantiations_functions/elements.expected
+++ b/cpp/ql/test/library-tests/templates/instantiations_functions/elements.expected
@@ -1,4 +1,6 @@
 | file://:0:0:0:0 |  |
+| file://:0:0:0:0 | & |
+| file://:0:0:0:0 | && |
 | file://:0:0:0:0 | (composite<int> *)... |
 | file://:0:0:0:0 | (composite<int> *)... |
 | file://:0:0:0:0 | (global namespace) |

--- a/cpp/ql/test/library-tests/unnamed/elements.expected
+++ b/cpp/ql/test/library-tests/unnamed/elements.expected
@@ -1,4 +1,6 @@
 | file://:0:0:0:0 |  | Other |
+| file://:0:0:0:0 | & | Other |
+| file://:0:0:0:0 | && | Other |
 | file://:0:0:0:0 | (global namespace) | Other |
 | file://:0:0:0:0 | (unnamed global/namespace variable) | Other |
 | file://:0:0:0:0 | _Complex __float128 | Other |


### PR DESCRIPTION
This PR adds a notion of [ref-qualifiers](https://en.cppreference.com/w/cpp/language/member_functions#ref-qualified_member_functions).
This is a work in progress since I first wanted to ~bikeshed~ discuss the right place (`Declaration` or `MemberFunction`), the right predicate names (`isLValueQualified`? `isLValueRefQualified`? etc.), and the right specifier names 😄 

Any suggestions for better QL are also welcome :)
