### PR TITLE
CPP: Add a query to find incorrectly used switch

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.c
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.c
@@ -1,0 +1,34 @@
+...
+  int i1;
+  char c1;
+...
+  if((c1<50)&&(c>10))
+  switch(c1){
+    case 300: // BAD: the code will not be executed
+...  
+  if((i1<5)&&(i1>0))
+  switch(i1){ // BAD
+    case 21: // BAD: the code will not be executed
+...
+  switch(c1){
+...
+  dafault: // BAD: maybe it will be right `default`
+...
+  }
+
+...
+  switch(c1){ 
+      i1=c1*2; // BAD: the code will not be executed
+    case 12:
+...
+  switch(c1){ // GOOD
+    case 12:
+      break;
+    case 10:
+      break;
+    case 9:
+      break;
+    default:
+      break;
+  }
+...

--- a/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.qhelp
@@ -1,0 +1,24 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Finding places the dangerous use of a switch.</p>
+
+
+</overview>
+
+<example>
+<p>The following example demonstrates fallacious and fixed methods of using switch.</p>
+<sample src="FindIncorrectlyUsedSwitch.c" />
+
+</example>
+<references>
+
+<li>
+  CERT C Coding Standard:
+  <a href="https://wiki.sei.cmu.edu/confluence/display/c/MSC12-C.+Detect+and+remove+code+that+has+no+effect+or+is+never+executed">MSC12-C. Detect and remove code that has no effect or is never executed</a>.
+</li>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.qhelp
@@ -3,7 +3,7 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>Finding places the dangerous use of a switch.</p>
+<p>A mismatch between conditionals and <code>switch</code> cases can lead to control-flow violations (CWE-691) where the developer either does not handle all combinations of conditions or unintentionally created dead code (CWE-561).</p>
 
 
 </overview>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.qhelp
@@ -9,7 +9,7 @@
 </overview>
 
 <example>
-<p>The following example demonstrates fallacious and fixed methods of using switch.</p>
+<p>The following example demonstrates fallacious and fixed ways of using a <code>switch</code> statement.</p>
 <sample src="FindIncorrectlyUsedSwitch.c" />
 
 </example>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.ql
@@ -1,5 +1,5 @@
 /**
- * @name Operator Find Incorrectly Used Switch
+ * @name Incorrect switch statement
  * @description --Finding places the dangerous use of a switch.
  *              --For example, when the range of values for a condition does not cover all of the selection values..
  * @kind problem

--- a/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.ql
@@ -45,12 +45,7 @@ predicate isRealRange(Expr exp) {
   lowerBound(exp) != -8388608 and
   lowerBound(exp) != -65536 and
   lowerBound(exp) != -32768 and
-  lowerBound(exp) != -128 and
-  lowerBound(exp) != 0 and
-  lowerBound(exp) != upperBound(exp)
-  or
-  lowerBound(exp) = 0 and
-  upperBound(exp) = 1
+  lowerBound(exp) != -128
 }
 
 /** Holds if the range of values for the condition is less than the choices. */
@@ -115,6 +110,10 @@ predicate isWrongLableName(SwitchStmt swtmp) {
 predicate isCodeBeforeCase(SwitchStmt swtmp) {
   exists(Expr exp |
     exp.getEnclosingStmt().getParentStmt*() = swtmp.getStmt() and
+    not exists(Loop lp |
+      exp.getEnclosingStmt().getParentStmt*() = lp and
+      lp.getEnclosingStmt().getParentStmt*() = swtmp.getStmt()
+    ) and
     not exists(Stmt sttmp, SwitchCase sctmp |
       sttmp = swtmp.getASwitchCase().getAStmt() and
       sctmp = swtmp.getASwitchCase() and
@@ -129,6 +128,13 @@ predicate isCodeBeforeCase(SwitchStmt swtmp) {
 from SwitchStmt sw, string msg
 where
   isRealRange(sw.getExpr()) and
+  lowerBound(sw.getExpr()) != upperBound(sw.getExpr()) and
+  lowerBound(sw.getExpr()) != 0 and
+  not exists(Expr cexp |
+    cexp = sw.getASwitchCase().getExpr() and not isRealRange(cexp)
+    or
+    cexp = sw.getASwitchCase().getEndExpr() and not isRealRange(cexp)
+  ) and
   not exists(Expr exptmp |
     exptmp = sw.getExpr().getAChild*() and
     not exptmp.isConstant() and

--- a/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.ql
@@ -1,0 +1,137 @@
+/**
+ * @name Operator Find Incorrectly Used Switch
+ * @description --Finding places the dangerous use of a switch.
+ *              --For example, when the range of values for a condition does not cover all of the selection values..
+ * @kind problem
+ * @id cpp/operator-find-incorrectly-used-switch
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ *       security
+ *       external/cwe/cwe-561
+ *       external/cwe/cwe-691
+ *       external/cwe/cwe-478
+ */
+
+import cpp
+import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
+import semmle.code.cpp.commons.Exclusions
+
+/** Holds if the range contains no boundary values. */
+predicate isRealRange(Expr exp) {
+  upperBound(exp).toString() != "18446744073709551616" and
+  upperBound(exp).toString() != "9223372036854775807" and
+  upperBound(exp).toString() != "4294967295" and
+  upperBound(exp).toString() != "Infinity" and
+  upperBound(exp).toString() != "NaN" and
+  lowerBound(exp).toString() != "-9223372036854775808" and
+  lowerBound(exp).toString() != "-4294967296" and
+  lowerBound(exp).toString() != "-Infinity" and
+  lowerBound(exp).toString() != "NaN" and
+  upperBound(exp) != 2147483647 and
+  upperBound(exp) != 268435455 and
+  upperBound(exp) != 33554431 and
+  upperBound(exp) != 8388607 and
+  upperBound(exp) != 65535 and
+  upperBound(exp) != 32767 and
+  upperBound(exp) != 255 and
+  upperBound(exp) != 127 and
+  lowerBound(exp) != -2147483648 and
+  lowerBound(exp) != -268435456 and
+  lowerBound(exp) != -33554432 and
+  lowerBound(exp) != -8388608 and
+  lowerBound(exp) != -65536 and
+  lowerBound(exp) != -32768 and
+  lowerBound(exp) != -128
+  or
+  lowerBound(exp) = 0 and
+  upperBound(exp) = 1
+}
+
+/** Holds if the range of values for the condition is less than the choices. */
+predicate isNotAllSelected(SwitchStmt swtmp) {
+  not swtmp.getExpr().isConstant() and
+  exists(int i |
+    i != 0 and
+    (
+      i = lowerBound(swtmp.getASwitchCase().getExpr()) and
+      upperBound(swtmp.getExpr()) < i
+      or
+      (
+        i = upperBound(swtmp.getASwitchCase().getExpr()) or
+        i = upperBound(swtmp.getASwitchCase().getEndExpr())
+      ) and
+      lowerBound(swtmp.getExpr()) > i
+    )
+  )
+}
+
+/** Holds if the range of values for the condition is greater than the selection. */
+predicate isConditionBig(SwitchStmt swtmp) {
+  not swtmp.hasDefaultCase() and
+  not exists(int iu, int il |
+    (
+      iu = upperBound(swtmp.getASwitchCase().getExpr()) or
+      iu = upperBound(swtmp.getASwitchCase().getEndExpr())
+    ) and
+    upperBound(swtmp.getExpr()) = iu and
+    (
+      il = lowerBound(swtmp.getASwitchCase().getExpr()) or
+      il = lowerBound(swtmp.getASwitchCase().getEndExpr())
+    ) and
+    lowerBound(swtmp.getExpr()) = il
+  )
+}
+
+/** Holds if there are labels inside the block with names similar to `default` or `case`. */
+predicate isWrongLableName(SwitchStmt swtmp) {
+  not swtmp.hasDefaultCase() and
+  exists(LabelStmt lb |
+    (
+      (
+        lb.getName().charAt(0) = "d" or
+        lb.getName().charAt(0) = "c"
+      ) and
+      (
+        lb.getName().charAt(1) = "e" or
+        lb.getName().charAt(1) = "a"
+      ) and
+      (
+        lb.getName().charAt(2) = "f" or
+        lb.getName().charAt(2) = "s"
+      )
+    ) and
+    lb.getEnclosingStmt().getParentStmt*() = swtmp.getStmt() and
+    not exists(GotoStmt gs | gs.getName() = lb.getName())
+  )
+}
+
+/** Holds if the block contains code before the first `case`. */
+predicate isCodeBeforeCase(SwitchStmt swtmp) {
+  exists(Expr exp |
+    exp.getEnclosingStmt().getParentStmt*() = swtmp.getStmt() and
+    not exists(Stmt sttmp, SwitchCase sctmp |
+      sttmp = swtmp.getASwitchCase().getAStmt() and
+      sctmp = swtmp.getASwitchCase() and
+      (
+        exp.getEnclosingStmt().getParentStmt*() = sttmp or
+        exp.getEnclosingStmt() = sctmp
+      )
+    )
+  )
+}
+
+from SwitchStmt sw, string msg
+where
+  isRealRange(sw.getExpr()) and
+  isRealRange(sw.getExpr().getAChild*()) and
+  (
+    isNotAllSelected(sw) and msg = "The range of condition values is less than the selection."
+    or
+    isConditionBig(sw) and msg = "The range of condition values is wider than the choices."
+  )
+  or
+  isWrongLableName(sw) and msg = "Possibly erroneous label name."
+  or
+  isCodeBeforeCase(sw) and msg = "Code before case will not be executed."
+select sw, msg

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/FindIncorrectlyUsedSwitch.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/FindIncorrectlyUsedSwitch.expected
@@ -1,4 +1,4 @@
-| test.c:14:3:22:3 | switch (...) ...  | Possibly erroneous label name. |
-| test.c:24:3:32:3 | switch (...) ...  | Code before case will not be executed. |
-| test.c:36:3:45:3 | switch (...) ...  | The range of condition values is less than the selection. |
-| test.c:48:3:53:3 | switch (...) ...  | The range of condition values is wider than the choices. |
+| test.c:20:3:28:3 | switch (...) ...  | Possibly erroneous label name. |
+| test.c:30:3:38:3 | switch (...) ...  | Code before case will not be executed. |
+| test.c:41:3:50:3 | switch (...) ...  | The range of condition values is less than the selection. |
+| test.c:53:3:58:3 | switch (...) ...  | The range of condition values is wider than the choices. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/FindIncorrectlyUsedSwitch.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/FindIncorrectlyUsedSwitch.expected
@@ -1,0 +1,4 @@
+| test.c:14:3:22:3 | switch (...) ...  | Possibly erroneous label name. |
+| test.c:24:3:32:3 | switch (...) ...  | Code before case will not be executed. |
+| test.c:36:3:45:3 | switch (...) ...  | The range of condition values is less than the selection. |
+| test.c:48:3:53:3 | switch (...) ...  | The range of condition values is wider than the choices. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/FindIncorrectlyUsedSwitch.qlref
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/FindIncorrectlyUsedSwitch.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.ql

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/test.c
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/test.c
@@ -1,6 +1,5 @@
-void testFunction(char c1)
+void testFunction(char c1,int i1)
 {
-
 
   switch(c1){ // GOOD
     case 12:
@@ -10,7 +9,14 @@ void testFunction(char c1)
     case 9:
       break;
   }
-  
+
+  switch(i1){ // GOOD
+    for(i1=0;i1<20;i1++){
+      case 12:
+      case 10:
+      case 9:
+    }
+  }
   switch(c1){ // BAD
     case 12:
       break;
@@ -20,7 +26,7 @@ void testFunction(char c1)
       break;
   dafault:
   }
-  
+
   switch(c1){ // BAD
       c1=c1*2;
     case 12:
@@ -31,10 +37,9 @@ void testFunction(char c1)
       break;
   }
 
-  
   if((c1<6)&&(c1>0))
   switch(c1){ // BAD
-    case 7:
+    case 8:
       break;
     case 5:
       break;
@@ -43,7 +48,7 @@ void testFunction(char c1)
     case 1:
       break;
   }
-  
+
   if((c1<6)&&(c1>0))
   switch(c1){ // BAD
     case 3:

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/test.c
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/test.c
@@ -1,0 +1,55 @@
+void testFunction()
+{
+  char c1;
+
+  switch(c1){ // GOOD
+    case 12:
+      break;
+    case 10:
+      break;
+    case 9:
+      break;
+  }
+  
+  switch(c1){ // BAD
+    case 12:
+      break;
+    case 10:
+      break;
+    case 9:
+      break;
+  dafault:
+  }
+  
+  switch(c1){ // BAD
+      c1=c1*2;
+    case 12:
+      break;
+    case 10:
+      break;
+    case 9:
+      break;
+  }
+
+  
+  if((c1<6)&&(c1>0))
+  switch(c1){ // BAD
+    case 7:
+      break;
+    case 5:
+      break;
+    case 3:
+      break;
+    case 1:
+      break;
+  }
+  
+  if((c1<6)&&(c1>0))
+  switch(c1){ // BAD
+    case 3:
+      break;
+    case 1:
+      break;
+  }
+  
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/test.c
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-561/semmle/tests/test.c
@@ -1,6 +1,6 @@
-void testFunction()
+void testFunction(char c1)
 {
-  char c1;
+
 
   switch(c1){ // GOOD
     case 12:


### PR DESCRIPTION
good day.
in this request, I am considering finding a error use of the `switch` block.
I have identified 4 main areas:
1.when the value range of the condition is less than the selection items.
2. when the selection items are larger than the range of values.
3.when there are labels in the body with names similar to `default` or` case`
4.when there is code before the first case element.

I would like to draw your attention to the predicate `isRealRange` unfortunately the restriction on` int` did not allow using `bitShiftRight` and make it more elegant.

regarding fixes in real software, I am currently awaiting a response from some projects and continue to look for a solution in others.
https://github.com/htacg/tidy-html5/pull/953
https://github.com/Hamlib/Hamlib/issues/723