### PR TITLE
[Already shipped] Docs: Update setting in CodeQL for VS Code

### DIFF
--- a/docs/codeql/codeql-for-visual-studio-code/customizing-settings.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/customizing-settings.rst
@@ -30,7 +30,7 @@ Choosing a version of the CodeQL CLI
 
 The CodeQL extension uses the CodeQL CLI to run commands. If you already have the CLI installed and added to your ``PATH``, the extension uses that version. This might be the case if you create your own CodeQL databases instead of downloading them from LGTM.com. Otherwise, the extension automatically manages access to the executable of the CLI for you. For more information about creating databases, see ":ref:`Creating CodeQL databases <creating-codeql-databases>`" in the CLI help.
 
-To override the default behavior and use a different CLI, you can specify the CodeQL CLI **Executable Path**. Note that this is only available as a user setting, not as a workspace setting.
+To override the default behavior and use a different CLI, you can specify the CodeQL CLI **Executable Path**.
 
 Changing the labels of query history items
 --------------------------------------------


### PR DESCRIPTION
Just a one-line change!

In release [v1.5.0](https://github.com/github/vscode-codeql/releases/tag/v1.5.0) of CodeQL for VS Code, we support "[workspace trust](https://code.visualstudio.com/docs/editor/workspace-trust)", which is a new(ish) VS Code feature that lets users explicitly mark workspaces as safe.

Therefore, we no longer restrict the CLI **Executable Path** setting in safe workspaces. In untrusted workspaces, the VS Code UI displays a clear warning message, so I don't think we need to document this on our end. Example:
![image](https://user-images.githubusercontent.com/42641846/118016834-c68e4b80-b34d-11eb-8f5b-41607bab4fa9.png)


---- 
Associated issue: https://github.com/github/vscode-codeql/issues/849
Implemented in: https://github.com/github/vscode-codeql/pull/861