### PR TITLE
Java: CWE-326 Query to detect weak HMAC secret keys used to sign JWT

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-326/WeakJwtSecretKey.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/WeakJwtSecretKey.java
@@ -1,0 +1,70 @@
+public class WeakJwtSecretKey {
+	public void testJjwtSignature() throws Exception {
+		{
+			// BAD: jjwt with a weak secret key shorter than 32 bytes
+			String secretKeyString = "mysecret";
+		}
+
+		{
+			// GOOD: jjwt with a strong secret key longer than 32 bytes
+			String secretKeyString = "rsaftyqumeowxt123m5mop0682atkjlo57quizs49rghbv";
+		}
+
+		String token = Jwts.builder().setSubject("Joe")
+			.signWith(SignatureAlgorithm.HS256, secretKeyString)
+			.compact();
+
+		Jws parseClaimsJws = Jwts.parser().setSigningKey(secretKeyString)
+			.parseClaimsJws(token);
+	}
+
+	// BAD: jose4j with a weak key and key validation disabled
+	public void testWeakJose4jSignature() throws Exception {
+		String secretKeyString = "mysecret";
+
+		JwtClaims claims = new JwtClaims(); 
+		claims.setExpirationTimeMinutesInTheFuture(10); 
+		claims.setSubject("Joe"); 
+
+		Key key = new HmacKey(secretKeyString.getBytes("UTF-8"));
+		JsonWebSignature jws = new JsonWebSignature(); 
+		jws.setPayload(claims.toJson()); 
+		jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.HMAC_SHA256); 
+		jws.setKey(key); 
+		jws.setDoKeyValidation(false); // relaxes the key length requirement
+		String jwt = jws.getCompactSerialization();
+		
+		JwtConsumer jwtConsumer = new JwtConsumerBuilder()
+			.setRequireExpirationTime()
+			.setAllowedClockSkewInSeconds(30)
+			.setRequireSubject()
+			.setVerificationKey(key)
+			.setRelaxVerificationKeyValidation() // relaxes key length requirement
+			.build();
+		JwtClaims processedClaims = jwtConsumer.processToClaims(jwt); 	
+	}
+
+	// GOOD: jose4j with a strong key
+	public void testStrongJose4jSignature() throws Exception {
+		String secretKeyString = "rsaftyqumeowxt123m5mop0682atkjlo57quizs49rghbv";
+
+		JwtClaims claims = new JwtClaims(); 
+		claims.setExpirationTimeMinutesInTheFuture(10); 
+		claims.setSubject("Joe"); 
+
+		Key key = new HmacKey(secretKeyString.getBytes("UTF-8"));
+		JsonWebSignature jws = new JsonWebSignature(); 
+		jws.setPayload(claims.toJson()); 
+		jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.HMAC_SHA256); 
+		jws.setKey(key); 
+		String jwt = jws.getCompactSerialization();
+
+		JwtConsumer jwtConsumer = new JwtConsumerBuilder()
+			.setRequireExpirationTime()
+			.setAllowedClockSkewInSeconds(30)
+			.setRequireSubject()
+			.setVerificationKey(key)
+			.build();
+		JwtClaims processedClaims = jwtConsumer.processToClaims(jwt); 	
+	}
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-326/WeakJwtSecretKey.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/WeakJwtSecretKey.qhelp
@@ -1,0 +1,54 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+    <overview>
+        <p>JSON Web Token (JWT) is an open standard (RFC 7519) that defines a compact and
+            self-contained way for securely transmitting information between parties as a 
+            JSON object. This information can be verified and trusted through a digital
+            signature. JWTs can be signed using a secret (with the HMAC algorithm) or a 
+            public/private key pair using RSA or ECDSA.</p>
+        <p>JWT Best Practices require human-memorizable passwords MUST NOT be directly used
+            as the key to a keyed-MAC algorithm such as “HS256”. RFC 7518 recommends to use
+            a password that is as large as (or larger than) the derived key length in JSON
+            web algorithms. Common JWT signature algorithms are HS256, HS384, and HS512.</p>
+        <p>Popular JWT libraries offer a method to set signing key with a handy string argument
+            in addition to the method with a byte array argument taking the binary cryptographic
+            key. It is a common mistake that JWT users are confused by the method signature and 
+            attempted to use raw password strings as the key argument, which is almost always
+            incorrect for cryptographic hashes and can produce insecure results.</p>
+        <p>This rule finds uses of signature algorithms with a weak key of shorter length.
+            Signature algorithms are vulnerable to brute force attack when a weak key of 
+            shorter length is used.</p>
+    </overview>
+
+    <recommendation>
+        <p>The password to generate a signing key shall be as large as (or larger than) 
+            the derived key length, which is 256 bits long at the minimum for the 
+            algorithm HS256, and have sufficient entropy.</p>
+    </recommendation>
+
+    <example>
+        <p>The following example shows both 'BAD' and 'GOOD' implementations. In the 'BAD'
+            implementation, a key with insufficient entropy is used. In the 'GOOD' case,
+            a strong key is used.</p>
+        <sample src="WeakJwtSecretKey.java" />
+    </example>
+
+    <references>
+        <li>
+            IETF
+            <a href="https://tools.ietf.org/id/draft-ietf-oauth-jwt-bcp-02.html#rfc.section.3.5">JSON Web Token Best Current Practices - Ensure Cryptographic Keys have Sufficient Entropy</a>
+        </li>
+        <li>
+            IETF
+            <a href="https://datatracker.ietf.org/doc/html/rfc7518#section-8.8">Password Considerations</a>
+        </li>
+        <li>
+            Auth0
+            <a href="https://auth0.com/blog/brute-forcing-hs256-is-possible-the-importance-of-using-strong-keys-to-sign-jwts/">Brute Forcing HS256 is Possible: The Importance of Using Strong Keys in Signing JWTs</a>
+        </li>
+        <li>
+            JWT
+            <a href="https://jwt.io/introduction">Introduction to JSON Web Tokens</a>
+        </li>
+    </references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-326/WeakJwtSecretKey.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/WeakJwtSecretKey.ql
@@ -1,0 +1,75 @@
+/**
+ * @name Weak HMAC secret key used to sign JWT (Json Web Tokens)
+ * @description JWT requires a minimum of 32 bytes of full-entropy key to sign and verify
+ *              JWT messages. Weak HMAC secrets are vulnerable to brute-force attacks.
+ * @kind path-problem
+ * @id java/weak-jwt-hmac-secret
+ * @tags security
+ *       external/cwe/cwe-326
+ */
+
+import java
+import semmle.code.java.dataflow.TaintTracking
+import experimental.semmle.code.java.frameworks.Jjwt
+import experimental.semmle.code.java.frameworks.Jose4j
+import DataFlow::PathGraph
+
+/**
+ * Weak HMAC key with a length shorter than 32 bytes or 43 characters in base64.
+ */
+class WeakSecretKey extends Expr {
+  WeakSecretKey() { this.(CompileTimeConstantExpr).getStringValue().length() < 43 }
+}
+
+/**
+ * A taint-tracking configuration for using a weak secret key in JWT signing.
+ */
+class InsecureJwtSigningFlowConfig extends TaintTracking::Configuration {
+  InsecureJwtSigningFlowConfig() { this = "WeakJwtSecureKey:InsecureJwtSigningFlowConfig" }
+
+  override predicate isSource(DataFlow::Node src) { src.asExpr() instanceof WeakSecretKey }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma |
+      (
+        ma.getMethod() instanceof SetSigningKeyMethod
+        or
+        ma.getMethod() instanceof SetJwtVerificationKey and
+        exists(MethodAccess rma |
+          rma.getMethod() instanceof SetRelaxJwtKeyValidation and
+          (
+            DataFlow::localExprFlow(ma, rma.getQualifier()) or
+            DataFlow::localExprFlow(rma, ma.getQualifier())
+          )
+        )
+      ) and
+      sink.asExpr() = ma.getArgument(0)
+    )
+  }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(
+      ConstructorCall cc // new HmacKey(secretKeyString.getBytes("UTF-8"))
+    |
+      cc.getConstructedType().getASupertype*().hasQualifiedName("java.security", "Key") and
+      pred.asExpr() = cc.getAnArgument() and
+      succ.asExpr() = cc
+    )
+    or
+    exists(
+      MethodAccess ma // md.digest(secretKeyString.getBytes())
+    |
+      ma.getMethod()
+          .getDeclaringType()
+          .getASupertype*()
+          .hasQualifiedName("java.security", "MessageDigest") and
+      pred.asExpr() = ma.getArgument(0) and
+      succ.asExpr() = ma
+    )
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, InsecureJwtSigningFlowConfig config
+where config.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Insecure JWT signing configuration with $@.",
+  source.getNode(), "weak HMAC Key"

--- a/java/ql/src/experimental/Security/CWE/CWE-347/MissingJWTSignatureCheck.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-347/MissingJWTSignatureCheck.ql
@@ -11,67 +11,7 @@
 
 import java
 import semmle.code.java.dataflow.DataFlow
-
-/** The interface `io.jsonwebtoken.JwtParser`. */
-class TypeJwtParser extends Interface {
-  TypeJwtParser() { this.hasQualifiedName("io.jsonwebtoken", "JwtParser") }
-}
-
-/** The interface `io.jsonwebtoken.JwtParser` or a type derived from it. */
-class TypeDerivedJwtParser extends RefType {
-  TypeDerivedJwtParser() { this.getASourceSupertype*() instanceof TypeJwtParser }
-}
-
-/** The interface `io.jsonwebtoken.JwtParserBuilder`. */
-class TypeJwtParserBuilder extends Interface {
-  TypeJwtParserBuilder() { this.hasQualifiedName("io.jsonwebtoken", "JwtParserBuilder") }
-}
-
-/** The interface `io.jsonwebtoken.JwtHandler`. */
-class TypeJwtHandler extends Interface {
-  TypeJwtHandler() { this.hasQualifiedName("io.jsonwebtoken", "JwtHandler") }
-}
-
-/** The class `io.jsonwebtoken.JwtHandlerAdapter`. */
-class TypeJwtHandlerAdapter extends Class {
-  TypeJwtHandlerAdapter() { this.hasQualifiedName("io.jsonwebtoken", "JwtHandlerAdapter") }
-}
-
-/** The `parse(token, handler)` method defined in `JwtParser`. */
-private class JwtParserParseHandlerMethod extends Method {
-  JwtParserParseHandlerMethod() {
-    this.hasName("parse") and
-    this.getDeclaringType() instanceof TypeJwtParser and
-    this.getNumberOfParameters() = 2
-  }
-}
-
-/** The `parse(token)`, `parseClaimsJwt(token)` and `parsePlaintextJwt(token)` methods defined in `JwtParser`. */
-private class JwtParserInsecureParseMethod extends Method {
-  JwtParserInsecureParseMethod() {
-    this.hasName(["parse", "parseClaimsJwt", "parsePlaintextJwt"]) and
-    this.getNumberOfParameters() = 1 and
-    this.getDeclaringType() instanceof TypeJwtParser
-  }
-}
-
-/** The `on(Claims|Plaintext)Jwt` methods defined in `JwtHandler`. */
-private class JwtHandlerOnJwtMethod extends Method {
-  JwtHandlerOnJwtMethod() {
-    this.hasName(["onClaimsJwt", "onPlaintextJwt"]) and
-    this.getNumberOfParameters() = 1 and
-    this.getDeclaringType() instanceof TypeJwtHandler
-  }
-}
-
-/** The `on(Claims|Plaintext)Jwt` methods defined in `JwtHandlerAdapter`. */
-private class JwtHandlerAdapterOnJwtMethod extends Method {
-  JwtHandlerAdapterOnJwtMethod() {
-    this.hasName(["onClaimsJwt", "onPlaintextJwt"]) and
-    this.getNumberOfParameters() = 1 and
-    this.getDeclaringType() instanceof TypeJwtHandlerAdapter
-  }
-}
+import experimental.semmle.code.java.frameworks.Jjwt
 
 /**
  * Holds if `parseHandlerExpr` is an insecure `JwtHandler`.

--- a/java/ql/src/experimental/semmle/code/java/frameworks/Jjwt.qll
+++ b/java/ql/src/experimental/semmle/code/java/frameworks/Jjwt.qll
@@ -1,0 +1,86 @@
+/**
+ * Provides classes for working with the jjwt framework.
+ */
+
+import java
+
+/** The interface `io.jsonwebtoken.JwtParser`. */
+class TypeJwtParser extends Interface {
+  TypeJwtParser() { this.hasQualifiedName("io.jsonwebtoken", "JwtParser") }
+}
+
+/** The interface `io.jsonwebtoken.JwtParser` or a type derived from it. */
+class TypeDerivedJwtParser extends RefType {
+  TypeDerivedJwtParser() { this.getASourceSupertype*() instanceof TypeJwtParser }
+}
+
+/** The interface `io.jsonwebtoken.JwtParserBuilder`. */
+class TypeJwtParserBuilder extends Interface {
+  TypeJwtParserBuilder() { this.hasQualifiedName("io.jsonwebtoken", "JwtParserBuilder") }
+}
+
+/** The interface `io.jsonwebtoken.JwtHandler`. */
+class TypeJwtHandler extends Interface {
+  TypeJwtHandler() { this.hasQualifiedName("io.jsonwebtoken", "JwtHandler") }
+}
+
+/** The class `io.jsonwebtoken.JwtHandlerAdapter`. */
+class TypeJwtHandlerAdapter extends Class {
+  TypeJwtHandlerAdapter() { this.hasQualifiedName("io.jsonwebtoken", "JwtHandlerAdapter") }
+}
+
+/** The `parse(token, handler)` method defined in `JwtParser`. */
+class JwtParserParseHandlerMethod extends Method {
+  JwtParserParseHandlerMethod() {
+    this.hasName("parse") and
+    this.getDeclaringType() instanceof TypeJwtParser and
+    this.getNumberOfParameters() = 2
+  }
+}
+
+/** The `parse(token)`, `parseClaimsJwt(token)` and `parsePlaintextJwt(token)` methods defined in `JwtParser`. */
+class JwtParserInsecureParseMethod extends Method {
+  JwtParserInsecureParseMethod() {
+    this.hasName(["parse", "parseClaimsJwt", "parsePlaintextJwt"]) and
+    this.getNumberOfParameters() = 1 and
+    this.getDeclaringType() instanceof TypeJwtParser
+  }
+}
+
+/** The `on(Claims|Plaintext)Jwt` methods defined in `JwtHandler`. */
+class JwtHandlerOnJwtMethod extends Method {
+  JwtHandlerOnJwtMethod() {
+    this.hasName(["onClaimsJwt", "onPlaintextJwt"]) and
+    this.getNumberOfParameters() = 1 and
+    this.getDeclaringType() instanceof TypeJwtHandler
+  }
+}
+
+/** The `on(Claims|Plaintext)Jwt` methods defined in `JwtHandlerAdapter`. */
+class JwtHandlerAdapterOnJwtMethod extends Method {
+  JwtHandlerAdapterOnJwtMethod() {
+    this.hasName(["onClaimsJwt", "onPlaintextJwt"]) and
+    this.getNumberOfParameters() = 1 and
+    this.getDeclaringType() instanceof TypeJwtHandlerAdapter
+  }
+}
+
+/** The interface `io.jsonwebtoken.JwtParserBuilder` or a type derived from it. */
+class TypeDerivedJwtParserBuilder extends RefType {
+  TypeDerivedJwtParserBuilder() { this.getASourceSupertype*() instanceof TypeJwtParserBuilder }
+}
+
+/**
+ * The `setSigningKey(byte[] key)` and `setSigningKey(String base64EncodedKeyBytes)` methods
+ * defined in `JwtParser` or `JwtParserBuilder`.
+ */
+class SetSigningKeyMethod extends Method {
+  SetSigningKeyMethod() {
+    this.hasName("setSigningKey") and
+    this.getNumberOfParameters() = 1 and
+    (
+      this.getDeclaringType() instanceof TypeDerivedJwtParser or
+      this.getDeclaringType() instanceof TypeDerivedJwtParserBuilder
+    )
+  }
+}

--- a/java/ql/src/experimental/semmle/code/java/frameworks/Jose4j.qll
+++ b/java/ql/src/experimental/semmle/code/java/frameworks/Jose4j.qll
@@ -1,0 +1,38 @@
+/**
+ * Provides classes for working with the jose4j framework.
+ */
+
+import java
+
+/** The class `org.jose4j.jws.JsonWebSignature`. */
+class TypeJsonWebSignature extends RefType {
+  TypeJsonWebSignature() { this.hasQualifiedName("org.jose4j.jws", "JsonWebSignature") }
+}
+
+/** The class `org.jose4j.jwt.consumer.JwtConsumer`. */
+class TypeJwtConsumer extends RefType {
+  TypeJwtConsumer() { this.hasQualifiedName("org.jose4j.jwt.consumer", "JwtConsumer") }
+}
+
+/** The class `org.jose4j.jwt.consumer.JwtConsumerBuilder`. */
+class TypeJwtConsumerBuilder extends RefType {
+  TypeJwtConsumerBuilder() {
+    this.hasQualifiedName("org.jose4j.jwt.consumer", "JwtConsumerBuilder")
+  }
+}
+
+/** The `setVerificationKey()` method defined in `JwtConsumerBuilder`. */
+class SetJwtVerificationKey extends Method {
+  SetJwtVerificationKey() {
+    this.hasName("setVerificationKey") and
+    this.getDeclaringType() instanceof TypeJwtConsumerBuilder
+  }
+}
+
+/** The `setRelaxVerificationKeyValidation()` method defined in `JwtConsumerBuilder`. */
+class SetRelaxJwtKeyValidation extends Method {
+  SetRelaxJwtKeyValidation() {
+    this.hasName("setRelaxVerificationKeyValidation") and
+    this.getDeclaringType() instanceof TypeJwtConsumerBuilder
+  }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-326/WeakJwtSecretKey.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/WeakJwtSecretKey.expected
@@ -1,0 +1,19 @@
+edges
+| WeakJwtSecretKey.java:19:28:19:37 | "mysecret" : String | WeakJwtSecretKey.java:25:52:25:66 | secretKeyString |
+| WeakJwtSecretKey.java:43:28:43:37 | "mysecret" : String | WeakJwtSecretKey.java:47:66:47:78 | messageDigest : byte[] |
+| WeakJwtSecretKey.java:47:31:47:79 | encodeToString(...) : String | WeakJwtSecretKey.java:53:59:53:76 | hashedSecretKeyStr |
+| WeakJwtSecretKey.java:47:66:47:78 | messageDigest : byte[] | WeakJwtSecretKey.java:47:31:47:79 | encodeToString(...) : String |
+| WeakJwtSecretKey.java:73:28:73:37 | "mysecret" : String | WeakJwtSecretKey.java:91:24:91:26 | key |
+nodes
+| WeakJwtSecretKey.java:19:28:19:37 | "mysecret" : String | semmle.label | "mysecret" : String |
+| WeakJwtSecretKey.java:25:52:25:66 | secretKeyString | semmle.label | secretKeyString |
+| WeakJwtSecretKey.java:43:28:43:37 | "mysecret" : String | semmle.label | "mysecret" : String |
+| WeakJwtSecretKey.java:47:31:47:79 | encodeToString(...) : String | semmle.label | encodeToString(...) : String |
+| WeakJwtSecretKey.java:47:66:47:78 | messageDigest : byte[] | semmle.label | messageDigest : byte[] |
+| WeakJwtSecretKey.java:53:59:53:76 | hashedSecretKeyStr | semmle.label | hashedSecretKeyStr |
+| WeakJwtSecretKey.java:73:28:73:37 | "mysecret" : String | semmle.label | "mysecret" : String |
+| WeakJwtSecretKey.java:91:24:91:26 | key | semmle.label | key |
+#select
+| WeakJwtSecretKey.java:25:52:25:66 | secretKeyString | WeakJwtSecretKey.java:19:28:19:37 | "mysecret" : String | WeakJwtSecretKey.java:25:52:25:66 | secretKeyString | Insecure JWT signing configuration with $@. | WeakJwtSecretKey.java:19:28:19:37 | "mysecret" | weak HMAC Key |
+| WeakJwtSecretKey.java:53:59:53:76 | hashedSecretKeyStr | WeakJwtSecretKey.java:43:28:43:37 | "mysecret" : String | WeakJwtSecretKey.java:53:59:53:76 | hashedSecretKeyStr | Insecure JWT signing configuration with $@. | WeakJwtSecretKey.java:43:28:43:37 | "mysecret" | weak HMAC Key |
+| WeakJwtSecretKey.java:91:24:91:26 | key | WeakJwtSecretKey.java:73:28:73:37 | "mysecret" : String | WeakJwtSecretKey.java:91:24:91:26 | key | Insecure JWT signing configuration with $@. | WeakJwtSecretKey.java:73:28:73:37 | "mysecret" | weak HMAC Key |

--- a/java/ql/test/experimental/query-tests/security/CWE-326/WeakJwtSecretKey.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/WeakJwtSecretKey.java
@@ -1,0 +1,120 @@
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import java.security.Key;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.jose4j.keys.HmacKey;
+
+public class WeakJwtSecretKey {
+	// BAD: jjwt with a weak secret key shorter than 32 bytes
+	public void testJjwtWithWeakKey() throws Exception {
+		String secretKeyString = "mysecret";
+		
+		String token = Jwts.builder().setSubject("Joe")
+			.signWith(SignatureAlgorithm.HS256, secretKeyString)
+			.compact();
+
+		Jws parseClaimsJws = Jwts.parser().setSigningKey(secretKeyString)
+			.parseClaimsJws(token);
+	}
+
+	// GOOD: jjwt with a strong secret key longer than 32 bytes using parser()
+	public void testJjwtWithStrongKey() throws Exception {
+		String secretKeyString = "rsaftyqumeowxt123m5mop0682atkjlo57quizs49rghbv";
+		
+		String token = Jwts.builder().setSubject("Joe")
+			.signWith(SignatureAlgorithm.HS256, secretKeyString)
+			.compact();
+
+		Jws parseClaimsJws = Jwts.parser().setSigningKey(secretKeyString)
+			.parseClaimsJws(token);
+	}
+
+	// BAD: jjwt with a hash directly generated from a weak secret key shorter than 32 bytes using parserBuilder()
+	public void testJjwtWithWeakKey2() throws Exception {
+		String secretKeyString = "mysecret";
+
+		MessageDigest md = MessageDigest.getInstance("SHA-256");
+		byte[] messageDigest = md.digest(secretKeyString.getBytes());
+		String hashedSecretKeyStr = Base64.getEncoder().encodeToString(messageDigest);
+
+		String token = Jwts.builder().setSubject("Joe")
+			.signWith(SignatureAlgorithm.HS256, hashedSecretKeyStr)
+			.compact();
+
+		Jws parseClaimsJws = Jwts.parserBuilder().setSigningKey(hashedSecretKeyStr)
+			.build()			
+			.parseClaimsJws(token);
+	}
+
+	// GOOD: jjwt with a strong secret key longer than 32 bytes using parserBuilder()
+	public void testJjwtWithStrongKey2() throws Exception {
+		String secretKeyString = "rsaftyqumeowxt123m5mop0682atkjlo57quizs49rghbv";
+		
+		String token = Jwts.builder().setSubject("Joe")
+			.signWith(SignatureAlgorithm.HS256, secretKeyString)
+			.compact();
+
+		Jws parseClaimsJws = Jwts.parserBuilder().setSigningKey(secretKeyString)
+			.build()			
+			.parseClaimsJws(token);
+	}
+
+	// BAD: jose4j with a weak key and key validation disabled
+	public void testJose4jWithWeakKey() throws Exception {
+		String secretKeyString = "mysecret";
+
+		JwtClaims claims = new JwtClaims(); 
+		claims.setExpirationTimeMinutesInTheFuture(10); 
+		claims.setSubject("Joe"); 
+
+		Key key = new HmacKey(secretKeyString.getBytes("UTF-8"));
+		JsonWebSignature jws = new JsonWebSignature(); 
+		jws.setPayload(claims.toJson()); 
+		jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.HMAC_SHA256); 
+		jws.setKey(key); 
+		jws.setDoKeyValidation(false); // relaxes the key length requirement
+		String jwt = jws.getCompactSerialization();
+		
+		JwtConsumer jwtConsumer = new JwtConsumerBuilder()
+			.setRequireExpirationTime()
+			.setAllowedClockSkewInSeconds(30)
+			.setRequireSubject()
+			.setVerificationKey(key)
+			.setRelaxVerificationKeyValidation() // relaxes key length requirement
+			.build();
+		JwtClaims processedClaims = jwtConsumer.processToClaims(jwt); 	
+	}
+
+	// GOOD: jose4j with a strong key
+	public void testJose4jWithStrongKey() throws Exception {
+		String secretKeyString = "rsaftyqumeowxt123m5mop0682atkjlo57quizs49rghbv";
+
+		JwtClaims claims = new JwtClaims(); 
+		claims.setExpirationTimeMinutesInTheFuture(10); 
+		claims.setSubject("Joe"); 
+
+		Key key = new HmacKey(secretKeyString.getBytes("UTF-8"));
+		JsonWebSignature jws = new JsonWebSignature(); 
+		jws.setPayload(claims.toJson()); 
+		jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.HMAC_SHA256); 
+		jws.setKey(key); 
+		String jwt = jws.getCompactSerialization();
+
+		JwtConsumer jwtConsumer = new JwtConsumerBuilder()
+			.setRequireExpirationTime()
+			.setAllowedClockSkewInSeconds(30)
+			.setRequireSubject()
+			.setVerificationKey(key)
+			.build();
+		JwtClaims processedClaims = jwtConsumer.processToClaims(jwt); 	
+	}
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-326/WeakJwtSecretKey.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/WeakJwtSecretKey.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-326/WeakJwtSecretKey.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-326/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-326/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../experimental/stubs/jwtk-jjwt-0.11.2:${testdir}/../../../../experimental/stubs/jose4j-0.7.7

--- a/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jws/AlgorithmIdentifiers.java
+++ b/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jws/AlgorithmIdentifiers.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2017 Brian Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jose4j.jws;
+
+/**
+ */
+public class AlgorithmIdentifiers
+{
+    public static final String NONE = "none";
+
+    public static final String HMAC_SHA256 = "HS256";
+    public static final String HMAC_SHA384 = "HS384";
+    public static final String HMAC_SHA512 = "HS512";
+
+    public static final String RSA_USING_SHA256 = "RS256";
+    public static final String RSA_USING_SHA384 = "RS384";
+    public static final String RSA_USING_SHA512 = "RS512";
+
+    public static final String ECDSA_USING_P256_CURVE_AND_SHA256 = "ES256";
+    public static final String ECDSA_USING_P384_CURVE_AND_SHA384 = "ES384";
+    public static final String ECDSA_USING_P521_CURVE_AND_SHA512 = "ES512";
+
+    public static final String RSA_PSS_USING_SHA256 = "PS256";
+    public static final String RSA_PSS_USING_SHA384 = "PS384";
+    public static final String RSA_PSS_USING_SHA512 = "PS512";
+
+}

--- a/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jws/JsonWebSignature.java
+++ b/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jws/JsonWebSignature.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2017 Brian Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jose4j.jws;
+
+import org.jose4j.jwx.JsonWebStructure;
+import org.jose4j.lang.JoseException;
+
+/**
+ * The JsonWebSignature class is used to produce and consume JSON Web Signature (JWS) as defined in
+ * RFC 7515.
+ */
+public class JsonWebSignature extends JsonWebStructure
+{
+    public JsonWebSignature()
+    {
+    }
+
+    /**
+     * Sets the JWS payload as a string.
+     * Use {@link #setPayloadCharEncoding(String)} before calling this method, to use a character
+     * encoding other than UTF-8.
+     * @param payload the payload, as a string, to be singed.
+     */
+    public void setPayload(String payload)
+    {
+    }
+
+    /**
+     * <p>
+     * Sign and produce the JWS Compact Serialization.
+     * </p>
+     * <p>
+     * The JWS Compact Serialization represents digitally signed or MACed
+     * content as a compact, URL-safe string.  This string is:
+     * <p>
+     * BASE64URL(UTF8(JWS Protected Header)) || '.' ||
+     * BASE64URL(JWS Payload) || '.' ||
+     * BASE64URL(JWS Signature)
+     * </p>
+     * @return the Compact Serialization: the encoded header + "." + the encoded payload + "." + the encoded signature
+     * @throws JoseException
+     */
+    public String getCompactSerialization() throws JoseException
+    {
+        return null;
+    }    
+}

--- a/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwt/JwtClaims.java
+++ b/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwt/JwtClaims.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2012-2017 Brian Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jose4j.jwt;
+
+import java.util.*;
+
+/**
+ *
+ */
+public class JwtClaims
+{
+    public JwtClaims()
+    {
+    }
+
+    public String getIssuer() throws MalformedClaimException
+    {
+        return null;
+    }
+
+    public void setIssuer(String issuer)
+    {
+    }
+
+    public String getSubject()  throws MalformedClaimException
+    {
+        return null;
+    }
+
+    public void setSubject(String subject)
+    {
+    }
+
+    public void setAudience(String audience)
+    {
+    }
+
+    public void setAudience(String... audience)
+    {
+    }
+
+    public void setAudience(List<String> audiences)
+    {
+    }
+
+    public void setExpirationTimeMinutesInTheFuture(float minutes)
+    {
+    }
+
+    public void setNotBeforeMinutesInThePast(float minutes)
+    {
+    }
+
+    public void setIssuedAtToNow()
+    {
+    }
+
+    public String getJwtId() throws MalformedClaimException
+    {
+        return null;
+    }
+
+    public void setJwtId(String jwtId)
+    {
+    }
+
+    public void setGeneratedJwtId(int numberOfBytes)
+    {
+    }
+
+    public void setGeneratedJwtId()
+    {
+    }
+
+    public void unsetClaim(String claimName)
+    {
+    }
+
+    public Object getClaimValue(String claimName)
+    {
+        return null;
+    }
+
+    public String getStringClaimValue(String claimName) throws MalformedClaimException
+    {
+        return null;
+    }
+
+    public String toJson()
+    {
+        return null;
+    }
+
+    public String getRawJson()
+    {
+        return null;
+    }
+}

--- a/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwt/MalformedClaimException.java
+++ b/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwt/MalformedClaimException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-2017 Brian Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jose4j.jwt;
+
+/**
+ *
+ */
+public class MalformedClaimException extends Exception
+{
+    public MalformedClaimException(String message)
+    {
+    }
+
+    public MalformedClaimException(String message, Throwable cause)
+    {
+    }
+}

--- a/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwt/consumer/InvalidJwtException.java
+++ b/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwt/consumer/InvalidJwtException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2017 Brian Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jose4j.jwt.consumer;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An exception thrown when a JWT is considered invalid or otherwise cannot be
+ * processed/consumed.
+ */
+public class InvalidJwtException extends Exception
+{
+}

--- a/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwt/consumer/JwtConsumer.java
+++ b/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwt/consumer/JwtConsumer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012-2017 Brian Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jose4j.jwt.consumer;
+
+import org.jose4j.jwt.JwtClaims;
+
+import java.security.Key;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *
+ */
+public class JwtConsumer
+{
+    JwtConsumer()
+    {
+    }
+
+    void setRequireSignature(boolean requireSignature)
+    {
+    }
+
+    void setRequireEncryption(boolean requireEncryption)
+    {
+    }
+
+    void setRequireIntegrity(boolean requireIntegrity)
+    {
+    }
+
+    void setSkipSignatureVerification(boolean skipSignatureVerification)
+    {
+    }
+
+    void setRelaxVerificationKeyValidation(boolean relaxVerificationKeyValidation)
+    {
+    }
+
+    public void setSkipVerificationKeyResolutionOnNone(boolean skipVerificationKeyResolutionOnNone)
+    {
+    }
+
+    void setRelaxDecryptionKeyValidation(boolean relaxDecryptionKeyValidation)
+    {
+    }
+
+    public JwtClaims processToClaims(String jwt) throws InvalidJwtException
+    {
+        return null;
+    }
+}

--- a/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwt/consumer/JwtConsumerBuilder.java
+++ b/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwt/consumer/JwtConsumerBuilder.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright 2012-2017 Brian Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jose4j.jwt.consumer;
+
+import java.security.Key;
+import java.util.*;
+
+/**
+ * <p>
+ * Use the JwtConsumerBuilder to create the appropriate JwtConsumer for your JWT processing needs.
+ * </p>
+ *
+ * The specific validation requirements for a JWT are context dependent, however,
+ * it typically advisable to require a (reasonable) expiration time, a trusted issuer, and
+ * and audience that identifies your system as the intended recipient.
+ * For example, a {@code JwtConsumer} might be set up and used like this:
+ *
+ * <pre>
+ *
+ *   JwtConsumer jwtConsumer = new JwtConsumerBuilder()
+     .setRequireExpirationTime() // the JWT must have an expiration time
+     .setMaxFutureValidityInMinutes(300) // but the  expiration time can't be too crazy
+     .setExpectedIssuer("Issuer") // whom the JWT needs to have been issued by
+     .setExpectedAudience("Audience") // to whom the JWT is intended for
+     .setVerificationKey(publicKey) // verify the signature with the public key
+     .build(); // create the JwtConsumer instance
+
+   try
+   {
+     //  Validate the JWT and process it to the Claims
+     JwtClaims jwtClaims = jwtConsumer.processToClaims(jwt);
+     System.out.println("JWT validation succeeded! " + jwtClaims);
+   }
+   catch (InvalidJwtException e)
+   {
+     // InvalidJwtException will be thrown, if the JWT failed processing or validation in anyway.
+     // Hopefully with meaningful explanations(s) about what went wrong.
+     System.out.println("Invalid JWT! " + e);
+   }
+ *
+ * </pre>
+ *
+ * <p>
+ *   JwtConsumer instances created from this are thread safe and reusable (as long as
+ *   any custom Validators or Customizers used are also thread safe).
+ * </p>
+ */
+public class JwtConsumerBuilder
+{
+    /**
+     * Creates a new JwtConsumerBuilder, which is set up by default to build a JwtConsumer
+     * that requires a signature and will validate the core JWT claims when they
+     * are present. The various methods on the builder should be used to customize
+     * the JwtConsumer's behavior as appropriate.
+     */
+    public JwtConsumerBuilder()
+    {
+    }
+
+    /**
+     * Require that the JWT be encrypted, which is not required by default.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setEnableRequireEncryption()
+    {
+        return null;
+    }
+
+    /**
+     * Require that the JWT have some integrity protection, 
+     * either a signature/MAC JWS or a JWE using a symmetric key management algorithm.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setEnableRequireIntegrity()
+    {
+        return null;
+    }
+
+    /**
+     * Because integrity protection is needed in most usages of JWT, a signature on the JWT is required by default.
+     * Calling this turns that requirement off. It may be necessary, for example, when integrity is ensured though
+     * other means like a JWE using a symmetric key management algorithm. Use this in conjunction with
+     * {@link #setEnableRequireIntegrity()} for that case.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setDisableRequireSignature()
+    {
+        return null;
+    }
+
+    /**
+     * <p>
+     * According to <a href="http://tools.ietf.org/html/rfc7519#section-5.2">section 5.2 of the JWT spec</a>,
+     * when nested signing or encryption is employed with a JWT, the "cty" header parameter has to be present and
+     * have a value of "JWT" to indicate that a nested JWT is the payload of the outer JWT.
+     * </p>
+     * <p>
+     * Not all JWTs follow that requirement of the spec and this provides a work around for
+     * consuming non-compliant JWTs.
+     * Calling this method tells the JwtConsumer to be a bit more liberal in processing and
+     * make a best effort when the "cty" header isnâ€™t present and the payload doesn't parse as JSON
+     * but can be parsed into a JOSE object.
+     * </p>
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setEnableLiberalContentTypeHandling()
+    {
+        return null;
+    }
+
+    /**
+     * <p>
+     * Skip signature verification.
+     * </p>
+     * This might be useful in cases where you don't have enough
+     * information to set up a validating JWT consumer without cracking open the JWT first. For example,
+     * in some contexts you might not know who issued the token without looking at the "iss" claim inside the JWT.
+     * In such a case two JwtConsumers cab be used in a "two-pass" validation of sorts - the first JwtConsumer parses the JWT but
+     * doesn't validate the signature or claims due to the use of methods like this one and the second JwtConsumers
+     * does the actual validation.
+     *
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setSkipSignatureVerification()
+    {
+        return null;
+    }
+
+    /**
+     * <p>
+     * Skip all claims validation.
+     * </p>
+     * This might be useful in cases where you don't have enough
+     * information to set up a validating JWT consumer without cracking open the JWT first. For example,
+     * in some contexts you might not know who issued the token without looking at the "iss" claim inside the JWT.
+     * In such a case two JwtConsumers cab be used in a "two-pass" validation of sorts - the first JwtConsumer parses the JWT but
+     * doesn't validate the signature or claims due to the use of methods like this one and the second JwtConsumers
+     * does the actual validation.
+     *
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setSkipAllValidators()
+    {
+        return null;
+    }
+
+    /**
+     * Skip all the default claim validation but not those provided via {@link #registerValidator(Validator)}.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setSkipAllDefaultValidators()
+    {
+        return null;
+    }
+
+    /**
+     * Set the key to be used for JWS signature/MAC verification.
+     * @param verificationKey the verification key.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setVerificationKey(Key verificationKey)
+    {
+        return null;
+    }
+
+    /**
+     * Indicates that the JwtConsumer will not call the VerificationKeyResolver for a JWS using the
+     * 'none' algorithm.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setSkipVerificationKeyResolutionOnNone()
+    {
+        return null;
+    }
+
+    /**
+     * Set the key to be used for JWE decryption.
+     * @param decryptionKey the decryption key.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setDecryptionKey(Key decryptionKey)
+    {
+        return null;
+    }
+
+    /**
+     * <p>
+     * Set the audience value(s) to use when validating the audience ("aud") claim of a JWT
+     * and require that an audience claim be present.
+     * Audience validation will succeed, if any one of the provided values is equal to any one
+     * of the values of the "aud" claim in the JWT.
+     * </p>
+     * <p>
+     * From <a href="http://tools.ietf.org/html/rfc7519#section-4.1.3">Section 4.1.3 of RFC 7519</a>:
+     *  The "aud" (audience) claim identifies the recipients that the JWT is
+     * intended for.  Each principal intended to process the JWT MUST
+     * identify itself with a value in the audience claim.  If the principal
+     * processing the claim does not identify itself with a value in the
+     * "aud" claim when this claim is present, then the JWT MUST be
+     * rejected.  In the general case, the "aud" value is an array of case-
+     * sensitive strings, each containing a StringOrURI value.  In the
+     * special case when the JWT has one audience, the "aud" value MAY be a
+     * single case-sensitive string containing a StringOrURI value.  The
+     * interpretation of audience values is generally application specific.
+     * Use of this claim is OPTIONAL.
+     * </p>
+     * <p>Equivalent to calling {@link #setExpectedAudience(boolean, String...)} with {@code true} as the first argument.</p>
+     * @param audience the audience value(s) that identify valid recipient(s) of a JWT
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setExpectedAudience(String... audience)
+    {
+        return null;
+    }
+
+    /**
+     * Set the audience value(s) to use when validating the audience ("aud") claim of a JWT.
+     * Audience validation will succeed, if any one of the provided values is equal to any one
+     * of the values of the "aud" claim in the JWT.
+     * </p>
+     * <p>
+     * If present, the audience claim will always be validated (unless explicitly disabled). The {@code requireAudienceClaim} parameter
+     * can be used to indicate whether or not the presence of the audience claim is required. In most cases
+     *  {@code requireAudienceClaim} should be {@code true}.
+     * </p>
+     * <p>
+     * From <a href="http://tools.ietf.org/html/rfc7519#section-4.1.3">Section 4.1.3 of RFC 7519</a>:
+     *  The "aud" (audience) claim identifies the recipients that the JWT is
+     * intended for.  Each principal intended to process the JWT MUST
+     * identify itself with a value in the audience claim.  If the principal
+     * processing the claim does not identify itself with a value in the
+     * "aud" claim when this claim is present, then the JWT MUST be
+     * rejected.  In the general case, the "aud" value is an array of case-
+     * sensitive strings, each containing a StringOrURI value.  In the
+     * special case when the JWT has one audience, the "aud" value MAY be a
+     * single case-sensitive string containing a StringOrURI value.  The
+     * interpretation of audience values is generally application specific.
+     * Use of this claim is OPTIONAL.
+     * </p>
+     * @param requireAudienceClaim true, if an audience claim has to be present for validation to succeed. false, otherwise
+     * @param audience the audience value(s) that identify valid recipient(s) of a JWT
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setExpectedAudience(boolean requireAudienceClaim, String... audience)
+    {
+        return null;
+    }
+
+    /**
+     * Skip the default audience validation.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setSkipDefaultAudienceValidation()
+    {
+        return null;
+    }
+
+    /**
+     * Indicates whether or not the issuer ("iss") claim is required and optionally what the expected values can be.
+     * @param requireIssuer true if issuer claim is required, false otherwise
+     * @param expectedIssuers the values, one of which the issuer claim must match to pass validation, {@code null} means that any value is acceptable
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setExpectedIssuers(boolean requireIssuer, String... expectedIssuers)
+    {
+        return null;
+    }
+
+    /**
+     * Indicates whether or not the issuer ("iss") claim is required and optionally what the expected value is.
+     * @param requireIssuer true if issuer is required, false otherwise
+     * @param expectedIssuer the value that the issuer claim must have to pass validation, {@code null} means that any value is acceptable
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setExpectedIssuer(boolean requireIssuer, String expectedIssuer)
+    {
+        return null;
+    }
+
+    /**
+     * Indicates the expected value of the issuer ("iss") claim and that the claim is required.
+     * Equivalent to calling {@link #setExpectedIssuer(boolean, String)} with {@code true} as the first argument.
+     * @param expectedIssuer the value that the issuer claim must have to pass validation, {@code null} means that any value is acceptable
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setExpectedIssuer(String expectedIssuer)
+    {
+        return null;
+    }
+
+    /**
+     * Require that a subject ("sub") claim be present in the JWT.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setRequireSubject()
+    {
+        return null;
+    }
+
+    /**
+     * Require that a subject ("sub") claim be present in the JWT and that its value
+     * match that of the provided subject.
+     * The subject ("sub") claim is defined in <a href="http://tools.ietf.org/html/rfc7519#section-4.1.2">Section 4.1.2 of RFC 7519</a>.
+     *
+     * @param subject the required value of the subject claim.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setExpectedSubject(String subject)
+    {
+        return null;
+    }
+
+    /**
+     * Require that a <a href="http://tools.ietf.org/html/rfc7519#section-4.1.7">JWT ID ("jti") claim</a> be present in the JWT.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setRequireJwtId()
+    {
+        return null;
+    }
+
+    /**
+     * Require that the JWT contain an <a href="http://tools.ietf.org/html/rfc7519#section-4.1.4">expiration time ("exp") claim</a>.
+     * The expiration time is always checked when present (unless explicitly disabled) but
+     * calling this method strengthens the requirement such that a JWT without an expiration time
+     * will not pass validation.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setRequireExpirationTime()
+    {
+        return null;
+    }
+
+    /**
+     * Require that the JWT contain an <a href="http://tools.ietf.org/html/rfc7519#section-4.1.6">issued at time ("iat") claim</a>.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setRequireIssuedAt()
+    {
+        return null;
+    }
+
+    /**
+     * Places restrictions on how far from the time of evaluation the value of an
+     * <a href="http://tools.ietf.org/html/rfc7519#section-4.1.6">issued at time ("iat") claim</a> can be while still
+     * accepting the token as valid. Also use {@link #setRequireIssuedAt()} to require that an "iat" claim be present.
+     * @param allowedSecondsInTheFuture how many seconds ahead of the current evaluation time the value of the "iat" claim can be
+     * @param allowedSecondsInThePast how many seconds ago the value of the "iat" claim can be
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setIssuedAtRestrictions(int allowedSecondsInTheFuture, int allowedSecondsInThePast)
+    {
+        return null;
+    }
+
+    /**
+     * Require that the JWT contain an <a href="http://tools.ietf.org/html/rfc7519#section-4.1.5">not before ("nbf") claim</a>.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setRequireNotBefore()
+    {
+        return null;
+    }
+
+    /**
+     * Set the amount of clock skew to allow for when validate the expiration time, issued at time, and not before time claims.
+     * @param secondsOfAllowedClockSkew the number of seconds of leniency in date comparisons
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setAllowedClockSkewInSeconds(int secondsOfAllowedClockSkew)
+    {
+        return null;
+    }
+
+    /**
+     * Set maximum on how far in the future the "exp" claim can be.
+     * @param maxFutureValidityInMinutes how far is too far (in minutes)
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setMaxFutureValidityInMinutes(int maxFutureValidityInMinutes)
+    {
+        return null;
+    }
+
+    /**
+     * Bypass the strict checks on the verification key. This might be needed, for example, if the
+     * JWT issuer is using 1024 bit RSA keys or HMAC secrets that are too small (smaller than the size of the hash output).
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setRelaxVerificationKeyValidation()
+    {
+        return null;
+    }
+
+    /**
+     * Bypass the strict checks on the decryption key.
+     * @return the same JwtConsumerBuilder
+     */
+    public JwtConsumerBuilder setRelaxDecryptionKeyValidation()
+    {
+        return null;
+    }
+
+    /**
+     * Create the JwtConsumer with the options provided to the builder.
+     * @return the JwtConsumer
+     */
+    public JwtConsumer build()
+    {
+        return null;
+   }
+}

--- a/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwx/JsonWebStructure.java
+++ b/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/jwx/JsonWebStructure.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2012-2017 Brian Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jose4j.jwx;
+
+import org.jose4j.lang.JoseException;
+
+import java.security.Key;
+
+/**
+ */
+public abstract class JsonWebStructure
+{
+    public static JsonWebStructure fromCompactSerialization(String cs) throws JoseException
+    {
+        return null;
+    }
+
+    public void setCompactSerialization(String compactSerialization) throws JoseException
+    {
+    }
+
+    /**
+     * @deprecated replaced by {@link #getHeaders()} and {@link org.jose4j.jwx.Headers#getFullHeaderAsJsonString()}
+     */
+    public String getHeader()
+    {
+        return null;
+    }
+
+    protected String getEncodedHeader()
+    {
+        return null;
+    }
+
+    public void setHeader(String name, String value)
+    {
+    }
+
+    public String getHeader(String name)
+    {
+        return null;
+    }
+
+    public void setHeader(String name, Object value)
+    {
+    }
+
+    public Object getObjectHeader(String name)
+    {
+        return null;
+    }
+
+    public void setAlgorithmHeaderValue(String alg)
+    {
+    }
+
+    public String getAlgorithmHeaderValue()
+    {
+        return null;
+    }
+
+    public void setContentTypeHeaderValue(String cty)
+    {
+    }
+
+    public String getContentTypeHeaderValue()
+    {
+        return null;
+    }
+
+    public void setKeyIdHeaderValue(String kid)
+    {
+    }
+
+    public String getKeyIdHeaderValue()
+    {
+        return null;
+    }
+
+    public Key getKey()
+    {
+        return null;
+    }
+
+    public void setKey(Key key)
+    {
+    }
+
+    public boolean isDoKeyValidation()
+    {
+        return false;
+    }
+
+    public void setDoKeyValidation(boolean doKeyValidation)
+    {
+    }
+
+    /**
+     * Sets the value(s) of the critical ("crit") header, defined in
+     * <a href="http://tools.ietf.org/html/rfc7515#section-4.1.11">section 4.1.11 of RFC 7515</a>,
+     * which indicates that those headers MUST be understood and processed by the recipient.
+     * @param headerNames the name(s) of headers that will be marked as critical
+     */
+    public void setCriticalHeaderNames(String... headerNames)
+    {
+    }
+
+    /**
+     * Sets the values of the critical ("crit") header that are acceptable for the library to process.
+     * Basically calling this  is telling the jose4j library to allow these headers marked as critical
+     * and saying that the caller knows how to process them and will do so.
+     * @param knownCriticalHeaders one or more header names that will be allowed as values of the critical header
+     */
+    public void setKnownCriticalHeaders(String... knownCriticalHeaders)
+    {
+    }
+}
+

--- a/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/keys/HmacKey.java
+++ b/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/keys/HmacKey.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-2017 Brian Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jose4j.keys;
+
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ */
+public class HmacKey extends SecretKeySpec
+{
+    public static final String ALGORITHM = "HMAC";
+
+    public HmacKey(byte[] bytes)
+    {
+        super(bytes, ALGORITHM);
+    }
+}

--- a/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/lang/JoseException.java
+++ b/java/ql/test/experimental/stubs/jose4j-0.7.7/org/jose4j/lang/JoseException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-2017 Brian Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jose4j.lang;
+
+/**
+ */
+public class JoseException extends Exception
+{
+}

--- a/java/ql/test/experimental/stubs/jwtk-jjwt-0.11.2/io/jsonwebtoken/JwtBuilder.java
+++ b/java/ql/test/experimental/stubs/jwtk-jjwt-0.11.2/io/jsonwebtoken/JwtBuilder.java
@@ -1,0 +1,467 @@
+/*
+ * Copyright (C) 2014 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jsonwebtoken;
+
+import io.jsonwebtoken.security.InvalidKeyException;
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * A builder for constructing JWTs.
+ *
+ * @since 0.1
+ */
+public interface JwtBuilder {
+
+    //replaces any existing header with the specified header.
+
+    /**
+     * Sets (and replaces) any existing header with the specified header.  If you do not want to replace the existing
+     * header and only want to append to it, use the {@link #setHeaderParams(java.util.Map)} method instead.
+     *
+     * @param header the header to set (and potentially replace any existing header).
+     * @return the builder for method chaining.
+     */
+    JwtBuilder setHeader(Header header);
+
+    /**
+     * Sets (and replaces) any existing header with the specified header.  If you do not want to replace the existing
+     * header and only want to append to it, use the {@link #setHeaderParams(java.util.Map)} method instead.
+     *
+     * @param header the header to set (and potentially replace any existing header).
+     * @return the builder for method chaining.
+     */
+    JwtBuilder setHeader(Map<String, Object> header);
+
+    /**
+     * Applies the specified name/value pairs to the header.  If a header does not yet exist at the time this method
+     * is called, one will be created automatically before applying the name/value pairs.
+     *
+     * @param params the header name/value pairs to append to the header.
+     * @return the builder for method chaining.
+     */
+    JwtBuilder setHeaderParams(Map<String, Object> params);
+
+    //sets the specified header parameter, overwriting any previous value under the same name.
+
+    /**
+     * Applies the specified name/value pair to the header.  If a header does not yet exist at the time this method
+     * is called, one will be created automatically before applying the name/value pair.
+     *
+     * @param name  the header parameter name
+     * @param value the header parameter value
+     * @return the builder for method chaining.
+     */
+    JwtBuilder setHeaderParam(String name, Object value);
+
+    /**
+     * Sets the JWT's payload to be a plaintext (non-JSON) string.  If you want the JWT body to be JSON, use the
+     * {@link #setClaims(Claims)} or {@link #setClaims(java.util.Map)} methods instead.
+     *
+     * <p>The payload and claims properties are mutually exclusive - only one of the two may be used.</p>
+     *
+     * @param payload the plaintext (non-JSON) string that will be the body of the JWT.
+     * @return the builder for method chaining.
+     */
+    JwtBuilder setPayload(String payload);
+
+    /**
+     * Sets the JWT payload to be a JSON Claims instance.  If you do not want the JWT body to be JSON and instead want
+     * it to be a plaintext string, use the {@link #setPayload(String)} method instead.
+     *
+     * <p>The payload and claims properties are mutually exclusive - only one of the two may be used.</p>
+     *
+     * @param claims the JWT claims to be set as the JWT body.
+     * @return the builder for method chaining.
+     */
+    JwtBuilder setClaims(Claims claims);
+
+    /**
+     * Sets the JWT payload to be a JSON Claims instance populated by the specified name/value pairs.  If you do not
+     * want the JWT body to be JSON and instead want it to be a plaintext string, use the {@link #setPayload(String)}
+     * method instead.
+     *
+     * <p>The payload* and claims* properties are mutually exclusive - only one of the two may be used.</p>
+     *
+     * @param claims the JWT claims to be set as the JWT body.
+     * @return the builder for method chaining.
+     */
+    JwtBuilder setClaims(Map<String, ?> claims);
+
+    /**
+     * Adds all given name/value pairs to the JSON Claims in the payload. If a Claims instance does not yet exist at the
+     * time this method is called, one will be created automatically before applying the name/value pairs.
+     *
+     * <p>The payload and claims properties are mutually exclusive - only one of the two may be used.</p>
+     *
+     * @param claims the JWT claims to be added to the JWT body.
+     * @return the builder for method chaining.
+     * @since 0.8
+     */
+    JwtBuilder addClaims(Map<String, Object> claims);
+
+    /**
+     * Sets the JWT Claims <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.1">
+     * <code>iss</code></a> (issuer) value.  A {@code null} value will remove the property from the Claims.
+     *
+     * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set
+     * the Claims {@link Claims#setIssuer(String) issuer} field with the specified value.  This allows you to write
+     * code like this:</p>
+     *
+     * <pre>
+     * String jwt = Jwts.builder().setIssuer("Joe").compact();
+     * </pre>
+     *
+     * <p>instead of this:</p>
+     * <pre>
+     * Claims claims = Jwts.claims().setIssuer("Joe");
+     * String jwt = Jwts.builder().setClaims(claims).compact();
+     * </pre>
+     * <p>if desired.</p>
+     *
+     * @param iss the JWT {@code iss} value or {@code null} to remove the property from the Claims map.
+     * @return the builder instance for method chaining.
+     * @since 0.2
+     */
+    //only for better/targeted JavaDoc
+    JwtBuilder setIssuer(String iss);
+
+    /**
+     * Sets the JWT Claims <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.2">
+     * <code>sub</code></a> (subject) value.  A {@code null} value will remove the property from the Claims.
+     *
+     * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set
+     * the Claims {@link Claims#setSubject(String) subject} field with the specified value.  This allows you to write
+     * code like this:</p>
+     *
+     * <pre>
+     * String jwt = Jwts.builder().setSubject("Me").compact();
+     * </pre>
+     *
+     * <p>instead of this:</p>
+     * <pre>
+     * Claims claims = Jwts.claims().setSubject("Me");
+     * String jwt = Jwts.builder().setClaims(claims).compact();
+     * </pre>
+     * <p>if desired.</p>
+     *
+     * @param sub the JWT {@code sub} value or {@code null} to remove the property from the Claims map.
+     * @return the builder instance for method chaining.
+     * @since 0.2
+     */
+    //only for better/targeted JavaDoc
+    JwtBuilder setSubject(String sub);
+
+    /**
+     * Sets the JWT Claims <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.3">
+     * <code>aud</code></a> (audience) value.  A {@code null} value will remove the property from the Claims.
+     *
+     * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set
+     * the Claims {@link Claims#setAudience(String) audience} field with the specified value.  This allows you to write
+     * code like this:</p>
+     *
+     * <pre>
+     * String jwt = Jwts.builder().setAudience("You").compact();
+     * </pre>
+     *
+     * <p>instead of this:</p>
+     * <pre>
+     * Claims claims = Jwts.claims().setAudience("You");
+     * String jwt = Jwts.builder().setClaims(claims).compact();
+     * </pre>
+     * <p>if desired.</p>
+     *
+     * @param aud the JWT {@code aud} value or {@code null} to remove the property from the Claims map.
+     * @return the builder instance for method chaining.
+     * @since 0.2
+     */
+    //only for better/targeted JavaDoc
+    JwtBuilder setAudience(String aud);
+
+    /**
+     * Sets the JWT Claims <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.4">
+     * <code>exp</code></a> (expiration) value.  A {@code null} value will remove the property from the Claims.
+     *
+     * <p>A JWT obtained after this timestamp should not be used.</p>
+     *
+     * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set
+     * the Claims {@link Claims#setExpiration(java.util.Date) expiration} field with the specified value.  This allows
+     * you to write code like this:</p>
+     *
+     * <pre>
+     * String jwt = Jwts.builder().setExpiration(new Date(System.currentTimeMillis() + 3600000)).compact();
+     * </pre>
+     *
+     * <p>instead of this:</p>
+     * <pre>
+     * Claims claims = Jwts.claims().setExpiration(new Date(System.currentTimeMillis() + 3600000));
+     * String jwt = Jwts.builder().setClaims(claims).compact();
+     * </pre>
+     * <p>if desired.</p>
+     *
+     * @param exp the JWT {@code exp} value or {@code null} to remove the property from the Claims map.
+     * @return the builder instance for method chaining.
+     * @since 0.2
+     */
+    //only for better/targeted JavaDoc
+    JwtBuilder setExpiration(Date exp);
+
+    /**
+     * Sets the JWT Claims <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.5">
+     * <code>nbf</code></a> (not before) value.  A {@code null} value will remove the property from the Claims.
+     *
+     * <p>A JWT obtained before this timestamp should not be used.</p>
+     *
+     * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set
+     * the Claims {@link Claims#setNotBefore(java.util.Date) notBefore} field with the specified value.  This allows
+     * you to write code like this:</p>
+     *
+     * <pre>
+     * String jwt = Jwts.builder().setNotBefore(new Date()).compact();
+     * </pre>
+     *
+     * <p>instead of this:</p>
+     * <pre>
+     * Claims claims = Jwts.claims().setNotBefore(new Date());
+     * String jwt = Jwts.builder().setClaims(claims).compact();
+     * </pre>
+     * <p>if desired.</p>
+     *
+     * @param nbf the JWT {@code nbf} value or {@code null} to remove the property from the Claims map.
+     * @return the builder instance for method chaining.
+     * @since 0.2
+     */
+    //only for better/targeted JavaDoc
+    JwtBuilder setNotBefore(Date nbf);
+
+    /**
+     * Sets the JWT Claims <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.6">
+     * <code>iat</code></a> (issued at) value.  A {@code null} value will remove the property from the Claims.
+     *
+     * <p>The value is the timestamp when the JWT was created.</p>
+     *
+     * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set
+     * the Claims {@link Claims#setIssuedAt(java.util.Date) issuedAt} field with the specified value.  This allows
+     * you to write code like this:</p>
+     *
+     * <pre>
+     * String jwt = Jwts.builder().setIssuedAt(new Date()).compact();
+     * </pre>
+     *
+     * <p>instead of this:</p>
+     * <pre>
+     * Claims claims = Jwts.claims().setIssuedAt(new Date());
+     * String jwt = Jwts.builder().setClaims(claims).compact();
+     * </pre>
+     * <p>if desired.</p>
+     *
+     * @param iat the JWT {@code iat} value or {@code null} to remove the property from the Claims map.
+     * @return the builder instance for method chaining.
+     * @since 0.2
+     */
+    //only for better/targeted JavaDoc
+    JwtBuilder setIssuedAt(Date iat);
+
+    /**
+     * Sets the JWT Claims <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.7">
+     * <code>jti</code></a> (JWT ID) value.  A {@code null} value will remove the property from the Claims.
+     *
+     * <p>The value is a CaSe-SenSiTiVe unique identifier for the JWT. If specified, this value MUST be assigned in a
+     * manner that ensures that there is a negligible probability that the same value will be accidentally
+     * assigned to a different data object.  The ID can be used to prevent the JWT from being replayed.</p>
+     *
+     * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set
+     * the Claims {@link Claims#setId(String) id} field with the specified value.  This allows
+     * you to write code like this:</p>
+     *
+     * <pre>
+     * String jwt = Jwts.builder().setId(UUID.randomUUID().toString()).compact();
+     * </pre>
+     *
+     * <p>instead of this:</p>
+     * <pre>
+     * Claims claims = Jwts.claims().setId(UUID.randomUUID().toString());
+     * String jwt = Jwts.builder().setClaims(claims).compact();
+     * </pre>
+     * <p>if desired.</p>
+     *
+     * @param jti the JWT {@code jti} (id) value or {@code null} to remove the property from the Claims map.
+     * @return the builder instance for method chaining.
+     * @since 0.2
+     */
+    //only for better/targeted JavaDoc
+    JwtBuilder setId(String jti);
+
+    /**
+     * Sets a custom JWT Claims parameter value.  A {@code null} value will remove the property from the Claims.
+     *
+     * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set the
+     * named property on the Claims instance using the Claims {@link Claims#put(Object, Object) put} method. This allows
+     * you to write code like this:</p>
+     *
+     * <pre>
+     * String jwt = Jwts.builder().claim("aName", "aValue").compact();
+     * </pre>
+     *
+     * <p>instead of this:</p>
+     * <pre>
+     * Claims claims = Jwts.claims().put("aName", "aValue");
+     * String jwt = Jwts.builder().setClaims(claims).compact();
+     * </pre>
+     * <p>if desired.</p>
+     *
+     * @param name  the JWT Claims property name
+     * @param value the value to set for the specified Claims property name
+     * @return the builder instance for method chaining.
+     * @since 0.2
+     */
+    JwtBuilder claim(String name, Object value);
+
+    /**
+     * Signs the constructed JWT with the specified key using the key's
+     * {@link SignatureAlgorithm#forSigningKey(Key) recommended signature algorithm}, producing a JWS. If the
+     * recommended signature algorithm isn't sufficient for your needs, consider using
+     * {@link #signWith(Key, SignatureAlgorithm)} instead.
+     *
+     * <p>If you are looking to invoke this method with a byte array that you are confident may be used for HMAC-SHA
+     * algorithms, consider using {@link Keys Keys}.{@link Keys#hmacShaKeyFor(byte[]) hmacShaKeyFor(bytes)} to
+     * convert the byte array into a valid {@code Key}.</p>
+     *
+     * @param key the key to use for signing
+     * @return the builder instance for method chaining.
+     * @throws InvalidKeyException if the Key is insufficient or explicitly disallowed by the JWT specification as
+     *                             described by {@link SignatureAlgorithm#forSigningKey(Key)}.
+     * @see #signWith(Key, SignatureAlgorithm)
+     * @since 0.10.0
+     */
+    JwtBuilder signWith(Key key) throws InvalidKeyException;
+
+    /**
+     * Signs the constructed JWT using the specified algorithm with the specified key, producing a JWS.
+     *
+     * <h4>Deprecation Notice: Deprecated as of 0.10.0</h4>
+     *
+     * <p>Use {@link Keys Keys}.{@link Keys#hmacShaKeyFor(byte[]) hmacShaKeyFor(bytes)} to
+     * obtain the {@code Key} and then invoke {@link #signWith(Key)} or {@link #signWith(Key, SignatureAlgorithm)}.</p>
+     *
+     * <p>This method will be removed in the 1.0 release.</p>
+     *
+     * @param alg       the JWS algorithm to use to digitally sign the JWT, thereby producing a JWS.
+     * @param secretKey the algorithm-specific signing key to use to digitally sign the JWT.
+     * @return the builder for method chaining.
+     * @throws InvalidKeyException if the Key is insufficient or explicitly disallowed by the JWT specification as
+     *                             described by {@link SignatureAlgorithm#forSigningKey(Key)}.
+     * @deprecated as of 0.10.0: use {@link Keys Keys}.{@link Keys#hmacShaKeyFor(byte[]) hmacShaKeyFor(bytes)} to
+     * obtain the {@code Key} and then invoke {@link #signWith(Key)} or {@link #signWith(Key, SignatureAlgorithm)}.
+     * This method will be removed in the 1.0 release.
+     */
+    @Deprecated
+    JwtBuilder signWith(SignatureAlgorithm alg, byte[] secretKey) throws InvalidKeyException;
+
+    /**
+     * Signs the constructed JWT using the specified algorithm with the specified key, producing a JWS.
+     *
+     * <p>This is a convenience method: the string argument is first BASE64-decoded to a byte array and this resulting
+     * byte array is used to invoke {@link #signWith(SignatureAlgorithm, byte[])}.</p>
+     *
+     * <h4>Deprecation Notice: Deprecated as of 0.10.0, will be removed in the 1.0 release.</h4>
+     *
+     * <p>This method has been deprecated because the {@code key} argument for this method can be confusing: keys for
+     * cryptographic operations are always binary (byte arrays), and many people were confused as to how bytes were
+     * obtained from the String argument.</p>
+     *
+     * <p>This method always expected a String argument that was effectively the same as the result of the following
+     * (pseudocode):</p>
+     *
+     * <p>{@code String base64EncodedSecretKey = base64Encode(secretKeyBytes);}</p>
+     *
+     * <p>However, a non-trivial number of JJWT users were confused by the method signature and attempted to
+     * use raw password strings as the key argument - for example {@code signWith(HS256, myPassword)} - which is
+     * almost always incorrect for cryptographic hashes and can produce erroneous or insecure results.</p>
+     *
+     * <p>See this
+     * <a href="https://stackoverflow.com/questions/40252903/static-secret-as-byte-key-or-string/40274325#40274325">
+     * StackOverflow answer</a> explaining why raw (non-base64-encoded) strings are almost always incorrect for
+     * signature operations.</p>
+     *
+     * <p>To perform the correct logic with base64EncodedSecretKey strings with JJWT >= 0.10.0, you may do this:
+     * <pre><code>
+     * byte[] keyBytes = {@link Decoders Decoders}.{@link Decoders#BASE64 BASE64}.{@link Decoder#decode(Object) decode(base64EncodedSecretKey)};
+     * Key key = {@link Keys Keys}.{@link Keys#hmacShaKeyFor(byte[]) hmacShaKeyFor(keyBytes)};
+     * jwtBuilder.signWith(key); //or {@link #signWith(Key, SignatureAlgorithm)}
+     * </code></pre>
+     * </p>
+     *
+     * <p>This method will be removed in the 1.0 release.</p>
+     *
+     * @param alg                    the JWS algorithm to use to digitally sign the JWT, thereby producing a JWS.
+     * @param base64EncodedSecretKey the BASE64-encoded algorithm-specific signing key to use to digitally sign the
+     *                               JWT.
+     * @return the builder for method chaining.
+     * @throws InvalidKeyException if the Key is insufficient or explicitly disallowed by the JWT specification as
+     *                             described by {@link SignatureAlgorithm#forSigningKey(Key)}.
+     * @deprecated as of 0.10.0: use {@link #signWith(Key)} or {@link #signWith(Key, SignatureAlgorithm)} instead.  This
+     * method will be removed in the 1.0 release.
+     */
+    @Deprecated
+    JwtBuilder signWith(SignatureAlgorithm alg, String base64EncodedSecretKey) throws InvalidKeyException;
+
+    /**
+     * Signs the constructed JWT using the specified algorithm with the specified key, producing a JWS.
+     *
+     * <p>It is typically recommended to call the {@link #signWith(Key)} instead for simplicity.
+     * However, this method can be useful if the recommended algorithm heuristics do not meet your needs or if
+     * you want explicit control over the signature algorithm used with the specified key.</p>
+     *
+     * @param alg the JWS algorithm to use to digitally sign the JWT, thereby producing a JWS.
+     * @param key the algorithm-specific signing key to use to digitally sign the JWT.
+     * @return the builder for method chaining.
+     * @throws InvalidKeyException if the Key is insufficient or explicitly disallowed by the JWT specification for
+     *                             the specified algorithm.
+     * @see #signWith(Key)
+     * @deprecated since 0.10.0: use {@link #signWith(Key, SignatureAlgorithm)} instead.  This method will be removed
+     * in the 1.0 release.
+     */
+    @Deprecated
+    JwtBuilder signWith(SignatureAlgorithm alg, Key key) throws InvalidKeyException;
+
+    /**
+     * Signs the constructed JWT with the specified key using the specified algorithm, producing a JWS.
+     *
+     * <p>It is typically recommended to call the {@link #signWith(Key)} instead for simplicity.
+     * However, this method can be useful if the recommended algorithm heuristics do not meet your needs or if
+     * you want explicit control over the signature algorithm used with the specified key.</p>
+     *
+     * @param key the signing key to use to digitally sign the JWT.
+     * @param alg the JWS algorithm to use with the key to digitally sign the JWT, thereby producing a JWS.
+     * @return the builder for method chaining.
+     * @throws InvalidKeyException if the Key is insufficient or explicitly disallowed by the JWT specification for
+     *                             the specified algorithm.
+     * @see #signWith(Key)
+     * @since 0.10.0
+     */
+    JwtBuilder signWith(Key key, SignatureAlgorithm alg) throws InvalidKeyException;
+
+    /**
+     * Actually builds the JWT and serializes it to a compact, URL-safe string according to the
+     * <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-7">JWT Compact Serialization</a>
+     * rules.
+     *
+     * @return A compact URL-safe JWT string.
+     */
+    String compact();
+}

--- a/java/ql/test/experimental/stubs/jwtk-jjwt-0.11.2/io/jsonwebtoken/Jwts.java
+++ b/java/ql/test/experimental/stubs/jwtk-jjwt-0.11.2/io/jsonwebtoken/Jwts.java
@@ -63,4 +63,15 @@ public final class Jwts {
     public static JwtParserBuilder parserBuilder() {
         return null;
     }
+
+    /**
+     * Returns a new {@link JwtBuilder} instance that can be configured and then used to create JWT compact serialized
+     * strings.
+     *
+     * @return a new {@link JwtBuilder} instance that can be configured and then used to create JWT compact serialized
+     * strings.
+     */
+    public static JwtBuilder builder() {
+        return null;
+    }
 }

--- a/java/ql/test/experimental/stubs/jwtk-jjwt-0.11.2/io/jsonwebtoken/SignatureAlgorithm.java
+++ b/java/ql/test/experimental/stubs/jwtk-jjwt-0.11.2/io/jsonwebtoken/SignatureAlgorithm.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2014 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jsonwebtoken;
+
+/**
+ * Type-safe representation of standard JWT signature algorithm names as defined in the
+ * <a href="https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-31">JSON Web Algorithms</a> specification.
+ *
+ * @since 0.1
+ */
+public enum SignatureAlgorithm {
+
+    /**
+     * JWA name for {@code No digital signature or MAC performed}
+     */
+    NONE("none", "No digital signature or MAC performed", "None", null, false, 0, 0),
+
+    /**
+     * JWA algorithm name for {@code HMAC using SHA-256}
+     */
+    HS256("HS256", "HMAC using SHA-256", "HMAC", "HmacSHA256", true, 256, 256, "1.2.840.113549.2.9"),
+
+    /**
+     * JWA algorithm name for {@code HMAC using SHA-384}
+     */
+    HS384("HS384", "HMAC using SHA-384", "HMAC", "HmacSHA384", true, 384, 384, "1.2.840.113549.2.10"),
+
+    /**
+     * JWA algorithm name for {@code HMAC using SHA-512}
+     */
+    HS512("HS512", "HMAC using SHA-512", "HMAC", "HmacSHA512", true, 512, 512, "1.2.840.113549.2.11"),
+
+    /**
+     * JWA algorithm name for {@code RSASSA-PKCS-v1_5 using SHA-256}
+     */
+    RS256("RS256", "RSASSA-PKCS-v1_5 using SHA-256", "RSA", "SHA256withRSA", true, 256, 2048),
+
+    /**
+     * JWA algorithm name for {@code RSASSA-PKCS-v1_5 using SHA-384}
+     */
+    RS384("RS384", "RSASSA-PKCS-v1_5 using SHA-384", "RSA", "SHA384withRSA", true, 384, 2048),
+
+    /**
+     * JWA algorithm name for {@code RSASSA-PKCS-v1_5 using SHA-512}
+     */
+    RS512("RS512", "RSASSA-PKCS-v1_5 using SHA-512", "RSA", "SHA512withRSA", true, 512, 2048),
+
+    /**
+     * JWA algorithm name for {@code ECDSA using P-256 and SHA-256}
+     */
+    ES256("ES256", "ECDSA using P-256 and SHA-256", "ECDSA", "SHA256withECDSA", true, 256, 256),
+
+    /**
+     * JWA algorithm name for {@code ECDSA using P-384 and SHA-384}
+     */
+    ES384("ES384", "ECDSA using P-384 and SHA-384", "ECDSA", "SHA384withECDSA", true, 384, 384),
+
+    /**
+     * JWA algorithm name for {@code ECDSA using P-521 and SHA-512}
+     */
+    ES512("ES512", "ECDSA using P-521 and SHA-512", "ECDSA", "SHA512withECDSA", true, 512, 521),
+
+    /**
+     * JWA algorithm name for {@code RSASSA-PSS using SHA-256 and MGF1 with SHA-256}.  <b>This algorithm requires
+     * Java 11 or later or a JCA provider like BouncyCastle to be in the runtime classpath.</b>  If on Java 10 or
+     * earlier, BouncyCastle will be used automatically if found in the runtime classpath.
+     */
+    PS256("PS256", "RSASSA-PSS using SHA-256 and MGF1 with SHA-256", "RSA", "RSASSA-PSS", false, 256, 2048),
+
+    /**
+     * JWA algorithm name for {@code RSASSA-PSS using SHA-384 and MGF1 with SHA-384}.  <b>This algorithm requires
+     * Java 11 or later or a JCA provider like BouncyCastle to be in the runtime classpath.</b>  If on Java 10 or
+     * earlier, BouncyCastle will be used automatically if found in the runtime classpath.
+     */
+    PS384("PS384", "RSASSA-PSS using SHA-384 and MGF1 with SHA-384", "RSA", "RSASSA-PSS", false, 384, 2048),
+
+    /**
+     * JWA algorithm name for {@code RSASSA-PSS using SHA-512 and MGF1 with SHA-512}. <b>This algorithm requires
+     * Java 11 or later or a JCA provider like BouncyCastle to be in the runtime classpath.</b>  If on Java 10 or
+     * earlier, BouncyCastle will be used automatically if found in the runtime classpath.
+     */
+    PS512("PS512", "RSASSA-PSS using SHA-512 and MGF1 with SHA-512", "RSA", "RSASSA-PSS", false, 512, 2048);
+
+    SignatureAlgorithm(String value, String description, String familyName, String jcaName, boolean jdkStandard,
+                       int digestLength, int minKeyLength) {
+    }
+
+    SignatureAlgorithm(String value, String description, String familyName, String jcaName, boolean jdkStandard,
+                       int digestLength, int minKeyLength, String pkcs12Name) {
+    }
+}

--- a/java/ql/test/experimental/stubs/jwtk-jjwt-0.11.2/io/jsonwebtoken/security/InvalidKeyException.java
+++ b/java/ql/test/experimental/stubs/jwtk-jjwt-0.11.2/io/jsonwebtoken/security/InvalidKeyException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2014 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jsonwebtoken.security;
+
+/**
+ * @since 0.10.0
+ */
+public class InvalidKeyException extends Exception {
+
+    public InvalidKeyException(String message) {
+    }
+}


### PR DESCRIPTION
JSON Web Token (JWT) is an open standard (RFC 7519) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object. This information can be verified and trusted through a digital signature. JWTs can be signed using a secret (with the HMAC algorithm) or a public/private key pair using RSA or ECDSA.

JWT Best Practices require human-memorizable passwords MUST NOT be directly used as the key to a keyed-MAC algorithm such as “HS256”. RFC 7518 recommends to use a password that is as large as (or larger than) the derived key length in JSON web algorithms. Common JWT signature algorithms are HS256, HS384, and HS512.

Popular JWT libraries offer a method to set signing key with a handy string argument in addition to the method with a byte array argument taking the binary cryptographic key. It is a common mistake that JWT users are confused by the method signature and attempted to use raw password strings as the key argument, which is almost always incorrect for cryptographic hashes and can produce insecure results.

Signature algorithms are vulnerable to brute force attack when a weak key of shorter length is used. This query detect uses of signature algorithms with a weak key of shorter length. It checks the following three scenarios with two popular JWT frameworks jjwt and jose4j:
- Weak keys allowed by jjwt builds before version 0.10.0 released on July 30, 2018 that are still being used by many GitHub repositories
- Weak keys explicitly enabled by jose4j through the method call of relaxing key validation
- Weak keys hashed to meet the length requirement but don't have have sufficient entropy

Please consider to merge the PR. Thanks.
