### PR TITLE
Python: Fix CWE tag for py/use-of-input

### DIFF
--- a/python/ql/src/Expressions/UseofInput.ql
+++ b/python/ql/src/Expressions/UseofInput.ql
@@ -4,7 +4,8 @@
  * @kind problem
  * @tags security
  *       correctness
- *       security/cwe/cwe-78
+ *       security/cwe/cwe-94
+ *       security/cwe/cwe-95
  * @problem.severity error
  * @security-severity 5.9
  * @sub-severity high


### PR DESCRIPTION
So it better matches what is in `py/code-injection`. I had my doubts about CWE-95, but after reading
https://owasp.org/www-community/attacks/Direct_Dynamic_Code_Evaluation_Eval%20Injection I think it's fine to add CWE-95 as well :+1:

Definitions are:

CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')

CWE-94: Improper Control of Generation of Code ('Code Injection')

CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')