### PR TITLE
JS: Add models for `promisify` functions

### DIFF
--- a/javascript/change-notes/2021-06-21-promisify.md
+++ b/javascript/change-notes/2021-06-21-promisify.md
@@ -2,4 +2,5 @@ lgtm,codescanning
 * Support for libraries modeling `promisify` and `promisifyAll` functions have been improved. 
   Affected packages are
     [pify](https://www.npmjs.com/package/pify),
-    [util.promisify](https://www.npmjs.com/package/util.promisify)
+    [util.promisify](https://www.npmjs.com/package/util.promisify),
+    [thenify](https://www.npmjs.com/package/thenify)

--- a/javascript/change-notes/2021-06-21-promisify.md
+++ b/javascript/change-notes/2021-06-21-promisify.md
@@ -1,4 +1,5 @@
 lgtm,codescanning
 * Support for libraries modeling `promisify` and `promisifyAll` functions have been improved. 
   Affected packages are
-    [pify](https://www.npmjs.com/package/pify)
+    [pify](https://www.npmjs.com/package/pify),
+    [util.promisify](https://www.npmjs.com/package/util.promisify)

--- a/javascript/change-notes/2021-06-21-promisify.md
+++ b/javascript/change-notes/2021-06-21-promisify.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* Support for libraries modeling `promisify` and `promisifyAll` functions have been improved. 
+  Affected packages are
+    [pify](https://www.npmjs.com/package/pify)

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -686,9 +686,7 @@ module API {
       promisified = false and
       boundArgs = 0
       or
-      exists(DataFlow::CallNode promisify |
-        promisify = DataFlow::moduleImport(["util", "bluebird"]).getAMemberCall("promisify")
-      |
+      exists(Promisify::PromisifyCall promisify |
         trackUseNode(nd, false, boundArgs, t.continue()).flowsTo(promisify.getArgument(0)) and
         promisified = true and
         result = promisify

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -686,6 +686,10 @@ module Promisify {
       this = DataFlow::moduleImport(["util", "bluebird"]).getAMemberCall("promisify")
       or
       this = DataFlow::moduleImport(["pify", "util.promisify"]).getACall()
+      or
+      this = DataFlow::moduleImport("thenify").getACall()
+      or
+      this = DataFlow::moduleMember("thenify", "withCallback").getACall()
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -672,10 +672,8 @@ module Promisify {
   class PromisifyAllCall extends DataFlow::CallNode {
     PromisifyAllCall() {
       this =
-        [
-          DataFlow::moduleMember("bluebird", "promisifyAll"),
-          DataFlow::moduleImport("util-promisifyall")
-        ].getACall()
+        [DataFlow::moduleMember("bluebird", "promisifyAll"), DataFlow::moduleImport("pify")]
+            .getACall()
     }
   }
 
@@ -686,6 +684,8 @@ module Promisify {
   class PromisifyCall extends DataFlow::CallNode {
     PromisifyCall() {
       this = DataFlow::moduleImport(["util", "bluebird"]).getAMemberCall("promisify")
+      or
+      this = DataFlow::moduleImport("pify").getACall()
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -685,7 +685,7 @@ module Promisify {
     PromisifyCall() {
       this = DataFlow::moduleImport(["util", "bluebird"]).getAMemberCall("promisify")
       or
-      this = DataFlow::moduleImport("pify").getACall()
+      this = DataFlow::moduleImport(["pify", "util.promisify"]).getACall()
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -672,8 +672,10 @@ module Promisify {
   class PromisifyAllCall extends DataFlow::CallNode {
     PromisifyAllCall() {
       this =
-        [DataFlow::moduleMember("bluebird", "promisifyAll"), DataFlow::moduleImport("pify")]
-            .getACall()
+        [
+          DataFlow::moduleMember("bluebird", "promisifyAll"),
+          DataFlow::moduleImport(["util-promisifyall", "pify"])
+        ].getACall()
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -659,3 +659,33 @@ private module DynamicImportSteps {
     }
   }
 }
+
+/**
+ * Provides classes modeling libraries implementing `promisify` functions.
+ * That is, functions that convert callback style functions to functions that return a promise.
+ */
+module Promisify {
+  /**
+   * Gets a call to a `promisifyAll` function.
+   * E.g. `require("bluebird").promisifyAll(...)`.
+   */
+  class PromisifyAllCall extends DataFlow::CallNode {
+    PromisifyAllCall() {
+      this =
+        [
+          DataFlow::moduleMember("bluebird", "promisifyAll"),
+          DataFlow::moduleImport("util-promisifyall")
+        ].getACall()
+    }
+  }
+
+  /**
+   * Gets a call to a `promisify` function.
+   * E.g. `require("util").promisify(...)`.
+   */
+  class PromisifyCall extends DataFlow::CallNode {
+    PromisifyCall() {
+      this = DataFlow::moduleImport(["util", "bluebird"]).getAMemberCall("promisify")
+    }
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -472,14 +472,9 @@ module NodeJSLib {
         result = pred.track(t2, t)
         or
         t.continue() = t2 and
-        exists(DataFlow::CallNode promisifyAllCall |
+        exists(Promisify::PromisifyAllCall promisifyAllCall |
           result = promisifyAllCall and
-          pred.flowsTo(promisifyAllCall.getArgument(0)) and
-          promisifyAllCall =
-            [
-              DataFlow::moduleMember("bluebird", "promisifyAll"),
-              DataFlow::moduleImport("util-promisifyall")
-            ].getACall()
+          pred.flowsTo(promisifyAllCall.getArgument(0))
         )
         or
         // const fs = require('fs');
@@ -648,9 +643,7 @@ module NodeJSLib {
   private DataFlow::SourceNode maybePromisified(DataFlow::SourceNode callback) {
     result = callback
     or
-    exists(DataFlow::CallNode promisify |
-      promisify = DataFlow::moduleMember(["util", "bluebird"], "promisify").getACall()
-    |
+    exists(Promisify::PromisifyCall promisify |
       result = promisify and promisify.getArgument(0).getALocalSource() = callback
     )
   }

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -2305,6 +2305,23 @@ nodes
 | other-fs-libraries.js:55:36:55:39 | path |
 | other-fs-libraries.js:55:36:55:39 | path |
 | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:57:46:57:49 | path |
 | prettier.js:6:11:6:28 | p |
 | prettier.js:6:11:6:28 | p |
 | prettier.js:6:11:6:28 | p |
@@ -6717,6 +6734,38 @@ edges
 | other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
 | other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
 | other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
 | other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
 | other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
 | other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
@@ -8452,6 +8501,7 @@ edges
 | other-fs-libraries.js:52:24:52:27 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:52:24:52:27 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
 | other-fs-libraries.js:54:36:54:39 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:54:36:54:39 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
 | other-fs-libraries.js:55:36:55:39 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:55:36:55:39 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
+| other-fs-libraries.js:57:46:57:49 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:57:46:57:49 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
 | prettier.js:7:28:7:28 | p | prettier.js:6:13:6:13 | p | prettier.js:7:28:7:28 | p | This path depends on $@. | prettier.js:6:13:6:13 | p | a user-provided value |
 | prettier.js:11:44:11:44 | p | prettier.js:6:13:6:13 | p | prettier.js:11:44:11:44 | p | This path depends on $@. | prettier.js:6:13:6:13 | p | a user-provided value |
 | pupeteer.js:9:28:9:34 | tainted | pupeteer.js:5:28:5:53 | parseTo ... t).name | pupeteer.js:9:28:9:34 | tainted | This path depends on $@. | pupeteer.js:5:28:5:53 | parseTo ... t).name | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -2271,6 +2271,40 @@ nodes
 | other-fs-libraries.js:52:24:52:27 | path |
 | other-fs-libraries.js:52:24:52:27 | path |
 | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:55:36:55:39 | path |
 | prettier.js:6:11:6:28 | p |
 | prettier.js:6:11:6:28 | p |
 | prettier.js:6:11:6:28 | p |
@@ -6619,6 +6653,70 @@ edges
 | other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
 | other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
 | other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:52:24:52:27 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:54:36:54:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:55:36:55:39 | path |
 | other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
 | other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
 | other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
@@ -8352,6 +8450,8 @@ edges
 | other-fs-libraries.js:42:53:42:56 | path | other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:42:53:42:56 | path | This path depends on $@. | other-fs-libraries.js:38:24:38:30 | req.url | a user-provided value |
 | other-fs-libraries.js:51:19:51:22 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:51:19:51:22 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
 | other-fs-libraries.js:52:24:52:27 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:52:24:52:27 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
+| other-fs-libraries.js:54:36:54:39 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:54:36:54:39 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
+| other-fs-libraries.js:55:36:55:39 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:55:36:55:39 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
 | prettier.js:7:28:7:28 | p | prettier.js:6:13:6:13 | p | prettier.js:7:28:7:28 | p | This path depends on $@. | prettier.js:6:13:6:13 | p | a user-provided value |
 | prettier.js:11:44:11:44 | p | prettier.js:6:13:6:13 | p | prettier.js:11:44:11:44 | p | This path depends on $@. | prettier.js:6:13:6:13 | p | a user-provided value |
 | pupeteer.js:9:28:9:34 | tainted | pupeteer.js:5:28:5:53 | parseTo ... t).name | pupeteer.js:9:28:9:34 | tainted | This path depends on $@. | pupeteer.js:5:28:5:53 | parseTo ... t).name | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -2322,6 +2322,23 @@ nodes
 | other-fs-libraries.js:57:46:57:49 | path |
 | other-fs-libraries.js:57:46:57:49 | path |
 | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:59:39:59:42 | path |
 | prettier.js:6:11:6:28 | p |
 | prettier.js:6:11:6:28 | p |
 | prettier.js:6:11:6:28 | p |
@@ -6766,6 +6783,38 @@ edges
 | other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
 | other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
 | other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:57:46:57:49 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
+| other-fs-libraries.js:49:7:49:48 | path | other-fs-libraries.js:59:39:59:42 | path |
 | other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
 | other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
 | other-fs-libraries.js:49:14:49:37 | url.par ... , true) | other-fs-libraries.js:49:14:49:43 | url.par ... ).query |
@@ -8502,6 +8551,7 @@ edges
 | other-fs-libraries.js:54:36:54:39 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:54:36:54:39 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
 | other-fs-libraries.js:55:36:55:39 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:55:36:55:39 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
 | other-fs-libraries.js:57:46:57:49 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:57:46:57:49 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
+| other-fs-libraries.js:59:39:59:42 | path | other-fs-libraries.js:49:24:49:30 | req.url | other-fs-libraries.js:59:39:59:42 | path | This path depends on $@. | other-fs-libraries.js:49:24:49:30 | req.url | a user-provided value |
 | prettier.js:7:28:7:28 | p | prettier.js:6:13:6:13 | p | prettier.js:7:28:7:28 | p | This path depends on $@. | prettier.js:6:13:6:13 | p | a user-provided value |
 | prettier.js:11:44:11:44 | p | prettier.js:6:13:6:13 | p | prettier.js:11:44:11:44 | p | This path depends on $@. | prettier.js:6:13:6:13 | p | a user-provided value |
 | pupeteer.js:9:28:9:34 | tainted | pupeteer.js:5:28:5:53 | parseTo ... t).name | pupeteer.js:9:28:9:34 | tainted | This path depends on $@. | pupeteer.js:5:28:5:53 | parseTo ... t).name | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
@@ -50,4 +50,7 @@ http.createServer(function(req, res) {
 
   fs.readFileSync(path); // NOT OK
   asyncFS.readFileSync(path); // NOT OK
+
+  require("pify")(fs.readFileSync)(path); // NOT OK
+  require("pify")(fs).readFileSync(path); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
@@ -53,4 +53,6 @@ http.createServer(function(req, res) {
 
   require("pify")(fs.readFileSync)(path); // NOT OK
   require("pify")(fs).readFileSync(path); // NOT OK
+
+  require('util.promisify')(fs.readFileSync)(path); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
@@ -55,4 +55,6 @@ http.createServer(function(req, res) {
   require("pify")(fs).readFileSync(path); // NOT OK
 
   require('util.promisify')(fs.readFileSync)(path); // NOT OK
+
+  require("thenify")(fs.readFileSync)(path); // NOT OK
 });


### PR DESCRIPTION
While working on https://github.com/github/codeql/pull/6113 I stumbled upon some highly dependent upon packages implementing `promisify` functions.  
So I added support for those.   