### PR TITLE
Jax-RS: implement content-type tracking

### DIFF
--- a/java/change-notes/2021-06-25-jax-rs-content-types.md
+++ b/java/change-notes/2021-06-25-jax-rs-content-types.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The XSS query now accounts for more ways to set the content-type of an entity served via a Jax-RS HTTP endpoint. This may flag more cases where an XSS-vulnerable content-type is set, and exclude more cases where a non-vulnerable content-type such as `application/json` is set.

--- a/java/ql/src/Security/CWE/CWE-079/XSS.ql
+++ b/java/ql/src/Security/CWE/CWE-079/XSS.ql
@@ -25,6 +25,8 @@ class XSSConfig extends TaintTracking::Configuration {
 
   override predicate isSanitizer(DataFlow::Node node) { node instanceof XssSanitizer }
 
+  override predicate isSanitizerOut(DataFlow::Node node) { node instanceof XssSinkBarrier }
+
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(XssAdditionalTaintStep s).step(node1, node2)
   }

--- a/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
@@ -308,11 +308,9 @@ class JaxRSProducesAnnotation extends JaxRSAnnotation {
    * Gets a declared content type that can be produced by this resource.
    */
   Expr getADeclaredContentTypeExpr() {
-    (
-      result = this.getAValue() and not result instanceof ArrayInit
-      or
-      result = this.getAValue().(ArrayInit).getAnInit()
-    )
+    result = this.getAValue() and not result instanceof ArrayInit
+    or
+    result = this.getAValue().(ArrayInit).getAnInit()
   }
 }
 
@@ -823,7 +821,7 @@ private predicate isXssSafeContentTypeExpr(Expr e) { isXssSafeContentType(getCon
  * This could be an instance of `Response.ResponseBuilder`, `Variant`, `Variant.VariantListBuilder` or
  * a `List<Variant>`.
  *
- * This routine is used to search forwards for response entities set after the content-type is configured.
+ * This predicate is used to search forwards for response entities set after the content-type is configured.
  * It does not need to consider cases where the entity is set in the same call, or the entity has already
  * been set: these are handled by simple sanitization below.
  */
@@ -882,7 +880,7 @@ private DataFlow::Node getABuilderWithExplicitContentType(Expr contentType) {
     )
   or
   // Recursive case: ordinary local dataflow
-  DataFlow::localFlow(getABuilderWithExplicitContentType(contentType), result)
+  DataFlow::localFlowStep(getABuilderWithExplicitContentType(contentType), result)
 }
 
 private DataFlow::Node getASanitizedBuilder() {

--- a/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/src/semmle/code/java/frameworks/JaxWS.qll
@@ -283,7 +283,10 @@ class MessageBodyReaderRead extends Method {
   }
 }
 
-private string getContentTypeString(Expr e) {
+/**
+ * Gets a constant content-type described by expression `e` (either a string constant or a Jax-RS MediaType field access).
+ */
+string getContentTypeString(Expr e) {
   result = e.(CompileTimeConstantExpr).getStringValue() and
   result != ""
   or

--- a/java/ql/src/semmle/code/java/security/XSS.qll
+++ b/java/ql/src/semmle/code/java/security/XSS.qll
@@ -150,3 +150,20 @@ class ServletWriterSource extends MethodAccess {
     )
   }
 }
+
+/**
+ * Holds if `s` is an HTTP Content-Type vulnerable to XSS.
+ */
+bindingset[s]
+predicate isXssVulnerableContentType(string s) {
+  s.regexpMatch("(?i)text/(html|xml|xsl|rdf|vtt|cache-manifest).*") or
+  s.regexpMatch("(?i)application/(.*\\+)?xml.*") or
+  s.regexpMatch("(?i)cache-manifest.*") or
+  s.regexpMatch("(?i)image/svg\\+xml.*")
+}
+
+/**
+ * Holds if `s` is an HTTP Content-Type that is not vulnerable to XSS.
+ */
+bindingset[s]
+predicate isXssSafeContentType(string s) { not isXssVulnerableContentType(s) }

--- a/java/ql/src/semmle/code/java/security/XSS.qll
+++ b/java/ql/src/semmle/code/java/security/XSS.qll
@@ -16,6 +16,12 @@ abstract class XssSink extends DataFlow::Node { }
 abstract class XssSanitizer extends DataFlow::Node { }
 
 /**
+ * A sink that represent a method that outputs data without applying contextual output encoding,
+ * and which should truncate flow paths such that downstream sinks are not flagged as well.
+ */
+abstract class XssSinkBarrier extends XssSink { }
+
+/**
  * A unit class for adding additional taint steps.
  *
  * Extend this class to add additional taint steps that should apply to the XSS

--- a/java/ql/test/library-tests/frameworks/JaxWs/JakartaRs1.java
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JakartaRs1.java
@@ -71,7 +71,7 @@ public class JakartaRs1 { // $ RootResourceClass
     @Produces("text/html") // $ ProducesAnnotation=text/html
     @POST
     boolean Post() { // $ ResourceMethod=text/html ResourceMethodOnResourceClass
-      return false;
+      return false; // $ XssSink
     }
 
     @Produces(MediaType.TEXT_PLAIN) // $ ProducesAnnotation=text/plain

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxRs.ql
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxRs.ql
@@ -25,7 +25,8 @@ class JaxRsTest extends InlineExpectationsTest {
       element = resourceMethod.toString() and
       if exists(resourceMethod.getProducesAnnotation())
       then
-        value = resourceMethod.getProducesAnnotation().getADeclaredContentType() and
+        value =
+          getContentTypeString(resourceMethod.getProducesAnnotation().getADeclaredContentTypeExpr()) and
         value != ""
       else
         // Filter out empty strings that stem from using stubs.
@@ -143,7 +144,7 @@ class JaxRsTest extends InlineExpectationsTest {
     exists(JaxRSProducesAnnotation producesAnnotation |
       producesAnnotation.getLocation() = location and
       element = producesAnnotation.toString() and
-      value = producesAnnotation.getADeclaredContentType() and
+      value = getContentTypeString(producesAnnotation.getADeclaredContentTypeExpr()) and
       value != ""
       // Filter out empty strings that stem from using stubs.
       // If we built the test against the real JAR then the field

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxRs1.java
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxRs1.java
@@ -71,7 +71,7 @@ public class JaxRs1 { // $ RootResourceClass
     @Produces("text/html") // $ ProducesAnnotation=text/html
     @POST
     boolean Post() { // $ ResourceMethod=text/html ResourceMethodOnResourceClass
-      return false;
+      return false; // $ XssSink
     }
 
     @Produces(MediaType.TEXT_PLAIN) // $ ProducesAnnotation=text/plain

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/JaxXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/JaxXSS.java
@@ -37,18 +37,18 @@ public class JaxXSS {
     else {
       if(chainDirectly) {
         if(contentTypeFirst)
-          return builder.type(MediaType.APPLICATION_JSON).entity(userControlled).build(); // $SPURIOUS: xss
+          return builder.type(MediaType.APPLICATION_JSON).entity(userControlled).build();
         else
-          return builder.entity(userControlled).type(MediaType.APPLICATION_JSON).build(); // $SPURIOUS: xss
+          return builder.entity(userControlled).type(MediaType.APPLICATION_JSON).build();
       }
       else {
         if(contentTypeFirst) {
           Response.ResponseBuilder builder2 = builder.type(MediaType.APPLICATION_JSON);
-          return builder2.entity(userControlled).build(); // $SPURIOUS: xss
+          return builder2.entity(userControlled).build();
         }
         else {
           Response.ResponseBuilder builder2 = builder.entity(userControlled);
-          return builder2.type(MediaType.APPLICATION_JSON).build(); // $SPURIOUS: xss
+          return builder2.type(MediaType.APPLICATION_JSON).build();
         }
       }
     }

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/JaxXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/JaxXSS.java
@@ -63,39 +63,43 @@ public class JaxXSS {
     if(safeContentType) {
       if(route == 0) {
         // via ok, as a string literal:
-        return Response.ok(userControlled, "application/json").build(); // $SPURIOUS: xss
+        return Response.ok(userControlled, "application/json").build();
       }
       else if(route == 1) {
         // via ok, as a string constant:
-        return Response.ok(userControlled, MediaType.APPLICATION_JSON).build(); // $SPURIOUS: xss
+        return Response.ok(userControlled, MediaType.APPLICATION_JSON).build();
       }
       else if(route == 2) {
         // via ok, as a MediaType constant:
-        return Response.ok(userControlled, MediaType.APPLICATION_JSON_TYPE).build(); // $SPURIOUS: xss
+        return Response.ok(userControlled, MediaType.APPLICATION_JSON_TYPE).build();
       }
       else if(route == 3) {
         // via ok, as a Variant, via constructor:
-        return Response.ok(userControlled, new Variant(MediaType.APPLICATION_JSON_TYPE, "language", "encoding")).build(); // $SPURIOUS: xss
+        return Response.ok(userControlled, new Variant(MediaType.APPLICATION_JSON_TYPE, "language", "encoding")).build();
       }
       else if(route == 4) {
         // via ok, as a Variant, via static method:
-        return Response.ok(userControlled, Variant.mediaTypes(MediaType.APPLICATION_JSON_TYPE).build().get(0)).build(); // $SPURIOUS: xss
+        return Response.ok(userControlled, Variant.mediaTypes(MediaType.APPLICATION_JSON_TYPE).build().get(0)).build();
+      }
+      else if(route == -4) {
+        // via ok, as a Variant, via static method (testing multiple media types):
+        return Response.ok(userControlled, Variant.mediaTypes(MediaType.APPLICATION_JSON_TYPE, MediaType.APPLICATION_OCTET_STREAM_TYPE).build().get(0)).build();
       }
       else if(route == 5) {
         // via ok, as a Variant, via instance method:
-        return Response.ok(userControlled, Variant.languages(Locale.UK).mediaTypes(MediaType.APPLICATION_JSON_TYPE).build().get(0)).build(); // $SPURIOUS: xss
+        return Response.ok(userControlled, Variant.languages(Locale.UK).mediaTypes(MediaType.APPLICATION_JSON_TYPE).build().get(0)).build();
       }
       else if(route == 6) {
         // via builder variant, before entity:
-        return Response.ok().variant(new Variant(MediaType.APPLICATION_JSON_TYPE, "language", "encoding")).entity(userControlled).build(); // $SPURIOUS: xss
+        return Response.ok().variant(new Variant(MediaType.APPLICATION_JSON_TYPE, "language", "encoding")).entity(userControlled).build();
       }
       else if(route == 7) {
         // via builder variant, after entity:
-        return Response.ok().entity(userControlled).variant(new Variant(MediaType.APPLICATION_JSON_TYPE, "language", "encoding")).build(); // $SPURIOUS: xss
+        return Response.ok().entity(userControlled).variant(new Variant(MediaType.APPLICATION_JSON_TYPE, "language", "encoding")).build();
       }
       else if(route == 8) {
         // provide entity via ok, then content-type via builder:
-        return Response.ok(userControlled).type(MediaType.APPLICATION_JSON_TYPE).build(); // $SPURIOUS: xss
+        return Response.ok(userControlled).type(MediaType.APPLICATION_JSON_TYPE).build();
       }
     }
     else {
@@ -158,27 +162,27 @@ public class JaxXSS {
 
   @GET @Produces(MediaType.TEXT_HTML)
   public static Response methodContentTypeUnsafe(String userControlled) {
-    return Response.ok(userControlled).build(); // $MISSING: xss
+    return Response.ok(userControlled).build(); // $xss
   }
 
   @POST @Produces(MediaType.TEXT_HTML)
   public static Response methodContentTypeUnsafePost(String userControlled) {
-    return Response.ok(userControlled).build(); // $MISSING: xss
+    return Response.ok(userControlled).build(); // $xss
   }
 
   @GET @Produces("text/html")
   public static Response methodContentTypeUnsafeStringLiteral(String userControlled) {
-    return Response.ok(userControlled).build(); // $MISSING: xss
+    return Response.ok(userControlled).build(); // $xss
   }
 
   @GET @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
   public static Response methodContentTypeMaybeSafe(String userControlled) {
-    return Response.ok(userControlled).build(); // $MISSING: xss
+    return Response.ok(userControlled).build(); // $xss
   }
 
   @GET @Produces(MediaType.APPLICATION_JSON)
   public static Response methodContentTypeSafeOverriddenWithUnsafe(String userControlled) {
-    return Response.ok().type(MediaType.TEXT_HTML).entity(userControlled).build(); // $MISSING: xss
+    return Response.ok().type(MediaType.TEXT_HTML).entity(userControlled).build(); // $xss
   }
 
   @GET @Produces(MediaType.TEXT_HTML)
@@ -201,12 +205,12 @@ public class JaxXSS {
 
     @GET @Produces({"text/html"})
     public Response overridesWithUnsafe(String userControlled) {
-      return Response.ok(userControlled).build(); // $MISSING: xss
+      return Response.ok(userControlled).build(); // $xss
     }
 
     @GET
     public Response overridesWithUnsafe2(String userControlled) {
-      return Response.ok().type(MediaType.TEXT_HTML).entity(userControlled).build(); // $MISSING: xss
+      return Response.ok().type(MediaType.TEXT_HTML).entity(userControlled).build(); // $xss
     }
   }
 
@@ -215,12 +219,12 @@ public class JaxXSS {
   public static class ClassContentTypeUnsafe {
     @GET
     public Response test(String userControlled) {
-      return Response.ok(userControlled).build(); // $MISSING: xss
+      return Response.ok(userControlled).build(); // $xss
     }
 
     @GET
     public String testDirectReturn(String userControlled) {
-      return userControlled; // $MISSING: xss
+      return userControlled; // $xss
     }
 
     @GET @Produces({"application/json"})


### PR DESCRIPTION
This matches https://github.com/github/codeql-securitylab/blob/main/java/ql/src/pwntester/security/RestXSS.ql in terms of tracking content-types in order to sanitize or sink entity bodies:

* ResponseBuilders and related types with a specified content-type are followed forwards to find entities that have a known good or bad type, and are sanitized or sunk (with a barrier to avoid a duplicate hit) respectively
* Those that can't be conclusively identified either way are followed through to a resource method return site as before (this means the sink location varies depending on whether the content-type is set explicitly or by an annotation)
* With slightly more restricted logic, entities are followed forward to find a dangerous future content-type setting