### PR TITLE
Change ID and description of cloned query

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.ql
@@ -1,11 +1,11 @@
 /**
- * @name Uncontrolled command line
+ * @name Uncontrolled command line (experimental sinks)
  * @description Using externally controlled strings in a command line is vulnerable to malicious
- *              changes in the strings.
+ *              changes in the strings (includes experimental sinks).
  * @kind path-problem
  * @problem.severity error
  * @precision high
- * @id java/command-line-injection
+ * @id java/command-line-injection-experimental
  * @tags security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
@@ -18,6 +18,7 @@ import ExecCommon
 import JSchOSInjection
 import DataFlow::PathGraph
 
+// This is a clone of query `java/command-line-injection` that also includes experimental sinks.
 from DataFlow::PathNode source, DataFlow::PathNode sink, ArgumentToExec execArg
 where execTainted(source, sink, execArg)
 select execArg, source, sink, "$@ flows to here and is used in a command.", source.getNode(),


### PR DESCRIPTION
This should be cleaned up more effectively soon, but this suffices to fix the clashing-id problem.