### PR TITLE
Performance: Fix bad join order in Java dataflow library

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -1247,7 +1247,8 @@ private module Stage2 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -1928,7 +1929,8 @@ private module Stage3 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself
@@ -2683,7 +2685,8 @@ private module Stage4 {
       parameterFlow(p, ap, ap0, c, config) and
       c = getNodeEnclosingCallable(ret) and
       revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+        pragma[only_bind_into](config)) and
       kind = ret.getKind() and
       p.isParameterOf(_, pos) and
       // we don't expect a parameter to return stored in itself


### PR DESCRIPTION
A recent change the CodeQL engine caused a major performance regression in the Java dataflow library due to a change in join ordering. This PR adds two `pragma[only_bind_into]` annotations which should fix the performance issue.

cc. @github/codeql-core 