### PR TITLE
Inline expectation tests: accept // $MISSING: and // $SPURIOUS:

### DIFF
--- a/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -181,14 +181,14 @@ private int getEndOfColumnPosition(int start, string content) {
     min(string name, int cand |
       exists(TNamedColumn(name)) and
       cand = content.indexOf(name + ":") and
-      cand > start
+      cand >= start
     |
       cand
     )
   or
   not exists(string name |
     exists(TNamedColumn(name)) and
-    content.indexOf(name + ":") > start
+    content.indexOf(name + ":") >= start
   ) and
   result = content.length()
 }

--- a/java/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/java/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -181,14 +181,14 @@ private int getEndOfColumnPosition(int start, string content) {
     min(string name, int cand |
       exists(TNamedColumn(name)) and
       cand = content.indexOf(name + ":") and
-      cand > start
+      cand >= start
     |
       cand
     )
   or
   not exists(string name |
     exists(TNamedColumn(name)) and
-    content.indexOf(name + ":") > start
+    content.indexOf(name + ":") >= start
   ) and
   result = content.length()
 }

--- a/python/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/python/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -181,14 +181,14 @@ private int getEndOfColumnPosition(int start, string content) {
     min(string name, int cand |
       exists(TNamedColumn(name)) and
       cand = content.indexOf(name + ":") and
-      cand > start
+      cand >= start
     |
       cand
     )
   or
   not exists(string name |
     exists(TNamedColumn(name)) and
-    content.indexOf(name + ":") > start
+    content.indexOf(name + ":") >= start
   ) and
   result = content.length()
 }


### PR DESCRIPTION
Previously there had to be a space after the $ token, unlike ordinary expectations (i.e., // $xss was already accepted)

This is an improvement on the fix already shown in https://github.com/github/codeql/pull/6087 suggested by @aschackmull 