### PR TITLE
C++: Add range analysis to `cpp/static-buffer-overflow`

### DIFF
--- a/cpp/change-notes/2021-05-18-static-buffer-overflow.md
+++ b/cpp/change-notes/2021-05-18-static-buffer-overflow.md
@@ -1,0 +1,2 @@
+lgtm
+* The "Static buffer overflow" query (cpp/static-buffer-overflow) has been improved to produce fewer false positives.

--- a/cpp/ql/src/Critical/OverflowStatic.ql
+++ b/cpp/ql/src/Critical/OverflowStatic.ql
@@ -101,7 +101,7 @@ class CallWithBufferSize extends FunctionCall {
     // result in this case we pick the minimum value obtainable from dataflow and range analysis.
     result =
       upperBound(statedSizeExpr())
-          .minimum(any(Expr statedSizeSrc |
+          .minimum(min(Expr statedSizeSrc |
               DataFlow::localExprFlow(statedSizeSrc, statedSizeExpr())
             |
               statedSizeSrc.getValue().toInt()
@@ -112,7 +112,7 @@ class CallWithBufferSize extends FunctionCall {
 predicate wrongBufferSize(Expr error, string msg) {
   exists(CallWithBufferSize call, int bufsize, Variable buf, int statedSize |
     staticBuffer(call.buffer(), buf, bufsize) and
-    statedSize = min(call.statedSizeValue()) and
+    statedSize = call.statedSizeValue() and
     statedSize > bufsize and
     error = call.statedSizeExpr() and
     msg =

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowStatic.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowStatic.expected
@@ -5,8 +5,6 @@
 | tests.cpp:245:42:245:42 | 6 | Potential buffer-overflow: 'global_array_5' has size 5 not 6. |
 | tests.cpp:349:2:349:14 | access to array | Potential buffer-overflow: 'charArray' has size 10 but 'charArray[10]' is accessed here. |
 | tests.cpp:350:17:350:29 | access to array | Potential buffer-overflow: 'charArray' has size 10 but 'charArray[10]' is accessed here. |
-| tests.cpp:594:4:594:12 | access to array | Potential buffer-overflow: counter 'k' <= 100 but 'buffer' has 16 elements. |
-| tests.cpp:603:24:603:24 | n | Potential buffer-overflow: 'dest' has size 128 not 132. |
 | var_size_struct.cpp:54:5:54:14 | access to array | Potential buffer-overflow: 'str' has size 1 but 'str[1]' is accessed here. |
 | var_size_struct.cpp:55:5:55:14 | access to array | Potential buffer-overflow: 'str' has size 1 but 'str[1]' is accessed here. |
 | var_size_struct.cpp:103:39:103:41 | 129 | Potential buffer-overflow: 'str' has size 128 not 129. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowStatic.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowStatic.expected
@@ -5,6 +5,8 @@
 | tests.cpp:245:42:245:42 | 6 | Potential buffer-overflow: 'global_array_5' has size 5 not 6. |
 | tests.cpp:349:2:349:14 | access to array | Potential buffer-overflow: 'charArray' has size 10 but 'charArray[10]' is accessed here. |
 | tests.cpp:350:17:350:29 | access to array | Potential buffer-overflow: 'charArray' has size 10 but 'charArray[10]' is accessed here. |
+| tests.cpp:594:4:594:12 | access to array | Potential buffer-overflow: counter 'k' <= 100 but 'buffer' has 16 elements. |
+| tests.cpp:603:24:603:24 | n | Potential buffer-overflow: 'dest' has size 128 not 132. |
 | var_size_struct.cpp:54:5:54:14 | access to array | Potential buffer-overflow: 'str' has size 1 but 'str[1]' is accessed here. |
 | var_size_struct.cpp:55:5:55:14 | access to array | Potential buffer-overflow: 'str' has size 1 but 'str[1]' is accessed here. |
 | var_size_struct.cpp:103:39:103:41 | 129 | Potential buffer-overflow: 'str' has size 128 not 129. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
@@ -586,6 +586,23 @@ void test21(bool cond)
 	if (ptr[-1] == 0) { return; } // GOOD: accesses buffer[1]
 }
 
+void test22(bool b, const char* source) {
+	char buffer[16];
+	int k;
+	for (k = 0; k <= 100; k++) {
+		if(k < 16) {
+			buffer[k] = 'x'; // GOOD [FALSE POSITIVE]
+		}
+	}
+
+	char dest[128];
+	int n = b ? 1024 : 132;
+	if (n >= 128) {
+    return;
+  }
+  memcpy(dest, source, n); // GOOD [FALSE POSITIVE]
+}
+
 int main(int argc, char *argv[])
 {
 	long long arr17[19];
@@ -609,6 +626,7 @@ int main(int argc, char *argv[])
 	test19(argc == 0);
 	test20();
 	test21(argc == 0);
+	test22(argc == 0, argv[0]);
 
 	return 0;
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
@@ -591,7 +591,7 @@ void test22(bool b, const char* source) {
 	int k;
 	for (k = 0; k <= 100; k++) {
 		if(k < 16) {
-			buffer[k] = 'x'; // GOOD [FALSE POSITIVE]
+			buffer[k] = 'x'; // GOOD
 		}
 	}
 
@@ -600,7 +600,7 @@ void test22(bool b, const char* source) {
 	if (n >= 128) {
     return;
   }
-  memcpy(dest, source, n); // GOOD [FALSE POSITIVE]
+  memcpy(dest, source, n); // GOOD
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
(Part of https://github.com/github/codeql-c-analysis-team/issues/191.)

This PR uses range analysis to filter out false positives in 2 out of the 3 kinds of problems identified by `cpp/static-buffer-overflow`.

It does remove a couple of false positives on our usual list of LGTM projects: https://lgtm.com/query/3164577302384476236/. Hopefully, once this PR is merged, we can see what the next class of low-hanging fruit is after the next LGTM upgrade.