### PR TITLE
Python: Avoid `__main__.py` files as entry points.

### DIFF
--- a/python/ql/src/semmle/python/Files.qll
+++ b/python/ql/src/semmle/python/Files.qll
@@ -92,6 +92,11 @@ class File extends Container {
       ) and
       // Exclude files named `__main__.py`. These are often _not_ meant to be run directly, but
       // contain this construct anyway.
+      //
+      // Their presence in a package (say, `foo`) means one can execute the package directly using
+      // `python -m foo` (which will run the `foo/__main__.py` file). Since being an entry point for
+      // execution means treating imports as absolute, this causes trouble, since when run with
+      // `python -m`, the interpreter uses the usual package semantics.
       not this.getShortName() = "__main__.py"
       or
       // The file contains a `#!` line referencing the python interpreter

--- a/python/ql/src/semmle/python/Files.qll
+++ b/python/ql/src/semmle/python/Files.qll
@@ -89,7 +89,10 @@ class File extends Container {
         i.getTest().(Compare).compares(name, op, main) and
         name.getId() = "__name__" and
         main.getText() = "__main__"
-      )
+      ) and
+      // Exclude files named `__main__.py`. These are often _not_ meant to be run directly, but
+      // contain this construct anyway.
+      not this.getShortName() = "__main__.py"
       or
       // The file contains a `#!` line referencing the python interpreter
       exists(Comment c |


### PR DESCRIPTION
According to the official documentation, the purpose of `__main__.py`
files is that their presence in a package (say, `foo`) means one can
execute the package directly using `python -m foo` (which will run the
aforementioned `foo/__main__.py` file).

In principle this means that adding `if __name__ == "__main__"` in these
files is superfluous, as they are only intended to be executed (and not
imported by some other file).

However, in practice people often _do_ include the above construct.
Here are some instances of this on LGTM.com:
https://lgtm.com/query/7521266095072095777/

In particular, 10 out of 33 files in `cpython` have this construct.

This causes some confusion in our module naming, as we usually see the
presence of `__name__ == "__main__"` as an indication that a file may
be run directly (and hence with "absolute import" semantics). However,
when run with `python -m`, the interpreter uses the usual package
semantics, and this leads to modules getting multiple names.

For this reason, I think it makes sense to simply exclude `__main__.py`
files from consideration. Note that if there is a `#!` line mentioning
the Python interpreter, then they will still be included as entry
points.

---
This is a minor change, and so I don't think this requires a change note.