### PR TITLE
Python: expand `ArgumentNode` to include arguments of non-resolved calls

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -267,8 +267,11 @@ ParameterNode parameterNode(Parameter p) { result.getParameter() = p }
 /** A data flow node that represents a call argument. */
 class ArgumentNode extends Node {
   ArgumentNode() {
-    this = any(DataFlowCall c).getArg(_) and
+    this = any(DataFlowCall c).getArg(_)
+    or
     this.(CfgNode).getNode() = any(CallNode c).getArg(_)
+    or
+    this.(CfgNode).getNode() = any(CallNode c).getArgByName(_)
   }
 
   /** Holds if this argument occurs at the given position in the given call. */

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -266,7 +266,10 @@ ParameterNode parameterNode(Parameter p) { result.getParameter() = p }
 
 /** A data flow node that represents a call argument. */
 class ArgumentNode extends Node {
-  ArgumentNode() { this = any(DataFlowCall c).getArg(_) }
+  ArgumentNode() {
+    this = any(DataFlowCall c).getArg(_) and
+    this.(CfgNode).getNode() = any(CallNode c).getArg(_)
+  }
 
   /** Holds if this argument occurs at the given position in the given call. */
   predicate argumentOf(DataFlowCall call, int pos) { this = call.getArg(pos) }


### PR DESCRIPTION
As an attempt to fix https://github.com/github/codeql-python-team/issues/373