### PR TITLE
Python: Prevent magic in `hasAttribute`

### DIFF
--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -105,7 +105,6 @@ class Value extends TObject {
   final string getName() { result = this.(ObjectInternal).getName() }
 
   /** Holds if this value has the attribute `name` */
-  pragma[nomagic]
   predicate hasAttribute(string name) { this.(ObjectInternal).hasAttribute(name) }
 
   /** Whether this value is absent from the database, but has been inferred to likely exist */

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -105,6 +105,7 @@ class Value extends TObject {
   final string getName() { result = this.(ObjectInternal).getName() }
 
   /** Holds if this value has the attribute `name` */
+  pragma[nomagic]
   predicate hasAttribute(string name) { this.(ObjectInternal).hasAttribute(name) }
 
   /** Whether this value is absent from the database, but has been inferred to likely exist */
@@ -635,6 +636,7 @@ class ClassValue extends Value {
    * Holds if this class has the attribute `name`, including attributes
    * declared by super classes.
    */
+  pragma[nomagic]
   override predicate hasAttribute(string name) { this.getMro().declares(name) }
 
   /**


### PR DESCRIPTION
This resulted in the following bad join for `py/unnecessary-lambda` on
`django`:

```
[2021-06-30 15:52:00] (18s) Tuple counts for ObjectAPI::ClassValue::hasAttribute_dispred#bb/2@caa2db:
  88630    ~938%       {1} r1 = SCAN Exprs::Attribute::getName_dispred#bf OUTPUT In.1 'name'
  76969715 ~15608%     {2} r2 = JOIN r1 WITH MRO::ClassList::declares#fb_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'name'
  69219914 ~16578%     {2} r3 = JOIN r2 WITH PointsTo::Types::getMro#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'this', Lhs.1 'name'
  69219273 ~16578%     {2} r4 = JOIN r3 WITH ObjectAPI::ClassValue#class#f ON FIRST 1 OUTPUT Lhs.0 'this', Lhs.1 'name'
  212091   ~29613%     {2} r5 = JOIN r4 WITH ObjectAPI::ClassValue::getScope_dispred#fb ON FIRST 1 OUTPUT Lhs.0 'this', Lhs.1 'name'
                       return r5
```