### PR TITLE
C++: Reorder some predicates in SSAConstruction

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/PrintSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/PrintSSA.qll
@@ -52,7 +52,7 @@ class PropertyProvider extends IRPropertyProvider {
       )
     or
     exists(MemoryLocation useLocation, IRBlock defBlock, int defRank, int defOffset |
-      hasDefinitionAtRank(useLocation, _, defBlock, defRank, defOffset) and
+      hasDefinitionAtRank(useLocation, defBlock, defRank, _, defOffset) and
       defBlock.getInstruction(getIndexForOffset(defOffset)) = instruction and
       key = "DefinitionRank" + getKeySuffixForOffset(defOffset) + "[" + useLocation.toString() + "]" and
       result = defRank.toString()
@@ -65,7 +65,7 @@ class PropertyProvider extends IRPropertyProvider {
     )
     or
     exists(MemoryLocation useLocation, IRBlock defBlock, int defRank, int defOffset |
-      hasDefinitionAtRank(useLocation, _, defBlock, defRank, defOffset) and
+      hasDefinitionAtRank(useLocation, defBlock, defRank, _, defOffset) and
       defBlock.getInstruction(getIndexForOffset(defOffset)) = instruction and
       key =
         "DefinitionReachesUse" + getKeySuffixForOffset(defOffset) + "[" + useLocation.toString() +
@@ -87,14 +87,14 @@ class PropertyProvider extends IRPropertyProvider {
 
   override string getBlockProperty(IRBlock block, string key) {
     exists(MemoryLocation useLocation, int defRank, int defIndex |
-      hasDefinitionAtRank(useLocation, _, block, defRank, defIndex) and
+      hasDefinitionAtRank(useLocation, block, defRank, _, defIndex) and
       defIndex = -1 and
       key = "DefinitionRank(Phi)[" + useLocation.toString() + "]" and
       result = defRank.toString()
     )
     or
     exists(MemoryLocation useLocation, MemoryLocation defLocation, int defRank, int defIndex |
-      hasDefinitionAtRank(useLocation, defLocation, block, defRank, defIndex) and
+      hasDefinitionAtRank(useLocation, block, defRank, defLocation, defIndex) and
       defIndex = -1 and
       key = "DefinitionReachesUse(Phi)[" + useLocation.toString() + "]" and
       result =
@@ -125,7 +125,7 @@ class PropertyProvider extends IRPropertyProvider {
     key = "LiveOnEntry" and
     result =
       strictconcat(MemoryLocation useLocation |
-        locationLiveOnEntryToBlock(useLocation, block)
+        locationLiveOnEntryToBlock(block, useLocation)
       |
         useLocation.toString(), ", " order by useLocation.toString()
       )
@@ -141,7 +141,7 @@ class PropertyProvider extends IRPropertyProvider {
     key = "DefsLiveOnEntry" and
     result =
       strictconcat(MemoryLocation defLocation |
-        definitionLiveOnEntryToBlock(defLocation, block)
+        definitionLiveOnEntryToBlock(block, defLocation)
       |
         defLocation.toString(), ", " order by defLocation.toString()
       )
@@ -149,7 +149,7 @@ class PropertyProvider extends IRPropertyProvider {
     key = "DefsLiveOnExit" and
     result =
       strictconcat(MemoryLocation defLocation |
-        definitionLiveOnExitFromBlock(defLocation, block)
+        definitionLiveOnExitFromBlock(block, defLocation)
       |
         defLocation.toString(), ", " order by defLocation.toString()
       )

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/reachability/ReachableBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/reachability/ReachableBlock.qll
@@ -14,15 +14,15 @@ predicate isInfeasibleEdge(IRBlockBase block, EdgeKind kind) {
   isInfeasibleInstructionSuccessor(block.getLastInstruction(), kind)
 }
 
-private IRBlock getAFeasiblePredecessorBlock(IRBlock successor) {
+private predicate getAFeasiblePredecessorBlock(IRBlock successor, IRBlock block) {
   exists(EdgeKind kind |
-    result.getSuccessor(kind) = successor and
-    not isInfeasibleEdge(result, kind)
+    block.getSuccessor(kind) = successor and
+    not isInfeasibleEdge(block, kind)
   )
 }
 
 private predicate isBlockReachable(IRBlock block) {
-  exists(IRFunction f | getAFeasiblePredecessorBlock*(block) = f.getEntryBlock())
+  exists(IRFunction f | getAFeasiblePredecessorBlock*(block, f.getEntryBlock()))
 }
 
 /**
@@ -32,9 +32,11 @@ private predicate isBlockReachable(IRBlock block) {
 class ReachableBlock extends IRBlockBase {
   ReachableBlock() { isBlockReachable(this) }
 
-  final ReachableBlock getAFeasiblePredecessor() { result = getAFeasiblePredecessorBlock(this) }
+  pragma[inline]
+  final ReachableBlock getAFeasiblePredecessor() { getAFeasiblePredecessorBlock(this, result) }
 
-  final ReachableBlock getAFeasibleSuccessor() { this = getAFeasiblePredecessorBlock(result) }
+  pragma[inline]
+  final ReachableBlock getAFeasibleSuccessor() { getAFeasiblePredecessorBlock(result, this) }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/PrintSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/PrintSSA.qll
@@ -52,7 +52,7 @@ class PropertyProvider extends IRPropertyProvider {
       )
     or
     exists(MemoryLocation useLocation, IRBlock defBlock, int defRank, int defOffset |
-      hasDefinitionAtRank(useLocation, _, defBlock, defRank, defOffset) and
+      hasDefinitionAtRank(useLocation, defBlock, defRank, _, defOffset) and
       defBlock.getInstruction(getIndexForOffset(defOffset)) = instruction and
       key = "DefinitionRank" + getKeySuffixForOffset(defOffset) + "[" + useLocation.toString() + "]" and
       result = defRank.toString()
@@ -65,7 +65,7 @@ class PropertyProvider extends IRPropertyProvider {
     )
     or
     exists(MemoryLocation useLocation, IRBlock defBlock, int defRank, int defOffset |
-      hasDefinitionAtRank(useLocation, _, defBlock, defRank, defOffset) and
+      hasDefinitionAtRank(useLocation, defBlock, defRank, _, defOffset) and
       defBlock.getInstruction(getIndexForOffset(defOffset)) = instruction and
       key =
         "DefinitionReachesUse" + getKeySuffixForOffset(defOffset) + "[" + useLocation.toString() +
@@ -87,14 +87,14 @@ class PropertyProvider extends IRPropertyProvider {
 
   override string getBlockProperty(IRBlock block, string key) {
     exists(MemoryLocation useLocation, int defRank, int defIndex |
-      hasDefinitionAtRank(useLocation, _, block, defRank, defIndex) and
+      hasDefinitionAtRank(useLocation, block, defRank, _, defIndex) and
       defIndex = -1 and
       key = "DefinitionRank(Phi)[" + useLocation.toString() + "]" and
       result = defRank.toString()
     )
     or
     exists(MemoryLocation useLocation, MemoryLocation defLocation, int defRank, int defIndex |
-      hasDefinitionAtRank(useLocation, defLocation, block, defRank, defIndex) and
+      hasDefinitionAtRank(useLocation, block, defRank, defLocation, defIndex) and
       defIndex = -1 and
       key = "DefinitionReachesUse(Phi)[" + useLocation.toString() + "]" and
       result =
@@ -125,7 +125,7 @@ class PropertyProvider extends IRPropertyProvider {
     key = "LiveOnEntry" and
     result =
       strictconcat(MemoryLocation useLocation |
-        locationLiveOnEntryToBlock(useLocation, block)
+        locationLiveOnEntryToBlock(block, useLocation)
       |
         useLocation.toString(), ", " order by useLocation.toString()
       )
@@ -141,7 +141,7 @@ class PropertyProvider extends IRPropertyProvider {
     key = "DefsLiveOnEntry" and
     result =
       strictconcat(MemoryLocation defLocation |
-        definitionLiveOnEntryToBlock(defLocation, block)
+        definitionLiveOnEntryToBlock(block, defLocation)
       |
         defLocation.toString(), ", " order by defLocation.toString()
       )
@@ -149,7 +149,7 @@ class PropertyProvider extends IRPropertyProvider {
     key = "DefsLiveOnExit" and
     result =
       strictconcat(MemoryLocation defLocation |
-        definitionLiveOnExitFromBlock(defLocation, block)
+        definitionLiveOnExitFromBlock(block, defLocation)
       |
         defLocation.toString(), ", " order by defLocation.toString()
       )

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/reachability/ReachableBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/reachability/ReachableBlock.qll
@@ -14,15 +14,15 @@ predicate isInfeasibleEdge(IRBlockBase block, EdgeKind kind) {
   isInfeasibleInstructionSuccessor(block.getLastInstruction(), kind)
 }
 
-private IRBlock getAFeasiblePredecessorBlock(IRBlock successor) {
+private predicate getAFeasiblePredecessorBlock(IRBlock successor, IRBlock block) {
   exists(EdgeKind kind |
-    result.getSuccessor(kind) = successor and
-    not isInfeasibleEdge(result, kind)
+    block.getSuccessor(kind) = successor and
+    not isInfeasibleEdge(block, kind)
   )
 }
 
 private predicate isBlockReachable(IRBlock block) {
-  exists(IRFunction f | getAFeasiblePredecessorBlock*(block) = f.getEntryBlock())
+  exists(IRFunction f | getAFeasiblePredecessorBlock*(block, f.getEntryBlock()))
 }
 
 /**
@@ -32,9 +32,11 @@ private predicate isBlockReachable(IRBlock block) {
 class ReachableBlock extends IRBlockBase {
   ReachableBlock() { isBlockReachable(this) }
 
-  final ReachableBlock getAFeasiblePredecessor() { result = getAFeasiblePredecessorBlock(this) }
+  pragma[inline]
+  final ReachableBlock getAFeasiblePredecessor() { getAFeasiblePredecessorBlock(this, result) }
 
-  final ReachableBlock getAFeasibleSuccessor() { this = getAFeasiblePredecessorBlock(result) }
+  pragma[inline]
+  final ReachableBlock getAFeasibleSuccessor() { getAFeasiblePredecessorBlock(result, this) }
 }
 
 /**

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/PrintSSA.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/PrintSSA.qll
@@ -52,7 +52,7 @@ class PropertyProvider extends IRPropertyProvider {
       )
     or
     exists(MemoryLocation useLocation, IRBlock defBlock, int defRank, int defOffset |
-      hasDefinitionAtRank(useLocation, _, defBlock, defRank, defOffset) and
+      hasDefinitionAtRank(useLocation, defBlock, defRank, _, defOffset) and
       defBlock.getInstruction(getIndexForOffset(defOffset)) = instruction and
       key = "DefinitionRank" + getKeySuffixForOffset(defOffset) + "[" + useLocation.toString() + "]" and
       result = defRank.toString()
@@ -65,7 +65,7 @@ class PropertyProvider extends IRPropertyProvider {
     )
     or
     exists(MemoryLocation useLocation, IRBlock defBlock, int defRank, int defOffset |
-      hasDefinitionAtRank(useLocation, _, defBlock, defRank, defOffset) and
+      hasDefinitionAtRank(useLocation, defBlock, defRank, _, defOffset) and
       defBlock.getInstruction(getIndexForOffset(defOffset)) = instruction and
       key =
         "DefinitionReachesUse" + getKeySuffixForOffset(defOffset) + "[" + useLocation.toString() +
@@ -87,14 +87,14 @@ class PropertyProvider extends IRPropertyProvider {
 
   override string getBlockProperty(IRBlock block, string key) {
     exists(MemoryLocation useLocation, int defRank, int defIndex |
-      hasDefinitionAtRank(useLocation, _, block, defRank, defIndex) and
+      hasDefinitionAtRank(useLocation, block, defRank, _, defIndex) and
       defIndex = -1 and
       key = "DefinitionRank(Phi)[" + useLocation.toString() + "]" and
       result = defRank.toString()
     )
     or
     exists(MemoryLocation useLocation, MemoryLocation defLocation, int defRank, int defIndex |
-      hasDefinitionAtRank(useLocation, defLocation, block, defRank, defIndex) and
+      hasDefinitionAtRank(useLocation, block, defRank, defLocation, defIndex) and
       defIndex = -1 and
       key = "DefinitionReachesUse(Phi)[" + useLocation.toString() + "]" and
       result =
@@ -125,7 +125,7 @@ class PropertyProvider extends IRPropertyProvider {
     key = "LiveOnEntry" and
     result =
       strictconcat(MemoryLocation useLocation |
-        locationLiveOnEntryToBlock(useLocation, block)
+        locationLiveOnEntryToBlock(block, useLocation)
       |
         useLocation.toString(), ", " order by useLocation.toString()
       )
@@ -141,7 +141,7 @@ class PropertyProvider extends IRPropertyProvider {
     key = "DefsLiveOnEntry" and
     result =
       strictconcat(MemoryLocation defLocation |
-        definitionLiveOnEntryToBlock(defLocation, block)
+        definitionLiveOnEntryToBlock(block, defLocation)
       |
         defLocation.toString(), ", " order by defLocation.toString()
       )
@@ -149,7 +149,7 @@ class PropertyProvider extends IRPropertyProvider {
     key = "DefsLiveOnExit" and
     result =
       strictconcat(MemoryLocation defLocation |
-        definitionLiveOnExitFromBlock(defLocation, block)
+        definitionLiveOnExitFromBlock(block, defLocation)
       |
         defLocation.toString(), ", " order by defLocation.toString()
       )


### PR DESCRIPTION
When comparing on https://asgerf.github.io/codeql-flamegraph-viewer/, this reduces the `tuples from dominated dependencies` number from the IR stage by about 10% when running on `OpenJDK`. I don't know if it has a measurable impact, but it's worth a try!

CPP-Differences: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/2100/