### PR TITLE
Performance: Improve join order in data flow library

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -1393,9 +1393,9 @@ private module Stage2 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2087,9 +2087,9 @@ private module Stage3 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself
@@ -2850,9 +2850,9 @@ private module Stage4 {
     exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
-      revFlow(ret, true, apSome(_), ap0, config) and
-      fwdFlow(ret, any(CcCall ccc), apSome(ap), pragma[only_bind_into](ap0),
+      revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
         pragma[only_bind_into](config)) and
+      fwdFlow(ret, any(CcCall ccc), apSome(ap), ap0, config) and
       kind = ret.getKind() and
       p.getPosition() = pos and
       // we don't expect a parameter to return stored in itself


### PR DESCRIPTION
Follows on from https://github.com/github/codeql/pull/6149

This adds a few more `pragma`s that are unfortunately needed to convince the optimiser to pick the right join order for this predicate in a few cases. This should hopefully fix the remaining regression from the optimiser's recent heuristics change.

cc. @github/codeql-core 

### Differences jobs

C++: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/2125/
Python: https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/596/
C#: https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1163/
Java: https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/1479/