### PR TITLE
C++: Add CWE-789 tag to cpp/uncontrolled-allocation-size.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -9,6 +9,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-190
+ *       external/cwe/cwe-789
  */
 
 import cpp


### PR DESCRIPTION
Add the CWE-789 ("Memory Allocation with Excessive Size Value") tag to `cpp/uncontrolled-allocation-size` ("Overflow in uncontrolled allocation size") in addition to the existing CWE-190 ("Integer Overflow or Wraparound") tag.

I considered increasing the `@precision medium` of the query to `high` as well.  I think the main issue holding it back is uncertainty about taint sources (such as from `getenv`, `argv`), an issue we're going to have to address properly at some point.  There are also some cases involving `strlen` which may not actually be abusable.