### PR TITLE
Upgrade database in coverage report jobs

### DIFF
--- a/misc/scripts/library-coverage/generate-report.py
+++ b/misc/scripts/library-coverage/generate-report.py
@@ -134,8 +134,7 @@ for lang in settings.languages:
     db = "empty-" + lang
     ql_output = output_ql_csv.format(language=lang)
     utils.create_empty_database(lang, config.ext, db)
-    utils.upgrade_codeql_database(db, query_prefix)
-    utils.run_codeql_query(config.ql_path, db, ql_output)
+    utils.run_codeql_query(config.ql_path, db, ql_output, query_prefix)
     shutil.rmtree(db)
 
     packages = pack.PackageCollection(ql_output)

--- a/misc/scripts/library-coverage/generate-report.py
+++ b/misc/scripts/library-coverage/generate-report.py
@@ -134,6 +134,7 @@ for lang in settings.languages:
     db = "empty-" + lang
     ql_output = output_ql_csv.format(language=lang)
     utils.create_empty_database(lang, config.ext, db)
+    utils.upgrade_codeql_database(db, query_prefix)
     utils.run_codeql_query(config.ql_path, db, ql_output)
     shutil.rmtree(db)
 

--- a/misc/scripts/library-coverage/generate-timeseries.py
+++ b/misc/scripts/library-coverage/generate-timeseries.py
@@ -48,8 +48,7 @@ def get_packages(lang, query, search_path):
         if os.path.isdir(db):
             shutil.rmtree(db)
         utils.create_empty_database(lang, ".java", db)
-        utils.upgrade_codeql_database(db, search_path)
-        utils.run_codeql_query(query, db, ql_output)
+        utils.run_codeql_query(query, db, ql_output, search_path)
 
         return pack.PackageCollection(ql_output)
     except:

--- a/misc/scripts/library-coverage/generate-timeseries.py
+++ b/misc/scripts/library-coverage/generate-timeseries.py
@@ -41,13 +41,14 @@ class Git:
         return (parent_sha, parent_date)
 
 
-def get_packages(lang, query):
+def get_packages(lang, query, search_path):
     try:
         db = "empty_" + lang
         ql_output = "output-" + lang + ".csv"
         if os.path.isdir(db):
             shutil.rmtree(db)
         utils.create_empty_database(lang, ".java", db)
+        utils.upgrade_codeql_database(db, search_path)
         utils.run_codeql_query(query, db, ql_output)
 
         return pack.PackageCollection(ql_output)
@@ -142,7 +143,7 @@ try:
                 csvwriter_total = language_utils[lang]["csvwriter_total"]
                 csvwriter_packages = language_utils[lang]["csvwriter_packages"]
 
-                packages = get_packages(lang, config.ql_path)
+                packages = get_packages(lang, config.ql_path, ".")
 
                 csvwriter_total.writerow([
                     current_sha,

--- a/misc/scripts/library-coverage/utils.py
+++ b/misc/scripts/library-coverage/utils.py
@@ -27,15 +27,11 @@ def create_empty_database(lang, extension, database):
                    database, "--no-pre-finalize"])
 
 
-def upgrade_codeql_database(database, search_path):
-    subprocess_run(["codeql", "database", "upgrade", database,
-                   "--search-path", search_path])
-
-
-def run_codeql_query(query, database, output):
+def run_codeql_query(query, database, output, search_path):
     """Runs a codeql query on the given database."""
-    subprocess_run(["codeql", "query", "run", query,
-                   "--database", database, "--output", output + ".bqrs"])
+    # --search-path is required when the CLI needs to upgrade the database scheme.
+    subprocess_run(["codeql", "query", "run", query, "--database", database,
+                   "--output", output + ".bqrs", "--search-path", search_path])
     subprocess_run(["codeql", "bqrs", "decode", output + ".bqrs",
                    "--format=csv", "--no-titles", "--output", output])
     os.remove(output + ".bqrs")

--- a/misc/scripts/library-coverage/utils.py
+++ b/misc/scripts/library-coverage/utils.py
@@ -27,6 +27,11 @@ def create_empty_database(lang, extension, database):
                    database, "--no-pre-finalize"])
 
 
+def upgrade_codeql_database(database, search_path):
+    subprocess_run(["codeql", "database", "upgrade", database,
+                   "--search-path", search_path])
+
+
 def run_codeql_query(query, database, output):
     """Runs a codeql query on the given database."""
     subprocess_run(["codeql", "query", "run", query,


### PR DESCRIPTION
The framework coverage jobs download the last released codeql CLI, create a DB, and then run some queries. If the database schema is updated since the release, then the query execution fails. Therefore, this PR adds a `codeql database upgrade` call to upgrade the created database.

Jobs on `main`: 
- [current coverage](https://github.com/github/codeql/actions/runs/982370413) is failing
- [timeseries coverage](https://github.com/github/codeql/actions/runs/982385044) is producing empty report
- [Failing PR check](https://github.com/github/codeql/actions/runs/982027422)

Working jobs in `dsp-testing` based on this PR: 
- [current coverage](https://github.com/dsp-testing/codeql-csv-coverage-pr-commenter/actions/runs/982369802)
- [timeseries coverage](https://github.com/dsp-testing/codeql-csv-coverage-pr-commenter/actions/runs/982384721)
- [PR check](https://github.com/dsp-testing/codeql-csv-coverage-pr-commenter/actions/runs/982400274)