### PR TITLE
Improve error reporting in CI check for CSV coverage report comparison

### DIFF
--- a/misc/scripts/library-coverage/settings.py
+++ b/misc/scripts/library-coverage/settings.py
@@ -13,8 +13,10 @@ if sys.argv[0].endswith("generate-report.py"):
 if len(sys.argv) > index:
     data_prefix = sys.argv[index] + "/"
 
-documentation_folder = data_prefix + \
-    "{language}/documentation/library-coverage/"
+documentation_folder_no_prefix = "{language}/documentation/library-coverage/"
+documentation_folder = data_prefix + documentation_folder_no_prefix
 
-repo_output_rst = documentation_folder + "flow-model-coverage.rst"
-repo_output_csv = documentation_folder + "flow-model-coverage.csv"
+output_rst_file_name = "flow-model-coverage.rst"
+output_csv_file_name = "flow-model-coverage.csv"
+repo_output_rst = documentation_folder + output_rst_file_name
+repo_output_csv = documentation_folder + output_csv_file_name


### PR DESCRIPTION
This PR improves the error reporting in the CSV coverage CI job:
- Errors are reported in all files, and not only in the first failing one.
- Instructions are added how to get the updated CSV coverage report.
- The reported file paths are matching the ones in the repo, and not the full path used by the job (which is prefixed with `codeqlModels`).