### PR TITLE
JS: Experimental: support reverse-steps in type tracking

### DIFF
--- a/javascript/ql/test/library-tests/TypeTracking/PredicateStyle.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/PredicateStyle.expected
@@ -10,6 +10,12 @@ apiObject
 | tst_conflict.js:6:38:6:49 | api.chain1() |
 | tst_conflict.js:6:38:6:58 | api.cha ... hain2() |
 connection
+| type tracker reversed with call steps with property connection | tst.js:7:14:7:13 | this |
+| type tracker reversed without call steps with property MyApplication.namespace.connection | file://:0:0:0:0 | global access path |
+| type tracker reversed without call steps with property conflict | tst.js:63:3:63:25 | MyAppli ... mespace |
+| type tracker reversed without call steps with property conflict | tst_conflict.js:6:3:6:25 | MyAppli ... mespace |
+| type tracker reversed without call steps with property connection | tst.js:62:3:62:25 | MyAppli ... mespace |
+| type tracker reversed without call steps with property x | tst.js:114:6:114:27 | { x: ge ... ion() } |
 | type tracker with call steps | tst.js:7:15:7:18 | conn |
 | type tracker with call steps | tst.js:11:5:11:19 | this.connection |
 | type tracker with call steps | tst.js:80:16:80:19 | conn |
@@ -20,7 +26,6 @@ connection
 | type tracker with call steps | tst.js:103:17:103:17 | x |
 | type tracker with call steps | tst.js:104:10:106:6 | (functi ... \\n  })() |
 | type tracker with call steps | tst.js:112:10:112:14 | obj.x |
-| type tracker with call steps with property connection | tst.js:7:14:7:13 | this |
 | type tracker with call steps with property x | tst.js:111:15:111:17 | obj |
 | type tracker without call steps | client.js:1:10:1:27 | exportedConnection |
 | type tracker without call steps | tst.js:16:10:16:49 | api.cha ... ction() |
@@ -41,11 +46,6 @@ connection
 | type tracker without call steps | tst.js:114:1:114:28 | getX({  ... on() }) |
 | type tracker without call steps | tst.js:114:11:114:25 | getConnection() |
 | type tracker without call steps | tst_conflict.js:6:38:6:77 | api.cha ... ction() |
-| type tracker without call steps with property MyApplication.namespace.connection | file://:0:0:0:0 | global access path |
-| type tracker without call steps with property conflict | tst.js:63:3:63:25 | MyAppli ... mespace |
-| type tracker without call steps with property conflict | tst_conflict.js:6:3:6:25 | MyAppli ... mespace |
-| type tracker without call steps with property connection | tst.js:62:3:62:25 | MyAppli ... mespace |
-| type tracker without call steps with property x | tst.js:114:6:114:27 | { x: ge ... ion() } |
 dataCallback
 | client.js:3:28:3:34 | x => {} |
 | tst.js:10:11:10:12 | cb |

--- a/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
@@ -1,1 +1,0 @@
-| side-effect.js:9:20:9:32 | // track: SE1 | Failed to track SE1 here. |

--- a/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/TypeTracking.expected
@@ -1,0 +1,1 @@
+| side-effect.js:9:20:9:32 | // track: SE1 | Failed to track SE1 here. |

--- a/javascript/ql/test/library-tests/TypeTracking/side-effect.js
+++ b/javascript/ql/test/library-tests/TypeTracking/side-effect.js
@@ -1,0 +1,11 @@
+function assignSource(obj) {
+    let tracked = function() {}; // name: SE1
+    obj.f = tracked;
+}
+
+function useAssignSource() {
+    let obj = {};
+    assignSource(obj);
+    let f = obj.f; // track: SE1
+}
+


### PR DESCRIPTION
EXPERIMENTAL. Just putting up for discussion.

Type trackers can now be in a "reverse" state meaning they are allowed to use any number of backward steps before resuming forward flow. This backward-forward flow corresponds to an alias edge in CFL reachability.

After using a store step, the type tracker switches to "reverse" mode to find aliases for the base object. This allows us to track the `tracked` function below out to the call site:
```js
function assignSource(obj) {
    let tracked = function() {}; // name: SE1
    obj.f = tracked;
}

function useAssignSource() {
    let obj = {};
    assignSource(obj);
    let f = obj.f; // track: SE1
}
```

- Switching freely from forward to backward flow is not allowed as it would produce a transitive alias relation.
- Reverse-call edges are only allowed if a forward call edge has not been used (to ensure we don't backtrack to a different call site than where we came from).
- Reverse-return edges are not allowed as I believe they're rarely useful (but would be needed for sound analysis of closures or re-entrant functions). For this reason, we also don't need a "hasReverseCall" flag to prevent mismatching reverse-return and reverse-call edges.
- Reverse-load edges are ignored as it would always require at least two levels of property tracking (we only reverse while already inside a property).
- Reverse-store edges are ignored as they can never match a reverse-load edge (for the above reason).
