### PR TITLE
C++: Fix join order in `addressOperandAllocationAndOffset`

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
@@ -411,7 +411,7 @@ predicate addressOperandAllocationAndOffset(
     allocation.getABaseInstruction() = base and
     hasBaseAndOffset(addrOperand, base, bitOffset) and
     not exists(Instruction previousBase |
-      hasBaseAndOffset(addrOperand, previousBase, _) and
+      hasBaseAndOffset(addrOperand, pragma[only_bind_out](previousBase), _) and
       previousBase = base.getAnOperand().getDef()
     )
   )

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -411,7 +411,7 @@ predicate addressOperandAllocationAndOffset(
     allocation.getABaseInstruction() = base and
     hasBaseAndOffset(addrOperand, base, bitOffset) and
     not exists(Instruction previousBase |
-      hasBaseAndOffset(addrOperand, previousBase, _) and
+      hasBaseAndOffset(addrOperand, pragma[only_bind_out](previousBase), _) and
       previousBase = base.getAnOperand().getDef()
     )
   )

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -411,7 +411,7 @@ predicate addressOperandAllocationAndOffset(
     allocation.getABaseInstruction() = base and
     hasBaseAndOffset(addrOperand, base, bitOffset) and
     not exists(Instruction previousBase |
-      hasBaseAndOffset(addrOperand, previousBase, _) and
+      hasBaseAndOffset(addrOperand, pragma[only_bind_out](previousBase), _) and
       previousBase = base.getAnOperand().getDef()
     )
   )


### PR DESCRIPTION
In https://github.com/github/codeql/pull/5522, the join order in the antijoin of `addressOperandAllocationAndOffset` was ever-so-slightly changed from:

```
Tuple counts for AliasAnalysis::addressOperandAllocationAndOffset#2#fff#antijoin_rhs/3@4e4f70:
  3661341 ~0%     {3} r1 = SCAN AliasAnalysis::hasBaseAndOffset#2#fff OUTPUT In.1 'arg1', In.0 'arg0', In.2 'arg2'
  3790495 ~0%     {4} r2 = JOIN r1 WITH Operand::Operand::getUse_dispred#2#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'arg0', Lhs.0 'arg1', Lhs.2 'arg2'
  3680168 ~0%     {4} r3 = JOIN r2 WITH Operand::Operand::getDef_dispred#2#ff ON FIRST 1 OUTPUT Lhs.1 'arg0', Rhs.1, Lhs.2 'arg1', Lhs.3 'arg2'
  1462851 ~0%     {3} r4 = JOIN r3 WITH project#AliasAnalysis::hasBaseAndOffset#2#fff ON FIRST 2 OUTPUT Lhs.0 'arg0', Lhs.2 'arg1', Lhs.3 'arg2'
                  return r4
```

to

```
Tuple counts for AliasAnalysis::addressOperandAllocationAndOffset#2#fff#antijoin_rhs/3@5312c3:
  3653328  ~2%     {3} r1 = SCAN AliasAnalysis::hasBaseAndOffset#2#fff OUTPUT In.1 'arg1', In.0 'arg0', In.2 'arg2'
  3779909  ~2%     {4} r2 = JOIN r1 WITH Operand::Operand::getUse_dispred#2#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1 'arg0', Lhs.0 'arg1', Lhs.2 'arg2', Rhs.1
  10402878 ~5%     {5} r3 = JOIN r2 WITH project#AliasAnalysis::hasBaseAndOffset#2#fff ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.0 'arg0', Lhs.1 'arg1', Lhs.2 'arg2'
  1454838  ~0%     {3} r4 = JOIN r3 WITH Operand::Operand::getDef_dispred#2#ff ON FIRST 2 OUTPUT Lhs.2 'arg0', Lhs.3 'arg1', Lhs.4 'arg2'
                    return r4
```

this PR brings back the old join order. Now we get:

```
Tuple counts for AliasAnalysis::addressOperandAllocationAndOffset#2#fff#antijoin_rhs/3@b08726:
  3653328 ~0%     {3} r1 = SCAN AliasAnalysis::hasBaseAndOffset#2#fff OUTPUT In.1 'arg1', In.0 'arg0', In.2 'arg2'
  3779909 ~0%     {4} r2 = JOIN r1 WITH Operand::Operand::getUse_dispred#2#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'arg0', Lhs.0 'arg1', Lhs.2 'arg2'
  3663583 ~0%     {4} r3 = JOIN r2 WITH Operand::Operand::getDef_dispred#2#ff ON FIRST 1 OUTPUT Lhs.1 'arg0', Rhs.1, Lhs.2 'arg1', Lhs.3 'arg2'
  1454838 ~0%     {3} r4 = JOIN r3 WITH project#AliasAnalysis::hasBaseAndOffset#2#fff ON FIRST 2 OUTPUT Lhs.0 'arg0', Lhs.2 'arg1', Lhs.3 'arg2'
                  return r4
```

(These numbers are all from `chakracore`.)