### PR TITLE
CPP/Java: Fix getAPrimaryQlClass implementations

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Specifier.qll
+++ b/cpp/ql/src/semmle/code/cpp/Specifier.qll
@@ -37,7 +37,7 @@ class FunctionSpecifier extends Specifier {
     this.hasName("explicit")
   }
 
-  override string getAPrimaryQlClass() { result = "FunctionSpecifier)" }
+  override string getAPrimaryQlClass() { result = "FunctionSpecifier" }
 }
 
 /**

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -739,7 +739,7 @@ class LabeledStmt extends Stmt, @labeledstmt {
   /** This statement's Halstead ID (used to compute Halstead metrics). */
   override string getHalsteadID() { result = this.getLabel() + ":" }
 
-  override string getAPrimaryQlClass() { result = "LabelStmt" }
+  override string getAPrimaryQlClass() { result = "LabeledStmt" }
 }
 
 /** An `assert` statement. */


### PR DESCRIPTION
Found using QL-for-QL