### PR TITLE
C#: Various CFG related performance tweaks

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
@@ -403,7 +403,7 @@ private module JoinBlockPredecessors {
   private import semmle.code.csharp.controlflow.internal.ControlFlowGraphImpl
 
   int getId(JoinBlockPredecessor jbp) {
-    exists(ControlFlowTree::Range t | ControlFlowTree::idOf(t, result) |
+    exists(ControlFlowTree::Range_ t | ControlFlowTree::idOf(t, result) |
       t = jbp.getFirstNode().getElement()
       or
       t = jbp.(EntryBasicBlock).getCallable()

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
@@ -2,6 +2,7 @@
 
 import csharp
 private import semmle.code.csharp.ExprOrStmtParent
+private import semmle.code.csharp.commons.Compilation
 private import ControlFlow
 private import ControlFlow::BasicBlocks
 private import SuccessorTypes
@@ -22,7 +23,12 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
   Callable getEnclosingCallable() { none() }
 
   /** Gets the assembly that this element was compiled into. */
-  Assembly getAssembly() { result = this.getEnclosingCallable().getDeclaringType().getALocation() }
+  Assembly getAssembly() {
+    exists(Compilation c |
+      c.getAFileCompiled() = this.getFile() and
+      result = c.getOutputAssembly()
+    )
+  }
 
   /**
    * Gets a control flow node for this element. That is, a node in the

--- a/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
@@ -1466,8 +1466,10 @@ module Internal {
         PreSsa::Definition def, AssignableRead read
       ) {
         read = def.getAFirstRead() and
-        not exists(AssignableRead other | PreSsa::adjacentReadPairSameVar(other, read) |
-          other != read
+        (
+          not PreSsa::adjacentReadPairSameVar(_, read)
+          or
+          read = unique(AssignableRead read0 | PreSsa::adjacentReadPairSameVar(read0, read))
         )
       }
 
@@ -1651,10 +1653,14 @@ module Internal {
         AssignableRead read1, AssignableRead read2
       ) {
         PreSsa::adjacentReadPairSameVar(read1, read2) and
-        not exists(AssignableRead other |
-          PreSsa::adjacentReadPairSameVar(other, read2) and
-          other != read1 and
-          other != read2
+        (
+          read1 = read2 and
+          read1 = unique(AssignableRead other | PreSsa::adjacentReadPairSameVar(other, read2))
+          or
+          read1 =
+            unique(AssignableRead other |
+              PreSsa::adjacentReadPairSameVar(other, read2) and other != read2
+            )
         )
       }
 
@@ -1887,10 +1893,14 @@ module Internal {
       Ssa::Definition def, ControlFlow::Node cfn1, ControlFlow::Node cfn2
     ) {
       SsaImpl::adjacentReadPairSameVar(def, cfn1, cfn2) and
-      not exists(ControlFlow::Node other |
-        SsaImpl::adjacentReadPairSameVar(def, other, cfn2) and
-        other != cfn1 and
-        other != cfn2
+      (
+        cfn1 = cfn2 and
+        cfn1 = unique(ControlFlow::Node other | SsaImpl::adjacentReadPairSameVar(def, other, cfn2))
+        or
+        cfn1 =
+          unique(ControlFlow::Node other |
+            SsaImpl::adjacentReadPairSameVar(def, other, cfn2) and other != cfn2
+          )
       )
     }
 

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
@@ -77,7 +77,7 @@ class CfgScope extends Element, @top_level_exprorstmt_parent {
 }
 
 module ControlFlowTree {
-  private class Range_ = @callable or @control_flow_element;
+  class Range_ = @callable or @control_flow_element;
 
   class Range extends Element, Range_ {
     Range() { this = getAChild*(any(CfgScope scope)) }
@@ -88,9 +88,9 @@ module ControlFlowTree {
     result = p.(AssignOperation).getExpandedAssignment()
   }
 
-  private predicate id(Range x, Range y) { x = y }
+  private predicate id(Range_ x, Range_ y) { x = y }
 
-  predicate idOf(Range x, int y) = equivalenceRelation(id/2)(x, y)
+  predicate idOf(Range_ x, int y) = equivalenceRelation(id/2)(x, y)
 }
 
 abstract private class ControlFlowTree extends ControlFlowTree::Range {

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/NonReturning.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/NonReturning.qll
@@ -39,8 +39,10 @@ private class ThrowingCall extends NonReturningCall {
       or
       this.(FailingAssertion).getAssertionFailure().isException(c.getExceptionClass())
       or
-      exists(CIL::Method m, CIL::Type ex |
-        this.getTarget().matchesHandle(m) and
+      exists(Callable target, CIL::Method m, CIL::Type ex |
+        target = this.getTarget() and
+        not target.hasBody() and
+        target.matchesHandle(m) and
         alwaysThrowsException(m, ex) and
         c.getExceptionClass().matchesHandle(ex) and
         not m.isVirtual()

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/ModulusAnalysisSpecific.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/ModulusAnalysisSpecific.qll
@@ -49,7 +49,7 @@ module Private {
   }
 
   int getId(PhiInputEdgeBlock bb) {
-    exists(CfgImpl::ControlFlowTree::Range t | CfgImpl::ControlFlowTree::idOf(t, result) |
+    exists(CfgImpl::ControlFlowTree::Range_ t | CfgImpl::ControlFlowTree::idOf(t, result) |
       t = bb.getFirstNode().getElement()
       or
       t = bb.(CS::ControlFlow::BasicBlocks::EntryBlock).getCallable()


### PR DESCRIPTION
- Commit 1: Enforce early join on `succ` in `SplitImpl::hasSuccessor`.
- Commit 2: Use `unique` in place of `forall` to avoid large Cartesian products.
- Commit 3: Use `Compilation::getOutputAssembly()` to simplify `ControlFlowElement::getAssembly()`. This change is strictly speaking not needed, because Commit 4 removes the use of `ControlFlowElement::getAssembly()`, but it is a nice improvement regardless.
- Commit 4: Remove complexity introduced on https://github.com/github/codeql/pull/990, since we can no longer have multiple corelibs (https://github.com/github/codeql/pull/4017).
- Commit 5: Avoid recomputing a potentially expensive `boundedFastTC` relation multiple times.
- Commit 6: This commit removes some false-positives on `mono/mono` and `dotnet/runtime` that were uncovered by Commit 4. (Commit 4 meant that some code that previously did not have a CFG now does.)

~https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1087/~
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1093/

These changes mostly make a difference for Extremely Big databases.