### PR TITLE
JS: model `serve-handler` in `js/exposure-of-private-files`

### DIFF
--- a/javascript/change-notes/2021-06-06-serve-handler.md
+++ b/javascript/change-notes/2021-06-06-serve-handler.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* Private folders exposed using the [`serve-handler`](https://npmjs.com/package/serve-handler) library is not recognized by `js/exposure-of-private-files`.
+  Affected packages are
+    [serve-handler](https://npmjs.com/package/serve-handler)

--- a/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
+++ b/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
@@ -126,8 +126,27 @@ DataFlow::CallNode servesAPrivateFolder(string description) {
   result.getArgument(0) = getAPrivateFolderPath(description)
 }
 
-from Express::RouteSetup setup, string path
+/**
+ * Gets an [`express`](https://npmjs.com/package/express) route-setup
+ * that exposes a private folder described by `path`.
+ */
+Express::RouteSetup getAnExposingExpressSetup(string path) {
+  result.isUseCall() and
+  result.getArgument([0 .. 1]) = servesAPrivateFolder(path).getEnclosingExpr()
+}
+
+/**
+ * Gets a call to [`serve-handler`](https://npmjs.com/package/serve-handler)
+ * that exposes a private folder described by `path`.
+ */
+DataFlow::CallNode getAnExposingServeSetup(string path) {
+  result = DataFlow::moduleImport("serve-handler").getACall() and
+  result.getOptionArgument(2, "public") = getAPrivateFolderPath(path)
+}
+
+from DataFlow::Node node, string path
 where
-  setup.isUseCall() and
-  setup.getArgument([0 .. 1]) = servesAPrivateFolder(path).getEnclosingExpr()
-select setup, "Serves " + path + ", which can contain private information."
+  node = getAnExposingExpressSetup(path).flow()
+  or
+  node = getAnExposingServeSetup(path)
+select node, "Serves " + path + ", which can contain private information."

--- a/javascript/ql/test/query-tests/Security/CWE-200/PrivateFileExposure.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-200/PrivateFileExposure.expected
@@ -19,4 +19,5 @@
 | private-file-exposure.js:42:1:42:66 | app.use ... dir())) | Serves the home folder, which can contain private information. |
 | private-file-exposure.js:43:1:43:46 | app.use ... )("/")) | Serves the root folder, which can contain private information. |
 | private-file-exposure.js:51:5:51:88 | app.use ... les'))) | Serves the folder "../node_modules", which can contain private information. |
+| private-file-exposure.js:70:5:70:71 | serveHa ... ular"}) | Serves the folder "./node_modules/angular", which can contain private information. |
 | subfolder/private-file-exposure-2.js:6:1:6:34 | app.use ... rname)) | Serves the folder query-tests/Security/CWE-200/subfolder, which can contain private information. |

--- a/javascript/ql/test/query-tests/Security/CWE-200/private-file-exposure.js
+++ b/javascript/ql/test/query-tests/Security/CWE-200/private-file-exposure.js
@@ -62,3 +62,12 @@ function good() {
 }
 
 app.use(express.static(__dirname)) // NOT OK
+
+const serveHandler = require("serve-handler");
+const http = require("http");
+
+http.createServer((request, response) => {
+    serveHandler(request, response, {public: "./node_modules/angular"}); // NOT OK
+
+    serveHandler(request, response); // OK
+}).listen(8080);


### PR DESCRIPTION
[Evaluation was uneventful](https://github.com/dsp-testing/erik-krogh-dca/tree/run/serve-default-CustomSuite/reports). 