### PR TITLE
C#: Extract correct method symbol as target of extension method calls

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -250,10 +250,11 @@ namespace Semmle.Extraction.CSharp.Entities
                 case MethodKind.Constructor:
                     return Constructor.Create(cx, methodDecl);
                 case MethodKind.ReducedExtension:
-                    return OrdinaryMethod.Create(cx,
-                        methodDecl.ReducedFrom!.IsGenericMethod && methodDecl.TypeArguments.Any()
-                            ? methodDecl.ReducedFrom!.Construct(methodDecl.TypeArguments, methodDecl.TypeArgumentNullableAnnotations)
-                            : methodDecl.ReducedFrom!);
+                    if (SymbolEqualityComparer.Default.Equals(methodDecl, methodDecl.ConstructedFrom))
+                    {
+                        return OrdinaryMethod.Create(cx, methodDecl.ReducedFrom!);
+                    }
+                    return OrdinaryMethod.Create(cx, methodDecl.ReducedFrom!.Construct(methodDecl.TypeArguments, methodDecl.TypeArgumentNullableAnnotations));
                 case MethodKind.Ordinary:
                 case MethodKind.DelegateInvoke:
                     return OrdinaryMethod.Create(cx, methodDecl);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -272,6 +272,10 @@ namespace Semmle.Extraction.CSharp.Entities
                 case MethodKind.Constructor:
                     return Constructor.Create(cx, methodDecl);
                 case MethodKind.ReducedExtension:
+                    return OrdinaryMethod.Create(cx,
+                        methodDecl.ReducedFrom!.IsGenericMethod && methodDecl.TypeArguments.Any()
+                            ? methodDecl.ReducedFrom!.Construct(methodDecl.TypeArguments, methodDecl.TypeArgumentNullableAnnotations)
+                            : methodDecl.ReducedFrom!);
                 case MethodKind.Ordinary:
                 case MethodKind.DelegateInvoke:
                     return OrdinaryMethod.Create(cx, methodDecl);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
@@ -15,14 +15,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         protected override IMethodSymbol BodyDeclaringSymbol => Symbol.PartialImplementationPart ?? Symbol;
 
-        public IMethodSymbol SourceDeclaration
-        {
-            get
-            {
-                var reducedFrom = Symbol.ReducedFrom ?? Symbol;
-                return reducedFrom.OriginalDefinition;
-            }
-        }
+        public IMethodSymbol SourceDeclaration => Symbol.OriginalDefinition;
 
         public override Microsoft.CodeAnalysis.Location ReportingLocation => Symbol.GetSymbolLocation();
 
@@ -53,7 +46,15 @@ namespace Semmle.Extraction.CSharp.Entities
             ExtractCompilerGenerated(trapFile);
         }
 
-        public static new OrdinaryMethod Create(Context cx, IMethodSymbol method) => OrdinaryMethodFactory.Instance.CreateEntityFromSymbol(cx, method);
+        public static new OrdinaryMethod Create(Context cx, IMethodSymbol method)
+        {
+            if (method.MethodKind == MethodKind.ReducedExtension)
+            {
+                cx.Extractor.Logger.Log(Util.Logging.Severity.Warning, "Reduced extension method symbols should not be directly extracted.");
+            }
+
+            return OrdinaryMethodFactory.Instance.CreateEntityFromSymbol(cx, method);
+        }
 
         private class OrdinaryMethodFactory : CachedEntityFactory<IMethodSymbol, OrdinaryMethod>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Parameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Parameter.cs
@@ -27,20 +27,7 @@ namespace Semmle.Extraction.CSharp.Entities
             None, Ref, Out, Params, This, In
         }
 
-        protected virtual int Ordinal
-        {
-            get
-            {
-                // For some reason, methods of kind ReducedExtension
-                // omit the "this" parameter, so the parameters are
-                // actually numbered from 1.
-                // This is to be consistent from the original (unreduced) extension method.
-                var isReducedExtension =
-                    Symbol.ContainingSymbol is IMethodSymbol method &&
-                    method.MethodKind == MethodKind.ReducedExtension;
-                return Symbol.Ordinal + (isReducedExtension ? 1 : 0);
-            }
-        }
+        protected virtual int Ordinal => Symbol.Ordinal;
 
         private Kind ParamKind
         {
@@ -268,35 +255,6 @@ namespace Semmle.Extraction.CSharp.Entities
             public static VarargsParamFactory Instance { get; } = new VarargsParamFactory();
 
             public override VarargsParam Create(Context cx, Method init) => new VarargsParam(cx, init);
-        }
-    }
-
-    internal class ConstructedExtensionParameter : Parameter
-    {
-        private readonly ITypeSymbol constructedType;
-
-        private ConstructedExtensionParameter(Context cx, Method method, Parameter original)
-            : base(cx, original.Symbol, method, original)
-        {
-            constructedType = method.Symbol.ReceiverType!;
-        }
-
-        public override void Populate(TextWriter trapFile)
-        {
-            var typeKey = Type.Create(Context, constructedType);
-            trapFile.@params(this, Original.Symbol.Name, typeKey.TypeRef, 0, Kind.This, Parent!, Original);
-            trapFile.param_location(this, Original.Location);
-        }
-
-        public static ConstructedExtensionParameter Create(Context cx, Method method, Parameter parameter) =>
-            ExtensionParamFactory.Instance.CreateEntity(cx, (new SymbolEqualityWrapper(parameter.Symbol), new SymbolEqualityWrapper(method.Symbol.ReceiverType!)), (method, parameter));
-
-        private class ExtensionParamFactory : CachedEntityFactory<(Method, Parameter), ConstructedExtensionParameter>
-        {
-            public static ExtensionParamFactory Instance { get; } = new ExtensionParamFactory();
-
-            public override ConstructedExtensionParameter Create(Context cx, (Method, Parameter) init) =>
-                new ConstructedExtensionParameter(cx, init.Item1, init.Item2);
         }
     }
 }

--- a/csharp/ql/test/library-tests/extension-method-call/ExtensionMethodCalls.expected
+++ b/csharp/ql/test/library-tests/extension-method-call/ExtensionMethodCalls.expected
@@ -1,0 +1,40 @@
+methodCallTargets
+| methods.cs:19:13:19:22 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
+| methods.cs:20:13:20:27 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
+| methods.cs:21:13:21:30 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(double) |
+| methods.cs:22:13:22:33 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(object) |
+| methods.cs:23:13:23:34 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
+| methods.cs:24:13:24:39 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
+| methods.cs:25:13:25:42 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) |
+| methods.cs:26:13:26:45 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) |
+| methods.cs:28:13:28:22 | call to method Ext1 | methods.cs:10:28:10:31 | Ext1 | Ext1(string, int) |
+| methods.cs:29:13:29:34 | call to method Ext1 | methods.cs:10:28:10:31 | Ext1 | Ext1(string, int) |
+| methods.cs:31:13:31:21 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
+| methods.cs:32:13:32:26 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
+| methods.cs:33:13:33:22 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
+| methods.cs:34:13:34:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
+| methods.cs:35:13:35:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) |
+| methods.cs:36:13:36:33 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
+| methods.cs:37:13:37:38 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
+| methods.cs:38:13:38:34 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
+| methods.cs:39:13:39:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
+| methods.cs:40:13:40:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) |
+genericMethodCallTargets
+| methods.cs:19:13:19:22 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:20:13:20:27 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:21:13:21:30 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(double) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:22:13:22:33 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(object) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:23:13:23:34 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:24:13:24:39 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:25:13:25:42 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:26:13:26:45 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:31:13:31:21 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:32:13:32:26 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:33:13:33:22 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:34:13:34:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:35:13:35:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:36:13:36:33 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:37:13:37:38 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:38:13:38:34 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:39:13:39:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:40:13:40:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |

--- a/csharp/ql/test/library-tests/extension-method-call/ExtensionMethodCalls.expected
+++ b/csharp/ql/test/library-tests/extension-method-call/ExtensionMethodCalls.expected
@@ -1,8 +1,8 @@
 methodCallTargets
 | methods.cs:19:13:19:22 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
 | methods.cs:20:13:20:27 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
-| methods.cs:21:13:21:30 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(double) |
-| methods.cs:22:13:22:33 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(object) |
+| methods.cs:21:13:21:30 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) |
+| methods.cs:22:13:22:33 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) |
 | methods.cs:23:13:23:34 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
 | methods.cs:24:13:24:39 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
 | methods.cs:25:13:25:42 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) |
@@ -22,8 +22,8 @@ methodCallTargets
 genericMethodCallTargets
 | methods.cs:19:13:19:22 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
 | methods.cs:20:13:20:27 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
-| methods.cs:21:13:21:30 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(double) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
-| methods.cs:22:13:22:33 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(object) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:21:13:21:30 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:22:13:22:33 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
 | methods.cs:23:13:23:34 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
 | methods.cs:24:13:24:39 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
 | methods.cs:25:13:25:42 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |

--- a/csharp/ql/test/library-tests/extension-method-call/ExtensionMethodCalls.expected
+++ b/csharp/ql/test/library-tests/extension-method-call/ExtensionMethodCalls.expected
@@ -1,40 +1,42 @@
 methodCallTargets
-| methods.cs:19:13:19:22 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
-| methods.cs:20:13:20:27 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
-| methods.cs:21:13:21:30 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) |
-| methods.cs:22:13:22:33 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) |
-| methods.cs:23:13:23:34 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
-| methods.cs:24:13:24:39 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
-| methods.cs:25:13:25:42 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) |
-| methods.cs:26:13:26:45 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) |
-| methods.cs:28:13:28:22 | call to method Ext1 | methods.cs:10:28:10:31 | Ext1 | Ext1(string, int) |
-| methods.cs:29:13:29:34 | call to method Ext1 | methods.cs:10:28:10:31 | Ext1 | Ext1(string, int) |
-| methods.cs:31:13:31:21 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
-| methods.cs:32:13:32:26 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
-| methods.cs:33:13:33:22 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
-| methods.cs:34:13:34:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
-| methods.cs:35:13:35:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) |
-| methods.cs:36:13:36:33 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
-| methods.cs:37:13:37:38 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
-| methods.cs:38:13:38:34 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
-| methods.cs:39:13:39:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
-| methods.cs:40:13:40:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) |
+| methods.cs:14:60:14:73 | call to method Ext3 | methods.cs:14:28:14:34 | Ext3 | Ext3<T>(T, int) |
+| methods.cs:16:60:16:74 | call to method Ext4 | methods.cs:16:28:16:34 | Ext4 | Ext4<T>(T, int) |
+| methods.cs:23:13:23:22 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
+| methods.cs:24:13:24:27 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
+| methods.cs:25:13:25:30 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) |
+| methods.cs:26:13:26:33 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) |
+| methods.cs:27:13:27:34 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
+| methods.cs:28:13:28:39 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) |
+| methods.cs:29:13:29:42 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) |
+| methods.cs:30:13:30:45 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) |
+| methods.cs:32:13:32:22 | call to method Ext1 | methods.cs:10:28:10:31 | Ext1 | Ext1(string, int) |
+| methods.cs:33:13:33:34 | call to method Ext1 | methods.cs:10:28:10:31 | Ext1 | Ext1(string, int) |
+| methods.cs:35:13:35:21 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
+| methods.cs:36:13:36:26 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
+| methods.cs:37:13:37:22 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
+| methods.cs:38:13:38:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
+| methods.cs:39:13:39:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) |
+| methods.cs:40:13:40:33 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
+| methods.cs:41:13:41:38 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) |
+| methods.cs:42:13:42:34 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
+| methods.cs:43:13:43:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) |
+| methods.cs:44:13:44:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) |
 genericMethodCallTargets
-| methods.cs:19:13:19:22 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
-| methods.cs:20:13:20:27 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
-| methods.cs:21:13:21:30 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
-| methods.cs:22:13:22:33 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
-| methods.cs:23:13:23:34 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
-| methods.cs:24:13:24:39 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
-| methods.cs:25:13:25:42 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
-| methods.cs:26:13:26:45 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
-| methods.cs:31:13:31:21 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
-| methods.cs:32:13:32:26 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
-| methods.cs:33:13:33:22 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
-| methods.cs:34:13:34:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
-| methods.cs:35:13:35:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
-| methods.cs:36:13:36:33 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
-| methods.cs:37:13:37:38 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
-| methods.cs:38:13:38:34 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
-| methods.cs:39:13:39:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
-| methods.cs:40:13:40:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:23:13:23:22 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:24:13:24:27 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:25:13:25:30 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:26:13:26:33 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:27:13:27:34 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:28:13:28:39 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<int>(string, int) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:29:13:29:42 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<double>(string, double) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:30:13:30:45 | call to method Ext0 | methods.cs:8:28:8:34 | Ext0 | Ext0<object>(string, object) | methods.cs:8:28:8:34 | Ext0 | Ext0<T>(string, T) |
+| methods.cs:35:13:35:21 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:36:13:36:26 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:37:13:37:22 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:38:13:38:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:39:13:39:30 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:40:13:40:33 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:41:13:41:38 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<int>(int, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:42:13:42:34 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:43:13:43:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<string>(string, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |
+| methods.cs:44:13:44:42 | call to method Ext2 | methods.cs:12:28:12:34 | Ext2 | Ext2<object>(object, int) | methods.cs:12:28:12:34 | Ext2 | Ext2<T>(T, int) |

--- a/csharp/ql/test/library-tests/extension-method-call/ExtensionMethodCalls.ql
+++ b/csharp/ql/test/library-tests/extension-method-call/ExtensionMethodCalls.ql
@@ -1,0 +1,14 @@
+import csharp
+
+query predicate methodCallTargets(MethodCall mc, Method m, string sig) {
+  m = mc.getTarget() and sig = m.toStringWithTypes()
+}
+
+query predicate genericMethodCallTargets(
+  MethodCall mc, ConstructedMethod cm, string sig1, UnboundGenericMethod ugm, string sig2
+) {
+  cm = mc.getTarget() and
+  sig1 = cm.toStringWithTypes() and
+  ugm = cm.getUnboundGeneric() and
+  sig2 = ugm.toStringWithTypes()
+}

--- a/csharp/ql/test/library-tests/extension-method-call/methods.cs
+++ b/csharp/ql/test/library-tests/extension-method-call/methods.cs
@@ -10,6 +10,10 @@ namespace Test
         public static void Ext1(this string self, int arg) { }
 
         public static void Ext2<T>(this T self, int arg) { }
+
+        public static void Ext3<T>(this T self, int arg) { self.Ext3(arg); }
+
+        public static void Ext4<T>(this T self, int arg) { Ext4(self, arg); }
     }
 
     public class Program

--- a/csharp/ql/test/library-tests/extension-method-call/methods.cs
+++ b/csharp/ql/test/library-tests/extension-method-call/methods.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Test
+{
+
+    public static class Extensions
+    {
+        public static void Ext0<T>(this string self, T arg) { }
+
+        public static void Ext1(this string self, int arg) { }
+
+        public static void Ext2<T>(this T self, int arg) { }
+    }
+
+    public class Program
+    {
+        public static void M()
+        {
+            "".Ext0(1);
+            "".Ext0<int>(1);
+            "".Ext0<double>(1);
+            "".Ext0<object>(null);
+            Extensions.Ext0("", 1);
+            Extensions.Ext0<int>("", 1);
+            Extensions.Ext0<double>("", 1);
+            Extensions.Ext0<object>("", null);
+
+            "".Ext1(1);
+            Extensions.Ext1("", 1);
+
+            1.Ext2(1);
+            1.Ext2<int>(1);
+            "".Ext2(1);
+            "".Ext2<string>(1);
+            "".Ext2<object>(1);
+            Extensions.Ext2(1, 1);
+            Extensions.Ext2<int>(1, 1);
+            Extensions.Ext2("", 1);
+            Extensions.Ext2<string>("", 1);
+            Extensions.Ext2<object>("", 1);
+        }
+    }
+}

--- a/csharp/ql/test/library-tests/methods/Parameters8.expected
+++ b/csharp/ql/test/library-tests/methods/Parameters8.expected
@@ -16,11 +16,10 @@
 | methods.cs:73:21:73:24 | F | methods.cs:73:28:73:28 | x |
 | methods.cs:78:21:78:21 | F | methods.cs:78:30:78:30 | x |
 | methods.cs:78:21:78:21 | F | methods.cs:78:40:78:40 | y |
-| methods.cs:100:27:100:33 | ToInt32 | methods.cs:100:35:100:47 | s |
 | methods.cs:100:27:100:33 | ToInt32 | methods.cs:100:47:100:47 | s |
 | methods.cs:105:28:105:33 | ToBool | methods.cs:105:47:105:47 | s |
 | methods.cs:105:28:105:33 | ToBool | methods.cs:105:69:105:69 | f |
-| methods.cs:110:27:110:34 | Slice | methods.cs:110:36:110:50 | source |
+| methods.cs:110:27:110:34 | Slice | methods.cs:110:45:110:50 | source |
 | methods.cs:110:27:110:34 | Slice | methods.cs:110:45:110:50 | source |
 | methods.cs:110:27:110:34 | Slice | methods.cs:110:57:110:61 | index |
 | methods.cs:110:27:110:34 | Slice | methods.cs:110:57:110:61 | index |
@@ -35,7 +34,7 @@
 | methods.cs:146:14:146:20 | Method2 | methods.cs:146:65:146:65 | e |
 | methods.cs:169:27:169:30 | Plus | methods.cs:169:41:169:44 | left |
 | methods.cs:169:27:169:30 | Plus | methods.cs:169:51:169:55 | right |
-| methods.cs:174:65:174:74 | SkipTwo | methods.cs:174:76:174:126 | list |
+| methods.cs:174:65:174:74 | SkipTwo | methods.cs:174:123:174:126 | list |
 | methods.cs:174:65:174:74 | SkipTwo | methods.cs:174:123:174:126 | list |
 | methods.cs:174:65:174:74 | SkipTwo | methods.cs:174:133:174:133 | i |
 | methods.cs:174:65:174:74 | SkipTwo | methods.cs:174:133:174:133 | i |


### PR DESCRIPTION
This PR fixes extension method extraction when the method symbol is retrieved from a call in the member-like (reduced) form. 

~~[Differences job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1109/)~~
[Differences job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1112/)
