### PR TITLE
Java: CWE-093 Crlf Injection

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.java
@@ -80,16 +80,27 @@ public class CrlfInjection {
 	@RequestMapping(value = "/crlf3", method = RequestMethod.GET)
 	@ResponseBody
 	public void bad3(String subject) {
+		//Bad
 		logger.info(subject);
 	}
 
 	@RequestMapping(value = "/crlf4", method = RequestMethod.GET)
 	@ResponseBody
 	public void good1(String subject) throws Exception {
-		//good
+		//Good
+		//Check whether the string contains \r\n or \n dangerous characters
 		if (subject.contains("\r\n") || subject.contains("\n")) {
 			throw new Exception("error");
 		}
 		logger.info(subject);
+	}
+
+	@RequestMapping(value = "/crlf5", method = RequestMethod.GET)
+	@ResponseBody
+	public void good2(String subject){
+		//Good
+		//Replace \r\n or \n with spaces
+		String infoMes = subject.replace("\r\n","").replace("\n","");
+		logger.info(infoMes);
 	}
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.java
@@ -1,0 +1,95 @@
+import java.io.UnsupportedEncodingException;
+import java.util.Properties;
+import javax.mail.Authenticator;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import javax.mail.internet.MimeUtility;
+import org.apache.commons.mail.DefaultAuthenticator;
+import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail.SimpleEmail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+public class CrlfInjection {
+
+	private static final Logger logger = LoggerFactory.getLogger(CrlfInjection.class);
+
+	@RequestMapping(value = "/crlf1", method = RequestMethod.GET)
+	@ResponseBody
+	public void bad1(String subject) {
+		Properties properties = new Properties();
+		properties.setProperty("mail.debug", "false");
+		properties.setProperty("mail.smtp.auth", "true");
+		properties.setProperty("mail.smtp.host", "smtp.xx.com");
+		properties.setProperty("mail.smtp.port", "587");
+		properties.setProperty("mail.transport.protocol", "smtp");
+
+		Session session = Session.getInstance(properties, new Authenticator() {
+			@Override
+			protected PasswordAuthentication getPasswordAuthentication() {
+				return new PasswordAuthentication("userName", "password");
+			}
+		});
+		MimeMessage msg = new MimeMessage(session);
+		try {
+			//Bad
+			msg.setSubject(subject);
+			msg.setFrom(new InternetAddress("\"" + MimeUtility.encodeText("test") + "\"<" + "test@xx.com" + ">"));
+			MimeMultipart msgMultipart = new MimeMultipart("mixed");
+			msg.setContent(msgMultipart);
+			MimeBodyPart htmlPart = new MimeBodyPart();
+			msgMultipart.addBodyPart(htmlPart);
+			htmlPart.setContent("test", "text/html;charset=utf-8");
+			Transport.send(msg, msg.getAllRecipients());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@RequestMapping(value = "/crlf2", method = RequestMethod.GET)
+	@ResponseBody
+	public void bad2(String subject) {
+		SimpleEmail email = new SimpleEmail();
+		email.setSSL(true);
+		email.setHostName("smtp.xxx.com");
+		email.setSmtpPort(465);
+		email.setAuthenticator(new DefaultAuthenticator("userName", "password"));
+		try {
+			email.setFrom("yyy@xx.com");
+			email.addTo("xxx@xx.com");
+			//Bad
+			email.setSubject(subject);
+			email.setMsg("test");
+			email.send();
+		} catch (EmailException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@RequestMapping(value = "/crlf3", method = RequestMethod.GET)
+	@ResponseBody
+	public void bad3(String subject) {
+		logger.info(subject);
+	}
+
+	@RequestMapping(value = "/crlf4", method = RequestMethod.GET)
+	@ResponseBody
+	public void good1(String subject) throws Exception {
+		//good
+		if (subject.contains("\r\n") || subject.contains("\n")) {
+			throw new Exception("error");
+		}
+		logger.info(subject);
+	}
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.qhelp
@@ -1,0 +1,39 @@
+
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+
+<p>If unprocessed user input is directly added to email headers or written to logs, malicious users can carry out email or 
+log injection attacks.</p>
+
+</overview>
+
+<recommendation>
+<p>
+User input should be verified before it is added to email headers or written to logs.
+</p>
+<p>
+To avoid header injection vulnerabilities and many other vulnerabilities, programmers must never trust any user input. Especially to avoid email injection or 
+log injection, you cannot allow any line breaks in the contact form input, because they will allow the attacker to append the email header or log content
+</p>
+
+</recommendation>
+
+<example>
+
+<p>The following examples show the bad case and the good case respectively. In <code>bad1</code> method and code>bad2</code> method, the user input is sent 
+as the email header content, and the malicious user may introduce additional headers in the email to indicate that the mail server's behavior is different 
+from expected. In <code>bad3</code> method, user input is used as the output of the log content, and malicious users may forge the log content. 
+In <code>good1</code> method, the program determines whether the user input contains <code>\r\n or \n</code> through <code>contains</code> to prevent crlf injection.</p>
+
+<sample src="CrlfInjection.java" />
+</example>
+
+<references>
+<li>Acunetix: <a href="https://www.acunetix.com/blog/articles/email-header-injection/">Email Header Injection</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-community/vulnerabilities/CRLF_Injection">CRLF Injection</a>.</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.qhelp
@@ -5,10 +5,13 @@
 <qhelp>
 
 <overview>
-
-<p>If unprocessed user input is directly added to email headers or written to logs, malicious users can carry out email or 
-log injection attacks.</p>
-
+<p>
+CRLF is the abbreviation of "carriage return + line feed" (\r\n). CRLF is used as line termination in HTTP protocol, logging, and SMTP protocol. 
+If you add unprocessed user input directly to HTTP Header, log Log injection, http header injection, and email header injection are easy to cause in records or emails.
+</p>
+<p>
+This taint tracking configuration supports querying whether there are Log injection and email header injection in your code.
+</p>
 </overview>
 
 <recommendation>
@@ -19,22 +22,19 @@ User input should be verified before it is added to email headers or written to 
 To avoid header injection vulnerabilities and many other vulnerabilities, programmers must never trust any user input. Especially to avoid email injection or 
 log injection, you cannot allow any line breaks in the contact form input, because they will allow the attacker to append the email header or log content
 </p>
-
 </recommendation>
 
 <example>
-
 <p>The following examples show the bad case and the good case respectively. In <code>bad1</code> method and code>bad2</code> method, the user input is sent 
 as the email header content, and the malicious user may introduce additional headers in the email to indicate that the mail server's behavior is different 
 from expected. In <code>bad3</code> method, user input is used as the output of the log content, and malicious users may forge the log content. 
 In <code>good1</code> method, the program determines whether the user input contains <code>\r\n or \n</code> through <code>contains</code> to prevent crlf injection.
 In <code>good2</code> method, use string replacement method to replace <code>\r\n or \n</code> in the string with spaces.</p>
-
 <sample src="CrlfInjection.java" />
 </example>
 
 <references>
-<li>Acunetix: <a href="https://www.acunetix.com/blog/articles/email-header-injection/">Email Header Injection</a>.</li>
+<li>Acunetix: <a href="https://www.acunetix.com/blog/articles/email-header-injection">Email Header Injection</a>.</li>
 <li>OWASP: <a href="https://owasp.org/www-community/vulnerabilities/CRLF_Injection">CRLF Injection</a>.</li>
 </references>
 </qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.qhelp
@@ -27,7 +27,8 @@ log injection, you cannot allow any line breaks in the contact form input, becau
 <p>The following examples show the bad case and the good case respectively. In <code>bad1</code> method and code>bad2</code> method, the user input is sent 
 as the email header content, and the malicious user may introduce additional headers in the email to indicate that the mail server's behavior is different 
 from expected. In <code>bad3</code> method, user input is used as the output of the log content, and malicious users may forge the log content. 
-In <code>good1</code> method, the program determines whether the user input contains <code>\r\n or \n</code> through <code>contains</code> to prevent crlf injection.</p>
+In <code>good1</code> method, the program determines whether the user input contains <code>\r\n or \n</code> through <code>contains</code> to prevent crlf injection.
+In <code>good2</code> method, use string replacement method to replace <code>\r\n or \n</code> in the string with spaces.</p>
 
 <sample src="CrlfInjection.java" />
 </example>

--- a/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjection.ql
@@ -1,0 +1,52 @@
+/**
+ * @name Crlf Injection
+ * @description Through CRLF injection, attackers can maliciously exploit CRLF vulnerabilities
+ *              to manipulate the functionality of web applications.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/crlf-injection
+ * @tags security
+ *       external/cwe/cwe-093
+ */
+
+import java
+import CrlfInjectionLib
+import DataFlow::PathGraph
+import semmle.code.java.dataflow.FlowSources
+
+private class ContainsSanitizer extends DataFlow::BarrierGuard {
+  ContainsSanitizer() {
+    this.(MethodAccess).getMethod().hasName("contains") and
+    this.(MethodAccess).getMethod().getNumberOfParameters() = 1 and
+    this.(MethodAccess).getMethod().getDeclaringType() instanceof TypeString and
+    (
+      this.(MethodAccess).getAnArgument().(CompileTimeConstantExpr).getStringValue() = "\r\n"
+      or
+      this.(MethodAccess).getAnArgument().(CompileTimeConstantExpr).getStringValue() = "\n"
+    )
+  }
+
+  override predicate checks(Expr e, boolean branch) {
+    e = this.(MethodAccess).getQualifier() and branch = false
+  }
+}
+
+/**
+ * A taint-tracking configuration for unvalidated user input that is used in emails or logs.
+ */
+class CrlfInjectionConfiguration extends TaintTracking::Configuration {
+  CrlfInjectionConfiguration() { this = "Crlf Injection" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof CrlfInjectionSink }
+
+  override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
+    guard instanceof ContainsSanitizer
+  }
+}
+
+from CrlfInjectionConfiguration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "CRLF injection from $@.", source.getNode(), "this user input"

--- a/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjectionLib.qll
@@ -1,0 +1,32 @@
+import java
+import DataFlow
+import experimental.semmle.code.java.Logging
+import semmle.code.java.dataflow.FlowSources
+
+/** The method `org.apache.commons.mail.Email.setSubject`. */
+class EmailSetSubjectMethod extends Method {
+  EmailSetSubjectMethod() {
+    this.getDeclaringType().hasQualifiedName("org.apache.commons.mail", "Email") and
+    this.hasName("setSubject")
+  }
+}
+
+/** The method `javax.mail.internet.MimeMessage.setSubject`. */
+class MimeMessageSetSubjectMethod extends Method {
+  MimeMessageSetSubjectMethod() {
+    this.getDeclaringType().hasQualifiedName("javax.mail.internet", "MimeMessage") and
+    this.hasName("setSubject")
+  }
+}
+
+/** A sink for crlf injection vulnerabilities. */
+class CrlfInjectionSink extends DataFlow::ExprNode {
+  CrlfInjectionSink() {
+    exists(MethodAccess ma, Method m | m = ma.getMethod() and ma.getAnArgument() = this.getExpr() |
+      m instanceof MimeMessageSetSubjectMethod or
+      m instanceof EmailSetSubjectMethod
+    )
+    or
+    exists(LoggingCall c | c.getALogArgument() = this.asExpr())
+  }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-093/CrlfInjectionLib.qll
@@ -3,6 +3,17 @@ import DataFlow
 import experimental.semmle.code.java.Logging
 import semmle.code.java.dataflow.FlowSources
 
+/**
+ * A String replacement method. This is either `String.replace` or `String.replaceAll`.
+ */
+class ReplaceMethod extends Method {
+  ReplaceMethod() {
+    this.getName() in ["replace", "replaceAll"] and
+    this.getDeclaringType() instanceof TypeString and
+    this.getNumberOfParameters() = 2
+  }
+}
+
 /** The method `org.apache.commons.mail.Email.setSubject`. */
 class EmailSetSubjectMethod extends Method {
   EmailSetSubjectMethod() {

--- a/java/ql/test/experimental/query-tests/security/CWE-093/CrlfInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-093/CrlfInjection.expected
@@ -1,0 +1,15 @@
+edges
+| CrlfInjection.java:30:19:30:32 | subject : String | CrlfInjection.java:47:19:47:25 | subject |
+| CrlfInjection.java:62:19:62:32 | subject : String | CrlfInjection.java:72:21:72:27 | subject |
+| CrlfInjection.java:82:19:82:32 | subject : String | CrlfInjection.java:83:15:83:21 | subject |
+nodes
+| CrlfInjection.java:30:19:30:32 | subject : String | semmle.label | subject : String |
+| CrlfInjection.java:47:19:47:25 | subject | semmle.label | subject |
+| CrlfInjection.java:62:19:62:32 | subject : String | semmle.label | subject : String |
+| CrlfInjection.java:72:21:72:27 | subject | semmle.label | subject |
+| CrlfInjection.java:82:19:82:32 | subject : String | semmle.label | subject : String |
+| CrlfInjection.java:83:15:83:21 | subject | semmle.label | subject |
+#select
+| CrlfInjection.java:47:19:47:25 | subject | CrlfInjection.java:30:19:30:32 | subject : String | CrlfInjection.java:47:19:47:25 | subject | CRLF injection from $@. | CrlfInjection.java:30:19:30:32 | subject | this user input |
+| CrlfInjection.java:72:21:72:27 | subject | CrlfInjection.java:62:19:62:32 | subject : String | CrlfInjection.java:72:21:72:27 | subject | CRLF injection from $@. | CrlfInjection.java:62:19:62:32 | subject | this user input |
+| CrlfInjection.java:83:15:83:21 | subject | CrlfInjection.java:82:19:82:32 | subject : String | CrlfInjection.java:83:15:83:21 | subject | CRLF injection from $@. | CrlfInjection.java:82:19:82:32 | subject | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-093/CrlfInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-093/CrlfInjection.expected
@@ -1,15 +1,15 @@
 edges
 | CrlfInjection.java:30:19:30:32 | subject : String | CrlfInjection.java:47:19:47:25 | subject |
 | CrlfInjection.java:62:19:62:32 | subject : String | CrlfInjection.java:72:21:72:27 | subject |
-| CrlfInjection.java:82:19:82:32 | subject : String | CrlfInjection.java:83:15:83:21 | subject |
+| CrlfInjection.java:82:19:82:32 | subject : String | CrlfInjection.java:84:15:84:21 | subject |
 nodes
 | CrlfInjection.java:30:19:30:32 | subject : String | semmle.label | subject : String |
 | CrlfInjection.java:47:19:47:25 | subject | semmle.label | subject |
 | CrlfInjection.java:62:19:62:32 | subject : String | semmle.label | subject : String |
 | CrlfInjection.java:72:21:72:27 | subject | semmle.label | subject |
 | CrlfInjection.java:82:19:82:32 | subject : String | semmle.label | subject : String |
-| CrlfInjection.java:83:15:83:21 | subject | semmle.label | subject |
+| CrlfInjection.java:84:15:84:21 | subject | semmle.label | subject |
 #select
 | CrlfInjection.java:47:19:47:25 | subject | CrlfInjection.java:30:19:30:32 | subject : String | CrlfInjection.java:47:19:47:25 | subject | CRLF injection from $@. | CrlfInjection.java:30:19:30:32 | subject | this user input |
 | CrlfInjection.java:72:21:72:27 | subject | CrlfInjection.java:62:19:62:32 | subject : String | CrlfInjection.java:72:21:72:27 | subject | CRLF injection from $@. | CrlfInjection.java:62:19:62:32 | subject | this user input |
-| CrlfInjection.java:83:15:83:21 | subject | CrlfInjection.java:82:19:82:32 | subject : String | CrlfInjection.java:83:15:83:21 | subject | CRLF injection from $@. | CrlfInjection.java:82:19:82:32 | subject | this user input |
+| CrlfInjection.java:84:15:84:21 | subject | CrlfInjection.java:82:19:82:32 | subject : String | CrlfInjection.java:84:15:84:21 | subject | CRLF injection from $@. | CrlfInjection.java:82:19:82:32 | subject | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-093/CrlfInjection.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-093/CrlfInjection.java
@@ -80,16 +80,27 @@ public class CrlfInjection {
 	@RequestMapping(value = "/crlf3", method = RequestMethod.GET)
 	@ResponseBody
 	public void bad3(String subject) {
+		//Bad
 		logger.info(subject);
 	}
 
 	@RequestMapping(value = "/crlf4", method = RequestMethod.GET)
 	@ResponseBody
 	public void good1(String subject) throws Exception {
-		//good
+		//Good
+		//Check whether the string contains \r\n or \n dangerous characters
 		if (subject.contains("\r\n") || subject.contains("\n")) {
 			throw new Exception("error");
 		}
 		logger.info(subject);
+	}
+
+	@RequestMapping(value = "/crlf5", method = RequestMethod.GET)
+	@ResponseBody
+	public void good2(String subject){
+		//Good
+		//Replace \r\n or \n with spaces
+		String infoMes = subject.replace("\r\n","").replace("\n","");
+		logger.info(infoMes);
 	}
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-093/CrlfInjection.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-093/CrlfInjection.java
@@ -1,0 +1,95 @@
+import java.io.UnsupportedEncodingException;
+import java.util.Properties;
+import javax.mail.Authenticator;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import javax.mail.internet.MimeUtility;
+import org.apache.commons.mail.DefaultAuthenticator;
+import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail.SimpleEmail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+public class CrlfInjection {
+
+	private static final Logger logger = LoggerFactory.getLogger(CrlfInjection.class);
+
+	@RequestMapping(value = "/crlf1", method = RequestMethod.GET)
+	@ResponseBody
+	public void bad1(String subject) {
+		Properties properties = new Properties();
+		properties.setProperty("mail.debug", "false");
+		properties.setProperty("mail.smtp.auth", "true");
+		properties.setProperty("mail.smtp.host", "smtp.xx.com");
+		properties.setProperty("mail.smtp.port", "587");
+		properties.setProperty("mail.transport.protocol", "smtp");
+
+		Session session = Session.getInstance(properties, new Authenticator() {
+			@Override
+			protected PasswordAuthentication getPasswordAuthentication() {
+				return new PasswordAuthentication("userName", "password");
+			}
+		});
+		MimeMessage msg = new MimeMessage(session);
+		try {
+			//Bad
+			msg.setSubject(subject);
+			msg.setFrom(new InternetAddress("\"" + MimeUtility.encodeText("test") + "\"<" + "test@xx.com" + ">"));
+			MimeMultipart msgMultipart = new MimeMultipart("mixed");
+			msg.setContent(msgMultipart);
+			MimeBodyPart htmlPart = new MimeBodyPart();
+			msgMultipart.addBodyPart(htmlPart);
+			htmlPart.setContent("test", "text/html;charset=utf-8");
+			Transport.send(msg, msg.getAllRecipients());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@RequestMapping(value = "/crlf2", method = RequestMethod.GET)
+	@ResponseBody
+	public void bad2(String subject) {
+		SimpleEmail email = new SimpleEmail();
+		email.setSSL(true);
+		email.setHostName("smtp.xxx.com");
+		email.setSmtpPort(465);
+		email.setAuthenticator(new DefaultAuthenticator("userName", "password"));
+		try {
+			email.setFrom("yyy@xx.com");
+			email.addTo("xxx@xx.com");
+			//Bad
+			email.setSubject(subject);
+			email.setMsg("test");
+			email.send();
+		} catch (EmailException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@RequestMapping(value = "/crlf3", method = RequestMethod.GET)
+	@ResponseBody
+	public void bad3(String subject) {
+		logger.info(subject);
+	}
+
+	@RequestMapping(value = "/crlf4", method = RequestMethod.GET)
+	@ResponseBody
+	public void good1(String subject) throws Exception {
+		//good
+		if (subject.contains("\r\n") || subject.contains("\n")) {
+			throw new Exception("error");
+		}
+		logger.info(subject);
+	}
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-093/CrlfInjection.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-093/CrlfInjection.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-093/CrlfInjection.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-093/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-093/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/servlet-api-2.4:${testdir}/../../../../stubs/springframework-5.2.3/:${testdir}/../../../../stubs/javamail-api-1.6.2:${testdir}/../../../../stubs/apache-commons-email-1.6.0:${testdir}/../../../../stubs/slf4j-1.6.4

--- a/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/Address.java
+++ b/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/Address.java
@@ -1,0 +1,15 @@
+package javax.mail;
+
+import java.io.Serializable;
+
+public abstract class Address implements Serializable {
+
+    public Address() {
+    }
+
+    public abstract String getType();
+
+    public abstract String toString();
+
+    public abstract boolean equals(Object var1);
+}

--- a/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/BodyPart.java
+++ b/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/BodyPart.java
@@ -1,0 +1,5 @@
+package javax.mail;
+
+public abstract class BodyPart {
+    
+}

--- a/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/Message.java
+++ b/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/Message.java
@@ -1,0 +1,5 @@
+package javax.mail;
+
+public abstract class Message {
+    
+}

--- a/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/Multipart.java
+++ b/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/Multipart.java
@@ -1,0 +1,5 @@
+package javax.mail;
+
+public abstract class Multipart {
+
+}

--- a/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/Transport.java
+++ b/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/Transport.java
@@ -1,0 +1,6 @@
+package javax.mail;
+
+public abstract class Transport {
+
+    public static void send(Message msg, Address[] addresses) { }
+}

--- a/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/internet/InternetAddress.java
+++ b/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/internet/InternetAddress.java
@@ -1,0 +1,22 @@
+package javax.mail.internet;
+
+import javax.mail.Address;
+
+public class InternetAddress extends Address implements Cloneable {
+
+    public InternetAddress() { }
+
+    public InternetAddress(String address) { }
+
+    public String getType() {
+        return null;
+    }
+
+    public String toString() {
+        return null;
+    }
+    
+    public boolean equals(Object a) {
+        return true;
+    }
+}

--- a/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/internet/MimeBodyPart.java
+++ b/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/internet/MimeBodyPart.java
@@ -1,0 +1,8 @@
+package javax.mail.internet;
+
+import javax.mail.BodyPart;
+
+public class MimeBodyPart extends BodyPart {
+
+    public void setContent(Object o, String type) { }
+}

--- a/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/internet/MimeMessage.java
+++ b/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/internet/MimeMessage.java
@@ -1,0 +1,21 @@
+package javax.mail.internet;
+
+import javax.mail.Address;
+import javax.mail.Session;
+import javax.mail.Multipart;
+import javax.mail.Message;
+
+public class MimeMessage extends Message {
+
+    public MimeMessage(Session session) { }
+
+    public void setSubject(String subject) { }
+
+    public void setFrom(Address address) { }
+
+    public void setContent(Multipart mp) { }
+
+    public Address[] getAllRecipients() {
+        return null;
+    }
+}

--- a/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/internet/MimeMultipart.java
+++ b/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/internet/MimeMultipart.java
@@ -1,0 +1,11 @@
+package javax.mail.internet;
+
+import javax.mail.Multipart;
+import javax.mail.BodyPart;
+
+public class MimeMultipart extends Multipart {
+
+    public MimeMultipart(String subtype) { }
+
+    public synchronized void addBodyPart(BodyPart part) { }
+}

--- a/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/internet/MimeUtility.java
+++ b/java/ql/test/stubs/javamail-api-1.6.2/javax/mail/internet/MimeUtility.java
@@ -1,0 +1,8 @@
+package javax.mail.internet;
+
+public class MimeUtility {
+
+    public static String encodeText(String text) {
+        return null;
+    }
+}

--- a/java/ql/test/stubs/slf4j-1.6.4/org/slf4j/Logger.java
+++ b/java/ql/test/stubs/slf4j-1.6.4/org/slf4j/Logger.java
@@ -1,0 +1,6 @@
+package org.slf4j;
+
+public interface Logger {
+
+    void info(String var1);
+}

--- a/java/ql/test/stubs/slf4j-1.6.4/org/slf4j/LoggerFactory.java
+++ b/java/ql/test/stubs/slf4j-1.6.4/org/slf4j/LoggerFactory.java
@@ -1,0 +1,14 @@
+package org.slf4j;
+
+
+
+public final class LoggerFactory {
+
+    public static Logger getLogger(String name) {
+        return null;
+    }
+
+    public static Logger getLogger(Class clazz) {
+        return null;
+    }
+}

--- a/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/RestController.java
+++ b/java/ql/test/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/RestController.java
@@ -1,0 +1,17 @@
+package org.springframework.web.bind.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.stereotype.Controller;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Controller
+@ResponseBody
+public @interface RestController {
+    String value() default "";
+}


### PR DESCRIPTION
If unprocessed user input is directly added to email headers or written to logs, malicious users can carry out email or 
log injection attacks.
