### PR TITLE
Python: Add `Node::getPreUpdateNode`

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -274,7 +274,7 @@ private module Cached {
   predicate outNodeExt(Node n) {
     n instanceof OutNode
     or
-    n.(PostUpdateNode).getPreUpdateNode() instanceof ArgNode
+    n.getPreUpdateNode() instanceof ArgNode
   }
 
   cached
@@ -285,7 +285,7 @@ private module Cached {
     result = getAnOutNode(call, k.(ValueReturnKind).getKind())
     or
     exists(ArgNode arg |
-      result.(PostUpdateNode).getPreUpdateNode() = arg and
+      result.getPreUpdateNode() = arg and
       arg.argumentOf(call, k.(ParamUpdateReturnKind).getPosition())
     )
   }
@@ -729,8 +729,8 @@ private module Cached {
     containerType = getNodeDataFlowType(node2)
     or
     exists(Node n1, Node n2 |
-      n1 = node1.(PostUpdateNode).getPreUpdateNode() and
-      n2 = node2.(PostUpdateNode).getPreUpdateNode()
+      n1 = node1.getPreUpdateNode() and
+      n2 = node2.getPreUpdateNode()
     |
       argumentValueFlowsThrough(n2, TReadStepTypesSome(containerType, c, contentType), n1)
       or

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -274,7 +274,7 @@ private module Cached {
   predicate outNodeExt(Node n) {
     n instanceof OutNode
     or
-    n.getPreUpdateNode() instanceof ArgNode
+    n.(PostUpdateNode).getPreUpdateNode() instanceof ArgNode
   }
 
   cached
@@ -285,7 +285,7 @@ private module Cached {
     result = getAnOutNode(call, k.(ValueReturnKind).getKind())
     or
     exists(ArgNode arg |
-      result.getPreUpdateNode() = arg and
+      result.(PostUpdateNode).getPreUpdateNode() = arg and
       arg.argumentOf(call, k.(ParamUpdateReturnKind).getPosition())
     )
   }
@@ -729,8 +729,8 @@ private module Cached {
     containerType = getNodeDataFlowType(node2)
     or
     exists(Node n1, Node n2 |
-      n1 = node1.getPreUpdateNode() and
-      n2 = node2.getPreUpdateNode()
+      n1 = node1.(PostUpdateNode).getPreUpdateNode() and
+      n2 = node2.(PostUpdateNode).getPreUpdateNode()
     |
       argumentValueFlowsThrough(n2, TReadStepTypesSome(containerType, c, contentType), n1)
       or

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -32,7 +32,9 @@ module syntheticPreUpdateNode {
   class NeedsSyntheticPreUpdateNode extends PostUpdateNode {
     NeedsSyntheticPreUpdateNode() { this = objectCreationNode() }
 
-    override Node getPreUpdateNode() { result.(SyntheticPreUpdateNode).getPostUpdateNode() = this }
+    override Node getPreUpdateNodeImpl() {
+      result.(SyntheticPreUpdateNode).getPostUpdateNode() = this
+    }
 
     /**
      * A label for this kind of node. This will figure in the textual representation of the synthesized pre-update node.
@@ -60,7 +62,7 @@ module syntheticPostUpdateNode {
 
     SyntheticPostUpdateNode() { this = TSyntheticPostUpdateNode(pre) }
 
-    override Node getPreUpdateNode() { result = pre }
+    override Node getPreUpdateNodeImpl() { result = pre }
 
     override string toString() { result = "[post " + pre.label() + "] " + pre.toString() }
 
@@ -263,7 +265,7 @@ private predicate localEssaStep(EssaNode nodeFrom, EssaNode nodeTo) {
 private Node update(Node node) {
   result = node
   or
-  result.(PostUpdateNode).getPreUpdateNode() = node
+  result.getPreUpdateNode() = node
 }
 
 // TODO: Make modules for these headings

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -120,6 +120,14 @@ class Node extends TNode {
   Expr asExpr() { none() }
 
   /**
+   * Gets the pre-update node corresponding to this node, if any.
+   * Only holds if this node is itself a `PostUpdateNode`.
+   *
+   * See the class `PostUpdateNode` for more information
+   */
+  Node getPreUpdateNode() { result = this.(PostUpdateNode).getPreUpdateNodeImpl() }
+
+  /**
    * Gets a local source node from which data may flow to this node in zero or more local data-flow steps.
    */
   LocalSourceNode getALocalSource() { result.flowsTo(this) }
@@ -250,7 +258,7 @@ class ArgumentNode extends Node {
  */
 abstract class PostUpdateNode extends Node {
   /** Gets the node before the state update. */
-  abstract Node getPreUpdateNode();
+  abstract Node getPreUpdateNodeImpl();
 }
 
 /**

--- a/python/ql/src/semmle/python/dataflow/new/internal/TaintTrackingPrivate.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/TaintTrackingPrivate.qll
@@ -178,8 +178,7 @@ predicate containerStep(DataFlow::CfgNode nodeFrom, DataFlow::Node nodeTo) {
   // list.append, set.add
   exists(CallNode call, string name |
     name in ["append", "add"] and
-    call.getFunction().(AttrNode).getObject(name) =
-      nodeTo.(DataFlow::PostUpdateNode).getPreUpdateNode().asCfgNode() and
+    call.getFunction().(AttrNode).getObject(name) = nodeTo.getPreUpdateNode().asCfgNode() and
     call.getArg(0) = nodeFrom.getNode()
   )
 }

--- a/python/ql/src/semmle/python/frameworks/Simplejson.qll
+++ b/python/ql/src/semmle/python/frameworks/Simplejson.qll
@@ -40,9 +40,7 @@ private module SimplejsonModel {
     override DataFlow::Node getAnInput() { result in [this.getArg(0), this.getArgByName("obj")] }
 
     override DataFlow::Node getOutput() {
-      result.(DataFlow::PostUpdateNode).getPreUpdateNode() in [
-          this.getArg(1), this.getArgByName("fp")
-        ]
+      result.getPreUpdateNode() in [this.getArg(1), this.getArgByName("fp")]
     }
 
     override string getFormat() { result = "JSON" }

--- a/python/ql/src/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/src/semmle/python/frameworks/Stdlib.qll
@@ -558,9 +558,7 @@ private module Stdlib {
     override DataFlow::Node getAnInput() { result in [this.getArg(0), this.getArgByName("obj")] }
 
     override DataFlow::Node getOutput() {
-      result.(DataFlow::PostUpdateNode).getPreUpdateNode() in [
-          this.getArg(1), this.getArgByName("fp")
-        ]
+      result.getPreUpdateNode() in [this.getArg(1), this.getArgByName("fp")]
     }
 
     override string getFormat() { result = "JSON" }

--- a/python/ql/src/semmle/python/frameworks/Ujson.qll
+++ b/python/ql/src/semmle/python/frameworks/Ujson.qll
@@ -35,9 +35,7 @@ private module UjsonModel {
 
     override DataFlow::Node getAnInput() { result = this.getArg(0) }
 
-    override DataFlow::Node getOutput() {
-      result.(DataFlow::PostUpdateNode).getPreUpdateNode() = this.getArg(1)
-    }
+    override DataFlow::Node getOutput() { result.getPreUpdateNode() = this.getArg(1) }
 
     override string getFormat() { result = "JSON" }
   }

--- a/python/ql/test/experimental/dataflow/TestUtil/PrintNode.qll
+++ b/python/ql/test/experimental/dataflow/TestUtil/PrintNode.qll
@@ -43,13 +43,13 @@ string prettyNodeForInlineTest(DataFlow::Node node) {
   exists(node.asExpr()) and
   result = prettyExpr(node.asExpr())
   or
-  exists(Expr e | e = node.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr() |
+  exists(Expr e | e = node.getPreUpdateNode().asExpr() |
     // since PostUpdateNode both has space in the `[post <thing>]` annotation, and does
     // not pretty print the pre-update node, we do custom handling of this.
     result = "[post]" + prettyExpr(e)
   )
   or
   not exists(node.asExpr()) and
-  not exists(Expr e | e = node.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr()) and
+  not exists(Expr e | e = node.getPreUpdateNode().asExpr()) and
   result = node.toString()
 }


### PR DESCRIPTION
This is mostly as a convenience, as
`foo.(PostUpdateNode).getPreUpdateNode()` can be a bit of a mouthful.

This does not change the external API in any meaningful way, so I don't
think a change note is necessary.