### PR TITLE
JS: Add basic support for various `Promise` libraries and polyfills.

### DIFF
--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -10,4 +10,5 @@ lgtm,codescanning
     [when](https://npmjs.com/package/when),
     [pinkie-promise](https://npmjs.com/package/pinkie-promise),
     [pinkie](https://npmjs.com/package/pinkie),
-    [synchronous-promise](https://npmjs.com/package/synchronous-promise)
+    [synchronous-promise](https://npmjs.com/package/synchronous-promise),
+    [any-promise](https://npmjs.com/package/any-promise)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -8,4 +8,5 @@ lgtm,codescanning
     [es6-promise](https://npmjs.com/package/es6-promise),
     [native-promise-only](https://npmjs.com/package/native-promise-only),
     [when](https://npmjs.com/package/when),
-    [pinkie-promise](https://npmjs.com/package/pinkie-promise)
+    [pinkie-promise](https://npmjs.com/package/pinkie-promise),
+    [pinkie](https://npmjs.com/package/pinkie)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -2,4 +2,5 @@ lgtm,codescanning
 * The security queries now track flow through various `Promise` polyfills.
   Affected packages are
     [kew](https://npmjs.com/package/kew),
-    [promise](https://npmjs.com/package/promise)
+    [promise](https://npmjs.com/package/promise),
+    [promise-polyfill](https://npmjs.com/package/promise-polyfill)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -7,4 +7,5 @@ lgtm,codescanning
     [rsvp](https://npmjs.com/package/rsvp),
     [es6-promise](https://npmjs.com/package/es6-promise),
     [native-promise-only](https://npmjs.com/package/native-promise-only),
-    [when](https://npmjs.com/package/when)
+    [when](https://npmjs.com/package/when),
+    [pinkie-promise](https://npmjs.com/package/pinkie-promise)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -12,4 +12,5 @@ lgtm,codescanning
     [pinkie](https://npmjs.com/package/pinkie),
     [synchronous-promise](https://npmjs.com/package/synchronous-promise),
     [any-promise](https://npmjs.com/package/any-promise),
-    [lie](https://npmjs.com/package/lie)
+    [lie](https://npmjs.com/package/lie),
+    [promise.allsettled](https://npmjs.com/package/promise.allsettled)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -6,4 +6,5 @@ lgtm,codescanning
     [promise-polyfill](https://npmjs.com/package/promise-polyfill),
     [rsvp](https://npmjs.com/package/rsvp),
     [es6-promise](https://npmjs.com/package/es6-promise),
-    [native-promise-only](https://npmjs.com/package/native-promise-only)
+    [native-promise-only](https://npmjs.com/package/native-promise-only),
+    [when](https://npmjs.com/package/when)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -5,4 +5,5 @@ lgtm,codescanning
     [promise](https://npmjs.com/package/promise),
     [promise-polyfill](https://npmjs.com/package/promise-polyfill),
     [rsvp](https://npmjs.com/package/rsvp),
-    [es6-promise](https://npmjs.com/package/es6-promise)
+    [es6-promise](https://npmjs.com/package/es6-promise),
+    [native-promise-only](https://npmjs.com/package/native-promise-only)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -1,4 +1,5 @@
 lgtm,codescanning
 * The security queries now track flow through various `Promise` polyfills.
   Affected packages are
-    [kew](https://npmjs.com/package/kew)
+    [kew](https://npmjs.com/package/kew),
+    [promise](https://npmjs.com/package/promise)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -9,4 +9,5 @@ lgtm,codescanning
     [native-promise-only](https://npmjs.com/package/native-promise-only),
     [when](https://npmjs.com/package/when),
     [pinkie-promise](https://npmjs.com/package/pinkie-promise),
-    [pinkie](https://npmjs.com/package/pinkie)
+    [pinkie](https://npmjs.com/package/pinkie),
+    [synchronous-promise](https://npmjs.com/package/synchronous-promise)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -3,4 +3,6 @@ lgtm,codescanning
   Affected packages are
     [kew](https://npmjs.com/package/kew),
     [promise](https://npmjs.com/package/promise),
-    [promise-polyfill](https://npmjs.com/package/promise-polyfill)
+    [promise-polyfill](https://npmjs.com/package/promise-polyfill),
+    [rsvp](https://npmjs.com/package/rsvp),
+    [es6-promise](https://npmjs.com/package/es6-promise)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* The security queries now track flow through various `Promise` polyfills.
+  Affected packages are
+    [kew](https://npmjs.com/package/kew)

--- a/javascript/change-notes/2021-06-18-promises.md
+++ b/javascript/change-notes/2021-06-18-promises.md
@@ -11,4 +11,5 @@ lgtm,codescanning
     [pinkie-promise](https://npmjs.com/package/pinkie-promise),
     [pinkie](https://npmjs.com/package/pinkie),
     [synchronous-promise](https://npmjs.com/package/synchronous-promise),
-    [any-promise](https://npmjs.com/package/any-promise)
+    [any-promise](https://npmjs.com/package/any-promise),
+    [lie](https://npmjs.com/package/lie)

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -77,6 +77,8 @@ private DataFlow::SourceNode getAPromiseObject() {
   result = DataFlow::moduleMember(["promise-polyfill", "promise-polyfill/src/polyfill"], "default")
   or
   result = DataFlow::moduleImport(["promise-polyfill", "promise-polyfill/src/polyfill"])
+  or
+  result = DataFlow::moduleMember(["es6-promise", "rsvp"], "Promise")
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -81,6 +81,8 @@ private DataFlow::SourceNode getAPromiseObject() {
   result = DataFlow::moduleMember(["es6-promise", "rsvp"], "Promise")
   or
   result = DataFlow::moduleImport("native-promise-only")
+  or
+  result = DataFlow::moduleImport("when")
 }
 
 /**
@@ -97,10 +99,11 @@ class PromiseCandidate extends DataFlow::InvokeNode {
 }
 
 /**
- * A promise object created by the standard ECMAScript 2015 `Promise` constructor.
+ * A promise object created by the standard ECMAScript 2015 `Promise` constructor,
+ * or a polyfill implementing a superset of the ECMAScript 2015 `Promise` API.
  */
-private class ES2015PromiseDefinition extends PromiseDefinition, DataFlow::NewNode {
-  ES2015PromiseDefinition() { this = getAPromiseObject().getAnInstantiation() }
+private class ES2015PromiseDefinition extends PromiseDefinition, DataFlow::InvokeNode {
+  ES2015PromiseDefinition() { this = getAPromiseObject().getAnInvocation() }
 
   override DataFlow::FunctionNode getExecutor() { result = getCallback(0) }
 }

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -157,8 +157,11 @@ class ResolvedES2015PromiseDefinition extends ResolvedPromiseDefinition {
  */
 class AggregateES2015PromiseDefinition extends PromiseCreationCall {
   AggregateES2015PromiseDefinition() {
+    exists(string m | m = "all" or m = "race" or m = "any" or m = "allSettled" |
       this = getAPromiseObject().getAMemberCall(m)
     )
+    or
+    this = DataFlow::moduleImport("promise.allsettled").getACall()
   }
 
   override DataFlow::Node getValue() {

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -72,6 +72,11 @@ private DataFlow::SourceNode getAPromiseObject() {
         "promise", "promise/domains", "promise/setimmediate", "promise/lib/es6-extensions",
         "promise/domains/es6-extensions", "promise/setimmediate/es6-extensions"
       ])
+  or
+  // polyfill from the [`promise-polyfill`](https://npmjs.org/package/promise-polyfill) library.
+  result = DataFlow::moduleMember(["promise-polyfill", "promise-polyfill/src/polyfill"], "default")
+  or
+  result = DataFlow::moduleImport(["promise-polyfill", "promise-polyfill/src/polyfill"])
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -89,6 +89,8 @@ private DataFlow::SourceNode getAPromiseObject() {
   result = DataFlow::moduleImport("pinkie")
   or
   result = DataFlow::moduleMember("synchronous-promise", "SynchronousPromise")
+  or
+  result = DataFlow::moduleImport("any-promise")
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -85,6 +85,8 @@ private DataFlow::SourceNode getAPromiseObject() {
   result = DataFlow::moduleImport("when")
   or
   result = DataFlow::moduleImport("pinkie-promise")
+  or
+  result = DataFlow::moduleImport("pinkie")
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -79,6 +79,8 @@ private DataFlow::SourceNode getAPromiseObject() {
   result = DataFlow::moduleImport(["promise-polyfill", "promise-polyfill/src/polyfill"])
   or
   result = DataFlow::moduleMember(["es6-promise", "rsvp"], "Promise")
+  or
+  result = DataFlow::moduleImport("native-promise-only")
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -87,6 +87,8 @@ private DataFlow::SourceNode getAPromiseObject() {
   result = DataFlow::moduleImport("pinkie-promise")
   or
   result = DataFlow::moduleImport("pinkie")
+  or
+  result = DataFlow::moduleMember("synchronous-promise", "SynchronousPromise")
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -83,6 +83,8 @@ private DataFlow::SourceNode getAPromiseObject() {
   result = DataFlow::moduleImport("native-promise-only")
   or
   result = DataFlow::moduleImport("when")
+  or
+  result = DataFlow::moduleImport("pinkie-promise")
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -562,14 +562,14 @@ module Bluebird {
 }
 
 /**
- * Provides classes for working with the `q` library (https://github.com/kriskowal/q).
+ * Provides classes for working with the `q` library (https://github.com/kriskowal/q) and the compatible `kew` library (https://github.com/Medium/kew).
  */
 module Q {
   /**
    * A promise object created by the q `Promise` constructor.
    */
   private class QPromiseDefinition extends PromiseDefinition, DataFlow::CallNode {
-    QPromiseDefinition() { this = DataFlow::moduleMember("q", "Promise").getACall() }
+    QPromiseDefinition() { this = DataFlow::moduleMember(["q", "kew"], "Promise").getACall() }
 
     override DataFlow::FunctionNode getExecutor() { result = getCallback(0) }
   }

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -91,6 +91,8 @@ private DataFlow::SourceNode getAPromiseObject() {
   result = DataFlow::moduleMember("synchronous-promise", "SynchronousPromise")
   or
   result = DataFlow::moduleImport("any-promise")
+  or
+  result = DataFlow::moduleImport("lie")
 }
 
 /**

--- a/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
+++ b/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
@@ -82,3 +82,4 @@
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) |
 | promises.js:112:17:112:62 | new RSV ... ct) {}) |
 | promises.js:124:19:124:30 | when(source) |
+| promises.js:130:14:130:69 | new Pro ... s'); }) |

--- a/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
+++ b/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
@@ -79,3 +79,4 @@
 | promises.js:71:5:71:27 | Promise ... source) |
 | promises.js:72:5:72:41 | new Pro ... ource)) |
 | promises.js:79:19:79:41 | Promise ... source) |
+| promises.js:88:17:90:4 | Q.Promi ... );\\n  }) |

--- a/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
+++ b/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
@@ -84,3 +84,4 @@
 | promises.js:124:19:124:30 | when(source) |
 | promises.js:130:14:130:69 | new Pro ... s'); }) |
 | promises.js:135:3:137:4 | new Pro ... );\\n  }) |
+| promises.js:148:10:148:49 | new Pro ... ect){}) |

--- a/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
+++ b/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
@@ -83,3 +83,4 @@
 | promises.js:112:17:112:62 | new RSV ... ct) {}) |
 | promises.js:124:19:124:30 | when(source) |
 | promises.js:130:14:130:69 | new Pro ... s'); }) |
+| promises.js:135:3:137:4 | new Pro ... );\\n  }) |

--- a/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
+++ b/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
@@ -81,3 +81,4 @@
 | promises.js:79:19:79:41 | Promise ... source) |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) |
 | promises.js:112:17:112:62 | new RSV ... ct) {}) |
+| promises.js:124:19:124:30 | when(source) |

--- a/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
+++ b/javascript/ql/test/library-tests/Promises/AdditionalPromises.expected
@@ -80,3 +80,4 @@
 | promises.js:72:5:72:41 | new Pro ... ource)) |
 | promises.js:79:19:79:41 | Promise ... source) |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) |
+| promises.js:112:17:112:62 | new RSV ... ct) {}) |

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -142,3 +142,8 @@
   // is technically not a promise, but behaves like one.
   var promise = SynchronousPromise.resolve(source);
 })();
+
+(function() {
+  var Promise = require('any-promise');
+  return new Promise(function(resolve, reject){})
+})();

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -136,3 +136,9 @@
     resolve(data);
   });
 })();
+
+(function() {
+  import { SynchronousPromise } from 'synchronous-promise';
+  // is technically not a promise, but behaves like one.
+  var promise = SynchronousPromise.resolve(source);
+})();

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -99,3 +99,10 @@
   PromiseA.resolve(source);
   PromiseB.resolve(source);
 })();
+
+(function() {
+  var PromiseA = require('promise-polyfill').default;
+  import PromiseB from 'promise-polyfill';
+  PromiseA.resolve(source);
+  PromiseB.resolve(source);
+})();

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -147,3 +147,8 @@
   var Promise = require('any-promise');
   return new Promise(function(resolve, reject){})
 })();
+
+(function() {
+  var Promise = require('lie');
+  var promise = Promise.resolve(source);
+})();

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -81,3 +81,14 @@
         var sink = val;
     });
 })();
+
+
+(function() {
+  var Q = require("kew");
+  var promise = Q.Promise(function (resolve, reject) {
+      resolve(source);
+  });
+  promise.then(function (val) {
+      var sink = val;
+  });
+})();

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -92,3 +92,10 @@
       var sink = val;
   });
 })();
+
+(function() {
+  var PromiseA = require('promise');
+  var PromiseB = require('promise/domains');
+  PromiseA.resolve(source);
+  PromiseB.resolve(source);
+})();

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -118,3 +118,9 @@
   var Promise = require('native-promise-only');
   Promise.resolve(source);
 })();
+
+(function() {
+  const when = require('when');
+  const promise = when(source);
+  const promise2 = when.resolve(source);
+})();

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -113,3 +113,8 @@
   var Promise = require('es6-promise').Promise;
   Promise.resolve(source);
 })();
+
+(function() {
+  var Promise = require('native-promise-only');
+  Promise.resolve(source);
+})();

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -129,3 +129,10 @@
   var Promise = require('pinkie-promise');
   var prom = new Promise(function (resolve) { resolve('unicorns'); });
 })();
+
+(function() {
+  var Promise = require('pinkie');
+  new Promise(function (resolve, reject) {
+    resolve(data);
+  });
+})();

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -124,3 +124,8 @@
   const promise = when(source);
   const promise2 = when.resolve(source);
 })();
+
+(function() {
+  var Promise = require('pinkie-promise');
+  var prom = new Promise(function (resolve) { resolve('unicorns'); });
+})();

--- a/javascript/ql/test/library-tests/Promises/promises.js
+++ b/javascript/ql/test/library-tests/Promises/promises.js
@@ -106,3 +106,10 @@
   PromiseA.resolve(source);
   PromiseB.resolve(source);
 })();
+
+(function() {
+  var RSVP = require('rsvp');
+  var promise = new RSVP.Promise(function(resolve, reject) {});
+  var Promise = require('es6-promise').Promise;
+  Promise.resolve(source);
+})();

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -43,6 +43,7 @@ test_ResolvedPromiseDefinition
 | promises.js:114:3:114:25 | Promise ... source) | promises.js:114:19:114:24 | source |
 | promises.js:119:3:119:25 | Promise ... source) | promises.js:119:19:119:24 | source |
 | promises.js:125:20:125:39 | when.resolve(source) | promises.js:125:33:125:38 | source |
+| promises.js:143:17:143:50 | Synchro ... source) | promises.js:143:44:143:49 | source |
 test_PromiseDefinition_getARejectHandler
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:69:26:80 | y => sink(y) |
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
@@ -442,3 +443,5 @@ typetrack
 | promises.js:125:20:125:39 | when.resolve(source) | promises.js:125:33:125:38 | source | store $PromiseResolveField$ |
 | promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:136:13:136:16 | data | copy $PromiseResolveField$ |
 | promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:136:13:136:16 | data | store $PromiseResolveField$ |
+| promises.js:143:17:143:50 | Synchro ... source) | promises.js:143:44:143:49 | source | copy $PromiseResolveField$ |
+| promises.js:143:17:143:50 | Synchro ... source) | promises.js:143:44:143:49 | source | store $PromiseResolveField$ |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -36,6 +36,8 @@ test_ResolvedPromiseDefinition
 | promises.js:62:19:62:41 | Promise ... source) | promises.js:62:35:62:40 | source |
 | promises.js:71:5:71:27 | Promise ... source) | promises.js:71:21:71:26 | source |
 | promises.js:79:19:79:41 | Promise ... source) | promises.js:79:35:79:40 | source |
+| promises.js:99:3:99:26 | Promise ... source) | promises.js:99:20:99:25 | source |
+| promises.js:100:3:100:26 | Promise ... source) | promises.js:100:20:100:25 | source |
 test_PromiseDefinition_getARejectHandler
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:69:26:80 | y => sink(y) |
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
@@ -407,3 +409,7 @@ typetrack
 | promises.js:75:27:75:29 | val | promises.js:75:5:75:20 | resolver.promise | load $PromiseResolveField$ |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:89:15:89:20 | source | copy $PromiseResolveField$ |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:89:15:89:20 | source | store $PromiseResolveField$ |
+| promises.js:99:3:99:26 | Promise ... source) | promises.js:99:20:99:25 | source | copy $PromiseResolveField$ |
+| promises.js:99:3:99:26 | Promise ... source) | promises.js:99:20:99:25 | source | store $PromiseResolveField$ |
+| promises.js:100:3:100:26 | Promise ... source) | promises.js:100:20:100:25 | source | copy $PromiseResolveField$ |
+| promises.js:100:3:100:26 | Promise ... source) | promises.js:100:20:100:25 | source | store $PromiseResolveField$ |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -91,6 +91,7 @@ test_PromiseDefinition_getExecutor
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) | promises.js:43:29:45:5 | functio ... ;\\n    } |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:27:90:3 | functio ... e);\\n  } |
 | promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:34:112:61 | functio ... ect) {} |
+| promises.js:130:14:130:69 | new Pro ... s'); }) | promises.js:130:26:130:68 | functio ... ns'); } |
 test_PromiseDefinition_getAFinallyHandler
 | flow.js:105:2:105:48 | new Pro ... "BLA")) | flow.js:105:58:105:76 | x => {throw source} |
 | flow.js:109:2:109:48 | new Pro ... "BLA")) | flow.js:109:58:109:70 | x => rejected |
@@ -129,6 +130,7 @@ test_PromiseDefinition
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) |
 | promises.js:112:17:112:62 | new RSV ... ct) {}) |
 | promises.js:124:19:124:30 | when(source) |
+| promises.js:130:14:130:69 | new Pro ... s'); }) |
 test_PromiseDefinition_getAResolveHandler
 | flow.js:24:2:24:49 | new Pro ... ource)) | flow.js:24:56:24:67 | x => sink(x) |
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:56:26:66 | x => foo(x) |
@@ -211,6 +213,7 @@ test_PromiseDefinition_getResolveParameter
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) | promises.js:43:39:43:45 | resolve |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:37:88:43 | resolve |
 | promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:43:112:49 | resolve |
+| promises.js:130:14:130:69 | new Pro ... s'); }) | promises.js:130:36:130:42 | resolve |
 test_PromiseDefinition_getACatchHandler
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
 | flow.js:48:2:48:36 | new Pro ... urce }) | flow.js:48:44:48:55 | x => sink(x) |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -38,6 +38,8 @@ test_ResolvedPromiseDefinition
 | promises.js:79:19:79:41 | Promise ... source) | promises.js:79:35:79:40 | source |
 | promises.js:99:3:99:26 | Promise ... source) | promises.js:99:20:99:25 | source |
 | promises.js:100:3:100:26 | Promise ... source) | promises.js:100:20:100:25 | source |
+| promises.js:106:3:106:26 | Promise ... source) | promises.js:106:20:106:25 | source |
+| promises.js:107:3:107:26 | Promise ... source) | promises.js:107:20:107:25 | source |
 test_PromiseDefinition_getARejectHandler
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:69:26:80 | y => sink(y) |
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
@@ -413,3 +415,7 @@ typetrack
 | promises.js:99:3:99:26 | Promise ... source) | promises.js:99:20:99:25 | source | store $PromiseResolveField$ |
 | promises.js:100:3:100:26 | Promise ... source) | promises.js:100:20:100:25 | source | copy $PromiseResolveField$ |
 | promises.js:100:3:100:26 | Promise ... source) | promises.js:100:20:100:25 | source | store $PromiseResolveField$ |
+| promises.js:106:3:106:26 | Promise ... source) | promises.js:106:20:106:25 | source | copy $PromiseResolveField$ |
+| promises.js:106:3:106:26 | Promise ... source) | promises.js:106:20:106:25 | source | store $PromiseResolveField$ |
+| promises.js:107:3:107:26 | Promise ... source) | promises.js:107:20:107:25 | source | copy $PromiseResolveField$ |
+| promises.js:107:3:107:26 | Promise ... source) | promises.js:107:20:107:25 | source | store $PromiseResolveField$ |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -92,6 +92,7 @@ test_PromiseDefinition_getExecutor
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:27:90:3 | functio ... e);\\n  } |
 | promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:34:112:61 | functio ... ect) {} |
 | promises.js:130:14:130:69 | new Pro ... s'); }) | promises.js:130:26:130:68 | functio ... ns'); } |
+| promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:135:15:137:3 | functio ... a);\\n  } |
 test_PromiseDefinition_getAFinallyHandler
 | flow.js:105:2:105:48 | new Pro ... "BLA")) | flow.js:105:58:105:76 | x => {throw source} |
 | flow.js:109:2:109:48 | new Pro ... "BLA")) | flow.js:109:58:109:70 | x => rejected |
@@ -131,6 +132,7 @@ test_PromiseDefinition
 | promises.js:112:17:112:62 | new RSV ... ct) {}) |
 | promises.js:124:19:124:30 | when(source) |
 | promises.js:130:14:130:69 | new Pro ... s'); }) |
+| promises.js:135:3:137:4 | new Pro ... );\\n  }) |
 test_PromiseDefinition_getAResolveHandler
 | flow.js:24:2:24:49 | new Pro ... ource)) | flow.js:24:56:24:67 | x => sink(x) |
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:56:26:66 | x => foo(x) |
@@ -181,6 +183,7 @@ test_PromiseDefinition_getRejectParameter
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) | promises.js:43:48:43:53 | reject |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:46:88:51 | reject |
 | promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:52:112:57 | reject |
+| promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:135:34:135:39 | reject |
 test_PromiseDefinition_getResolveParameter
 | flow.js:7:11:7:59 | new Pro ... ource)) | flow.js:7:24:7:30 | resolve |
 | flow.js:10:11:10:58 | new Pro ... ource)) | flow.js:10:24:10:30 | resolve |
@@ -214,6 +217,7 @@ test_PromiseDefinition_getResolveParameter
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:37:88:43 | resolve |
 | promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:43:112:49 | resolve |
 | promises.js:130:14:130:69 | new Pro ... s'); }) | promises.js:130:36:130:42 | resolve |
+| promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:135:25:135:31 | resolve |
 test_PromiseDefinition_getACatchHandler
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
 | flow.js:48:2:48:36 | new Pro ... urce }) | flow.js:48:44:48:55 | x => sink(x) |
@@ -436,3 +440,5 @@ typetrack
 | promises.js:119:3:119:25 | Promise ... source) | promises.js:119:19:119:24 | source | store $PromiseResolveField$ |
 | promises.js:125:20:125:39 | when.resolve(source) | promises.js:125:33:125:38 | source | copy $PromiseResolveField$ |
 | promises.js:125:20:125:39 | when.resolve(source) | promises.js:125:33:125:38 | source | store $PromiseResolveField$ |
+| promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:136:13:136:16 | data | copy $PromiseResolveField$ |
+| promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:136:13:136:16 | data | store $PromiseResolveField$ |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -82,6 +82,7 @@ test_PromiseDefinition_getExecutor
 | promises.js:10:18:17:4 | new Pro ... );\\n  }) | promises.js:10:30:17:3 | (res, r ... e);\\n  } |
 | promises.js:33:19:35:6 | new Pro ... \\n    }) | promises.js:33:31:35:5 | functio ... ;\\n    } |
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) | promises.js:43:29:45:5 | functio ... ;\\n    } |
+| promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:27:90:3 | functio ... e);\\n  } |
 test_PromiseDefinition_getAFinallyHandler
 | flow.js:105:2:105:48 | new Pro ... "BLA")) | flow.js:105:58:105:76 | x => {throw source} |
 | flow.js:109:2:109:48 | new Pro ... "BLA")) | flow.js:109:58:109:70 | x => rejected |
@@ -117,6 +118,7 @@ test_PromiseDefinition
 | promises.js:10:18:17:4 | new Pro ... );\\n  }) |
 | promises.js:33:19:35:6 | new Pro ... \\n    }) |
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) |
+| promises.js:88:17:90:4 | Q.Promi ... );\\n  }) |
 test_PromiseDefinition_getAResolveHandler
 | flow.js:24:2:24:49 | new Pro ... ource)) | flow.js:24:56:24:67 | x => sink(x) |
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:56:26:66 | x => foo(x) |
@@ -134,6 +136,7 @@ test_PromiseDefinition_getAResolveHandler
 | promises.js:10:18:17:4 | new Pro ... );\\n  }) | promises.js:26:20:28:3 | (v) =>  ...  v;\\n  } |
 | promises.js:33:19:35:6 | new Pro ... \\n    }) | promises.js:36:18:38:5 | functio ... ;\\n    } |
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) | promises.js:46:18:48:5 | functio ... ;\\n    } |
+| promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:91:16:93:3 | functio ... al;\\n  } |
 test_PromiseDefinition_getRejectParameter
 | flow.js:7:11:7:59 | new Pro ... ource)) | flow.js:7:33:7:38 | reject |
 | flow.js:10:11:10:58 | new Pro ... ource)) | flow.js:10:33:10:38 | reject |
@@ -164,6 +167,7 @@ test_PromiseDefinition_getRejectParameter
 | promises.js:10:18:17:4 | new Pro ... );\\n  }) | promises.js:10:36:10:38 | rej |
 | promises.js:33:19:35:6 | new Pro ... \\n    }) | promises.js:33:50:33:55 | reject |
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) | promises.js:43:48:43:53 | reject |
+| promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:46:88:51 | reject |
 test_PromiseDefinition_getResolveParameter
 | flow.js:7:11:7:59 | new Pro ... ource)) | flow.js:7:24:7:30 | resolve |
 | flow.js:10:11:10:58 | new Pro ... ource)) | flow.js:10:24:10:30 | resolve |
@@ -194,6 +198,7 @@ test_PromiseDefinition_getResolveParameter
 | promises.js:10:18:17:4 | new Pro ... );\\n  }) | promises.js:10:31:10:33 | res |
 | promises.js:33:19:35:6 | new Pro ... \\n    }) | promises.js:33:41:33:47 | resolve |
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) | promises.js:43:39:43:45 | resolve |
+| promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:37:88:43 | resolve |
 test_PromiseDefinition_getACatchHandler
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
 | flow.js:48:2:48:36 | new Pro ... urce }) | flow.js:48:44:48:55 | x => sink(x) |
@@ -400,3 +405,5 @@ typetrack
 | promises.js:71:34:71:36 | val | promises.js:71:5:71:27 | Promise ... source) | load $PromiseResolveField$ |
 | promises.js:72:48:72:50 | val | promises.js:72:5:72:41 | new Pro ... ource)) | load $PromiseResolveField$ |
 | promises.js:75:27:75:29 | val | promises.js:75:5:75:20 | resolver.promise | load $PromiseResolveField$ |
+| promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:89:15:89:20 | source | copy $PromiseResolveField$ |
+| promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:89:15:89:20 | source | store $PromiseResolveField$ |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -44,6 +44,7 @@ test_ResolvedPromiseDefinition
 | promises.js:119:3:119:25 | Promise ... source) | promises.js:119:19:119:24 | source |
 | promises.js:125:20:125:39 | when.resolve(source) | promises.js:125:33:125:38 | source |
 | promises.js:143:17:143:50 | Synchro ... source) | promises.js:143:44:143:49 | source |
+| promises.js:153:17:153:39 | Promise ... source) | promises.js:153:33:153:38 | source |
 test_PromiseDefinition_getARejectHandler
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:69:26:80 | y => sink(y) |
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
@@ -449,3 +450,5 @@ typetrack
 | promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:136:13:136:16 | data | store $PromiseResolveField$ |
 | promises.js:143:17:143:50 | Synchro ... source) | promises.js:143:44:143:49 | source | copy $PromiseResolveField$ |
 | promises.js:143:17:143:50 | Synchro ... source) | promises.js:143:44:143:49 | source | store $PromiseResolveField$ |
+| promises.js:153:17:153:39 | Promise ... source) | promises.js:153:33:153:38 | source | copy $PromiseResolveField$ |
+| promises.js:153:17:153:39 | Promise ... source) | promises.js:153:33:153:38 | source | store $PromiseResolveField$ |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -42,6 +42,7 @@ test_ResolvedPromiseDefinition
 | promises.js:107:3:107:26 | Promise ... source) | promises.js:107:20:107:25 | source |
 | promises.js:114:3:114:25 | Promise ... source) | promises.js:114:19:114:24 | source |
 | promises.js:119:3:119:25 | Promise ... source) | promises.js:119:19:119:24 | source |
+| promises.js:125:20:125:39 | when.resolve(source) | promises.js:125:33:125:38 | source |
 test_PromiseDefinition_getARejectHandler
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:69:26:80 | y => sink(y) |
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
@@ -127,6 +128,7 @@ test_PromiseDefinition
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) |
 | promises.js:112:17:112:62 | new RSV ... ct) {}) |
+| promises.js:124:19:124:30 | when(source) |
 test_PromiseDefinition_getAResolveHandler
 | flow.js:24:2:24:49 | new Pro ... ource)) | flow.js:24:56:24:67 | x => sink(x) |
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:56:26:66 | x => foo(x) |
@@ -429,3 +431,5 @@ typetrack
 | promises.js:114:3:114:25 | Promise ... source) | promises.js:114:19:114:24 | source | store $PromiseResolveField$ |
 | promises.js:119:3:119:25 | Promise ... source) | promises.js:119:19:119:24 | source | copy $PromiseResolveField$ |
 | promises.js:119:3:119:25 | Promise ... source) | promises.js:119:19:119:24 | source | store $PromiseResolveField$ |
+| promises.js:125:20:125:39 | when.resolve(source) | promises.js:125:33:125:38 | source | copy $PromiseResolveField$ |
+| promises.js:125:20:125:39 | when.resolve(source) | promises.js:125:33:125:38 | source | store $PromiseResolveField$ |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -40,6 +40,7 @@ test_ResolvedPromiseDefinition
 | promises.js:100:3:100:26 | Promise ... source) | promises.js:100:20:100:25 | source |
 | promises.js:106:3:106:26 | Promise ... source) | promises.js:106:20:106:25 | source |
 | promises.js:107:3:107:26 | Promise ... source) | promises.js:107:20:107:25 | source |
+| promises.js:114:3:114:25 | Promise ... source) | promises.js:114:19:114:24 | source |
 test_PromiseDefinition_getARejectHandler
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:69:26:80 | y => sink(y) |
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
@@ -87,6 +88,7 @@ test_PromiseDefinition_getExecutor
 | promises.js:33:19:35:6 | new Pro ... \\n    }) | promises.js:33:31:35:5 | functio ... ;\\n    } |
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) | promises.js:43:29:45:5 | functio ... ;\\n    } |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:27:90:3 | functio ... e);\\n  } |
+| promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:34:112:61 | functio ... ect) {} |
 test_PromiseDefinition_getAFinallyHandler
 | flow.js:105:2:105:48 | new Pro ... "BLA")) | flow.js:105:58:105:76 | x => {throw source} |
 | flow.js:109:2:109:48 | new Pro ... "BLA")) | flow.js:109:58:109:70 | x => rejected |
@@ -123,6 +125,7 @@ test_PromiseDefinition
 | promises.js:33:19:35:6 | new Pro ... \\n    }) |
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) |
+| promises.js:112:17:112:62 | new RSV ... ct) {}) |
 test_PromiseDefinition_getAResolveHandler
 | flow.js:24:2:24:49 | new Pro ... ource)) | flow.js:24:56:24:67 | x => sink(x) |
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:56:26:66 | x => foo(x) |
@@ -172,6 +175,7 @@ test_PromiseDefinition_getRejectParameter
 | promises.js:33:19:35:6 | new Pro ... \\n    }) | promises.js:33:50:33:55 | reject |
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) | promises.js:43:48:43:53 | reject |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:46:88:51 | reject |
+| promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:52:112:57 | reject |
 test_PromiseDefinition_getResolveParameter
 | flow.js:7:11:7:59 | new Pro ... ource)) | flow.js:7:24:7:30 | resolve |
 | flow.js:10:11:10:58 | new Pro ... ource)) | flow.js:10:24:10:30 | resolve |
@@ -203,6 +207,7 @@ test_PromiseDefinition_getResolveParameter
 | promises.js:33:19:35:6 | new Pro ... \\n    }) | promises.js:33:41:33:47 | resolve |
 | promises.js:43:19:45:6 | Q.Promi ... \\n    }) | promises.js:43:39:43:45 | resolve |
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:37:88:43 | resolve |
+| promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:43:112:49 | resolve |
 test_PromiseDefinition_getACatchHandler
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
 | flow.js:48:2:48:36 | new Pro ... urce }) | flow.js:48:44:48:55 | x => sink(x) |
@@ -419,3 +424,5 @@ typetrack
 | promises.js:106:3:106:26 | Promise ... source) | promises.js:106:20:106:25 | source | store $PromiseResolveField$ |
 | promises.js:107:3:107:26 | Promise ... source) | promises.js:107:20:107:25 | source | copy $PromiseResolveField$ |
 | promises.js:107:3:107:26 | Promise ... source) | promises.js:107:20:107:25 | source | store $PromiseResolveField$ |
+| promises.js:114:3:114:25 | Promise ... source) | promises.js:114:19:114:24 | source | copy $PromiseResolveField$ |
+| promises.js:114:3:114:25 | Promise ... source) | promises.js:114:19:114:24 | source | store $PromiseResolveField$ |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -41,6 +41,7 @@ test_ResolvedPromiseDefinition
 | promises.js:106:3:106:26 | Promise ... source) | promises.js:106:20:106:25 | source |
 | promises.js:107:3:107:26 | Promise ... source) | promises.js:107:20:107:25 | source |
 | promises.js:114:3:114:25 | Promise ... source) | promises.js:114:19:114:24 | source |
+| promises.js:119:3:119:25 | Promise ... source) | promises.js:119:19:119:24 | source |
 test_PromiseDefinition_getARejectHandler
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:69:26:80 | y => sink(y) |
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
@@ -426,3 +427,5 @@ typetrack
 | promises.js:107:3:107:26 | Promise ... source) | promises.js:107:20:107:25 | source | store $PromiseResolveField$ |
 | promises.js:114:3:114:25 | Promise ... source) | promises.js:114:19:114:24 | source | copy $PromiseResolveField$ |
 | promises.js:114:3:114:25 | Promise ... source) | promises.js:114:19:114:24 | source | store $PromiseResolveField$ |
+| promises.js:119:3:119:25 | Promise ... source) | promises.js:119:19:119:24 | source | copy $PromiseResolveField$ |
+| promises.js:119:3:119:25 | Promise ... source) | promises.js:119:19:119:24 | source | store $PromiseResolveField$ |

--- a/javascript/ql/test/library-tests/Promises/tests.expected
+++ b/javascript/ql/test/library-tests/Promises/tests.expected
@@ -94,6 +94,7 @@ test_PromiseDefinition_getExecutor
 | promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:34:112:61 | functio ... ect) {} |
 | promises.js:130:14:130:69 | new Pro ... s'); }) | promises.js:130:26:130:68 | functio ... ns'); } |
 | promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:135:15:137:3 | functio ... a);\\n  } |
+| promises.js:148:10:148:49 | new Pro ... ect){}) | promises.js:148:22:148:48 | functio ... ject){} |
 test_PromiseDefinition_getAFinallyHandler
 | flow.js:105:2:105:48 | new Pro ... "BLA")) | flow.js:105:58:105:76 | x => {throw source} |
 | flow.js:109:2:109:48 | new Pro ... "BLA")) | flow.js:109:58:109:70 | x => rejected |
@@ -134,6 +135,7 @@ test_PromiseDefinition
 | promises.js:124:19:124:30 | when(source) |
 | promises.js:130:14:130:69 | new Pro ... s'); }) |
 | promises.js:135:3:137:4 | new Pro ... );\\n  }) |
+| promises.js:148:10:148:49 | new Pro ... ect){}) |
 test_PromiseDefinition_getAResolveHandler
 | flow.js:24:2:24:49 | new Pro ... ource)) | flow.js:24:56:24:67 | x => sink(x) |
 | flow.js:26:2:26:49 | new Pro ... ource)) | flow.js:26:56:26:66 | x => foo(x) |
@@ -185,6 +187,7 @@ test_PromiseDefinition_getRejectParameter
 | promises.js:88:17:90:4 | Q.Promi ... );\\n  }) | promises.js:88:46:88:51 | reject |
 | promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:52:112:57 | reject |
 | promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:135:34:135:39 | reject |
+| promises.js:148:10:148:49 | new Pro ... ect){}) | promises.js:148:40:148:45 | reject |
 test_PromiseDefinition_getResolveParameter
 | flow.js:7:11:7:59 | new Pro ... ource)) | flow.js:7:24:7:30 | resolve |
 | flow.js:10:11:10:58 | new Pro ... ource)) | flow.js:10:24:10:30 | resolve |
@@ -219,6 +222,7 @@ test_PromiseDefinition_getResolveParameter
 | promises.js:112:17:112:62 | new RSV ... ct) {}) | promises.js:112:43:112:49 | resolve |
 | promises.js:130:14:130:69 | new Pro ... s'); }) | promises.js:130:36:130:42 | resolve |
 | promises.js:135:3:137:4 | new Pro ... );\\n  }) | promises.js:135:25:135:31 | resolve |
+| promises.js:148:10:148:49 | new Pro ... ect){}) | promises.js:148:31:148:37 | resolve |
 test_PromiseDefinition_getACatchHandler
 | flow.js:32:2:32:49 | new Pro ... ource)) | flow.js:32:57:32:68 | x => sink(x) |
 | flow.js:48:2:48:36 | new Pro ... urce }) | flow.js:48:44:48:55 | x => sink(x) |


### PR DESCRIPTION
We were lacking support for the highly dependent upon [`promise`](https://www.npmjs.com/package/promise) library.  
I went ahead and searched for other similar libraries, and also added support for those. 

The combined downloads of the libraries modeled are about 77 million a week on NPM. 