### PR TITLE
Ensure only one query per language is tagged `lines-of-code`

### DIFF
--- a/cpp/ql/src/Summary/LinesOfCode.ql
+++ b/cpp/ql/src/Summary/LinesOfCode.ql
@@ -4,7 +4,6 @@
  * @description The total number of lines of C/C++ code across all files, including system headers, libraries, and auto-generated files. This is a useful metric of the size of a database. For all files that were seen during the build, this query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
- *       lines-of-code
  */
 
 import cpp

--- a/javascript/ql/src/Summary/LinesOfCode.ql
+++ b/javascript/ql/src/Summary/LinesOfCode.ql
@@ -4,7 +4,6 @@
  * @description The total number of lines of JavaScript or TypeScript code across all files checked into the repository, except in `node_modules`. This is a useful metric of the size of a database. For all files that were seen during extraction, this query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary
- *       lines-of-code
  */
 
 import javascript


### PR DESCRIPTION
Some languages have multiple `summary` queries for lines of code, representing different forms of counting (user written, total, etc). When Code Scanning sees results from multiple such summary queries in a single run, it will need to choose one as the primary LoC count to display in the UI.

By ensuring only one query per language has the `lines-of-code` tag, in future we can teach Code Scanning to look for this particular tag to identify the primary LoC count.

If a "lines of user code" query is available, use that.
Otherwise use the total "lines of code".

(It is completely fine for multiple queries to be tagged with `summary`, and for there to be multiple forms of LoC query.)