### PR TITLE
Python: Treat `py/summary/lines-of-user-code` as the primary summary metric

### DIFF
--- a/python/ql/src/Summary/LinesOfCode.ql
+++ b/python/ql/src/Summary/LinesOfCode.ql
@@ -5,7 +5,6 @@
  *   database. This query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
- *       lines-of-code
  * @id py/summary/lines-of-code
  */
 

--- a/python/ql/src/Summary/LinesOfUserCode.ql
+++ b/python/ql/src/Summary/LinesOfUserCode.ql
@@ -7,6 +7,7 @@
  *   be counted as user written code.
  * @kind metric
  * @tags summary
+ *       lines-of-code
  * @id py/summary/lines-of-user-code
  */
 


### PR DESCRIPTION
Move the `lines-of-code` tag from `py/summary/lines-of-code`.
Code Scanning will eventually look for this tag in the results.

The intent is to treat the number of lines of user code for Python as the summary of
how much code was analysed, ignoring both external libraries and generated code.
This matches the current baseline metric the CodeQL Action computes for Python.
We'll revisit this decision, and the baseline, if necessary.

@rneatherway @henrymercer @AlonaHlobina FYI