### PR TITLE
Java: Add Map key-read-steps as local additional taint steps

### DIFF
--- a/java/change-notes/2021-06-11-tainted-key-read-steps.md
+++ b/java/change-notes/2021-06-11-tainted-key-read-steps.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Data flow now propagates taint from tainted Maps to read steps of their keys (e.g. `tainted.keySet()`).

--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -69,6 +69,7 @@ private module Cached {
     |
       f instanceof ArrayContent or
       f instanceof CollectionContent or
+      f instanceof MapKeyContent or
       f instanceof MapValueContent
     )
     or


### PR DESCRIPTION
The work done in #5751 allows us to propagate taint through collections more accurately. Because of that, it seems sensible to add key-read-steps as additional taint steps now, since `Map` keys can be tainted too (either because a previous key-store-step with tainted data was found, or because the whole Map is tainted).