### PR TITLE
Python: Fixup for names of supported PyPI packages

### DIFF
--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -166,7 +166,8 @@ Python built-in support
    multidict, Utility library
    yarl, Utility library
    mysql-connector-python, Database
-   MySQLdb, Database
+   mysql-connector, Database
+   MySQL-python, Database
    psycopg2, Database
    sqlite3, Database
    cryptography, Cryptography library

--- a/python/ql/src/semmle/python/Frameworks.qll
+++ b/python/ql/src/semmle/python/Frameworks.qll
@@ -14,7 +14,7 @@ private import semmle.python.frameworks.Flask
 private import semmle.python.frameworks.Idna
 private import semmle.python.frameworks.Invoke
 private import semmle.python.frameworks.Multidict
-private import semmle.python.frameworks.MysqlConnectorPython
+private import semmle.python.frameworks.Mysql
 private import semmle.python.frameworks.MySQLdb
 private import semmle.python.frameworks.Psycopg2
 private import semmle.python.frameworks.PyMySQL

--- a/python/ql/src/semmle/python/frameworks/MySQLdb.qll
+++ b/python/ql/src/semmle/python/frameworks/MySQLdb.qll
@@ -1,5 +1,7 @@
 /**
- * Provides classes modeling security-relevant aspects of the `MySQLdb` PyPI package.
+ * Provides classes modeling security-relevant aspects of the `MySQL-python` PyPI package
+ * (imported as `MySQLdb`).
+ *
  * See
  * - https://mysqlclient.readthedocs.io/index.html
  * - https://pypi.org/project/MySQL-python/
@@ -13,7 +15,7 @@ private import semmle.python.ApiGraphs
 private import semmle.python.frameworks.PEP249
 
 /**
- * Provides models for the `MySQLdb` PyPI package.
+ * Provides models for the `MySQL-python` PyPI package (imported as `MySQLdb`).
  * See
  * - https://mysqlclient.readthedocs.io/index.html
  * - https://pypi.org/project/MySQL-python/

--- a/python/ql/src/semmle/python/frameworks/Mysql.qll
+++ b/python/ql/src/semmle/python/frameworks/Mysql.qll
@@ -20,7 +20,7 @@ private import semmle.python.frameworks.PEP249
  * - https://dev.mysql.com/doc/connector-python/en/
  * - https://dev.mysql.com/doc/connector-python/en/connector-python-example-connecting.html
  */
-private module MysqlConnectorPython {
+private module Mysql {
   // ---------------------------------------------------------------------------
   // mysql
   // ---------------------------------------------------------------------------

--- a/python/ql/src/semmle/python/frameworks/MysqlConnectorPython.qll
+++ b/python/ql/src/semmle/python/frameworks/MysqlConnectorPython.qll
@@ -1,5 +1,6 @@
 /**
- * Provides classes modeling security-relevant aspects of the `mysql-connector-python` package.
+ * Provides classes modeling security-relevant aspects of the `mysql-connector-python`
+ * and `mysql-connector` (old package name) PyPI packages (imported as `mysql`).
  * See
  * - https://dev.mysql.com/doc/connector-python/en/
  * - https://dev.mysql.com/doc/connector-python/en/connector-python-example-connecting.html
@@ -13,7 +14,8 @@ private import semmle.python.ApiGraphs
 private import semmle.python.frameworks.PEP249
 
 /**
- * Provides models for the `mysql-connector-python` package.
+ * Provides classes modeling security-relevant aspects of the `mysql-connector-python`
+ * and `mysql-connector` (old package name) PyPI packages (imported as `mysql`).
  * See
  * - https://dev.mysql.com/doc/connector-python/en/
  * - https://dev.mysql.com/doc/connector-python/en/connector-python-example-connecting.html


### PR DESCRIPTION
Also renames the .qll file for `mysql-connector-python`/`mysql-connector` support. Just like our support for the `PyYAML` PyPI package that you import with `import yaml` is in `Yaml.qll`.

Since this file does not provide any public predicates/modules, it
should be safe to rename it.