### PR TITLE
JS: model webpack-merge as an extend call

### DIFF
--- a/javascript/change-notes/2021-06-02-webpack-merge.md
+++ b/javascript/change-notes/2021-06-02-webpack-merge.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* The security queries recognize the merge call from [webpack-merge](https://npmjs.com/package/webpack-merge). 
+  Affected packages are
+    [webpack-merge](https://npmjs.com/package/webpack-merge)

--- a/javascript/ql/src/semmle/javascript/Extend.qll
+++ b/javascript/ql/src/semmle/javascript/Extend.qll
@@ -188,3 +188,23 @@ private class CloneStep extends PreCallGraphStep {
     )
   }
 }
+
+/**
+ * A deep extend call from the [webpack-merge](https://npmjs.org/package/webpack-merge) library.
+ */
+private class WebpackMergeDeep extends ExtendCall, DataFlow::CallNode {
+  WebpackMergeDeep() {
+    this = DataFlow::moduleMember("webpack-merge", "merge").getACall()
+    or
+    this =
+      DataFlow::moduleMember("webpack-merge", ["mergeWithCustomize", "mergeWithRules"])
+          .getACall()
+          .getACall()
+  }
+
+  override DataFlow::Node getASourceOperand() { result = getAnArgument() }
+
+  override DataFlow::Node getDestinationOperand() { none() }
+
+  override predicate isDeep() { any() }
+}

--- a/javascript/ql/test/library-tests/Extend/ExtendCalls.expected
+++ b/javascript/ql/test/library-tests/Extend/ExtendCalls.expected
@@ -41,3 +41,5 @@
 | tst.js:79:1:79:45 | checkSh ... arg())) | OK |
 | tst.js:80:1:80:55 | checkSh ... arg())) | OK |
 | tst.js:81:1:81:51 | checkSh ... arg())) | OK |
+| tst.js:85:1:85:44 | checkDe ... arg())) | OK |
+| tst.js:86:1:86:61 | checkDe ... arg())) | OK |

--- a/javascript/ql/test/library-tests/Extend/tst.js
+++ b/javascript/ql/test/library-tests/Extend/tst.js
@@ -79,3 +79,8 @@ checkShallow(require('lodash').extend(base(), arg()));
 checkShallow(require("xtend")(base(), arg()));
 checkShallow(require("xtend/immutable")(base(), arg()));
 checkShallow(require("ramda").merge(base(), arg()));
+
+// webpack-merge. deep. 
+const webpackMerge = require('webpack-merge');
+checkDeep(webpackMerge.merge(base(), arg()));
+checkDeep(webpackMerge.mergeWithCustomize({})(base(), arg()));


### PR DESCRIPTION
[A smoke/smoke evaluation looks fine](https://github.com/dsp-testing/erik-krogh-dca/tree/run/webpack-merge-smoke-test-smoke-test/reports). 