### PR TITLE
JS: Add steps through terminal styling 

### DIFF
--- a/javascript/change-notes/2021-06-22-colors.md
+++ b/javascript/change-notes/2021-06-22-colors.md
@@ -6,4 +6,5 @@ lgtm,codescanning
     [wrap-ansi](https://npmjs.com/package/wrap-ansi),
     [colorette](https://npmjs.com/package/colorette),
     [cli-highlight](https://npmjs.com/package/cli-highlight),
-    [cli-color](https://npmjs.com/package/cli-color)
+    [cli-color](https://npmjs.com/package/cli-color),
+    [slice-ansi](https://npmjs.com/package/slice-ansi)

--- a/javascript/change-notes/2021-06-22-colors.md
+++ b/javascript/change-notes/2021-06-22-colors.md
@@ -1,4 +1,5 @@
 lgtm,codescanning
 * The dataflow libraries now model dataflow through console styling libraries.
   Affected packages are
-    [ansi-colors](https://npmjs.com/package/ansi-colors)
+    [ansi-colors](https://npmjs.com/package/ansi-colors),
+    [colors](https://npmjs.com/package/colors)

--- a/javascript/change-notes/2021-06-22-colors.md
+++ b/javascript/change-notes/2021-06-22-colors.md
@@ -8,4 +8,5 @@ lgtm,codescanning
     [cli-highlight](https://npmjs.com/package/cli-highlight),
     [cli-color](https://npmjs.com/package/cli-color),
     [slice-ansi](https://npmjs.com/package/slice-ansi),
-    [kleur](https://npmjs.com/package/kleur)
+    [kleur](https://npmjs.com/package/kleur),
+    [chalk](https://npmjs.com/package/chalk)

--- a/javascript/change-notes/2021-06-22-colors.md
+++ b/javascript/change-notes/2021-06-22-colors.md
@@ -7,4 +7,5 @@ lgtm,codescanning
     [colorette](https://npmjs.com/package/colorette),
     [cli-highlight](https://npmjs.com/package/cli-highlight),
     [cli-color](https://npmjs.com/package/cli-color),
-    [slice-ansi](https://npmjs.com/package/slice-ansi)
+    [slice-ansi](https://npmjs.com/package/slice-ansi),
+    [kleur](https://npmjs.com/package/kleur)

--- a/javascript/change-notes/2021-06-22-colors.md
+++ b/javascript/change-notes/2021-06-22-colors.md
@@ -4,4 +4,5 @@ lgtm,codescanning
     [ansi-colors](https://npmjs.com/package/ansi-colors),
     [colors](https://npmjs.com/package/colors),
     [wrap-ansi](https://npmjs.com/package/wrap-ansi),
-    [colorette](https://npmjs.com/package/colorette)
+    [colorette](https://npmjs.com/package/colorette),
+    [cli-highlight](https://npmjs.com/package/cli-highlight)

--- a/javascript/change-notes/2021-06-22-colors.md
+++ b/javascript/change-notes/2021-06-22-colors.md
@@ -5,4 +5,5 @@ lgtm,codescanning
     [colors](https://npmjs.com/package/colors),
     [wrap-ansi](https://npmjs.com/package/wrap-ansi),
     [colorette](https://npmjs.com/package/colorette),
-    [cli-highlight](https://npmjs.com/package/cli-highlight)
+    [cli-highlight](https://npmjs.com/package/cli-highlight),
+    [cli-color](https://npmjs.com/package/cli-color)

--- a/javascript/change-notes/2021-06-22-colors.md
+++ b/javascript/change-notes/2021-06-22-colors.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* The dataflow libraries now model dataflow through console styling libraries.
+  Affected packages are
+    [ansi-colors](https://npmjs.com/package/ansi-colors)

--- a/javascript/change-notes/2021-06-22-colors.md
+++ b/javascript/change-notes/2021-06-22-colors.md
@@ -2,4 +2,5 @@ lgtm,codescanning
 * The dataflow libraries now model dataflow through console styling libraries.
   Affected packages are
     [ansi-colors](https://npmjs.com/package/ansi-colors),
-    [colors](https://npmjs.com/package/colors)
+    [colors](https://npmjs.com/package/colors),
+    [wrap-ansi](https://npmjs.com/package/wrap-ansi)

--- a/javascript/change-notes/2021-06-22-colors.md
+++ b/javascript/change-notes/2021-06-22-colors.md
@@ -3,4 +3,5 @@ lgtm,codescanning
   Affected packages are
     [ansi-colors](https://npmjs.com/package/ansi-colors),
     [colors](https://npmjs.com/package/colors),
-    [wrap-ansi](https://npmjs.com/package/wrap-ansi)
+    [wrap-ansi](https://npmjs.com/package/wrap-ansi),
+    [colorette](https://npmjs.com/package/colorette)

--- a/javascript/change-notes/2021-06-22-colors.md
+++ b/javascript/change-notes/2021-06-22-colors.md
@@ -9,4 +9,5 @@ lgtm,codescanning
     [cli-color](https://npmjs.com/package/cli-color),
     [slice-ansi](https://npmjs.com/package/slice-ansi),
     [kleur](https://npmjs.com/package/kleur),
-    [chalk](https://npmjs.com/package/chalk)
+    [chalk](https://npmjs.com/package/chalk),
+    [strip-ansi](https://npmjs.com/package/strip-ansi)

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -221,7 +221,8 @@ class AnsiColorsStep extends TaintTracking::SharedTaintStep {
 class ColorsStep extends TaintTracking::SharedTaintStep {
   override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
     exists(API::CallNode call |
-      call = API::moduleImport(["colors", "colors/safe"]).getAMember*().getACall()
+
+      call = API::moduleImport(["colors", "colors/safe" /* this variant avoids modifying the prototype methods */ ]).getAMember*().getACall()
     |
       pred = call.getArgument(0) and
       succ = call

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -320,3 +320,15 @@ class ChalkStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A step through the [`strip-ansi`](https://npmjs.org/package/strip-ansi) library.
+ */
+class StripAnsiStep extends TaintTracking::SharedTaintStep {
+  override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call | call = API::moduleImport("strip-ansi").getACall() |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -201,3 +201,15 @@ private class DebugLoggerCall extends LoggerCall, API::CallNode {
 
   override DataFlow::Node getAMessageComponent() { result = getAnArgument() }
 }
+
+/**
+ * A step through the [`ansi-colors`](https://https://npmjs.org/package/ansi-colors) library.
+ */
+class AnsiColorsStep extends TaintTracking::SharedTaintStep {
+  override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call | call = API::moduleImport("ansi-colors").getAMember*().getACall() |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -228,3 +228,15 @@ class ColorsStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A step through the [`wrap-ansi`](https://npmjs.org/package/wrap-ansi) library.
+ */
+class WrapAnsiStep extends TaintTracking::SharedTaintStep {
+  override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call | call = API::moduleImport("wrap-ansi").getACall() |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -290,3 +290,21 @@ class SliceAnsiStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A step through the [`kleur`](https://npmjs.org/package/kleur) library.
+ */
+class KleurStep extends TaintTracking::SharedTaintStep {
+  private API::Node kleurInstance() {
+    result = API::moduleImport("kleur")
+    or
+    result = kleurInstance().getAMember().getReturn()
+  }
+
+  override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call | call = kleurInstance().getAMember().getACall() |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -252,3 +252,17 @@ class ColoretteStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A step through the [`cli-highlight`](https://npmjs.org/package/cli-highlight) library.
+ */
+class CliHighlightStep extends TaintTracking::SharedTaintStep {
+  override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call |
+      call = API::moduleImport("cli-highlight").getMember("highlight").getACall()
+    |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -308,3 +308,15 @@ class KleurStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A step through the [`chalk`](https://npmjs.org/package/chalk) library.
+ */
+class ChalkStep extends TaintTracking::SharedTaintStep {
+  override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call | call = API::moduleImport("chalk").getAMember*().getACall() |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -213,3 +213,18 @@ class AnsiColorsStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A step through the [`colors`](https://npmjs.org/package/colors) library.
+ * This step ignores the `String.prototype` modifying part of the `colors` library.
+ */
+class ColorsStep extends TaintTracking::SharedTaintStep {
+  override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call |
+      call = API::moduleImport(["colors", "colors/safe"]).getAMember*().getACall()
+    |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -266,3 +266,15 @@ class CliHighlightStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A step through the [`cli-color`](https://npmjs.org/package/cli-color) library.
+ */
+class CliColorStep extends TaintTracking::SharedTaintStep {
+  override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call | call = API::moduleImport("cli-color").getAMember*().getACall() |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -240,3 +240,15 @@ class WrapAnsiStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A step through the [`colorette`](https://npmjs.org/package/colorette) library.
+ */
+class ColoretteStep extends TaintTracking::SharedTaintStep {
+  override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call | call = API::moduleImport("colorette").getAMember().getACall() |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -278,3 +278,15 @@ class CliColorStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A step through the [`slice-ansi`](https://npmjs.org/package/slice-ansi) library.
+ */
+class SliceAnsiStep extends TaintTracking::SharedTaintStep {
+  override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call | call = API::moduleImport("slice-ansi").getACall() |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -221,8 +221,12 @@ class AnsiColorsStep extends TaintTracking::SharedTaintStep {
 class ColorsStep extends TaintTracking::SharedTaintStep {
   override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
     exists(API::CallNode call |
-
-      call = API::moduleImport(["colors", "colors/safe" /* this variant avoids modifying the prototype methods */ ]).getAMember*().getACall()
+      call =
+        API::moduleImport([
+            "colors",
+            // the `colors/safe` variant avoids modifying the prototype methods
+            "colors/safe"
+          ]).getAMember*().getACall()
     |
       pred = call.getArgument(0) and
       succ = call

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -22,29 +22,32 @@ nodes
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error |
-| logInjectionBad.js:40:9:40:36 | q |
-| logInjectionBad.js:40:13:40:36 | url.par ... , true) |
-| logInjectionBad.js:40:23:40:29 | req.url |
-| logInjectionBad.js:40:23:40:29 | req.url |
-| logInjectionBad.js:41:9:41:35 | username |
-| logInjectionBad.js:41:20:41:20 | q |
-| logInjectionBad.js:41:20:41:26 | q.query |
-| logInjectionBad.js:41:20:41:35 | q.query.username |
-| logInjectionBad.js:43:18:43:54 | ansiCol ... ername) |
-| logInjectionBad.js:43:18:43:54 | ansiCol ... ername) |
-| logInjectionBad.js:43:46:43:53 | username |
-| logInjectionBad.js:44:18:44:47 | colors. ... ername) |
-| logInjectionBad.js:44:18:44:47 | colors. ... ername) |
-| logInjectionBad.js:44:39:44:46 | username |
-| logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:45:27:45:56 | colors. ... ername) |
-| logInjectionBad.js:45:48:45:55 | username |
-| logInjectionBad.js:46:17:46:47 | underli ... name))) |
-| logInjectionBad.js:46:17:46:47 | underli ... name))) |
-| logInjectionBad.js:46:27:46:46 | bold(blue(username)) |
-| logInjectionBad.js:46:32:46:45 | blue(username) |
-| logInjectionBad.js:46:37:46:44 | username |
+| logInjectionBad.js:41:9:41:36 | q |
+| logInjectionBad.js:41:13:41:36 | url.par ... , true) |
+| logInjectionBad.js:41:23:41:29 | req.url |
+| logInjectionBad.js:41:23:41:29 | req.url |
+| logInjectionBad.js:42:9:42:35 | username |
+| logInjectionBad.js:42:20:42:20 | q |
+| logInjectionBad.js:42:20:42:26 | q.query |
+| logInjectionBad.js:42:20:42:35 | q.query.username |
+| logInjectionBad.js:44:18:44:54 | ansiCol ... ername) |
+| logInjectionBad.js:44:18:44:54 | ansiCol ... ername) |
+| logInjectionBad.js:44:46:44:53 | username |
+| logInjectionBad.js:45:18:45:47 | colors. ... ername) |
+| logInjectionBad.js:45:18:45:47 | colors. ... ername) |
+| logInjectionBad.js:45:39:45:46 | username |
+| logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:46:27:46:56 | colors. ... ername) |
+| logInjectionBad.js:46:48:46:55 | username |
+| logInjectionBad.js:47:17:47:47 | underli ... name))) |
+| logInjectionBad.js:47:17:47:47 | underli ... name))) |
+| logInjectionBad.js:47:27:47:46 | bold(blue(username)) |
+| logInjectionBad.js:47:32:47:45 | blue(username) |
+| logInjectionBad.js:47:37:47:44 | username |
+| logInjectionBad.js:48:17:48:76 | highlig ...  true}) |
+| logInjectionBad.js:48:17:48:76 | highlig ...  true}) |
+| logInjectionBad.js:48:27:48:34 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -68,35 +71,39 @@ edges
 | logInjectionBad.js:29:14:29:18 | error | logInjectionBad.js:30:42:30:46 | error |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
-| logInjectionBad.js:40:9:40:36 | q | logInjectionBad.js:41:20:41:20 | q |
-| logInjectionBad.js:40:13:40:36 | url.par ... , true) | logInjectionBad.js:40:9:40:36 | q |
-| logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:40:13:40:36 | url.par ... , true) |
-| logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:40:13:40:36 | url.par ... , true) |
-| logInjectionBad.js:41:9:41:35 | username | logInjectionBad.js:43:46:43:53 | username |
-| logInjectionBad.js:41:9:41:35 | username | logInjectionBad.js:44:39:44:46 | username |
-| logInjectionBad.js:41:9:41:35 | username | logInjectionBad.js:45:48:45:55 | username |
-| logInjectionBad.js:41:9:41:35 | username | logInjectionBad.js:46:37:46:44 | username |
-| logInjectionBad.js:41:20:41:20 | q | logInjectionBad.js:41:20:41:26 | q.query |
-| logInjectionBad.js:41:20:41:26 | q.query | logInjectionBad.js:41:20:41:35 | q.query.username |
-| logInjectionBad.js:41:20:41:35 | q.query.username | logInjectionBad.js:41:9:41:35 | username |
-| logInjectionBad.js:43:46:43:53 | username | logInjectionBad.js:43:18:43:54 | ansiCol ... ername) |
-| logInjectionBad.js:43:46:43:53 | username | logInjectionBad.js:43:18:43:54 | ansiCol ... ername) |
-| logInjectionBad.js:44:39:44:46 | username | logInjectionBad.js:44:18:44:47 | colors. ... ername) |
-| logInjectionBad.js:44:39:44:46 | username | logInjectionBad.js:44:18:44:47 | colors. ... ername) |
-| logInjectionBad.js:45:27:45:56 | colors. ... ername) | logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:45:27:45:56 | colors. ... ername) | logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:45:48:45:55 | username | logInjectionBad.js:45:27:45:56 | colors. ... ername) |
-| logInjectionBad.js:46:27:46:46 | bold(blue(username)) | logInjectionBad.js:46:17:46:47 | underli ... name))) |
-| logInjectionBad.js:46:27:46:46 | bold(blue(username)) | logInjectionBad.js:46:17:46:47 | underli ... name))) |
-| logInjectionBad.js:46:32:46:45 | blue(username) | logInjectionBad.js:46:27:46:46 | bold(blue(username)) |
-| logInjectionBad.js:46:37:46:44 | username | logInjectionBad.js:46:32:46:45 | blue(username) |
+| logInjectionBad.js:41:9:41:36 | q | logInjectionBad.js:42:20:42:20 | q |
+| logInjectionBad.js:41:13:41:36 | url.par ... , true) | logInjectionBad.js:41:9:41:36 | q |
+| logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:41:13:41:36 | url.par ... , true) |
+| logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:41:13:41:36 | url.par ... , true) |
+| logInjectionBad.js:42:9:42:35 | username | logInjectionBad.js:44:46:44:53 | username |
+| logInjectionBad.js:42:9:42:35 | username | logInjectionBad.js:45:39:45:46 | username |
+| logInjectionBad.js:42:9:42:35 | username | logInjectionBad.js:46:48:46:55 | username |
+| logInjectionBad.js:42:9:42:35 | username | logInjectionBad.js:47:37:47:44 | username |
+| logInjectionBad.js:42:9:42:35 | username | logInjectionBad.js:48:27:48:34 | username |
+| logInjectionBad.js:42:20:42:20 | q | logInjectionBad.js:42:20:42:26 | q.query |
+| logInjectionBad.js:42:20:42:26 | q.query | logInjectionBad.js:42:20:42:35 | q.query.username |
+| logInjectionBad.js:42:20:42:35 | q.query.username | logInjectionBad.js:42:9:42:35 | username |
+| logInjectionBad.js:44:46:44:53 | username | logInjectionBad.js:44:18:44:54 | ansiCol ... ername) |
+| logInjectionBad.js:44:46:44:53 | username | logInjectionBad.js:44:18:44:54 | ansiCol ... ername) |
+| logInjectionBad.js:45:39:45:46 | username | logInjectionBad.js:45:18:45:47 | colors. ... ername) |
+| logInjectionBad.js:45:39:45:46 | username | logInjectionBad.js:45:18:45:47 | colors. ... ername) |
+| logInjectionBad.js:46:27:46:56 | colors. ... ername) | logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:46:27:46:56 | colors. ... ername) | logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:46:48:46:55 | username | logInjectionBad.js:46:27:46:56 | colors. ... ername) |
+| logInjectionBad.js:47:27:47:46 | bold(blue(username)) | logInjectionBad.js:47:17:47:47 | underli ... name))) |
+| logInjectionBad.js:47:27:47:46 | bold(blue(username)) | logInjectionBad.js:47:17:47:47 | underli ... name))) |
+| logInjectionBad.js:47:32:47:45 | blue(username) | logInjectionBad.js:47:27:47:46 | bold(blue(username)) |
+| logInjectionBad.js:47:37:47:44 | username | logInjectionBad.js:47:32:47:45 | blue(username) |
+| logInjectionBad.js:48:27:48:34 | username | logInjectionBad.js:48:17:48:76 | highlig ...  true}) |
+| logInjectionBad.js:48:27:48:34 | username | logInjectionBad.js:48:17:48:76 | highlig ...  true}) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:24:35:24:42 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:24:35:24:42 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:25:36:25:43 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:25:36:25:43 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
-| logInjectionBad.js:43:18:43:54 | ansiCol ... ername) | logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:43:18:43:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:40:23:40:29 | req.url | User-provided value |
-| logInjectionBad.js:44:18:44:47 | colors. ... ername) | logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:44:18:44:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:40:23:40:29 | req.url | User-provided value |
-| logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) | logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:40:23:40:29 | req.url | User-provided value |
-| logInjectionBad.js:46:17:46:47 | underli ... name))) | logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:46:17:46:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:40:23:40:29 | req.url | User-provided value |
+| logInjectionBad.js:44:18:44:54 | ansiCol ... ername) | logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:44:18:44:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:41:23:41:29 | req.url | User-provided value |
+| logInjectionBad.js:45:18:45:47 | colors. ... ername) | logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:45:18:45:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:41:23:41:29 | req.url | User-provided value |
+| logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) | logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:41:23:41:29 | req.url | User-provided value |
+| logInjectionBad.js:47:17:47:47 | underli ... name))) | logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:47:17:47:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:41:23:41:29 | req.url | User-provided value |
+| logInjectionBad.js:48:17:48:76 | highlig ...  true}) | logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:48:17:48:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:41:23:41:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -22,42 +22,45 @@ nodes
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error |
-| logInjectionBad.js:44:9:44:36 | q |
-| logInjectionBad.js:44:13:44:36 | url.par ... , true) |
-| logInjectionBad.js:44:23:44:29 | req.url |
-| logInjectionBad.js:44:23:44:29 | req.url |
-| logInjectionBad.js:45:9:45:35 | username |
-| logInjectionBad.js:45:20:45:20 | q |
-| logInjectionBad.js:45:20:45:26 | q.query |
-| logInjectionBad.js:45:20:45:35 | q.query.username |
-| logInjectionBad.js:47:18:47:54 | ansiCol ... ername) |
-| logInjectionBad.js:47:18:47:54 | ansiCol ... ername) |
-| logInjectionBad.js:47:46:47:53 | username |
-| logInjectionBad.js:48:18:48:47 | colors. ... ername) |
-| logInjectionBad.js:48:18:48:47 | colors. ... ername) |
-| logInjectionBad.js:48:39:48:46 | username |
-| logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:49:27:49:56 | colors. ... ername) |
-| logInjectionBad.js:49:48:49:55 | username |
-| logInjectionBad.js:50:17:50:47 | underli ... name))) |
-| logInjectionBad.js:50:17:50:47 | underli ... name))) |
-| logInjectionBad.js:50:27:50:46 | bold(blue(username)) |
-| logInjectionBad.js:50:32:50:45 | blue(username) |
-| logInjectionBad.js:50:37:50:44 | username |
-| logInjectionBad.js:51:17:51:76 | highlig ...  true}) |
-| logInjectionBad.js:51:17:51:76 | highlig ...  true}) |
-| logInjectionBad.js:51:27:51:34 | username |
-| logInjectionBad.js:52:17:52:51 | clc.red ... ername) |
-| logInjectionBad.js:52:17:52:51 | clc.red ... ername) |
-| logInjectionBad.js:52:43:52:50 | username |
-| logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:53:27:53:56 | colors. ... ername) |
-| logInjectionBad.js:53:48:53:55 | username |
-| logInjectionBad.js:54:17:54:55 | kleur.b ... ername) |
-| logInjectionBad.js:54:17:54:55 | kleur.b ... ername) |
-| logInjectionBad.js:54:47:54:54 | username |
+| logInjectionBad.js:45:9:45:36 | q |
+| logInjectionBad.js:45:13:45:36 | url.par ... , true) |
+| logInjectionBad.js:45:23:45:29 | req.url |
+| logInjectionBad.js:45:23:45:29 | req.url |
+| logInjectionBad.js:46:9:46:35 | username |
+| logInjectionBad.js:46:20:46:20 | q |
+| logInjectionBad.js:46:20:46:26 | q.query |
+| logInjectionBad.js:46:20:46:35 | q.query.username |
+| logInjectionBad.js:48:18:48:54 | ansiCol ... ername) |
+| logInjectionBad.js:48:18:48:54 | ansiCol ... ername) |
+| logInjectionBad.js:48:46:48:53 | username |
+| logInjectionBad.js:49:18:49:47 | colors. ... ername) |
+| logInjectionBad.js:49:18:49:47 | colors. ... ername) |
+| logInjectionBad.js:49:39:49:46 | username |
+| logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:50:27:50:56 | colors. ... ername) |
+| logInjectionBad.js:50:48:50:55 | username |
+| logInjectionBad.js:51:17:51:47 | underli ... name))) |
+| logInjectionBad.js:51:17:51:47 | underli ... name))) |
+| logInjectionBad.js:51:27:51:46 | bold(blue(username)) |
+| logInjectionBad.js:51:32:51:45 | blue(username) |
+| logInjectionBad.js:51:37:51:44 | username |
+| logInjectionBad.js:52:17:52:76 | highlig ...  true}) |
+| logInjectionBad.js:52:17:52:76 | highlig ...  true}) |
+| logInjectionBad.js:52:27:52:34 | username |
+| logInjectionBad.js:53:17:53:51 | clc.red ... ername) |
+| logInjectionBad.js:53:17:53:51 | clc.red ... ername) |
+| logInjectionBad.js:53:43:53:50 | username |
+| logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:54:27:54:56 | colors. ... ername) |
+| logInjectionBad.js:54:48:54:55 | username |
+| logInjectionBad.js:55:17:55:55 | kleur.b ... ername) |
+| logInjectionBad.js:55:17:55:55 | kleur.b ... ername) |
+| logInjectionBad.js:55:47:55:54 | username |
+| logInjectionBad.js:56:17:56:48 | chalk.u ... ername) |
+| logInjectionBad.js:56:17:56:48 | chalk.u ... ername) |
+| logInjectionBad.js:56:40:56:47 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -81,52 +84,56 @@ edges
 | logInjectionBad.js:29:14:29:18 | error | logInjectionBad.js:30:42:30:46 | error |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
-| logInjectionBad.js:44:9:44:36 | q | logInjectionBad.js:45:20:45:20 | q |
-| logInjectionBad.js:44:13:44:36 | url.par ... , true) | logInjectionBad.js:44:9:44:36 | q |
-| logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:44:13:44:36 | url.par ... , true) |
-| logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:44:13:44:36 | url.par ... , true) |
-| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:47:46:47:53 | username |
-| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:48:39:48:46 | username |
-| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:49:48:49:55 | username |
-| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:50:37:50:44 | username |
-| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:51:27:51:34 | username |
-| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:52:43:52:50 | username |
-| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:53:48:53:55 | username |
-| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:54:47:54:54 | username |
-| logInjectionBad.js:45:20:45:20 | q | logInjectionBad.js:45:20:45:26 | q.query |
-| logInjectionBad.js:45:20:45:26 | q.query | logInjectionBad.js:45:20:45:35 | q.query.username |
-| logInjectionBad.js:45:20:45:35 | q.query.username | logInjectionBad.js:45:9:45:35 | username |
-| logInjectionBad.js:47:46:47:53 | username | logInjectionBad.js:47:18:47:54 | ansiCol ... ername) |
-| logInjectionBad.js:47:46:47:53 | username | logInjectionBad.js:47:18:47:54 | ansiCol ... ername) |
-| logInjectionBad.js:48:39:48:46 | username | logInjectionBad.js:48:18:48:47 | colors. ... ername) |
-| logInjectionBad.js:48:39:48:46 | username | logInjectionBad.js:48:18:48:47 | colors. ... ername) |
-| logInjectionBad.js:49:27:49:56 | colors. ... ername) | logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:49:27:49:56 | colors. ... ername) | logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:49:48:49:55 | username | logInjectionBad.js:49:27:49:56 | colors. ... ername) |
-| logInjectionBad.js:50:27:50:46 | bold(blue(username)) | logInjectionBad.js:50:17:50:47 | underli ... name))) |
-| logInjectionBad.js:50:27:50:46 | bold(blue(username)) | logInjectionBad.js:50:17:50:47 | underli ... name))) |
-| logInjectionBad.js:50:32:50:45 | blue(username) | logInjectionBad.js:50:27:50:46 | bold(blue(username)) |
-| logInjectionBad.js:50:37:50:44 | username | logInjectionBad.js:50:32:50:45 | blue(username) |
-| logInjectionBad.js:51:27:51:34 | username | logInjectionBad.js:51:17:51:76 | highlig ...  true}) |
-| logInjectionBad.js:51:27:51:34 | username | logInjectionBad.js:51:17:51:76 | highlig ...  true}) |
-| logInjectionBad.js:52:43:52:50 | username | logInjectionBad.js:52:17:52:51 | clc.red ... ername) |
-| logInjectionBad.js:52:43:52:50 | username | logInjectionBad.js:52:17:52:51 | clc.red ... ername) |
-| logInjectionBad.js:53:27:53:56 | colors. ... ername) | logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:53:27:53:56 | colors. ... ername) | logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:53:48:53:55 | username | logInjectionBad.js:53:27:53:56 | colors. ... ername) |
-| logInjectionBad.js:54:47:54:54 | username | logInjectionBad.js:54:17:54:55 | kleur.b ... ername) |
-| logInjectionBad.js:54:47:54:54 | username | logInjectionBad.js:54:17:54:55 | kleur.b ... ername) |
+| logInjectionBad.js:45:9:45:36 | q | logInjectionBad.js:46:20:46:20 | q |
+| logInjectionBad.js:45:13:45:36 | url.par ... , true) | logInjectionBad.js:45:9:45:36 | q |
+| logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:45:13:45:36 | url.par ... , true) |
+| logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:45:13:45:36 | url.par ... , true) |
+| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:48:46:48:53 | username |
+| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:49:39:49:46 | username |
+| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:50:48:50:55 | username |
+| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:51:37:51:44 | username |
+| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:52:27:52:34 | username |
+| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:53:43:53:50 | username |
+| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:54:48:54:55 | username |
+| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:55:47:55:54 | username |
+| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:56:40:56:47 | username |
+| logInjectionBad.js:46:20:46:20 | q | logInjectionBad.js:46:20:46:26 | q.query |
+| logInjectionBad.js:46:20:46:26 | q.query | logInjectionBad.js:46:20:46:35 | q.query.username |
+| logInjectionBad.js:46:20:46:35 | q.query.username | logInjectionBad.js:46:9:46:35 | username |
+| logInjectionBad.js:48:46:48:53 | username | logInjectionBad.js:48:18:48:54 | ansiCol ... ername) |
+| logInjectionBad.js:48:46:48:53 | username | logInjectionBad.js:48:18:48:54 | ansiCol ... ername) |
+| logInjectionBad.js:49:39:49:46 | username | logInjectionBad.js:49:18:49:47 | colors. ... ername) |
+| logInjectionBad.js:49:39:49:46 | username | logInjectionBad.js:49:18:49:47 | colors. ... ername) |
+| logInjectionBad.js:50:27:50:56 | colors. ... ername) | logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:50:27:50:56 | colors. ... ername) | logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:50:48:50:55 | username | logInjectionBad.js:50:27:50:56 | colors. ... ername) |
+| logInjectionBad.js:51:27:51:46 | bold(blue(username)) | logInjectionBad.js:51:17:51:47 | underli ... name))) |
+| logInjectionBad.js:51:27:51:46 | bold(blue(username)) | logInjectionBad.js:51:17:51:47 | underli ... name))) |
+| logInjectionBad.js:51:32:51:45 | blue(username) | logInjectionBad.js:51:27:51:46 | bold(blue(username)) |
+| logInjectionBad.js:51:37:51:44 | username | logInjectionBad.js:51:32:51:45 | blue(username) |
+| logInjectionBad.js:52:27:52:34 | username | logInjectionBad.js:52:17:52:76 | highlig ...  true}) |
+| logInjectionBad.js:52:27:52:34 | username | logInjectionBad.js:52:17:52:76 | highlig ...  true}) |
+| logInjectionBad.js:53:43:53:50 | username | logInjectionBad.js:53:17:53:51 | clc.red ... ername) |
+| logInjectionBad.js:53:43:53:50 | username | logInjectionBad.js:53:17:53:51 | clc.red ... ername) |
+| logInjectionBad.js:54:27:54:56 | colors. ... ername) | logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:54:27:54:56 | colors. ... ername) | logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:54:48:54:55 | username | logInjectionBad.js:54:27:54:56 | colors. ... ername) |
+| logInjectionBad.js:55:47:55:54 | username | logInjectionBad.js:55:17:55:55 | kleur.b ... ername) |
+| logInjectionBad.js:55:47:55:54 | username | logInjectionBad.js:55:17:55:55 | kleur.b ... ername) |
+| logInjectionBad.js:56:40:56:47 | username | logInjectionBad.js:56:17:56:48 | chalk.u ... ername) |
+| logInjectionBad.js:56:40:56:47 | username | logInjectionBad.js:56:17:56:48 | chalk.u ... ername) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:24:35:24:42 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:24:35:24:42 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:25:36:25:43 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:25:36:25:43 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
-| logInjectionBad.js:47:18:47:54 | ansiCol ... ername) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:47:18:47:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
-| logInjectionBad.js:48:18:48:47 | colors. ... ername) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:48:18:48:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
-| logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
-| logInjectionBad.js:50:17:50:47 | underli ... name))) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:50:17:50:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
-| logInjectionBad.js:51:17:51:76 | highlig ...  true}) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:51:17:51:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
-| logInjectionBad.js:52:17:52:51 | clc.red ... ername) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:52:17:52:51 | clc.red ... ername) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
-| logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
-| logInjectionBad.js:54:17:54:55 | kleur.b ... ername) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:54:17:54:55 | kleur.b ... ername) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
+| logInjectionBad.js:48:18:48:54 | ansiCol ... ername) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:48:18:48:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
+| logInjectionBad.js:49:18:49:47 | colors. ... ername) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:49:18:49:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
+| logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
+| logInjectionBad.js:51:17:51:47 | underli ... name))) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:51:17:51:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
+| logInjectionBad.js:52:17:52:76 | highlig ...  true}) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:52:17:52:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
+| logInjectionBad.js:53:17:53:51 | clc.red ... ername) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:53:17:53:51 | clc.red ... ername) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
+| logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
+| logInjectionBad.js:55:17:55:55 | kleur.b ... ername) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:55:17:55:55 | kleur.b ... ername) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
+| logInjectionBad.js:56:17:56:48 | chalk.u ... ername) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:56:17:56:48 | chalk.u ... ername) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -22,39 +22,42 @@ nodes
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error |
-| logInjectionBad.js:43:9:43:36 | q |
-| logInjectionBad.js:43:13:43:36 | url.par ... , true) |
-| logInjectionBad.js:43:23:43:29 | req.url |
-| logInjectionBad.js:43:23:43:29 | req.url |
-| logInjectionBad.js:44:9:44:35 | username |
-| logInjectionBad.js:44:20:44:20 | q |
-| logInjectionBad.js:44:20:44:26 | q.query |
-| logInjectionBad.js:44:20:44:35 | q.query.username |
-| logInjectionBad.js:46:18:46:54 | ansiCol ... ername) |
-| logInjectionBad.js:46:18:46:54 | ansiCol ... ername) |
-| logInjectionBad.js:46:46:46:53 | username |
-| logInjectionBad.js:47:18:47:47 | colors. ... ername) |
-| logInjectionBad.js:47:18:47:47 | colors. ... ername) |
-| logInjectionBad.js:47:39:47:46 | username |
-| logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:48:27:48:56 | colors. ... ername) |
-| logInjectionBad.js:48:48:48:55 | username |
-| logInjectionBad.js:49:17:49:47 | underli ... name))) |
-| logInjectionBad.js:49:17:49:47 | underli ... name))) |
-| logInjectionBad.js:49:27:49:46 | bold(blue(username)) |
-| logInjectionBad.js:49:32:49:45 | blue(username) |
-| logInjectionBad.js:49:37:49:44 | username |
-| logInjectionBad.js:50:17:50:76 | highlig ...  true}) |
-| logInjectionBad.js:50:17:50:76 | highlig ...  true}) |
-| logInjectionBad.js:50:27:50:34 | username |
-| logInjectionBad.js:51:17:51:51 | clc.red ... ername) |
-| logInjectionBad.js:51:17:51:51 | clc.red ... ername) |
-| logInjectionBad.js:51:43:51:50 | username |
-| logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:52:27:52:56 | colors. ... ername) |
-| logInjectionBad.js:52:48:52:55 | username |
+| logInjectionBad.js:44:9:44:36 | q |
+| logInjectionBad.js:44:13:44:36 | url.par ... , true) |
+| logInjectionBad.js:44:23:44:29 | req.url |
+| logInjectionBad.js:44:23:44:29 | req.url |
+| logInjectionBad.js:45:9:45:35 | username |
+| logInjectionBad.js:45:20:45:20 | q |
+| logInjectionBad.js:45:20:45:26 | q.query |
+| logInjectionBad.js:45:20:45:35 | q.query.username |
+| logInjectionBad.js:47:18:47:54 | ansiCol ... ername) |
+| logInjectionBad.js:47:18:47:54 | ansiCol ... ername) |
+| logInjectionBad.js:47:46:47:53 | username |
+| logInjectionBad.js:48:18:48:47 | colors. ... ername) |
+| logInjectionBad.js:48:18:48:47 | colors. ... ername) |
+| logInjectionBad.js:48:39:48:46 | username |
+| logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:49:27:49:56 | colors. ... ername) |
+| logInjectionBad.js:49:48:49:55 | username |
+| logInjectionBad.js:50:17:50:47 | underli ... name))) |
+| logInjectionBad.js:50:17:50:47 | underli ... name))) |
+| logInjectionBad.js:50:27:50:46 | bold(blue(username)) |
+| logInjectionBad.js:50:32:50:45 | blue(username) |
+| logInjectionBad.js:50:37:50:44 | username |
+| logInjectionBad.js:51:17:51:76 | highlig ...  true}) |
+| logInjectionBad.js:51:17:51:76 | highlig ...  true}) |
+| logInjectionBad.js:51:27:51:34 | username |
+| logInjectionBad.js:52:17:52:51 | clc.red ... ername) |
+| logInjectionBad.js:52:17:52:51 | clc.red ... ername) |
+| logInjectionBad.js:52:43:52:50 | username |
+| logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:53:27:53:56 | colors. ... ername) |
+| logInjectionBad.js:53:48:53:55 | username |
+| logInjectionBad.js:54:17:54:55 | kleur.b ... ername) |
+| logInjectionBad.js:54:17:54:55 | kleur.b ... ername) |
+| logInjectionBad.js:54:47:54:54 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -78,48 +81,52 @@ edges
 | logInjectionBad.js:29:14:29:18 | error | logInjectionBad.js:30:42:30:46 | error |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
-| logInjectionBad.js:43:9:43:36 | q | logInjectionBad.js:44:20:44:20 | q |
-| logInjectionBad.js:43:13:43:36 | url.par ... , true) | logInjectionBad.js:43:9:43:36 | q |
-| logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:43:13:43:36 | url.par ... , true) |
-| logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:43:13:43:36 | url.par ... , true) |
-| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:46:46:46:53 | username |
-| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:47:39:47:46 | username |
-| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:48:48:48:55 | username |
-| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:49:37:49:44 | username |
-| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:50:27:50:34 | username |
-| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:51:43:51:50 | username |
-| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:52:48:52:55 | username |
-| logInjectionBad.js:44:20:44:20 | q | logInjectionBad.js:44:20:44:26 | q.query |
-| logInjectionBad.js:44:20:44:26 | q.query | logInjectionBad.js:44:20:44:35 | q.query.username |
-| logInjectionBad.js:44:20:44:35 | q.query.username | logInjectionBad.js:44:9:44:35 | username |
-| logInjectionBad.js:46:46:46:53 | username | logInjectionBad.js:46:18:46:54 | ansiCol ... ername) |
-| logInjectionBad.js:46:46:46:53 | username | logInjectionBad.js:46:18:46:54 | ansiCol ... ername) |
-| logInjectionBad.js:47:39:47:46 | username | logInjectionBad.js:47:18:47:47 | colors. ... ername) |
-| logInjectionBad.js:47:39:47:46 | username | logInjectionBad.js:47:18:47:47 | colors. ... ername) |
-| logInjectionBad.js:48:27:48:56 | colors. ... ername) | logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:48:27:48:56 | colors. ... ername) | logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:48:48:48:55 | username | logInjectionBad.js:48:27:48:56 | colors. ... ername) |
-| logInjectionBad.js:49:27:49:46 | bold(blue(username)) | logInjectionBad.js:49:17:49:47 | underli ... name))) |
-| logInjectionBad.js:49:27:49:46 | bold(blue(username)) | logInjectionBad.js:49:17:49:47 | underli ... name))) |
-| logInjectionBad.js:49:32:49:45 | blue(username) | logInjectionBad.js:49:27:49:46 | bold(blue(username)) |
-| logInjectionBad.js:49:37:49:44 | username | logInjectionBad.js:49:32:49:45 | blue(username) |
-| logInjectionBad.js:50:27:50:34 | username | logInjectionBad.js:50:17:50:76 | highlig ...  true}) |
-| logInjectionBad.js:50:27:50:34 | username | logInjectionBad.js:50:17:50:76 | highlig ...  true}) |
-| logInjectionBad.js:51:43:51:50 | username | logInjectionBad.js:51:17:51:51 | clc.red ... ername) |
-| logInjectionBad.js:51:43:51:50 | username | logInjectionBad.js:51:17:51:51 | clc.red ... ername) |
-| logInjectionBad.js:52:27:52:56 | colors. ... ername) | logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:52:27:52:56 | colors. ... ername) | logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:52:48:52:55 | username | logInjectionBad.js:52:27:52:56 | colors. ... ername) |
+| logInjectionBad.js:44:9:44:36 | q | logInjectionBad.js:45:20:45:20 | q |
+| logInjectionBad.js:44:13:44:36 | url.par ... , true) | logInjectionBad.js:44:9:44:36 | q |
+| logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:44:13:44:36 | url.par ... , true) |
+| logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:44:13:44:36 | url.par ... , true) |
+| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:47:46:47:53 | username |
+| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:48:39:48:46 | username |
+| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:49:48:49:55 | username |
+| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:50:37:50:44 | username |
+| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:51:27:51:34 | username |
+| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:52:43:52:50 | username |
+| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:53:48:53:55 | username |
+| logInjectionBad.js:45:9:45:35 | username | logInjectionBad.js:54:47:54:54 | username |
+| logInjectionBad.js:45:20:45:20 | q | logInjectionBad.js:45:20:45:26 | q.query |
+| logInjectionBad.js:45:20:45:26 | q.query | logInjectionBad.js:45:20:45:35 | q.query.username |
+| logInjectionBad.js:45:20:45:35 | q.query.username | logInjectionBad.js:45:9:45:35 | username |
+| logInjectionBad.js:47:46:47:53 | username | logInjectionBad.js:47:18:47:54 | ansiCol ... ername) |
+| logInjectionBad.js:47:46:47:53 | username | logInjectionBad.js:47:18:47:54 | ansiCol ... ername) |
+| logInjectionBad.js:48:39:48:46 | username | logInjectionBad.js:48:18:48:47 | colors. ... ername) |
+| logInjectionBad.js:48:39:48:46 | username | logInjectionBad.js:48:18:48:47 | colors. ... ername) |
+| logInjectionBad.js:49:27:49:56 | colors. ... ername) | logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:49:27:49:56 | colors. ... ername) | logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:49:48:49:55 | username | logInjectionBad.js:49:27:49:56 | colors. ... ername) |
+| logInjectionBad.js:50:27:50:46 | bold(blue(username)) | logInjectionBad.js:50:17:50:47 | underli ... name))) |
+| logInjectionBad.js:50:27:50:46 | bold(blue(username)) | logInjectionBad.js:50:17:50:47 | underli ... name))) |
+| logInjectionBad.js:50:32:50:45 | blue(username) | logInjectionBad.js:50:27:50:46 | bold(blue(username)) |
+| logInjectionBad.js:50:37:50:44 | username | logInjectionBad.js:50:32:50:45 | blue(username) |
+| logInjectionBad.js:51:27:51:34 | username | logInjectionBad.js:51:17:51:76 | highlig ...  true}) |
+| logInjectionBad.js:51:27:51:34 | username | logInjectionBad.js:51:17:51:76 | highlig ...  true}) |
+| logInjectionBad.js:52:43:52:50 | username | logInjectionBad.js:52:17:52:51 | clc.red ... ername) |
+| logInjectionBad.js:52:43:52:50 | username | logInjectionBad.js:52:17:52:51 | clc.red ... ername) |
+| logInjectionBad.js:53:27:53:56 | colors. ... ername) | logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:53:27:53:56 | colors. ... ername) | logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:53:48:53:55 | username | logInjectionBad.js:53:27:53:56 | colors. ... ername) |
+| logInjectionBad.js:54:47:54:54 | username | logInjectionBad.js:54:17:54:55 | kleur.b ... ername) |
+| logInjectionBad.js:54:47:54:54 | username | logInjectionBad.js:54:17:54:55 | kleur.b ... ername) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:24:35:24:42 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:24:35:24:42 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:25:36:25:43 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:25:36:25:43 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
-| logInjectionBad.js:46:18:46:54 | ansiCol ... ername) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:46:18:46:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
-| logInjectionBad.js:47:18:47:47 | colors. ... ername) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:47:18:47:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
-| logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
-| logInjectionBad.js:49:17:49:47 | underli ... name))) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:49:17:49:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
-| logInjectionBad.js:50:17:50:76 | highlig ...  true}) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:50:17:50:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
-| logInjectionBad.js:51:17:51:51 | clc.red ... ername) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:51:17:51:51 | clc.red ... ername) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
-| logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
+| logInjectionBad.js:47:18:47:54 | ansiCol ... ername) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:47:18:47:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
+| logInjectionBad.js:48:18:48:47 | colors. ... ername) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:48:18:48:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
+| logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:49:18:49:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
+| logInjectionBad.js:50:17:50:47 | underli ... name))) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:50:17:50:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
+| logInjectionBad.js:51:17:51:76 | highlig ...  true}) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:51:17:51:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
+| logInjectionBad.js:52:17:52:51 | clc.red ... ername) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:52:17:52:51 | clc.red ... ername) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
+| logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:53:17:53:65 | sliceAn ... 20, 30) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |
+| logInjectionBad.js:54:17:54:55 | kleur.b ... ername) | logInjectionBad.js:44:23:44:29 | req.url | logInjectionBad.js:54:17:54:55 | kleur.b ... ername) | $@ flows to log entry. | logInjectionBad.js:44:23:44:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -22,45 +22,49 @@ nodes
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error |
-| logInjectionBad.js:45:9:45:36 | q |
-| logInjectionBad.js:45:13:45:36 | url.par ... , true) |
-| logInjectionBad.js:45:23:45:29 | req.url |
-| logInjectionBad.js:45:23:45:29 | req.url |
-| logInjectionBad.js:46:9:46:35 | username |
-| logInjectionBad.js:46:20:46:20 | q |
-| logInjectionBad.js:46:20:46:26 | q.query |
-| logInjectionBad.js:46:20:46:35 | q.query.username |
-| logInjectionBad.js:48:18:48:54 | ansiCol ... ername) |
-| logInjectionBad.js:48:18:48:54 | ansiCol ... ername) |
-| logInjectionBad.js:48:46:48:53 | username |
-| logInjectionBad.js:49:18:49:47 | colors. ... ername) |
-| logInjectionBad.js:49:18:49:47 | colors. ... ername) |
-| logInjectionBad.js:49:39:49:46 | username |
-| logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:50:27:50:56 | colors. ... ername) |
-| logInjectionBad.js:50:48:50:55 | username |
-| logInjectionBad.js:51:17:51:47 | underli ... name))) |
-| logInjectionBad.js:51:17:51:47 | underli ... name))) |
-| logInjectionBad.js:51:27:51:46 | bold(blue(username)) |
-| logInjectionBad.js:51:32:51:45 | blue(username) |
-| logInjectionBad.js:51:37:51:44 | username |
-| logInjectionBad.js:52:17:52:76 | highlig ...  true}) |
-| logInjectionBad.js:52:17:52:76 | highlig ...  true}) |
-| logInjectionBad.js:52:27:52:34 | username |
-| logInjectionBad.js:53:17:53:51 | clc.red ... ername) |
-| logInjectionBad.js:53:17:53:51 | clc.red ... ername) |
-| logInjectionBad.js:53:43:53:50 | username |
-| logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:54:27:54:56 | colors. ... ername) |
-| logInjectionBad.js:54:48:54:55 | username |
-| logInjectionBad.js:55:17:55:55 | kleur.b ... ername) |
-| logInjectionBad.js:55:17:55:55 | kleur.b ... ername) |
-| logInjectionBad.js:55:47:55:54 | username |
-| logInjectionBad.js:56:17:56:48 | chalk.u ... ername) |
-| logInjectionBad.js:56:17:56:48 | chalk.u ... ername) |
-| logInjectionBad.js:56:40:56:47 | username |
+| logInjectionBad.js:46:9:46:36 | q |
+| logInjectionBad.js:46:13:46:36 | url.par ... , true) |
+| logInjectionBad.js:46:23:46:29 | req.url |
+| logInjectionBad.js:46:23:46:29 | req.url |
+| logInjectionBad.js:47:9:47:35 | username |
+| logInjectionBad.js:47:20:47:20 | q |
+| logInjectionBad.js:47:20:47:26 | q.query |
+| logInjectionBad.js:47:20:47:35 | q.query.username |
+| logInjectionBad.js:49:18:49:54 | ansiCol ... ername) |
+| logInjectionBad.js:49:18:49:54 | ansiCol ... ername) |
+| logInjectionBad.js:49:46:49:53 | username |
+| logInjectionBad.js:50:18:50:47 | colors. ... ername) |
+| logInjectionBad.js:50:18:50:47 | colors. ... ername) |
+| logInjectionBad.js:50:39:50:46 | username |
+| logInjectionBad.js:51:18:51:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:51:18:51:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:51:27:51:56 | colors. ... ername) |
+| logInjectionBad.js:51:48:51:55 | username |
+| logInjectionBad.js:52:17:52:47 | underli ... name))) |
+| logInjectionBad.js:52:17:52:47 | underli ... name))) |
+| logInjectionBad.js:52:27:52:46 | bold(blue(username)) |
+| logInjectionBad.js:52:32:52:45 | blue(username) |
+| logInjectionBad.js:52:37:52:44 | username |
+| logInjectionBad.js:53:17:53:76 | highlig ...  true}) |
+| logInjectionBad.js:53:17:53:76 | highlig ...  true}) |
+| logInjectionBad.js:53:27:53:34 | username |
+| logInjectionBad.js:54:17:54:51 | clc.red ... ername) |
+| logInjectionBad.js:54:17:54:51 | clc.red ... ername) |
+| logInjectionBad.js:54:43:54:50 | username |
+| logInjectionBad.js:55:17:55:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:55:17:55:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:55:27:55:56 | colors. ... ername) |
+| logInjectionBad.js:55:48:55:55 | username |
+| logInjectionBad.js:56:17:56:55 | kleur.b ... ername) |
+| logInjectionBad.js:56:17:56:55 | kleur.b ... ername) |
+| logInjectionBad.js:56:47:56:54 | username |
+| logInjectionBad.js:57:17:57:48 | chalk.u ... ername) |
+| logInjectionBad.js:57:17:57:48 | chalk.u ... ername) |
+| logInjectionBad.js:57:40:57:47 | username |
+| logInjectionBad.js:58:17:58:59 | stripAn ... rname)) |
+| logInjectionBad.js:58:17:58:59 | stripAn ... rname)) |
+| logInjectionBad.js:58:27:58:58 | chalk.u ... ername) |
+| logInjectionBad.js:58:50:58:57 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -84,56 +88,61 @@ edges
 | logInjectionBad.js:29:14:29:18 | error | logInjectionBad.js:30:42:30:46 | error |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
-| logInjectionBad.js:45:9:45:36 | q | logInjectionBad.js:46:20:46:20 | q |
-| logInjectionBad.js:45:13:45:36 | url.par ... , true) | logInjectionBad.js:45:9:45:36 | q |
-| logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:45:13:45:36 | url.par ... , true) |
-| logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:45:13:45:36 | url.par ... , true) |
-| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:48:46:48:53 | username |
-| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:49:39:49:46 | username |
-| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:50:48:50:55 | username |
-| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:51:37:51:44 | username |
-| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:52:27:52:34 | username |
-| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:53:43:53:50 | username |
-| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:54:48:54:55 | username |
-| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:55:47:55:54 | username |
-| logInjectionBad.js:46:9:46:35 | username | logInjectionBad.js:56:40:56:47 | username |
-| logInjectionBad.js:46:20:46:20 | q | logInjectionBad.js:46:20:46:26 | q.query |
-| logInjectionBad.js:46:20:46:26 | q.query | logInjectionBad.js:46:20:46:35 | q.query.username |
-| logInjectionBad.js:46:20:46:35 | q.query.username | logInjectionBad.js:46:9:46:35 | username |
-| logInjectionBad.js:48:46:48:53 | username | logInjectionBad.js:48:18:48:54 | ansiCol ... ername) |
-| logInjectionBad.js:48:46:48:53 | username | logInjectionBad.js:48:18:48:54 | ansiCol ... ername) |
-| logInjectionBad.js:49:39:49:46 | username | logInjectionBad.js:49:18:49:47 | colors. ... ername) |
-| logInjectionBad.js:49:39:49:46 | username | logInjectionBad.js:49:18:49:47 | colors. ... ername) |
-| logInjectionBad.js:50:27:50:56 | colors. ... ername) | logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:50:27:50:56 | colors. ... ername) | logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:50:48:50:55 | username | logInjectionBad.js:50:27:50:56 | colors. ... ername) |
-| logInjectionBad.js:51:27:51:46 | bold(blue(username)) | logInjectionBad.js:51:17:51:47 | underli ... name))) |
-| logInjectionBad.js:51:27:51:46 | bold(blue(username)) | logInjectionBad.js:51:17:51:47 | underli ... name))) |
-| logInjectionBad.js:51:32:51:45 | blue(username) | logInjectionBad.js:51:27:51:46 | bold(blue(username)) |
-| logInjectionBad.js:51:37:51:44 | username | logInjectionBad.js:51:32:51:45 | blue(username) |
-| logInjectionBad.js:52:27:52:34 | username | logInjectionBad.js:52:17:52:76 | highlig ...  true}) |
-| logInjectionBad.js:52:27:52:34 | username | logInjectionBad.js:52:17:52:76 | highlig ...  true}) |
-| logInjectionBad.js:53:43:53:50 | username | logInjectionBad.js:53:17:53:51 | clc.red ... ername) |
-| logInjectionBad.js:53:43:53:50 | username | logInjectionBad.js:53:17:53:51 | clc.red ... ername) |
-| logInjectionBad.js:54:27:54:56 | colors. ... ername) | logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:54:27:54:56 | colors. ... ername) | logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) |
-| logInjectionBad.js:54:48:54:55 | username | logInjectionBad.js:54:27:54:56 | colors. ... ername) |
-| logInjectionBad.js:55:47:55:54 | username | logInjectionBad.js:55:17:55:55 | kleur.b ... ername) |
-| logInjectionBad.js:55:47:55:54 | username | logInjectionBad.js:55:17:55:55 | kleur.b ... ername) |
-| logInjectionBad.js:56:40:56:47 | username | logInjectionBad.js:56:17:56:48 | chalk.u ... ername) |
-| logInjectionBad.js:56:40:56:47 | username | logInjectionBad.js:56:17:56:48 | chalk.u ... ername) |
+| logInjectionBad.js:46:9:46:36 | q | logInjectionBad.js:47:20:47:20 | q |
+| logInjectionBad.js:46:13:46:36 | url.par ... , true) | logInjectionBad.js:46:9:46:36 | q |
+| logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:46:13:46:36 | url.par ... , true) |
+| logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:46:13:46:36 | url.par ... , true) |
+| logInjectionBad.js:47:9:47:35 | username | logInjectionBad.js:49:46:49:53 | username |
+| logInjectionBad.js:47:9:47:35 | username | logInjectionBad.js:50:39:50:46 | username |
+| logInjectionBad.js:47:9:47:35 | username | logInjectionBad.js:51:48:51:55 | username |
+| logInjectionBad.js:47:9:47:35 | username | logInjectionBad.js:52:37:52:44 | username |
+| logInjectionBad.js:47:9:47:35 | username | logInjectionBad.js:53:27:53:34 | username |
+| logInjectionBad.js:47:9:47:35 | username | logInjectionBad.js:54:43:54:50 | username |
+| logInjectionBad.js:47:9:47:35 | username | logInjectionBad.js:55:48:55:55 | username |
+| logInjectionBad.js:47:9:47:35 | username | logInjectionBad.js:56:47:56:54 | username |
+| logInjectionBad.js:47:9:47:35 | username | logInjectionBad.js:57:40:57:47 | username |
+| logInjectionBad.js:47:9:47:35 | username | logInjectionBad.js:58:50:58:57 | username |
+| logInjectionBad.js:47:20:47:20 | q | logInjectionBad.js:47:20:47:26 | q.query |
+| logInjectionBad.js:47:20:47:26 | q.query | logInjectionBad.js:47:20:47:35 | q.query.username |
+| logInjectionBad.js:47:20:47:35 | q.query.username | logInjectionBad.js:47:9:47:35 | username |
+| logInjectionBad.js:49:46:49:53 | username | logInjectionBad.js:49:18:49:54 | ansiCol ... ername) |
+| logInjectionBad.js:49:46:49:53 | username | logInjectionBad.js:49:18:49:54 | ansiCol ... ername) |
+| logInjectionBad.js:50:39:50:46 | username | logInjectionBad.js:50:18:50:47 | colors. ... ername) |
+| logInjectionBad.js:50:39:50:46 | username | logInjectionBad.js:50:18:50:47 | colors. ... ername) |
+| logInjectionBad.js:51:27:51:56 | colors. ... ername) | logInjectionBad.js:51:18:51:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:51:27:51:56 | colors. ... ername) | logInjectionBad.js:51:18:51:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:51:48:51:55 | username | logInjectionBad.js:51:27:51:56 | colors. ... ername) |
+| logInjectionBad.js:52:27:52:46 | bold(blue(username)) | logInjectionBad.js:52:17:52:47 | underli ... name))) |
+| logInjectionBad.js:52:27:52:46 | bold(blue(username)) | logInjectionBad.js:52:17:52:47 | underli ... name))) |
+| logInjectionBad.js:52:32:52:45 | blue(username) | logInjectionBad.js:52:27:52:46 | bold(blue(username)) |
+| logInjectionBad.js:52:37:52:44 | username | logInjectionBad.js:52:32:52:45 | blue(username) |
+| logInjectionBad.js:53:27:53:34 | username | logInjectionBad.js:53:17:53:76 | highlig ...  true}) |
+| logInjectionBad.js:53:27:53:34 | username | logInjectionBad.js:53:17:53:76 | highlig ...  true}) |
+| logInjectionBad.js:54:43:54:50 | username | logInjectionBad.js:54:17:54:51 | clc.red ... ername) |
+| logInjectionBad.js:54:43:54:50 | username | logInjectionBad.js:54:17:54:51 | clc.red ... ername) |
+| logInjectionBad.js:55:27:55:56 | colors. ... ername) | logInjectionBad.js:55:17:55:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:55:27:55:56 | colors. ... ername) | logInjectionBad.js:55:17:55:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:55:48:55:55 | username | logInjectionBad.js:55:27:55:56 | colors. ... ername) |
+| logInjectionBad.js:56:47:56:54 | username | logInjectionBad.js:56:17:56:55 | kleur.b ... ername) |
+| logInjectionBad.js:56:47:56:54 | username | logInjectionBad.js:56:17:56:55 | kleur.b ... ername) |
+| logInjectionBad.js:57:40:57:47 | username | logInjectionBad.js:57:17:57:48 | chalk.u ... ername) |
+| logInjectionBad.js:57:40:57:47 | username | logInjectionBad.js:57:17:57:48 | chalk.u ... ername) |
+| logInjectionBad.js:58:27:58:58 | chalk.u ... ername) | logInjectionBad.js:58:17:58:59 | stripAn ... rname)) |
+| logInjectionBad.js:58:27:58:58 | chalk.u ... ername) | logInjectionBad.js:58:17:58:59 | stripAn ... rname)) |
+| logInjectionBad.js:58:50:58:57 | username | logInjectionBad.js:58:27:58:58 | chalk.u ... ername) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:24:35:24:42 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:24:35:24:42 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:25:36:25:43 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:25:36:25:43 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
-| logInjectionBad.js:48:18:48:54 | ansiCol ... ername) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:48:18:48:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
-| logInjectionBad.js:49:18:49:47 | colors. ... ername) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:49:18:49:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
-| logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:50:18:50:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
-| logInjectionBad.js:51:17:51:47 | underli ... name))) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:51:17:51:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
-| logInjectionBad.js:52:17:52:76 | highlig ...  true}) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:52:17:52:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
-| logInjectionBad.js:53:17:53:51 | clc.red ... ername) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:53:17:53:51 | clc.red ... ername) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
-| logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:54:17:54:65 | sliceAn ... 20, 30) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
-| logInjectionBad.js:55:17:55:55 | kleur.b ... ername) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:55:17:55:55 | kleur.b ... ername) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
-| logInjectionBad.js:56:17:56:48 | chalk.u ... ername) | logInjectionBad.js:45:23:45:29 | req.url | logInjectionBad.js:56:17:56:48 | chalk.u ... ername) | $@ flows to log entry. | logInjectionBad.js:45:23:45:29 | req.url | User-provided value |
+| logInjectionBad.js:49:18:49:54 | ansiCol ... ername) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:49:18:49:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
+| logInjectionBad.js:50:18:50:47 | colors. ... ername) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:50:18:50:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
+| logInjectionBad.js:51:18:51:61 | wrapAns ... e), 20) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:51:18:51:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
+| logInjectionBad.js:52:17:52:47 | underli ... name))) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:52:17:52:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
+| logInjectionBad.js:53:17:53:76 | highlig ...  true}) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:53:17:53:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
+| logInjectionBad.js:54:17:54:51 | clc.red ... ername) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:54:17:54:51 | clc.red ... ername) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
+| logInjectionBad.js:55:17:55:65 | sliceAn ... 20, 30) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:55:17:55:65 | sliceAn ... 20, 30) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
+| logInjectionBad.js:56:17:56:55 | kleur.b ... ername) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:56:17:56:55 | kleur.b ... ername) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
+| logInjectionBad.js:57:17:57:48 | chalk.u ... ername) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:57:17:57:48 | chalk.u ... ername) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
+| logInjectionBad.js:58:17:58:59 | stripAn ... rname)) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:58:17:58:59 | stripAn ... rname)) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -22,35 +22,39 @@ nodes
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error |
-| logInjectionBad.js:42:9:42:36 | q |
-| logInjectionBad.js:42:13:42:36 | url.par ... , true) |
-| logInjectionBad.js:42:23:42:29 | req.url |
-| logInjectionBad.js:42:23:42:29 | req.url |
-| logInjectionBad.js:43:9:43:35 | username |
-| logInjectionBad.js:43:20:43:20 | q |
-| logInjectionBad.js:43:20:43:26 | q.query |
-| logInjectionBad.js:43:20:43:35 | q.query.username |
-| logInjectionBad.js:45:18:45:54 | ansiCol ... ername) |
-| logInjectionBad.js:45:18:45:54 | ansiCol ... ername) |
-| logInjectionBad.js:45:46:45:53 | username |
-| logInjectionBad.js:46:18:46:47 | colors. ... ername) |
-| logInjectionBad.js:46:18:46:47 | colors. ... ername) |
-| logInjectionBad.js:46:39:46:46 | username |
-| logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:47:27:47:56 | colors. ... ername) |
-| logInjectionBad.js:47:48:47:55 | username |
-| logInjectionBad.js:48:17:48:47 | underli ... name))) |
-| logInjectionBad.js:48:17:48:47 | underli ... name))) |
-| logInjectionBad.js:48:27:48:46 | bold(blue(username)) |
-| logInjectionBad.js:48:32:48:45 | blue(username) |
-| logInjectionBad.js:48:37:48:44 | username |
-| logInjectionBad.js:49:17:49:76 | highlig ...  true}) |
-| logInjectionBad.js:49:17:49:76 | highlig ...  true}) |
-| logInjectionBad.js:49:27:49:34 | username |
-| logInjectionBad.js:50:17:50:51 | clc.red ... ername) |
-| logInjectionBad.js:50:17:50:51 | clc.red ... ername) |
-| logInjectionBad.js:50:43:50:50 | username |
+| logInjectionBad.js:43:9:43:36 | q |
+| logInjectionBad.js:43:13:43:36 | url.par ... , true) |
+| logInjectionBad.js:43:23:43:29 | req.url |
+| logInjectionBad.js:43:23:43:29 | req.url |
+| logInjectionBad.js:44:9:44:35 | username |
+| logInjectionBad.js:44:20:44:20 | q |
+| logInjectionBad.js:44:20:44:26 | q.query |
+| logInjectionBad.js:44:20:44:35 | q.query.username |
+| logInjectionBad.js:46:18:46:54 | ansiCol ... ername) |
+| logInjectionBad.js:46:18:46:54 | ansiCol ... ername) |
+| logInjectionBad.js:46:46:46:53 | username |
+| logInjectionBad.js:47:18:47:47 | colors. ... ername) |
+| logInjectionBad.js:47:18:47:47 | colors. ... ername) |
+| logInjectionBad.js:47:39:47:46 | username |
+| logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:48:27:48:56 | colors. ... ername) |
+| logInjectionBad.js:48:48:48:55 | username |
+| logInjectionBad.js:49:17:49:47 | underli ... name))) |
+| logInjectionBad.js:49:17:49:47 | underli ... name))) |
+| logInjectionBad.js:49:27:49:46 | bold(blue(username)) |
+| logInjectionBad.js:49:32:49:45 | blue(username) |
+| logInjectionBad.js:49:37:49:44 | username |
+| logInjectionBad.js:50:17:50:76 | highlig ...  true}) |
+| logInjectionBad.js:50:17:50:76 | highlig ...  true}) |
+| logInjectionBad.js:50:27:50:34 | username |
+| logInjectionBad.js:51:17:51:51 | clc.red ... ername) |
+| logInjectionBad.js:51:17:51:51 | clc.red ... ername) |
+| logInjectionBad.js:51:43:51:50 | username |
+| logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:52:27:52:56 | colors. ... ername) |
+| logInjectionBad.js:52:48:52:55 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -74,43 +78,48 @@ edges
 | logInjectionBad.js:29:14:29:18 | error | logInjectionBad.js:30:42:30:46 | error |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
-| logInjectionBad.js:42:9:42:36 | q | logInjectionBad.js:43:20:43:20 | q |
-| logInjectionBad.js:42:13:42:36 | url.par ... , true) | logInjectionBad.js:42:9:42:36 | q |
-| logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:42:13:42:36 | url.par ... , true) |
-| logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:42:13:42:36 | url.par ... , true) |
-| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:45:46:45:53 | username |
-| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:46:39:46:46 | username |
-| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:47:48:47:55 | username |
-| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:48:37:48:44 | username |
-| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:49:27:49:34 | username |
-| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:50:43:50:50 | username |
-| logInjectionBad.js:43:20:43:20 | q | logInjectionBad.js:43:20:43:26 | q.query |
-| logInjectionBad.js:43:20:43:26 | q.query | logInjectionBad.js:43:20:43:35 | q.query.username |
-| logInjectionBad.js:43:20:43:35 | q.query.username | logInjectionBad.js:43:9:43:35 | username |
-| logInjectionBad.js:45:46:45:53 | username | logInjectionBad.js:45:18:45:54 | ansiCol ... ername) |
-| logInjectionBad.js:45:46:45:53 | username | logInjectionBad.js:45:18:45:54 | ansiCol ... ername) |
-| logInjectionBad.js:46:39:46:46 | username | logInjectionBad.js:46:18:46:47 | colors. ... ername) |
-| logInjectionBad.js:46:39:46:46 | username | logInjectionBad.js:46:18:46:47 | colors. ... ername) |
-| logInjectionBad.js:47:27:47:56 | colors. ... ername) | logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:47:27:47:56 | colors. ... ername) | logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:47:48:47:55 | username | logInjectionBad.js:47:27:47:56 | colors. ... ername) |
-| logInjectionBad.js:48:27:48:46 | bold(blue(username)) | logInjectionBad.js:48:17:48:47 | underli ... name))) |
-| logInjectionBad.js:48:27:48:46 | bold(blue(username)) | logInjectionBad.js:48:17:48:47 | underli ... name))) |
-| logInjectionBad.js:48:32:48:45 | blue(username) | logInjectionBad.js:48:27:48:46 | bold(blue(username)) |
-| logInjectionBad.js:48:37:48:44 | username | logInjectionBad.js:48:32:48:45 | blue(username) |
-| logInjectionBad.js:49:27:49:34 | username | logInjectionBad.js:49:17:49:76 | highlig ...  true}) |
-| logInjectionBad.js:49:27:49:34 | username | logInjectionBad.js:49:17:49:76 | highlig ...  true}) |
-| logInjectionBad.js:50:43:50:50 | username | logInjectionBad.js:50:17:50:51 | clc.red ... ername) |
-| logInjectionBad.js:50:43:50:50 | username | logInjectionBad.js:50:17:50:51 | clc.red ... ername) |
+| logInjectionBad.js:43:9:43:36 | q | logInjectionBad.js:44:20:44:20 | q |
+| logInjectionBad.js:43:13:43:36 | url.par ... , true) | logInjectionBad.js:43:9:43:36 | q |
+| logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:43:13:43:36 | url.par ... , true) |
+| logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:43:13:43:36 | url.par ... , true) |
+| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:46:46:46:53 | username |
+| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:47:39:47:46 | username |
+| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:48:48:48:55 | username |
+| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:49:37:49:44 | username |
+| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:50:27:50:34 | username |
+| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:51:43:51:50 | username |
+| logInjectionBad.js:44:9:44:35 | username | logInjectionBad.js:52:48:52:55 | username |
+| logInjectionBad.js:44:20:44:20 | q | logInjectionBad.js:44:20:44:26 | q.query |
+| logInjectionBad.js:44:20:44:26 | q.query | logInjectionBad.js:44:20:44:35 | q.query.username |
+| logInjectionBad.js:44:20:44:35 | q.query.username | logInjectionBad.js:44:9:44:35 | username |
+| logInjectionBad.js:46:46:46:53 | username | logInjectionBad.js:46:18:46:54 | ansiCol ... ername) |
+| logInjectionBad.js:46:46:46:53 | username | logInjectionBad.js:46:18:46:54 | ansiCol ... ername) |
+| logInjectionBad.js:47:39:47:46 | username | logInjectionBad.js:47:18:47:47 | colors. ... ername) |
+| logInjectionBad.js:47:39:47:46 | username | logInjectionBad.js:47:18:47:47 | colors. ... ername) |
+| logInjectionBad.js:48:27:48:56 | colors. ... ername) | logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:48:27:48:56 | colors. ... ername) | logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:48:48:48:55 | username | logInjectionBad.js:48:27:48:56 | colors. ... ername) |
+| logInjectionBad.js:49:27:49:46 | bold(blue(username)) | logInjectionBad.js:49:17:49:47 | underli ... name))) |
+| logInjectionBad.js:49:27:49:46 | bold(blue(username)) | logInjectionBad.js:49:17:49:47 | underli ... name))) |
+| logInjectionBad.js:49:32:49:45 | blue(username) | logInjectionBad.js:49:27:49:46 | bold(blue(username)) |
+| logInjectionBad.js:49:37:49:44 | username | logInjectionBad.js:49:32:49:45 | blue(username) |
+| logInjectionBad.js:50:27:50:34 | username | logInjectionBad.js:50:17:50:76 | highlig ...  true}) |
+| logInjectionBad.js:50:27:50:34 | username | logInjectionBad.js:50:17:50:76 | highlig ...  true}) |
+| logInjectionBad.js:51:43:51:50 | username | logInjectionBad.js:51:17:51:51 | clc.red ... ername) |
+| logInjectionBad.js:51:43:51:50 | username | logInjectionBad.js:51:17:51:51 | clc.red ... ername) |
+| logInjectionBad.js:52:27:52:56 | colors. ... ername) | logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:52:27:52:56 | colors. ... ername) | logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) |
+| logInjectionBad.js:52:48:52:55 | username | logInjectionBad.js:52:27:52:56 | colors. ... ername) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:24:35:24:42 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:24:35:24:42 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:25:36:25:43 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:25:36:25:43 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
-| logInjectionBad.js:45:18:45:54 | ansiCol ... ername) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:45:18:45:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
-| logInjectionBad.js:46:18:46:47 | colors. ... ername) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:46:18:46:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
-| logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
-| logInjectionBad.js:48:17:48:47 | underli ... name))) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:48:17:48:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
-| logInjectionBad.js:49:17:49:76 | highlig ...  true}) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:49:17:49:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
-| logInjectionBad.js:50:17:50:51 | clc.red ... ername) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:50:17:50:51 | clc.red ... ername) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
+| logInjectionBad.js:46:18:46:54 | ansiCol ... ername) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:46:18:46:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
+| logInjectionBad.js:47:18:47:47 | colors. ... ername) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:47:18:47:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
+| logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:48:18:48:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
+| logInjectionBad.js:49:17:49:47 | underli ... name))) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:49:17:49:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
+| logInjectionBad.js:50:17:50:76 | highlig ...  true}) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:50:17:50:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
+| logInjectionBad.js:51:17:51:51 | clc.red ... ername) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:51:17:51:51 | clc.red ... ername) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |
+| logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) | logInjectionBad.js:43:23:43:29 | req.url | logInjectionBad.js:52:17:52:65 | sliceAn ... 20, 30) | $@ flows to log entry. | logInjectionBad.js:43:23:43:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -22,20 +22,24 @@ nodes
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error |
-| logInjectionBad.js:38:9:38:36 | q |
-| logInjectionBad.js:38:13:38:36 | url.par ... , true) |
-| logInjectionBad.js:38:23:38:29 | req.url |
-| logInjectionBad.js:38:23:38:29 | req.url |
-| logInjectionBad.js:39:9:39:35 | username |
-| logInjectionBad.js:39:20:39:20 | q |
-| logInjectionBad.js:39:20:39:26 | q.query |
-| logInjectionBad.js:39:20:39:35 | q.query.username |
-| logInjectionBad.js:41:18:41:54 | ansiCol ... ername) |
-| logInjectionBad.js:41:18:41:54 | ansiCol ... ername) |
-| logInjectionBad.js:41:46:41:53 | username |
-| logInjectionBad.js:42:18:42:47 | colors. ... ername) |
-| logInjectionBad.js:42:18:42:47 | colors. ... ername) |
-| logInjectionBad.js:42:39:42:46 | username |
+| logInjectionBad.js:39:9:39:36 | q |
+| logInjectionBad.js:39:13:39:36 | url.par ... , true) |
+| logInjectionBad.js:39:23:39:29 | req.url |
+| logInjectionBad.js:39:23:39:29 | req.url |
+| logInjectionBad.js:40:9:40:35 | username |
+| logInjectionBad.js:40:20:40:20 | q |
+| logInjectionBad.js:40:20:40:26 | q.query |
+| logInjectionBad.js:40:20:40:35 | q.query.username |
+| logInjectionBad.js:42:18:42:54 | ansiCol ... ername) |
+| logInjectionBad.js:42:18:42:54 | ansiCol ... ername) |
+| logInjectionBad.js:42:46:42:53 | username |
+| logInjectionBad.js:43:18:43:47 | colors. ... ername) |
+| logInjectionBad.js:43:18:43:47 | colors. ... ername) |
+| logInjectionBad.js:43:39:43:46 | username |
+| logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:44:27:44:56 | colors. ... ername) |
+| logInjectionBad.js:44:48:44:55 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -59,24 +63,29 @@ edges
 | logInjectionBad.js:29:14:29:18 | error | logInjectionBad.js:30:42:30:46 | error |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
-| logInjectionBad.js:38:9:38:36 | q | logInjectionBad.js:39:20:39:20 | q |
-| logInjectionBad.js:38:13:38:36 | url.par ... , true) | logInjectionBad.js:38:9:38:36 | q |
-| logInjectionBad.js:38:23:38:29 | req.url | logInjectionBad.js:38:13:38:36 | url.par ... , true) |
-| logInjectionBad.js:38:23:38:29 | req.url | logInjectionBad.js:38:13:38:36 | url.par ... , true) |
-| logInjectionBad.js:39:9:39:35 | username | logInjectionBad.js:41:46:41:53 | username |
-| logInjectionBad.js:39:9:39:35 | username | logInjectionBad.js:42:39:42:46 | username |
-| logInjectionBad.js:39:20:39:20 | q | logInjectionBad.js:39:20:39:26 | q.query |
-| logInjectionBad.js:39:20:39:26 | q.query | logInjectionBad.js:39:20:39:35 | q.query.username |
-| logInjectionBad.js:39:20:39:35 | q.query.username | logInjectionBad.js:39:9:39:35 | username |
-| logInjectionBad.js:41:46:41:53 | username | logInjectionBad.js:41:18:41:54 | ansiCol ... ername) |
-| logInjectionBad.js:41:46:41:53 | username | logInjectionBad.js:41:18:41:54 | ansiCol ... ername) |
-| logInjectionBad.js:42:39:42:46 | username | logInjectionBad.js:42:18:42:47 | colors. ... ername) |
-| logInjectionBad.js:42:39:42:46 | username | logInjectionBad.js:42:18:42:47 | colors. ... ername) |
+| logInjectionBad.js:39:9:39:36 | q | logInjectionBad.js:40:20:40:20 | q |
+| logInjectionBad.js:39:13:39:36 | url.par ... , true) | logInjectionBad.js:39:9:39:36 | q |
+| logInjectionBad.js:39:23:39:29 | req.url | logInjectionBad.js:39:13:39:36 | url.par ... , true) |
+| logInjectionBad.js:39:23:39:29 | req.url | logInjectionBad.js:39:13:39:36 | url.par ... , true) |
+| logInjectionBad.js:40:9:40:35 | username | logInjectionBad.js:42:46:42:53 | username |
+| logInjectionBad.js:40:9:40:35 | username | logInjectionBad.js:43:39:43:46 | username |
+| logInjectionBad.js:40:9:40:35 | username | logInjectionBad.js:44:48:44:55 | username |
+| logInjectionBad.js:40:20:40:20 | q | logInjectionBad.js:40:20:40:26 | q.query |
+| logInjectionBad.js:40:20:40:26 | q.query | logInjectionBad.js:40:20:40:35 | q.query.username |
+| logInjectionBad.js:40:20:40:35 | q.query.username | logInjectionBad.js:40:9:40:35 | username |
+| logInjectionBad.js:42:46:42:53 | username | logInjectionBad.js:42:18:42:54 | ansiCol ... ername) |
+| logInjectionBad.js:42:46:42:53 | username | logInjectionBad.js:42:18:42:54 | ansiCol ... ername) |
+| logInjectionBad.js:43:39:43:46 | username | logInjectionBad.js:43:18:43:47 | colors. ... ername) |
+| logInjectionBad.js:43:39:43:46 | username | logInjectionBad.js:43:18:43:47 | colors. ... ername) |
+| logInjectionBad.js:44:27:44:56 | colors. ... ername) | logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:44:27:44:56 | colors. ... ername) | logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:44:48:44:55 | username | logInjectionBad.js:44:27:44:56 | colors. ... ername) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:24:35:24:42 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:24:35:24:42 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:25:36:25:43 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:25:36:25:43 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
-| logInjectionBad.js:41:18:41:54 | ansiCol ... ername) | logInjectionBad.js:38:23:38:29 | req.url | logInjectionBad.js:41:18:41:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:38:23:38:29 | req.url | User-provided value |
-| logInjectionBad.js:42:18:42:47 | colors. ... ername) | logInjectionBad.js:38:23:38:29 | req.url | logInjectionBad.js:42:18:42:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:38:23:38:29 | req.url | User-provided value |
+| logInjectionBad.js:42:18:42:54 | ansiCol ... ername) | logInjectionBad.js:39:23:39:29 | req.url | logInjectionBad.js:42:18:42:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:39:23:39:29 | req.url | User-provided value |
+| logInjectionBad.js:43:18:43:47 | colors. ... ername) | logInjectionBad.js:39:23:39:29 | req.url | logInjectionBad.js:43:18:43:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:39:23:39:29 | req.url | User-provided value |
+| logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) | logInjectionBad.js:39:23:39:29 | req.url | logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:39:23:39:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -22,32 +22,35 @@ nodes
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error |
-| logInjectionBad.js:41:9:41:36 | q |
-| logInjectionBad.js:41:13:41:36 | url.par ... , true) |
-| logInjectionBad.js:41:23:41:29 | req.url |
-| logInjectionBad.js:41:23:41:29 | req.url |
-| logInjectionBad.js:42:9:42:35 | username |
-| logInjectionBad.js:42:20:42:20 | q |
-| logInjectionBad.js:42:20:42:26 | q.query |
-| logInjectionBad.js:42:20:42:35 | q.query.username |
-| logInjectionBad.js:44:18:44:54 | ansiCol ... ername) |
-| logInjectionBad.js:44:18:44:54 | ansiCol ... ername) |
-| logInjectionBad.js:44:46:44:53 | username |
-| logInjectionBad.js:45:18:45:47 | colors. ... ername) |
-| logInjectionBad.js:45:18:45:47 | colors. ... ername) |
-| logInjectionBad.js:45:39:45:46 | username |
-| logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:46:27:46:56 | colors. ... ername) |
-| logInjectionBad.js:46:48:46:55 | username |
-| logInjectionBad.js:47:17:47:47 | underli ... name))) |
-| logInjectionBad.js:47:17:47:47 | underli ... name))) |
-| logInjectionBad.js:47:27:47:46 | bold(blue(username)) |
-| logInjectionBad.js:47:32:47:45 | blue(username) |
-| logInjectionBad.js:47:37:47:44 | username |
-| logInjectionBad.js:48:17:48:76 | highlig ...  true}) |
-| logInjectionBad.js:48:17:48:76 | highlig ...  true}) |
-| logInjectionBad.js:48:27:48:34 | username |
+| logInjectionBad.js:42:9:42:36 | q |
+| logInjectionBad.js:42:13:42:36 | url.par ... , true) |
+| logInjectionBad.js:42:23:42:29 | req.url |
+| logInjectionBad.js:42:23:42:29 | req.url |
+| logInjectionBad.js:43:9:43:35 | username |
+| logInjectionBad.js:43:20:43:20 | q |
+| logInjectionBad.js:43:20:43:26 | q.query |
+| logInjectionBad.js:43:20:43:35 | q.query.username |
+| logInjectionBad.js:45:18:45:54 | ansiCol ... ername) |
+| logInjectionBad.js:45:18:45:54 | ansiCol ... ername) |
+| logInjectionBad.js:45:46:45:53 | username |
+| logInjectionBad.js:46:18:46:47 | colors. ... ername) |
+| logInjectionBad.js:46:18:46:47 | colors. ... ername) |
+| logInjectionBad.js:46:39:46:46 | username |
+| logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:47:27:47:56 | colors. ... ername) |
+| logInjectionBad.js:47:48:47:55 | username |
+| logInjectionBad.js:48:17:48:47 | underli ... name))) |
+| logInjectionBad.js:48:17:48:47 | underli ... name))) |
+| logInjectionBad.js:48:27:48:46 | bold(blue(username)) |
+| logInjectionBad.js:48:32:48:45 | blue(username) |
+| logInjectionBad.js:48:37:48:44 | username |
+| logInjectionBad.js:49:17:49:76 | highlig ...  true}) |
+| logInjectionBad.js:49:17:49:76 | highlig ...  true}) |
+| logInjectionBad.js:49:27:49:34 | username |
+| logInjectionBad.js:50:17:50:51 | clc.red ... ername) |
+| logInjectionBad.js:50:17:50:51 | clc.red ... ername) |
+| logInjectionBad.js:50:43:50:50 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -71,39 +74,43 @@ edges
 | logInjectionBad.js:29:14:29:18 | error | logInjectionBad.js:30:42:30:46 | error |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
-| logInjectionBad.js:41:9:41:36 | q | logInjectionBad.js:42:20:42:20 | q |
-| logInjectionBad.js:41:13:41:36 | url.par ... , true) | logInjectionBad.js:41:9:41:36 | q |
-| logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:41:13:41:36 | url.par ... , true) |
-| logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:41:13:41:36 | url.par ... , true) |
-| logInjectionBad.js:42:9:42:35 | username | logInjectionBad.js:44:46:44:53 | username |
-| logInjectionBad.js:42:9:42:35 | username | logInjectionBad.js:45:39:45:46 | username |
-| logInjectionBad.js:42:9:42:35 | username | logInjectionBad.js:46:48:46:55 | username |
-| logInjectionBad.js:42:9:42:35 | username | logInjectionBad.js:47:37:47:44 | username |
-| logInjectionBad.js:42:9:42:35 | username | logInjectionBad.js:48:27:48:34 | username |
-| logInjectionBad.js:42:20:42:20 | q | logInjectionBad.js:42:20:42:26 | q.query |
-| logInjectionBad.js:42:20:42:26 | q.query | logInjectionBad.js:42:20:42:35 | q.query.username |
-| logInjectionBad.js:42:20:42:35 | q.query.username | logInjectionBad.js:42:9:42:35 | username |
-| logInjectionBad.js:44:46:44:53 | username | logInjectionBad.js:44:18:44:54 | ansiCol ... ername) |
-| logInjectionBad.js:44:46:44:53 | username | logInjectionBad.js:44:18:44:54 | ansiCol ... ername) |
-| logInjectionBad.js:45:39:45:46 | username | logInjectionBad.js:45:18:45:47 | colors. ... ername) |
-| logInjectionBad.js:45:39:45:46 | username | logInjectionBad.js:45:18:45:47 | colors. ... ername) |
-| logInjectionBad.js:46:27:46:56 | colors. ... ername) | logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:46:27:46:56 | colors. ... ername) | logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:46:48:46:55 | username | logInjectionBad.js:46:27:46:56 | colors. ... ername) |
-| logInjectionBad.js:47:27:47:46 | bold(blue(username)) | logInjectionBad.js:47:17:47:47 | underli ... name))) |
-| logInjectionBad.js:47:27:47:46 | bold(blue(username)) | logInjectionBad.js:47:17:47:47 | underli ... name))) |
-| logInjectionBad.js:47:32:47:45 | blue(username) | logInjectionBad.js:47:27:47:46 | bold(blue(username)) |
-| logInjectionBad.js:47:37:47:44 | username | logInjectionBad.js:47:32:47:45 | blue(username) |
-| logInjectionBad.js:48:27:48:34 | username | logInjectionBad.js:48:17:48:76 | highlig ...  true}) |
-| logInjectionBad.js:48:27:48:34 | username | logInjectionBad.js:48:17:48:76 | highlig ...  true}) |
+| logInjectionBad.js:42:9:42:36 | q | logInjectionBad.js:43:20:43:20 | q |
+| logInjectionBad.js:42:13:42:36 | url.par ... , true) | logInjectionBad.js:42:9:42:36 | q |
+| logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:42:13:42:36 | url.par ... , true) |
+| logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:42:13:42:36 | url.par ... , true) |
+| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:45:46:45:53 | username |
+| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:46:39:46:46 | username |
+| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:47:48:47:55 | username |
+| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:48:37:48:44 | username |
+| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:49:27:49:34 | username |
+| logInjectionBad.js:43:9:43:35 | username | logInjectionBad.js:50:43:50:50 | username |
+| logInjectionBad.js:43:20:43:20 | q | logInjectionBad.js:43:20:43:26 | q.query |
+| logInjectionBad.js:43:20:43:26 | q.query | logInjectionBad.js:43:20:43:35 | q.query.username |
+| logInjectionBad.js:43:20:43:35 | q.query.username | logInjectionBad.js:43:9:43:35 | username |
+| logInjectionBad.js:45:46:45:53 | username | logInjectionBad.js:45:18:45:54 | ansiCol ... ername) |
+| logInjectionBad.js:45:46:45:53 | username | logInjectionBad.js:45:18:45:54 | ansiCol ... ername) |
+| logInjectionBad.js:46:39:46:46 | username | logInjectionBad.js:46:18:46:47 | colors. ... ername) |
+| logInjectionBad.js:46:39:46:46 | username | logInjectionBad.js:46:18:46:47 | colors. ... ername) |
+| logInjectionBad.js:47:27:47:56 | colors. ... ername) | logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:47:27:47:56 | colors. ... ername) | logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:47:48:47:55 | username | logInjectionBad.js:47:27:47:56 | colors. ... ername) |
+| logInjectionBad.js:48:27:48:46 | bold(blue(username)) | logInjectionBad.js:48:17:48:47 | underli ... name))) |
+| logInjectionBad.js:48:27:48:46 | bold(blue(username)) | logInjectionBad.js:48:17:48:47 | underli ... name))) |
+| logInjectionBad.js:48:32:48:45 | blue(username) | logInjectionBad.js:48:27:48:46 | bold(blue(username)) |
+| logInjectionBad.js:48:37:48:44 | username | logInjectionBad.js:48:32:48:45 | blue(username) |
+| logInjectionBad.js:49:27:49:34 | username | logInjectionBad.js:49:17:49:76 | highlig ...  true}) |
+| logInjectionBad.js:49:27:49:34 | username | logInjectionBad.js:49:17:49:76 | highlig ...  true}) |
+| logInjectionBad.js:50:43:50:50 | username | logInjectionBad.js:50:17:50:51 | clc.red ... ername) |
+| logInjectionBad.js:50:43:50:50 | username | logInjectionBad.js:50:17:50:51 | clc.red ... ername) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:24:35:24:42 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:24:35:24:42 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:25:36:25:43 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:25:36:25:43 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
-| logInjectionBad.js:44:18:44:54 | ansiCol ... ername) | logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:44:18:44:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:41:23:41:29 | req.url | User-provided value |
-| logInjectionBad.js:45:18:45:47 | colors. ... ername) | logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:45:18:45:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:41:23:41:29 | req.url | User-provided value |
-| logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) | logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:46:18:46:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:41:23:41:29 | req.url | User-provided value |
-| logInjectionBad.js:47:17:47:47 | underli ... name))) | logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:47:17:47:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:41:23:41:29 | req.url | User-provided value |
-| logInjectionBad.js:48:17:48:76 | highlig ...  true}) | logInjectionBad.js:41:23:41:29 | req.url | logInjectionBad.js:48:17:48:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:41:23:41:29 | req.url | User-provided value |
+| logInjectionBad.js:45:18:45:54 | ansiCol ... ername) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:45:18:45:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
+| logInjectionBad.js:46:18:46:47 | colors. ... ername) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:46:18:46:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
+| logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:47:18:47:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
+| logInjectionBad.js:48:17:48:47 | underli ... name))) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:48:17:48:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
+| logInjectionBad.js:49:17:49:76 | highlig ...  true}) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:49:17:49:76 | highlig ...  true}) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |
+| logInjectionBad.js:50:17:50:51 | clc.red ... ername) | logInjectionBad.js:42:23:42:29 | req.url | logInjectionBad.js:50:17:50:51 | clc.red ... ername) | $@ flows to log entry. | logInjectionBad.js:42:23:42:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -22,6 +22,17 @@ nodes
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error |
+| logInjectionBad.js:37:9:37:36 | q |
+| logInjectionBad.js:37:13:37:36 | url.par ... , true) |
+| logInjectionBad.js:37:23:37:29 | req.url |
+| logInjectionBad.js:37:23:37:29 | req.url |
+| logInjectionBad.js:38:9:38:35 | username |
+| logInjectionBad.js:38:20:38:20 | q |
+| logInjectionBad.js:38:20:38:26 | q.query |
+| logInjectionBad.js:38:20:38:35 | q.query.username |
+| logInjectionBad.js:40:18:40:54 | ansiCol ... ername) |
+| logInjectionBad.js:40:18:40:54 | ansiCol ... ername) |
+| logInjectionBad.js:40:46:40:53 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -45,9 +56,20 @@ edges
 | logInjectionBad.js:29:14:29:18 | error | logInjectionBad.js:30:42:30:46 | error |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
+| logInjectionBad.js:37:9:37:36 | q | logInjectionBad.js:38:20:38:20 | q |
+| logInjectionBad.js:37:13:37:36 | url.par ... , true) | logInjectionBad.js:37:9:37:36 | q |
+| logInjectionBad.js:37:23:37:29 | req.url | logInjectionBad.js:37:13:37:36 | url.par ... , true) |
+| logInjectionBad.js:37:23:37:29 | req.url | logInjectionBad.js:37:13:37:36 | url.par ... , true) |
+| logInjectionBad.js:38:9:38:35 | username | logInjectionBad.js:40:46:40:53 | username |
+| logInjectionBad.js:38:20:38:20 | q | logInjectionBad.js:38:20:38:26 | q.query |
+| logInjectionBad.js:38:20:38:26 | q.query | logInjectionBad.js:38:20:38:35 | q.query.username |
+| logInjectionBad.js:38:20:38:35 | q.query.username | logInjectionBad.js:38:9:38:35 | username |
+| logInjectionBad.js:40:46:40:53 | username | logInjectionBad.js:40:18:40:54 | ansiCol ... ername) |
+| logInjectionBad.js:40:46:40:53 | username | logInjectionBad.js:40:18:40:54 | ansiCol ... ername) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:24:35:24:42 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:24:35:24:42 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:25:36:25:43 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:25:36:25:43 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
+| logInjectionBad.js:40:18:40:54 | ansiCol ... ername) | logInjectionBad.js:37:23:37:29 | req.url | logInjectionBad.js:40:18:40:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:37:23:37:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -22,24 +22,29 @@ nodes
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error |
-| logInjectionBad.js:39:9:39:36 | q |
-| logInjectionBad.js:39:13:39:36 | url.par ... , true) |
-| logInjectionBad.js:39:23:39:29 | req.url |
-| logInjectionBad.js:39:23:39:29 | req.url |
-| logInjectionBad.js:40:9:40:35 | username |
-| logInjectionBad.js:40:20:40:20 | q |
-| logInjectionBad.js:40:20:40:26 | q.query |
-| logInjectionBad.js:40:20:40:35 | q.query.username |
-| logInjectionBad.js:42:18:42:54 | ansiCol ... ername) |
-| logInjectionBad.js:42:18:42:54 | ansiCol ... ername) |
-| logInjectionBad.js:42:46:42:53 | username |
-| logInjectionBad.js:43:18:43:47 | colors. ... ername) |
-| logInjectionBad.js:43:18:43:47 | colors. ... ername) |
-| logInjectionBad.js:43:39:43:46 | username |
-| logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:44:27:44:56 | colors. ... ername) |
-| logInjectionBad.js:44:48:44:55 | username |
+| logInjectionBad.js:40:9:40:36 | q |
+| logInjectionBad.js:40:13:40:36 | url.par ... , true) |
+| logInjectionBad.js:40:23:40:29 | req.url |
+| logInjectionBad.js:40:23:40:29 | req.url |
+| logInjectionBad.js:41:9:41:35 | username |
+| logInjectionBad.js:41:20:41:20 | q |
+| logInjectionBad.js:41:20:41:26 | q.query |
+| logInjectionBad.js:41:20:41:35 | q.query.username |
+| logInjectionBad.js:43:18:43:54 | ansiCol ... ername) |
+| logInjectionBad.js:43:18:43:54 | ansiCol ... ername) |
+| logInjectionBad.js:43:46:43:53 | username |
+| logInjectionBad.js:44:18:44:47 | colors. ... ername) |
+| logInjectionBad.js:44:18:44:47 | colors. ... ername) |
+| logInjectionBad.js:44:39:44:46 | username |
+| logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:45:27:45:56 | colors. ... ername) |
+| logInjectionBad.js:45:48:45:55 | username |
+| logInjectionBad.js:46:17:46:47 | underli ... name))) |
+| logInjectionBad.js:46:17:46:47 | underli ... name))) |
+| logInjectionBad.js:46:27:46:46 | bold(blue(username)) |
+| logInjectionBad.js:46:32:46:45 | blue(username) |
+| logInjectionBad.js:46:37:46:44 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -63,29 +68,35 @@ edges
 | logInjectionBad.js:29:14:29:18 | error | logInjectionBad.js:30:42:30:46 | error |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
-| logInjectionBad.js:39:9:39:36 | q | logInjectionBad.js:40:20:40:20 | q |
-| logInjectionBad.js:39:13:39:36 | url.par ... , true) | logInjectionBad.js:39:9:39:36 | q |
-| logInjectionBad.js:39:23:39:29 | req.url | logInjectionBad.js:39:13:39:36 | url.par ... , true) |
-| logInjectionBad.js:39:23:39:29 | req.url | logInjectionBad.js:39:13:39:36 | url.par ... , true) |
-| logInjectionBad.js:40:9:40:35 | username | logInjectionBad.js:42:46:42:53 | username |
-| logInjectionBad.js:40:9:40:35 | username | logInjectionBad.js:43:39:43:46 | username |
-| logInjectionBad.js:40:9:40:35 | username | logInjectionBad.js:44:48:44:55 | username |
-| logInjectionBad.js:40:20:40:20 | q | logInjectionBad.js:40:20:40:26 | q.query |
-| logInjectionBad.js:40:20:40:26 | q.query | logInjectionBad.js:40:20:40:35 | q.query.username |
-| logInjectionBad.js:40:20:40:35 | q.query.username | logInjectionBad.js:40:9:40:35 | username |
-| logInjectionBad.js:42:46:42:53 | username | logInjectionBad.js:42:18:42:54 | ansiCol ... ername) |
-| logInjectionBad.js:42:46:42:53 | username | logInjectionBad.js:42:18:42:54 | ansiCol ... ername) |
-| logInjectionBad.js:43:39:43:46 | username | logInjectionBad.js:43:18:43:47 | colors. ... ername) |
-| logInjectionBad.js:43:39:43:46 | username | logInjectionBad.js:43:18:43:47 | colors. ... ername) |
-| logInjectionBad.js:44:27:44:56 | colors. ... ername) | logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:44:27:44:56 | colors. ... ername) | logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) |
-| logInjectionBad.js:44:48:44:55 | username | logInjectionBad.js:44:27:44:56 | colors. ... ername) |
+| logInjectionBad.js:40:9:40:36 | q | logInjectionBad.js:41:20:41:20 | q |
+| logInjectionBad.js:40:13:40:36 | url.par ... , true) | logInjectionBad.js:40:9:40:36 | q |
+| logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:40:13:40:36 | url.par ... , true) |
+| logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:40:13:40:36 | url.par ... , true) |
+| logInjectionBad.js:41:9:41:35 | username | logInjectionBad.js:43:46:43:53 | username |
+| logInjectionBad.js:41:9:41:35 | username | logInjectionBad.js:44:39:44:46 | username |
+| logInjectionBad.js:41:9:41:35 | username | logInjectionBad.js:45:48:45:55 | username |
+| logInjectionBad.js:41:9:41:35 | username | logInjectionBad.js:46:37:46:44 | username |
+| logInjectionBad.js:41:20:41:20 | q | logInjectionBad.js:41:20:41:26 | q.query |
+| logInjectionBad.js:41:20:41:26 | q.query | logInjectionBad.js:41:20:41:35 | q.query.username |
+| logInjectionBad.js:41:20:41:35 | q.query.username | logInjectionBad.js:41:9:41:35 | username |
+| logInjectionBad.js:43:46:43:53 | username | logInjectionBad.js:43:18:43:54 | ansiCol ... ername) |
+| logInjectionBad.js:43:46:43:53 | username | logInjectionBad.js:43:18:43:54 | ansiCol ... ername) |
+| logInjectionBad.js:44:39:44:46 | username | logInjectionBad.js:44:18:44:47 | colors. ... ername) |
+| logInjectionBad.js:44:39:44:46 | username | logInjectionBad.js:44:18:44:47 | colors. ... ername) |
+| logInjectionBad.js:45:27:45:56 | colors. ... ername) | logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:45:27:45:56 | colors. ... ername) | logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) |
+| logInjectionBad.js:45:48:45:55 | username | logInjectionBad.js:45:27:45:56 | colors. ... ername) |
+| logInjectionBad.js:46:27:46:46 | bold(blue(username)) | logInjectionBad.js:46:17:46:47 | underli ... name))) |
+| logInjectionBad.js:46:27:46:46 | bold(blue(username)) | logInjectionBad.js:46:17:46:47 | underli ... name))) |
+| logInjectionBad.js:46:32:46:45 | blue(username) | logInjectionBad.js:46:27:46:46 | bold(blue(username)) |
+| logInjectionBad.js:46:37:46:44 | username | logInjectionBad.js:46:32:46:45 | blue(username) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:24:35:24:42 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:24:35:24:42 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:25:36:25:43 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:25:36:25:43 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
-| logInjectionBad.js:42:18:42:54 | ansiCol ... ername) | logInjectionBad.js:39:23:39:29 | req.url | logInjectionBad.js:42:18:42:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:39:23:39:29 | req.url | User-provided value |
-| logInjectionBad.js:43:18:43:47 | colors. ... ername) | logInjectionBad.js:39:23:39:29 | req.url | logInjectionBad.js:43:18:43:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:39:23:39:29 | req.url | User-provided value |
-| logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) | logInjectionBad.js:39:23:39:29 | req.url | logInjectionBad.js:44:18:44:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:39:23:39:29 | req.url | User-provided value |
+| logInjectionBad.js:43:18:43:54 | ansiCol ... ername) | logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:43:18:43:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:40:23:40:29 | req.url | User-provided value |
+| logInjectionBad.js:44:18:44:47 | colors. ... ername) | logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:44:18:44:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:40:23:40:29 | req.url | User-provided value |
+| logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) | logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:45:18:45:61 | wrapAns ... e), 20) | $@ flows to log entry. | logInjectionBad.js:40:23:40:29 | req.url | User-provided value |
+| logInjectionBad.js:46:17:46:47 | underli ... name))) | logInjectionBad.js:40:23:40:29 | req.url | logInjectionBad.js:46:17:46:47 | underli ... name))) | $@ flows to log entry. | logInjectionBad.js:40:23:40:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -22,17 +22,20 @@ nodes
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error |
-| logInjectionBad.js:37:9:37:36 | q |
-| logInjectionBad.js:37:13:37:36 | url.par ... , true) |
-| logInjectionBad.js:37:23:37:29 | req.url |
-| logInjectionBad.js:37:23:37:29 | req.url |
-| logInjectionBad.js:38:9:38:35 | username |
-| logInjectionBad.js:38:20:38:20 | q |
-| logInjectionBad.js:38:20:38:26 | q.query |
-| logInjectionBad.js:38:20:38:35 | q.query.username |
-| logInjectionBad.js:40:18:40:54 | ansiCol ... ername) |
-| logInjectionBad.js:40:18:40:54 | ansiCol ... ername) |
-| logInjectionBad.js:40:46:40:53 | username |
+| logInjectionBad.js:38:9:38:36 | q |
+| logInjectionBad.js:38:13:38:36 | url.par ... , true) |
+| logInjectionBad.js:38:23:38:29 | req.url |
+| logInjectionBad.js:38:23:38:29 | req.url |
+| logInjectionBad.js:39:9:39:35 | username |
+| logInjectionBad.js:39:20:39:20 | q |
+| logInjectionBad.js:39:20:39:26 | q.query |
+| logInjectionBad.js:39:20:39:35 | q.query.username |
+| logInjectionBad.js:41:18:41:54 | ansiCol ... ername) |
+| logInjectionBad.js:41:18:41:54 | ansiCol ... ername) |
+| logInjectionBad.js:41:46:41:53 | username |
+| logInjectionBad.js:42:18:42:47 | colors. ... ername) |
+| logInjectionBad.js:42:18:42:47 | colors. ... ername) |
+| logInjectionBad.js:42:39:42:46 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -56,20 +59,24 @@ edges
 | logInjectionBad.js:29:14:29:18 | error | logInjectionBad.js:30:42:30:46 | error |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
 | logInjectionBad.js:30:42:30:46 | error | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` |
-| logInjectionBad.js:37:9:37:36 | q | logInjectionBad.js:38:20:38:20 | q |
-| logInjectionBad.js:37:13:37:36 | url.par ... , true) | logInjectionBad.js:37:9:37:36 | q |
-| logInjectionBad.js:37:23:37:29 | req.url | logInjectionBad.js:37:13:37:36 | url.par ... , true) |
-| logInjectionBad.js:37:23:37:29 | req.url | logInjectionBad.js:37:13:37:36 | url.par ... , true) |
-| logInjectionBad.js:38:9:38:35 | username | logInjectionBad.js:40:46:40:53 | username |
-| logInjectionBad.js:38:20:38:20 | q | logInjectionBad.js:38:20:38:26 | q.query |
-| logInjectionBad.js:38:20:38:26 | q.query | logInjectionBad.js:38:20:38:35 | q.query.username |
-| logInjectionBad.js:38:20:38:35 | q.query.username | logInjectionBad.js:38:9:38:35 | username |
-| logInjectionBad.js:40:46:40:53 | username | logInjectionBad.js:40:18:40:54 | ansiCol ... ername) |
-| logInjectionBad.js:40:46:40:53 | username | logInjectionBad.js:40:18:40:54 | ansiCol ... ername) |
+| logInjectionBad.js:38:9:38:36 | q | logInjectionBad.js:39:20:39:20 | q |
+| logInjectionBad.js:38:13:38:36 | url.par ... , true) | logInjectionBad.js:38:9:38:36 | q |
+| logInjectionBad.js:38:23:38:29 | req.url | logInjectionBad.js:38:13:38:36 | url.par ... , true) |
+| logInjectionBad.js:38:23:38:29 | req.url | logInjectionBad.js:38:13:38:36 | url.par ... , true) |
+| logInjectionBad.js:39:9:39:35 | username | logInjectionBad.js:41:46:41:53 | username |
+| logInjectionBad.js:39:9:39:35 | username | logInjectionBad.js:42:39:42:46 | username |
+| logInjectionBad.js:39:20:39:20 | q | logInjectionBad.js:39:20:39:26 | q.query |
+| logInjectionBad.js:39:20:39:26 | q.query | logInjectionBad.js:39:20:39:35 | q.query.username |
+| logInjectionBad.js:39:20:39:35 | q.query.username | logInjectionBad.js:39:9:39:35 | username |
+| logInjectionBad.js:41:46:41:53 | username | logInjectionBad.js:41:18:41:54 | ansiCol ... ername) |
+| logInjectionBad.js:41:46:41:53 | username | logInjectionBad.js:41:18:41:54 | ansiCol ... ername) |
+| logInjectionBad.js:42:39:42:46 | username | logInjectionBad.js:42:18:42:47 | colors. ... ername) |
+| logInjectionBad.js:42:39:42:46 | username | logInjectionBad.js:42:18:42:47 | colors. ... ername) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:24:35:24:42 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:24:35:24:42 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:25:36:25:43 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:25:36:25:43 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:30:23:30:49 | `[ERROR ... rror}"` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
-| logInjectionBad.js:40:18:40:54 | ansiCol ... ername) | logInjectionBad.js:37:23:37:29 | req.url | logInjectionBad.js:40:18:40:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:37:23:37:29 | req.url | User-provided value |
+| logInjectionBad.js:41:18:41:54 | ansiCol ... ername) | logInjectionBad.js:38:23:38:29 | req.url | logInjectionBad.js:41:18:41:54 | ansiCol ... ername) | $@ flows to log entry. | logInjectionBad.js:38:23:38:29 | req.url | User-provided value |
+| logInjectionBad.js:42:18:42:47 | colors. ... ername) | logInjectionBad.js:38:23:38:29 | req.url | logInjectionBad.js:42:18:42:47 | colors. ... ername) | $@ flows to log entry. | logInjectionBad.js:38:23:38:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -37,6 +37,7 @@ import wrapAnsi from 'wrap-ansi';
 import { blue, bold, underline } from "colorette"
 const highlight = require('cli-highlight').highlight;
 var clc = require("cli-color");
+import sliceAnsi from 'slice-ansi';
 
 const server2 = http.createServer((req, res) => {
     let q = url.parse(req.url, true);
@@ -48,4 +49,5 @@ const server2 = http.createServer((req, res) => {
     console.log(underline(bold(blue(username)))); // NOT OK
     console.log(highlight(username, {language: 'sql', ignoreIllegals: true})); // NOT OK
     console.log(clc.red.bgWhite.underline(username)); // NOT OK
+    console.log(sliceAnsi(colors.red.underline(username), 20, 30)); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -33,6 +33,7 @@ const server = http.createServer((req, res) => {
 
 const ansiColors = require('ansi-colors');
 const colors = require('colors');
+import wrapAnsi from 'wrap-ansi';
 
 const server2 = http.createServer((req, res) => {
     let q = url.parse(req.url, true);
@@ -40,4 +41,5 @@ const server2 = http.createServer((req, res) => {
 
     console.info(ansiColors.yellow.underline(username)); // NOT OK
     console.info(colors.red.underline(username)); // NOT OK
+    console.info(wrapAnsi(colors.red.underline(username), 20)); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -32,10 +32,12 @@ const server = http.createServer((req, res) => {
 });
 
 const ansiColors = require('ansi-colors');
+const colors = require('colors');
 
 const server2 = http.createServer((req, res) => {
     let q = url.parse(req.url, true);
     let username = q.query.username;
 
     console.info(ansiColors.yellow.underline(username)); // NOT OK
+    console.info(colors.red.underline(username)); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -30,3 +30,12 @@ const server = http.createServer((req, res) => {
         console.error(`[ERROR] Error: "${error}"`); // NOT OK
     }
 });
+
+const ansiColors = require('ansi-colors');
+
+const server2 = http.createServer((req, res) => {
+    let q = url.parse(req.url, true);
+    let username = q.query.username;
+
+    console.info(ansiColors.yellow.underline(username)); // NOT OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -36,6 +36,7 @@ const colors = require('colors');
 import wrapAnsi from 'wrap-ansi';
 import { blue, bold, underline } from "colorette"
 const highlight = require('cli-highlight').highlight;
+var clc = require("cli-color");
 
 const server2 = http.createServer((req, res) => {
     let q = url.parse(req.url, true);
@@ -46,4 +47,5 @@ const server2 = http.createServer((req, res) => {
     console.info(wrapAnsi(colors.red.underline(username), 20)); // NOT OK
     console.log(underline(bold(blue(username)))); // NOT OK
     console.log(highlight(username, {language: 'sql', ignoreIllegals: true})); // NOT OK
+    console.log(clc.red.bgWhite.underline(username)); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -40,6 +40,7 @@ var clc = require("cli-color");
 import sliceAnsi from 'slice-ansi';
 import kleur from 'kleur';
 const chalk = require('chalk');
+import stripAnsi from 'strip-ansi';
 
 const server2 = http.createServer((req, res) => {
     let q = url.parse(req.url, true);
@@ -54,4 +55,5 @@ const server2 = http.createServer((req, res) => {
     console.log(sliceAnsi(colors.red.underline(username), 20, 30)); // NOT OK
     console.log(kleur.blue().bold().underline(username)); // NOT OK
     console.log(chalk.underline.bgBlue(username)); // NOT OK
+    console.log(stripAnsi(chalk.underline.bgBlue(username))); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -39,6 +39,7 @@ const highlight = require('cli-highlight').highlight;
 var clc = require("cli-color");
 import sliceAnsi from 'slice-ansi';
 import kleur from 'kleur';
+const chalk = require('chalk');
 
 const server2 = http.createServer((req, res) => {
     let q = url.parse(req.url, true);
@@ -52,4 +53,5 @@ const server2 = http.createServer((req, res) => {
     console.log(clc.red.bgWhite.underline(username)); // NOT OK
     console.log(sliceAnsi(colors.red.underline(username), 20, 30)); // NOT OK
     console.log(kleur.blue().bold().underline(username)); // NOT OK
+    console.log(chalk.underline.bgBlue(username)); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -38,6 +38,7 @@ import { blue, bold, underline } from "colorette"
 const highlight = require('cli-highlight').highlight;
 var clc = require("cli-color");
 import sliceAnsi from 'slice-ansi';
+import kleur from 'kleur';
 
 const server2 = http.createServer((req, res) => {
     let q = url.parse(req.url, true);
@@ -50,4 +51,5 @@ const server2 = http.createServer((req, res) => {
     console.log(highlight(username, {language: 'sql', ignoreIllegals: true})); // NOT OK
     console.log(clc.red.bgWhite.underline(username)); // NOT OK
     console.log(sliceAnsi(colors.red.underline(username), 20, 30)); // NOT OK
+    console.log(kleur.blue().bold().underline(username)); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -35,6 +35,7 @@ const ansiColors = require('ansi-colors');
 const colors = require('colors');
 import wrapAnsi from 'wrap-ansi';
 import { blue, bold, underline } from "colorette"
+const highlight = require('cli-highlight').highlight;
 
 const server2 = http.createServer((req, res) => {
     let q = url.parse(req.url, true);
@@ -44,4 +45,5 @@ const server2 = http.createServer((req, res) => {
     console.info(colors.red.underline(username)); // NOT OK
     console.info(wrapAnsi(colors.red.underline(username), 20)); // NOT OK
     console.log(underline(bold(blue(username)))); // NOT OK
+    console.log(highlight(username, {language: 'sql', ignoreIllegals: true})); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -34,6 +34,7 @@ const server = http.createServer((req, res) => {
 const ansiColors = require('ansi-colors');
 const colors = require('colors');
 import wrapAnsi from 'wrap-ansi';
+import { blue, bold, underline } from "colorette"
 
 const server2 = http.createServer((req, res) => {
     let q = url.parse(req.url, true);
@@ -42,4 +43,5 @@ const server2 = http.createServer((req, res) => {
     console.info(ansiColors.yellow.underline(username)); // NOT OK
     console.info(colors.red.underline(username)); // NOT OK
     console.info(wrapAnsi(colors.red.underline(username), 20)); // NOT OK
+    console.log(underline(bold(blue(username)))); // NOT OK
 });


### PR DESCRIPTION
Inspired by missing support for the highly dependent upon library [`colors`](https://www.npmjs.com/package/colors). 
And I found a few others to model by searching NPM tags. 

They account for a combined [320 million weekly downloads on NPM](https://i.imgur.com/eXJz9GP.jpg). 

[Evaluation looks fine](https://github.com/dsp-testing/erik-krogh-dca/tree/run/colors-nightly-security-extended/reports).   
No change in results. 