### PR TITLE
C#: Fix isEffectively* visibility predicates

### DIFF
--- a/csharp/change-notes/2021-06-15-effective-visibility.md
+++ b/csharp/change-notes/2021-06-15-effective-visibility.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The `isEffectivelyPrivate`, `isEffectivelyInternal` and `isEffectivelyPublic` predicates on `Modifiable` have been reworked to handle `private protected` and `internal protected` visibilities and explicitly implemented interfaces.

--- a/csharp/ql/src/semmle/code/csharp/Member.qll
+++ b/csharp/ql/src/semmle/code/csharp/Member.qll
@@ -96,14 +96,22 @@ class Modifiable extends Declaration, @modifiable {
   /** Holds if this declaration is `async`. */
   predicate isAsync() { this.hasModifier("async") }
 
+  private predicate isReallyPrivate() { this.isPrivate() and not this.isProtected() }
+
   /**
    * Holds if this declaration is effectively `private` (either directly or
    * because one of the enclosing types is `private`).
    */
   predicate isEffectivelyPrivate() {
-    this.isPrivate() or
-    this.getDeclaringType+().isPrivate() or
+    this.isReallyPrivate() or
+    this.getDeclaringType+().(Modifiable).isReallyPrivate() or
     this.(Virtualizable).getExplicitlyImplementedInterface().isEffectivelyPrivate()
+  }
+
+  private predicate isReallyInternal() {
+    this.isInternal() and not this.isProtected()
+    or
+    this.isPrivate() and this.isProtected()
   }
 
   /**
@@ -111,9 +119,9 @@ class Modifiable extends Declaration, @modifiable {
    * because one of the enclosing types is `internal`).
    */
   predicate isEffectivelyInternal() {
-    this.isInternal() or
-    this.getDeclaringType+().isInternal() or
-    this.(Virtualizable).getExplicitlyImplementedInterface().isInternal()
+    this.isReallyInternal() or
+    this.getDeclaringType+().(Modifiable).isReallyInternal() or
+    this.(Virtualizable).getExplicitlyImplementedInterface().isEffectivelyInternal()
   }
 
   /**

--- a/csharp/ql/src/semmle/code/csharp/Member.qll
+++ b/csharp/ql/src/semmle/code/csharp/Member.qll
@@ -102,7 +102,8 @@ class Modifiable extends Declaration, @modifiable {
    */
   predicate isEffectivelyPrivate() {
     this.isPrivate() or
-    this.getDeclaringType+().isPrivate()
+    this.getDeclaringType+().isPrivate() or
+    this.(Virtualizable).getExplicitlyImplementedInterface().isEffectivelyPrivate()
   }
 
   /**
@@ -111,7 +112,8 @@ class Modifiable extends Declaration, @modifiable {
    */
   predicate isEffectivelyInternal() {
     this.isInternal() or
-    this.getDeclaringType+().isInternal()
+    this.getDeclaringType+().isInternal() or
+    this.(Virtualizable).getExplicitlyImplementedInterface().isInternal()
   }
 
   /**
@@ -157,6 +159,11 @@ class Virtualizable extends Member, @virtualizable {
   override predicate isPublic() {
     Member.super.isPublic() or
     implementsExplicitInterface()
+  }
+
+  override predicate isPrivate() {
+    Member.super.isPrivate() and
+    not implementsExplicitInterface()
   }
 
   /**

--- a/csharp/ql/src/semmle/code/csharp/Member.qll
+++ b/csharp/ql/src/semmle/code/csharp/Member.qll
@@ -99,8 +99,15 @@ class Modifiable extends Declaration, @modifiable {
   private predicate isReallyPrivate() { this.isPrivate() and not this.isProtected() }
 
   /**
-   * Holds if this declaration is effectively `private` (either directly or
-   * because one of the enclosing types is `private`).
+   * Holds if this declaration is effectively `private`. A declaration is considered
+   * effectively `private` if it can only be referenced from
+   * - the declaring and its nested types, similarly to `private` declarations, and
+   * - the enclosing types.
+   *
+   * Note that explicit interface implementation are also considered effectively
+   * `private` if the implemented interface is itself effectively `private`. Finally,
+   * `private protected` members are not considered effectively `private`, because
+   * they can be overriden within the declaring assembly.
    */
   predicate isEffectivelyPrivate() {
     this.isReallyPrivate() or
@@ -115,8 +122,14 @@ class Modifiable extends Declaration, @modifiable {
   }
 
   /**
-   * Holds if this declaration is effectively `internal` (either directly or
-   * because one of the enclosing types is `internal`).
+   * Holds if this declaration is effectively `internal`. A declaration is considered
+   * effectively `internal` if it can only be referenced from the declaring assembly.
+   *
+   * Note that friend assemblies declared in `InternalsVisibleToAttribute` are not
+   * considered. Explicit interface implementation are also considered effectively
+   * `internal` if the implemented interface is itself effectively `internal`. Finally,
+   * `internal protected` members are not considered effectively `internal`, because
+   * they can be overriden outside the declaring assembly.
    */
   predicate isEffectivelyInternal() {
     this.isReallyInternal() or
@@ -125,8 +138,8 @@ class Modifiable extends Declaration, @modifiable {
   }
 
   /**
-   * Holds if this declaration is effectively `public`, because it
-   * and all enclosing types are `public`.
+   * Holds if this declaration is effectively `public`, meaning that it can be
+   * referenced outside the declaring assembly.
    */
   predicate isEffectivelyPublic() { not isEffectivelyPrivate() and not isEffectivelyInternal() }
 }

--- a/csharp/ql/src/semmle/code/csharp/Member.qll
+++ b/csharp/ql/src/semmle/code/csharp/Member.qll
@@ -96,7 +96,12 @@ class Modifiable extends Declaration, @modifiable {
   /** Holds if this declaration is `async`. */
   predicate isAsync() { this.hasModifier("async") }
 
-  private predicate isReallyPrivate() { this.isPrivate() and not this.isProtected() }
+  private predicate isReallyPrivate() {
+    this.isPrivate() and
+    not this.isProtected() and
+    // Rare case when a member is defined with the same name in multiple assemblies with different visibility
+    not this.isPublic()
+  }
 
   /**
    * Holds if this declaration is effectively `private`. A declaration is considered
@@ -116,9 +121,13 @@ class Modifiable extends Declaration, @modifiable {
   }
 
   private predicate isReallyInternal() {
-    this.isInternal() and not this.isProtected()
-    or
-    this.isPrivate() and this.isProtected()
+    (
+      this.isInternal() and not this.isProtected()
+      or
+      this.isPrivate() and this.isProtected()
+    ) and
+    // Rare case when a member is defined with the same name in multiple assemblies with different visibility
+    not this.isPublic()
   }
 
   /**

--- a/csharp/ql/src/semmle/code/csharp/Member.qll
+++ b/csharp/ql/src/semmle/code/csharp/Member.qll
@@ -109,7 +109,7 @@ class Modifiable extends Declaration, @modifiable {
    * - the declaring and its nested types, similarly to `private` declarations, and
    * - the enclosing types.
    *
-   * Note that explicit interface implementation are also considered effectively
+   * Note that explicit interface implementations are also considered effectively
    * `private` if the implemented interface is itself effectively `private`. Finally,
    * `private protected` members are not considered effectively `private`, because
    * they can be overriden within the declaring assembly.
@@ -135,7 +135,7 @@ class Modifiable extends Declaration, @modifiable {
    * effectively `internal` if it can only be referenced from the declaring assembly.
    *
    * Note that friend assemblies declared in `InternalsVisibleToAttribute` are not
-   * considered. Explicit interface implementation are also considered effectively
+   * considered. Explicit interface implementations are also considered effectively
    * `internal` if the implemented interface is itself effectively `internal`. Finally,
    * `internal protected` members are not considered effectively `internal`, because
    * they can be overriden outside the declaring assembly.
@@ -192,7 +192,7 @@ class Virtualizable extends Member, @virtualizable {
   }
 
   override predicate isPrivate() {
-    Member.super.isPrivate() and
+    super.isPrivate() and
     not implementsExplicitInterface()
   }
 

--- a/csharp/ql/test/library-tests/modifiers/Effectively.expected
+++ b/csharp/ql/test/library-tests/modifiers/Effectively.expected
@@ -27,3 +27,5 @@
 | Modifiers.cs:68:14:68:15 | M1 | internal |
 | Modifiers.cs:71:18:71:19 | C2 | public |
 | Modifiers.cs:73:17:73:18 | M1 | internal |
+| Modifiers.cs:75:32:75:33 | M2 | internal |
+| Modifiers.cs:76:33:76:34 | M3 | public |

--- a/csharp/ql/test/library-tests/modifiers/Effectively.expected
+++ b/csharp/ql/test/library-tests/modifiers/Effectively.expected
@@ -26,3 +26,4 @@
 | Modifiers.cs:63:14:63:15 | M2 | public |
 | Modifiers.cs:68:14:68:15 | M1 | internal |
 | Modifiers.cs:71:18:71:19 | C2 | public |
+| Modifiers.cs:73:17:73:18 | M1 | internal |

--- a/csharp/ql/test/library-tests/modifiers/Effectively.expected
+++ b/csharp/ql/test/library-tests/modifiers/Effectively.expected
@@ -24,3 +24,5 @@
 | Modifiers.cs:60:22:60:23 | I1 | public |
 | Modifiers.cs:62:14:62:15 | M1 | public |
 | Modifiers.cs:63:14:63:15 | M2 | public |
+| Modifiers.cs:68:14:68:15 | M1 | internal |
+| Modifiers.cs:71:18:71:19 | C2 | public |

--- a/csharp/ql/test/library-tests/modifiers/Modifiers.cs
+++ b/csharp/ql/test/library-tests/modifiers/Modifiers.cs
@@ -62,4 +62,17 @@ namespace N
         void M1();
         void M2() => throw null;
     }
+
+    internal interface I2
+    {
+        void M1() => throw null;
+    }
+
+    public class C2 : I2
+    {
+        void I2.M1() => throw null;
+
+        protected private void M2() { }
+        protected internal void M3() { }
+    }
 }

--- a/csharp/ql/test/library-tests/modifiers/Modifiers.expected
+++ b/csharp/ql/test/library-tests/modifiers/Modifiers.expected
@@ -49,3 +49,12 @@
 | Modifiers.cs:62:14:62:15 | M1 | file://:0:0:0:0 | public |
 | Modifiers.cs:63:14:63:15 | M2 | file://:0:0:0:0 | public |
 | Modifiers.cs:63:14:63:15 | M2 | file://:0:0:0:0 | virtual |
+| Modifiers.cs:66:24:66:25 | I2 | file://:0:0:0:0 | internal |
+| Modifiers.cs:68:14:68:15 | M1 | file://:0:0:0:0 | public |
+| Modifiers.cs:68:14:68:15 | M1 | file://:0:0:0:0 | virtual |
+| Modifiers.cs:71:18:71:19 | C2 | file://:0:0:0:0 | public |
+| Modifiers.cs:73:17:73:18 | M1 | file://:0:0:0:0 | private |
+| Modifiers.cs:75:32:75:33 | M2 | file://:0:0:0:0 | private |
+| Modifiers.cs:75:32:75:33 | M2 | file://:0:0:0:0 | protected |
+| Modifiers.cs:76:33:76:34 | M3 | file://:0:0:0:0 | internal |
+| Modifiers.cs:76:33:76:34 | M3 | file://:0:0:0:0 | protected |


### PR DESCRIPTION
Extracted from https://github.com/github/codeql/pull/5664.

[Differences job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1130/)