### PR TITLE
Java: Improve performance of `isUnreachableInCall()`

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -296,7 +296,9 @@ predicate isUnreachableInCall(Node n, DataFlowCall call) {
     // which is used in a guard
     param.getAUse() = guard and
     // which controls `n` with the opposite value of `arg`
-    guard.controls(n.asExpr().getBasicBlock(), arg.getBooleanValue().booleanNot())
+    guard
+        .controls(n.asExpr().getBasicBlock(),
+          pragma[only_bind_out](arg.getBooleanValue()).booleanNot())
   )
 }
 


### PR DESCRIPTION
Before:
```
[2021-06-02 20:24:26] (382s)  >>> Created relation DataFlowImplCommon::Cached::viableParamArg#fff_120#join_rhs/3@79096c with 4551906 rows.
[2021-06-02 20:24:26] (382s) Starting to evaluate predicate DataFlowImplCommon::Cached::isUnreachableInCallCached#ff/2@c37898
[2021-06-02 20:24:53] (409s) Tuple counts for DataFlowImplCommon::Cached::isUnreachableInCallCached#ff/2@c37898:
                      5418125   ~1%     {2} r1 = JOIN DataFlowNodes::TExprNode#ff WITH Expr::Expr::getBasicBlock_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'n'
                      2088480   ~4%     {3} r2 = JOIN r1 WITH Guards::guardControls_v3#bff#reorder_0_2_1_201#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'n', booleanNot(Rhs.2)
                      393491    ~0%     {3} r3 = JOIN r2 WITH SSA::SsaVariable::getAUse_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'n', Lhs.2
                      48432     ~0%     {3} r4 = JOIN r3 WITH SSA::SsaImplicitInit::isParameterDefinition_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'n', Lhs.2
                      48432     ~3%     {3} r5 = JOIN r4 WITH DataFlowNodes::TExplicitParameterNode#ff ON FIRST 1 OUTPUT Lhs.2, Lhs.1 'n', Rhs.1
                      475844745 ~0%     {3} r6 = JOIN r5 WITH DataFlowPrivate::ConstantBooleanArgumentNode::getBooleanValue_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.1 'n'
                      55699     ~0%     {2} r7 = JOIN r6 WITH DataFlowImplCommon::Cached::viableParamArg#fff_120#join_rhs ON FIRST 2 OUTPUT Lhs.2 'n', Rhs.2 'call'
                                        return r7
```

After:
```
[2021-06-02 20:37:24] (1s) Starting to evaluate predicate DataFlowImplCommon::Cached::isUnreachableInCallCached#ff/2@f8691f
[2021-06-02 20:37:24] (1s) Tuple counts for DataFlowImplCommon::Cached::isUnreachableInCallCached#ff/2@f8691f:
                      19493   ~0%     {2} r1 = SCAN DataFlowPrivate::ConstantBooleanArgumentNode::getBooleanValue_dispred#ff OUTPUT In.0, booleanNot(In.1)
                      24484   ~0%     {3} r2 = JOIN r1 WITH DataFlowImplCommon::Cached::viableParamArg#fff_201#join_rhs ON FIRST 1 OUTPUT Rhs.2, Lhs.1, Rhs.1 'call'
                      24484   ~1%     {3} r3 = JOIN r2 WITH DataFlowNodes::TExplicitParameterNode#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2 'call'
                      24484   ~0%     {3} r4 = JOIN r3 WITH SSA::SsaImplicitInit::isParameterDefinition_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2 'call'
                      31725   ~0%     {3} r5 = JOIN r4 WITH SSA::SsaVariable::getAUse_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2 'call'
                      15271   ~8%     {2} r6 = JOIN r5 WITH Guards::guardControls_v3#bff#reorder_0_2_1 ON FIRST 2 OUTPUT Rhs.2, Lhs.2 'call'
                      59421   ~3%     {2} r7 = JOIN r6 WITH Expr::Expr::getBasicBlock_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'call'
                      55699   ~0%     {2} r8 = JOIN r7 WITH DataFlowNodes::TExprNode#ff ON FIRST 1 OUTPUT Rhs.1 'n', Lhs.1 'call'
                                      return r8
```