### PR TITLE
C++: More `cpp/uncontrolled-arithmetic` improvements

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -18,16 +18,8 @@ import semmle.code.cpp.security.TaintTracking
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import TaintedWithPath
 
-string getAMinPattern() { result = ["%min%", "l%"] }
-
-string getAMaxPattern() { result = ["%max%", "%bound%", "h%"] }
-
 predicate isUnboundedRandCall(FunctionCall fc) {
-  exists(Function func | func = fc.getTarget() |
-    func.getName() = "rand" and
-    not bounded(fc) and
-    not func.getAParameter().getName().toLowerCase().matches([getAMinPattern(), getAMaxPattern()])
-  )
+  fc.getTarget().hasGlobalOrStdOrBslName("rand") and not bounded(fc)
 }
 
 /**

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -19,7 +19,11 @@ import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import TaintedWithPath
 
 predicate isUnboundedRandCall(FunctionCall fc) {
-  fc.getTarget().hasGlobalOrStdOrBslName("rand") and not bounded(fc)
+  exists(Function func | func = fc.getTarget() |
+    func.hasGlobalOrStdOrBslName("rand") and
+    not bounded(fc) and
+    func.getNumberOfParameters() = 0
+  )
 }
 
 /**

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -18,8 +18,16 @@ import semmle.code.cpp.security.TaintTracking
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import TaintedWithPath
 
+string getAMinPattern() { result = ["%min%", "l%"] }
+
+string getAMaxPattern() { result = ["%max%", "%bound%", "h%"] }
+
 predicate isUnboundedRandCall(FunctionCall fc) {
-  fc.getTarget().getName() = "rand" and not bounded(fc)
+  exists(Function func | func = fc.getTarget() |
+    func.getName() = "rand" and
+    not bounded(fc) and
+    not func.getAParameter().getName().toLowerCase().matches([getAMinPattern(), getAMaxPattern()])
+  )
 }
 
 /**
@@ -84,6 +92,10 @@ predicate bounded(Expr e) {
   boundedDiv(e, any(DivExpr div).getLeftOperand())
   or
   boundedDiv(e, any(AssignDivExpr div).getLValue())
+  or
+  boundedDiv(e, any(RShiftExpr shift).getLeftOperand())
+  or
+  boundedDiv(e, any(AssignRShiftExpr div).getLValue())
 }
 
 predicate isUnboundedRandCallOrParent(Expr e) {

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -36,14 +36,6 @@ edges
 | test.cpp:36:13:36:13 | Chi | test.cpp:37:7:37:7 | r |
 | test.cpp:36:13:36:13 | Chi | test.cpp:37:7:37:7 | r |
 | test.cpp:36:13:36:13 | get_rand3 output argument [array content] | test.cpp:36:13:36:13 | Chi |
-| test.cpp:45:11:45:14 | call to rand | test.cpp:46:3:46:3 | r |
-| test.cpp:45:11:45:14 | call to rand | test.cpp:46:3:46:3 | r |
-| test.cpp:45:11:45:14 | call to rand | test.cpp:46:3:46:3 | r |
-| test.cpp:45:11:45:14 | call to rand | test.cpp:46:3:46:3 | r |
-| test.cpp:48:24:48:27 | call to rand | test.cpp:49:2:49:11 | unsigned_r |
-| test.cpp:48:24:48:27 | call to rand | test.cpp:49:2:49:11 | unsigned_r |
-| test.cpp:48:24:48:27 | call to rand | test.cpp:49:2:49:11 | unsigned_r |
-| test.cpp:48:24:48:27 | call to rand | test.cpp:49:2:49:11 | unsigned_r |
 nodes
 | test.c:18:13:18:16 | call to rand | semmle.label | call to rand |
 | test.c:18:13:18:16 | call to rand | semmle.label | call to rand |
@@ -95,16 +87,6 @@ nodes
 | test.cpp:37:7:37:7 | r | semmle.label | r |
 | test.cpp:37:7:37:7 | r | semmle.label | r |
 | test.cpp:37:7:37:7 | r | semmle.label | r |
-| test.cpp:45:11:45:14 | call to rand | semmle.label | call to rand |
-| test.cpp:45:11:45:14 | call to rand | semmle.label | call to rand |
-| test.cpp:46:3:46:3 | r | semmle.label | r |
-| test.cpp:46:3:46:3 | r | semmle.label | r |
-| test.cpp:46:3:46:3 | r | semmle.label | r |
-| test.cpp:48:24:48:27 | call to rand | semmle.label | call to rand |
-| test.cpp:48:24:48:27 | call to rand | semmle.label | call to rand |
-| test.cpp:49:2:49:11 | unsigned_r | semmle.label | unsigned_r |
-| test.cpp:49:2:49:11 | unsigned_r | semmle.label | unsigned_r |
-| test.cpp:49:2:49:11 | unsigned_r | semmle.label | unsigned_r |
 #select
 | test.c:21:17:21:17 | r | test.c:18:13:18:16 | call to rand | test.c:21:17:21:17 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:18:13:18:16 | call to rand | Uncontrolled value |
 | test.c:35:5:35:5 | r | test.c:34:13:34:18 | call to rand | test.c:35:5:35:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:34:13:34:18 | call to rand | Uncontrolled value |
@@ -114,5 +96,3 @@ nodes
 | test.cpp:25:7:25:7 | r | test.cpp:8:9:8:12 | call to rand | test.cpp:25:7:25:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:8:9:8:12 | call to rand | Uncontrolled value |
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | Uncontrolled value |
 | test.cpp:37:7:37:7 | r | test.cpp:18:9:18:12 | call to rand | test.cpp:37:7:37:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:18:9:18:12 | call to rand | Uncontrolled value |
-| test.cpp:46:3:46:3 | r | test.cpp:45:11:45:14 | call to rand | test.cpp:46:3:46:3 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:45:11:45:14 | call to rand | Uncontrolled value |
-| test.cpp:49:2:49:11 | unsigned_r | test.cpp:48:24:48:27 | call to rand | test.cpp:49:2:49:11 | unsigned_r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:48:24:48:27 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -36,6 +36,14 @@ edges
 | test.cpp:36:13:36:13 | Chi | test.cpp:37:7:37:7 | r |
 | test.cpp:36:13:36:13 | Chi | test.cpp:37:7:37:7 | r |
 | test.cpp:36:13:36:13 | get_rand3 output argument [array content] | test.cpp:36:13:36:13 | Chi |
+| test.cpp:45:11:45:14 | call to rand | test.cpp:46:3:46:3 | r |
+| test.cpp:45:11:45:14 | call to rand | test.cpp:46:3:46:3 | r |
+| test.cpp:45:11:45:14 | call to rand | test.cpp:46:3:46:3 | r |
+| test.cpp:45:11:45:14 | call to rand | test.cpp:46:3:46:3 | r |
+| test.cpp:48:24:48:27 | call to rand | test.cpp:49:2:49:11 | unsigned_r |
+| test.cpp:48:24:48:27 | call to rand | test.cpp:49:2:49:11 | unsigned_r |
+| test.cpp:48:24:48:27 | call to rand | test.cpp:49:2:49:11 | unsigned_r |
+| test.cpp:48:24:48:27 | call to rand | test.cpp:49:2:49:11 | unsigned_r |
 nodes
 | test.c:18:13:18:16 | call to rand | semmle.label | call to rand |
 | test.c:18:13:18:16 | call to rand | semmle.label | call to rand |
@@ -87,6 +95,16 @@ nodes
 | test.cpp:37:7:37:7 | r | semmle.label | r |
 | test.cpp:37:7:37:7 | r | semmle.label | r |
 | test.cpp:37:7:37:7 | r | semmle.label | r |
+| test.cpp:45:11:45:14 | call to rand | semmle.label | call to rand |
+| test.cpp:45:11:45:14 | call to rand | semmle.label | call to rand |
+| test.cpp:46:3:46:3 | r | semmle.label | r |
+| test.cpp:46:3:46:3 | r | semmle.label | r |
+| test.cpp:46:3:46:3 | r | semmle.label | r |
+| test.cpp:48:24:48:27 | call to rand | semmle.label | call to rand |
+| test.cpp:48:24:48:27 | call to rand | semmle.label | call to rand |
+| test.cpp:49:2:49:11 | unsigned_r | semmle.label | unsigned_r |
+| test.cpp:49:2:49:11 | unsigned_r | semmle.label | unsigned_r |
+| test.cpp:49:2:49:11 | unsigned_r | semmle.label | unsigned_r |
 #select
 | test.c:21:17:21:17 | r | test.c:18:13:18:16 | call to rand | test.c:21:17:21:17 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:18:13:18:16 | call to rand | Uncontrolled value |
 | test.c:35:5:35:5 | r | test.c:34:13:34:18 | call to rand | test.c:35:5:35:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:34:13:34:18 | call to rand | Uncontrolled value |
@@ -96,3 +114,5 @@ nodes
 | test.cpp:25:7:25:7 | r | test.cpp:8:9:8:12 | call to rand | test.cpp:25:7:25:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:8:9:8:12 | call to rand | Uncontrolled value |
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | Uncontrolled value |
 | test.cpp:37:7:37:7 | r | test.cpp:18:9:18:12 | call to rand | test.cpp:37:7:37:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:18:9:18:12 | call to rand | Uncontrolled value |
+| test.cpp:46:3:46:3 | r | test.cpp:45:11:45:14 | call to rand | test.cpp:46:3:46:3 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:45:11:45:14 | call to rand | Uncontrolled value |
+| test.cpp:49:2:49:11 | unsigned_r | test.cpp:48:24:48:27 | call to rand | test.cpp:49:2:49:11 | unsigned_r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:48:24:48:27 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
@@ -43,8 +43,8 @@ unsigned rand(int max);
 
 void test_with_bounded_randomness() {
   int r = rand(0, 10);
-  r++; // GOOD [FALSE POSITIVE]
+  r++; // GOOD
 
 	unsigned unsigned_r = rand(10);
-	unsigned_r++; // GOOD [FALSE POSITIVE]
+	unsigned_r++; // GOOD
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
@@ -37,3 +37,14 @@ void randomTester2()
 		r = r + 100; // BAD
 	}
 }
+
+int rand(int min, int max);
+unsigned rand(int max);
+
+void test_with_bounded_randomness() {
+  int r = rand(0, 10);
+  r++; // GOOD [FALSE POSITIVE]
+
+	unsigned unsigned_r = rand(10);
+	unsigned_r++; // GOOD [FALSE POSITIVE]
+}


### PR DESCRIPTION
(Part of https://github.com/github/codeql-c-team/issues/272.)

This PR fixes two sources of false positives I've seen when inspecting the results for `cpp/uncontrolled-arithmetic` on [LGTM](https://lgtm.com/rules/2156240609/alerts/).

- First, we recognize right shifts as a barrier similar to how we recognize division as a barrier. This removes the FPs seen on [love2d/love](https://lgtm.com/projects/g/love2d/love/snapshot/457ba444aa4bfe22d71b396f9f456092e42fa87a/files/src/modules/graphics/ParticleSystem.cpp?sort=name&dir=ASC&mode=heatmap#xe21dd8136e8fdd49:1).
- Second, we check if the `rand()` call is given arguments that explicitly bound the return value. This is rather ad-hoc for now and should be improved by proper modeling of randomness at some point. It does remove many FPs on [gemrb/gemrb](https://lgtm.com/projects/g/gemrb/gemrb/snapshot/1369e9c0464623071fda6d88be2a675d672baae9/files/gemrb/core/Projectile.cpp?sort=name&dir=ASC&mode=heatmap#L157) (querying this project locally we go from 57 results to 0).