### PR TITLE
Fix diff in the framework coverage PR comment

### DIFF
--- a/.github/workflows/csv-coverage-pr-comment.yml
+++ b/.github/workflows/csv-coverage-pr-comment.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         PR=$(cat "pr/NR")
         python misc/scripts/library-coverage/compare-files-comment-pr.py \
-          out_merge out_base comparison.md "$GITHUB_REPOSITORY" "$PR" "$RUN_ID"
+          out_base out_merge comparison.md "$GITHUB_REPOSITORY" "$PR" "$RUN_ID"
     - name: Upload comparison results
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
This PR intends to fix the incorrect https://github.com/github/codeql/pull/5796#issuecomment-864044871, which happens to report the diff in the wrong way.