### PR TITLE
C++: More effective barriers in the `bounded` predicate for CWE-190

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-190/Bounded.qll
+++ b/cpp/ql/src/Security/CWE/CWE-190/Bounded.qll
@@ -8,20 +8,6 @@ private import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 private import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
 
 /**
- * An operand `e` of a division expression (i.e., `e` is an operand of either a `DivExpr` or
- * a `AssignDivExpr`) is bounded when `e` is the left-hand side of the division.
- */
-pragma[inline]
-private predicate boundedDiv(Expr e, Expr left) { e = left }
-
-/**
- * An operand `e` of a remainder expression (i.e., `e` is an operand of either a `RemExpr` or
- * a `AssignRemExpr`) is bounded when `e` is the left-hand side of the remainder.
- */
-pragma[inline]
-private predicate boundedRem(Expr e, Expr left) { e = left }
-
-/**
  * An operand `e` of a bitwise and expression `andExpr` (i.e., `andExpr` is either an `BitwiseAndExpr`
  * or an `AssignAndExpr`) with operands `operand1` and `operand2` is the operand that is not `e` is upper
  * bounded by some number that is less than the maximum integer allowed by the result type of `andExpr`.
@@ -45,9 +31,10 @@ predicate bounded(Expr e) {
   ) and
   not convertedExprMightOverflow(e)
   or
-  boundedRem(e, any(RemExpr rem).getLeftOperand())
+  // Optimitically assume that a remainder expression always yields a much smaller value.
+  e = any(RemExpr rem).getLeftOperand()
   or
-  boundedRem(e, any(AssignRemExpr rem).getLValue())
+  e = any(AssignRemExpr rem).getLValue()
   or
   exists(BitwiseAndExpr andExpr |
     boundedBitwiseAnd(e, andExpr, andExpr.getAnOperand(), andExpr.getAnOperand())
@@ -58,11 +45,11 @@ predicate bounded(Expr e) {
   )
   or
   // Optimitically assume that a division always yields a much smaller value.
-  boundedDiv(e, any(DivExpr div).getLeftOperand())
+  e = any(DivExpr div).getLeftOperand()
   or
-  boundedDiv(e, any(AssignDivExpr div).getLValue())
+  e = any(AssignDivExpr div).getLValue()
   or
-  boundedDiv(e, any(RShiftExpr shift).getLeftOperand())
+  e = any(RShiftExpr shift).getLeftOperand()
   or
-  boundedDiv(e, any(AssignRShiftExpr div).getLValue())
+  e = any(AssignRShiftExpr div).getLValue()
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -7,8 +7,6 @@ edges
 | test.c:81:14:81:17 | call to rand | test.c:83:9:83:9 | r |
 | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r |
 | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r |
-| test.c:115:12:115:15 | call to rand | test.c:116:3:116:4 | r1 |
-| test.c:118:13:118:16 | call to rand | test.c:119:3:119:4 | r2 |
 | test.cpp:8:9:8:12 | Store | test.cpp:24:11:24:18 | call to get_rand |
 | test.cpp:8:9:8:12 | call to rand | test.cpp:8:9:8:12 | Store |
 | test.cpp:13:2:13:15 | Chi [[]] | test.cpp:30:13:30:14 | get_rand2 output argument [[]] |
@@ -35,10 +33,6 @@ nodes
 | test.c:83:9:83:9 | r | semmle.label | r |
 | test.c:99:14:99:19 | call to rand | semmle.label | call to rand |
 | test.c:100:5:100:5 | r | semmle.label | r |
-| test.c:115:12:115:15 | call to rand | semmle.label | call to rand |
-| test.c:116:3:116:4 | r1 | semmle.label | r1 |
-| test.c:118:13:118:16 | call to rand | semmle.label | call to rand |
-| test.c:119:3:119:4 | r2 | semmle.label | r2 |
 | test.cpp:8:9:8:12 | Store | semmle.label | Store |
 | test.cpp:8:9:8:12 | call to rand | semmle.label | call to rand |
 | test.cpp:13:2:13:15 | Chi [[]] | semmle.label | Chi [[]] |
@@ -62,8 +56,6 @@ nodes
 | test.c:83:9:83:9 | r | test.c:81:14:81:17 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:81:14:81:17 | call to rand | Uncontrolled value |
 | test.c:83:9:83:9 | r | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:81:23:81:26 | call to rand | Uncontrolled value |
 | test.c:100:5:100:5 | r | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:99:14:99:19 | call to rand | Uncontrolled value |
-| test.c:116:3:116:4 | r1 | test.c:115:12:115:15 | call to rand | test.c:116:3:116:4 | r1 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:115:12:115:15 | call to rand | Uncontrolled value |
-| test.c:119:3:119:4 | r2 | test.c:118:13:118:16 | call to rand | test.c:119:3:119:4 | r2 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:118:13:118:16 | call to rand | Uncontrolled value |
 | test.cpp:25:7:25:7 | r | test.cpp:8:9:8:12 | call to rand | test.cpp:25:7:25:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:8:9:8:12 | call to rand | Uncontrolled value |
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | Uncontrolled value |
 | test.cpp:37:7:37:7 | r | test.cpp:18:9:18:12 | call to rand | test.cpp:37:7:37:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:18:9:18:12 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -7,6 +7,8 @@ edges
 | test.c:81:14:81:17 | call to rand | test.c:83:9:83:9 | r |
 | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r |
 | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r |
+| test.c:115:12:115:15 | call to rand | test.c:116:3:116:4 | r1 |
+| test.c:118:13:118:16 | call to rand | test.c:119:3:119:4 | r2 |
 | test.cpp:8:9:8:12 | Store | test.cpp:24:11:24:18 | call to get_rand |
 | test.cpp:8:9:8:12 | call to rand | test.cpp:8:9:8:12 | Store |
 | test.cpp:13:2:13:15 | Chi [[]] | test.cpp:30:13:30:14 | get_rand2 output argument [[]] |
@@ -33,6 +35,10 @@ nodes
 | test.c:83:9:83:9 | r | semmle.label | r |
 | test.c:99:14:99:19 | call to rand | semmle.label | call to rand |
 | test.c:100:5:100:5 | r | semmle.label | r |
+| test.c:115:12:115:15 | call to rand | semmle.label | call to rand |
+| test.c:116:3:116:4 | r1 | semmle.label | r1 |
+| test.c:118:13:118:16 | call to rand | semmle.label | call to rand |
+| test.c:119:3:119:4 | r2 | semmle.label | r2 |
 | test.cpp:8:9:8:12 | Store | semmle.label | Store |
 | test.cpp:8:9:8:12 | call to rand | semmle.label | call to rand |
 | test.cpp:13:2:13:15 | Chi [[]] | semmle.label | Chi [[]] |
@@ -56,6 +62,8 @@ nodes
 | test.c:83:9:83:9 | r | test.c:81:14:81:17 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:81:14:81:17 | call to rand | Uncontrolled value |
 | test.c:83:9:83:9 | r | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:81:23:81:26 | call to rand | Uncontrolled value |
 | test.c:100:5:100:5 | r | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:99:14:99:19 | call to rand | Uncontrolled value |
+| test.c:116:3:116:4 | r1 | test.c:115:12:115:15 | call to rand | test.c:116:3:116:4 | r1 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:115:12:115:15 | call to rand | Uncontrolled value |
+| test.c:119:3:119:4 | r2 | test.c:118:13:118:16 | call to rand | test.c:119:3:119:4 | r2 | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:118:13:118:16 | call to rand | Uncontrolled value |
 | test.cpp:25:7:25:7 | r | test.cpp:8:9:8:12 | call to rand | test.cpp:25:7:25:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:8:9:8:12 | call to rand | Uncontrolled value |
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | Uncontrolled value |
 | test.cpp:37:7:37:7 | r | test.cpp:18:9:18:12 | call to rand | test.cpp:37:7:37:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:18:9:18:12 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
@@ -113,9 +113,9 @@ void add_100(int r) {
 
 void randomTester2(int bound, int min, int max) {
   int r1 = rand() % bound;
-  r1 += 100; // GOOD [FALSE POSITIVE] (`bound` may possibly be MAX_INT in which case this could
-             //                        still overflow, but it's most likely fine)
+  r1 += 100; // GOOD (`bound` may possibly be MAX_INT in which case this could
+             //       still overflow, but it's most likely fine)
 
   int r2 = (rand() % (max - min + 1)) + min;
-  r2 += 100; // GOOD [FALSE POSITIVE] (This is a common way to clamp the random value between [min, max])
+  r2 += 100; // GOOD (This is a common way to clamp the random value between [min, max])
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
@@ -110,3 +110,12 @@ void randomTester() {
 void add_100(int r) {
   r += 100; // GOOD
 }
+
+void randomTester2(int bound, int min, int max) {
+  int r1 = rand() % bound;
+  r1 += 100; // GOOD [FALSE POSITIVE] (`bound` may possibly be MAX_INT in which case this could
+             //                        still overflow, but it's most likely fine)
+
+  int r2 = (rand() % (max - min + 1)) + min;
+  r2 += 100; // GOOD [FALSE POSITIVE] (This is a common way to clamp the random value between [min, max])
+}


### PR DESCRIPTION
<s><b>Note</b>: This PR is based on top of https://github.com/github/codeql/pull/6154. Please start the review at 142b78fe5a1ccdf308fff9b65220f0407838360b. Once #6154 has been merged I'll rebase those commits away.</s> <-- That PR is now merged, and has been rebased out of this PR.

---

This PR makes `%` a barrier regardless of whether or not we can bound the right-hand side of the operator using range analysis.

The barrier (with that restriction) was introduced in https://github.com/github/codeql/pull/5887. At that point, we didn't have a lot of results on the query since it only recognized calls to `rand()` as random sources.

Now that we have more sources of randomness (i.e., since https://github.com/github/codeql/pull/6154) we have a lot more results, and it looks like the `%` barrier doesn't rule out as many results as we want it to. For examples of this, see the first two bullet points I wrote here: https://github.com/github/codeql-c-team/issues/553#issuecomment-867670535.

Here's a difference run on our usual LGTM projects: https://lgtm.com/query/2650148462537684414/. All of the removed results look like false positives to me. It also removes some false positives on the `cpp/tainted-arithmetic` query, but it's difficult to create an LGTM difference query since `cpp/tainted-arithmetic` is still using the `TaintTrackingConfiguration` configuration.

This change has no effect on SAMATE.

