### PR TITLE
Spring HTTP: improve content-type sensitivity

### DIFF
--- a/java/change-notes/2021-08-03-spring-content-types.md
+++ b/java/change-notes/2021-08-03-spring-content-types.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The XSS query now accounts for more ways to set the content-type of an entity served via a Spring HTTP endpoint. This may flag more cases where an XSS-vulnerable content-type is set, and exclude more cases where a non-vulnerable content-type such as `application/json` is set.

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringController.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringController.qll
@@ -131,7 +131,7 @@ class SpringRequestMappingMethod extends SpringControllerMethod {
   /** Gets a request mapping parameter. */
   SpringRequestMappingParameter getARequestParameter() { result = getAParameter() }
 
-  /** Gets the "produces" @RequestMapping annotation value, if present. */
+  /** Gets the "produces" @RequestMapping annotation value, if present. If an array is specified, gets the array. */
   Expr getProducesExpr() {
     result = requestMappingAnnotation.getValue("produces")
     or
@@ -139,7 +139,7 @@ class SpringRequestMappingMethod extends SpringControllerMethod {
     result = getProducesExpr(this.getDeclaringType())
   }
 
-  /** Gets the "produces" @RequestMapping annotation value, if present. */
+  /** Gets a "produces" @RequestMapping annotation value. If an array is specified, gets a member of the array. */
   Expr getAProducesExpr() {
     result = this.getProducesExpr() and not result instanceof ArrayInit
     or

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringController.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringController.qll
@@ -121,9 +121,18 @@ class SpringRequestMappingMethod extends SpringControllerMethod {
   SpringRequestMappingParameter getARequestParameter() { result = getAParameter() }
 
   /** Gets the "produces" @RequestMapping annotation value, if present. */
+  Expr getProducesExpr() { result = requestMappingAnnotation.getValue("produces") }
+
+  /** Gets the "produces" @RequestMapping annotation value, if present. */
+  Expr getAProducesExpr() {
+    result = this.getProducesExpr() and not result instanceof ArrayInit
+    or
+    result = this.getProducesExpr().(ArrayInit).getAnInit()
+  }
+
+  /** Gets the "produces" @RequestMapping annotation value, if present and a string constant. */
   string getProduces() {
-    result =
-      requestMappingAnnotation.getValue("produces").(CompileTimeConstantExpr).getStringValue()
+    result = this.getProducesExpr().(CompileTimeConstantExpr).getStringValue()
   }
 
   /** Gets the "value" @RequestMapping annotation value, if present. */

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
@@ -194,58 +194,60 @@ private class SpringXssSink extends XSS::XssSink {
 private string getSpringConstantContentType(FieldAccess e) {
   e.getQualifier().getType().(RefType).hasQualifiedName("org.springframework.http", "MediaType") and
   exists(string fieldName | e.getField().hasName(fieldName) |
-    fieldName = "APPLICATION_ATOM_XML" and result = "application/atom+xml"
+    fieldName = "APPLICATION_ATOM_XML" + ["", "_VALUE"] and result = "application/atom+xml"
     or
-    fieldName = "APPLICATION_CBOR" and result = "application/cbor"
+    fieldName = "APPLICATION_CBOR" + ["", "_VALUE"] and result = "application/cbor"
     or
-    fieldName = "APPLICATION_FORM_URLENCODED" and result = "application/x-www-form-urlencoded"
+    fieldName = "APPLICATION_FORM_URLENCODED" + ["", "_VALUE"] and
+    result = "application/x-www-form-urlencoded"
     or
-    fieldName = "APPLICATION_JSON" and result = "application/json"
+    fieldName = "APPLICATION_JSON" + ["", "_VALUE"] and result = "application/json"
     or
-    fieldName = "APPLICATION_JSON_UTF8" and result = "application/json;charset=UTF-8"
+    fieldName = "APPLICATION_JSON_UTF8" + ["", "_VALUE"] and
+    result = "application/json;charset=UTF-8"
     or
-    fieldName = "APPLICATION_NDJSON" and result = "application/x-ndjson"
+    fieldName = "APPLICATION_NDJSON" + ["", "_VALUE"] and result = "application/x-ndjson"
     or
-    fieldName = "APPLICATION_OCTET_STREAM" and result = "application/octet-stream"
+    fieldName = "APPLICATION_OCTET_STREAM" + ["", "_VALUE"] and result = "application/octet-stream"
     or
-    fieldName = "APPLICATION_PDF" and result = "application/pdf"
+    fieldName = "APPLICATION_PDF" + ["", "_VALUE"] and result = "application/pdf"
     or
-    fieldName = "APPLICATION_PROBLEM_JSON" and result = "application/problem+json"
+    fieldName = "APPLICATION_PROBLEM_JSON" + ["", "_VALUE"] and result = "application/problem+json"
     or
-    fieldName = "APPLICATION_PROBLEM_JSON_UTF8" and
+    fieldName = "APPLICATION_PROBLEM_JSON_UTF8" + ["", "_VALUE"] and
     result = "application/problem+json;charset=UTF-8"
     or
-    fieldName = "APPLICATION_PROBLEM_XML" and result = "application/problem+xml"
+    fieldName = "APPLICATION_PROBLEM_XML" + ["", "_VALUE"] and result = "application/problem+xml"
     or
-    fieldName = "APPLICATION_RSS_XML" and result = "application/rss+xml"
+    fieldName = "APPLICATION_RSS_XML" + ["", "_VALUE"] and result = "application/rss+xml"
     or
-    fieldName = "APPLICATION_STREAM_JSON" and result = "application/stream+json"
+    fieldName = "APPLICATION_STREAM_JSON" + ["", "_VALUE"] and result = "application/stream+json"
     or
-    fieldName = "APPLICATION_XHTML_XML" and result = "application/xhtml+xml"
+    fieldName = "APPLICATION_XHTML_XML" + ["", "_VALUE"] and result = "application/xhtml+xml"
     or
-    fieldName = "APPLICATION_XML" and result = "application/xml"
+    fieldName = "APPLICATION_XML" + ["", "_VALUE"] and result = "application/xml"
     or
-    fieldName = "IMAGE_GIF" and result = "image/gif"
+    fieldName = "IMAGE_GIF" + ["", "_VALUE"] and result = "image/gif"
     or
-    fieldName = "IMAGE_JPEG" and result = "image/jpeg"
+    fieldName = "IMAGE_JPEG" + ["", "_VALUE"] and result = "image/jpeg"
     or
-    fieldName = "IMAGE_PNG" and result = "image/png"
+    fieldName = "IMAGE_PNG" + ["", "_VALUE"] and result = "image/png"
     or
-    fieldName = "MULTIPART_FORM_DATA" and result = "multipart/form-data"
+    fieldName = "MULTIPART_FORM_DATA" + ["", "_VALUE"] and result = "multipart/form-data"
     or
-    fieldName = "MULTIPART_MIXED" and result = "multipart/mixed"
+    fieldName = "MULTIPART_MIXED" + ["", "_VALUE"] and result = "multipart/mixed"
     or
-    fieldName = "MULTIPART_RELATED" and result = "multipart/related"
+    fieldName = "MULTIPART_RELATED" + ["", "_VALUE"] and result = "multipart/related"
     or
-    fieldName = "TEXT_EVENT_STREAM" and result = "text/event-stream"
+    fieldName = "TEXT_EVENT_STREAM" + ["", "_VALUE"] and result = "text/event-stream"
     or
-    fieldName = "TEXT_HTML" and result = "text/html"
+    fieldName = "TEXT_HTML" + ["", "_VALUE"] and result = "text/html"
     or
-    fieldName = "TEXT_MARKDOWN" and result = "text/markdown"
+    fieldName = "TEXT_MARKDOWN" + ["", "_VALUE"] and result = "text/markdown"
     or
-    fieldName = "TEXT_PLAIN" and result = "text/plain"
+    fieldName = "TEXT_PLAIN" + ["", "_VALUE"] and result = "text/plain"
     or
-    fieldName = "TEXT_XML" and result = "text/xml"
+    fieldName = "TEXT_XML" + ["", "_VALUE"] and result = "text/xml"
   )
 }
 

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
@@ -145,8 +145,7 @@ private class SpringHttpFlowStep extends SummaryModelCsv {
 }
 
 private predicate specifiesContentType(SpringRequestMappingMethod method) {
-  method.getProducesExpr().(ArrayInit).getSize() != 0 or
-  not method.getProducesExpr() instanceof ArrayInit
+  exists(method.getAProducesExpr())
 }
 
 private class SpringXssSink extends XSS::XssSink {

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
@@ -4,7 +4,6 @@
  */
 
 import java
-
 private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.frameworks.spring.SpringController
@@ -270,8 +269,7 @@ private DataFlow::Node getABodyBuilderWithExplicitContentType(Expr contentType) 
   result.asExpr() =
     any(MethodAccess ma |
       ma.getCallee()
-          .hasQualifiedName("org.springframework.http", "ResponseEntity<>$BodyBuilder",
-            "contentType") and
+          .hasQualifiedName("org.springframework.http", "ResponseEntity$BodyBuilder", "contentType") and
       contentType = ma.getArgument(0)
     )
   or
@@ -280,7 +278,7 @@ private DataFlow::Node getABodyBuilderWithExplicitContentType(Expr contentType) 
       ma.getQualifier() = getABodyBuilderWithExplicitContentType(contentType).asExpr() and
       ma.getType()
           .(RefType)
-          .hasQualifiedName("org.springframework.http", "ResponseEntity<>$BodyBuilder")
+          .hasQualifiedName("org.springframework.http", "ResponseEntity$BodyBuilder")
     )
   or
   DataFlow::localFlow(getABodyBuilderWithExplicitContentType(contentType), result)

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
@@ -4,8 +4,10 @@
  */
 
 import java
+
 private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.DataFlow
+private import semmle.code.java.frameworks.spring.SpringController
 private import semmle.code.java.security.XSS as XSS
 
 /** The class `org.springframework.http.HttpEntity` or an instantiation of it. */
@@ -140,6 +142,52 @@ private class SpringHttpFlowStep extends SummaryModelCsv {
         "org.springframework.http;HttpHeaders;true;formatHeaders;(MultiValueMap);;Element of MapValue of Argument[0];ReturnValue;taint",
         "org.springframework.http;HttpHeaders;true;encodeBasicAuth;(String,String,Charset);;Argument[0..1];ReturnValue;taint"
       ]
+  }
+}
+
+private class SpringXssSink extends XSS::XssSink {
+  SpringXssSink() {
+    exists(SpringRequestMappingMethod requestMappingMethod, ReturnStmt rs |
+      requestMappingMethod = rs.getEnclosingCallable() and
+      this.asExpr() = rs.getResult() and
+      (
+        not exists(requestMappingMethod.getProduces()) or
+        requestMappingMethod.getProduces().matches("text/%")
+      )
+    |
+      // If a Spring request mapping method is either annotated with @ResponseBody (or equivalent),
+      // or returns a HttpEntity or sub-type, then the return value of the method is converted into
+      // a HTTP reponse using a HttpMessageConverter implementation. The implementation is chosen
+      // based on the return type of the method, and the Accept header of the request.
+      //
+      // By default, the only message converter which produces a response which is vulnerable to
+      // XSS is the StringHttpMessageConverter, which "Accept"s all text/* content types, including
+      // text/html. Therefore, if a browser request includes "text/html" in the "Accept" header,
+      // any String returned will be converted into a text/html response.
+      requestMappingMethod.isResponseBody() and
+      requestMappingMethod.getReturnType() instanceof TypeString
+      or
+      exists(Type returnType |
+        // A return type of HttpEntity<T> or ResponseEntity<T> represents an HTTP response with both
+        // a body and a set of headers. The body is subject to the same HttpMessageConverter
+        // process as above.
+        returnType = requestMappingMethod.getReturnType() and
+        (
+          returnType instanceof SpringHttpEntity
+          or
+          returnType instanceof SpringResponseEntity
+        )
+      |
+        // The type argument, representing the type of the body, is type String
+        returnType.(ParameterizedClass).getTypeArgument(0) instanceof TypeString
+        or
+        // Return type is a Raw class, which means no static type information on the body. In this
+        // case we will still treat this as an XSS sink, but rely on our taint flow steps for
+        // HttpEntity/ResponseEntity to only pass taint into those instances if the body type was
+        // String.
+        returnType instanceof RawClass
+      )
+    )
   }
 }
 

--- a/java/ql/lib/semmle/code/java/security/XSS.qll
+++ b/java/ql/lib/semmle/code/java/security/XSS.qll
@@ -45,48 +45,6 @@ private class DefaultXssSink extends XssSink {
       writer.hasFlowToExpr(ma.getQualifier()) and
       this.asExpr() = ma.getArgument(_)
     )
-    or
-    exists(SpringRequestMappingMethod requestMappingMethod, ReturnStmt rs |
-      requestMappingMethod = rs.getEnclosingCallable() and
-      this.asExpr() = rs.getResult() and
-      (
-        not exists(requestMappingMethod.getProduces()) or
-        requestMappingMethod.getProduces().matches("text/%")
-      )
-    |
-      // If a Spring request mapping method is either annotated with @ResponseBody (or equivalent),
-      // or returns a HttpEntity or sub-type, then the return value of the method is converted into
-      // a HTTP reponse using a HttpMessageConverter implementation. The implementation is chosen
-      // based on the return type of the method, and the Accept header of the request.
-      //
-      // By default, the only message converter which produces a response which is vulnerable to
-      // XSS is the StringHttpMessageConverter, which "Accept"s all text/* content types, including
-      // text/html. Therefore, if a browser request includes "text/html" in the "Accept" header,
-      // any String returned will be converted into a text/html response.
-      requestMappingMethod.isResponseBody() and
-      requestMappingMethod.getReturnType() instanceof TypeString
-      or
-      exists(Type returnType |
-        // A return type of HttpEntity<T> or ResponseEntity<T> represents an HTTP response with both
-        // a body and a set of headers. The body is subject to the same HttpMessageConverter
-        // process as above.
-        returnType = requestMappingMethod.getReturnType() and
-        (
-          returnType instanceof SpringHttpEntity
-          or
-          returnType instanceof SpringResponseEntity
-        )
-      |
-        // The type argument, representing the type of the body, is type String
-        returnType.(ParameterizedClass).getTypeArgument(0) instanceof TypeString
-        or
-        // Return type is a Raw class, which means no static type information on the body. In this
-        // case we will still treat this as an XSS sink, but rely on our taint flow steps for
-        // HttpEntity/ResponseEntity to only pass taint into those instances if the body type was
-        // String.
-        returnType instanceof RawClass
-      )
-    )
   }
 }
 

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
@@ -28,11 +28,11 @@ public class SpringXSS {
     }
     else {
       if(chainDirectly) {
-        return builder.contentType(MediaType.APPLICATION_JSON).body(userControlled); // $SPURIOUS: xss
+        return builder.contentType(MediaType.APPLICATION_JSON).body(userControlled);
       }
       else {
         ResponseEntity.BodyBuilder builder2 = builder.contentType(MediaType.APPLICATION_JSON);
-        return builder2.body(userControlled); // $SPURIOUS: xss
+        return builder2.body(userControlled);
       }
     }
 

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
@@ -60,7 +60,7 @@ public class SpringXSS {
 
   @GetMapping(value = "/xyz", produces = MediaType.TEXT_HTML_VALUE)
   public static ResponseEntity<String> methodContentTypeUnsafe(String userControlled) {
-    return ResponseEntity.ok(userControlled); // $MISSING: xss
+    return ResponseEntity.ok(userControlled); // $xss
   }
 
   @GetMapping(value = "/xyz", produces = "text/html")

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
@@ -139,12 +139,12 @@ public class SpringXSS {
 
     @GetMapping(value = "/xyz", produces = {"application/json"})
     public ResponseEntity<String> overridesWithSafe(String userControlled) {
-      return ResponseEntity.ok(userControlled); // $SPURIOUS: xss
+      return ResponseEntity.ok(userControlled);
     }
 
     @GetMapping(value = "/abc")
     public ResponseEntity<String> overridesWithSafe2(String userControlled) {
-      return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(userControlled); // $SPURIOUS: xss
+      return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(userControlled);
     }
   }
 

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
@@ -105,12 +105,12 @@ public class SpringXSS {
   private static class ClassContentTypeSafe {
     @GetMapping(value = "/abc")
     public ResponseEntity<String> test(String userControlled) {
-      return ResponseEntity.ok(userControlled); // $SPURIOUS: xss
+      return ResponseEntity.ok(userControlled);
     }
 
     @GetMapping(value = "/abc")
     public String testDirectReturn(String userControlled) {
-      return userControlled; // $SPURIOUS: xss
+      return userControlled;
     }
 
     @GetMapping(value = "/xyz", produces = {"text/html"})

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
@@ -75,7 +75,7 @@ public class SpringXSS {
 
   @GetMapping(value = "/xyz", produces = MediaType.APPLICATION_JSON_VALUE)
   public static ResponseEntity<String> methodContentTypeSafeOverriddenWithUnsafe(String userControlled) {
-    return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(userControlled); // $MISSING: xss
+    return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(userControlled); // $xss
   }
 
   @GetMapping(value = "/xyz", produces = MediaType.TEXT_HTML_VALUE)


### PR DESCRIPTION
~Based on https://github.com/github/codeql/pull/6087~ (merged)

In brief, this replicates the content-type logic in https://github.com/github/codeql-securitylab/blob/main/java/ql/src/pwntester/security/RestXSS.ql:

* An explicit BodyBuilder `contentType` call has top priority, overriding any `@Produces` annotation. This is implemented by making a related `body` call a sanitizer or a sink if the content-type can be determined; in the vulnerable case the sink is also an out-barrier to prevent duplicate paths arising from a return from a request-handler method
* Second priority is a `@Produces` annotation on a request-handler method. We already did this, but I bring in @pwntester's broader regex to recognise more XSS'able content-types, and recognise the Spring MediaType constants as well as `@Produces` annotations giving multiple possible result types.
* Third priority is inheriting a `@Produces` annotation from an enclosing type.