### PR TITLE
Python: Expand test of py/use-of-input

### DIFF
--- a/python/ql/test/2/query-tests/Expressions/UseofApply.expected
+++ b/python/ql/test/2/query-tests/Expressions/UseofApply.expected
@@ -1,2 +1,2 @@
 | UseofApply.py:19:3:19:17 | ControlFlowNode for apply() | Call to the obsolete builtin function 'apply'. |
-| expressions_test.py:3:5:3:21 | ControlFlowNode for apply() | Call to the obsolete builtin function 'apply'. |
+| expressions_test.py:2:5:2:21 | ControlFlowNode for apply() | Call to the obsolete builtin function 'apply'. |

--- a/python/ql/test/2/query-tests/Expressions/expressions_test.py
+++ b/python/ql/test/2/query-tests/Expressions/expressions_test.py
@@ -1,7 +1,18 @@
-
 def use_of_apply(func, args):
     apply(func, args)
 
-def use_of_input():
-    return input()
 
+def use_of_input():
+    return input() # NOT OK
+
+
+def not_use_of_input():
+    input = raw_input
+    return input() # OK
+
+
+if __name__ == "__main__":
+    # if you enter 4+4 each time, you'll see that results are: 8, '4+4', 8
+    print("result:", use_of_input())
+    print("result:", not_use_of_input())
+    print("result:", use_of_input())


### PR DESCRIPTION
I had these expanded tests lying around. I thought they were useful to see that the porting of the query from https://github.com/github/codeql/pull/5880 does _actually_ handle the case of `input = raw_input` :+1: