### PR TITLE
C#: Encode `"` in `BuildDisplayName`

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -373,7 +373,7 @@ namespace Semmle.Extraction.CSharp
                         var elementType = array.ElementType;
                         if (elementType.MetadataName.Contains("`"))
                         {
-                            trapFile.Write(elementType.Name);
+                            trapFile.Write(TrapExtensions.EncodeString(elementType.Name));
                             return;
                         }
                         elementType.BuildDisplayName(cx, trapFile);
@@ -480,7 +480,7 @@ namespace Semmle.Extraction.CSharp
             }
             else
             {
-                trapFile.Write(namedType.Name);
+                trapFile.Write(TrapExtensions.EncodeString(namedType.Name));
             }
 
             if (namedType.IsGenericType && namedType.TypeKind != TypeKind.Error && namedType.TypeArguments.Any())

--- a/csharp/extractor/Semmle.Extraction/TrapExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction/TrapExtensions.cs
@@ -117,7 +117,7 @@ namespace Semmle.Extraction
             return s;
         }
 
-        private static string EncodeString(string s) => s.Replace("\"", "\"\"");
+        public static string EncodeString(string s) => s.Replace("\"", "\"\"");
 
         /// <summary>
         /// Output a string to the trap file, such that the encoded output does not exceed


### PR DESCRIPTION
Apparently, compiler-generated type names may contain `"`, so we need to escape these before writing to TRAP.