### PR TITLE
Python: Make `import python` private in Concepts.qll

### DIFF
--- a/python/ql/src/semmle/python/Concepts.qll
+++ b/python/ql/src/semmle/python/Concepts.qll
@@ -4,7 +4,7 @@
  * provide concrete subclasses.
  */
 
-import python
+private import python
 private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.dataflow.new.RemoteFlowSources
 private import semmle.python.dataflow.new.TaintTracking


### PR DESCRIPTION
Just a mistake that we have never caught on to