### PR TITLE
Fix framework coverage commenter to use merge commit parent instead o…

### DIFF
--- a/.github/workflows/csv-coverage-pr-artifacts.yml
+++ b/.github/workflows/csv-coverage-pr-artifacts.yml
@@ -32,8 +32,12 @@ jobs:
     - name: Clone self (github/codeql) - BASE
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.base.sha }}
+        fetch-depth: 2
         path: base
+    - run: |
+        git checkout HEAD^1
+        git log -1 --format='%H'
+      working-directory: base
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -47,13 +51,13 @@ jobs:
       run: unzip -d codeql-cli codeql-linux64.zip
     - name: Generate CSV files on merge and base of the PR
       run: |
-        echo "Running generator on ${{github.sha}}"
+        echo "Running generator on merge"
         PATH="$PATH:codeql-cli/codeql" python merge/misc/scripts/library-coverage/generate-report.py ci merge merge
         mkdir out_merge
         cp framework-coverage-*.csv out_merge/
         cp framework-coverage-*.rst out_merge/
 
-        echo "Running generator on ${{github.event.pull_request.base.sha}}"
+        echo "Running generator on base"
         PATH="$PATH:codeql-cli/codeql" python base/misc/scripts/library-coverage/generate-report.py ci base base
         mkdir out_base
         cp framework-coverage-*.csv out_base/


### PR DESCRIPTION
…f (old) base repo SHA

This PR fixes the CSV framework coverage commenter GitHub action. Previously the tip of the base branch was compared to the merge commit. The `github.event.pull_request.base.sha` SHA was used as the tip, but that is actually the tip of the branch when the PR was created. Instead the first parent of the merge commit should be used, which is the case in this PR.

The change was tested in https://github.com/dsp-testing/codeql-csv-coverage-pr-commenter/pull/10. Before pushing a CSV change, a commit was pushed to `main`. And then the job picks up the correct SHA (tip of `main` at the start of the job, vs tip of `main` at the creation of the PR): https://github.com/dsp-testing/codeql-csv-coverage-pr-commenter/runs/2884298538?check_suite_focus=true#step:5:7. 

This bug was revealed in https://github.com/github/codeql/pull/6117#issuecomment-865846232.