### PR TITLE
JS: Add support for more date libraries

### DIFF
--- a/javascript/change-notes/2021-06-21-dates.md
+++ b/javascript/change-notes/2021-06-21-dates.md
@@ -2,5 +2,8 @@ lgtm,codescanning
 * Improved support for date parsing libraries, resulting in more results in security queries.
   Affected packages are
     [dayjs](https://npmjs.com/package/dayjs),
-    [luxon](https://npmjs.com/package/luxon)
+    [luxon](https://npmjs.com/package/luxon),
+    [@date-io/moment](https://npmjs.com/package/@date-io/moment),
+    [@date-io/luxon](https://npmjs.com/package/@date-io/luxon),
+    [@date-io/dayjs](https://npmjs.com/package/@date-io/dayjs)
 

--- a/javascript/change-notes/2021-06-21-dates.md
+++ b/javascript/change-notes/2021-06-21-dates.md
@@ -1,0 +1,5 @@
+lgtm,codescanning
+* Improved support for date parsing libraries, resulting in more results in security queries.
+  Affected packages are
+    [dayjs](https://npmjs.com/package/dayjs)
+

--- a/javascript/change-notes/2021-06-21-dates.md
+++ b/javascript/change-notes/2021-06-21-dates.md
@@ -1,5 +1,6 @@
 lgtm,codescanning
 * Improved support for date parsing libraries, resulting in more results in security queries.
   Affected packages are
-    [dayjs](https://npmjs.com/package/dayjs)
+    [dayjs](https://npmjs.com/package/dayjs),
+    [luxon](https://npmjs.com/package/luxon)
 

--- a/javascript/ql/src/semmle/javascript/frameworks/DateFunctions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/DateFunctions.qll
@@ -73,6 +73,35 @@ private module DateIO {
       )
     }
   }
+
+  /** Gets a method name from an `@date-io` adapter that returns an instance of the adapted library. */
+  private string getAnAdapterMethodName() {
+    result =
+      [
+        "addSeconds", "addMinutes", "addHours", "addDays", "addWeeks", "addMonths", "endOfDay",
+        "setHours", "setMinutes", "setSeconds", "startOfMonth", "endOfMonth", "startOfWeek",
+        "endOfWeek", "setYear", "date", "parse", "setMonth", "getNextMonth", "getPreviousMonth"
+      ]
+  }
+
+  /**
+   * Gets an instance of `library` that has been created by an `@date-io` adapter.
+   * Library is one of: "moment", "luxon", or "dayjs".
+   */
+  API::Node getAnAdaptedInstance(string library) {
+    exists(API::Node adapter |
+      library = "moment" and
+      adapter = API::moduleImport("@date-io/moment")
+      or
+      library = "luxon" and
+      adapter = API::moduleImport("@date-io/luxon")
+      or
+      library = "dayjs" and
+      adapter = API::moduleImport("@date-io/dayjs")
+    |
+      result = adapter.getInstance().getMember(getAnAdapterMethodName()).getReturn()
+    )
+  }
 }
 
 /**
@@ -99,6 +128,8 @@ private module Luxon {
       result = luxonDateTime().getAMember()
       or
       result = luxonDateTime().getReturn()
+      or
+      result = DateIO::getAnAdaptedInstance("luxon")
     )
   }
 
@@ -125,6 +156,8 @@ private module Moment {
     result = moment().getReturn()
     or
     result = moment().getAMember()
+    or
+    result = DateIO::getAnAdaptedInstance(["moment", "dayjs"])
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/DateFunctions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/DateFunctions.qll
@@ -58,6 +58,9 @@ private module Moment {
   private API::Node moment() {
     result = API::moduleImport(["moment", "moment-timezone"])
     or
+    // `dayjs` largely has a similar API to `moment`
+    result = API::moduleImport("dayjs")
+    or
     result = moment().getReturn()
     or
     result = moment().getAMember()

--- a/javascript/ql/src/semmle/javascript/frameworks/DateFunctions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/DateFunctions.qll
@@ -53,6 +53,28 @@ private module DateFns {
   }
 }
 
+/**
+ * Provides classes and predicates modelling the `@date-io` libraries.
+ */
+private module DateIO {
+  private class FormatStep extends TaintTracking::SharedTaintStep {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(API::CallNode formatCall |
+        formatCall =
+          API::moduleImport("@date-io/" +
+              ["date-fns", "moment", "luxon", "dayjs", "date-fns-jalali", "jalaali", "hijri"])
+              .getInstance()
+              // the `format` function only select between a predefined list of formats, but the `formatByString` function formats using any string.
+              .getMember(["formatByString", "formatNumber"])
+              .getACall()
+      |
+        pred = formatCall.getArgument(1) and
+        succ = formatCall
+      )
+    }
+  }
+}
+
 private module Moment {
   /** Gets a reference to a `moment` object. */
   private API::Node moment() {

--- a/javascript/ql/src/semmle/javascript/frameworks/DateFunctions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/DateFunctions.qll
@@ -75,6 +75,45 @@ private module DateIO {
   }
 }
 
+/**
+ * Provides classes and predicates modelling the `luxon` library.
+ */
+private module Luxon {
+  /**
+   * Gets a reference to a `DateTime` object from the `luxon` library.
+   */
+  private API::Node luxonDateTime() {
+    exists(API::Node constructor | constructor = API::moduleImport("luxon").getMember("DateTime") |
+      result = constructor.getInstance()
+      or
+      result =
+        constructor
+            .getMember([
+                "fromJSDate", "fromJSDate", "fromISO", "now", "fromMillis", "fromHTTP",
+                "fromObject", "fromRFC2822", "fromSeconds", "fromSQL", "fromFormat", "fromString",
+                "invalid", "local", "utc"
+              ])
+            .getReturn()
+      or
+      // fluent API that return immutable objects
+      result = luxonDateTime().getAMember()
+      or
+      result = luxonDateTime().getReturn()
+    )
+  }
+
+  /**
+   * A step of the form: `f -> luxonDateTime.toFormat(f)`.
+   */
+  private class ToFormatStep extends TaintTracking::SharedTaintStep {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(API::CallNode call | call = luxonDateTime().getMember("toFormat").getACall() |
+        pred = call.getArgument(0) and succ = call
+      )
+    }
+  }
+}
+
 private module Moment {
   /** Gets a reference to a `moment` object. */
   private API::Node moment() {

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -130,6 +130,27 @@ nodes
 | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:61:21:65 | taint |
+| dates.js:30:9:30:69 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) |
+| dates.js:30:36:30:55 | window.location.hash |
+| dates.js:30:36:30:55 | window.location.hash |
+| dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:37:77:37:81 | taint |
+| dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:38:77:38:81 | taint |
+| dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:39:79:39:83 | taint |
+| dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) |
+| dates.js:40:77:40:81 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -782,6 +803,26 @@ edges
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
+| dates.js:30:9:30:69 | taint | dates.js:37:77:37:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:38:77:38:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:39:79:39:83 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:40:77:40:81 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) | dates.js:30:9:30:69 | taint |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:68 | window. ... ring(1) | dates.js:30:17:30:69 | decodeU ... ing(1)) |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:77:37:81 | taint | dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:77:38:81 | taint | dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:79:39:83 | taint | dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
@@ -1294,6 +1335,10 @@ edges
 | dates.js:16:31:16:69 | `Time i ... aint)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:16:31:16:69 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
 | dates.js:18:31:18:66 | `Time i ... aint)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:18:31:18:66 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
 | dates.js:21:31:21:68 | `Time i ... aint)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:21:31:21:68 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
+| dates.js:37:31:37:84 | `Time i ... aint)}` | dates.js:30:36:30:55 | window.location.hash | dates.js:37:31:37:84 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:30:36:30:55 | window.location.hash | user-provided value |
+| dates.js:38:31:38:84 | `Time i ... aint)}` | dates.js:30:36:30:55 | window.location.hash | dates.js:38:31:38:84 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:30:36:30:55 | window.location.hash | user-provided value |
+| dates.js:39:31:39:86 | `Time i ... aint)}` | dates.js:30:36:30:55 | window.location.hash | dates.js:39:31:39:86 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:30:36:30:55 | window.location.hash | user-provided value |
+| dates.js:40:31:40:84 | `Time i ... aint)}` | dates.js:30:36:30:55 | window.location.hash | dates.js:40:31:40:84 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:30:36:30:55 | window.location.hash | user-provided value |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | Cross-site scripting vulnerability due to $@. | event-handler-receiver.js:2:49:2:61 | location.href | user-provided value |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") | Cross-site scripting vulnerability due to $@. | express.js:7:15:7:33 | req.param("wobble") | user-provided value |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" | jquery.js:2:17:2:40 | documen ... .search | jquery.js:7:5:7:34 | "<div i ... + "\\">" | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:40 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -151,6 +151,23 @@ nodes
 | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:77:40:81 | taint |
+| dates.js:46:9:46:69 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) |
+| dates.js:46:36:46:55 | window.location.hash |
+| dates.js:46:36:46:55 | window.location.hash |
+| dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:48:83:48:87 | taint |
+| dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:49:82:49:86 | taint |
+| dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) |
+| dates.js:50:97:50:101 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -823,6 +840,22 @@ edges
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
+| dates.js:46:9:46:69 | taint | dates.js:48:83:48:87 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:49:82:49:86 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:50:97:50:101 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) | dates.js:46:9:46:69 | taint |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:68 | window. ... ring(1) | dates.js:46:17:46:69 | decodeU ... ing(1)) |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:83:48:87 | taint | dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:82:49:86 | taint | dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
@@ -1339,6 +1372,9 @@ edges
 | dates.js:38:31:38:84 | `Time i ... aint)}` | dates.js:30:36:30:55 | window.location.hash | dates.js:38:31:38:84 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:30:36:30:55 | window.location.hash | user-provided value |
 | dates.js:39:31:39:86 | `Time i ... aint)}` | dates.js:30:36:30:55 | window.location.hash | dates.js:39:31:39:86 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:30:36:30:55 | window.location.hash | user-provided value |
 | dates.js:40:31:40:84 | `Time i ... aint)}` | dates.js:30:36:30:55 | window.location.hash | dates.js:40:31:40:84 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:30:36:30:55 | window.location.hash | user-provided value |
+| dates.js:48:31:48:90 | `Time i ... aint)}` | dates.js:46:36:46:55 | window.location.hash | dates.js:48:31:48:90 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:46:36:46:55 | window.location.hash | user-provided value |
+| dates.js:49:31:49:89 | `Time i ... aint)}` | dates.js:46:36:46:55 | window.location.hash | dates.js:49:31:49:89 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:46:36:46:55 | window.location.hash | user-provided value |
+| dates.js:50:31:50:104 | `Time i ... aint)}` | dates.js:46:36:46:55 | window.location.hash | dates.js:50:31:50:104 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:46:36:46:55 | window.location.hash | user-provided value |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | Cross-site scripting vulnerability due to $@. | event-handler-receiver.js:2:49:2:61 | location.href | user-provided value |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") | Cross-site scripting vulnerability due to $@. | express.js:7:15:7:33 | req.param("wobble") | user-provided value |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" | jquery.js:2:17:2:40 | documen ... .search | jquery.js:7:5:7:34 | "<div i ... + "\\">" | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:40 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -168,6 +168,23 @@ nodes
 | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:97:50:101 | taint |
+| dates.js:54:9:54:69 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) |
+| dates.js:54:36:54:55 | window.location.hash |
+| dates.js:54:36:54:55 | window.location.hash |
+| dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:57:94:57:98 | taint |
+| dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:59:80:59:84 | taint |
+| dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:81:61:85 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -856,6 +873,22 @@ edges
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
+| dates.js:54:9:54:69 | taint | dates.js:57:94:57:98 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:59:80:59:84 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:61:81:61:85 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) | dates.js:54:9:54:69 | taint |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:68 | window. ... ring(1) | dates.js:54:17:54:69 | decodeU ... ing(1)) |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:94:57:98 | taint | dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:80:59:84 | taint | dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:81:61:85 | taint | dates.js:61:42:61:86 | dayjs.s ... (taint) |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
@@ -1375,6 +1408,9 @@ edges
 | dates.js:48:31:48:90 | `Time i ... aint)}` | dates.js:46:36:46:55 | window.location.hash | dates.js:48:31:48:90 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:46:36:46:55 | window.location.hash | user-provided value |
 | dates.js:49:31:49:89 | `Time i ... aint)}` | dates.js:46:36:46:55 | window.location.hash | dates.js:49:31:49:89 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:46:36:46:55 | window.location.hash | user-provided value |
 | dates.js:50:31:50:104 | `Time i ... aint)}` | dates.js:46:36:46:55 | window.location.hash | dates.js:50:31:50:104 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:46:36:46:55 | window.location.hash | user-provided value |
+| dates.js:57:31:57:101 | `Time i ... aint)}` | dates.js:54:36:54:55 | window.location.hash | dates.js:57:31:57:101 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:54:36:54:55 | window.location.hash | user-provided value |
+| dates.js:59:31:59:87 | `Time i ... aint)}` | dates.js:54:36:54:55 | window.location.hash | dates.js:59:31:59:87 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:54:36:54:55 | window.location.hash | user-provided value |
+| dates.js:61:31:61:88 | `Time i ... aint)}` | dates.js:54:36:54:55 | window.location.hash | dates.js:61:31:61:88 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:54:36:54:55 | window.location.hash | user-provided value |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | Cross-site scripting vulnerability due to $@. | event-handler-receiver.js:2:49:2:61 | location.href | user-provided value |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") | Cross-site scripting vulnerability due to $@. | express.js:7:15:7:33 | req.param("wobble") | user-provided value |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" | jquery.js:2:17:2:40 | documen ... .search | jquery.js:7:5:7:34 | "<div i ... + "\\">" | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:40 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -126,6 +126,10 @@ nodes
 | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) |
 | dates.js:18:59:18:63 | taint |
+| dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) |
+| dates.js:21:61:21:65 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -755,6 +759,7 @@ edges
 | dates.js:9:9:9:69 | taint | dates.js:13:59:13:63 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:21:61:21:65 | taint |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
@@ -774,6 +779,9 @@ edges
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
@@ -1285,6 +1293,7 @@ edges
 | dates.js:13:31:13:72 | `Time i ... time)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:13:31:13:72 | `Time i ... time)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
 | dates.js:16:31:16:69 | `Time i ... aint)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:16:31:16:69 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
 | dates.js:18:31:18:66 | `Time i ... aint)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:18:31:18:66 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
+| dates.js:21:31:21:68 | `Time i ... aint)}` | dates.js:9:36:9:55 | window.location.hash | dates.js:21:31:21:68 | `Time i ... aint)}` | Cross-site scripting vulnerability due to $@. | dates.js:9:36:9:55 | window.location.hash | user-provided value |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' | Cross-site scripting vulnerability due to $@. | event-handler-receiver.js:2:49:2:61 | location.href | user-provided value |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") | Cross-site scripting vulnerability due to $@. | express.js:7:15:7:33 | req.param("wobble") | user-provided value |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" | jquery.js:2:17:2:40 | documen ... .search | jquery.js:7:5:7:34 | "<div i ... + "\\">" | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:40 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -126,6 +126,10 @@ nodes
 | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) |
 | dates.js:18:59:18:63 | taint |
+| dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) |
+| dates.js:21:61:21:65 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -773,6 +777,7 @@ edges
 | dates.js:9:9:9:69 | taint | dates.js:13:59:13:63 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:21:61:21:65 | taint |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
@@ -792,6 +797,9 @@ edges
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -168,6 +168,23 @@ nodes
 | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:97:50:101 | taint |
+| dates.js:54:9:54:69 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) |
+| dates.js:54:36:54:55 | window.location.hash |
+| dates.js:54:36:54:55 | window.location.hash |
+| dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:57:94:57:98 | taint |
+| dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:59:80:59:84 | taint |
+| dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:81:61:85 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -874,6 +891,22 @@ edges
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
+| dates.js:54:9:54:69 | taint | dates.js:57:94:57:98 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:59:80:59:84 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:61:81:61:85 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) | dates.js:54:9:54:69 | taint |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:68 | window. ... ring(1) | dates.js:54:17:54:69 | decodeU ... ing(1)) |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:94:57:98 | taint | dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:80:59:84 | taint | dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:81:61:85 | taint | dates.js:61:42:61:86 | dayjs.s ... (taint) |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -151,6 +151,23 @@ nodes
 | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:77:40:81 | taint |
+| dates.js:46:9:46:69 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) |
+| dates.js:46:36:46:55 | window.location.hash |
+| dates.js:46:36:46:55 | window.location.hash |
+| dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:48:83:48:87 | taint |
+| dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:49:82:49:86 | taint |
+| dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) |
+| dates.js:50:97:50:101 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -841,6 +858,22 @@ edges
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
+| dates.js:46:9:46:69 | taint | dates.js:48:83:48:87 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:49:82:49:86 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:50:97:50:101 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) | dates.js:46:9:46:69 | taint |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:68 | window. ... ring(1) | dates.js:46:17:46:69 | decodeU ... ing(1)) |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:83:48:87 | taint | dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:82:49:86 | taint | dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -130,6 +130,27 @@ nodes
 | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:61:21:65 | taint |
+| dates.js:30:9:30:69 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) |
+| dates.js:30:36:30:55 | window.location.hash |
+| dates.js:30:36:30:55 | window.location.hash |
+| dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:37:77:37:81 | taint |
+| dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:38:77:38:81 | taint |
+| dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:39:79:39:83 | taint |
+| dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) |
+| dates.js:40:77:40:81 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -800,6 +821,26 @@ edges
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
+| dates.js:30:9:30:69 | taint | dates.js:37:77:37:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:38:77:38:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:39:79:39:83 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:40:77:40:81 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) | dates.js:30:9:30:69 | taint |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:68 | window. ... ring(1) | dates.js:30:17:30:69 | decodeU ... ing(1)) |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:77:37:81 | taint | dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:77:38:81 | taint | dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:79:39:83 | taint | dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/dates.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/dates.js
@@ -50,3 +50,13 @@ function luxon() {
     document.body.innerHTML = `Time is ${DateTime.fromISO("2020-01-01").startOf('day').toFormat(taint)}`; // NOT OK
 }
 
+function dateio2() {
+    let taint = decodeURIComponent(window.location.hash.substring(1));
+
+    const moment = new MomentAdapter();
+    document.body.innerHTML = `Time is ${moment.addDays(moment.date("2020-06-21"), 1).format(taint)}`; // NOT OK
+    const luxon = new LuxonAdapter();
+    document.body.innerHTML = `Time is ${luxon.endOfDay(luxon.date()).toFormat(taint)}`; // NOT OK
+    const dayjs = new DayJSAdapter();
+    document.body.innerHTML = `Time is ${dayjs.setHours(dayjs.date(), 4).format(taint)}`; // NOT OK
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/dates.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/dates.js
@@ -39,3 +39,14 @@ function dateio() {
     document.body.innerHTML = `Time is ${moment.formatByString(moment.date(), taint)}`; // NOT OK
     document.body.innerHTML = `Time is ${dayjs.formatByString(dayjs.date(), taint)}`; // NOT OK
 }
+
+import { DateTime } from "luxon";
+
+function luxon() {
+    let taint = decodeURIComponent(window.location.hash.substring(1));
+
+    document.body.innerHTML = `Time is ${DateTime.now().plus({years: 1}).toFormat(taint)}`; // NOT OK
+    document.body.innerHTML = `Time is ${new DateTime().setLocale('fr').toFormat(taint)}`; // NOT OK
+    document.body.innerHTML = `Time is ${DateTime.fromISO("2020-01-01").startOf('day').toFormat(taint)}`; // NOT OK
+}
+

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/dates.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/dates.js
@@ -16,4 +16,7 @@ function main() {
     document.body.innerHTML = `Time is ${moment(time).format(taint)}`; // NOT OK
     document.body.innerHTML = `Time is ${moment(taint).format()}`; // OK
     document.body.innerHTML = `Time is ${dateformat(time, taint)}`; // NOT OK
+
+    import dayjs from 'dayjs';
+    document.body.innerHTML = `Time is ${dayjs(time).format(taint)}`; // NOT OK
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/dates.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/dates.js
@@ -20,3 +20,22 @@ function main() {
     import dayjs from 'dayjs';
     document.body.innerHTML = `Time is ${dayjs(time).format(taint)}`; // NOT OK
 }
+
+import LuxonAdapter from "@date-io/luxon";
+import DateFnsAdapter from "@date-io/date-fns";
+import MomentAdapter from "@date-io/moment";
+import DayJSAdapter from "@date-io/dayjs"
+
+function dateio() {
+    let taint = decodeURIComponent(window.location.hash.substring(1));
+
+    const dateFns = new DateFnsAdapter();
+    const luxon = new LuxonAdapter();
+    const moment = new MomentAdapter();
+    const dayjs = new DayJSAdapter();
+
+    document.body.innerHTML = `Time is ${dateFns.formatByString(new Date(), taint)}`; // NOT OK
+    document.body.innerHTML = `Time is ${luxon.formatByString(luxon.date(), taint)}`; // NOT OK
+    document.body.innerHTML = `Time is ${moment.formatByString(moment.date(), taint)}`; // NOT OK
+    document.body.innerHTML = `Time is ${dayjs.formatByString(dayjs.date(), taint)}`; // NOT OK
+}


### PR DESCRIPTION
We were lacking support for the highly dependent upon [`dayjs`](https://www.npmjs.com/package/dayjs) and [`luxon`](https://www.npmjs.com/package/luxon) libraries.  

And I also added support for [`@date-io`](https://github.com/dmtrKovalenko/date-io). 

[Evaluation appears fine](https://github.com/dsp-testing/erik-krogh-dca/tree/run/dates-nightly-security-extended/reports).   
No change in results. 