### PR TITLE
Add information for generating qhelp files locally

### DIFF
--- a/docs/query-help-style-guide.md
+++ b/docs/query-help-style-guide.md
@@ -110,6 +110,18 @@ For example:
 
 If your query checks code for a CWE weakness, you should use the `@tags` element in the query file to reference the associated CWEs, as explained [here](query-metadata-style-guide.md). When you use these tags, a link to the appropriate entry from the [MITRE.org](https://cwe.mitre.org/scoring/index.html) site will automatically appear as a reference in the output HTML file.
 
+## Validating qhelp files
+
+Before making a pull request you should ensure the `.qhelp` file is well-formed and can be generated without problems. For example, this can be done locally with `codeql-cli` tool. In order to do so just start the `codeql-cli` with the appropriate parameters, as seen in the following example:
+
+```bash
+# codeql generate query-help <path_to_your_qhelp_file> --format=<format>
+# For example:
+codeql generate query-help ./myCustomQuery.qhelp --format=markdown
+```
+
+More information on how to test your `.qhelp` files can be found [within the documentation](https://codeql.github.com/docs/codeql-cli/testing-query-help-files/)
+
 ## Query help example
 
 The following example is a query help file for a query from the standard query suite for Java:

--- a/docs/query-help-style-guide.md
+++ b/docs/query-help-style-guide.md
@@ -112,13 +112,16 @@ If your query checks code for a CWE weakness, you should use the `@tags` element
 
 ## Validating qhelp files
 
-Before making a pull request you should ensure the `.qhelp` file is well-formed and can be generated without problems. For example, this can be done locally with `codeql-cli` tool. In order to do so just start the `codeql-cli` with the appropriate parameters, as seen in the following example:
+Before making a pull request, please ensure the `.qhelp` files are well-formed and can be generated without errors. This can be done locally with the CodeQL CLI, as shown in the following example:
 
 ```bash
 # codeql generate query-help <path_to_your_qhelp_file> --format=<format>
 # For example:
 codeql generate query-help ./myCustomQuery.qhelp --format=markdown
 ```
+
+
+Please include the `.qhelp` files (and any associated code snippets) in your pull request, but do not commit the generated Markdown.
 
 More information on how to test your `.qhelp` files can be found [within the documentation](https://codeql.github.com/docs/codeql-cli/testing-query-help-files/)
 


### PR DESCRIPTION
Added a small getting started on how to test qhelp files locally, including a link to the official detailed documentation.

When searching for CodeQL qhelp files this document is pretty far up within google, so I figured it would be nice to reference to the qhelp testing/generating suite within the codeql-cli.
