### PR TITLE
Python: add support for sql exec through self attr

### DIFF
--- a/python/ql/src/semmle/python/SelfAttribute.qll
+++ b/python/ql/src/semmle/python/SelfAttribute.qll
@@ -88,3 +88,8 @@ private predicate attr_assigned_in_method_arg_n(FunctionObject method, string na
 predicate attribute_assigned_in_method(FunctionObject method, string name) {
   attr_assigned_in_method_arg_n(method, name, 0)
 }
+
+predicate same_attribute_store_read(SelfAttributeStore selfstore, SelfAttributeRead selfread) {
+  selfstore.getName() = selfread.getName() and
+  selfstore.getClass() = selfread.getClass()
+}

--- a/python/ql/test/library-tests/frameworks/mysql-connector-python/pep249.py
+++ b/python/ql/test/library-tests/frameworks/mysql-connector-python/pep249.py
@@ -35,3 +35,15 @@ cnx.commit()
 
 cursor.close()
 cnx.close()
+
+class Conn:
+  def __init__(self):
+    self.conn = mysql.connector.connect(user='scott', database='employees')
+
+  def query(self, query, params):
+    cur = self.conn.cursor()
+    cur.execute(query, params)  # $getSql=query
+    cur.close()
+
+classconn = Conn()
+classconn.query(add_salary, data_salary)

--- a/python/ql/test/library-tests/frameworks/mysqldb/pep249.py
+++ b/python/ql/test/library-tests/frameworks/mysqldb/pep249.py
@@ -5,3 +5,15 @@ db=MySQLdb.connect(passwd="moonpie",db="thangs")
 c=db.cursor()
 max_price=5
 c.execute("some sql", (max_price,))  # $getSql="some sql"
+
+class Conn:
+  def __init__(self):
+    self.conn = MySQLdb.connect(passwd="moonpie",db="thangs")
+
+  def query(self, query, params):
+    cur = self.conn.cursor()
+    cur.execute(query, params)  # $getSql=query
+    cur.close()
+
+classconn = Conn()
+classconn.query("some sql", (max_price,))

--- a/python/ql/test/library-tests/frameworks/pymysql/pep249.py
+++ b/python/ql/test/library-tests/frameworks/pymysql/pep249.py
@@ -3,3 +3,15 @@ connection = pymysql.connect(host="localhost", user="user", password="passwd")
 
 cursor = connection.cursor()
 cursor.execute("some sql", (42,))  # $ getSql="some sql"
+
+class Conn:
+  def __init__(self):
+    self.conn = pymysql.connect(host="localhost", user="user", password="passwd")
+
+  def query(self, query, params):
+    cur = self.conn.cursor()
+    cur.execute(query, params)  # $getSql=query
+    cur.close()
+
+classconn = Conn()
+classconn.query("some sql", (42,))


### PR DESCRIPTION
Hello!

In this PR i want to add support for dealing with local flow to determine sql execution calls and self attribute writes and reads. For example, currently codeql does not detect db connections and cursors stored in self attribute of a class. Code snippet:
```python
class Conn:
  def __init__(self):
    self.conn = pymysql.connect(host="localhost", user="user", password="passwd")
  
  def query(self, query, params):
    cur = self.conn.cursor()
    cur.execute(query, params)  # $getSql=query
    cur.close()

classconn = Conn()
classconn.query("some sql", (42,))
```
I duplicated it in test file.

In this PR i add
* Predicate to match self store and read corresponding to the same class and attr name
* Additional code for PEP249 module
* Tests

This PR allows to find more sql injection vulnerabilities. Example projects:
* https://github.com/riasatullah/ZuriCapWeb
* https://github.com/dkvirus/py-novel
* https://github.com/freQuensy23-coder/CaptchServiceAPI
* https://github.com/abhiagar90/power_networks
* https://github.com/shengxinjing/woniu-cmdb
* https://github.com/EvanKaminsky/idb
* https://github.com/NinadNaik2811/flask-app-nosql-tutorial
* https://github.com/junneyang/bmemonitor
* etc...

I have tested this approach on more than 5k projects. Did not detect false positives.
I think this approach could be successfully extended to other places where TypeTracking is used.