### PR TITLE
C++: Replace an odd `queries.xml` with `qlpack.yml`

### DIFF
--- a/.codeqlmanifest.json
+++ b/.codeqlmanifest.json
@@ -1,5 +1,6 @@
 { "provide": [ "*/ql/src/qlpack.yml",
                "*/ql/test/qlpack.yml",
+               "cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml",
                "*/ql/examples/qlpack.yml",
                "*/upgrades/qlpack.yml",
                "misc/legacy-support/*/qlpack.yml",

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml
@@ -1,0 +1,6 @@
+# This directory has its own qlpack for reasons detailed in commit 2550788598010fa2117274607c9d58f64f997f34
+name: codeql-cpp-tests-cwe-190-tainted
+version: 0.0.0
+libraryPathDependencies: codeql-cpp
+extractor: cpp
+tests: .

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/queries.xml
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/queries.xml
@@ -1,1 +1,0 @@
-<queries language="cpp"/>


### PR DESCRIPTION
This one C++ test has its own `queries.xml` to make "outside-of-source" path filtering work, as detailed in commit 2550788. I've replaced the `queries.xml` with `qlpack.yml`, added a comment, and added that pack to the `.codeqlmanifest.json` at the root of the repo. This will allow the library dependencies of this pack to be resolved without the need for a `--search-path` option with the upcoming packaging changes.
