### PR TITLE
Java: Preserve taint on field-read-steps on entrypoint types

### DIFF
--- a/java/change-notes/2021-06-17-tainted-field-read-step-on-entrypoint-types.md
+++ b/java/change-notes/2021-06-17-tainted-field-read-step-on-entrypoint-types.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Data flow now propagates taint from remote source `Parameter` types to read steps of their fields (e.g. `tainted.publicField` or `tainted.getField()`). This also applies to their subtypes and the types of their fields, recursively.

--- a/java/ql/lib/change-notes/2021-12-15-tainted-field-read-step-on-entrypoint-types.md
+++ b/java/ql/lib/change-notes/2021-12-15-tainted-field-read-step-on-entrypoint-types.md
@@ -1,2 +1,4 @@
-lgtm,codescanning
+---
+category: majorAnalysis
+---
 * Data flow now propagates taint from remote source `Parameter` types to read steps of their fields (e.g. `tainted.publicField` or `tainted.getField()`). This also applies to their subtypes and the types of their fields, recursively.

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -596,12 +596,13 @@ private MethodAccess callReturningSameType(Expr ref) {
 }
 
 private SrcRefType entrypointType() {
-  result =
-    pragma[only_bind_out](any(RemoteFlowSource s | s instanceof DataFlow::ExplicitParameterNode))
-        .getType()
-        .(RefType)
-        .getASubtype*()
-        .getSourceDeclaration() or
+  exists(RemoteFlowSource s, RefType t |
+    s instanceof DataFlow::ExplicitParameterNode and
+    t = pragma[only_bind_out](s).getType() and
+    not t instanceof TypeObject and
+    result = t.getASubtype*().getSourceDeclaration()
+  )
+  or
   result = entrypointType().getAField().getType().(RefType).getSourceDeclaration()
 }
 

--- a/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.java
+++ b/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.java
@@ -43,10 +43,10 @@ public class EntryPointTypesTest {
     }
 
     public static void testParameterized(
-            ParameterizedTestObject<String, AnotherTestObject> source) {
+            ParameterizedTestObject<TestObject, AnotherTestObject> source) {
         sink(source.field6); // $hasTaintFlow
-        sink(source.getField7().field1); // $hasTaintFlow
-        sink(source.getField7().getField2()); // $hasTaintFlow
+        sink(source.field7.field1); // $hasTaintFlow
+        sink(source.field7.getField2()); // $hasTaintFlow
         sink(source.getField8().field4); // $hasTaintFlow
         sink(source.getField8().getField5()); // $hasTaintFlow
     }

--- a/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.java
+++ b/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.java
@@ -23,6 +23,16 @@ public class EntryPointTypesTest {
         }
     }
 
+    static class ParameterizedTestObject<T, K> {
+        public String field6;
+        public T field7;
+        private K field8;
+
+        public K getField8() {
+            return field8;
+        }
+    }
+
     private static void sink(String sink) {}
 
     public static void test(TestObject source) {
@@ -30,5 +40,14 @@ public class EntryPointTypesTest {
         sink(source.getField2()); // $hasTaintFlow
         sink(source.getField3().field4); // $hasTaintFlow
         sink(source.getField3().getField5()); // $hasTaintFlow
+    }
+
+    public static void testParameterized(
+            ParameterizedTestObject<String, AnotherTestObject> source) {
+        sink(source.field6); // $hasTaintFlow
+        sink(source.getField7().field1); // $hasTaintFlow
+        sink(source.getField7().getField2()); // $hasTaintFlow
+        sink(source.getField8().field4); // $hasTaintFlow
+        sink(source.getField8().getField5()); // $hasTaintFlow
     }
 }

--- a/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.java
+++ b/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.java
@@ -1,0 +1,34 @@
+public class EntryPointTypesTest {
+
+    static class TestObject {
+        public String field1;
+        private String field2;
+        private AnotherTestObject field3;
+
+        public String getField2() {
+            return field2;
+        }
+
+        public AnotherTestObject getField3() {
+            return field3;
+        }
+    }
+
+    static class AnotherTestObject {
+        public String field4;
+        private String field5;
+
+        public String getField5() {
+            return field5;
+        }
+    }
+
+    private static void sink(String sink) {}
+
+    public static void test(TestObject source) {
+        sink(source.field1); // $hasTaintFlow
+        sink(source.getField2()); // $hasTaintFlow
+        sink(source.getField3().field4); // $hasTaintFlow
+        sink(source.getField3().getField5()); // $hasTaintFlow
+    }
+}

--- a/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.java
+++ b/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.java
@@ -33,6 +33,14 @@ public class EntryPointTypesTest {
         }
     }
 
+    static class ChildObject extends ParameterizedTestObject<TestObject, Object> {
+        public Object field9;
+    }
+
+    class UnrelatedObject {
+        public String safeField;
+    }
+
     private static void sink(String sink) {}
 
     public static void test(TestObject source) {
@@ -49,5 +57,17 @@ public class EntryPointTypesTest {
         sink(source.field7.getField2()); // $hasTaintFlow
         sink(source.getField8().field4); // $hasTaintFlow
         sink(source.getField8().getField5()); // $hasTaintFlow
+    }
+
+    public static void testSubtype(ParameterizedTestObject<?, ?> source) {
+        ChildObject subtypeSource = (ChildObject) source;
+        sink(subtypeSource.field6); // $hasTaintFlow
+        sink(subtypeSource.field7.field1); // $hasTaintFlow
+        sink(subtypeSource.field7.getField2()); // $hasTaintFlow
+        sink((String) subtypeSource.getField8()); // $hasTaintFlow
+        sink((String) subtypeSource.field9); // $hasTaintFlow
+        // Ensure that we are not tainting every subclass of Object
+        UnrelatedObject unrelated = (UnrelatedObject) subtypeSource.getField8();
+        sink(unrelated.safeField); // Safe
     }
 }

--- a/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.ql
+++ b/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.ql
@@ -1,0 +1,34 @@
+import java
+import semmle.code.java.dataflow.FlowSources
+import TestUtilities.InlineExpectationsTest
+
+class TestRemoteFlowSource extends RemoteFlowSource {
+  TestRemoteFlowSource() { this.asParameter().hasName("source") }
+
+  override string getSourceType() { result = "test" }
+}
+
+class TaintFlowConf extends TaintTracking::Configuration {
+  TaintFlowConf() { this = "qltest:dataflow:entrypoint-types-taint" }
+
+  override predicate isSource(DataFlow::Node n) { n instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node n) {
+    exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
+  }
+}
+
+class HasFlowTest extends InlineExpectationsTest {
+  HasFlowTest() { this = "HasFlowTest" }
+
+  override string getARelevantTag() { result = ["hasTaintFlow"] }
+
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    tag = "hasTaintFlow" and
+    exists(DataFlow::Node src, DataFlow::Node sink, TaintFlowConf conf | conf.hasFlow(src, sink) |
+      sink.getLocation() = location and
+      element = sink.toString() and
+      value = ""
+    )
+  }
+}


### PR DESCRIPTION
This PR adds an additional taint step between remote source `Parameter` types (e.g. parameters of a `JAX-RS` resource method) and field reads on said types (either directly or through getters).

Credits to @pwntester for the solution proposal.