### PR TITLE
C#: Fix container type extraction of tuple members

### DIFF
--- a/csharp/change-notes/2021-06-04-tuple-members.md
+++ b/csharp/change-notes/2021-06-04-tuple-members.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Members extracted from `TupleTypes` have been fixed to be assigned to the underlying ``struct ValueTuple`N``.

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/CachedSymbol.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/CachedSymbol.cs
@@ -16,7 +16,11 @@ namespace Semmle.Extraction.CSharp.Entities
         {
         }
 
-        public virtual Type? ContainingType => Symbol.ContainingType is not null ? Type.Create(Context, Symbol.ContainingType) : null;
+        public virtual Type? ContainingType => Symbol.ContainingType is not null
+            ? Symbol.ContainingType.IsTupleType
+                ? NamedType.CreateNamedTypeFromTupleType(Context, Symbol.ContainingType)
+                : Type.Create(Context, Symbol.ContainingType)
+            : null;
 
         public void PopulateModifiers(TextWriter trapFile)
         {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -1848,8 +1848,15 @@ class SystemTupleFlow extends LibraryTypeDataFlow, ValueOrRefType {
         c.(Constructor).getDeclaringType() = this and
         t = this
         or
-        c = this.getAMethod(any(string name | name.regexpMatch("Create(<,*>)?"))) and
-        t = c.getReturnType().getUnboundDeclaration()
+        exists(ValueOrRefType namedType |
+          namedType = this or namedType = this.(TupleType).getUnderlyingType()
+        |
+          c = namedType.getAMethod(any(string name | name.regexpMatch("Create(<,*>)?"))) and
+          (
+            t = c.getReturnType().getUnboundDeclaration() or
+            t = c.getReturnType().(TupleType).getUnderlyingType().getUnboundDeclaration()
+          )
+        )
       )
       or
       c =

--- a/csharp/ql/test/library-tests/csharp7/TupleTypes.expected
+++ b/csharp/ql/test/library-tests/csharp7/TupleTypes.expected
@@ -3,8 +3,8 @@
 | (Int32,Double) | (int, double) | ValueTuple<Int32, Double> | 2 | 0 | CSharp7.cs:215:6:215:8 | Item1 |
 | (Int32,Double) | (int, double) | ValueTuple<Int32, Double> | 2 | 1 | CSharp7.cs:215:11:215:16 | Item2 |
 | (Int32,Int32) | (int, int) | ValueTuple<Int32, Int32> | 2 | 0 | CSharp7.cs:64:10:64:10 | Item1 |
-| (Int32,Int32) | (int, int) | ValueTuple<Int32, Int32> | 2 | 1 | file://:0:0:0:0 | Item2 |
+| (Int32,Int32) | (int, int) | ValueTuple<Int32, Int32> | 2 | 1 | CSharp7.cs:64:17:64:17 | Item2 |
 | (String,Int32) | (string, int) | ValueTuple<String, Int32> | 2 | 0 | CSharp7.cs:84:17:84:17 | Item1 |
-| (String,Int32) | (string, int) | ValueTuple<String, Int32> | 2 | 1 | file://:0:0:0:0 | Item2 |
+| (String,Int32) | (string, int) | ValueTuple<String, Int32> | 2 | 1 | CSharp7.cs:84:23:84:23 | Item2 |
 | (String,String) | (string, string) | ValueTuple<String, String> | 2 | 0 | CSharp7.cs:89:19:89:27 | Item1 |
 | (String,String) | (string, string) | ValueTuple<String, String> | 2 | 1 | CSharp7.cs:89:30:89:33 | Item2 |

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.expected
@@ -1,96 +1,4 @@
 | MS.Internal.Xml.Linq.ComponentModel.XDeferredAxis<>.GetEnumerator() | element of argument -1 -> property Current of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 0 -> field Item1 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 1 -> field Item2 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 2 -> field Item3 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 3 -> field Item4 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 4 -> field Item5 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 5 -> field Item6 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 6 -> field Item7 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 7 -> field Item8 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 0 -> field Item1 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 1 -> field Item2 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 2 -> field Item3 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 3 -> field Item4 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 4 -> field Item5 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 5 -> field Item6 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 6 -> field Item7 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 0 -> field Item1 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 1 -> field Item2 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 2 -> field Item3 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 3 -> field Item4 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 4 -> field Item5 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 5 -> field Item6 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5>(T1, T2, T3, T4, T5) | argument 0 -> field Item1 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5>(T1, T2, T3, T4, T5) | argument 1 -> field Item2 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5>(T1, T2, T3, T4, T5) | argument 2 -> field Item3 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5>(T1, T2, T3, T4, T5) | argument 3 -> field Item4 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4, T5>(T1, T2, T3, T4, T5) | argument 4 -> field Item5 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4>(T1, T2, T3, T4) | argument 0 -> field Item1 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4>(T1, T2, T3, T4) | argument 1 -> field Item2 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4>(T1, T2, T3, T4) | argument 2 -> field Item3 of return (normal) | true |
-| System.().Create<T1, T2, T3, T4>(T1, T2, T3, T4) | argument 3 -> field Item4 of return (normal) | true |
-| System.().Create<T1, T2, T3>(T1, T2, T3) | argument 0 -> field Item1 of return (normal) | true |
-| System.().Create<T1, T2, T3>(T1, T2, T3) | argument 1 -> field Item2 of return (normal) | true |
-| System.().Create<T1, T2, T3>(T1, T2, T3) | argument 2 -> field Item3 of return (normal) | true |
-| System.().Create<T1, T2>(T1, T2) | argument 0 -> field Item1 of return (normal) | true |
-| System.().Create<T1, T2>(T1, T2) | argument 1 -> field Item2 of return (normal) | true |
-| System.().Create<T1>(T1) | argument 0 -> field Item1 of return (normal) | true |
-| System.(T1).ValueTuple(T1) | argument 0 -> field Item1 of return (normal) | true |
-| System.(T1).get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
-| System.(T1,T2).ValueTuple(T1, T2) | argument 0 -> field Item1 of return (normal) | true |
-| System.(T1,T2).ValueTuple(T1, T2) | argument 1 -> field Item2 of return (normal) | true |
-| System.(T1,T2).get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
-| System.(T1,T2).get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3).ValueTuple(T1, T2, T3) | argument 0 -> field Item1 of return (normal) | true |
-| System.(T1,T2,T3).ValueTuple(T1, T2, T3) | argument 1 -> field Item2 of return (normal) | true |
-| System.(T1,T2,T3).ValueTuple(T1, T2, T3) | argument 2 -> field Item3 of return (normal) | true |
-| System.(T1,T2,T3).get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3).get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3).get_Item(int) | field Item3 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4).ValueTuple(T1, T2, T3, T4) | argument 0 -> field Item1 of return (normal) | true |
-| System.(T1,T2,T3,T4).ValueTuple(T1, T2, T3, T4) | argument 1 -> field Item2 of return (normal) | true |
-| System.(T1,T2,T3,T4).ValueTuple(T1, T2, T3, T4) | argument 2 -> field Item3 of return (normal) | true |
-| System.(T1,T2,T3,T4).ValueTuple(T1, T2, T3, T4) | argument 3 -> field Item4 of return (normal) | true |
-| System.(T1,T2,T3,T4).get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4).get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4).get_Item(int) | field Item3 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4).get_Item(int) | field Item4 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5).ValueTuple(T1, T2, T3, T4, T5) | argument 0 -> field Item1 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5).ValueTuple(T1, T2, T3, T4, T5) | argument 1 -> field Item2 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5).ValueTuple(T1, T2, T3, T4, T5) | argument 2 -> field Item3 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5).ValueTuple(T1, T2, T3, T4, T5) | argument 3 -> field Item4 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5).ValueTuple(T1, T2, T3, T4, T5) | argument 4 -> field Item5 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5).get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5).get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5).get_Item(int) | field Item3 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5).get_Item(int) | field Item4 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5).get_Item(int) | field Item5 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).ValueTuple(T1, T2, T3, T4, T5, T6) | argument 0 -> field Item1 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).ValueTuple(T1, T2, T3, T4, T5, T6) | argument 1 -> field Item2 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).ValueTuple(T1, T2, T3, T4, T5, T6) | argument 2 -> field Item3 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).ValueTuple(T1, T2, T3, T4, T5, T6) | argument 3 -> field Item4 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).ValueTuple(T1, T2, T3, T4, T5, T6) | argument 4 -> field Item5 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).ValueTuple(T1, T2, T3, T4, T5, T6) | argument 5 -> field Item6 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).get_Item(int) | field Item3 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).get_Item(int) | field Item4 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).get_Item(int) | field Item5 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6).get_Item(int) | field Item6 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 0 -> field Item1 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 1 -> field Item2 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 2 -> field Item3 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 3 -> field Item4 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 4 -> field Item5 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 5 -> field Item6 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 6 -> field Item7 of return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).get_Item(int) | field Item3 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).get_Item(int) | field Item4 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).get_Item(int) | field Item5 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).get_Item(int) | field Item6 of argument -1 -> return (normal) | true |
-| System.(T1,T2,T3,T4,T5,T6,T7).get_Item(int) | field Item7 of argument -1 -> return (normal) | true |
 | System.Array.Add(object) | argument 0 -> element of argument -1 | true |
 | System.Array.AsReadOnly<T>(T[]) | element of argument 0 -> element of return (normal) | true |
 | System.Array.Clone() | element of argument 0 -> element of return (normal) | true |
@@ -2785,6 +2693,41 @@
 | System.Uri.get_OriginalString() | argument -1 -> return (normal) | false |
 | System.Uri.get_PathAndQuery() | argument -1 -> return (normal) | false |
 | System.Uri.get_Query() | argument -1 -> return (normal) | false |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 3 -> field Item4 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 4 -> field Item5 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 5 -> field Item6 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1, T2, T3, T4, T5, T6, T7, T8) | argument 6 -> field Item7 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 3 -> field Item4 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 4 -> field Item5 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 5 -> field Item6 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6, T7>(T1, T2, T3, T4, T5, T6, T7) | argument 6 -> field Item7 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 3 -> field Item4 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 4 -> field Item5 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5, T6>(T1, T2, T3, T4, T5, T6) | argument 5 -> field Item6 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5>(T1, T2, T3, T4, T5) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5>(T1, T2, T3, T4, T5) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5>(T1, T2, T3, T4, T5) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5>(T1, T2, T3, T4, T5) | argument 3 -> field Item4 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4, T5>(T1, T2, T3, T4, T5) | argument 4 -> field Item5 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4>(T1, T2, T3, T4) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4>(T1, T2, T3, T4) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4>(T1, T2, T3, T4) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3, T4>(T1, T2, T3, T4) | argument 3 -> field Item4 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3>(T1, T2, T3) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3>(T1, T2, T3) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2, T3>(T1, T2, T3) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2>(T1, T2) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple.Create<T1, T2>(T1, T2) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple.Create<T1>(T1) | argument 0 -> field Item1 of return (normal) | true |
 | System.ValueTuple<,,,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6, T7, TRest) | argument 0 -> field Item1 of return (normal) | true |
 | System.ValueTuple<,,,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6, T7, TRest) | argument 1 -> field Item2 of return (normal) | true |
 | System.ValueTuple<,,,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6, T7, TRest) | argument 2 -> field Item3 of return (normal) | true |
@@ -2799,6 +2742,62 @@
 | System.ValueTuple<,,,,,,,>.get_Item(int) | field Item5 of argument -1 -> return (normal) | true |
 | System.ValueTuple<,,,,,,,>.get_Item(int) | field Item6 of argument -1 -> return (normal) | true |
 | System.ValueTuple<,,,,,,,>.get_Item(int) | field Item7 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple<,,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple<,,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple<,,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 3 -> field Item4 of return (normal) | true |
+| System.ValueTuple<,,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 4 -> field Item5 of return (normal) | true |
+| System.ValueTuple<,,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 5 -> field Item6 of return (normal) | true |
+| System.ValueTuple<,,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6, T7) | argument 6 -> field Item7 of return (normal) | true |
+| System.ValueTuple<,,,,,,>.get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,,>.get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,,>.get_Item(int) | field Item3 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,,>.get_Item(int) | field Item4 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,,>.get_Item(int) | field Item5 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,,>.get_Item(int) | field Item6 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,,>.get_Item(int) | field Item7 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple<,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple<,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple<,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6) | argument 3 -> field Item4 of return (normal) | true |
+| System.ValueTuple<,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6) | argument 4 -> field Item5 of return (normal) | true |
+| System.ValueTuple<,,,,,>.ValueTuple(T1, T2, T3, T4, T5, T6) | argument 5 -> field Item6 of return (normal) | true |
+| System.ValueTuple<,,,,,>.get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,>.get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,>.get_Item(int) | field Item3 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,>.get_Item(int) | field Item4 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,>.get_Item(int) | field Item5 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,,>.get_Item(int) | field Item6 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,>.ValueTuple(T1, T2, T3, T4, T5) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple<,,,,>.ValueTuple(T1, T2, T3, T4, T5) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple<,,,,>.ValueTuple(T1, T2, T3, T4, T5) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple<,,,,>.ValueTuple(T1, T2, T3, T4, T5) | argument 3 -> field Item4 of return (normal) | true |
+| System.ValueTuple<,,,,>.ValueTuple(T1, T2, T3, T4, T5) | argument 4 -> field Item5 of return (normal) | true |
+| System.ValueTuple<,,,,>.get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,>.get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,>.get_Item(int) | field Item3 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,>.get_Item(int) | field Item4 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,,>.get_Item(int) | field Item5 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,>.ValueTuple(T1, T2, T3, T4) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple<,,,>.ValueTuple(T1, T2, T3, T4) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple<,,,>.ValueTuple(T1, T2, T3, T4) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple<,,,>.ValueTuple(T1, T2, T3, T4) | argument 3 -> field Item4 of return (normal) | true |
+| System.ValueTuple<,,,>.get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,>.get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,>.get_Item(int) | field Item3 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,,>.get_Item(int) | field Item4 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,>.ValueTuple(T1, T2, T3) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple<,,>.ValueTuple(T1, T2, T3) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple<,,>.ValueTuple(T1, T2, T3) | argument 2 -> field Item3 of return (normal) | true |
+| System.ValueTuple<,,>.get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,>.get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,,>.get_Item(int) | field Item3 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,>.ValueTuple(T1, T2) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple<,>.ValueTuple(T1, T2) | argument 1 -> field Item2 of return (normal) | true |
+| System.ValueTuple<,>.get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
+| System.ValueTuple<,>.get_Item(int) | field Item2 of argument -1 -> return (normal) | true |
+| System.ValueTuple<>.ValueTuple(T1) | argument 0 -> field Item1 of return (normal) | true |
+| System.ValueTuple<>.get_Item(int) | field Item1 of argument -1 -> return (normal) | true |
 | System.Web.HttpCookie.get_Value() | argument -1 -> return (normal) | false |
 | System.Web.HttpCookie.get_Values() | argument -1 -> return (normal) | false |
 | System.Web.HttpServerUtility.UrlEncode(string) | argument 0 -> return (normal) | false |

--- a/csharp/ql/test/library-tests/tuples/tuple.cs
+++ b/csharp/ql/test/library-tests/tuples/tuple.cs
@@ -1,0 +1,21 @@
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var x = (1, 2);
+        Console.WriteLine(x.GetType());
+        x = new ValueTuple<int, int>(1, 2);
+        Console.WriteLine(x.GetType());
+
+        var y = (1, 2, 3, 4, 5, 6, 7);
+        Console.WriteLine(y.GetType());
+
+        var z = (1, 2, 3, 4, 5, 6, 7, 8);
+        Console.WriteLine(z.GetType());
+
+        var w = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        Console.WriteLine(w.GetType());
+    }
+}

--- a/csharp/ql/test/library-tests/tuples/tuples.expected
+++ b/csharp/ql/test/library-tests/tuples/tuples.expected
@@ -8,6 +8,7 @@ members2
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Equals(object, IEqualityComparer) |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | GetHashCode() |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | GetHashCode(IEqualityComparer) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | GetHashCodeCore(IEqualityComparer) |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Item1 |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Item2 |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Item[int] |
@@ -24,6 +25,7 @@ members2
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Equals(object, IEqualityComparer) |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | GetHashCode() |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | GetHashCode(IEqualityComparer) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | GetHashCodeCore(IEqualityComparer) |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item1 |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item2 |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item3 |
@@ -45,6 +47,7 @@ members2
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Equals(object, IEqualityComparer) |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | GetHashCode() |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | GetHashCode(IEqualityComparer) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | GetHashCodeCore(IEqualityComparer) |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item1 |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item2 |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item3 |
@@ -68,6 +71,7 @@ members2
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Equals(object, IEqualityComparer) |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | GetHashCode() |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | GetHashCode(IEqualityComparer) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | GetHashCodeCore(IEqualityComparer) |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item1 |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item2 |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item3 |

--- a/csharp/ql/test/library-tests/tuples/tuples.expected
+++ b/csharp/ql/test/library-tests/tuples/tuples.expected
@@ -1,0 +1,87 @@
+members1
+| tuple.cs:7:17:7:22 | (Int32,Int32) | CompareTo((int, int)) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | CompareTo(object) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | CompareTo(object, IComparer) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | Equals((int, int)) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | Equals(object) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | Equals(object, IEqualityComparer) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | GetHashCode() |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | GetHashCode(IEqualityComparer) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | Item1 |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | Item2 |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | Item[int] |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | Length |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ToString() |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ToStringEnd() |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple() |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple(int, int) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo((int, int, int, int, int, int, int)) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object, IComparer) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals((int, int, int, int, int, int, int)) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object, IEqualityComparer) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode() |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode(IEqualityComparer) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item1 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item2 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item3 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item4 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item5 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item6 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item7 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item[int] |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Length |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToString() |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToStringEnd() |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple() |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple(int, int, int, int, int, int, int) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo((int, int, int, int, int, int, int, int)) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object, IComparer) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals((int, int, int, int, int, int, int, int)) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object, IEqualityComparer) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode() |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode(IEqualityComparer) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item1 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item2 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item3 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item4 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item5 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item6 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item7 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item8 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item[int] |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Length |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Rest |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToString() |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToStringEnd() |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple() |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple(int, int, int, int, int, int, int, (int)) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo((int, int, int, int, int, int, int, int, int, int)) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object, IComparer) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals((int, int, int, int, int, int, int, int, int, int)) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object, IEqualityComparer) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode() |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode(IEqualityComparer) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item1 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item2 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item3 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item4 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item5 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item6 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item7 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item8 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item9 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item10 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item[int] |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Length |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Rest |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToString() |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToStringEnd() |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple() |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple(int, int, int, int, int, int, int, (int, int, int)) |
+members2

--- a/csharp/ql/test/library-tests/tuples/tuples.expected
+++ b/csharp/ql/test/library-tests/tuples/tuples.expected
@@ -1,87 +1,87 @@
 members1
-| tuple.cs:7:17:7:22 | (Int32,Int32) | CompareTo((int, int)) |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | CompareTo(object) |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | CompareTo(object, IComparer) |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | Equals((int, int)) |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | Equals(object) |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | Equals(object, IEqualityComparer) |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | GetHashCode() |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | GetHashCode(IEqualityComparer) |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | Item1 |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | Item2 |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | Item[int] |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | Length |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | ToString() |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | ToStringEnd() |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple() |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple(int, int) |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo((int, int, int, int, int, int, int)) |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object) |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object, IComparer) |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals((int, int, int, int, int, int, int)) |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object) |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object, IEqualityComparer) |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode() |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode(IEqualityComparer) |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item1 |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item2 |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item3 |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item4 |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item5 |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item6 |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item7 |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item[int] |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Length |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToString() |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToStringEnd() |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple() |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple(int, int, int, int, int, int, int) |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo((int, int, int, int, int, int, int, int)) |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object) |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object, IComparer) |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals((int, int, int, int, int, int, int, int)) |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object) |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object, IEqualityComparer) |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode() |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode(IEqualityComparer) |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item1 |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item2 |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item3 |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item4 |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item5 |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item6 |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item7 |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item8 |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item[int] |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Length |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Rest |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToString() |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToStringEnd() |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple() |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple(int, int, int, int, int, int, int, (int)) |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo((int, int, int, int, int, int, int, int, int, int)) |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object) |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | CompareTo(object, IComparer) |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals((int, int, int, int, int, int, int, int, int, int)) |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object) |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Equals(object, IEqualityComparer) |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode() |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | GetHashCode(IEqualityComparer) |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item1 |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item2 |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item3 |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item4 |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item5 |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item6 |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item7 |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item8 |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item9 |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item10 |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Item[int] |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Length |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | Rest |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToString() |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ToStringEnd() |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple() |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple(int, int, int, int, int, int, int, (int, int, int)) |
 members2
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | CompareTo((int, int)) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | CompareTo(object) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | CompareTo(object, IComparer) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Equals((int, int)) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Equals(object) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Equals(object, IEqualityComparer) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | GetHashCode() |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | GetHashCode(IEqualityComparer) |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Item1 |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Item2 |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Item[int] |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | Length |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | ToString() |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | ToStringEnd() |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | ValueTuple() |
+| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<Int32, Int32> | ValueTuple(int, int) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | CompareTo((int, int, int, int, int, int, int)) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | CompareTo(object) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | CompareTo(object, IComparer) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Equals((int, int, int, int, int, int, int)) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Equals(object) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Equals(object, IEqualityComparer) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | GetHashCode() |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | GetHashCode(IEqualityComparer) |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item1 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item2 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item3 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item4 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item5 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item6 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item7 |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Item[int] |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | Length |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | ToString() |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | ToStringEnd() |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | ValueTuple() |
+| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32> | ValueTuple(int, int, int, int, int, int, int) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | CompareTo((int, int, int, int, int, int, int, int)) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | CompareTo(object) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | CompareTo(object, IComparer) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Equals((int, int, int, int, int, int, int, int)) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Equals(object) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Equals(object, IEqualityComparer) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | GetHashCode() |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | GetHashCode(IEqualityComparer) |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item1 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item2 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item3 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item4 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item5 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item6 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item7 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item8 |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Item[int] |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Length |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | Rest |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | ToString() |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | ToStringEnd() |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | ValueTuple() |
+| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32)> | ValueTuple(int, int, int, int, int, int, int, (int)) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | CompareTo((int, int, int, int, int, int, int, int, int, int)) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | CompareTo(object) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | CompareTo(object, IComparer) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Equals((int, int, int, int, int, int, int, int, int, int)) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Equals(object) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Equals(object, IEqualityComparer) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | GetHashCode() |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | GetHashCode(IEqualityComparer) |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item1 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item2 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item3 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item4 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item5 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item6 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item7 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item8 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item9 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item10 |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Item[int] |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Length |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | Rest |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | ToString() |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | ToStringEnd() |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | ValueTuple() |
+| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32,Int32,Int32)> | ValueTuple(int, int, int, int, int, int, int, (int, int, int)) |

--- a/csharp/ql/test/library-tests/tuples/tuples.ql
+++ b/csharp/ql/test/library-tests/tuples/tuples.ql
@@ -1,0 +1,12 @@
+import csharp
+
+query predicate members1(TupleType t, string m) {
+  t.fromSource() and
+  m = t.getAMember().toStringWithTypes()
+}
+
+query predicate members2(TupleType t, string s, string m) {
+  t.fromSource() and
+  s = t.getUnderlyingType().toStringWithTypes() and
+  m = t.getUnderlyingType().getAMember().toStringWithTypes()
+}


### PR DESCRIPTION
Split out from #5664.

[Differences job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1114/)