### PR TITLE
CPP: Add a query to find incorrectly used exceptions.

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.cpp
@@ -1,10 +1,10 @@
 ...
-testClass1 :: testMethod()
+void testClass1 :: testMethod()
 {
    throw "my exception!";  // BAD
 }
 ...
-testClass3 :: testMethod()
+void testClass3 :: testMethod()
 {
   try { throw "my exception!"; } // GOOD
   catch (...) { clean(); }

--- a/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.cpp
@@ -1,10 +1,10 @@
 ...
-testClass1 :: ~testClass1()
+testClass1 :: testMethod()
 {
    throw "my exception!";  // BAD
 }
 ...
-testClass3 :: ~testClass3()
+testClass3 :: testMethod()
 {
   try { throw "my exception!"; } // GOOD
   catch (...) { clean(); }

--- a/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.cpp
@@ -1,0 +1,16 @@
+...
+testClass1 :: ~testClass1()
+{
+   throw "my exception!";  // BAD
+}
+...
+testClass3 :: ~testClass3()
+{
+  try { throw "my exception!"; } // GOOD
+  catch (...) { clean(); }
+}
+...
+std::runtime_error("msg error"); // BAD
+...
+throw std::runtime_error("msg error"); // GOOD
+...

--- a/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.qhelp
@@ -7,13 +7,9 @@
 
 
 </overview>
-<recommendation>
 
-<p>We recommend that you handle exceptions inside the destructor.</p>
-
-</recommendation>
 <example>
-<p>The following example demonstrates erroneous and fixed methods for using exceptions.</p>
+<p>Finding for places of incomplete use of objects, type exception.</p>
 <sample src="FindIncorrectlyUsedExceptions.cpp" />
 
 </example>
@@ -21,7 +17,7 @@
 
 <li>
   CERT CPP Coding Standard:
-  <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL57-CPP.+Do+not+let+exceptions+escape+from+destructors+or+deallocation+functions">DCL57-CPP. Do not let exceptions escape from destructors or deallocation functions</a>.
+  <a href="https://wiki.sei.cmu.edu/confluence/display/java/ERR00-J.+Do+not+suppress+or+ignore+checked+exceptions">ERR00-J. Do not suppress or ignore checked exceptions</a>.
 </li>
 
 </references>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.qhelp
@@ -1,0 +1,28 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Finding places for the dangerous use of exceptions.</p>
+
+
+</overview>
+<recommendation>
+
+<p>We recommend that you handle exceptions inside the destructor.</p>
+
+</recommendation>
+<example>
+<p>The following example demonstrates erroneous and fixed methods for using exceptions.</p>
+<sample src="FindIncorrectlyUsedExceptions.cpp" />
+
+</example>
+<references>
+
+<li>
+  CERT CPP Coding Standard:
+  <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL57-CPP.+Do+not+let+exceptions+escape+from+destructors+or+deallocation+functions">DCL57-CPP. Do not let exceptions escape from destructors or deallocation functions</a>.
+</li>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.ql
@@ -1,0 +1,38 @@
+/**
+ * @name Operator Find Incorrectly Used Exceptions
+ * @description --Finding places for the dangerous use of exceptions.
+ *              --For example, when the distructor throws an exception but does not handle it.
+ * @kind problem
+ * @id cpp/operator-find-incorrectly-used-exceptions
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ *       security
+ *       external/cwe/cwe-703
+ *       external/cwe/cwe-248
+ *       external/cwe/cwe-390
+ */
+
+import cpp
+
+from FunctionCall fc, string msg
+where
+  exists(ThrowExpr texp |
+    texp.getEnclosingFunction() = fc.(DestructorCall).getTarget() and
+    not exists(TryStmt ts |
+      texp.getEnclosingStmt().getParentStmt*() = ts.getStmt() and
+      not ts.getACatchClause().isEmpty()
+    ) and
+    msg = "This distructor contains exeption no wrapped to try..catch blocks"
+  )
+  or
+  fc.getTarget() instanceof Constructor and
+  fc.getTargetType().(Class).getABaseClass+().hasGlobalOrStdName("exception") and
+  not fc.isInMacroExpansion() and
+  not exists(ThrowExpr texp | fc.getEnclosingStmt() = texp.getEnclosingStmt()) and
+  not exists(FunctionCall fctmp | fctmp.getAnArgument() = fc) and
+  not fc instanceof ConstructorDirectInit and
+  not fc.getEnclosingStmt() instanceof DeclStmt and
+  not fc instanceof ConstructorDelegationInit and
+  msg = "This object does not generate an exception."
+select fc, msg

--- a/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.ql
@@ -1,7 +1,6 @@
 /**
  * @name Operator Find Incorrectly Used Exceptions
- * @description --Finding places for the dangerous use of exceptions.
- *              --For example, when the distructor throws an exception but does not handle it.
+ * @description --Finding for places of incomplete use of objects, type exception.
  * @kind problem
  * @id cpp/operator-find-incorrectly-used-exceptions
  * @problem.severity warning
@@ -18,12 +17,12 @@ import cpp
 from FunctionCall fc, string msg
 where
   exists(ThrowExpr texp |
-    texp.getEnclosingFunction() = fc.(DestructorCall).getTarget() and
+    texp.getEnclosingFunction() = fc.getTarget() and
     not exists(TryStmt ts |
       texp.getEnclosingStmt().getParentStmt*() = ts.getStmt() and
       not ts.getACatchClause().isEmpty()
     ) and
-    msg = "This distructor contains exeption no wrapped to try..catch blocks"
+    msg = "Exception inside this function requires more handling."
   )
   or
   fc.getTarget() instanceof Constructor and

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-703/semmle/tests/FindIncorrectlyUsedExceptions.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-703/semmle/tests/FindIncorrectlyUsedExceptions.expected
@@ -1,2 +1,2 @@
-| test.cpp:47:1:47:1 | call to ~testClass1 | This distructor contains exeption no wrapped to try..catch blocks |
-| test.cpp:47:1:47:1 | call to ~testClass2 | This distructor contains exeption no wrapped to try..catch blocks |
+| test.cpp:45:6:45:15 | call to testMethod | Exception inside this function requires more handling. |
+| test.cpp:47:6:47:15 | call to testMethod | Exception inside this function requires more handling. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-703/semmle/tests/FindIncorrectlyUsedExceptions.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-703/semmle/tests/FindIncorrectlyUsedExceptions.expected
@@ -1,0 +1,2 @@
+| test.cpp:47:1:47:1 | call to ~testClass1 | This distructor contains exeption no wrapped to try..catch blocks |
+| test.cpp:47:1:47:1 | call to ~testClass2 | This distructor contains exeption no wrapped to try..catch blocks |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-703/semmle/tests/FindIncorrectlyUsedExceptions.qlref
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-703/semmle/tests/FindIncorrectlyUsedExceptions.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.ql

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-703/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-703/semmle/tests/test.cpp
@@ -1,0 +1,47 @@
+typedef unsigned int size_t;
+void clean();
+
+
+class testClass1
+{
+public:
+	~testClass1();
+};
+
+
+testClass1 :: ~testClass1()
+{
+   throw "my exception!";  // BAD
+}
+
+class testClass2
+{
+public:
+	~testClass2();
+};
+
+
+testClass2 :: ~testClass2()
+{
+  try { throw "my exception!"; } // BAD
+  catch (...) {  }
+}
+
+class testClass3
+{
+public:
+	~testClass3();
+};
+
+
+testClass3 :: ~testClass3()
+{
+  try { throw "my exception!"; } // GOOD
+  catch (...) { clean(); }
+}
+void TestFunc()
+{
+  testClass1 cl1;
+  testClass2 cl2;
+  testClass3 cl3;
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-703/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-703/semmle/tests/test.cpp
@@ -5,11 +5,11 @@ void clean();
 class testClass1
 {
 public:
-	~testClass1();
+	void testMethod();
 };
 
 
-testClass1 :: ~testClass1()
+void testClass1 :: testMethod()
 {
    throw "my exception!";  // BAD
 }
@@ -17,11 +17,11 @@ testClass1 :: ~testClass1()
 class testClass2
 {
 public:
-	~testClass2();
+	void testMethod();
 };
 
 
-testClass2 :: ~testClass2()
+void testClass2 :: testMethod()
 {
   try { throw "my exception!"; } // BAD
   catch (...) {  }
@@ -30,11 +30,11 @@ testClass2 :: ~testClass2()
 class testClass3
 {
 public:
-	~testClass3();
+	void testMethod();
 };
 
 
-testClass3 :: ~testClass3()
+void testClass3 :: testMethod()
 {
   try { throw "my exception!"; } // GOOD
   catch (...) { clean(); }
@@ -42,6 +42,9 @@ testClass3 :: ~testClass3()
 void TestFunc()
 {
   testClass1 cl1;
+	cl1.testMethod();
   testClass2 cl2;
+	cl2.testMethod();
   testClass3 cl3;
+	cl3.testMethod();
 }


### PR DESCRIPTION
Good day.
in this request I am looking for errors when using exceptions.
I have identified 2 main areas:
1. the possibility of generating an exception in the body of the distructor, without full processing inside.
2. creating an exception object without generating the last one.

Regarding fixes in real software, my proposal is pending, but I plan to continue searching.
https://github.com/assimp/assimp/pull/3954