### PR TITLE
Increase field flow branch limit in Jax-RS tests

### DIFF
--- a/java/ql/test/library-tests/frameworks/JaxWs/JakartaRsFlow.java
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JakartaRsFlow.java
@@ -160,12 +160,12 @@ public class JakartaRsFlow {
   void testAbstractMultivaluedMap(Map<String, List<String>> map1, Map<String, List<String>> map2, List<String> list) {
     map1.put(taint(), list);
     AbstractMultivaluedMap<String, String> amm1 = new MyAbstractMultivaluedMapJak<String, String>(map1);
-    sink(amm1.keySet().iterator().next()); // $  MISSING: hasValueFlow
+    sink(amm1.keySet().iterator().next()); // $ hasValueFlow
 
     list.add(taint());
     map2.put("key", list);
     AbstractMultivaluedMap<String, String> amm2 = new MyAbstractMultivaluedMapJak<String, String>(map2);
-    sink(amm2.get("key").get(0)); // $  MISSING: hasValueFlow SPURIOUS: hasTaintFlow
+    sink(amm2.get("key").get(0)); // $ hasValueFlow
   }
 
   void testMultivaluedHashMap(Map<String, String> map1, Map<String, String> map2,

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.java
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.java
@@ -160,12 +160,12 @@ public class JaxRsFlow {
   void testAbstractMultivaluedMap(Map<String, List<String>> map1, Map<String, List<String>> map2, List<String> list) {
     map1.put(taint(), list);
     AbstractMultivaluedMap<String, String> amm1 = new MyAbstractMultivaluedMap<String, String>(map1);
-    sink(amm1.keySet().iterator().next()); // $  MISSING: hasValueFlow
+    sink(amm1.keySet().iterator().next()); // $ hasValueFlow
 
     list.add(taint());
     map2.put("key", list);
     AbstractMultivaluedMap<String, String> amm2 = new MyAbstractMultivaluedMap<String, String>(map2);
-    sink(amm2.get("key").get(0)); // $  MISSING: hasValueFlow SPURIOUS: hasTaintFlow
+    sink(amm2.get("key").get(0)); // $ hasValueFlow
   }
 
   void testMultivaluedHashMap(Map<String, String> map1, Map<String, String> map2,

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.ql
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.ql
@@ -13,7 +13,7 @@ class TaintFlowConf extends TaintTracking::Configuration {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
   }
 
-  override int fieldFlowBranchLimit() { result = 3 }
+  override int fieldFlowBranchLimit() { result = 1000 }
 }
 
 class ValueFlowConf extends DataFlow::Configuration {
@@ -27,7 +27,7 @@ class ValueFlowConf extends DataFlow::Configuration {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
   }
 
-  override int fieldFlowBranchLimit() { result = 3 }
+  override int fieldFlowBranchLimit() { result = 1000 }
 }
 
 class HasFlowTest extends InlineExpectationsTest {

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.ql
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.ql
@@ -12,6 +12,8 @@ class TaintFlowConf extends TaintTracking::Configuration {
   override predicate isSink(DataFlow::Node n) {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
   }
+
+  override int fieldFlowBranchLimit() { result = 3 }
 }
 
 class ValueFlowConf extends DataFlow::Configuration {
@@ -24,6 +26,8 @@ class ValueFlowConf extends DataFlow::Configuration {
   override predicate isSink(DataFlow::Node n) {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
   }
+
+  override int fieldFlowBranchLimit() { result = 3 }
 }
 
 class HasFlowTest extends InlineExpectationsTest {


### PR DESCRIPTION
@owen-mc @aschackmull was right: the Jax tests only fail due to the field-flow branch limit.

This fixes apparently-missing results by allowing the dataflow library to persist even when there are many Map implementations possibly available.