### PR TITLE
C#: Populate labels earlier

### DIFF
--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -35,12 +35,14 @@ namespace Semmle.Extraction
         // A recursion guard against writing to the trap file whilst writing an id to the trap file.
         private bool writingLabel = false;
 
+        private readonly Queue<IEntity> labelQueue = new();
+
         protected void DefineLabel(IEntity entity)
         {
             if (writingLabel)
             {
                 // Don't define a label whilst writing a label.
-                PopulateLater(() => DefineLabel(entity));
+                labelQueue.Enqueue(entity);
             }
             else
             {
@@ -52,6 +54,10 @@ namespace Semmle.Extraction
                 finally
                 {
                     writingLabel = false;
+                    if (labelQueue.Any())
+                    {
+                        DefineLabel(labelQueue.Dequeue());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/github/codeql-action/issues/544.

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1128/

This improves TRAP import time significantly on some projects:
<img width="779" alt="Screenshot 2021-06-15 at 09 13 02" src="https://user-images.githubusercontent.com/3667920/122009224-26976800-cdba-11eb-8eca-4c67e0732e71.png">
