### PR TITLE
JS: always have `arrayLikeElement` as TypeTracking properties

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/StepSummary.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/StepSummary.qll
@@ -27,6 +27,8 @@ private module Cached {
         SharedTypeTrackingStep::loadStoreStep(_, _, this, _)
         or
         SharedTypeTrackingStep::loadStoreStep(_, _, _, this)
+        or
+        this = DataFlow::PseudoProperties::arrayLikeElement()
       }
     }
 


### PR DESCRIPTION
Regains TP/TN for CVE-2018-1000620 

The `BadRandomness.ql` query [uses the `setElement` pseudo-property in a type-tracking predicate](https://github.com/github/codeql/blob/main/javascript/ql/src/Security/CWE-327/BadRandomness.ql#L73).  

But this pseudo-property [would only "be loaded"](https://github.com/github/codeql/blob/main/javascript/ql/src/semmle/javascript/dataflow/internal/StepSummary.qll#L14-L30) if there exists a shared type-tracking step that used this pseudo-property.  
That was not the case for CVE-2018-1000620.  

My fix is to always "load" the [`arrayLikeElement`](https://github.com/github/codeql/blob/main/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll#L812) pseudo-properties. 