### PR TITLE
Python: Add `getAMethodCall` to `LocalSourceNode`

### DIFF
--- a/python/change-notes/2021-06-15-add-method-call-conveniences.md
+++ b/python/change-notes/2021-06-15-add-method-call-conveniences.md
@@ -1,0 +1,5 @@
+lgtm,codescanning
+* A new class `DataFlow::MethodCallNode` extends `DataFlow::CallCfgNode` with convenient methods for
+  accessing the receiver and method name of a method call.
+* The `LocalSourceNode` class now has a `getAMethodCall` method, with which one can easily access
+  method calls with the given node as a receiver.

--- a/python/ql/src/Security/CWE-327/Ssl.qll
+++ b/python/ql/src/Security/CWE-327/Ssl.qll
@@ -42,7 +42,7 @@ API::Node sslContextInstance() {
 class WrapSocketCall extends ConnectionCreation, DataFlow::MethodCallNode {
   WrapSocketCall() { this = sslContextInstance().getMember("wrap_socket").getACall() }
 
-  override DataFlow::Node getContext() { result = this.getReceiver() }
+  override DataFlow::Node getContext() { result = this.getObject() }
 }
 
 class OptionsAugOr extends ProtocolRestriction, DataFlow::CfgNode {

--- a/python/ql/src/Security/CWE-327/Ssl.qll
+++ b/python/ql/src/Security/CWE-327/Ssl.qll
@@ -42,9 +42,7 @@ API::Node sslContextInstance() {
 class WrapSocketCall extends ConnectionCreation, DataFlow::MethodCallNode {
   WrapSocketCall() { this = sslContextInstance().getMember("wrap_socket").getACall() }
 
-  override DataFlow::Node getContext() {
-    result = this.getReceiver()
-  }
+  override DataFlow::Node getContext() { result = this.getReceiver() }
 }
 
 class OptionsAugOr extends ProtocolRestriction, DataFlow::CfgNode {

--- a/python/ql/src/Security/CWE-327/Ssl.qll
+++ b/python/ql/src/Security/CWE-327/Ssl.qll
@@ -39,11 +39,11 @@ API::Node sslContextInstance() {
   result = API::moduleImport("ssl").getMember(["SSLContext", "create_default_context"]).getReturn()
 }
 
-class WrapSocketCall extends ConnectionCreation, DataFlow::CallCfgNode {
+class WrapSocketCall extends ConnectionCreation, DataFlow::MethodCallNode {
   WrapSocketCall() { this = sslContextInstance().getMember("wrap_socket").getACall() }
 
   override DataFlow::Node getContext() {
-    result = this.getFunction().(DataFlow::AttrRead).getObject()
+    result = this.getReceiver()
   }
 }
 

--- a/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
@@ -70,7 +70,7 @@ private module Re {
     CompiledRegex() {
       exists(DataFlow::MethodCallNode patternCall |
         patternCall = API::moduleImport("re").getMember("compile").getACall() and
-        patternCall.flowsTo(this.getReceiver()) and
+        patternCall.flowsTo(this.getObject()) and
         this.getMethodName() instanceof RegexExecutionMethods and
         regexNode = patternCall.getArg(0)
       )

--- a/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
@@ -64,15 +64,14 @@ private module Re {
    *
    * See https://docs.python.org/3/library/re.html#regular-expression-objects
    */
-  private class CompiledRegex extends DataFlow::CallCfgNode, RegexExecution::Range {
+  private class CompiledRegex extends DataFlow::MethodCallNode, RegexExecution::Range {
     DataFlow::Node regexNode;
 
     CompiledRegex() {
-      exists(DataFlow::CallCfgNode patternCall, DataFlow::AttrRead reMethod |
-        this.getFunction() = reMethod and
+      exists(DataFlow::MethodCallNode patternCall |
         patternCall = API::moduleImport("re").getMember("compile").getACall() and
-        patternCall.flowsTo(reMethod.getObject()) and
-        reMethod.getAttributeName() instanceof RegexExecutionMethods and
+        patternCall.flowsTo(this.getReceiver()) and
+        this.getMethodName() instanceof RegexExecutionMethods and
         regexNode = patternCall.getArg(0)
       )
     }

--- a/python/ql/src/semmle/python/dataflow/new/internal/Attributes.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/Attributes.qll
@@ -191,7 +191,7 @@ private class ClassDefinitionAsAttrWrite extends AttrWrite, CfgNode {
  * - Dynamic attribute reads using `getattr`: `getattr(object, attr)`
  * - Qualified imports: `from module import attr as name`
  */
-abstract class AttrRead extends AttrRef, Node { }
+abstract class AttrRead extends AttrRef, Node, LocalSourceNode { }
 
 /** A simple attribute read, e.g. `object.attr` */
 private class AttributeReadAsAttrRead extends AttrRead, CfgNode {

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -181,6 +181,30 @@ class CallCfgNode extends CfgNode, LocalSourceNode {
 }
 
 /**
+ * A data-flow node corresponding to a method call, that is `foo.bar(...)`.
+ *
+ * Also covers the case where the method lookup is done separately from the call itself, as in
+ * `temp = foo.bar; temp(...)`.
+ */
+class MethodCallNode extends CallCfgNode {
+  AttrRead method_lookup;
+
+  MethodCallNode() { method_lookup = this.getFunction().getALocalSource() }
+
+  /** Gets the name of the method being invoked (the `bar` in `foo.bar(...)`, if it can be determined. */
+  string getMethodName() { result = method_lookup.getAttributeName() }
+
+  /** Gets the data-flow node corresponding to the receiver of this call. That is, the `foo` in `foo.bar(...)`. */
+  Node getReceiver() { result = method_lookup.getObject() }
+
+  /** Holds if this data-flow node calls method `methodName` on receiver node `receiver`. */
+  predicate calls(Node receiver, string methodName) {
+    receiver = this.getReceiver() and
+    methodName = this.getMethodName()
+  }
+}
+
+/**
  * An expression, viewed as a node in a data flow graph.
  *
  * Note that because of control-flow splitting, one `Expr` may correspond

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -184,23 +184,38 @@ class CallCfgNode extends CfgNode, LocalSourceNode {
  * A data-flow node corresponding to a method call, that is `foo.bar(...)`.
  *
  * Also covers the case where the method lookup is done separately from the call itself, as in
- * `temp = foo.bar; temp(...)`.
+ * `temp = foo.bar; temp(...)`. Note that this is only tracked through local scope.
  */
 class MethodCallNode extends CallCfgNode {
   AttrRead method_lookup;
 
   MethodCallNode() { method_lookup = this.getFunction().getALocalSource() }
 
-  /** Gets the name of the method being invoked (the `bar` in `foo.bar(...)`, if it can be determined. */
+  /**
+   * Gets the name of the method being invoked (the `bar` in `foo.bar(...)`) if it can be determined.
+   *
+   * Note that this method may have multiple results if a single call node represents calls to
+   * multiple different objects and methods. If you want to link up objects and method names
+   * accurately, use the `calls` method instead.
+   */
   string getMethodName() { result = method_lookup.getAttributeName() }
 
-  /** Gets the data-flow node corresponding to the receiver of this call. That is, the `foo` in `foo.bar(...)`. */
-  Node getReceiver() { result = method_lookup.getObject() }
+  /**
+   * Gets the data-flow node corresponding to the object receiving this call. That is, the `foo` in
+   * `foo.bar(...)`.
+   *
+   * Note that this method may have multiple results if a single call node represents calls to
+   * multiple different objects and methods. If you want to link up objects and method names
+   * accurately, use the `calls` method instead.
+   */
+  Node getObject() { result = method_lookup.getObject() }
 
-  /** Holds if this data-flow node calls method `methodName` on receiver node `receiver`. */
-  predicate calls(Node receiver, string methodName) {
-    receiver = this.getReceiver() and
-    methodName = this.getMethodName()
+  /** Holds if this data-flow node calls method `methodName` on the object node `object`. */
+  predicate calls(Node object, string methodName) {
+    // As `getObject` and `getMethodName` may both have multiple results, we must look up the object
+    // and method name directly on `method_lookup`.
+    object = method_lookup.getObject() and
+    methodName = method_lookup.getAttributeName()
   }
 }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/LocalSources.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/LocalSources.qll
@@ -84,7 +84,7 @@ class LocalSourceNode extends Node {
    * Includes both calls that have the syntactic shape of a method call (as in `obj.m(...)`), and
    * calls where the callee undergoes some additional local data flow (as in `tmp = obj.m; m(...)`).
    */
-  CallCfgNode getAMethodCall(string methodName) {
+  MethodCallNode getAMethodCall(string methodName) {
     result = this.getAnAttributeRead(methodName).getACall()
   }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/LocalSources.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/LocalSources.qll
@@ -79,6 +79,16 @@ class LocalSourceNode extends Node {
   CallCfgNode getACall() { Cached::call(this, result) }
 
   /**
+   * Gets a call to the method `methodName` on this node.
+   *
+   * Includes both calls that have the syntactic shape of a method call (as in `obj.m(...)`), and
+   * calls where the callee undergoes some additional local data flow (as in `tmp = obj.m; m(...)`).
+   */
+  CallCfgNode getAMethodCall(string methodName) {
+    result = this.getAnAttributeRead(methodName).getACall()
+  }
+
+  /**
    * Gets a node that this node may flow to using one heap and/or interprocedural step.
    *
    * See `TypeTracker` for more details about how to use this.

--- a/python/ql/src/semmle/python/frameworks/Cryptography.qll
+++ b/python/ql/src/semmle/python/frameworks/Cryptography.qll
@@ -228,11 +228,7 @@ private module CryptographyModel {
     /** Gets a reference to the encryptor of a Cipher instance using algorithm with `algorithmName`. */
     DataFlow::LocalSourceNode cipherEncryptor(DataFlow::TypeTracker t, string algorithmName) {
       t.start() and
-      exists(DataFlow::AttrRead attr |
-        result.(DataFlow::CallCfgNode).getFunction() = attr and
-        attr.getAttributeName() = "encryptor" and
-        attr.getObject() = cipherInstance(algorithmName)
-      )
+      result.(DataFlow::MethodCallNode).calls(cipherInstance(algorithmName), "encryptor")
       or
       exists(DataFlow::TypeTracker t2 | result = cipherEncryptor(t2, algorithmName).track(t2, t))
     }
@@ -249,11 +245,7 @@ private module CryptographyModel {
     /** Gets a reference to the dncryptor of a Cipher instance using algorithm with `algorithmName`. */
     DataFlow::LocalSourceNode cipherDecryptor(DataFlow::TypeTracker t, string algorithmName) {
       t.start() and
-      exists(DataFlow::AttrRead attr |
-        result.(DataFlow::CallCfgNode).getFunction() = attr and
-        attr.getAttributeName() = "decryptor" and
-        attr.getObject() = cipherInstance(algorithmName)
-      )
+      result.(DataFlow::MethodCallNode).calls(cipherInstance(algorithmName), "decryptor")
       or
       exists(DataFlow::TypeTracker t2 | result = cipherDecryptor(t2, algorithmName).track(t2, t))
     }
@@ -271,19 +263,12 @@ private module CryptographyModel {
      * An encrypt or decrypt operation from `cryptography.hazmat.primitives.ciphers`.
      */
     class CryptographyGenericCipherOperation extends Cryptography::CryptographicOperation::Range,
-      DataFlow::CallCfgNode {
+      DataFlow::MethodCallNode {
       string algorithmName;
 
       CryptographyGenericCipherOperation() {
-        exists(DataFlow::AttrRead attr |
-          this.getFunction() = attr and
-          attr.getAttributeName() = ["update", "update_into"] and
-          (
-            attr.getObject() = cipherEncryptor(algorithmName)
-            or
-            attr.getObject() = cipherDecryptor(algorithmName)
-          )
-        )
+        this.getMethodName() in ["update", "update_into"] and
+        this.getReceiver() in [cipherEncryptor(algorithmName), cipherDecryptor(algorithmName)]
       }
 
       override Cryptography::CryptographicAlgorithm getAlgorithm() {
@@ -337,16 +322,10 @@ private module CryptographyModel {
      * An hashing operation from `cryptography.hazmat.primitives.hashes`.
      */
     class CryptographyGenericHashOperation extends Cryptography::CryptographicOperation::Range,
-      DataFlow::CallCfgNode {
+      DataFlow::MethodCallNode {
       string algorithmName;
 
-      CryptographyGenericHashOperation() {
-        exists(DataFlow::AttrRead attr |
-          this.getFunction() = attr and
-          attr.getAttributeName() = "update" and
-          attr.getObject() = hashInstance(algorithmName)
-        )
-      }
+      CryptographyGenericHashOperation() { this.calls(hashInstance(algorithmName), "update") }
 
       override Cryptography::CryptographicAlgorithm getAlgorithm() {
         result.matchesName(algorithmName)

--- a/python/ql/src/semmle/python/frameworks/Cryptography.qll
+++ b/python/ql/src/semmle/python/frameworks/Cryptography.qll
@@ -267,8 +267,11 @@ private module CryptographyModel {
       string algorithmName;
 
       CryptographyGenericCipherOperation() {
-        this.getMethodName() in ["update", "update_into"] and
-        this.getReceiver() in [cipherEncryptor(algorithmName), cipherDecryptor(algorithmName)]
+        exists(DataFlow::Node object, string method |
+          object in [cipherEncryptor(algorithmName), cipherDecryptor(algorithmName)] and
+          method in ["update", "update_into"] and
+          this.calls(object, method)
+        )
       }
 
       override Cryptography::CryptographicAlgorithm getAlgorithm() {

--- a/python/ql/test/experimental/dataflow/method-calls/test.expected
+++ b/python/ql/test/experimental/dataflow/method-calls/test.expected
@@ -1,0 +1,8 @@
+conjunctive_lookup
+| test.py:6:1:6:6 | ControlFlowNode for meth() | meth() | obj1 | bar |
+| test.py:6:1:6:6 | ControlFlowNode for meth() | meth() | obj1 | foo |
+| test.py:6:1:6:6 | ControlFlowNode for meth() | meth() | obj2 | bar |
+| test.py:6:1:6:6 | ControlFlowNode for meth() | meth() | obj2 | foo |
+calls_lookup
+| test.py:6:1:6:6 | ControlFlowNode for meth() | meth() | obj1 | foo |
+| test.py:6:1:6:6 | ControlFlowNode for meth() | meth() | obj2 | bar |

--- a/python/ql/test/experimental/dataflow/method-calls/test.py
+++ b/python/ql/test/experimental/dataflow/method-calls/test.py
@@ -1,0 +1,6 @@
+if cond:
+    meth = obj1.foo
+else:
+    meth = obj2.bar
+
+meth()

--- a/python/ql/test/experimental/dataflow/method-calls/test.ql
+++ b/python/ql/test/experimental/dataflow/method-calls/test.ql
@@ -1,0 +1,18 @@
+import python
+import semmle.python.dataflow.new.DataFlow
+import experimental.dataflow.TestUtil.PrintNode
+
+query predicate conjunctive_lookup(
+  DataFlow::MethodCallNode methCall, string call, string object, string methodName
+) {
+  call = prettyNode(methCall) and
+  object = prettyNode(methCall.getObject()) and
+  methodName = methCall.getMethodName()
+}
+
+query predicate calls_lookup(
+  DataFlow::MethodCallNode methCall, string call, string object, string methodName
+) {
+  call = prettyNode(methCall) and
+  exists(DataFlow::Node o | methCall.calls(o, methodName) and object = prettyNode(o))
+}


### PR DESCRIPTION
This seems like something we have been missing for a while now, so I
figured it might be useful to add. It is roughly based on the JavaScript
equivalent, with one major difference: in the JavaScript libraries,
`getAMethodCall` is reserved for syntactic method calls (`obj.m(...)`)
whereas `getAMemberInvocation` is used for both this and the case where
the bound method `obj.m` is stored in a temporary variable and then
subsequently invoked in the same local scope.

It seems to me that the more general predicate is more useful, and hence
should have the simpler name. (And also we don't really work with a
notion of "invocation" in the Python libraries, so we would need a
better name for it anyway.)

I think as long as the documentation makes the behaviour clear, it
should be okay.

---
~Needs a change note, so I'm keeping it as draft for now.~ Change note added.