### PR TITLE
JS: add more template sinks for the `js/code-injection` query

### DIFF
--- a/javascript/change-notes/2021-06-22-templates.md
+++ b/javascript/change-notes/2021-06-22-templates.md
@@ -1,0 +1,10 @@
+lgtm,codescanning
+* More template engines are recognized as sinks for the `js/code-injection` query.
+  Affected packages are
+    [mustache](https://npmjs.com/package/mustache),
+    [handlebars](https://npmjs.com/package/handlebars),
+    [dot](https://npmjs.com/package/dot),
+    [hogan.js](https://npmjs.com/package/hogan.js)
+    [eta](https://npmjs.com/package/eta),
+    [squirrelly](https://npmjs.com/package/squirrelly),
+    [whiskers](https://npmjs.com/package/whiskers)

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
@@ -197,11 +197,63 @@ module CodeInjection {
   }
 
   /**
-   * A value interpreted as a tempalte by the `dot` library.
+   * A value interpreted as a template by the `handlebars` library.
+   */
+  class HandlebarsTemplateSink extends TemplateSink {
+    HandlebarsTemplateSink() {
+      this = any(Handlebars::Handlebars h).getAMemberCall("compile").getArgument(0)
+    }
+  }
+
+  /**
+   * A value interpreted as a template by the `mustache` library.
+   */
+  class MustacheTemplateSink extends TemplateSink {
+    MustacheTemplateSink() {
+      this = DataFlow::moduleMember("mustache", "render").getACall().getArgument(0)
+    }
+  }
+
+  /**
+   * A value interpreted as a template by the `hogan.js` library.
+   */
+  class HoganTemplateSink extends TemplateSink {
+    HoganTemplateSink() {
+      this = DataFlow::moduleMember("hogan.js", "compile").getACall().getArgument(0)
+    }
+  }
+
+  /**
+   * A value interpreted as a template by the `eta` library.
+   */
+  class EtaTemplateSink extends TemplateSink {
+    EtaTemplateSink() { this = DataFlow::moduleMember("eta", "render").getACall().getArgument(0) }
+  }
+
+  /**
+   * A value interpreted as a template by the `squirrelly` library.
+   */
+  class SquirrelTemplateSink extends TemplateSink {
+    SquirrelTemplateSink() {
+      this = DataFlow::moduleMember("squirrelly", "render").getACall().getArgument(0)
+    }
+  }
+
+  /**
+   * A value interpreted as a template by the `whiskers` library.
+   */
+  class WhiskersTemplateSink extends TemplateSink {
+    WhiskersTemplateSink() {
+      this = DataFlow::moduleMember("whiskers", "render").getACall().getArgument(0)
+    }
+  }
+
+  /**
+   * A value interpreted as a template by the `dot` library.
    */
   class DotTemplateSink extends TemplateSink {
     DotTemplateSink() {
-      this = DataFlow::moduleImport("dot").getAMemberCall("template").getArgument(0)
+      this = DataFlow::moduleImport("dot").getAMemberCall(["template", "compile"]).getArgument(0)
     }
   }
 

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
@@ -107,25 +107,37 @@ nodes
 | react.js:10:56:10:77 | documen ... on.hash |
 | react.js:10:56:10:77 | documen ... on.hash |
 | react.js:10:56:10:77 | documen ... on.hash |
-| template-sinks.js:12:9:12:31 | tainted |
-| template-sinks.js:12:19:12:31 | req.query.foo |
-| template-sinks.js:12:19:12:31 | req.query.foo |
-| template-sinks.js:14:17:14:23 | tainted |
-| template-sinks.js:14:17:14:23 | tainted |
-| template-sinks.js:15:16:15:22 | tainted |
-| template-sinks.js:15:16:15:22 | tainted |
-| template-sinks.js:16:18:16:24 | tainted |
-| template-sinks.js:16:18:16:24 | tainted |
-| template-sinks.js:17:17:17:23 | tainted |
-| template-sinks.js:17:17:17:23 | tainted |
-| template-sinks.js:18:18:18:24 | tainted |
-| template-sinks.js:18:18:18:24 | tainted |
-| template-sinks.js:19:16:19:22 | tainted |
-| template-sinks.js:19:16:19:22 | tainted |
-| template-sinks.js:20:27:20:33 | tainted |
-| template-sinks.js:20:27:20:33 | tainted |
-| template-sinks.js:21:21:21:27 | tainted |
-| template-sinks.js:21:21:21:27 | tainted |
+| template-sinks.js:17:9:17:31 | tainted |
+| template-sinks.js:17:19:17:31 | req.query.foo |
+| template-sinks.js:17:19:17:31 | req.query.foo |
+| template-sinks.js:19:17:19:23 | tainted |
+| template-sinks.js:19:17:19:23 | tainted |
+| template-sinks.js:20:16:20:22 | tainted |
+| template-sinks.js:20:16:20:22 | tainted |
+| template-sinks.js:21:18:21:24 | tainted |
+| template-sinks.js:21:18:21:24 | tainted |
+| template-sinks.js:22:17:22:23 | tainted |
+| template-sinks.js:22:17:22:23 | tainted |
+| template-sinks.js:23:18:23:24 | tainted |
+| template-sinks.js:23:18:23:24 | tainted |
+| template-sinks.js:24:16:24:22 | tainted |
+| template-sinks.js:24:16:24:22 | tainted |
+| template-sinks.js:25:27:25:33 | tainted |
+| template-sinks.js:25:27:25:33 | tainted |
+| template-sinks.js:26:21:26:27 | tainted |
+| template-sinks.js:26:21:26:27 | tainted |
+| template-sinks.js:27:17:27:23 | tainted |
+| template-sinks.js:27:17:27:23 | tainted |
+| template-sinks.js:28:24:28:30 | tainted |
+| template-sinks.js:28:24:28:30 | tainted |
+| template-sinks.js:29:21:29:27 | tainted |
+| template-sinks.js:29:21:29:27 | tainted |
+| template-sinks.js:30:19:30:25 | tainted |
+| template-sinks.js:30:19:30:25 | tainted |
+| template-sinks.js:31:16:31:22 | tainted |
+| template-sinks.js:31:16:31:22 | tainted |
+| template-sinks.js:32:17:32:23 | tainted |
+| template-sinks.js:32:17:32:23 | tainted |
 | tst.js:2:6:2:27 | documen ... on.href |
 | tst.js:2:6:2:27 | documen ... on.href |
 | tst.js:2:6:2:83 | documen ... t=")+8) |
@@ -216,24 +228,36 @@ edges
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react.js:10:56:10:77 | documen ... on.hash | react.js:10:56:10:77 | documen ... on.hash |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:15:16:15:22 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:15:16:15:22 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:16:18:16:24 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:16:18:16:24 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:17:17:17:23 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:17:17:17:23 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:18:18:18:24 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:18:18:18:24 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:19:16:19:22 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:19:16:19:22 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:20:27:20:33 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:20:27:20:33 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:21:21:21:27 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:21:21:21:27 | tainted |
-| template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:12:9:12:31 | tainted |
-| template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:12:9:12:31 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:19:17:19:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:19:17:19:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:20:16:20:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:20:16:20:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:21:18:21:24 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:21:18:21:24 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:22:17:22:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:22:17:22:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:23:18:23:24 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:23:18:23:24 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:24:16:24:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:24:16:24:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:25:27:25:33 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:25:27:25:33 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:26:21:26:27 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:26:21:26:27 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:27:17:27:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:27:17:27:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:28:24:28:30 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:28:24:28:30 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:29:21:29:27 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:29:21:29:27 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:30:19:30:25 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:30:19:30:25 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:31:16:31:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:31:16:31:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:32:17:32:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:32:17:32:23 | tainted |
+| template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:17:9:17:31 | tainted |
+| template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:17:9:17:31 | tainted |
 | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
 | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
 | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
@@ -284,14 +308,20 @@ edges
 | react-native.js:8:32:8:38 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:8:32:8:38 | tainted | $@ flows to here and is interpreted as code. | react-native.js:7:17:7:33 | req.param("code") | User-provided value |
 | react-native.js:10:23:10:29 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:10:23:10:29 | tainted | $@ flows to here and is interpreted as code. | react-native.js:7:17:7:33 | req.param("code") | User-provided value |
 | react.js:10:56:10:77 | documen ... on.hash | react.js:10:56:10:77 | documen ... on.hash | react.js:10:56:10:77 | documen ... on.hash | $@ flows to here and is interpreted as code. | react.js:10:56:10:77 | documen ... on.hash | User-provided value |
-| template-sinks.js:14:17:14:23 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:14:17:14:23 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
-| template-sinks.js:15:16:15:22 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:15:16:15:22 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
-| template-sinks.js:16:18:16:24 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:16:18:16:24 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
-| template-sinks.js:17:17:17:23 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:17:17:17:23 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
-| template-sinks.js:18:18:18:24 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:18:18:18:24 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
-| template-sinks.js:19:16:19:22 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:19:16:19:22 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
-| template-sinks.js:20:27:20:33 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:20:27:20:33 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
-| template-sinks.js:21:21:21:27 | tainted | template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:21:21:21:27 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:12:19:12:31 | req.query.foo | User-provided value |
+| template-sinks.js:19:17:19:23 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:19:17:19:23 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:20:16:20:22 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:20:16:20:22 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:21:18:21:24 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:21:18:21:24 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:22:17:22:23 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:22:17:22:23 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:23:18:23:24 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:23:18:23:24 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:24:16:24:22 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:24:16:24:22 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:25:27:25:33 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:25:27:25:33 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:26:21:26:27 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:26:21:26:27 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:27:17:27:23 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:27:17:27:23 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:28:24:28:30 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:28:24:28:30 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:29:21:29:27 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:29:21:29:27 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:30:19:30:25 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:30:19:30:25 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:31:16:31:22 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:31:16:31:22 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
+| template-sinks.js:32:17:32:23 | tainted | template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:32:17:32:23 | tainted | $@ flows to here and is interpreted as a template, which may contain code. | template-sinks.js:17:19:17:31 | req.query.foo | User-provided value |
 | tst.js:2:6:2:83 | documen ... t=")+8) | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) | $@ flows to here and is interpreted as code. | tst.js:2:6:2:27 | documen ... on.href | User-provided value |
 | tst.js:5:12:5:33 | documen ... on.hash | tst.js:5:12:5:33 | documen ... on.hash | tst.js:5:12:5:33 | documen ... on.hash | $@ flows to here and is interpreted as code. | tst.js:5:12:5:33 | documen ... on.hash | User-provided value |
 | tst.js:14:10:14:74 | documen ... , "$1") | tst.js:14:10:14:33 | documen ... .search | tst.js:14:10:14:74 | documen ... , "$1") | $@ flows to here and is interpreted as code. | tst.js:14:10:14:33 | documen ... .search | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
@@ -111,25 +111,37 @@ nodes
 | react.js:10:56:10:77 | documen ... on.hash |
 | react.js:10:56:10:77 | documen ... on.hash |
 | react.js:10:56:10:77 | documen ... on.hash |
-| template-sinks.js:12:9:12:31 | tainted |
-| template-sinks.js:12:19:12:31 | req.query.foo |
-| template-sinks.js:12:19:12:31 | req.query.foo |
-| template-sinks.js:14:17:14:23 | tainted |
-| template-sinks.js:14:17:14:23 | tainted |
-| template-sinks.js:15:16:15:22 | tainted |
-| template-sinks.js:15:16:15:22 | tainted |
-| template-sinks.js:16:18:16:24 | tainted |
-| template-sinks.js:16:18:16:24 | tainted |
-| template-sinks.js:17:17:17:23 | tainted |
-| template-sinks.js:17:17:17:23 | tainted |
-| template-sinks.js:18:18:18:24 | tainted |
-| template-sinks.js:18:18:18:24 | tainted |
-| template-sinks.js:19:16:19:22 | tainted |
-| template-sinks.js:19:16:19:22 | tainted |
-| template-sinks.js:20:27:20:33 | tainted |
-| template-sinks.js:20:27:20:33 | tainted |
-| template-sinks.js:21:21:21:27 | tainted |
-| template-sinks.js:21:21:21:27 | tainted |
+| template-sinks.js:17:9:17:31 | tainted |
+| template-sinks.js:17:19:17:31 | req.query.foo |
+| template-sinks.js:17:19:17:31 | req.query.foo |
+| template-sinks.js:19:17:19:23 | tainted |
+| template-sinks.js:19:17:19:23 | tainted |
+| template-sinks.js:20:16:20:22 | tainted |
+| template-sinks.js:20:16:20:22 | tainted |
+| template-sinks.js:21:18:21:24 | tainted |
+| template-sinks.js:21:18:21:24 | tainted |
+| template-sinks.js:22:17:22:23 | tainted |
+| template-sinks.js:22:17:22:23 | tainted |
+| template-sinks.js:23:18:23:24 | tainted |
+| template-sinks.js:23:18:23:24 | tainted |
+| template-sinks.js:24:16:24:22 | tainted |
+| template-sinks.js:24:16:24:22 | tainted |
+| template-sinks.js:25:27:25:33 | tainted |
+| template-sinks.js:25:27:25:33 | tainted |
+| template-sinks.js:26:21:26:27 | tainted |
+| template-sinks.js:26:21:26:27 | tainted |
+| template-sinks.js:27:17:27:23 | tainted |
+| template-sinks.js:27:17:27:23 | tainted |
+| template-sinks.js:28:24:28:30 | tainted |
+| template-sinks.js:28:24:28:30 | tainted |
+| template-sinks.js:29:21:29:27 | tainted |
+| template-sinks.js:29:21:29:27 | tainted |
+| template-sinks.js:30:19:30:25 | tainted |
+| template-sinks.js:30:19:30:25 | tainted |
+| template-sinks.js:31:16:31:22 | tainted |
+| template-sinks.js:31:16:31:22 | tainted |
+| template-sinks.js:32:17:32:23 | tainted |
+| template-sinks.js:32:17:32:23 | tainted |
 | tst.js:2:6:2:27 | documen ... on.href |
 | tst.js:2:6:2:27 | documen ... on.href |
 | tst.js:2:6:2:83 | documen ... t=")+8) |
@@ -224,24 +236,36 @@ edges
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react.js:10:56:10:77 | documen ... on.hash | react.js:10:56:10:77 | documen ... on.hash |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:14:17:14:23 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:15:16:15:22 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:15:16:15:22 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:16:18:16:24 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:16:18:16:24 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:17:17:17:23 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:17:17:17:23 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:18:18:18:24 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:18:18:18:24 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:19:16:19:22 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:19:16:19:22 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:20:27:20:33 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:20:27:20:33 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:21:21:21:27 | tainted |
-| template-sinks.js:12:9:12:31 | tainted | template-sinks.js:21:21:21:27 | tainted |
-| template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:12:9:12:31 | tainted |
-| template-sinks.js:12:19:12:31 | req.query.foo | template-sinks.js:12:9:12:31 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:19:17:19:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:19:17:19:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:20:16:20:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:20:16:20:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:21:18:21:24 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:21:18:21:24 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:22:17:22:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:22:17:22:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:23:18:23:24 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:23:18:23:24 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:24:16:24:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:24:16:24:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:25:27:25:33 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:25:27:25:33 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:26:21:26:27 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:26:21:26:27 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:27:17:27:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:27:17:27:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:28:24:28:30 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:28:24:28:30 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:29:21:29:27 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:29:21:29:27 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:30:19:30:25 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:30:19:30:25 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:31:16:31:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:31:16:31:22 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:32:17:32:23 | tainted |
+| template-sinks.js:17:9:17:31 | tainted | template-sinks.js:32:17:32:23 | tainted |
+| template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:17:9:17:31 | tainted |
+| template-sinks.js:17:19:17:31 | req.query.foo | template-sinks.js:17:9:17:31 | tainted |
 | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
 | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |
 | tst.js:2:6:2:27 | documen ... on.href | tst.js:2:6:2:83 | documen ... t=")+8) |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/template-sinks.js
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/template-sinks.js
@@ -5,6 +5,11 @@ import * as dot from 'dot';
 import * as ejs from 'ejs';
 import * as nunjucks from 'nunjucks';
 import * as lodash from 'lodash';
+import * as handlebars from 'handlebars';
+import * as mustache from 'mustache';
+const Hogan = require("hogan.js");
+import * as Eta from 'eta';
+import * as Sqrl from 'squirrelly'
 
 var app = express();
 
@@ -19,4 +24,10 @@ app.get('/some/path', function(req, res) {
     ejs.render(tainted); // NOT OK
     nunjucks.renderString(tainted); // NOT OK
     lodash.template(tainted); // NOT OK
+    dot.compile(tainted); // NOT OK
+    handlebars.compile(tainted); // NOT OK
+    mustache.render(tainted); // NOT OK
+    Hogan.compile(tainted); // NOT OK
+    Eta.render(tainted); // NOT OK
+    Sqrl.render(tainted); // NOT OK
 });


### PR DESCRIPTION
We were missing support for the highly dependent upon package `mustache`. 
And I also added support for a few other libraries. 

(The consistency test ensures that the `// NOT OK` comment are accurate, so no need to compare test outputs). 

I considered adding taint-steps for these libraries, but I think it's better to have them as sinks.  

[Evaluation looks fine](https://github.com/dsp-testing/erik-krogh-dca/tree/run/templates-default-CustomSuite/reports).  
No change in results.  