### PR TITLE
Java: Improve performance of virtual dispatch calculation.

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowDispatch.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowDispatch.qll
@@ -106,7 +106,7 @@ private module DispatchImpl {
       mayBenefitFromCallContext(ma, c, i) and
       c = viableCallable(ctx) and
       contextArgHasType(ctx, i, t, exact) and
-      ma.getMethod() = def
+      ma.getMethod().getSourceDeclaration() = def
     |
       exact = true and result = VirtualDispatch::exactMethodImpl(def, t.getSourceDeclaration())
       or

--- a/java/ql/src/semmle/code/java/dispatch/VirtualDispatch.qll
+++ b/java/ql/src/semmle/code/java/dispatch/VirtualDispatch.qll
@@ -39,9 +39,12 @@ Callable viableCallable(Call c) {
   c instanceof ConstructorCall and result = c.getCallee().getSourceDeclaration()
 }
 
-/** A method that is the target of a call. */
-class CalledMethod extends Method {
-  CalledMethod() { exists(MethodAccess ma | ma.getMethod() = this) }
+/** The source declaration of a method that is the target of a virtual call. */
+class VirtCalledSrcMethod extends SrcMethod {
+  pragma[nomagic]
+  VirtCalledSrcMethod() {
+    exists(VirtualMethodAccess ma | ma.getMethod().getSourceDeclaration() = this)
+  }
 }
 
 cached
@@ -185,8 +188,8 @@ private module Dispatch {
     not result.isAbstract() and
     if source instanceof VirtualMethodAccess
     then
-      exists(CalledMethod def, RefType t, boolean exact |
-        source.getMethod() = def and
+      exists(VirtCalledSrcMethod def, RefType t, boolean exact |
+        source.getMethod().getSourceDeclaration() = def and
         hasQualifierType(source, t, exact)
       |
         exact = true and result = exactMethodImpl(def, t.getSourceDeclaration())
@@ -301,14 +304,14 @@ private module Dispatch {
 
   /** Gets the implementation of `top` present on a value of precisely type `t`. */
   cached
-  Method exactMethodImpl(CalledMethod top, SrcRefType t) {
+  Method exactMethodImpl(VirtCalledSrcMethod top, SrcRefType t) {
     hasSrcMethod(t, result) and
-    top.getAPossibleImplementation() = result
+    top.getAPossibleImplementationOfSrcMethod() = result
   }
 
   /** Gets the implementations of `top` present on viable subtypes of `t`. */
   cached
-  Method viableMethodImpl(CalledMethod top, SrcRefType tsrc, RefType t) {
+  Method viableMethodImpl(VirtCalledSrcMethod top, SrcRefType tsrc, RefType t) {
     exists(SrcRefType sub |
       result = exactMethodImpl(top, sub) and
       tsrc = t.getSourceDeclaration() and

--- a/java/ql/src/semmle/code/java/dispatch/VirtualDispatch.qll
+++ b/java/ql/src/semmle/code/java/dispatch/VirtualDispatch.qll
@@ -76,7 +76,7 @@ private module Dispatch {
     (
       exists(Method def, RefType t, boolean exact |
         qualType(ma, t, exact) and
-        def = ma.getMethod()
+        def = ma.getMethod().getSourceDeclaration()
       |
         exact = true and result = exactMethodImpl(def, t.getSourceDeclaration())
         or


### PR DESCRIPTION
The predicate `getAPossibleImplementation()` is implemented as
```ql
  SrcMethod getAPossibleImplementation() {
    this.getSourceDeclaration().getAPossibleImplementationOfSrcMethod() = result
  }
```
so this small change merely moves the `.getSourceDeclaration()` join and should be completely behaviour-preserving (there's also a little bit of magic added through `VirtualMethodAccess`).
The performance impact is, however, potentially huge. On a test project using lots of protobuf, the `viableMethodImpl` goes from being infeasibly slow, to evaluating in less than a second.