### PR TITLE
C++: Fix warning from compile-query.

### DIFF
--- a/cpp/ql/src/Diagnostics/FailedExtractorInvocations.ql
+++ b/cpp/ql/src/Diagnostics/FailedExtractorInvocations.ql
@@ -1,15 +1,11 @@
 /**
  * @name Failed extractor invocations
  * @description Gives the command line of compilations for which extraction did not run to completion.
- * @kind table
+ * @kind diagnostic
  * @id cpp/diagnostics/failed-extractor-invocations
  */
 
 import cpp
-
-class AnonymousCompilation extends Compilation {
-  override string toString() { result = "<compilation>" }
-}
 
 string describe(Compilation c) {
   if c.getArgument(1) = "--mimic"
@@ -19,4 +15,4 @@ string describe(Compilation c) {
 
 from Compilation c
 where not c.normalTermination()
-select c, "Extraction aborted for " + describe(c)
+select "Extraction aborted for " + describe(c)

--- a/cpp/ql/src/Diagnostics/FailedExtractorInvocations.ql
+++ b/cpp/ql/src/Diagnostics/FailedExtractorInvocations.ql
@@ -1,7 +1,7 @@
 /**
  * @name Failed extractor invocations
  * @description Gives the command line of compilations for which extraction did not run to completion.
- * @kind diagnostic
+ * @kind table
  * @id cpp/diagnostics/failed-extractor-invocations
  */
 
@@ -19,4 +19,4 @@ string describe(Compilation c) {
 
 from Compilation c
 where not c.normalTermination()
-select c, "Extraction aborted for " + describe(c), 2
+select c, "Extraction aborted for " + describe(c)


### PR DESCRIPTION
Fixes  
```Warning: WARNING: Selected entity does not provide a location. (/home/runner/work/semmle-code/semmle-code/ql/cpp/ql/src/Diagnostics/FailedExtractorInvocations.ql:22,8-9)```