### PR TITLE
C++: Add another barrier to `cpp/use-after-free`

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/test.cpp
@@ -216,7 +216,7 @@ void regression_test_for_static_var_handling()
 
 void test16(int n, bool b) {
   char* data = NULL;
-	for(int i = 0; i < n; ++i) {
+  for(int i = 0; i < n; ++i) {
     if(b) data = (char*)malloc(10 * sizeof(char));
     if(!b || data == NULL) return;
     use(data); // GOOD

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/test.cpp
@@ -219,7 +219,7 @@ void test16(int n, bool b) {
 	for(int i = 0; i < n; ++i) {
     if(b) data = (char*)malloc(10 * sizeof(char));
     if(!b || data == NULL) return;
-    use(data); // GOOD [FALSE POSITIVE]
-    free(data); // GOOD [FALSE POSITIVE]
+    use(data); // GOOD
+    free(data); // GOOD
   }
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-416/semmle/tests/test.cpp
@@ -213,3 +213,13 @@ void regression_test_for_static_var_handling()
 	data = (char *)malloc(100*sizeof(char));
 	use(data); // GOOD
 }
+
+void test16(int n, bool b) {
+  char* data = NULL;
+	for(int i = 0; i < n; ++i) {
+    if(b) data = (char*)malloc(10 * sizeof(char));
+    if(!b || data == NULL) return;
+    use(data); // GOOD [FALSE POSITIVE]
+    free(data); // GOOD [FALSE POSITIVE]
+  }
+}


### PR DESCRIPTION
(Part of https://github.com/github/codeql-c-team/issues/272.)

This PR adds another barrier to the `cpp/use-after-free` query. The barrier identifies this pattern:

```cpp
free(data);
...
if(b) {
  data = (char*)malloc(10 * sizeof(char));
}
...
if(b) {
  use(data); // GOOD
}
```

This does exclude a number of false positives on the usual LGTM projects: https://lgtm.com/query/4026242432431015876/. It does lose ~25 results on an unrelated [CWE](https://cwe.mitre.org/data/definitions/761.html) on SAMATE, but I think the improved precision makes the change worth it (as this query isn't even intended to catch CWE-761).

I started a [CPP-difference](https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/2052/) before realizing that this query isn't even in the extended security suite.