### PR TITLE
Data flow: Fix `getLocalCallContext` join-order

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -2220,7 +2220,9 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
+    result =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3257,9 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
+    localCC =
+      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+        getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -2220,7 +2220,7 @@ private module Stage4 {
   bindingset[node, cc, config]
   private LocalCc getLocalCc(Node node, Cc cc, Configuration config) {
     localFlowEntry(node, config) and
-    result = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(node))
+    result = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(node))
   }
 
   private predicate localStep(
@@ -3255,7 +3255,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(pragma[only_bind_out](cc), getNodeEnclosingCallable(midnode)) and
+    localCC = getLocalCallContext(pragma[only_bind_into](cc), getNodeEnclosingCallable(midnode)) and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and


### PR DESCRIPTION
This improves performance for Ruby, where `isUnreachableInCall` is implemented as `none()`.

Bad join in `Stage4::fwdFlow0`:
```
[2021-06-17 09:27:55] (0s) Starting to evaluate predicate DataFlowImpl::Stage4::fwdFlow0#fffff/5@i3#25f3ez (iteration 3)
[2021-06-17 09:28:00] (4s) Tuple counts for DataFlowImpl::Stage4::fwdFlow0#fffff/5@i3#25f3ez:
                      0        ~0%     {5} r1 = SCAN DataFlowImpl::Stage4::fwdFlowOutNotFromArg#fffff#prev_delta OUTPUT In.1 'cc', In.2 'argAp', In.4 'config', In.3 'ap', In.0 'node'
                      
                      0        ~0%     {5} r2 = JOIN DataFlowImpl::Stage4::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2#prev_delta WITH DataFlowImpl::Stage4::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3#prev ON FIRST 3 OUTPUT Lhs.3 'cc', Lhs.4 'argAp', Lhs.2 'config', Rhs.4 'ap', Rhs.3 'node'
                      
                      0        ~0%     {5} r3 = r1 UNION r2
                      
                      0        ~0%     {5} r4 = JOIN DataFlowImpl::Stage4::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3#prev_delta WITH DataFlowImpl::Stage4::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2#prev ON FIRST 3 OUTPUT Rhs.3 'cc', Rhs.4 'argAp', Lhs.2 'config', Lhs.4 'ap', Lhs.3 'node'
                      
                      0        ~0%     {4} r5 = SCAN DataFlowImpl::Stage4::fwdFlowIn#fffffff#prev_delta OUTPUT In.5, In.1 'node', In.3 'cc', In.6 'config'
                      
                      0        ~0%     {5} r6 = JOIN r5 WITH DataFlowImpl::AccessPathApproxNil::getFront_dispred#ff ON FIRST 1 OUTPUT Rhs.0, Rhs.1, Lhs.1 'node', Lhs.2 'cc', Lhs.3 'config'
                      0        ~0%     {5} r7 = r6 AND NOT project#DataFlowImpl::Stage3::parameterMayFlowThrough#ffff#2(Lhs.2 'node', Lhs.1, Lhs.4 'config')
                      0        ~0%     {5} r8 = JOIN r7 WITH construct<TAccessPathApproxOption,0>@dom#DataFlowImpl::TAccessPathApproxNone#0#f CARTESIAN PRODUCT OUTPUT Lhs.3 'cc', Rhs.0, Lhs.4 'config', Lhs.0 'ap', Lhs.2 'node'
                      
                      0        ~0%     {5} r9 = r4 UNION r8
                      0        ~0%     {5} r10 = r3 UNION r9
                      
                      0        ~0%     {5} r11 = JOIN r5 WITH DataFlowImpl::AccessPathApproxNil::getFront_dispred#ff ON FIRST 1 OUTPUT Lhs.1 'node', Rhs.1, Lhs.3 'config', Rhs.0, Lhs.2 'cc'
                      0        ~0%     {4} r12 = JOIN r11 WITH project#DataFlowImpl::Stage3::parameterMayFlowThrough#ffff#2 ON FIRST 3 OUTPUT Lhs.3 'ap', Lhs.0 'node', Lhs.4 'cc', Lhs.2 'config'
                      0        ~0%     {5} r13 = JOIN r12 WITH construct<TAccessPathApproxOption,1>@dom#DataFlowImpl::TAccessPathApproxSome#1#ff ON FIRST 1 OUTPUT Lhs.2 'cc', Rhs.1 'argAp', Lhs.3 'config', Lhs.0 'ap', Lhs.1 'node'
                      
                      100      ~4%     {4} r14 = SCAN DataFlowImpl::Stage4::fwdFlow#fffff#prev_delta OUTPUT In.0, In.4 'config', In.1 'cc', In.2 'argAp'
                      100      ~0%     {6} r15 = JOIN r14 WITH DataFlowImpl::LocalFlowBigStep::localFlowEntry#ff ON FIRST 2 OUTPUT Lhs.2 'cc', Lhs.0, Lhs.2 'cc', Lhs.3 'argAp', Lhs.1 'config', Lhs.0
                      38540400 ~0%     {7} r16 = JOIN r15 WITH DataFlowImplCommon::getLocalCallContext#fff ON FIRST 1 OUTPUT Lhs.5, Rhs.1, Lhs.1, Lhs.2 'cc', Lhs.3 'argAp', Lhs.4 'config', Rhs.2
                      100      ~1%     {6} r17 = JOIN r16 WITH DataFlowImplCommon::Cached::nodeEnclosingCallable#ff@staged_ext ON FIRST 2 OUTPUT Lhs.2, false, Lhs.5 'config', Lhs.6, Lhs.3 'cc', Lhs.4 'argAp'
                      0        ~0%     {5} r18 = JOIN r17 WITH DataFlowImpl::Stage4::localStep#ffbfff_024513#join_rhs ON FIRST 4 OUTPUT Lhs.4 'cc', Lhs.5 'argAp', Lhs.2 'config', Rhs.5 'ap', Rhs.4 'node'
                      
                      0        ~0%     {5} r19 = r13 UNION r18
                      
                      100      ~0%     {5} r20 = SCAN DataFlowImpl::Stage4::fwdFlow#fffff#prev_delta OUTPUT In.0, In.4 'config', In.1 'cc', In.2 'argAp', In.3
                      100      ~0%     {7} r21 = JOIN r20 WITH DataFlowImpl::LocalFlowBigStep::localFlowEntry#ff ON FIRST 2 OUTPUT Lhs.2 'cc', Lhs.0, Lhs.2 'cc', Lhs.3 'argAp', Lhs.4 'ap', Lhs.1 'config', Lhs.0
                      38540400 ~0%     {8} r22 = JOIN r21 WITH DataFlowImplCommon::getLocalCallContext#fff ON FIRST 1 OUTPUT Lhs.6, Rhs.1, Lhs.1, Lhs.2 'cc', Lhs.3 'argAp', Lhs.4 'ap', Lhs.5 'config', Rhs.2
                      100      ~3%     {7} r23 = JOIN r22 WITH DataFlowImplCommon::Cached::nodeEnclosingCallable#ff@staged_ext ON FIRST 2 OUTPUT Lhs.2, true, Lhs.6 'config', Lhs.7, Lhs.3 'cc', Lhs.4 'argAp', Lhs.5 'ap'
                      5        ~0%     {5} r24 = JOIN r23 WITH DataFlowImpl::Stage4::localStep#ffbfff_02451#join_rhs ON FIRST 4 OUTPUT Lhs.4 'cc', Lhs.5 'argAp', Lhs.2 'config', Lhs.6 'ap', Rhs.4 'node'
                      
                      100      ~1%     {5} r25 = SELECT DataFlowImpl::Stage4::fwdFlow#fffff#prev_delta ON In.4 'config' = "HardcodedCredentialsConfiguration"
                      
                      100      ~0%     {3} r26 = SCAN r25 OUTPUT In.0, In.3 'ap', "HardcodedCredentialsConfiguration"
                      0        ~0%     {3} r27 = JOIN r26 WITH DataFlowImplCommon::Cached::jumpStepCached#ff@staged_ext ON FIRST 1 OUTPUT Rhs.1 'node', "HardcodedCredentialsConfiguration", Lhs.1 'ap'
                      0        ~0%     {3} r28 = JOIN r27 WITH project#DataFlowImpl::Stage3::revFlow#fffff ON FIRST 2 OUTPUT Lhs.2 'ap', "HardcodedCredentialsConfiguration", Lhs.0 'node'
                      0        ~0%     {4} r29 = JOIN r28 WITH DataFlowImplCommon::Cached::TAnyCallContext#f@staged_ext CARTESIAN PRODUCT OUTPUT Lhs.0 'ap', "HardcodedCredentialsConfiguration", Lhs.2 'node', Rhs.0
                      0        ~0%     {5} r30 = JOIN r29 WITH construct<TAccessPathApproxOption,0>@dom#DataFlowImpl::TAccessPathApproxNone#0#f CARTESIAN PRODUCT OUTPUT Lhs.3 'cc', Rhs.0, "HardcodedCredentialsConfiguration", Lhs.0 'ap', Lhs.2 'node'
                      
                      100      ~0%     {2} r31 = SCAN r25 OUTPUT In.0, "HardcodedCredentialsConfiguration"
                      0        ~0%     {2} r32 = JOIN r31 WITH DataFlowImpl::additionalJumpStep#fff#cpe#12 ON FIRST 1 OUTPUT Rhs.1 'node', "HardcodedCredentialsConfiguration"
                      0        ~0%     {3} r33 = JOIN r32 WITH DataFlowImpl::Stage4::getApNil#ff ON FIRST 1 OUTPUT Lhs.0 'node', "HardcodedCredentialsConfiguration", Rhs.1 'ap'
                      0        ~0%     {3} r34 = JOIN r33 WITH project#DataFlowImpl::Stage3::revFlow#fffff ON FIRST 2 OUTPUT "HardcodedCredentialsConfiguration", Lhs.0 'node', Lhs.2 'ap'
                      0        ~0%     {4} r35 = JOIN r34 WITH DataFlowImplCommon::Cached::TAnyCallContext#f@staged_ext CARTESIAN PRODUCT OUTPUT "HardcodedCredentialsConfiguration", Lhs.1 'node', Lhs.2 'ap', Rhs.0
                      0        ~0%     {5} r36 = JOIN r35 WITH construct<TAccessPathApproxOption,0>@dom#DataFlowImpl::TAccessPathApproxNone#0#f CARTESIAN PRODUCT OUTPUT Lhs.3 'cc', Rhs.0, "HardcodedCredentialsConfiguration", Lhs.2 'ap', Lhs.1 'node'
                      
                      0        ~0%     {5} r37 = r30 UNION r36
                      5        ~0%     {5} r38 = r24 UNION r37
                      5        ~0%     {5} r39 = r19 UNION r38
                      5        ~0%     {5} r40 = r10 UNION r39
                      5        ~0%     {5} r41 = r40 AND NOT DataFlowImpl::Stage4::fwdFlow0#fffff#prev(Lhs.4 'node', Lhs.0 'cc', Lhs.1 'argAp', Lhs.3 'ap', Lhs.2 'config')
                      5        ~0%     {5} r42 = SCAN r41 OUTPUT In.4 'node', In.0 'cc', In.1 'argAp', In.3 'ap', In.2 'config'
                                       return r42
```

Bad join in `pathStep`:
```
[2021-06-17 09:28:00] (5s) Starting to evaluate predicate DataFlowImpl::pathStep#fffff/5@i4#25a4c1 (iteration 4)
[2021-06-17 09:28:05] (9s) Tuple counts for DataFlowImpl::pathStep#fffff/5@i4#25a4c1:
                      100      ~0%       {2} r1 = JOIN DataFlowImpl::PathNodeMid#class#ffffff#reorder_4_0_1_2_3_5#prev_delta WITH construct<TAccessPath,0>@dom#DataFlowImpl::TAccessPathNil#1#ff_1#join_rhs ON FIRST 1 OUTPUT Lhs.1 'mid', Rhs.0
                      0        ~0%       {5} r2 = JOIN r1 WITH DataFlowImpl::pathIntoCallable#ffffff#prev ON FIRST 1 OUTPUT Lhs.0 'mid', Rhs.3 'cc', Rhs.4 'sc', Lhs.1 'ap', Rhs.1 'node'
                      
                      0        ~0%       {4} r3 = JOIN DataFlowImpl::pathThroughCallable#ffff#reorder_3_0_1_2#prev_delta WITH construct<TAccessPath,0>@dom#DataFlowImpl::TAccessPathNil#1#ff_1#join_rhs ON FIRST 1 OUTPUT Lhs.1 'mid', Rhs.0, Lhs.2 'node', Lhs.3 'cc'
                      0        ~0%       {5} r4 = JOIN r3 WITH DataFlowImpl::PathNodeMid#class#ffffff#reorder_0_5_1_2_3_4#prev ON FIRST 1 OUTPUT Lhs.0 'mid', Lhs.3 'cc', Rhs.4 'sc', Lhs.1 'ap', Lhs.2 'node'
                      
                      0        ~0%       {5} r5 = r2 UNION r4
                      
                      100      ~0%       {3} r6 = JOIN DataFlowImpl::PathNodeMid#class#ffffff#reorder_4_0_1_2_3_5#prev_delta WITH DataFlowImpl::pathStep#fffff#join_rhs#1 ON FIRST 1 OUTPUT Lhs.1 'mid', Rhs.1 'sc', Rhs.0
                      0        ~0%       {5} r7 = JOIN r6 WITH DataFlowImpl::pathOutOfCallable#fff#prev ON FIRST 1 OUTPUT Lhs.0 'mid', Rhs.2 'cc', Lhs.1 'sc', Lhs.2 'ap', Rhs.1 'node'
                      
                      100      ~0%       {2} r8 = SCAN DataFlowImpl::PathNodeMid#class#ffffff#reorder_0_5_1_2_3_4#prev_delta OUTPUT In.0 'mid', In.4 'sc'
                      0        ~0%       {5} r9 = JOIN r8 WITH DataFlowImpl::pathThroughCallable#ffff#prev ON FIRST 1 OUTPUT Rhs.3 'ap', Lhs.0 'mid', Lhs.1 'sc', Rhs.1 'node', Rhs.2 'cc'
                      0        ~0%       {5} r10 = JOIN r9 WITH construct<TAccessPath,0>@dom#DataFlowImpl::TAccessPathNil#1#ff_1#join_rhs ON FIRST 1 OUTPUT Lhs.1 'mid', Lhs.4 'cc', Lhs.2 'sc', Lhs.0 'ap', Lhs.3 'node'
                      
                      100      ~0%       {5} r11 = JOIN DataFlowImpl::PathNodeMid#class#ffffff#reorder_4_0_1_2_3_5#prev_delta WITH DataFlowImpl::pathStep#fffff#join_rhs ON FIRST 1 OUTPUT Lhs.2, Rhs.1 'cc', Rhs.2 'sc', Rhs.0, Lhs.1 'mid'
                      0        ~0%       {5} r12 = JOIN r11 WITH DataFlowImplCommon::Cached::jumpStepCached#ff@staged_ext ON FIRST 1 OUTPUT Lhs.4 'mid', Lhs.1 'cc', Lhs.2 'sc', Lhs.3 'ap', Rhs.1 'node'
                      
                      0        ~0%       {5} r13 = r10 UNION r12
                      0        ~0%       {5} r14 = r7 UNION r13
                      0        ~0%       {5} r15 = r5 UNION r14
                      
                      0        ~0%       {4} r16 = SCAN DataFlowImpl::pathIntoCallable#ffffff#prev_delta OUTPUT In.0 'mid', In.1 'node', In.3 'cc', In.4 'sc'
                      0        ~0%       {5} r17 = JOIN r16 WITH DataFlowImpl::PathNodeMid#class#ffffff#reorder_0_5_1_2_3_4#prev ON FIRST 1 OUTPUT Rhs.5, Lhs.0 'mid', Lhs.1 'node', Lhs.2 'cc', Lhs.3 'sc'
                      0        ~0%       {5} r18 = JOIN r17 WITH construct<TAccessPath,0>@dom#DataFlowImpl::TAccessPathNil#1#ff_1#join_rhs ON FIRST 1 OUTPUT Lhs.1 'mid', Lhs.3 'cc', Lhs.4 'sc', Lhs.0 'ap', Lhs.2 'node'
                      
                      0        ~0%       {4} r19 = JOIN DataFlowImpl::pathOutOfCallable#fff#prev_delta WITH DataFlowImpl::PathNodeMid#class#ffffff#reorder_0_5_1_2_3_4#prev ON FIRST 1 OUTPUT Rhs.5, Lhs.0 'mid', Lhs.1 'node', Lhs.2 'cc'
                      0        ~0%       {4} r20 = JOIN r19 WITH construct<TAccessPath,0>@dom#DataFlowImpl::TAccessPathNil#1#ff_1#join_rhs ON FIRST 1 OUTPUT Lhs.1 'mid', Lhs.2 'node', Lhs.3 'cc', Lhs.0 'ap'
                      0        ~0%       {5} r21 = JOIN r20 WITH construct<TSummaryCtx,0>@dom#DataFlowImpl::TSummaryCtxNone#0#f CARTESIAN PRODUCT OUTPUT Lhs.0 'mid', Lhs.2 'cc', Rhs.0, Lhs.3 'ap', Lhs.1 'node'
                      
                      0        ~0%       {5} r22 = r18 UNION r21
                      
                      100      ~1%       {2} r23 = JOIN DataFlowImpl::PathNodeMid#class#ffffff#reorder_5_0_1_2_3_4#prev_delta WITH DataFlowImpl::Stage1::fwdFlow#2#fff#join_rhs ON FIRST 1 OUTPUT Lhs.2, Lhs.1 'mid'
                      0        ~0%       {3} r24 = JOIN r23 WITH DataFlowImpl::additionalJumpStep#fff#cpe#12 ON FIRST 1 OUTPUT Rhs.1 'node', Lhs.1 'mid', Rhs.1 'node'
                      0        ~0%       {3} r25 = JOIN r24 WITH DataFlowImplCommon::Cached::nodeDataFlowType#ff@staged_ext ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'mid', Lhs.2 'node'
                      0        ~0%       {3} r26 = JOIN r25 WITH construct<TAccessPath,0>@dom#DataFlowImpl::TAccessPathNil#1#ff ON FIRST 1 OUTPUT Lhs.1 'mid', Lhs.2 'node', Rhs.1 'ap'
                      0        ~0%       {4} r27 = JOIN r26 WITH DataFlowImplCommon::Cached::TAnyCallContext#f@staged_ext CARTESIAN PRODUCT OUTPUT Lhs.0 'mid', Lhs.1 'node', Lhs.2 'ap', Rhs.0
                      0        ~0%       {5} r28 = JOIN r27 WITH construct<TSummaryCtx,0>@dom#DataFlowImpl::TSummaryCtxNone#0#f CARTESIAN PRODUCT OUTPUT Lhs.0 'mid', Lhs.3 'cc', Rhs.0, Lhs.2 'ap', Lhs.1 'node'
                      
                      100      ~3%       {8} r29 = SCAN DataFlowImpl::PathNodeMid#class#ffffff#reorder_0_5_1_2_3_4#prev_delta OUTPUT In.3, In.0 'mid', In.2, In.3, In.4 'sc', In.5, In.1, In.2
                      38540400 ~4%       {9} r30 = JOIN r29 WITH DataFlowImplCommon::getLocalCallContext#fff ON FIRST 1 OUTPUT Lhs.7, Rhs.1, Lhs.1 'mid', Lhs.2, Lhs.3 'cc', Lhs.4 'sc', Lhs.5 'ap', Lhs.6, Rhs.2
                      100      ~0%       {7} r31 = JOIN r30 WITH DataFlowImplCommon::Cached::nodeEnclosingCallable#ff@staged_ext ON FIRST 2 OUTPUT Lhs.6 'ap', Lhs.2 'mid', Lhs.3, Lhs.4 'cc', Lhs.5 'sc', Lhs.7, Lhs.8
                      100      ~0%       {8} r32 = JOIN r31 WITH construct<TAccessPath,0>@dom#DataFlowImpl::TAccessPathNil#1#ff_1#join_rhs ON FIRST 1 OUTPUT Lhs.2, true, Lhs.5, Lhs.6, Lhs.1 'mid', Lhs.3 'cc', Lhs.4 'sc', Lhs.0 'ap'
                      5        ~0%       {5} r33 = JOIN r32 WITH DataFlowImpl::LocalFlowBigStep::localFlowBigStep#ffffff_02451#join_rhs ON FIRST 4 OUTPUT Lhs.4 'mid', Lhs.5 'cc', Lhs.6 'sc', Lhs.7 'ap', Rhs.4 'node'
                      
                      100      ~1%       {7} r34 = SCAN DataFlowImpl::PathNodeMid#class#ffffff#reorder_0_5_1_2_3_4#prev_delta OUTPUT In.3, In.0 'mid', In.2, In.3, In.4 'sc', In.1, In.2
                      38540400 ~5%       {8} r35 = JOIN r34 WITH DataFlowImplCommon::getLocalCallContext#fff ON FIRST 1 OUTPUT Lhs.6, Rhs.1, Lhs.1 'mid', Lhs.2, Lhs.3 'cc', Lhs.4 'sc', Lhs.5, Rhs.2
                      100      ~3%       {7} r36 = JOIN r35 WITH DataFlowImplCommon::Cached::nodeEnclosingCallable#ff@staged_ext ON FIRST 2 OUTPUT Lhs.3, false, Lhs.6, Lhs.7, Lhs.2 'mid', Lhs.4 'cc', Lhs.5 'sc'
                      0        ~0%       {5} r37 = JOIN r36 WITH DataFlowImpl::LocalFlowBigStep::localFlowBigStep#ffffff_024513#join_rhs ON FIRST 4 OUTPUT Rhs.5, Lhs.4 'mid', Lhs.5 'cc', Lhs.6 'sc', Rhs.4 'node'
                      0        ~0%       {5} r38 = JOIN r37 WITH DataFlowImpl::AccessPath::getFront_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'ap', Lhs.1 'mid', Lhs.2 'cc', Lhs.3 'sc', Lhs.4 'node'
                      0        ~0%       {5} r39 = JOIN r38 WITH construct<TAccessPath,0>@dom#DataFlowImpl::TAccessPathNil#1#ff_1#join_rhs ON FIRST 1 OUTPUT Lhs.1 'mid', Lhs.2 'cc', Lhs.3 'sc', Lhs.0 'ap', Lhs.4 'node'
                      
                      5        ~0%       {5} r40 = r33 UNION r39
                      5        ~0%       {5} r41 = r28 UNION r40
                      5        ~0%       {5} r42 = r22 UNION r41
                      5        ~0%       {5} r43 = r15 UNION r42
                      5        ~0%       {5} r44 = r43 AND NOT DataFlowImpl::pathStep#fffff#prev(Lhs.0 'mid', Lhs.4 'node', Lhs.1 'cc', Lhs.2 'sc', Lhs.3 'ap')
                      5        ~0%       {5} r45 = SCAN r44 OUTPUT In.0 'mid', In.4 'node', In.1 'cc', In.2 'sc', In.3 'ap'
                                         return r45
```

~https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1139/
https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/2088/
https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/1452/
https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/578/~
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1142/
https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/2092/
https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/1459/
https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/580/