### PR TITLE
Update getting-started-with-the-codeql-cli.rst

### DIFF
--- a/docs/codeql/codeql-cli/getting-started-with-the-codeql-cli.rst
+++ b/docs/codeql/codeql-cli/getting-started-with-the-codeql-cli.rst
@@ -18,9 +18,9 @@ structures. To get started quickly, we recommend adopting a relatively simple
 setup, as outlined in the steps below.
 
 If you use Linux, Windows, or macOS version 10.14 ("Mojave") or earlier, simply
-follow the steps below. For macOS version 10.15 ("Catalina"), steps 1 and 4 are
-slightly different---for further details, see the sections labeled **Information
-for macOS "Catalina" users**.
+follow the steps below. For macOS version 10.15 ("Catalina") or newer, steps 1 
+and 4 are slightly different---for further details, see the sections labeled 
+**Information for macOS "Catalina" (or newer) users**.
 
 1. Download the CodeQL CLI zip package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,13 +61,14 @@ Alternatively, you can download ``codeql.zip``, which contains the CLI for all s
 
    .. container:: name
 
-      **Information for macOS "Catalina" users**
+      **Information for macOS "Catalina" (or newer) users**
 
-   .. pull-quote:: macOS "Catalina"
+   .. pull-quote:: macOS "Catalina" (or newer)
       
-      If you use macOS version 10.15 ("Catalina"), you need to ensure that your web
-      browser does not automatically extract zip files. If you use Safari,
-      complete the following steps before downloading the CodeQL CLI zip archive:
+      If you use macOS version 10.15 ("Catalina"), version 11 ("Big Sur"), or the upcoming 
+      version 12 ("Monterey"), you need to ensure that your web browser does not automatically 
+      extract zip files. If you use Safari, complete the following steps before downloading 
+      the CodeQL CLI zip archive:
           
       i. Open Safari.
       ii. From the Safari menu, select **Preferences...**.
@@ -159,16 +160,17 @@ For example, if the path to your copy of the CodeQL repository is
 
    .. container:: name
 
-      **Information for macOS "Catalina" users**
+      **Information for macOS "Catalina" (or newer) users**
 
    .. pull-quote:: macOS "Catalina"
    
-      macOS "Catalina" users should run the following commands in the Terminal,
-      where ``${install_loc}`` is the path to the directory you created in step 2:
+      macOS "Catalina", "Big Sur", or "Monterey" users should run the following 
+      commands in the Terminal, where ``${install_loc}`` is the path to the 
+      directory you created in step 2:
    
       i. ``mv ~/Downloads/codeql*.zip ${install_loc}``
       ii. ``cd ${install_loc}``
-      iii. ``xattr -c codeql*.zip``
+      iii. ``/usr/bin/xattr -c codeql*.zip``
       iv. ``unzip codeql*.zip``
    
 5. Launch ``codeql``


### PR DESCRIPTION
1. The documentation is at least one full macOS release behind, and we're past WWDC so we already know what the next version is. IMO, we should optimize the documentation for the now + future, rather than providing exceptions for them while favoring legacy releases. _Current_ macOS requires the steps that are currently hidden by default; I would recommend inverting the pattern so that _current_ is shown by default, and legacy releases are hidden away.

1. Homebrew is the bread and butter of many developers. Installing Python via Homebrew installs a custom version of `xattr` that is different from the system's `xattr`, which doesn't support the `-c` flag. By specifically executing the system-provided version of `xattr` by path, you are more-or-less guaranteed to get the system-provided `xattr` with the expected `-c` flag.