### PR TITLE
Update C/C++ Clang and GCC versions.rst

### DIFF
--- a/docs/codeql/support/reusables/versions-compilers.rst
+++ b/docs/codeql/support/reusables/versions-compilers.rst
@@ -6,7 +6,7 @@
    Language,Variants,Compilers,Extensions
    C/C++,"C89, C99, C11, C18, C++98, C++03, C++11, C++14, C++17","Clang (and clang-cl [1]_) extensions (up to Clang 12.0),
 
-   GNU extensions (up to GCC 9.4),
+   GNU extensions (up to GCC 11.1),
 
    Microsoft extensions (up to VS 2019),
 

--- a/docs/codeql/support/reusables/versions-compilers.rst
+++ b/docs/codeql/support/reusables/versions-compilers.rst
@@ -4,9 +4,9 @@
    :stub-columns: 1
 
    Language,Variants,Compilers,Extensions
-   C/C++,"C89, C99, C11, C18, C++98, C++03, C++11, C++14, C++17","Clang (and clang-cl [1]_) extensions (up to Clang 9.0),
+   C/C++,"C89, C99, C11, C18, C++98, C++03, C++11, C++14, C++17","Clang (and clang-cl [1]_) extensions (up to Clang 12.0),
 
-   GNU extensions (up to GCC 9.2),
+   GNU extensions (up to GCC 9.4),
 
    Microsoft extensions (up to VS 2019),
 


### PR DESCRIPTION
Updating Clang and GCC to the latest versions as discussed with @jbj:

- Clang 12, the latest major version of Clang as of April 2021, has full support for all published C++ standards up to C++17, implements most features of C++20.

- June 1, 2021, the release of GCC 9.4.

