### PR TITLE
C#: Start using CSV based flow models 

### DIFF
--- a/csharp/documentation/library-coverage/coverage.csv
+++ b/csharp/documentation/library-coverage/coverage.csv
@@ -1,2 +1,2 @@
-package,sink,source,summary,sink:html,source:local,summary:taint
-System,4,3,6,4,3,6
+package,sink,source,summary,sink:html,sink:xss,source:local,summary:taint
+System,5,3,6,4,1,3,6

--- a/csharp/documentation/library-coverage/coverage.csv
+++ b/csharp/documentation/library-coverage/coverage.csv
@@ -1,0 +1,2 @@
+package,sink,source,summary,sink:html,source:local,summary:taint
+System,4,3,6,4,3,6

--- a/csharp/documentation/library-coverage/coverage.rst
+++ b/csharp/documentation/library-coverage/coverage.rst
@@ -7,6 +7,6 @@ C# framework & library support
    :widths: auto
 
    Framework / library,Package,Remote flow sources,Taint & value steps,Sinks (total),`CWE-079` :sub:`Cross-site scripting`
-   System,"``System.*``, ``System``",,6,4,4
-   Totals,,,6,4,4
+   System,"``System.*``, ``System``",,6,5,5
+   Totals,,,6,5,5
 

--- a/csharp/documentation/library-coverage/coverage.rst
+++ b/csharp/documentation/library-coverage/coverage.rst
@@ -1,0 +1,12 @@
+C# framework & library support
+================================
+
+.. csv-table::
+   :header-rows: 1
+   :class: fullWidthTable
+   :widths: auto
+
+   Framework / library,Package,Remote flow sources,Taint & value steps,Sinks (total),`CWE-079` :sub:`Cross-site scripting`
+   System,"``System.*``, ``System``",,6,4,4
+   Totals,,,6,4,4
+

--- a/csharp/documentation/library-coverage/coverage.rst
+++ b/csharp/documentation/library-coverage/coverage.rst
@@ -6,7 +6,7 @@ C# framework & library support
    :class: fullWidthTable
    :widths: auto
 
-   Framework / library,Package,Remote flow sources,Taint & value steps,Sinks (total),`CWE-079` :sub:`Cross-site scripting`
-   System,"``System.*``, ``System``",,6,5,5
-   Totals,,,6,5,5
+   Framework / library,Package,Flow sources,Taint & value steps,Sinks (total),`CWE-079` :sub:`Cross-site scripting`
+   System,"``System.*``, ``System``",3,6,5,5
+   Totals,,3,6,5,5
 

--- a/csharp/documentation/library-coverage/cwe-sink.csv
+++ b/csharp/documentation/library-coverage/cwe-sink.csv
@@ -1,2 +1,2 @@
 CWE,Sink identifier,Label
-CWE-079,html,Cross-site scripting
+CWE-079,html xss,Cross-site scripting

--- a/csharp/documentation/library-coverage/cwe-sink.csv
+++ b/csharp/documentation/library-coverage/cwe-sink.csv
@@ -1,0 +1,2 @@
+CWE,Sink identifier,Label
+CWE-079,html,Cross-site scripting

--- a/csharp/documentation/library-coverage/frameworks.csv
+++ b/csharp/documentation/library-coverage/frameworks.csv
@@ -1,0 +1,2 @@
+Framework name,URL,Namespace prefixes
+System,,System.* System

--- a/csharp/ql/src/meta/frameworks/Coverage.ql
+++ b/csharp/ql/src/meta/frameworks/Coverage.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Framework coverage
+ * @description The number of API endpoints covered by CSV models sorted by
+ *              package and source-, sink-, and summary-kind.
+ * @kind table
+ * @id cs/meta/framework-coverage
+ */
+
+import csharp
+import semmle.code.csharp.dataflow.ExternalFlow
+
+from string namespace, int pkgs, string kind, string part, int n
+where modelCoverage(namespace, pkgs, kind, part, n)
+select namespace, pkgs, kind, part, n

--- a/csharp/ql/src/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -86,7 +86,7 @@ private import internal.FlowSummaryImplSpecific
 private module Frameworks {
   private import semmle.code.csharp.security.dataflow.flowsources.Local
   private import semmle.code.csharp.security.dataflow.flowsinks.Html
-  private import semmle.code.csharp.dataflow.LibraryTypeDataFlow
+  private import semmle.code.csharp.frameworks.System
   private import semmle.code.csharp.security.dataflow.XSS
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -84,7 +84,7 @@ private import internal.FlowSummaryImplSpecific
  * ensuring that they are visible to the taint tracking / data flow library.
  */
 private module Frameworks {
-  // TODO
+  private import semmle.code.csharp.security.dataflow.flowsources.Local
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -86,6 +86,7 @@ private import internal.FlowSummaryImplSpecific
 private module Frameworks {
   private import semmle.code.csharp.security.dataflow.flowsources.Local
   private import semmle.code.csharp.security.dataflow.flowsinks.Html
+  private import semmle.code.csharp.dataflow.LibraryTypeDataFlow
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -87,6 +87,7 @@ private module Frameworks {
   private import semmle.code.csharp.security.dataflow.flowsources.Local
   private import semmle.code.csharp.security.dataflow.flowsinks.Html
   private import semmle.code.csharp.dataflow.LibraryTypeDataFlow
+  private import semmle.code.csharp.security.dataflow.XSS
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -85,6 +85,7 @@ private import internal.FlowSummaryImplSpecific
  */
 private module Frameworks {
   private import semmle.code.csharp.security.dataflow.flowsources.Local
+  private import semmle.code.csharp.security.dataflow.flowsinks.Html
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -23,6 +23,7 @@ private import semmle.code.csharp.dataflow.internal.DelegateDataFlow
 private import semmle.code.csharp.frameworks.EntityFramework
 private import semmle.code.csharp.frameworks.JsonNET
 private import FlowSummary
+private import semmle.code.csharp.dataflow.ExternalFlow
 
 private newtype TAccessPath =
   TNilAccessPath() or
@@ -500,29 +501,17 @@ private module FrameworkDataFlowAdaptor {
 }
 
 /** Data flow for `System.Int32`. */
-class SystemInt32Flow extends LibraryTypeDataFlow, SystemInt32Struct {
-  override predicate callableFlow(
-    CallableFlowSource source, CallableFlowSink sink, SourceDeclarationCallable c,
-    boolean preservesValue
-  ) {
-    methodFlow(source, sink, c) and
-    preservesValue = false
-  }
-
-  private predicate methodFlow(
-    CallableFlowSource source, CallableFlowSink sink, SourceDeclarationMethod m
-  ) {
-    m = getParseMethod() and
-    source = TCallableFlowSourceArg(0) and
-    sink = TCallableFlowSinkReturn()
-    or
-    m = getTryParseMethod() and
-    source = TCallableFlowSourceArg(0) and
-    (
-      sink = TCallableFlowSinkReturn()
-      or
-      sink = TCallableFlowSinkArg(any(int i | m.getParameter(i).isOutOrRef()))
-    )
+private class SystemInt32FlowModelCsv extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "System;Int32;false;Parse;;;Argument[0];ReturnValue;taint",
+        "System;Int32;false;TryParse;;;Argument[0];ReturnValue;taint",
+        "System;Int32;false;TryParse;(System.String,System.Int32);;Argument[0];Argument[1];taint",
+        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Int32);;Argument[0];Argument[1];taint",
+        "System;Int32;false;TryParse;(System.String,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Argument[0];Argument[3];taint",
+        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Argument[0];Argument[3];taint"
+      ]
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -23,7 +23,6 @@ private import semmle.code.csharp.dataflow.internal.DelegateDataFlow
 private import semmle.code.csharp.frameworks.EntityFramework
 private import semmle.code.csharp.frameworks.JsonNET
 private import FlowSummary
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 private newtype TAccessPath =
   TNilAccessPath() or
@@ -497,21 +496,6 @@ private module FrameworkDataFlowAdaptor {
     }
 
     override predicate required(SummaryComponent c) { c = head }
-  }
-}
-
-/** Data flow for `System.Int32`. */
-private class SystemInt32FlowModelCsv extends SummaryModelCsv {
-  override predicate row(string row) {
-    row =
-      [
-        "System;Int32;false;Parse;;;Argument[0];ReturnValue;taint",
-        "System;Int32;false;TryParse;;;Argument[0];ReturnValue;taint",
-        "System;Int32;false;TryParse;(System.String,System.Int32);;Argument[0];Argument[1];taint",
-        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Int32);;Element of Argument[0];Argument[1];taint",
-        "System;Int32;false;TryParse;(System.String,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Argument[0];Argument[3];taint",
-        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Element of Argument[0];Argument[3];taint"
-      ]
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -508,9 +508,9 @@ private class SystemInt32FlowModelCsv extends SummaryModelCsv {
         "System;Int32;false;Parse;;;Argument[0];ReturnValue;taint",
         "System;Int32;false;TryParse;;;Argument[0];ReturnValue;taint",
         "System;Int32;false;TryParse;(System.String,System.Int32);;Argument[0];Argument[1];taint",
-        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Int32);;Argument[0];Argument[1];taint",
+        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Int32);;Element of Argument[0];Argument[1];taint",
         "System;Int32;false;TryParse;(System.String,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Argument[0];Argument[3];taint",
-        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Argument[0];Argument[3];taint"
+        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Element of Argument[0];Argument[3];taint"
       ]
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -6,6 +6,7 @@ private import DataFlowPublic
 private import DataFlowPrivate
 private import FlowSummaryImpl as FlowSummaryImpl
 private import semmle.code.csharp.dataflow.FlowSummary
+private import semmle.code.csharp.dataflow.ExternalFlow
 private import semmle.code.csharp.dispatch.Dispatch
 private import semmle.code.csharp.frameworks.system.Collections
 private import semmle.code.csharp.frameworks.system.collections.Generic
@@ -14,6 +15,8 @@ private predicate summarizedCallable(DataFlowCallable c) {
   c instanceof SummarizedCallable
   or
   FlowSummaryImpl::Private::summaryReturnNode(_, TJumpReturnKind(c, _))
+  or
+  c = interpretElement(_, _, _, _, _, _)
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/frameworks/System.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/System.qll
@@ -2,6 +2,7 @@
 
 import csharp
 private import system.Reflection
+private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System` namespace. */
 class SystemNamespace extends Namespace {
@@ -197,6 +198,28 @@ class SystemInt32Struct extends IntType {
     result.getParameter(0).getType() instanceof StringType and
     result.getParameter(result.getNumberOfParameters() - 1).getType() instanceof IntType and
     result.getReturnType() instanceof BoolType
+  }
+}
+
+/** Data flow for `System.Int32`. */
+private class SystemInt32FlowModelCsv extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "System;Int32;false;Parse;(System.String);;Argument[0];ReturnValue;taint",
+        "System;Int32;false;Parse;(System.String,System.IFormatProvider);;Argument[0];ReturnValue;taint",
+        "System;Int32;false;Parse;(System.String,System.Globalization.NumberStyles);;Argument[0];ReturnValue;taint",
+        "System;Int32;false;Parse;(System.String,System.Globalization.NumberStyles,System.IFormatProvider);;Argument[0];ReturnValue;taint",
+        "System;Int32;false;Parse;(System.ReadOnlySpan<System.Char>,System.Globalization.NumberStyles,System.IFormatProvider);;Element of Argument[0];ReturnValue;taint",
+        "System;Int32;false;TryParse;(System.String,System.Int32);;Argument[0];ReturnValue;taint",
+        "System;Int32;false;TryParse;(System.String,System.Int32);;Argument[0];Argument[1];taint",
+        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Int32);;Element of Argument[0];ReturnValue;taint",
+        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Int32);;Element of Argument[0];Argument[1];taint",
+        "System;Int32;false;TryParse;(System.String,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Argument[0];ReturnValue;taint",
+        "System;Int32;false;TryParse;(System.String,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Argument[0];Argument[3];taint",
+        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Element of Argument[0];ReturnValue;taint",
+        "System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>,System.Globalization.NumberStyles,System.IFormatProvider,System.Int32);;Element of Argument[0];Argument[3];taint"
+      ]
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/XSS.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/XSS.qll
@@ -16,6 +16,7 @@ module XSS {
   import semmle.code.csharp.security.dataflow.flowsources.Remote
   private import semmle.code.csharp.dataflow.DataFlow2
   private import semmle.code.csharp.dataflow.TaintTracking2
+  private import semmle.code.csharp.dataflow.ExternalFlow
 
   /**
    * Holds if there is tainted flow from `source` to `sink` that may lead to a
@@ -117,6 +118,10 @@ module XSS {
    */
   abstract class Sink extends DataFlow::ExprNode, RemoteFlowSink {
     string explanation() { none() }
+  }
+
+  private class ExternalXssSink extends Sink {
+    ExternalXssSink() { sinkNode(this, "xss") }
   }
 
   /**
@@ -406,12 +411,9 @@ module XSS {
   /**
    * An expression passed as the `content` argument to the constructor of `StringContent`.
    */
-  private class StringContent extends Sink {
-    StringContent() {
-      this.getExpr() =
-        any(ObjectCreation oc |
-          oc.getTarget().getDeclaringType().hasQualifiedName("System.Net.Http", "StringContent")
-        ).getArgumentForName("content")
+  private class StringContentSinkModelCsv extends SinkModelCsv {
+    override predicate row(string row) {
+      row = ["System.Net.Http;StringContent;false;StringContent;;;Argument[0];xss"]
     }
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/flowsinks/Html.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/flowsinks/Html.qll
@@ -13,6 +13,7 @@ private import semmle.code.csharp.frameworks.system.web.UI
 private import semmle.code.csharp.frameworks.system.web.ui.WebControls
 private import semmle.code.csharp.frameworks.system.windows.Forms
 private import semmle.code.csharp.security.dataflow.flowsources.Remote
+private import semmle.code.csharp.dataflow.ExternalFlow
 private import semmle.code.asp.AspNet
 
 /**
@@ -21,21 +22,23 @@ private import semmle.code.asp.AspNet
  */
 abstract class HtmlSink extends DataFlow::ExprNode, RemoteFlowSink { }
 
+private class ExternalHtmlSink extends HtmlSink {
+  ExternalHtmlSink() { sinkNode(this, "html") }
+}
+
 /**
  * An expression that is used as an argument to an HTML sink method on
  * `HttpResponse`.
  */
-class HttpResponseSink extends HtmlSink {
-  HttpResponseSink() {
-    exists(Method m, SystemWebHttpResponseClass responseClass |
-      m = responseClass.getAWriteMethod() or
-      m = responseClass.getAWriteFileMethod() or
-      m = responseClass.getATransmitFileMethod() or
-      m = responseClass.getABinaryWriteMethod()
-    |
-      // Calls to these methods, or overrides of them
-      this.getExpr() = m.getAnOverrider*().getParameter(0).getAnAssignedArgument()
-    )
+private class HttpResponseSinkModelCsv extends SinkModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "System.Web;HttpResponse;false;Write;;;Argument[0];html",
+        "System.Web;HttpResponse;false;WriteFile;;;Argument[0];html",
+        "System.Web;HttpResponse;false;TransmitFile;;;Argument[0];html",
+        "System.Web;HttpResponse;false;BinaryWrite;;;Argument[0];html"
+      ]
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/flowsources/Local.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/flowsources/Local.qll
@@ -4,11 +4,18 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.system.windows.Forms
+private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** A data flow source of local data. */
 abstract class LocalFlowSource extends DataFlow::Node {
   /** Gets a string that describes the type of this local flow source. */
   abstract string getSourceType();
+}
+
+private class ExternalLocalFlowSource extends LocalFlowSource {
+  ExternalLocalFlowSource() { sourceNode(this, "local") }
+
+  override string getSourceType() { result = "external" }
 }
 
 /** A data flow source of local user input. */
@@ -22,13 +29,13 @@ class TextFieldSource extends LocalUserInputSource {
 }
 
 /** A call to any `System.Console.Read*` method. */
-class SystemConsoleReadSource extends LocalUserInputSource {
-  SystemConsoleReadSource() {
-    this.asExpr() =
-      any(MethodCall call |
-        call.getTarget().hasQualifiedName("System.Console", ["ReadLine", "Read", "ReadKey"])
-      )
+private class SystemConsoleReadSourceModelCsv extends SourceModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "System;Console;false;ReadLine;;;ReturnValue;local",
+        "System;Console;false;Read;;;ReturnValue;local",
+        "System;Console;false;ReadKey;;;ReturnValue;local"
+      ]
   }
-
-  override string getSourceType() { result = "System.Console input" }
 }

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -23,36 +23,36 @@
 | GlobalDataFlow.cs:84:15:84:20 | access to local variable sink14 |
 | GlobalDataFlow.cs:86:15:86:20 | access to local variable sink15 |
 | GlobalDataFlow.cs:88:15:88:20 | access to local variable sink16 |
-| GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
-| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
-| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:475:15:475:20 | access to local variable sink45 |
-| GlobalDataFlow.cs:483:32:483:32 | access to parameter s |
+| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:148:15:148:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:164:15:164:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:166:15:166:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:168:15:168:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:185:15:185:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:202:15:202:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:219:15:219:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:221:15:221:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:243:15:243:20 | access to local variable sink41 |
+| GlobalDataFlow.cs:245:15:245:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:290:15:290:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:404:15:404:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 |
+| GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -55,7 +55,7 @@ edges
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String |
+| GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:257:26:257:35 | sinkParam0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String |
@@ -64,7 +64,7 @@ edges
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String |
+| GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:263:26:263:35 | sinkParam1 : String |
 | GlobalDataFlow.cs:45:30:45:39 | sinkParam2 : String | GlobalDataFlow.cs:45:50:45:59 | access to parameter sinkParam2 |
 | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:45:30:45:39 | sinkParam2 : String |
 | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String |
@@ -80,31 +80,31 @@ edges
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:379:41:379:41 | x : String |
+| GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:382:41:382:41 | x : String |
 | GlobalDataFlow.cs:54:15:54:15 | x : String | GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String |
-| GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String | GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String |
+| GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String | GlobalDataFlow.cs:273:26:273:35 | sinkParam4 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:379:41:379:41 | x : String |
+| GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:382:41:382:41 | x : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
+| GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:396:52:396:52 | x : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
+| GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:396:52:396:52 | x : String |
 | GlobalDataFlow.cs:57:37:57:37 | x : String | GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String |
-| GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String | GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String |
+| GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String | GlobalDataFlow.cs:288:26:288:35 | sinkParam7 : String |
 | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
+| GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:396:52:396:52 | x : String |
 | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:424:9:424:11 | value : String |
+| GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:427:9:427:11 | value : String |
 | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 |
 | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String |
 | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String |
@@ -118,7 +118,7 @@ edges
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
 | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String | GlobalDataFlow.cs:80:15:80:19 | access to local variable sink3 |
 | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String |
-| GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String | GlobalDataFlow.cs:136:29:136:33 | access to local variable sink3 : String |
+| GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String |
 | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven [element] : String | GlobalDataFlow.cs:81:22:81:93 | call to method First : String |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:83:22:83:95 | call to method First : String | GlobalDataFlow.cs:84:15:84:20 | access to local variable sink14 |
 | GlobalDataFlow.cs:83:22:83:95 | call to method First : String | GlobalDataFlow.cs:85:59:85:64 | access to local variable sink14 : String |
 | GlobalDataFlow.cs:83:23:83:66 | (...) ... [element] : String | GlobalDataFlow.cs:83:22:83:87 | call to method Select [element] : String |
-| GlobalDataFlow.cs:83:23:83:66 | (...) ... [element] : String | GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String |
+| GlobalDataFlow.cs:83:23:83:66 | (...) ... [element] : String | GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String |
 | GlobalDataFlow.cs:83:57:83:66 | { ..., ... } [element] : String | GlobalDataFlow.cs:83:23:83:66 | (...) ... [element] : String |
 | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String | GlobalDataFlow.cs:83:57:83:66 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:85:22:85:128 | call to method Zip [element] : String | GlobalDataFlow.cs:85:22:85:136 | call to method First : String |
@@ -143,96 +143,96 @@ edges
 | GlobalDataFlow.cs:87:70:87:113 | (...) ... [element] : String | GlobalDataFlow.cs:87:22:87:128 | call to method Zip [element] : String |
 | GlobalDataFlow.cs:87:104:87:113 | { ..., ... } [element] : String | GlobalDataFlow.cs:87:70:87:113 | (...) ... [element] : String |
 | GlobalDataFlow.cs:87:106:87:111 | access to local variable sink15 : String | GlobalDataFlow.cs:87:104:87:113 | { ..., ... } [element] : String |
-| GlobalDataFlow.cs:136:21:136:34 | delegate call : String | GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:136:21:136:34 | delegate call : String | GlobalDataFlow.cs:144:39:144:43 | access to local variable sink4 : String |
-| GlobalDataFlow.cs:136:29:136:33 | access to local variable sink3 : String | GlobalDataFlow.cs:136:21:136:34 | delegate call : String |
-| GlobalDataFlow.cs:144:21:144:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:144:39:144:43 | access to local variable sink4 : String | GlobalDataFlow.cs:144:21:144:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:154:21:154:25 | call to method Out : String | GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:162:22:162:31 | call to method OutYield [element] : String | GlobalDataFlow.cs:162:22:162:39 | call to method First : String |
-| GlobalDataFlow.cs:162:22:162:39 | call to method First : String | GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam : String | GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:180:35:180:48 | "taint source" : String | GlobalDataFlow.cs:181:21:181:26 | delegate call : String |
-| GlobalDataFlow.cs:181:21:181:26 | delegate call : String | GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> [property Value] : String | GlobalDataFlow.cs:190:22:190:48 | access to property Value : String |
-| GlobalDataFlow.cs:190:22:190:48 | access to property Value : String | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty : String | GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:208:38:208:61 | array creation of type String[] [element] : String | GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable [element] : String |
-| GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:215:22:215:28 | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:208:44:208:61 | { ..., ... } [element] : String | GlobalDataFlow.cs:208:38:208:61 | array creation of type String[] [element] : String |
-| GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:208:44:208:61 | { ..., ... } [element] : String |
-| GlobalDataFlow.cs:211:35:211:45 | sinkParam10 : String | GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:212:71:212:71 | x : String | GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String |
-| GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String | GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String |
-| GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:211:35:211:45 | sinkParam10 : String |
-| GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:213:22:213:39 | call to method Select [element] : String |
-| GlobalDataFlow.cs:213:22:213:39 | call to method Select [element] : String | GlobalDataFlow.cs:213:22:213:47 | call to method First : String |
-| GlobalDataFlow.cs:213:22:213:47 | call to method First : String | GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:215:22:215:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:212:71:212:71 | x : String |
-| GlobalDataFlow.cs:215:22:215:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:215:22:215:39 | call to method Select [element] : String |
-| GlobalDataFlow.cs:215:22:215:39 | call to method Select [element] : String | GlobalDataFlow.cs:215:22:215:47 | call to method First : String |
-| GlobalDataFlow.cs:215:22:215:47 | call to method First : String | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:217:22:217:49 | call to method Select [element] : String |
-| GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String |
-| GlobalDataFlow.cs:217:22:217:49 | call to method Select [element] : String | GlobalDataFlow.cs:217:22:217:57 | call to method First : String |
-| GlobalDataFlow.cs:217:22:217:57 | call to method First : String | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:238:20:238:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:239:22:239:25 | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:238:20:238:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:241:28:241:31 | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:238:20:238:49 | call to method Run [property Result] : String |
-| GlobalDataFlow.cs:239:22:239:25 | access to local variable task [property Result] : String | GlobalDataFlow.cs:239:22:239:32 | access to property Result : String |
-| GlobalDataFlow.cs:239:22:239:32 | access to property Result : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
-| GlobalDataFlow.cs:241:22:241:31 | await ... : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
-| GlobalDataFlow.cs:241:28:241:31 | access to local variable task [property Result] : String | GlobalDataFlow.cs:241:22:241:31 | await ... : String |
-| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String |
-| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String |
-| GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String | GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String | GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String | GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String | GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String | GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String | GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String | GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:154:21:154:25 | call to method Out : String |
-| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> [property Value] : String |
-| GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String | GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) : String |
-| GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String |
-| GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) : String |
-| GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String |
-| GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | GlobalDataFlow.cs:162:22:162:31 | call to method OutYield [element] : String |
-| GlobalDataFlow.cs:379:41:379:41 | x : String | GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String |
-| GlobalDataFlow.cs:379:41:379:41 | x : String | GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String |
-| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | GlobalDataFlow.cs:54:15:54:15 | x : String |
-| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:57:37:57:37 | x : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String |
-| GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String |
-| GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String | GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam : String |
-| GlobalDataFlow.cs:424:9:424:11 | value : String | GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty : String |
-| GlobalDataFlow.cs:471:20:471:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:472:25:472:28 | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:471:35:471:48 | "taint source" : String | GlobalDataFlow.cs:471:20:471:49 | call to method Run [property Result] : String |
-| GlobalDataFlow.cs:472:25:472:28 | access to local variable task [property Result] : String | GlobalDataFlow.cs:472:25:472:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String |
-| GlobalDataFlow.cs:472:25:472:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String | GlobalDataFlow.cs:473:23:473:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String |
-| GlobalDataFlow.cs:473:23:473:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String | GlobalDataFlow.cs:473:23:473:44 | call to method GetAwaiter [field m_task, property Result] : String |
-| GlobalDataFlow.cs:473:23:473:44 | call to method GetAwaiter [field m_task, property Result] : String | GlobalDataFlow.cs:474:22:474:28 | access to local variable awaiter [field m_task, property Result] : String |
-| GlobalDataFlow.cs:474:22:474:28 | access to local variable awaiter [field m_task, property Result] : String | GlobalDataFlow.cs:474:22:474:40 | call to method GetResult : String |
-| GlobalDataFlow.cs:474:22:474:40 | call to method GetResult : String | GlobalDataFlow.cs:475:15:475:20 | access to local variable sink45 |
-| GlobalDataFlow.cs:480:53:480:55 | arg : String | GlobalDataFlow.cs:484:15:484:17 | access to parameter arg : String |
-| GlobalDataFlow.cs:483:21:483:21 | s : String | GlobalDataFlow.cs:483:32:483:32 | access to parameter s |
-| GlobalDataFlow.cs:484:15:484:17 | access to parameter arg : String | GlobalDataFlow.cs:483:21:483:21 | s : String |
-| GlobalDataFlow.cs:487:27:487:40 | "taint source" : String | GlobalDataFlow.cs:480:53:480:55 | arg : String |
+| GlobalDataFlow.cs:139:21:139:34 | delegate call : String | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:139:21:139:34 | delegate call : String | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String |
+| GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
+| GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:148:15:148:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:157:21:157:25 | call to method Out : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:160:20:160:24 | SSA def(sink7) : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:163:20:163:24 | SSA def(sink8) : String | GlobalDataFlow.cs:164:15:164:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:165:22:165:31 | call to method OutYield [element] : String | GlobalDataFlow.cs:165:22:165:39 | call to method First : String |
+| GlobalDataFlow.cs:165:22:165:39 | call to method First : String | GlobalDataFlow.cs:166:15:166:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:167:22:167:43 | call to method TaintedParam : String | GlobalDataFlow.cs:168:15:168:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:183:35:183:48 | "taint source" : String | GlobalDataFlow.cs:184:21:184:26 | delegate call : String |
+| GlobalDataFlow.cs:184:21:184:26 | delegate call : String | GlobalDataFlow.cs:185:15:185:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:193:22:193:42 | object creation of type Lazy<String> [property Value] : String | GlobalDataFlow.cs:193:22:193:48 | access to property Value : String |
+| GlobalDataFlow.cs:193:22:193:48 | access to property Value : String | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:201:22:201:32 | access to property OutProperty : String | GlobalDataFlow.cs:202:15:202:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:211:38:211:61 | array creation of type String[] [element] : String | GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable [element] : String |
+| GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:211:44:211:61 | { ..., ... } [element] : String | GlobalDataFlow.cs:211:38:211:61 | array creation of type String[] [element] : String |
+| GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:211:44:211:61 | { ..., ... } [element] : String |
+| GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:215:71:215:71 | x : String | GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String |
+| GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String |
+| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String |
+| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:216:22:216:39 | call to method Select [element] : String |
+| GlobalDataFlow.cs:216:22:216:39 | call to method Select [element] : String | GlobalDataFlow.cs:216:22:216:47 | call to method First : String |
+| GlobalDataFlow.cs:216:22:216:47 | call to method First : String | GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:215:71:215:71 | x : String |
+| GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:218:22:218:39 | call to method Select [element] : String |
+| GlobalDataFlow.cs:218:22:218:39 | call to method Select [element] : String | GlobalDataFlow.cs:218:22:218:47 | call to method First : String |
+| GlobalDataFlow.cs:218:22:218:47 | call to method First : String | GlobalDataFlow.cs:219:15:219:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:220:22:220:49 | call to method Select [element] : String |
+| GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String |
+| GlobalDataFlow.cs:220:22:220:49 | call to method Select [element] : String | GlobalDataFlow.cs:220:22:220:57 | call to method First : String |
+| GlobalDataFlow.cs:220:22:220:57 | call to method First : String | GlobalDataFlow.cs:221:15:221:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:241:20:241:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:242:22:242:25 | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:241:20:241:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:244:28:244:31 | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:241:35:241:48 | "taint source" : String | GlobalDataFlow.cs:241:20:241:49 | call to method Run [property Result] : String |
+| GlobalDataFlow.cs:242:22:242:25 | access to local variable task [property Result] : String | GlobalDataFlow.cs:242:22:242:32 | access to property Result : String |
+| GlobalDataFlow.cs:242:22:242:32 | access to property Result : String | GlobalDataFlow.cs:243:15:243:20 | access to local variable sink41 |
+| GlobalDataFlow.cs:244:22:244:31 | await ... : String | GlobalDataFlow.cs:245:15:245:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:244:28:244:31 | access to local variable task [property Result] : String | GlobalDataFlow.cs:244:22:244:31 | await ... : String |
+| GlobalDataFlow.cs:257:26:257:35 | sinkParam0 : String | GlobalDataFlow.cs:259:16:259:25 | access to parameter sinkParam0 : String |
+| GlobalDataFlow.cs:257:26:257:35 | sinkParam0 : String | GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:259:16:259:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:257:26:257:35 | sinkParam0 : String |
+| GlobalDataFlow.cs:263:26:263:35 | sinkParam1 : String | GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:268:26:268:35 | sinkParam3 : String | GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:273:26:273:35 | sinkParam4 : String | GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:278:26:278:35 | sinkParam5 : String | GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:283:26:283:35 | sinkParam6 : String | GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:288:26:288:35 | sinkParam7 : String | GlobalDataFlow.cs:290:15:290:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:157:21:157:25 | call to method Out : String |
+| GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:193:22:193:42 | object creation of type Lazy<String> [property Value] : String |
+| GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink7) : String |
+| GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String |
+| GlobalDataFlow.cs:351:9:351:26 | SSA def(x) : String | GlobalDataFlow.cs:163:20:163:24 | SSA def(sink8) : String |
+| GlobalDataFlow.cs:351:13:351:26 | "taint source" : String | GlobalDataFlow.cs:351:9:351:26 | SSA def(x) : String |
+| GlobalDataFlow.cs:357:22:357:35 | "taint source" : String | GlobalDataFlow.cs:165:22:165:31 | call to method OutYield [element] : String |
+| GlobalDataFlow.cs:382:41:382:41 | x : String | GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String |
+| GlobalDataFlow.cs:382:41:382:41 | x : String | GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String |
+| GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | GlobalDataFlow.cs:54:15:54:15 | x : String |
+| GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | GlobalDataFlow.cs:268:26:268:35 | sinkParam3 : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | GlobalDataFlow.cs:57:37:57:37 | x : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | GlobalDataFlow.cs:278:26:278:35 | sinkParam5 : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | GlobalDataFlow.cs:283:26:283:35 | sinkParam6 : String |
+| GlobalDataFlow.cs:401:39:401:45 | tainted : String | GlobalDataFlow.cs:404:15:404:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:401:39:401:45 | tainted : String | GlobalDataFlow.cs:405:16:405:21 | access to local variable sink11 : String |
+| GlobalDataFlow.cs:405:16:405:21 | access to local variable sink11 : String | GlobalDataFlow.cs:167:22:167:43 | call to method TaintedParam : String |
+| GlobalDataFlow.cs:427:9:427:11 | value : String | GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:438:22:438:35 | "taint source" : String | GlobalDataFlow.cs:201:22:201:32 | access to property OutProperty : String |
+| GlobalDataFlow.cs:474:20:474:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:475:25:475:28 | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:474:35:474:48 | "taint source" : String | GlobalDataFlow.cs:474:20:474:49 | call to method Run [property Result] : String |
+| GlobalDataFlow.cs:475:25:475:28 | access to local variable task [property Result] : String | GlobalDataFlow.cs:475:25:475:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String |
+| GlobalDataFlow.cs:475:25:475:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String | GlobalDataFlow.cs:476:23:476:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String |
+| GlobalDataFlow.cs:476:23:476:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String | GlobalDataFlow.cs:476:23:476:44 | call to method GetAwaiter [field m_task, property Result] : String |
+| GlobalDataFlow.cs:476:23:476:44 | call to method GetAwaiter [field m_task, property Result] : String | GlobalDataFlow.cs:477:22:477:28 | access to local variable awaiter [field m_task, property Result] : String |
+| GlobalDataFlow.cs:477:22:477:28 | access to local variable awaiter [field m_task, property Result] : String | GlobalDataFlow.cs:477:22:477:40 | call to method GetResult : String |
+| GlobalDataFlow.cs:477:22:477:40 | call to method GetResult : String | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 |
+| GlobalDataFlow.cs:483:53:483:55 | arg : String | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String |
+| GlobalDataFlow.cs:486:21:486:21 | s : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
+| GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | GlobalDataFlow.cs:486:21:486:21 | s : String |
+| GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:483:53:483:55 | arg : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -343,116 +343,116 @@ nodes
 | GlobalDataFlow.cs:87:104:87:113 | { ..., ... } [element] : String | semmle.label | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:87:106:87:111 | access to local variable sink15 : String | semmle.label | access to local variable sink15 : String |
 | GlobalDataFlow.cs:88:15:88:20 | access to local variable sink16 | semmle.label | access to local variable sink16 |
-| GlobalDataFlow.cs:136:21:136:34 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:136:29:136:33 | access to local variable sink3 : String | semmle.label | access to local variable sink3 : String |
-| GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 | semmle.label | access to local variable sink4 |
-| GlobalDataFlow.cs:144:21:144:44 | call to method ApplyFunc : String | semmle.label | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:144:39:144:43 | access to local variable sink4 : String | semmle.label | access to local variable sink4 : String |
-| GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 | semmle.label | access to local variable sink5 |
-| GlobalDataFlow.cs:154:21:154:25 | call to method Out : String | semmle.label | call to method Out : String |
-| GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | semmle.label | access to local variable sink6 |
-| GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) : String | semmle.label | SSA def(sink7) : String |
-| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | semmle.label | access to local variable sink7 |
-| GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) : String | semmle.label | SSA def(sink8) : String |
-| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | semmle.label | access to local variable sink8 |
-| GlobalDataFlow.cs:162:22:162:31 | call to method OutYield [element] : String | semmle.label | call to method OutYield [element] : String |
-| GlobalDataFlow.cs:162:22:162:39 | call to method First : String | semmle.label | call to method First : String |
-| GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | semmle.label | access to local variable sink12 |
-| GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam : String | semmle.label | call to method TaintedParam : String |
-| GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | semmle.label | access to local variable sink23 |
-| GlobalDataFlow.cs:180:35:180:48 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:181:21:181:26 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 | semmle.label | access to local variable sink9 |
-| GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> [property Value] : String | semmle.label | object creation of type Lazy<String> [property Value] : String |
-| GlobalDataFlow.cs:190:22:190:48 | access to property Value : String | semmle.label | access to property Value : String |
-| GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | semmle.label | access to local variable sink10 |
-| GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty : String | semmle.label | access to property OutProperty : String |
-| GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | semmle.label | access to local variable sink19 |
-| GlobalDataFlow.cs:208:38:208:61 | array creation of type String[] [element] : String | semmle.label | array creation of type String[] [element] : String |
-| GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable [element] : String | semmle.label | call to method AsQueryable [element] : String |
-| GlobalDataFlow.cs:208:44:208:61 | { ..., ... } [element] : String | semmle.label | { ..., ... } [element] : String |
-| GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:211:35:211:45 | sinkParam10 : String | semmle.label | sinkParam10 : String |
-| GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 | semmle.label | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:212:71:212:71 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:213:22:213:39 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
-| GlobalDataFlow.cs:213:22:213:47 | call to method First : String | semmle.label | call to method First : String |
-| GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 | semmle.label | access to local variable sink24 |
-| GlobalDataFlow.cs:215:22:215:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:215:22:215:39 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
-| GlobalDataFlow.cs:215:22:215:47 | call to method First : String | semmle.label | call to method First : String |
-| GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 | semmle.label | access to local variable sink25 |
-| GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:217:22:217:49 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
-| GlobalDataFlow.cs:217:22:217:57 | call to method First : String | semmle.label | call to method First : String |
-| GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | semmle.label | access to local variable sink26 |
-| GlobalDataFlow.cs:238:20:238:49 | call to method Run [property Result] : String | semmle.label | call to method Run [property Result] : String |
-| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:239:22:239:25 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:239:22:239:32 | access to property Result : String | semmle.label | access to property Result : String |
-| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | semmle.label | access to local variable sink41 |
-| GlobalDataFlow.cs:241:22:241:31 | await ... : String | semmle.label | await ... : String |
-| GlobalDataFlow.cs:241:28:241:31 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | semmle.label | access to local variable sink42 |
-| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
-| GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |
-| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String | semmle.label | sinkParam1 : String |
-| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | semmle.label | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String | semmle.label | sinkParam3 : String |
-| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | semmle.label | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String | semmle.label | sinkParam4 : String |
-| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | semmle.label | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String | semmle.label | sinkParam5 : String |
-| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | semmle.label | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String | semmle.label | sinkParam6 : String |
-| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String | semmle.label | sinkParam7 : String |
-| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
-| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
-| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
-| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:379:41:379:41 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:379:41:379:41 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:398:39:398:45 | tainted : String | semmle.label | tainted : String |
-| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | semmle.label | access to local variable sink11 |
-| GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String | semmle.label | access to local variable sink11 : String |
-| GlobalDataFlow.cs:424:9:424:11 | value : String | semmle.label | value : String |
-| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | semmle.label | access to local variable sink20 |
-| GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:471:20:471:49 | call to method Run [property Result] : String | semmle.label | call to method Run [property Result] : String |
-| GlobalDataFlow.cs:471:35:471:48 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:472:25:472:28 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:472:25:472:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String | semmle.label | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String |
-| GlobalDataFlow.cs:473:23:473:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String | semmle.label | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String |
-| GlobalDataFlow.cs:473:23:473:44 | call to method GetAwaiter [field m_task, property Result] : String | semmle.label | call to method GetAwaiter [field m_task, property Result] : String |
-| GlobalDataFlow.cs:474:22:474:28 | access to local variable awaiter [field m_task, property Result] : String | semmle.label | access to local variable awaiter [field m_task, property Result] : String |
-| GlobalDataFlow.cs:474:22:474:40 | call to method GetResult : String | semmle.label | call to method GetResult : String |
-| GlobalDataFlow.cs:475:15:475:20 | access to local variable sink45 | semmle.label | access to local variable sink45 |
-| GlobalDataFlow.cs:480:53:480:55 | arg : String | semmle.label | arg : String |
-| GlobalDataFlow.cs:483:21:483:21 | s : String | semmle.label | s : String |
-| GlobalDataFlow.cs:483:32:483:32 | access to parameter s | semmle.label | access to parameter s |
-| GlobalDataFlow.cs:484:15:484:17 | access to parameter arg : String | semmle.label | access to parameter arg : String |
-| GlobalDataFlow.cs:487:27:487:40 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:139:21:139:34 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | semmle.label | access to local variable sink3 : String |
+| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink4 | semmle.label | access to local variable sink4 |
+| GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc : String | semmle.label | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | semmle.label | access to local variable sink4 : String |
+| GlobalDataFlow.cs:148:15:148:19 | access to local variable sink5 | semmle.label | access to local variable sink5 |
+| GlobalDataFlow.cs:157:21:157:25 | call to method Out : String | semmle.label | call to method Out : String |
+| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink6 | semmle.label | access to local variable sink6 |
+| GlobalDataFlow.cs:160:20:160:24 | SSA def(sink7) : String | semmle.label | SSA def(sink7) : String |
+| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink7 | semmle.label | access to local variable sink7 |
+| GlobalDataFlow.cs:163:20:163:24 | SSA def(sink8) : String | semmle.label | SSA def(sink8) : String |
+| GlobalDataFlow.cs:164:15:164:19 | access to local variable sink8 | semmle.label | access to local variable sink8 |
+| GlobalDataFlow.cs:165:22:165:31 | call to method OutYield [element] : String | semmle.label | call to method OutYield [element] : String |
+| GlobalDataFlow.cs:165:22:165:39 | call to method First : String | semmle.label | call to method First : String |
+| GlobalDataFlow.cs:166:15:166:20 | access to local variable sink12 | semmle.label | access to local variable sink12 |
+| GlobalDataFlow.cs:167:22:167:43 | call to method TaintedParam : String | semmle.label | call to method TaintedParam : String |
+| GlobalDataFlow.cs:168:15:168:20 | access to local variable sink23 | semmle.label | access to local variable sink23 |
+| GlobalDataFlow.cs:183:35:183:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:184:21:184:26 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:185:15:185:19 | access to local variable sink9 | semmle.label | access to local variable sink9 |
+| GlobalDataFlow.cs:193:22:193:42 | object creation of type Lazy<String> [property Value] : String | semmle.label | object creation of type Lazy<String> [property Value] : String |
+| GlobalDataFlow.cs:193:22:193:48 | access to property Value : String | semmle.label | access to property Value : String |
+| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink10 | semmle.label | access to local variable sink10 |
+| GlobalDataFlow.cs:201:22:201:32 | access to property OutProperty : String | semmle.label | access to property OutProperty : String |
+| GlobalDataFlow.cs:202:15:202:20 | access to local variable sink19 | semmle.label | access to local variable sink19 |
+| GlobalDataFlow.cs:211:38:211:61 | array creation of type String[] [element] : String | semmle.label | array creation of type String[] [element] : String |
+| GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable [element] : String | semmle.label | call to method AsQueryable [element] : String |
+| GlobalDataFlow.cs:211:44:211:61 | { ..., ... } [element] : String | semmle.label | { ..., ... } [element] : String |
+| GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | semmle.label | sinkParam10 : String |
+| GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 | semmle.label | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:215:71:215:71 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:216:22:216:39 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
+| GlobalDataFlow.cs:216:22:216:47 | call to method First : String | semmle.label | call to method First : String |
+| GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 | semmle.label | access to local variable sink24 |
+| GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:218:22:218:39 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
+| GlobalDataFlow.cs:218:22:218:47 | call to method First : String | semmle.label | call to method First : String |
+| GlobalDataFlow.cs:219:15:219:20 | access to local variable sink25 | semmle.label | access to local variable sink25 |
+| GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:220:22:220:49 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
+| GlobalDataFlow.cs:220:22:220:57 | call to method First : String | semmle.label | call to method First : String |
+| GlobalDataFlow.cs:221:15:221:20 | access to local variable sink26 | semmle.label | access to local variable sink26 |
+| GlobalDataFlow.cs:241:20:241:49 | call to method Run [property Result] : String | semmle.label | call to method Run [property Result] : String |
+| GlobalDataFlow.cs:241:35:241:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:242:22:242:25 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:242:22:242:32 | access to property Result : String | semmle.label | access to property Result : String |
+| GlobalDataFlow.cs:243:15:243:20 | access to local variable sink41 | semmle.label | access to local variable sink41 |
+| GlobalDataFlow.cs:244:22:244:31 | await ... : String | semmle.label | await ... : String |
+| GlobalDataFlow.cs:244:28:244:31 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:245:15:245:20 | access to local variable sink42 | semmle.label | access to local variable sink42 |
+| GlobalDataFlow.cs:257:26:257:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
+| GlobalDataFlow.cs:259:16:259:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |
+| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:263:26:263:35 | sinkParam1 : String | semmle.label | sinkParam1 : String |
+| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam1 | semmle.label | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:268:26:268:35 | sinkParam3 : String | semmle.label | sinkParam3 : String |
+| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam3 | semmle.label | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:273:26:273:35 | sinkParam4 : String | semmle.label | sinkParam4 : String |
+| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam4 | semmle.label | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:278:26:278:35 | sinkParam5 : String | semmle.label | sinkParam5 : String |
+| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam5 | semmle.label | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:283:26:283:35 | sinkParam6 : String | semmle.label | sinkParam6 : String |
+| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:288:26:288:35 | sinkParam7 : String | semmle.label | sinkParam7 : String |
+| GlobalDataFlow.cs:290:15:290:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
+| GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
+| GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
+| GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:351:9:351:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:351:13:351:26 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:357:22:357:35 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:382:41:382:41 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:382:41:382:41 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:401:39:401:45 | tainted : String | semmle.label | tainted : String |
+| GlobalDataFlow.cs:404:15:404:20 | access to local variable sink11 | semmle.label | access to local variable sink11 |
+| GlobalDataFlow.cs:405:16:405:21 | access to local variable sink11 : String | semmle.label | access to local variable sink11 : String |
+| GlobalDataFlow.cs:427:9:427:11 | value : String | semmle.label | value : String |
+| GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 | semmle.label | access to local variable sink20 |
+| GlobalDataFlow.cs:438:22:438:35 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:474:20:474:49 | call to method Run [property Result] : String | semmle.label | call to method Run [property Result] : String |
+| GlobalDataFlow.cs:474:35:474:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:475:25:475:28 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:475:25:475:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String | semmle.label | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String |
+| GlobalDataFlow.cs:476:23:476:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String | semmle.label | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String |
+| GlobalDataFlow.cs:476:23:476:44 | call to method GetAwaiter [field m_task, property Result] : String | semmle.label | call to method GetAwaiter [field m_task, property Result] : String |
+| GlobalDataFlow.cs:477:22:477:28 | access to local variable awaiter [field m_task, property Result] : String | semmle.label | access to local variable awaiter [field m_task, property Result] : String |
+| GlobalDataFlow.cs:477:22:477:40 | call to method GetResult : String | semmle.label | call to method GetResult : String |
+| GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 | semmle.label | access to local variable sink45 |
+| GlobalDataFlow.cs:483:53:483:55 | arg : String | semmle.label | arg : String |
+| GlobalDataFlow.cs:486:21:486:21 | s : String | semmle.label | s : String |
+| GlobalDataFlow.cs:486:32:486:32 | access to parameter s | semmle.label | access to parameter s |
+| GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | semmle.label | access to parameter arg : String |
+| GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | semmle.label | "taint source" : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return : String | semmle.label | [b (line 3): false] call to method Return : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return : String | semmle.label | [b (line 3): true] call to method Return : String |
@@ -490,20 +490,20 @@ nodes
 | Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |
 | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 | access to local variable sink0 |
 | GlobalDataFlow.cs:74:15:74:19 | access to local variable sink1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:74:15:74:19 | access to local variable sink1 | access to local variable sink1 |
-| GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | access to local variable sink10 |
-| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | access to local variable sink11 |
-| GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | access to local variable sink12 |
+| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink10 | GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink10 | access to local variable sink10 |
+| GlobalDataFlow.cs:404:15:404:20 | access to local variable sink11 | GlobalDataFlow.cs:401:39:401:45 | tainted : String | GlobalDataFlow.cs:404:15:404:20 | access to local variable sink11 | access to local variable sink11 |
+| GlobalDataFlow.cs:166:15:166:20 | access to local variable sink12 | GlobalDataFlow.cs:357:22:357:35 | "taint source" : String | GlobalDataFlow.cs:166:15:166:20 | access to local variable sink12 | access to local variable sink12 |
 | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 | access to local variable sink13 |
 | GlobalDataFlow.cs:84:15:84:20 | access to local variable sink14 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:84:15:84:20 | access to local variable sink14 | access to local variable sink14 |
 | GlobalDataFlow.cs:86:15:86:20 | access to local variable sink15 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:86:15:86:20 | access to local variable sink15 | access to local variable sink15 |
 | GlobalDataFlow.cs:88:15:88:20 | access to local variable sink16 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:88:15:88:20 | access to local variable sink16 | access to local variable sink16 |
-| GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | access to local variable sink19 |
+| GlobalDataFlow.cs:202:15:202:20 | access to local variable sink19 | GlobalDataFlow.cs:438:22:438:35 | "taint source" : String | GlobalDataFlow.cs:202:15:202:20 | access to local variable sink19 | access to local variable sink19 |
 | GlobalDataFlow.cs:77:15:77:19 | access to local variable sink2 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:77:15:77:19 | access to local variable sink2 | access to local variable sink2 |
-| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | access to local variable sink20 |
-| GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | access to local variable sink23 |
-| GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 | access to local variable sink24 |
-| GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 | access to local variable sink25 |
-| GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | access to local variable sink26 |
+| GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 | access to local variable sink20 |
+| GlobalDataFlow.cs:168:15:168:20 | access to local variable sink23 | GlobalDataFlow.cs:401:39:401:45 | tainted : String | GlobalDataFlow.cs:168:15:168:20 | access to local variable sink23 | access to local variable sink23 |
+| GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 | access to local variable sink24 |
+| GlobalDataFlow.cs:219:15:219:20 | access to local variable sink25 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:219:15:219:20 | access to local variable sink25 | access to local variable sink25 |
+| GlobalDataFlow.cs:221:15:221:20 | access to local variable sink26 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:221:15:221:20 | access to local variable sink26 | access to local variable sink26 |
 | Capture.cs:12:19:12:24 | access to local variable sink27 | Capture.cs:7:20:7:26 | tainted : String | Capture.cs:12:19:12:24 | access to local variable sink27 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 | Capture.cs:7:20:7:26 | tainted : String | Capture.cs:21:23:21:28 | access to local variable sink28 | access to local variable sink28 |
 | Capture.cs:30:19:30:24 | access to local variable sink29 | Capture.cs:7:20:7:26 | tainted : String | Capture.cs:30:19:30:24 | access to local variable sink29 | access to local variable sink29 |
@@ -517,31 +517,31 @@ nodes
 | Capture.cs:161:15:161:20 | access to local variable sink36 | Capture.cs:125:25:125:31 | tainted : String | Capture.cs:161:15:161:20 | access to local variable sink36 | access to local variable sink36 |
 | Capture.cs:169:15:169:20 | access to local variable sink37 | Capture.cs:125:25:125:31 | tainted : String | Capture.cs:169:15:169:20 | access to local variable sink37 | access to local variable sink37 |
 | Capture.cs:195:15:195:20 | access to local variable sink38 | Capture.cs:125:25:125:31 | tainted : String | Capture.cs:195:15:195:20 | access to local variable sink38 | access to local variable sink38 |
-| GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 | access to local variable sink4 |
+| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink4 | access to local variable sink4 |
 | Capture.cs:122:15:122:20 | access to local variable sink40 | Capture.cs:115:26:115:39 | "taint source" : String | Capture.cs:122:15:122:20 | access to local variable sink40 | access to local variable sink40 |
-| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | access to local variable sink41 |
-| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | access to local variable sink42 |
-| GlobalDataFlow.cs:475:15:475:20 | access to local variable sink45 | GlobalDataFlow.cs:471:35:471:48 | "taint source" : String | GlobalDataFlow.cs:475:15:475:20 | access to local variable sink45 | access to local variable sink45 |
-| GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 | access to local variable sink5 |
-| GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | access to local variable sink6 |
-| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | access to local variable sink7 |
-| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | access to local variable sink8 |
-| GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 | GlobalDataFlow.cs:180:35:180:48 | "taint source" : String | GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 | access to local variable sink9 |
+| GlobalDataFlow.cs:243:15:243:20 | access to local variable sink41 | GlobalDataFlow.cs:241:35:241:48 | "taint source" : String | GlobalDataFlow.cs:243:15:243:20 | access to local variable sink41 | access to local variable sink41 |
+| GlobalDataFlow.cs:245:15:245:20 | access to local variable sink42 | GlobalDataFlow.cs:241:35:241:48 | "taint source" : String | GlobalDataFlow.cs:245:15:245:20 | access to local variable sink42 | access to local variable sink42 |
+| GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 | GlobalDataFlow.cs:474:35:474:48 | "taint source" : String | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 | access to local variable sink45 |
+| GlobalDataFlow.cs:148:15:148:19 | access to local variable sink5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:148:15:148:19 | access to local variable sink5 | access to local variable sink5 |
+| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink6 | GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink6 | access to local variable sink6 |
+| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink7 | GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink7 | access to local variable sink7 |
+| GlobalDataFlow.cs:164:15:164:19 | access to local variable sink8 | GlobalDataFlow.cs:351:13:351:26 | "taint source" : String | GlobalDataFlow.cs:164:15:164:19 | access to local variable sink8 | access to local variable sink8 |
+| GlobalDataFlow.cs:185:15:185:19 | access to local variable sink9 | GlobalDataFlow.cs:183:35:183:48 | "taint source" : String | GlobalDataFlow.cs:185:15:185:19 | access to local variable sink9 | access to local variable sink9 |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:34:19:34:19 | access to local variable x | access to local variable x |
-| GlobalDataFlow.cs:483:32:483:32 | access to parameter s | GlobalDataFlow.cs:487:27:487:40 | "taint source" : String | GlobalDataFlow.cs:483:32:483:32 | access to parameter s | access to parameter s |
+| GlobalDataFlow.cs:486:32:486:32 | access to parameter s | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | access to parameter s |
 | Capture.cs:57:27:57:32 | access to parameter sink39 | Capture.cs:7:20:7:26 | tainted : String | Capture.cs:57:27:57:32 | access to parameter sink39 | access to parameter sink39 |
-| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 | access to parameter sinkParam11 |
 | GlobalDataFlow.cs:45:50:45:59 | access to parameter sinkParam2 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:45:50:45:59 | access to parameter sinkParam2 | access to parameter sinkParam2 |
-| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:290:15:290:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:290:15:290:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 | access to parameter sinkParam9 |
 | GlobalDataFlow.cs:27:15:27:32 | access to property SinkProperty0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:27:15:27:32 | access to property SinkProperty0 | access to property SinkProperty0 |
 | Splitting.cs:21:21:21:33 | call to method Return | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:21:21:21:33 | call to method Return | call to method Return |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -60,102 +60,105 @@
 | GlobalDataFlow.cs:97:9:97:41 | call to method TryParse | normal | GlobalDataFlow.cs:97:9:97:41 | call to method TryParse |
 | GlobalDataFlow.cs:97:9:97:41 | call to method TryParse | out parameter 1 | GlobalDataFlow.cs:97:35:97:40 | SSA def(sink22) |
 | GlobalDataFlow.cs:97:9:97:41 | call to method TryParse | ref parameter 1 | GlobalDataFlow.cs:97:35:97:40 | SSA def(sink22) |
-| GlobalDataFlow.cs:101:24:101:33 | call to method Return | normal | GlobalDataFlow.cs:101:24:101:33 | call to method Return |
-| GlobalDataFlow.cs:103:28:103:63 | call to method GetMethod | normal | GlobalDataFlow.cs:103:28:103:63 | call to method GetMethod |
-| GlobalDataFlow.cs:103:28:103:103 | call to method Invoke | normal | GlobalDataFlow.cs:103:28:103:103 | call to method Invoke |
-| GlobalDataFlow.cs:105:9:105:49 | call to method ReturnOut | out parameter 1 | GlobalDataFlow.cs:105:27:105:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:105:9:105:49 | call to method ReturnOut | ref parameter 1 | GlobalDataFlow.cs:105:27:105:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:107:9:107:49 | call to method ReturnOut | out parameter 2 | GlobalDataFlow.cs:107:41:107:48 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:107:9:107:49 | call to method ReturnOut | ref parameter 2 | GlobalDataFlow.cs:107:41:107:48 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:109:9:109:49 | call to method ReturnRef | out parameter 1 | GlobalDataFlow.cs:109:27:109:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:109:9:109:49 | call to method ReturnRef | ref parameter 1 | GlobalDataFlow.cs:109:27:109:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:111:9:111:49 | call to method ReturnRef | out parameter 1 | GlobalDataFlow.cs:111:30:111:34 | SSA def(sink1) |
-| GlobalDataFlow.cs:111:9:111:49 | call to method ReturnRef | ref parameter 1 | GlobalDataFlow.cs:111:30:111:34 | SSA def(sink1) |
-| GlobalDataFlow.cs:113:20:113:86 | call to method SelectEven | normal | GlobalDataFlow.cs:113:20:113:86 | call to method SelectEven |
-| GlobalDataFlow.cs:113:20:113:94 | call to method First | normal | GlobalDataFlow.cs:113:20:113:94 | call to method First |
-| GlobalDataFlow.cs:115:20:115:82 | call to method Select | normal | GlobalDataFlow.cs:115:20:115:82 | call to method Select |
-| GlobalDataFlow.cs:115:20:115:90 | call to method First | normal | GlobalDataFlow.cs:115:20:115:90 | call to method First |
-| GlobalDataFlow.cs:117:20:117:126 | call to method Zip | normal | GlobalDataFlow.cs:117:20:117:126 | call to method Zip |
-| GlobalDataFlow.cs:117:20:117:134 | call to method First | normal | GlobalDataFlow.cs:117:20:117:134 | call to method First |
-| GlobalDataFlow.cs:119:20:119:126 | call to method Zip | normal | GlobalDataFlow.cs:119:20:119:126 | call to method Zip |
-| GlobalDataFlow.cs:119:20:119:134 | call to method First | normal | GlobalDataFlow.cs:119:20:119:134 | call to method First |
-| GlobalDataFlow.cs:121:20:121:104 | call to method Aggregate | normal | GlobalDataFlow.cs:121:20:121:104 | call to method Aggregate |
-| GlobalDataFlow.cs:123:20:123:109 | call to method Aggregate | normal | GlobalDataFlow.cs:123:20:123:109 | call to method Aggregate |
-| GlobalDataFlow.cs:125:20:125:107 | call to method Aggregate | normal | GlobalDataFlow.cs:125:20:125:107 | call to method Aggregate |
-| GlobalDataFlow.cs:128:9:128:46 | call to method TryParse | normal | GlobalDataFlow.cs:128:9:128:46 | call to method TryParse |
-| GlobalDataFlow.cs:128:9:128:46 | call to method TryParse | out parameter 1 | GlobalDataFlow.cs:128:38:128:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:128:9:128:46 | call to method TryParse | ref parameter 1 | GlobalDataFlow.cs:128:38:128:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:131:9:131:45 | call to method TryParse | normal | GlobalDataFlow.cs:131:9:131:45 | call to method TryParse |
-| GlobalDataFlow.cs:131:9:131:45 | call to method TryParse | out parameter 1 | GlobalDataFlow.cs:131:37:131:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:131:9:131:45 | call to method TryParse | ref parameter 1 | GlobalDataFlow.cs:131:37:131:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:135:45:135:64 | call to method ApplyFunc | normal | GlobalDataFlow.cs:135:45:135:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:136:21:136:34 | delegate call | normal | GlobalDataFlow.cs:136:21:136:34 | delegate call |
-| GlobalDataFlow.cs:140:20:140:36 | delegate call | normal | GlobalDataFlow.cs:140:20:140:36 | delegate call |
-| GlobalDataFlow.cs:144:21:144:44 | call to method ApplyFunc | normal | GlobalDataFlow.cs:144:21:144:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:148:20:148:40 | call to method ApplyFunc | normal | GlobalDataFlow.cs:148:20:148:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:150:20:150:44 | call to method ApplyFunc | normal | GlobalDataFlow.cs:150:20:150:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:154:21:154:25 | call to method Out | normal | GlobalDataFlow.cs:154:21:154:25 | call to method Out |
-| GlobalDataFlow.cs:157:9:157:25 | call to method OutOut | out parameter 0 | GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:157:9:157:25 | call to method OutOut | ref parameter 0 | GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:160:9:160:25 | call to method OutRef | out parameter 0 | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) |
-| GlobalDataFlow.cs:160:9:160:25 | call to method OutRef | ref parameter 0 | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) |
-| GlobalDataFlow.cs:162:22:162:31 | call to method OutYield | normal | GlobalDataFlow.cs:162:22:162:31 | call to method OutYield |
-| GlobalDataFlow.cs:162:22:162:39 | call to method First | normal | GlobalDataFlow.cs:162:22:162:39 | call to method First |
-| GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam | normal | GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:168:20:168:27 | call to method NonOut | normal | GlobalDataFlow.cs:168:20:168:27 | call to method NonOut |
-| GlobalDataFlow.cs:170:9:170:31 | call to method NonOutOut | out parameter 0 | GlobalDataFlow.cs:170:23:170:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:170:9:170:31 | call to method NonOutOut | ref parameter 0 | GlobalDataFlow.cs:170:23:170:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:172:9:172:31 | call to method NonOutRef | out parameter 0 | GlobalDataFlow.cs:172:23:172:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:172:9:172:31 | call to method NonOutRef | ref parameter 0 | GlobalDataFlow.cs:172:23:172:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:174:20:174:32 | call to method NonOutYield | normal | GlobalDataFlow.cs:174:20:174:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:174:20:174:40 | call to method First | normal | GlobalDataFlow.cs:174:20:174:40 | call to method First |
-| GlobalDataFlow.cs:176:20:176:44 | call to method NonTaintedParam | normal | GlobalDataFlow.cs:176:20:176:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:181:21:181:26 | delegate call | normal | GlobalDataFlow.cs:181:21:181:26 | delegate call |
-| GlobalDataFlow.cs:186:20:186:27 | delegate call | normal | GlobalDataFlow.cs:186:20:186:27 | delegate call |
-| GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> | normal | GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:190:22:190:48 | access to property Value | normal | GlobalDataFlow.cs:190:22:190:48 | access to property Value |
-| GlobalDataFlow.cs:194:20:194:43 | object creation of type Lazy<String> | normal | GlobalDataFlow.cs:194:20:194:43 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:194:20:194:49 | access to property Value | normal | GlobalDataFlow.cs:194:20:194:49 | access to property Value |
-| GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty | normal | GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty |
-| GlobalDataFlow.cs:202:20:202:33 | access to property NonOutProperty | normal | GlobalDataFlow.cs:202:20:202:33 | access to property NonOutProperty |
-| GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable | normal | GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable |
-| GlobalDataFlow.cs:209:41:209:77 | call to method AsQueryable | normal | GlobalDataFlow.cs:209:41:209:77 | call to method AsQueryable |
-| GlobalDataFlow.cs:212:76:212:90 | call to method ReturnCheck2 | normal | GlobalDataFlow.cs:212:76:212:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:213:22:213:39 | call to method Select | normal | GlobalDataFlow.cs:213:22:213:39 | call to method Select |
-| GlobalDataFlow.cs:213:22:213:47 | call to method First | normal | GlobalDataFlow.cs:213:22:213:47 | call to method First |
-| GlobalDataFlow.cs:215:22:215:39 | call to method Select | normal | GlobalDataFlow.cs:215:22:215:39 | call to method Select |
-| GlobalDataFlow.cs:215:22:215:47 | call to method First | normal | GlobalDataFlow.cs:215:22:215:47 | call to method First |
-| GlobalDataFlow.cs:217:22:217:49 | call to method Select | normal | GlobalDataFlow.cs:217:22:217:49 | call to method Select |
-| GlobalDataFlow.cs:217:22:217:57 | call to method First | normal | GlobalDataFlow.cs:217:22:217:57 | call to method First |
-| GlobalDataFlow.cs:222:76:222:92 | call to method NonReturnCheck | normal | GlobalDataFlow.cs:222:76:222:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:223:23:223:43 | call to method Select | normal | GlobalDataFlow.cs:223:23:223:43 | call to method Select |
-| GlobalDataFlow.cs:223:23:223:51 | call to method First | normal | GlobalDataFlow.cs:223:23:223:51 | call to method First |
-| GlobalDataFlow.cs:225:19:225:39 | call to method Select | normal | GlobalDataFlow.cs:225:19:225:39 | call to method Select |
-| GlobalDataFlow.cs:225:19:225:47 | call to method First | normal | GlobalDataFlow.cs:225:19:225:47 | call to method First |
-| GlobalDataFlow.cs:227:19:227:39 | call to method Select | normal | GlobalDataFlow.cs:227:19:227:39 | call to method Select |
-| GlobalDataFlow.cs:227:19:227:47 | call to method First | normal | GlobalDataFlow.cs:227:19:227:47 | call to method First |
-| GlobalDataFlow.cs:229:19:229:39 | call to method Select | normal | GlobalDataFlow.cs:229:19:229:39 | call to method Select |
-| GlobalDataFlow.cs:229:19:229:47 | call to method First | normal | GlobalDataFlow.cs:229:19:229:47 | call to method First |
-| GlobalDataFlow.cs:231:19:231:49 | call to method Select | normal | GlobalDataFlow.cs:231:19:231:49 | call to method Select |
-| GlobalDataFlow.cs:231:19:231:57 | call to method First | normal | GlobalDataFlow.cs:231:19:231:57 | call to method First |
-| GlobalDataFlow.cs:238:20:238:49 | call to method Run | normal | GlobalDataFlow.cs:238:20:238:49 | call to method Run |
-| GlobalDataFlow.cs:239:22:239:32 | access to property Result | normal | GlobalDataFlow.cs:239:22:239:32 | access to property Result |
-| GlobalDataFlow.cs:245:16:245:33 | call to method Run | normal | GlobalDataFlow.cs:245:16:245:33 | call to method Run |
-| GlobalDataFlow.cs:246:24:246:34 | access to property Result | normal | GlobalDataFlow.cs:246:24:246:34 | access to property Result |
-| GlobalDataFlow.cs:297:17:297:38 | call to method ApplyFunc | normal | GlobalDataFlow.cs:297:17:297:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:386:16:386:19 | delegate call | normal | GlobalDataFlow.cs:386:16:386:19 | delegate call |
-| GlobalDataFlow.cs:445:9:445:20 | call to method Append | normal | GlobalDataFlow.cs:445:9:445:20 | call to method Append |
-| GlobalDataFlow.cs:450:18:450:36 | object creation of type StringBuilder | normal | GlobalDataFlow.cs:450:18:450:36 | object creation of type StringBuilder |
-| GlobalDataFlow.cs:452:22:452:34 | call to method ToString | normal | GlobalDataFlow.cs:452:22:452:34 | call to method ToString |
-| GlobalDataFlow.cs:455:9:455:18 | call to method Clear | normal | GlobalDataFlow.cs:455:9:455:18 | call to method Clear |
-| GlobalDataFlow.cs:456:23:456:35 | call to method ToString | normal | GlobalDataFlow.cs:456:23:456:35 | call to method ToString |
-| GlobalDataFlow.cs:462:22:462:65 | call to method Join | normal | GlobalDataFlow.cs:462:22:462:65 | call to method Join |
-| GlobalDataFlow.cs:465:23:465:65 | call to method Join | normal | GlobalDataFlow.cs:465:23:465:65 | call to method Join |
-| GlobalDataFlow.cs:471:20:471:49 | call to method Run | normal | GlobalDataFlow.cs:471:20:471:49 | call to method Run |
-| GlobalDataFlow.cs:472:25:472:50 | call to method ConfigureAwait | normal | GlobalDataFlow.cs:472:25:472:50 | call to method ConfigureAwait |
-| GlobalDataFlow.cs:473:23:473:44 | call to method GetAwaiter | normal | GlobalDataFlow.cs:473:23:473:44 | call to method GetAwaiter |
-| GlobalDataFlow.cs:474:22:474:40 | call to method GetResult | normal | GlobalDataFlow.cs:474:22:474:40 | call to method GetResult |
-| GlobalDataFlow.cs:498:44:498:47 | delegate call | normal | GlobalDataFlow.cs:498:44:498:47 | delegate call |
+| GlobalDataFlow.cs:100:9:100:89 | call to method TryParse | normal | GlobalDataFlow.cs:100:9:100:89 | call to method TryParse |
+| GlobalDataFlow.cs:100:9:100:89 | call to method TryParse | out parameter 3 | GlobalDataFlow.cs:100:82:100:88 | SSA def(sink21b) |
+| GlobalDataFlow.cs:100:9:100:89 | call to method TryParse | ref parameter 3 | GlobalDataFlow.cs:100:82:100:88 | SSA def(sink21b) |
+| GlobalDataFlow.cs:104:24:104:33 | call to method Return | normal | GlobalDataFlow.cs:104:24:104:33 | call to method Return |
+| GlobalDataFlow.cs:106:28:106:63 | call to method GetMethod | normal | GlobalDataFlow.cs:106:28:106:63 | call to method GetMethod |
+| GlobalDataFlow.cs:106:28:106:103 | call to method Invoke | normal | GlobalDataFlow.cs:106:28:106:103 | call to method Invoke |
+| GlobalDataFlow.cs:108:9:108:49 | call to method ReturnOut | out parameter 1 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:9:108:49 | call to method ReturnOut | ref parameter 1 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:110:9:110:49 | call to method ReturnOut | out parameter 2 | GlobalDataFlow.cs:110:41:110:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:110:9:110:49 | call to method ReturnOut | ref parameter 2 | GlobalDataFlow.cs:110:41:110:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:112:9:112:49 | call to method ReturnRef | out parameter 1 | GlobalDataFlow.cs:112:27:112:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:112:9:112:49 | call to method ReturnRef | ref parameter 1 | GlobalDataFlow.cs:112:27:112:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:114:9:114:49 | call to method ReturnRef | out parameter 1 | GlobalDataFlow.cs:114:30:114:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:114:9:114:49 | call to method ReturnRef | ref parameter 1 | GlobalDataFlow.cs:114:30:114:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:116:20:116:86 | call to method SelectEven | normal | GlobalDataFlow.cs:116:20:116:86 | call to method SelectEven |
+| GlobalDataFlow.cs:116:20:116:94 | call to method First | normal | GlobalDataFlow.cs:116:20:116:94 | call to method First |
+| GlobalDataFlow.cs:118:20:118:82 | call to method Select | normal | GlobalDataFlow.cs:118:20:118:82 | call to method Select |
+| GlobalDataFlow.cs:118:20:118:90 | call to method First | normal | GlobalDataFlow.cs:118:20:118:90 | call to method First |
+| GlobalDataFlow.cs:120:20:120:126 | call to method Zip | normal | GlobalDataFlow.cs:120:20:120:126 | call to method Zip |
+| GlobalDataFlow.cs:120:20:120:134 | call to method First | normal | GlobalDataFlow.cs:120:20:120:134 | call to method First |
+| GlobalDataFlow.cs:122:20:122:126 | call to method Zip | normal | GlobalDataFlow.cs:122:20:122:126 | call to method Zip |
+| GlobalDataFlow.cs:122:20:122:134 | call to method First | normal | GlobalDataFlow.cs:122:20:122:134 | call to method First |
+| GlobalDataFlow.cs:124:20:124:104 | call to method Aggregate | normal | GlobalDataFlow.cs:124:20:124:104 | call to method Aggregate |
+| GlobalDataFlow.cs:126:20:126:109 | call to method Aggregate | normal | GlobalDataFlow.cs:126:20:126:109 | call to method Aggregate |
+| GlobalDataFlow.cs:128:20:128:107 | call to method Aggregate | normal | GlobalDataFlow.cs:128:20:128:107 | call to method Aggregate |
+| GlobalDataFlow.cs:131:9:131:46 | call to method TryParse | normal | GlobalDataFlow.cs:131:9:131:46 | call to method TryParse |
+| GlobalDataFlow.cs:131:9:131:46 | call to method TryParse | out parameter 1 | GlobalDataFlow.cs:131:38:131:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:131:9:131:46 | call to method TryParse | ref parameter 1 | GlobalDataFlow.cs:131:38:131:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:134:9:134:45 | call to method TryParse | normal | GlobalDataFlow.cs:134:9:134:45 | call to method TryParse |
+| GlobalDataFlow.cs:134:9:134:45 | call to method TryParse | out parameter 1 | GlobalDataFlow.cs:134:37:134:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:134:9:134:45 | call to method TryParse | ref parameter 1 | GlobalDataFlow.cs:134:37:134:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc | normal | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:139:21:139:34 | delegate call | normal | GlobalDataFlow.cs:139:21:139:34 | delegate call |
+| GlobalDataFlow.cs:143:20:143:36 | delegate call | normal | GlobalDataFlow.cs:143:20:143:36 | delegate call |
+| GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc | normal | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:151:20:151:40 | call to method ApplyFunc | normal | GlobalDataFlow.cs:151:20:151:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:153:20:153:44 | call to method ApplyFunc | normal | GlobalDataFlow.cs:153:20:153:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:157:21:157:25 | call to method Out | normal | GlobalDataFlow.cs:157:21:157:25 | call to method Out |
+| GlobalDataFlow.cs:160:9:160:25 | call to method OutOut | out parameter 0 | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink7) |
+| GlobalDataFlow.cs:160:9:160:25 | call to method OutOut | ref parameter 0 | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink7) |
+| GlobalDataFlow.cs:163:9:163:25 | call to method OutRef | out parameter 0 | GlobalDataFlow.cs:163:20:163:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:163:9:163:25 | call to method OutRef | ref parameter 0 | GlobalDataFlow.cs:163:20:163:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:165:22:165:31 | call to method OutYield | normal | GlobalDataFlow.cs:165:22:165:31 | call to method OutYield |
+| GlobalDataFlow.cs:165:22:165:39 | call to method First | normal | GlobalDataFlow.cs:165:22:165:39 | call to method First |
+| GlobalDataFlow.cs:167:22:167:43 | call to method TaintedParam | normal | GlobalDataFlow.cs:167:22:167:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:171:20:171:27 | call to method NonOut | normal | GlobalDataFlow.cs:171:20:171:27 | call to method NonOut |
+| GlobalDataFlow.cs:173:9:173:31 | call to method NonOutOut | out parameter 0 | GlobalDataFlow.cs:173:23:173:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:173:9:173:31 | call to method NonOutOut | ref parameter 0 | GlobalDataFlow.cs:173:23:173:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:175:9:175:31 | call to method NonOutRef | out parameter 0 | GlobalDataFlow.cs:175:23:175:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:175:9:175:31 | call to method NonOutRef | ref parameter 0 | GlobalDataFlow.cs:175:23:175:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:177:20:177:32 | call to method NonOutYield | normal | GlobalDataFlow.cs:177:20:177:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:177:20:177:40 | call to method First | normal | GlobalDataFlow.cs:177:20:177:40 | call to method First |
+| GlobalDataFlow.cs:179:20:179:44 | call to method NonTaintedParam | normal | GlobalDataFlow.cs:179:20:179:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:184:21:184:26 | delegate call | normal | GlobalDataFlow.cs:184:21:184:26 | delegate call |
+| GlobalDataFlow.cs:189:20:189:27 | delegate call | normal | GlobalDataFlow.cs:189:20:189:27 | delegate call |
+| GlobalDataFlow.cs:193:22:193:42 | object creation of type Lazy<String> | normal | GlobalDataFlow.cs:193:22:193:42 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:193:22:193:48 | access to property Value | normal | GlobalDataFlow.cs:193:22:193:48 | access to property Value |
+| GlobalDataFlow.cs:197:20:197:43 | object creation of type Lazy<String> | normal | GlobalDataFlow.cs:197:20:197:43 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:197:20:197:49 | access to property Value | normal | GlobalDataFlow.cs:197:20:197:49 | access to property Value |
+| GlobalDataFlow.cs:201:22:201:32 | access to property OutProperty | normal | GlobalDataFlow.cs:201:22:201:32 | access to property OutProperty |
+| GlobalDataFlow.cs:205:20:205:33 | access to property NonOutProperty | normal | GlobalDataFlow.cs:205:20:205:33 | access to property NonOutProperty |
+| GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable | normal | GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable |
+| GlobalDataFlow.cs:212:41:212:77 | call to method AsQueryable | normal | GlobalDataFlow.cs:212:41:212:77 | call to method AsQueryable |
+| GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2 | normal | GlobalDataFlow.cs:215:76:215:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:216:22:216:39 | call to method Select | normal | GlobalDataFlow.cs:216:22:216:39 | call to method Select |
+| GlobalDataFlow.cs:216:22:216:47 | call to method First | normal | GlobalDataFlow.cs:216:22:216:47 | call to method First |
+| GlobalDataFlow.cs:218:22:218:39 | call to method Select | normal | GlobalDataFlow.cs:218:22:218:39 | call to method Select |
+| GlobalDataFlow.cs:218:22:218:47 | call to method First | normal | GlobalDataFlow.cs:218:22:218:47 | call to method First |
+| GlobalDataFlow.cs:220:22:220:49 | call to method Select | normal | GlobalDataFlow.cs:220:22:220:49 | call to method Select |
+| GlobalDataFlow.cs:220:22:220:57 | call to method First | normal | GlobalDataFlow.cs:220:22:220:57 | call to method First |
+| GlobalDataFlow.cs:225:76:225:92 | call to method NonReturnCheck | normal | GlobalDataFlow.cs:225:76:225:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:226:23:226:43 | call to method Select | normal | GlobalDataFlow.cs:226:23:226:43 | call to method Select |
+| GlobalDataFlow.cs:226:23:226:51 | call to method First | normal | GlobalDataFlow.cs:226:23:226:51 | call to method First |
+| GlobalDataFlow.cs:228:19:228:39 | call to method Select | normal | GlobalDataFlow.cs:228:19:228:39 | call to method Select |
+| GlobalDataFlow.cs:228:19:228:47 | call to method First | normal | GlobalDataFlow.cs:228:19:228:47 | call to method First |
+| GlobalDataFlow.cs:230:19:230:39 | call to method Select | normal | GlobalDataFlow.cs:230:19:230:39 | call to method Select |
+| GlobalDataFlow.cs:230:19:230:47 | call to method First | normal | GlobalDataFlow.cs:230:19:230:47 | call to method First |
+| GlobalDataFlow.cs:232:19:232:39 | call to method Select | normal | GlobalDataFlow.cs:232:19:232:39 | call to method Select |
+| GlobalDataFlow.cs:232:19:232:47 | call to method First | normal | GlobalDataFlow.cs:232:19:232:47 | call to method First |
+| GlobalDataFlow.cs:234:19:234:49 | call to method Select | normal | GlobalDataFlow.cs:234:19:234:49 | call to method Select |
+| GlobalDataFlow.cs:234:19:234:57 | call to method First | normal | GlobalDataFlow.cs:234:19:234:57 | call to method First |
+| GlobalDataFlow.cs:241:20:241:49 | call to method Run | normal | GlobalDataFlow.cs:241:20:241:49 | call to method Run |
+| GlobalDataFlow.cs:242:22:242:32 | access to property Result | normal | GlobalDataFlow.cs:242:22:242:32 | access to property Result |
+| GlobalDataFlow.cs:248:16:248:33 | call to method Run | normal | GlobalDataFlow.cs:248:16:248:33 | call to method Run |
+| GlobalDataFlow.cs:249:24:249:34 | access to property Result | normal | GlobalDataFlow.cs:249:24:249:34 | access to property Result |
+| GlobalDataFlow.cs:300:17:300:38 | call to method ApplyFunc | normal | GlobalDataFlow.cs:300:17:300:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:389:16:389:19 | delegate call | normal | GlobalDataFlow.cs:389:16:389:19 | delegate call |
+| GlobalDataFlow.cs:448:9:448:20 | call to method Append | normal | GlobalDataFlow.cs:448:9:448:20 | call to method Append |
+| GlobalDataFlow.cs:453:18:453:36 | object creation of type StringBuilder | normal | GlobalDataFlow.cs:453:18:453:36 | object creation of type StringBuilder |
+| GlobalDataFlow.cs:455:22:455:34 | call to method ToString | normal | GlobalDataFlow.cs:455:22:455:34 | call to method ToString |
+| GlobalDataFlow.cs:458:9:458:18 | call to method Clear | normal | GlobalDataFlow.cs:458:9:458:18 | call to method Clear |
+| GlobalDataFlow.cs:459:23:459:35 | call to method ToString | normal | GlobalDataFlow.cs:459:23:459:35 | call to method ToString |
+| GlobalDataFlow.cs:465:22:465:65 | call to method Join | normal | GlobalDataFlow.cs:465:22:465:65 | call to method Join |
+| GlobalDataFlow.cs:468:23:468:65 | call to method Join | normal | GlobalDataFlow.cs:468:23:468:65 | call to method Join |
+| GlobalDataFlow.cs:474:20:474:49 | call to method Run | normal | GlobalDataFlow.cs:474:20:474:49 | call to method Run |
+| GlobalDataFlow.cs:475:25:475:50 | call to method ConfigureAwait | normal | GlobalDataFlow.cs:475:25:475:50 | call to method ConfigureAwait |
+| GlobalDataFlow.cs:476:23:476:44 | call to method GetAwaiter | normal | GlobalDataFlow.cs:476:23:476:44 | call to method GetAwaiter |
+| GlobalDataFlow.cs:477:22:477:40 | call to method GetResult | normal | GlobalDataFlow.cs:477:22:477:40 | call to method GetResult |
+| GlobalDataFlow.cs:501:44:501:47 | delegate call | normal | GlobalDataFlow.cs:501:44:501:47 | delegate call |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return | normal | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return | normal | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return |
 | Splitting.cs:20:22:20:30 | call to method Return | normal | Splitting.cs:20:22:20:30 | call to method Return |

--- a/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
@@ -96,6 +96,9 @@ public class DataFlow
         bool sink22;
         bool.TryParse(sink18, out sink22);
         Check(sink22);
+        int sink21b;
+        Int32.TryParse(sink18, System.Globalization.NumberStyles.None, null, out sink21b);
+        Check(sink21b);
 
         // Flow through a callable that returns the argument (non-delegate), not tainted
         var nonSink0 = Return("");
@@ -484,7 +487,7 @@ public class DataFlow
             a(arg);
         }
 
-        Inner(_ => {}, b, "taint source");
+        Inner(_ => { }, b, "taint source");
     }
 }
 

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -27,38 +27,39 @@
 | GlobalDataFlow.cs:92:15:92:20 | access to local variable sink18 |
 | GlobalDataFlow.cs:95:15:95:20 | access to local variable sink21 |
 | GlobalDataFlow.cs:98:15:98:20 | access to local variable sink22 |
-| GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
-| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
-| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:453:15:453:20 | access to local variable sink43 |
-| GlobalDataFlow.cs:463:15:463:20 | access to local variable sink44 |
-| GlobalDataFlow.cs:475:15:475:20 | access to local variable sink45 |
-| GlobalDataFlow.cs:483:32:483:32 | access to parameter s |
+| GlobalDataFlow.cs:101:15:101:21 | access to local variable sink21b |
+| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:148:15:148:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:164:15:164:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:166:15:166:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:168:15:168:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:185:15:185:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:202:15:202:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:219:15:219:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:221:15:221:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:243:15:243:20 | access to local variable sink41 |
+| GlobalDataFlow.cs:245:15:245:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:290:15:290:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:404:15:404:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:456:15:456:20 | access to local variable sink43 |
+| GlobalDataFlow.cs:466:15:466:20 | access to local variable sink44 |
+| GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 |
+| GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -55,7 +55,7 @@ edges
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String |
+| GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:257:26:257:35 | sinkParam0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String |
@@ -64,7 +64,7 @@ edges
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String |
+| GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:263:26:263:35 | sinkParam1 : String |
 | GlobalDataFlow.cs:45:30:45:39 | sinkParam2 : String | GlobalDataFlow.cs:45:50:45:59 | access to parameter sinkParam2 |
 | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:45:30:45:39 | sinkParam2 : String |
 | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String |
@@ -80,31 +80,31 @@ edges
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:379:41:379:41 | x : String |
+| GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:382:41:382:41 | x : String |
 | GlobalDataFlow.cs:54:15:54:15 | x : String | GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String |
-| GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String | GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String |
+| GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String | GlobalDataFlow.cs:273:26:273:35 | sinkParam4 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:379:41:379:41 | x : String |
+| GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:382:41:382:41 | x : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
+| GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:396:52:396:52 | x : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
+| GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:396:52:396:52 | x : String |
 | GlobalDataFlow.cs:57:37:57:37 | x : String | GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String |
-| GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String | GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String |
+| GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String | GlobalDataFlow.cs:288:26:288:35 | sinkParam7 : String |
 | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
+| GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:396:52:396:52 | x : String |
 | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:424:9:424:11 | value : String |
+| GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:427:9:427:11 | value : String |
 | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 |
 | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String |
 | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String |
@@ -118,7 +118,7 @@ edges
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
 | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String | GlobalDataFlow.cs:80:15:80:19 | access to local variable sink3 |
 | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String |
-| GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String | GlobalDataFlow.cs:136:29:136:33 | access to local variable sink3 : String |
+| GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String |
 | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven [element] : String | GlobalDataFlow.cs:81:22:81:93 | call to method First : String |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
@@ -131,7 +131,7 @@ edges
 | GlobalDataFlow.cs:83:22:83:95 | call to method First : String | GlobalDataFlow.cs:89:59:89:64 | access to local variable sink14 : String |
 | GlobalDataFlow.cs:83:22:83:95 | call to method First : String | GlobalDataFlow.cs:91:75:91:80 | access to local variable sink14 : String |
 | GlobalDataFlow.cs:83:23:83:66 | (...) ... [element] : String | GlobalDataFlow.cs:83:22:83:87 | call to method Select [element] : String |
-| GlobalDataFlow.cs:83:23:83:66 | (...) ... [element] : String | GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String |
+| GlobalDataFlow.cs:83:23:83:66 | (...) ... [element] : String | GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String |
 | GlobalDataFlow.cs:83:57:83:66 | { ..., ... } [element] : String | GlobalDataFlow.cs:83:23:83:66 | (...) ... [element] : String |
 | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String | GlobalDataFlow.cs:83:57:83:66 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:85:22:85:128 | call to method Zip [element] : String | GlobalDataFlow.cs:85:22:85:136 | call to method First : String |
@@ -152,107 +152,110 @@ edges
 | GlobalDataFlow.cs:91:22:91:110 | call to method Aggregate : String | GlobalDataFlow.cs:92:15:92:20 | access to local variable sink18 |
 | GlobalDataFlow.cs:91:22:91:110 | call to method Aggregate : String | GlobalDataFlow.cs:94:24:94:29 | access to local variable sink18 : String |
 | GlobalDataFlow.cs:91:22:91:110 | call to method Aggregate : String | GlobalDataFlow.cs:97:23:97:28 | access to local variable sink18 : String |
+| GlobalDataFlow.cs:91:22:91:110 | call to method Aggregate : String | GlobalDataFlow.cs:100:24:100:29 | access to local variable sink18 : String |
 | GlobalDataFlow.cs:91:75:91:80 | access to local variable sink14 : String | GlobalDataFlow.cs:91:22:91:110 | call to method Aggregate : String |
 | GlobalDataFlow.cs:94:24:94:29 | access to local variable sink18 : String | GlobalDataFlow.cs:94:36:94:41 | SSA def(sink21) : Int32 |
 | GlobalDataFlow.cs:94:36:94:41 | SSA def(sink21) : Int32 | GlobalDataFlow.cs:95:15:95:20 | access to local variable sink21 |
 | GlobalDataFlow.cs:97:23:97:28 | access to local variable sink18 : String | GlobalDataFlow.cs:97:35:97:40 | SSA def(sink22) : Boolean |
 | GlobalDataFlow.cs:97:35:97:40 | SSA def(sink22) : Boolean | GlobalDataFlow.cs:98:15:98:20 | access to local variable sink22 |
-| GlobalDataFlow.cs:136:21:136:34 | delegate call : String | GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:136:21:136:34 | delegate call : String | GlobalDataFlow.cs:144:39:144:43 | access to local variable sink4 : String |
-| GlobalDataFlow.cs:136:29:136:33 | access to local variable sink3 : String | GlobalDataFlow.cs:136:21:136:34 | delegate call : String |
-| GlobalDataFlow.cs:144:21:144:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:144:39:144:43 | access to local variable sink4 : String | GlobalDataFlow.cs:144:21:144:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:154:21:154:25 | call to method Out : String | GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:162:22:162:31 | call to method OutYield [element] : String | GlobalDataFlow.cs:162:22:162:39 | call to method First : String |
-| GlobalDataFlow.cs:162:22:162:39 | call to method First : String | GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam : String | GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:180:35:180:48 | "taint source" : String | GlobalDataFlow.cs:181:21:181:26 | delegate call : String |
-| GlobalDataFlow.cs:181:21:181:26 | delegate call : String | GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> [property Value] : String | GlobalDataFlow.cs:190:22:190:48 | access to property Value : String |
-| GlobalDataFlow.cs:190:22:190:48 | access to property Value : String | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty : String | GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:208:38:208:61 | array creation of type String[] [element] : String | GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable [element] : String |
-| GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:215:22:215:28 | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:208:44:208:61 | { ..., ... } [element] : String | GlobalDataFlow.cs:208:38:208:61 | array creation of type String[] [element] : String |
-| GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:208:44:208:61 | { ..., ... } [element] : String |
-| GlobalDataFlow.cs:211:35:211:45 | sinkParam10 : String | GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:212:71:212:71 | x : String | GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String |
-| GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String | GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String |
-| GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:211:35:211:45 | sinkParam10 : String |
-| GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:213:22:213:39 | call to method Select [element] : String |
-| GlobalDataFlow.cs:213:22:213:39 | call to method Select [element] : String | GlobalDataFlow.cs:213:22:213:47 | call to method First : String |
-| GlobalDataFlow.cs:213:22:213:47 | call to method First : String | GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:215:22:215:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:212:71:212:71 | x : String |
-| GlobalDataFlow.cs:215:22:215:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:215:22:215:39 | call to method Select [element] : String |
-| GlobalDataFlow.cs:215:22:215:39 | call to method Select [element] : String | GlobalDataFlow.cs:215:22:215:47 | call to method First : String |
-| GlobalDataFlow.cs:215:22:215:47 | call to method First : String | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:217:22:217:49 | call to method Select [element] : String |
-| GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String |
-| GlobalDataFlow.cs:217:22:217:49 | call to method Select [element] : String | GlobalDataFlow.cs:217:22:217:57 | call to method First : String |
-| GlobalDataFlow.cs:217:22:217:57 | call to method First : String | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:238:20:238:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:239:22:239:25 | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:238:20:238:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:241:28:241:31 | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:238:20:238:49 | call to method Run [property Result] : String |
-| GlobalDataFlow.cs:239:22:239:25 | access to local variable task [property Result] : String | GlobalDataFlow.cs:239:22:239:32 | access to property Result : String |
-| GlobalDataFlow.cs:239:22:239:32 | access to property Result : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
-| GlobalDataFlow.cs:241:22:241:31 | await ... : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
-| GlobalDataFlow.cs:241:28:241:31 | access to local variable task [property Result] : String | GlobalDataFlow.cs:241:22:241:31 | await ... : String |
-| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String |
-| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String |
-| GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String | GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String | GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String | GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String | GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String | GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String | GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String | GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:154:21:154:25 | call to method Out : String |
-| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> [property Value] : String |
-| GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String | GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) : String |
-| GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String |
-| GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) : String |
-| GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String |
-| GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | GlobalDataFlow.cs:162:22:162:31 | call to method OutYield [element] : String |
-| GlobalDataFlow.cs:379:41:379:41 | x : String | GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String |
-| GlobalDataFlow.cs:379:41:379:41 | x : String | GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String |
-| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | GlobalDataFlow.cs:54:15:54:15 | x : String |
-| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:57:37:57:37 | x : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String |
-| GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String |
-| GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String | GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam : String |
-| GlobalDataFlow.cs:424:9:424:11 | value : String | GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty : String |
-| GlobalDataFlow.cs:451:31:451:32 | [post] access to local variable sb [element] : String | GlobalDataFlow.cs:452:22:452:23 | access to local variable sb [element] : String |
-| GlobalDataFlow.cs:451:35:451:48 | "taint source" : String | GlobalDataFlow.cs:451:31:451:32 | [post] access to local variable sb [element] : String |
-| GlobalDataFlow.cs:452:22:452:23 | access to local variable sb [element] : String | GlobalDataFlow.cs:452:22:452:34 | call to method ToString : String |
-| GlobalDataFlow.cs:452:22:452:34 | call to method ToString : String | GlobalDataFlow.cs:453:15:453:20 | access to local variable sink43 |
-| GlobalDataFlow.cs:462:22:462:65 | call to method Join : String | GlobalDataFlow.cs:463:15:463:20 | access to local variable sink44 |
-| GlobalDataFlow.cs:462:51:462:64 | "taint source" : String | GlobalDataFlow.cs:462:22:462:65 | call to method Join : String |
-| GlobalDataFlow.cs:471:20:471:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:472:25:472:28 | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:471:35:471:48 | "taint source" : String | GlobalDataFlow.cs:471:20:471:49 | call to method Run [property Result] : String |
-| GlobalDataFlow.cs:472:25:472:28 | access to local variable task [property Result] : String | GlobalDataFlow.cs:472:25:472:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String |
-| GlobalDataFlow.cs:472:25:472:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String | GlobalDataFlow.cs:473:23:473:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String |
-| GlobalDataFlow.cs:473:23:473:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String | GlobalDataFlow.cs:473:23:473:44 | call to method GetAwaiter [field m_task, property Result] : String |
-| GlobalDataFlow.cs:473:23:473:44 | call to method GetAwaiter [field m_task, property Result] : String | GlobalDataFlow.cs:474:22:474:28 | access to local variable awaiter [field m_task, property Result] : String |
-| GlobalDataFlow.cs:474:22:474:28 | access to local variable awaiter [field m_task, property Result] : String | GlobalDataFlow.cs:474:22:474:40 | call to method GetResult : String |
-| GlobalDataFlow.cs:474:22:474:40 | call to method GetResult : String | GlobalDataFlow.cs:475:15:475:20 | access to local variable sink45 |
-| GlobalDataFlow.cs:480:53:480:55 | arg : String | GlobalDataFlow.cs:484:15:484:17 | access to parameter arg : String |
-| GlobalDataFlow.cs:483:21:483:21 | s : String | GlobalDataFlow.cs:483:32:483:32 | access to parameter s |
-| GlobalDataFlow.cs:484:15:484:17 | access to parameter arg : String | GlobalDataFlow.cs:483:21:483:21 | s : String |
-| GlobalDataFlow.cs:487:27:487:40 | "taint source" : String | GlobalDataFlow.cs:480:53:480:55 | arg : String |
+| GlobalDataFlow.cs:100:24:100:29 | access to local variable sink18 : String | GlobalDataFlow.cs:100:82:100:88 | SSA def(sink21b) : Int32 |
+| GlobalDataFlow.cs:100:82:100:88 | SSA def(sink21b) : Int32 | GlobalDataFlow.cs:101:15:101:21 | access to local variable sink21b |
+| GlobalDataFlow.cs:139:21:139:34 | delegate call : String | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:139:21:139:34 | delegate call : String | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String |
+| GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
+| GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:148:15:148:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:157:21:157:25 | call to method Out : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:160:20:160:24 | SSA def(sink7) : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:163:20:163:24 | SSA def(sink8) : String | GlobalDataFlow.cs:164:15:164:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:165:22:165:31 | call to method OutYield [element] : String | GlobalDataFlow.cs:165:22:165:39 | call to method First : String |
+| GlobalDataFlow.cs:165:22:165:39 | call to method First : String | GlobalDataFlow.cs:166:15:166:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:167:22:167:43 | call to method TaintedParam : String | GlobalDataFlow.cs:168:15:168:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:183:35:183:48 | "taint source" : String | GlobalDataFlow.cs:184:21:184:26 | delegate call : String |
+| GlobalDataFlow.cs:184:21:184:26 | delegate call : String | GlobalDataFlow.cs:185:15:185:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:193:22:193:42 | object creation of type Lazy<String> [property Value] : String | GlobalDataFlow.cs:193:22:193:48 | access to property Value : String |
+| GlobalDataFlow.cs:193:22:193:48 | access to property Value : String | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:201:22:201:32 | access to property OutProperty : String | GlobalDataFlow.cs:202:15:202:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:211:38:211:61 | array creation of type String[] [element] : String | GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable [element] : String |
+| GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable [element] : String | GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:211:44:211:61 | { ..., ... } [element] : String | GlobalDataFlow.cs:211:38:211:61 | array creation of type String[] [element] : String |
+| GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:211:44:211:61 | { ..., ... } [element] : String |
+| GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:215:71:215:71 | x : String | GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String |
+| GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String |
+| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String |
+| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:216:22:216:39 | call to method Select [element] : String |
+| GlobalDataFlow.cs:216:22:216:39 | call to method Select [element] : String | GlobalDataFlow.cs:216:22:216:47 | call to method First : String |
+| GlobalDataFlow.cs:216:22:216:47 | call to method First : String | GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:215:71:215:71 | x : String |
+| GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:218:22:218:39 | call to method Select [element] : String |
+| GlobalDataFlow.cs:218:22:218:39 | call to method Select [element] : String | GlobalDataFlow.cs:218:22:218:47 | call to method First : String |
+| GlobalDataFlow.cs:218:22:218:47 | call to method First : String | GlobalDataFlow.cs:219:15:219:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:220:22:220:49 | call to method Select [element] : String |
+| GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted [element] : String | GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String |
+| GlobalDataFlow.cs:220:22:220:49 | call to method Select [element] : String | GlobalDataFlow.cs:220:22:220:57 | call to method First : String |
+| GlobalDataFlow.cs:220:22:220:57 | call to method First : String | GlobalDataFlow.cs:221:15:221:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:241:20:241:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:242:22:242:25 | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:241:20:241:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:244:28:244:31 | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:241:35:241:48 | "taint source" : String | GlobalDataFlow.cs:241:20:241:49 | call to method Run [property Result] : String |
+| GlobalDataFlow.cs:242:22:242:25 | access to local variable task [property Result] : String | GlobalDataFlow.cs:242:22:242:32 | access to property Result : String |
+| GlobalDataFlow.cs:242:22:242:32 | access to property Result : String | GlobalDataFlow.cs:243:15:243:20 | access to local variable sink41 |
+| GlobalDataFlow.cs:244:22:244:31 | await ... : String | GlobalDataFlow.cs:245:15:245:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:244:28:244:31 | access to local variable task [property Result] : String | GlobalDataFlow.cs:244:22:244:31 | await ... : String |
+| GlobalDataFlow.cs:257:26:257:35 | sinkParam0 : String | GlobalDataFlow.cs:259:16:259:25 | access to parameter sinkParam0 : String |
+| GlobalDataFlow.cs:257:26:257:35 | sinkParam0 : String | GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:259:16:259:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:257:26:257:35 | sinkParam0 : String |
+| GlobalDataFlow.cs:263:26:263:35 | sinkParam1 : String | GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:268:26:268:35 | sinkParam3 : String | GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:273:26:273:35 | sinkParam4 : String | GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:278:26:278:35 | sinkParam5 : String | GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:283:26:283:35 | sinkParam6 : String | GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:288:26:288:35 | sinkParam7 : String | GlobalDataFlow.cs:290:15:290:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:157:21:157:25 | call to method Out : String |
+| GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:193:22:193:42 | object creation of type Lazy<String> [property Value] : String |
+| GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink7) : String |
+| GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String |
+| GlobalDataFlow.cs:351:9:351:26 | SSA def(x) : String | GlobalDataFlow.cs:163:20:163:24 | SSA def(sink8) : String |
+| GlobalDataFlow.cs:351:13:351:26 | "taint source" : String | GlobalDataFlow.cs:351:9:351:26 | SSA def(x) : String |
+| GlobalDataFlow.cs:357:22:357:35 | "taint source" : String | GlobalDataFlow.cs:165:22:165:31 | call to method OutYield [element] : String |
+| GlobalDataFlow.cs:382:41:382:41 | x : String | GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String |
+| GlobalDataFlow.cs:382:41:382:41 | x : String | GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String |
+| GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | GlobalDataFlow.cs:54:15:54:15 | x : String |
+| GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | GlobalDataFlow.cs:268:26:268:35 | sinkParam3 : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | GlobalDataFlow.cs:57:37:57:37 | x : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | GlobalDataFlow.cs:278:26:278:35 | sinkParam5 : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | GlobalDataFlow.cs:283:26:283:35 | sinkParam6 : String |
+| GlobalDataFlow.cs:401:39:401:45 | tainted : String | GlobalDataFlow.cs:404:15:404:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:401:39:401:45 | tainted : String | GlobalDataFlow.cs:405:16:405:21 | access to local variable sink11 : String |
+| GlobalDataFlow.cs:405:16:405:21 | access to local variable sink11 : String | GlobalDataFlow.cs:167:22:167:43 | call to method TaintedParam : String |
+| GlobalDataFlow.cs:427:9:427:11 | value : String | GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:438:22:438:35 | "taint source" : String | GlobalDataFlow.cs:201:22:201:32 | access to property OutProperty : String |
+| GlobalDataFlow.cs:454:31:454:32 | [post] access to local variable sb [element] : String | GlobalDataFlow.cs:455:22:455:23 | access to local variable sb [element] : String |
+| GlobalDataFlow.cs:454:35:454:48 | "taint source" : String | GlobalDataFlow.cs:454:31:454:32 | [post] access to local variable sb [element] : String |
+| GlobalDataFlow.cs:455:22:455:23 | access to local variable sb [element] : String | GlobalDataFlow.cs:455:22:455:34 | call to method ToString : String |
+| GlobalDataFlow.cs:455:22:455:34 | call to method ToString : String | GlobalDataFlow.cs:456:15:456:20 | access to local variable sink43 |
+| GlobalDataFlow.cs:465:22:465:65 | call to method Join : String | GlobalDataFlow.cs:466:15:466:20 | access to local variable sink44 |
+| GlobalDataFlow.cs:465:51:465:64 | "taint source" : String | GlobalDataFlow.cs:465:22:465:65 | call to method Join : String |
+| GlobalDataFlow.cs:474:20:474:49 | call to method Run [property Result] : String | GlobalDataFlow.cs:475:25:475:28 | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:474:35:474:48 | "taint source" : String | GlobalDataFlow.cs:474:20:474:49 | call to method Run [property Result] : String |
+| GlobalDataFlow.cs:475:25:475:28 | access to local variable task [property Result] : String | GlobalDataFlow.cs:475:25:475:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String |
+| GlobalDataFlow.cs:475:25:475:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String | GlobalDataFlow.cs:476:23:476:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String |
+| GlobalDataFlow.cs:476:23:476:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String | GlobalDataFlow.cs:476:23:476:44 | call to method GetAwaiter [field m_task, property Result] : String |
+| GlobalDataFlow.cs:476:23:476:44 | call to method GetAwaiter [field m_task, property Result] : String | GlobalDataFlow.cs:477:22:477:28 | access to local variable awaiter [field m_task, property Result] : String |
+| GlobalDataFlow.cs:477:22:477:28 | access to local variable awaiter [field m_task, property Result] : String | GlobalDataFlow.cs:477:22:477:40 | call to method GetResult : String |
+| GlobalDataFlow.cs:477:22:477:40 | call to method GetResult : String | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 |
+| GlobalDataFlow.cs:483:53:483:55 | arg : String | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String |
+| GlobalDataFlow.cs:486:21:486:21 | s : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
+| GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | GlobalDataFlow.cs:486:21:486:21 | s : String |
+| GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:483:53:483:55 | arg : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -377,124 +380,127 @@ nodes
 | GlobalDataFlow.cs:97:23:97:28 | access to local variable sink18 : String | semmle.label | access to local variable sink18 : String |
 | GlobalDataFlow.cs:97:35:97:40 | SSA def(sink22) : Boolean | semmle.label | SSA def(sink22) : Boolean |
 | GlobalDataFlow.cs:98:15:98:20 | access to local variable sink22 | semmle.label | access to local variable sink22 |
-| GlobalDataFlow.cs:136:21:136:34 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:136:29:136:33 | access to local variable sink3 : String | semmle.label | access to local variable sink3 : String |
-| GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 | semmle.label | access to local variable sink4 |
-| GlobalDataFlow.cs:144:21:144:44 | call to method ApplyFunc : String | semmle.label | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:144:39:144:43 | access to local variable sink4 : String | semmle.label | access to local variable sink4 : String |
-| GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 | semmle.label | access to local variable sink5 |
-| GlobalDataFlow.cs:154:21:154:25 | call to method Out : String | semmle.label | call to method Out : String |
-| GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | semmle.label | access to local variable sink6 |
-| GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) : String | semmle.label | SSA def(sink7) : String |
-| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | semmle.label | access to local variable sink7 |
-| GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) : String | semmle.label | SSA def(sink8) : String |
-| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | semmle.label | access to local variable sink8 |
-| GlobalDataFlow.cs:162:22:162:31 | call to method OutYield [element] : String | semmle.label | call to method OutYield [element] : String |
-| GlobalDataFlow.cs:162:22:162:39 | call to method First : String | semmle.label | call to method First : String |
-| GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | semmle.label | access to local variable sink12 |
-| GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam : String | semmle.label | call to method TaintedParam : String |
-| GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | semmle.label | access to local variable sink23 |
-| GlobalDataFlow.cs:180:35:180:48 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:181:21:181:26 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 | semmle.label | access to local variable sink9 |
-| GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> [property Value] : String | semmle.label | object creation of type Lazy<String> [property Value] : String |
-| GlobalDataFlow.cs:190:22:190:48 | access to property Value : String | semmle.label | access to property Value : String |
-| GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | semmle.label | access to local variable sink10 |
-| GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty : String | semmle.label | access to property OutProperty : String |
-| GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | semmle.label | access to local variable sink19 |
-| GlobalDataFlow.cs:208:38:208:61 | array creation of type String[] [element] : String | semmle.label | array creation of type String[] [element] : String |
-| GlobalDataFlow.cs:208:38:208:75 | call to method AsQueryable [element] : String | semmle.label | call to method AsQueryable [element] : String |
-| GlobalDataFlow.cs:208:44:208:61 | { ..., ... } [element] : String | semmle.label | { ..., ... } [element] : String |
-| GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:211:35:211:45 | sinkParam10 : String | semmle.label | sinkParam10 : String |
-| GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 | semmle.label | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:212:71:212:71 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:213:22:213:39 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
-| GlobalDataFlow.cs:213:22:213:47 | call to method First : String | semmle.label | call to method First : String |
-| GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 | semmle.label | access to local variable sink24 |
-| GlobalDataFlow.cs:215:22:215:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:215:22:215:39 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
-| GlobalDataFlow.cs:215:22:215:47 | call to method First : String | semmle.label | call to method First : String |
-| GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 | semmle.label | access to local variable sink25 |
-| GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
-| GlobalDataFlow.cs:217:22:217:49 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
-| GlobalDataFlow.cs:217:22:217:57 | call to method First : String | semmle.label | call to method First : String |
-| GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | semmle.label | access to local variable sink26 |
-| GlobalDataFlow.cs:238:20:238:49 | call to method Run [property Result] : String | semmle.label | call to method Run [property Result] : String |
-| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:239:22:239:25 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:239:22:239:32 | access to property Result : String | semmle.label | access to property Result : String |
-| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | semmle.label | access to local variable sink41 |
-| GlobalDataFlow.cs:241:22:241:31 | await ... : String | semmle.label | await ... : String |
-| GlobalDataFlow.cs:241:28:241:31 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | semmle.label | access to local variable sink42 |
-| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
-| GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |
-| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String | semmle.label | sinkParam1 : String |
-| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | semmle.label | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String | semmle.label | sinkParam3 : String |
-| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | semmle.label | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String | semmle.label | sinkParam4 : String |
-| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | semmle.label | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String | semmle.label | sinkParam5 : String |
-| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | semmle.label | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String | semmle.label | sinkParam6 : String |
-| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String | semmle.label | sinkParam7 : String |
-| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
-| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
-| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
-| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:379:41:379:41 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:379:41:379:41 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:398:39:398:45 | tainted : String | semmle.label | tainted : String |
-| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | semmle.label | access to local variable sink11 |
-| GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String | semmle.label | access to local variable sink11 : String |
-| GlobalDataFlow.cs:424:9:424:11 | value : String | semmle.label | value : String |
-| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | semmle.label | access to local variable sink20 |
-| GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:451:31:451:32 | [post] access to local variable sb [element] : String | semmle.label | [post] access to local variable sb [element] : String |
-| GlobalDataFlow.cs:451:35:451:48 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:452:22:452:23 | access to local variable sb [element] : String | semmle.label | access to local variable sb [element] : String |
-| GlobalDataFlow.cs:452:22:452:34 | call to method ToString : String | semmle.label | call to method ToString : String |
-| GlobalDataFlow.cs:453:15:453:20 | access to local variable sink43 | semmle.label | access to local variable sink43 |
-| GlobalDataFlow.cs:462:22:462:65 | call to method Join : String | semmle.label | call to method Join : String |
-| GlobalDataFlow.cs:462:51:462:64 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:463:15:463:20 | access to local variable sink44 | semmle.label | access to local variable sink44 |
-| GlobalDataFlow.cs:471:20:471:49 | call to method Run [property Result] : String | semmle.label | call to method Run [property Result] : String |
-| GlobalDataFlow.cs:471:35:471:48 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:472:25:472:28 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
-| GlobalDataFlow.cs:472:25:472:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String | semmle.label | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String |
-| GlobalDataFlow.cs:473:23:473:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String | semmle.label | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String |
-| GlobalDataFlow.cs:473:23:473:44 | call to method GetAwaiter [field m_task, property Result] : String | semmle.label | call to method GetAwaiter [field m_task, property Result] : String |
-| GlobalDataFlow.cs:474:22:474:28 | access to local variable awaiter [field m_task, property Result] : String | semmle.label | access to local variable awaiter [field m_task, property Result] : String |
-| GlobalDataFlow.cs:474:22:474:40 | call to method GetResult : String | semmle.label | call to method GetResult : String |
-| GlobalDataFlow.cs:475:15:475:20 | access to local variable sink45 | semmle.label | access to local variable sink45 |
-| GlobalDataFlow.cs:480:53:480:55 | arg : String | semmle.label | arg : String |
-| GlobalDataFlow.cs:483:21:483:21 | s : String | semmle.label | s : String |
-| GlobalDataFlow.cs:483:32:483:32 | access to parameter s | semmle.label | access to parameter s |
-| GlobalDataFlow.cs:484:15:484:17 | access to parameter arg : String | semmle.label | access to parameter arg : String |
-| GlobalDataFlow.cs:487:27:487:40 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:100:24:100:29 | access to local variable sink18 : String | semmle.label | access to local variable sink18 : String |
+| GlobalDataFlow.cs:100:82:100:88 | SSA def(sink21b) : Int32 | semmle.label | SSA def(sink21b) : Int32 |
+| GlobalDataFlow.cs:101:15:101:21 | access to local variable sink21b | semmle.label | access to local variable sink21b |
+| GlobalDataFlow.cs:139:21:139:34 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | semmle.label | access to local variable sink3 : String |
+| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink4 | semmle.label | access to local variable sink4 |
+| GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc : String | semmle.label | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | semmle.label | access to local variable sink4 : String |
+| GlobalDataFlow.cs:148:15:148:19 | access to local variable sink5 | semmle.label | access to local variable sink5 |
+| GlobalDataFlow.cs:157:21:157:25 | call to method Out : String | semmle.label | call to method Out : String |
+| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink6 | semmle.label | access to local variable sink6 |
+| GlobalDataFlow.cs:160:20:160:24 | SSA def(sink7) : String | semmle.label | SSA def(sink7) : String |
+| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink7 | semmle.label | access to local variable sink7 |
+| GlobalDataFlow.cs:163:20:163:24 | SSA def(sink8) : String | semmle.label | SSA def(sink8) : String |
+| GlobalDataFlow.cs:164:15:164:19 | access to local variable sink8 | semmle.label | access to local variable sink8 |
+| GlobalDataFlow.cs:165:22:165:31 | call to method OutYield [element] : String | semmle.label | call to method OutYield [element] : String |
+| GlobalDataFlow.cs:165:22:165:39 | call to method First : String | semmle.label | call to method First : String |
+| GlobalDataFlow.cs:166:15:166:20 | access to local variable sink12 | semmle.label | access to local variable sink12 |
+| GlobalDataFlow.cs:167:22:167:43 | call to method TaintedParam : String | semmle.label | call to method TaintedParam : String |
+| GlobalDataFlow.cs:168:15:168:20 | access to local variable sink23 | semmle.label | access to local variable sink23 |
+| GlobalDataFlow.cs:183:35:183:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:184:21:184:26 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:185:15:185:19 | access to local variable sink9 | semmle.label | access to local variable sink9 |
+| GlobalDataFlow.cs:193:22:193:42 | object creation of type Lazy<String> [property Value] : String | semmle.label | object creation of type Lazy<String> [property Value] : String |
+| GlobalDataFlow.cs:193:22:193:48 | access to property Value : String | semmle.label | access to property Value : String |
+| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink10 | semmle.label | access to local variable sink10 |
+| GlobalDataFlow.cs:201:22:201:32 | access to property OutProperty : String | semmle.label | access to property OutProperty : String |
+| GlobalDataFlow.cs:202:15:202:20 | access to local variable sink19 | semmle.label | access to local variable sink19 |
+| GlobalDataFlow.cs:211:38:211:61 | array creation of type String[] [element] : String | semmle.label | array creation of type String[] [element] : String |
+| GlobalDataFlow.cs:211:38:211:75 | call to method AsQueryable [element] : String | semmle.label | call to method AsQueryable [element] : String |
+| GlobalDataFlow.cs:211:44:211:61 | { ..., ... } [element] : String | semmle.label | { ..., ... } [element] : String |
+| GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:214:35:214:45 | sinkParam10 : String | semmle.label | sinkParam10 : String |
+| GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 | semmle.label | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:215:71:215:71 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:215:89:215:89 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:216:22:216:39 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
+| GlobalDataFlow.cs:216:22:216:47 | call to method First : String | semmle.label | call to method First : String |
+| GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 | semmle.label | access to local variable sink24 |
+| GlobalDataFlow.cs:218:22:218:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:218:22:218:39 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
+| GlobalDataFlow.cs:218:22:218:47 | call to method First : String | semmle.label | call to method First : String |
+| GlobalDataFlow.cs:219:15:219:20 | access to local variable sink25 | semmle.label | access to local variable sink25 |
+| GlobalDataFlow.cs:220:22:220:28 | access to local variable tainted [element] : String | semmle.label | access to local variable tainted [element] : String |
+| GlobalDataFlow.cs:220:22:220:49 | call to method Select [element] : String | semmle.label | call to method Select [element] : String |
+| GlobalDataFlow.cs:220:22:220:57 | call to method First : String | semmle.label | call to method First : String |
+| GlobalDataFlow.cs:221:15:221:20 | access to local variable sink26 | semmle.label | access to local variable sink26 |
+| GlobalDataFlow.cs:241:20:241:49 | call to method Run [property Result] : String | semmle.label | call to method Run [property Result] : String |
+| GlobalDataFlow.cs:241:35:241:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:242:22:242:25 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:242:22:242:32 | access to property Result : String | semmle.label | access to property Result : String |
+| GlobalDataFlow.cs:243:15:243:20 | access to local variable sink41 | semmle.label | access to local variable sink41 |
+| GlobalDataFlow.cs:244:22:244:31 | await ... : String | semmle.label | await ... : String |
+| GlobalDataFlow.cs:244:28:244:31 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:245:15:245:20 | access to local variable sink42 | semmle.label | access to local variable sink42 |
+| GlobalDataFlow.cs:257:26:257:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
+| GlobalDataFlow.cs:259:16:259:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |
+| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:263:26:263:35 | sinkParam1 : String | semmle.label | sinkParam1 : String |
+| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam1 | semmle.label | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:268:26:268:35 | sinkParam3 : String | semmle.label | sinkParam3 : String |
+| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam3 | semmle.label | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:273:26:273:35 | sinkParam4 : String | semmle.label | sinkParam4 : String |
+| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam4 | semmle.label | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:278:26:278:35 | sinkParam5 : String | semmle.label | sinkParam5 : String |
+| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam5 | semmle.label | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:283:26:283:35 | sinkParam6 : String | semmle.label | sinkParam6 : String |
+| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:288:26:288:35 | sinkParam7 : String | semmle.label | sinkParam7 : String |
+| GlobalDataFlow.cs:290:15:290:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:315:31:315:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
+| GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:321:32:321:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
+| GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:327:32:327:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
+| GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:351:9:351:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:351:13:351:26 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:357:22:357:35 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:382:41:382:41 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:382:41:382:41 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:384:11:384:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:396:52:396:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:398:11:398:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:401:39:401:45 | tainted : String | semmle.label | tainted : String |
+| GlobalDataFlow.cs:404:15:404:20 | access to local variable sink11 | semmle.label | access to local variable sink11 |
+| GlobalDataFlow.cs:405:16:405:21 | access to local variable sink11 : String | semmle.label | access to local variable sink11 : String |
+| GlobalDataFlow.cs:427:9:427:11 | value : String | semmle.label | value : String |
+| GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 | semmle.label | access to local variable sink20 |
+| GlobalDataFlow.cs:438:22:438:35 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:454:31:454:32 | [post] access to local variable sb [element] : String | semmle.label | [post] access to local variable sb [element] : String |
+| GlobalDataFlow.cs:454:35:454:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:455:22:455:23 | access to local variable sb [element] : String | semmle.label | access to local variable sb [element] : String |
+| GlobalDataFlow.cs:455:22:455:34 | call to method ToString : String | semmle.label | call to method ToString : String |
+| GlobalDataFlow.cs:456:15:456:20 | access to local variable sink43 | semmle.label | access to local variable sink43 |
+| GlobalDataFlow.cs:465:22:465:65 | call to method Join : String | semmle.label | call to method Join : String |
+| GlobalDataFlow.cs:465:51:465:64 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:466:15:466:20 | access to local variable sink44 | semmle.label | access to local variable sink44 |
+| GlobalDataFlow.cs:474:20:474:49 | call to method Run [property Result] : String | semmle.label | call to method Run [property Result] : String |
+| GlobalDataFlow.cs:474:35:474:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:475:25:475:28 | access to local variable task [property Result] : String | semmle.label | access to local variable task [property Result] : String |
+| GlobalDataFlow.cs:475:25:475:50 | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String | semmle.label | call to method ConfigureAwait [field m_configuredTaskAwaiter, field m_task, property Result] : String |
+| GlobalDataFlow.cs:476:23:476:31 | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String | semmle.label | access to local variable awaitable [field m_configuredTaskAwaiter, field m_task, property Result] : String |
+| GlobalDataFlow.cs:476:23:476:44 | call to method GetAwaiter [field m_task, property Result] : String | semmle.label | call to method GetAwaiter [field m_task, property Result] : String |
+| GlobalDataFlow.cs:477:22:477:28 | access to local variable awaiter [field m_task, property Result] : String | semmle.label | access to local variable awaiter [field m_task, property Result] : String |
+| GlobalDataFlow.cs:477:22:477:40 | call to method GetResult : String | semmle.label | call to method GetResult : String |
+| GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 | semmle.label | access to local variable sink45 |
+| GlobalDataFlow.cs:483:53:483:55 | arg : String | semmle.label | arg : String |
+| GlobalDataFlow.cs:486:21:486:21 | s : String | semmle.label | s : String |
+| GlobalDataFlow.cs:486:32:486:32 | access to parameter s | semmle.label | access to parameter s |
+| GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | semmle.label | access to parameter arg : String |
+| GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | semmle.label | "taint source" : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return : String | semmle.label | [b (line 3): false] call to method Return : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return : String | semmle.label | [b (line 3): true] call to method Return : String |
@@ -551,38 +557,39 @@ nodes
 | GlobalDataFlow.cs:92:15:92:20 | access to local variable sink18 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:92:15:92:20 | access to local variable sink18 | access to local variable sink18 |
 | GlobalDataFlow.cs:95:15:95:20 | access to local variable sink21 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:95:15:95:20 | access to local variable sink21 | access to local variable sink21 |
 | GlobalDataFlow.cs:98:15:98:20 | access to local variable sink22 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:98:15:98:20 | access to local variable sink22 | access to local variable sink22 |
-| GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 | access to local variable sink4 |
-| GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 | access to local variable sink5 |
-| GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | access to local variable sink6 |
-| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | access to local variable sink7 |
-| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | access to local variable sink8 |
-| GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | access to local variable sink12 |
-| GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | access to local variable sink23 |
-| GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 | GlobalDataFlow.cs:180:35:180:48 | "taint source" : String | GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 | access to local variable sink9 |
-| GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | access to local variable sink10 |
-| GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | access to local variable sink19 |
-| GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 | access to local variable sink24 |
-| GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 | access to local variable sink25 |
-| GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | access to local variable sink26 |
-| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | access to local variable sink41 |
-| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | access to local variable sink42 |
-| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | access to local variable sink11 |
-| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | access to local variable sink20 |
-| GlobalDataFlow.cs:453:15:453:20 | access to local variable sink43 | GlobalDataFlow.cs:451:35:451:48 | "taint source" : String | GlobalDataFlow.cs:453:15:453:20 | access to local variable sink43 | access to local variable sink43 |
-| GlobalDataFlow.cs:463:15:463:20 | access to local variable sink44 | GlobalDataFlow.cs:462:51:462:64 | "taint source" : String | GlobalDataFlow.cs:463:15:463:20 | access to local variable sink44 | access to local variable sink44 |
-| GlobalDataFlow.cs:475:15:475:20 | access to local variable sink45 | GlobalDataFlow.cs:471:35:471:48 | "taint source" : String | GlobalDataFlow.cs:475:15:475:20 | access to local variable sink45 | access to local variable sink45 |
-| GlobalDataFlow.cs:483:32:483:32 | access to parameter s | GlobalDataFlow.cs:487:27:487:40 | "taint source" : String | GlobalDataFlow.cs:483:32:483:32 | access to parameter s | access to parameter s |
+| GlobalDataFlow.cs:101:15:101:21 | access to local variable sink21b | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:101:15:101:21 | access to local variable sink21b | access to local variable sink21b |
+| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink4 | access to local variable sink4 |
+| GlobalDataFlow.cs:148:15:148:19 | access to local variable sink5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:148:15:148:19 | access to local variable sink5 | access to local variable sink5 |
+| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink6 | GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink6 | access to local variable sink6 |
+| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink7 | GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink7 | access to local variable sink7 |
+| GlobalDataFlow.cs:164:15:164:19 | access to local variable sink8 | GlobalDataFlow.cs:351:13:351:26 | "taint source" : String | GlobalDataFlow.cs:164:15:164:19 | access to local variable sink8 | access to local variable sink8 |
+| GlobalDataFlow.cs:166:15:166:20 | access to local variable sink12 | GlobalDataFlow.cs:357:22:357:35 | "taint source" : String | GlobalDataFlow.cs:166:15:166:20 | access to local variable sink12 | access to local variable sink12 |
+| GlobalDataFlow.cs:168:15:168:20 | access to local variable sink23 | GlobalDataFlow.cs:401:39:401:45 | tainted : String | GlobalDataFlow.cs:168:15:168:20 | access to local variable sink23 | access to local variable sink23 |
+| GlobalDataFlow.cs:185:15:185:19 | access to local variable sink9 | GlobalDataFlow.cs:183:35:183:48 | "taint source" : String | GlobalDataFlow.cs:185:15:185:19 | access to local variable sink9 | access to local variable sink9 |
+| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink10 | GlobalDataFlow.cs:341:16:341:29 | "taint source" : String | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink10 | access to local variable sink10 |
+| GlobalDataFlow.cs:202:15:202:20 | access to local variable sink19 | GlobalDataFlow.cs:438:22:438:35 | "taint source" : String | GlobalDataFlow.cs:202:15:202:20 | access to local variable sink19 | access to local variable sink19 |
+| GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:214:58:214:68 | access to parameter sinkParam10 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:217:15:217:20 | access to local variable sink24 | access to local variable sink24 |
+| GlobalDataFlow.cs:219:15:219:20 | access to local variable sink25 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:219:15:219:20 | access to local variable sink25 | access to local variable sink25 |
+| GlobalDataFlow.cs:221:15:221:20 | access to local variable sink26 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:221:15:221:20 | access to local variable sink26 | access to local variable sink26 |
+| GlobalDataFlow.cs:243:15:243:20 | access to local variable sink41 | GlobalDataFlow.cs:241:35:241:48 | "taint source" : String | GlobalDataFlow.cs:243:15:243:20 | access to local variable sink41 | access to local variable sink41 |
+| GlobalDataFlow.cs:245:15:245:20 | access to local variable sink42 | GlobalDataFlow.cs:241:35:241:48 | "taint source" : String | GlobalDataFlow.cs:245:15:245:20 | access to local variable sink42 | access to local variable sink42 |
+| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:290:15:290:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:290:15:290:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:317:15:317:24 | access to parameter sinkParam8 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:323:15:323:24 | access to parameter sinkParam9 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:211:46:211:59 | "taint source" : String | GlobalDataFlow.cs:329:15:329:25 | access to parameter sinkParam11 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:404:15:404:20 | access to local variable sink11 | GlobalDataFlow.cs:401:39:401:45 | tainted : String | GlobalDataFlow.cs:404:15:404:20 | access to local variable sink11 | access to local variable sink11 |
+| GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 | access to local variable sink20 |
+| GlobalDataFlow.cs:456:15:456:20 | access to local variable sink43 | GlobalDataFlow.cs:454:35:454:48 | "taint source" : String | GlobalDataFlow.cs:456:15:456:20 | access to local variable sink43 | access to local variable sink43 |
+| GlobalDataFlow.cs:466:15:466:20 | access to local variable sink44 | GlobalDataFlow.cs:465:51:465:64 | "taint source" : String | GlobalDataFlow.cs:466:15:466:20 | access to local variable sink44 | access to local variable sink44 |
+| GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 | GlobalDataFlow.cs:474:35:474:48 | "taint source" : String | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 | access to local variable sink45 |
+| GlobalDataFlow.cs:486:32:486:32 | access to parameter s | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | access to parameter s |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.expected
@@ -1222,10 +1222,10 @@
 | System.Int32.Parse(string, IFormatProvider) | argument 0 -> return (normal) | false |
 | System.Int32.Parse(string, NumberStyles) | argument 0 -> return (normal) | false |
 | System.Int32.Parse(string, NumberStyles, IFormatProvider) | argument 0 -> return (normal) | false |
-| System.Int32.TryParse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider, out int) | argument 0 -> argument 3 | false |
 | System.Int32.TryParse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider, out int) | argument 0 -> return (normal) | false |
-| System.Int32.TryParse(ReadOnlySpan<Char>, out int) | argument 0 -> argument 1 | false |
+| System.Int32.TryParse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider, out int) | element of argument 0 -> argument 3 | false |
 | System.Int32.TryParse(ReadOnlySpan<Char>, out int) | argument 0 -> return (normal) | false |
+| System.Int32.TryParse(ReadOnlySpan<Char>, out int) | element of argument 0 -> argument 1 | false |
 | System.Int32.TryParse(string, NumberStyles, IFormatProvider, out int) | argument 0 -> argument 3 | false |
 | System.Int32.TryParse(string, NumberStyles, IFormatProvider, out int) | argument 0 -> return (normal) | false |
 | System.Int32.TryParse(string, out int) | argument 0 -> argument 1 | false |

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.expected
@@ -1217,15 +1217,15 @@
 | System.IO.UnmanagedMemoryStreamWrapper.ToArray() | argument -1 -> return (normal) | false |
 | System.IO.UnmanagedMemoryStreamWrapper.Write(Byte[], int, int) | argument 0 -> argument -1 | false |
 | System.IO.UnmanagedMemoryStreamWrapper.WriteAsync(Byte[], int, int, CancellationToken) | argument 0 -> argument -1 | false |
-| System.Int32.Parse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider) | argument 0 -> return (normal) | false |
+| System.Int32.Parse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider) | element of argument 0 -> return (normal) | false |
 | System.Int32.Parse(string) | argument 0 -> return (normal) | false |
 | System.Int32.Parse(string, IFormatProvider) | argument 0 -> return (normal) | false |
 | System.Int32.Parse(string, NumberStyles) | argument 0 -> return (normal) | false |
 | System.Int32.Parse(string, NumberStyles, IFormatProvider) | argument 0 -> return (normal) | false |
-| System.Int32.TryParse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider, out int) | argument 0 -> return (normal) | false |
 | System.Int32.TryParse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider, out int) | element of argument 0 -> argument 3 | false |
-| System.Int32.TryParse(ReadOnlySpan<Char>, out int) | argument 0 -> return (normal) | false |
+| System.Int32.TryParse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider, out int) | element of argument 0 -> return (normal) | false |
 | System.Int32.TryParse(ReadOnlySpan<Char>, out int) | element of argument 0 -> argument 1 | false |
+| System.Int32.TryParse(ReadOnlySpan<Char>, out int) | element of argument 0 -> return (normal) | false |
 | System.Int32.TryParse(string, NumberStyles, IFormatProvider, out int) | argument 0 -> argument 3 | false |
 | System.Int32.TryParse(string, NumberStyles, IFormatProvider, out int) | argument 0 -> return (normal) | false |
 | System.Int32.TryParse(string, out int) | argument 0 -> argument 1 | false |

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.expected
@@ -1217,10 +1217,15 @@
 | System.IO.UnmanagedMemoryStreamWrapper.ToArray() | argument -1 -> return (normal) | false |
 | System.IO.UnmanagedMemoryStreamWrapper.Write(Byte[], int, int) | argument 0 -> argument -1 | false |
 | System.IO.UnmanagedMemoryStreamWrapper.WriteAsync(Byte[], int, int, CancellationToken) | argument 0 -> argument -1 | false |
+| System.Int32.Parse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider) | argument 0 -> return (normal) | false |
 | System.Int32.Parse(string) | argument 0 -> return (normal) | false |
 | System.Int32.Parse(string, IFormatProvider) | argument 0 -> return (normal) | false |
 | System.Int32.Parse(string, NumberStyles) | argument 0 -> return (normal) | false |
 | System.Int32.Parse(string, NumberStyles, IFormatProvider) | argument 0 -> return (normal) | false |
+| System.Int32.TryParse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider, out int) | argument 0 -> argument 3 | false |
+| System.Int32.TryParse(ReadOnlySpan<Char>, NumberStyles, IFormatProvider, out int) | argument 0 -> return (normal) | false |
+| System.Int32.TryParse(ReadOnlySpan<Char>, out int) | argument 0 -> argument 1 | false |
+| System.Int32.TryParse(ReadOnlySpan<Char>, out int) | argument 0 -> return (normal) | false |
 | System.Int32.TryParse(string, NumberStyles, IFormatProvider, out int) | argument 0 -> argument 3 | false |
 | System.Int32.TryParse(string, NumberStyles, IFormatProvider, out int) | argument 0 -> return (normal) | false |
 | System.Int32.TryParse(string, out int) | argument 0 -> argument 1 | false |

--- a/misc/scripts/library-coverage/compare.py
+++ b/misc/scripts/library-coverage/compare.py
@@ -24,11 +24,9 @@ def compare_folders(folder1, folder2, output_file):
     Compares the contents of two folders and writes the differences to the output file.
     """
 
-    languages = ['java']
-
     return_md = ""
 
-    for lang in languages:
+    for lang in settings.languages:
         expected_files = ""
 
         generated_output_rst = settings.generated_output_rst.format(

--- a/misc/scripts/library-coverage/create-pr.py
+++ b/misc/scripts/library-coverage/create-pr.py
@@ -22,8 +22,7 @@ owner = repo.split('/')[0]
 
 
 def overwrite_files():
-    languages = ['java']
-    for lang in languages:
+    for lang in settings.languages:
         repo_output_rst = settings.repo_output_rst.format(language=lang)
         repo_output_csv = settings.repo_output_csv.format(language=lang)
 

--- a/misc/scripts/library-coverage/generate-report.py
+++ b/misc/scripts/library-coverage/generate-report.py
@@ -52,8 +52,10 @@ def collect_package_stats(packages: pack.PackageCollection, cwes, filter):
             sinks += package.get_part_count("sink")
 
             for cwe in cwes:
-                sink = "sink:" + cwes[cwe]["sink"]
-                count = package.get_kind_count(sink)
+                count = 0
+                for sink in cwes[cwe]["sink"].split(" "):
+                    sink = "sink:" + sink
+                    count += package.get_kind_count(sink)
                 if count > 0:
                     if cwe not in framework_cwes:
                         framework_cwes[cwe] = 0

--- a/misc/scripts/library-coverage/generate-report.py
+++ b/misc/scripts/library-coverage/generate-report.py
@@ -47,7 +47,7 @@ def collect_package_stats(packages: pack.PackageCollection, cwes, filter):
         package: pack.Package = package
         if filter(package):
             processed_packages.add(package)
-            sources += package.get_kind_count("source:remote")
+            sources += package.get_part_count("source")
             steps += package.get_part_count("summary")
             sinks += package.get_part_count("sink")
 
@@ -188,7 +188,7 @@ for lang in settings.languages:
         # Write CSV header.
         headers = [row_prefix + "Framework / library",
                    "Package",
-                   "Remote flow sources",
+                   "Flow sources",
                    "Taint & value steps",
                    "Sinks (total)"]
         for cwe in sorted_cwes:

--- a/misc/scripts/library-coverage/generate-report.py
+++ b/misc/scripts/library-coverage/generate-report.py
@@ -234,7 +234,8 @@ for lang in settings.languages:
         row[1] = ", ".join("``{0}``".format(p.name)
                            for p in sorted(other_packages, key=lambda x: x.name))
 
-        csvwriter.writerow(row)
+        if any(other_packages):
+            csvwriter.writerow(row)
 
         # Collect statistics on all packages
         row = [row_prefix + "Totals", None]

--- a/misc/scripts/library-coverage/generate-report.py
+++ b/misc/scripts/library-coverage/generate-report.py
@@ -110,7 +110,9 @@ if len(sys.argv) > 2:
 # Languages for which we want to generate coverage reports.
 configs = [
     utils.LanguageConfig(
-        "java", "Java", ".java", query_prefix + "java/ql/src/meta/frameworks/Coverage.ql")
+        "java", "Java", ".java", query_prefix + "java/ql/src/meta/frameworks/Coverage.ql"),
+    utils.LanguageConfig(
+        "csharp", "C#", ".cs", query_prefix + "csharp/ql/src/meta/frameworks/Coverage.ql")
 ]
 
 # The names of input and output files. The placeholder {language} is replaced with the language name.
@@ -125,8 +127,8 @@ else:
     output_rst = settings.generated_output_rst
     output_csv = settings.generated_output_csv
 
-for config in configs:
-    lang = config.lang
+for lang in settings.languages:
+    config = [c for c in configs if c.lang == lang][0]
     db = "empty-" + lang
     ql_output = output_ql_csv.format(language=lang)
     utils.create_empty_database(lang, config.ext, db)

--- a/misc/scripts/library-coverage/generate-timeseries.py
+++ b/misc/scripts/library-coverage/generate-timeseries.py
@@ -62,6 +62,7 @@ def get_packages(lang, query):
             shutil.rmtree(db)
 
 
+current_dir = os.getcwd()
 working_dir = ""
 if len(sys.argv) > 1:
     working_dir = sys.argv[1]
@@ -80,6 +81,7 @@ configs = [
 # only once and not per language
 output_prefix = "framework-coverage-timeseries-"
 for lang in settings.languages:
+    os.chdir(current_dir)
     config = [c for c in configs if c.lang == lang][0]
     with open(output_prefix + config.lang + ".csv", 'w', newline='') as csvfile_total:
         with open(output_prefix + config.lang + "-packages.csv", 'w', newline='') as csvfile_packages:

--- a/misc/scripts/library-coverage/generate-timeseries.py
+++ b/misc/scripts/library-coverage/generate-timeseries.py
@@ -71,13 +71,16 @@ else:
 
 configs = [
     utils.LanguageConfig(
-        "java", "Java", ".java", "java/ql/src/meta/frameworks/Coverage.ql")
+        "java", "Java", ".java", "java/ql/src/meta/frameworks/Coverage.ql"),
+    utils.LanguageConfig(
+        "csharp", "C#", ".cs", "csharp/ql/src/meta/frameworks/Coverage.ql")
 ]
 
 # todo: change this when we cover multiple languages. We should compute the SHAs
 # only once and not per language
 output_prefix = "framework-coverage-timeseries-"
-for config in configs:
+for lang in settings.languages:
+    config = [c for c in configs if c.lang == lang][0]
     with open(output_prefix + config.lang + ".csv", 'w', newline='') as csvfile_total:
         with open(output_prefix + config.lang + "-packages.csv", 'w', newline='') as csvfile_packages:
             csvwriter_total = csv.writer(csvfile_total)

--- a/misc/scripts/library-coverage/generate-timeseries.py
+++ b/misc/scripts/library-coverage/generate-timeseries.py
@@ -62,7 +62,6 @@ def get_packages(lang, query):
             shutil.rmtree(db)
 
 
-current_dir = os.getcwd()
 working_dir = ""
 if len(sys.argv) > 1:
     working_dir = sys.argv[1]
@@ -77,101 +76,150 @@ configs = [
         "csharp", "C#", ".cs", "csharp/ql/src/meta/frameworks/Coverage.ql")
 ]
 
-# todo: change this when we cover multiple languages. We should compute the SHAs
-# only once and not per language
 output_prefix = "framework-coverage-timeseries-"
+
+languages_to_process = set()
+language_utils = {}
+
+# Try to create output files for each language:
 for lang in settings.languages:
-    os.chdir(current_dir)
-    config = [c for c in configs if c.lang == lang][0]
-    with open(output_prefix + config.lang + ".csv", 'w', newline='') as csvfile_total:
-        with open(output_prefix + config.lang + "-packages.csv", 'w', newline='') as csvfile_packages:
-            csvwriter_total = csv.writer(csvfile_total)
-            csvwriter_packages = csv.writer(csvfile_packages)
-            csvwriter_total.writerow(
-                ["SHA", "Date", "Sources", "Sinks", "Summaries"])
-            csvwriter_packages.writerow(
-                ["SHA", "Date", "Framework", "Package", "Sources", "Sinks", "Summaries"])
+    try:
+        file_total = open(output_prefix + lang + ".csv", 'w', newline='')
+        file_packages = open(output_prefix + lang +
+                             "-packages.csv", 'w', newline='')
+        csvwriter_total = csv.writer(file_total)
+        csvwriter_packages = csv.writer(file_packages)
+    except:
+        print(
+            f"Unexpected error while opening files for {lang}:", sys.exc_info()[0])
+        if file_total is not None:
+            file_total.close()
+        if file_packages is not None:
+            file_packages.close()
+    else:
+        languages_to_process.add(lang)
+        language_utils[lang] = {
+            "file_total": file_total,
+            "file_packages": file_packages,
+            "csvwriter_total": csvwriter_total,
+            "csvwriter_packages": csvwriter_packages
+        }
 
-            os.chdir(working_dir)
+try:
+    # Write headers
+    for lang in languages_to_process:
+        csvwriter_total = language_utils[lang]["csvwriter_total"]
+        csvwriter_packages = language_utils[lang]["csvwriter_packages"]
+        csvwriter_total.writerow(
+            ["SHA", "Date", "Sources", "Sinks", "Summaries"])
+        csvwriter_packages.writerow(
+            ["SHA", "Date", "Framework", "Package", "Sources", "Sinks", "Summaries"])
 
-            utils.subprocess_run(["git", "checkout", "main"])
+    os.chdir(working_dir)
 
-            current_sha = Git.get_output(["git", "rev-parse", "HEAD"])
-            current_date = Git.get_date(current_sha)
+    utils.subprocess_run(["git", "checkout", "main"])
 
-            # Read the additional framework data, such as URL, friendly name from the latest commit
-            input_framework_csv = settings.documentation_folder_no_prefix + "frameworks.csv"
-            frameworks = fr.FrameworkCollection(
-                input_framework_csv.format(language=config.lang))
+    current_sha = Git.get_output(["git", "rev-parse", "HEAD"])
+    current_date = Git.get_date(current_sha)
 
-            while True:
-                print("Getting stats for " + current_sha)
-                utils.subprocess_run(["git", "checkout", current_sha])
+    # Read the additional framework data, such as URL, friendly name from the latest commit
+    for lang in languages_to_process:
+        input_framework_csv = settings.documentation_folder_no_prefix + "frameworks.csv"
+        language_utils[lang]["frameworks"] = fr.FrameworkCollection(
+            input_framework_csv.format(language=lang))
+        language_utils[lang]["config"] = [
+            c for c in configs if c.lang == lang][0]
 
-                try:
-                    packages = get_packages(config.lang, config.ql_path)
+    while True:
+        utils.subprocess_run(["git", "checkout", current_sha])
+        for lang in languages_to_process.copy():
+            try:
+                print(
+                    f"Getting stats for {lang} at {current_sha} on {current_date.isoformat()}")
 
-                    csvwriter_total.writerow([
-                        current_sha,
-                        current_date,
-                        packages.get_part_count("source"),
-                        packages.get_part_count("sink"),
-                        packages.get_part_count("summary")])
+                config: utils.LanguageConfig = language_utils[lang]["config"]
+                frameworks: fr.FrameworkCollection = language_utils[lang]["frameworks"]
+                csvwriter_total = language_utils[lang]["csvwriter_total"]
+                csvwriter_packages = language_utils[lang]["csvwriter_packages"]
 
-                    matched_packages = set()
+                packages = get_packages(lang, config.ql_path)
 
-                    for framework in frameworks.get_frameworks():
-                        framework: fr.Framework = framework
+                csvwriter_total.writerow([
+                    current_sha,
+                    current_date,
+                    packages.get_part_count("source"),
+                    packages.get_part_count("sink"),
+                    packages.get_part_count("summary")])
 
-                        row = [current_sha, current_date,
-                               framework.name, framework.package_pattern]
+                matched_packages = set()
 
-                        sources = 0
-                        sinks = 0
-                        summaries = 0
+                # Getting stats for frameworks:
+                for framework in frameworks.get_frameworks():
+                    framework: fr.Framework = framework
 
-                        for package in packages.get_packages():
-                            if frameworks.get_package_filter(framework)(package):
-                                sources += package.get_part_count("source")
-                                sinks += package.get_part_count("sink")
-                                summaries += package.get_part_count("summary")
-                                matched_packages.add(package.name)
-
-                        row.append(sources)
-                        row.append(sinks)
-                        row.append(summaries)
-
-                        csvwriter_packages.writerow(row)
-
-                    row = [current_sha, current_date, "Others"]
+                    row = [current_sha, current_date,
+                           framework.name, framework.package_pattern]
 
                     sources = 0
                     sinks = 0
                     summaries = 0
-                    other_packages = set()
 
                     for package in packages.get_packages():
-                        if not package.name in matched_packages:
+                        if frameworks.get_package_filter(framework)(package):
                             sources += package.get_part_count("source")
                             sinks += package.get_part_count("sink")
                             summaries += package.get_part_count("summary")
-                            other_packages.add(package.name)
+                            matched_packages.add(package.name)
 
-                    row.append(", ".join(sorted(other_packages)))
                     row.append(sources)
                     row.append(sinks)
                     row.append(summaries)
 
                     csvwriter_packages.writerow(row)
 
-                    print("Collected stats for " + current_sha +
-                          " at " + current_date.isoformat())
-                except:
-                    print("Error getting stats for " +
-                          current_sha + ". Stopping iteration.")
-                    break
+                # Getting stats for packages not included in frameworks:
+                row = [current_sha, current_date, "Others"]
 
-                current_sha, current_date = Git.get_previous_sha(
-                    current_sha, current_date)
+                sources = 0
+                sinks = 0
+                summaries = 0
+                other_packages = set()
 
+                for package in packages.get_packages():
+                    if not package.name in matched_packages:
+                        sources += package.get_part_count("source")
+                        sinks += package.get_part_count("sink")
+                        summaries += package.get_part_count("summary")
+                        other_packages.add(package.name)
+
+                row.append(", ".join(sorted(other_packages)))
+                row.append(sources)
+                row.append(sinks)
+                row.append(summaries)
+
+                csvwriter_packages.writerow(row)
+
+                print(
+                    f"Collected stats for {lang} at {current_sha} on {current_date.isoformat()}")
+
+            except:
+                print(
+                    f"Error getting stats for {lang} at {current_sha}. Stopping iteration for language.")
+                languages_to_process.remove(lang)
+        if len(languages_to_process) == 0:
+            break
+
+        current_sha, current_date = Git.get_previous_sha(
+            current_sha, current_date)
+
+finally:
     utils.subprocess_run(["git", "checkout", "main"])
+
+    # Close files:
+    for lang in settings.languages:
+        file_total = language_utils[lang]["file_total"]
+        file_packages = language_utils[lang]["file_packages"]
+        if file_total is not None:
+            file_total.close()
+        if file_packages is not None:
+            file_packages.close()

--- a/misc/scripts/library-coverage/settings.py
+++ b/misc/scripts/library-coverage/settings.py
@@ -20,3 +20,5 @@ output_rst_file_name = "coverage.rst"
 output_csv_file_name = "coverage.csv"
 repo_output_rst = documentation_folder + output_rst_file_name
 repo_output_csv = documentation_folder + output_csv_file_name
+
+languages = ['java', 'csharp']


### PR DESCRIPTION
This PR 
- migrates some sources, steps, and sinks to the new CSV format;
- adjusts the coverage report generators and workflows to cover C# too;
- modifies the RST generator to allow specifying multiple sink ids per CWE number. 

The workflows have been tested here:
- PR commenter: https://github.com/dsp-testing/codeql-csv-coverage-pr-commenter/pull/12#issuecomment-868509528
- Timeseries: ~~[run](https://github.com/dsp-testing/codeql-csv-coverage-pr-commenter/actions/runs/971694541)~~ [run](https://github.com/dsp-testing/codeql-csv-coverage-pr-commenter/actions/runs/978362996)
- Report updater: [PR](https://github.com/dsp-testing/codeql-csv-coverage-pr-commenter/pull/8/files) with [commit](  https://github.com/dsp-testing/codeql-csv-coverage-pr-commenter/pull/8/commits/5eb8c23a8d81e85028f35a920f21abc5a00a2f46)