### PR TITLE
Java: Fix bad join-order.

### DIFF
--- a/java/ql/src/semmle/code/java/Member.qll
+++ b/java/ql/src/semmle/code/java/Member.qll
@@ -584,9 +584,9 @@ class Field extends Member, ExprParent, @field, Variable {
     exists(AssignExpr e, InitializerMethod im |
       e.getDest() = this.getAnAccess() and
       e.getSource() = result and
-      result.getEnclosingCallable() = im and
+      pragma[only_bind_out](result).getEnclosingCallable() = im and
       // This rules out updates in explicit initializer blocks as they are nested inside the compiler generated initializer blocks.
-      e.getEnclosingStmt().getParent() = im.getBody()
+      pragma[only_bind_out](e.getEnclosingStmt().getParent()) = pragma[only_bind_out](im.getBody())
     )
   }
 


### PR DESCRIPTION
Before (cancelled, so only showing some of the tuples):
```
[2021-06-30 10:56:44] (13s)  >>> Created relation Expr::Expr::getEnclosingCallable_dispred#fb_10#join_rhs/2@dd2be8 with 1159802 rows.
Jun 30, 2021 11:05:17 AM org.eclipse.lsp4j.jsonrpc.RemoteEndpoint handleCancellation
WARNING: Unmatched cancel notification for request id 39
Jun 30, 2021 11:05:17 AM org.eclipse.lsp4j.jsonrpc.RemoteEndpoint handleCancellation
WARNING: Unmatched cancel notification for request id 40
[2021-06-30 11:05:17] (527s) Demand has vanished for evaluator Variable::Variable::getInitializer_dispred#ff/2@25f4a0
[2021-06-30 11:05:17] (527s) Cancelling evaluation of evaluator Variable::Variable::getInitializer_dispred#ff/2@25f4a0: No demand for this layer anymore.
[2021-06-30 11:05:17] (527s) Tuple counts for Variable::Variable::getInitializer_dispred#ff/2@25f4a0:
                      7117       ~0%     {3} r1 = SCAN localvars OUTPUT In.3, 0, In.0 'this'
                      6559       ~0%     {2} r2 = JOIN r1 WITH exprs_340#join_rhs ON FIRST 2 OUTPUT Lhs.2 'this', Rhs.2 'result'
                      3157       ~2%     {2} r3 = JOIN Member::InitializerMethod#class#f WITH Member::Callable::getBody_dispred#bf ON FIRST 1 OUTPUT Rhs.1, Lhs.0
                      217589     ~2%     {2} r4 = JOIN r3 WITH stmts_20#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1
                      4529767746 ~0%     {3} r5 = JOIN r4 WITH Expr::Expr::getEnclosingCallable_dispred#fb_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'result', 1, Lhs.1
                      1427567974 ~2%     {4} r6 = JOIN r5 WITH exprs_043#join_rhs ON FIRST 2 OUTPUT Rhs.2, 4, Lhs.2, Lhs.0 'result'
                      1397327954 ~3%     {3} r7 = JOIN r6 WITH exprs ON FIRST 2 OUTPUT Lhs.0, Lhs.2, Lhs.3 'result'
                      217564     ~0%     {3} r8 = JOIN r7 WITH Expr::Expr::getEnclosingStmt_dispred#bf ON FIRST 2 OUTPUT Lhs.0, 0, Lhs.2 'result'
                      217564     ~0%     {2} r9 = JOIN r8 WITH exprs_340#join_rhs ON FIRST 2 OUTPUT Rhs.2 'result', Lhs.2 'result'
                      217564     ~4%     {2} r10 = JOIN r9 WITH variableBinding ON FIRST 1 OUTPUT Rhs.1 'this', Lhs.1 'result'
                      217564     ~4%     {2} r11 = JOIN r10 WITH Member::Field#class#f ON FIRST 1 OUTPUT Lhs.0 'this', Lhs.1 'result'
                      224123     ~3%     {2} r12 = r2 UNION r11
                                         return r12
```
after:
```
[2021-06-30 11:41:33] (13s) Starting to evaluate predicate Variable::Variable::getInitializer_dispred#ff/2@d65412
[2021-06-30 11:41:34] (13s) Tuple counts for Variable::Variable::getInitializer_dispred#ff/2@d65412:
                      7117    ~0%     {3} r1 = SCAN localvars OUTPUT In.3, 0, In.0 'this'
                      6559    ~0%     {2} r2 = JOIN r1 WITH exprs_340#join_rhs ON FIRST 2 OUTPUT Lhs.2 'this', Rhs.2 'result'
                      
                      311434  ~0%     {3} r3 = JOIN Expr::Assignment::getSource_dispred#ff WITH Expr::Expr::getEnclosingStmt_dispred#bf ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1 'result'
                      311434  ~1%     {4} r4 = JOIN r3 WITH stmts ON FIRST 1 OUTPUT Lhs.1, 0, Lhs.2 'result', Rhs.2
                      311434  ~0%     {3} r5 = JOIN r4 WITH exprs_340#join_rhs ON FIRST 2 OUTPUT Rhs.2 'result', Lhs.2 'result', Lhs.3
                      311256  ~3%     {3} r6 = JOIN r5 WITH variableBinding ON FIRST 1 OUTPUT Rhs.1 'this', Lhs.1 'result', Lhs.2
                      309748  ~0%     {4} r7 = JOIN r6 WITH Member::Field#class#f ON FIRST 1 OUTPUT Lhs.2, 0, Lhs.1 'result', Lhs.0 'this'
                      309431  ~0%     {4} r8 = JOIN r7 WITH stmts ON FIRST 2 OUTPUT Lhs.2 'result', Lhs.2 'result', Lhs.3 'this', Lhs.0
                      309431  ~2%     {4} r9 = JOIN r8 WITH Expr::Expr::getEnclosingCallable_dispred#fb ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'result', Lhs.2 'this', Lhs.3
                      303093  ~3%     {4} r10 = JOIN r9 WITH Member::InitializerMethod#class#f ON FIRST 1 OUTPUT Lhs.0, Lhs.3, Lhs.1 'result', Lhs.2 'this'
                      303087  ~0%     {2} r11 = JOIN r10 WITH Member::Callable::getBody_dispred#bf ON FIRST 2 OUTPUT Lhs.3 'this', Lhs.2 'result'
                      
                      309646  ~0%     {2} r12 = r2 UNION r11
                                      return r12
[2021-06-30 11:41:34] (13s) Registering Variable::Variable::getInitializer_dispred#ff/2@d65412 + [] with content cb8958o43o5t32cagqv8fc53m83
[2021-06-30 11:41:34] (13s)  >>> Created relation Variable::Variable::getInitializer_dispred#ff/2@d65412 with 309646 rows.
```