### PR TITLE
JS: make MongooseFunction abstract

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -166,7 +166,7 @@ private module Mongoose {
   /**
    * A Mongoose function.
    */
-  private class MongooseFunction extends API::Node {
+  abstract private class MongooseFunction extends API::Node {
     /**
      * Gets the API-graph node for the result from this function (if the function returns a `Query`).
      */


### PR DESCRIPTION
Looks like we forgot an `abstract` modifier. 

Adding the `abstract` modifier shouldn't change any behavior, as all the predicates on the class were `abstract`. 