### PR TITLE
Python: Model `await request.post()` as MultiDictProxy

### DIFF
--- a/python/ql/src/semmle/python/frameworks/Aiohttp.qll
+++ b/python/ql/src/semmle/python/frameworks/Aiohttp.qll
@@ -444,6 +444,18 @@ module AiohttpWebModel {
     AiohttpRequestMultiDictProxyInstances() {
       this.(DataFlow::AttrRead).getObject() = Request::instance() and
       this.(DataFlow::AttrRead).getAttributeName() in ["query", "headers"]
+      or
+      // Handle the common case of `x = await request.post()`
+      // but don't try to handle anything else, since we don't have an easy way to do this yet.
+      // TODO: more complete handling of `await request.post()`
+      exists(Await await, DataFlow::CallCfgNode call, DataFlow::AttrRead read |
+        this.asExpr() = await
+      |
+        read.(DataFlow::AttrRead).getObject() = Request::instance() and
+        read.(DataFlow::AttrRead).getAttributeName() = "post" and
+        call.getFunction() = read and
+        await.getValue() = call.asExpr()
+      )
     }
   }
 

--- a/python/ql/test/library-tests/frameworks/aiohttp/taint_test.py
+++ b/python/ql/test/library-tests/frameworks/aiohttp/taint_test.py
@@ -104,7 +104,7 @@ async def test_taint(request: web.Request): # $ requestHandler
 
         # multidict.MultiDictProxy[str] (see `multidict` framework tests)
         await request.post(), # $ tainted
-        (await request.post()).getone("key"), # $ MISSING: tainted
+        (await request.post()).getone("key"), # $ tainted
     )
 
     import yarl


### PR DESCRIPTION
as highlight as being quite easy to do by @yoff :+1: