### PR TITLE
Fix CSV framework coverage commenter workflow

### DIFF
--- a/misc/scripts/library-coverage/comment-pr.py
+++ b/misc/scripts/library-coverage/comment-pr.py
@@ -121,10 +121,14 @@ def get_previous_run_id(repo, run_id, pr_number):
     pr_repo = this_run["head_repository"]
 
     # Get all previous runs that match branch, repo and workflow name:
-    ids = utils.subprocess_check_output(["gh", "api", "-X", "GET", f"repos/{repo}/actions/runs", "-f", "event=pull_request", "-f", "status=success", "-f", "name=\"" + artifacts_workflow_name + "\"", "--jq",
-                                        f"[.workflow_runs.[] | select(.head_branch==\"{pr_branch}\" and .head_repository.full_name==\"{pr_repo}\") | {{ created_at: .created_at, run_id: .id}}] | sort_by(.created_at) | reverse | [.[].run_id]"])
+    output = utils.subprocess_check_output(["gh", "api", "-X", "GET", f"repos/{repo}/actions/runs", "-f", "event=pull_request", "-f", "status=success", "-f", f"branch='{pr_branch}'", "--paginate",
+                                            "--jq", f"[.workflow_runs.[] | select(.head_repository.full_name==\"{pr_repo}\" and .name==\"{artifacts_workflow_name}\")] | sort_by(.id) | reverse | [.[].id]"])
 
-    ids = json.loads(ids)
+    ids = []
+    for l in [json.loads(l) for l in output.splitlines()]:
+        for id in l:
+            ids.append(id)
+
     if ids[0] != int(run_id):
         raise Exception(
             f"Expected to find {run_id} in the list of matching runs.")

--- a/misc/scripts/library-coverage/comment-pr.py
+++ b/misc/scripts/library-coverage/comment-pr.py
@@ -122,7 +122,7 @@ def get_previous_run_id(repo, run_id, pr_number):
 
     # Get all previous runs that match branch, repo and workflow name:
     output = utils.subprocess_check_output(["gh", "api", "-X", "GET", f"repos/{repo}/actions/runs", "-f", "event=pull_request", "-f", "status=success", "-f", f"branch='{pr_branch}'", "--paginate",
-                                            "--jq", f"[.workflow_runs.[] | select(.head_repository.full_name==\"{pr_repo}\" and .name==\"{artifacts_workflow_name}\")] | sort_by(.id) | reverse | [.[].id]"])
+                                            "--jq", f'[.workflow_runs.[] | select(.head_repository.full_name=="{pr_repo}" and .name=="{artifacts_workflow_name}")] | sort_by(.id) | reverse | [.[].id]'])
 
     ids = []
     for l in [json.loads(l) for l in output.splitlines()]:


### PR DESCRIPTION
There were multiple bugs in a `gh api` call previously in `comment-pr.py`:
- `--jq` runs on client side, so there might be significantly more results than what was queried before. `--paginate` is added, and the paged results are processed. (Didn't come out in testing because I had a lot less runs.)
- `-f name='artifacts_workflow_name'` actually did nothing. `workflow` can only be used on the UI to filter, the API doesn't have this parameter, (see [docs](https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository--parameters)), so the filter is moved to `--jq`.  (Didn't come out in testing, because the only job that matched the filters were the one I was interested in.)

Finally (not a bug, just an improvement), the `branch` filter is supported on the API, so that's moved out of the `--jq`. 

These fixes are in response to the change comment showing up multiple times in https://github.com/github/codeql/pull/6030.