### PR TITLE
JS: Improve import resolution

### DIFF
--- a/javascript/ql/src/javascript.qll
+++ b/javascript/ql/src/javascript.qll
@@ -61,6 +61,7 @@ import semmle.javascript.TypeAnnotations
 import semmle.javascript.TypeScript
 import semmle.javascript.Util
 import semmle.javascript.Variables
+import semmle.javascript.Webpack
 import semmle.javascript.XML
 import semmle.javascript.YAML
 import semmle.javascript.dataflow.DataFlow

--- a/javascript/ql/src/semmle/javascript/Modules.qll
+++ b/javascript/ql/src/semmle/javascript/Modules.qll
@@ -112,6 +112,13 @@ abstract class Module extends TopLevel {
   abstract DataFlow::Node getAnExportedValue(string name);
 
   /**
+   * Gets a value whose object properties become named exports of this module,
+   * or possibly becomes the entire exports object of the module.
+   */
+  cached
+  DataFlow::Node getABulkExportedValue() { none() }
+
+  /**
    * Gets the root folder relative to which the given import path (which must
    * appear in this module) is resolved.
    *

--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -412,7 +412,7 @@ private class JoinedPath extends PathExpr, @call_expr {
   JoinedPath() {
     exists(MethodCallExpr call | call = this |
       call.getReceiver().(VarAccess).getName() = "path" and
-      call.getMethodName() = "join" and
+      call.getMethodName() = ["join", "resolve"] and
       call.getNumArgument() = 2 and
       call.getArgument(0) instanceof PathExpr and
       call.getArgument(1) instanceof ConstantString

--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -99,6 +99,13 @@ class NodeModule extends Module {
     )
   }
 
+  override DataFlow::Node getABulkExportedValue() {
+    exists(AssignExpr assign |
+      assign.getTarget().(DotExpr).accesses(getModuleVariable().getAnAccess(), "exports") and
+      result = assign.getRhs().flow()
+    )
+  }
+
   /** Gets a symbol that the module object inherits from its prototypes. */
   private string getAnImplicitlyExportedSymbol() {
     exists(ExternalConstructor ec | ec = getPrototypeOfExportedExpr() |

--- a/javascript/ql/src/semmle/javascript/Paths.qll
+++ b/javascript/ql/src/semmle/javascript/Paths.qll
@@ -492,13 +492,9 @@ string getValueOfSsaDefinitionUse(VarUse e) {
 
 /** A variable that is an alias for a PathExpr, itself seen as a PathExpr. */
 private class AliasedPathExpr extends PathExpr, VarUse {
-  AliasedPathExpr() {
-    exists(getValueOfSsaDefinitionUse(this))
-  }
+  AliasedPathExpr() { exists(getValueOfSsaDefinitionUse(this)) }
 
-  override string getValue() {
-    result = getValueOfSsaDefinitionUse(this)
-  }
+  override string getValue() { result = getValueOfSsaDefinitionUse(this) }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Paths.qll
+++ b/javascript/ql/src/semmle/javascript/Paths.qll
@@ -475,6 +475,32 @@ private class ConcatPath extends PathExpr {
   }
 }
 
+/** Gets the value of the given SSA definition if it refers to a PathExpr. */
+pragma[noinline]
+string getValueOfSsaDefinition(SsaExplicitDefinition def) {
+  result = def.getDef().getSource().(PathExpr).getValue()
+}
+
+/** Gets the value of the given variable use, if its SSA definition refers to a PathExpr. */
+pragma[noinline]
+string getValueOfSsaDefinitionUse(VarUse e) {
+  exists(SsaExplicitDefinition def |
+    result = getValueOfSsaDefinition(def) and
+    e = def.getVariable().getAUse()
+  )
+}
+
+/** A variable that is an alias for a PathExpr, itself seen as a PathExpr. */
+private class AliasedPathExpr extends PathExpr, VarUse {
+  AliasedPathExpr() {
+    exists(getValueOfSsaDefinitionUse(this))
+  }
+
+  override string getValue() {
+    result = getValueOfSsaDefinitionUse(this)
+  }
+}
+
 /**
  * An expression that appears in a syntactic position where it may represent a path.
  *

--- a/javascript/ql/src/semmle/javascript/Paths.qll
+++ b/javascript/ql/src/semmle/javascript/Paths.qll
@@ -719,6 +719,10 @@ module ImportResolution {
         expr.getValue() = this and
         hasExtraSearchRoot(expr, result)
       )
+      or
+      // Absolute paths should be resolved from the root
+      charAt(0) = "/" and
+      not exists(result.getParentContainer())
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/Webpack.qll
+++ b/javascript/ql/src/semmle/javascript/Webpack.qll
@@ -1,6 +1,7 @@
 /**
  * Models the behavior of `webpack` configuration files.
  */
+
 private import javascript
 
 private class WebpackConfigModule extends TopLevel {

--- a/javascript/ql/src/semmle/javascript/Webpack.qll
+++ b/javascript/ql/src/semmle/javascript/Webpack.qll
@@ -1,3 +1,6 @@
+/**
+ * Models the behavior of `webpack` configuration files.
+ */
 private import javascript
 
 private class WebpackConfigModule extends TopLevel {

--- a/javascript/ql/src/semmle/javascript/Webpack.qll
+++ b/javascript/ql/src/semmle/javascript/Webpack.qll
@@ -1,0 +1,62 @@
+private import javascript
+
+private class WebpackConfigModule extends TopLevel {
+  WebpackConfigModule() { getFile().getStem() = "webpack.config" }
+
+  DataFlow::Node getExportedNode() { result = this.(Module).getABulkExportedValue() }
+
+  DataFlow::SourceNode getMainObject() {
+    result = getExportedNode().getALocalSource()
+    or
+    result = getMainObject().(DataFlow::ObjectLiteralNode).getASpreadProperty().getALocalSource()
+  }
+
+  DataFlow::SourceNode getResolveObject() {
+    result = getMainObject().getAPropertySource("resolve")
+    or
+    result = getResolveObject().(DataFlow::ObjectLiteralNode).getASpreadProperty().getALocalSource()
+  }
+
+  DataFlow::SourceNode getAliasObject() {
+    result = getResolveObject().getAPropertySource("alias")
+    or
+    result = getAliasObject().(DataFlow::ObjectLiteralNode).getASpreadProperty().getALocalSource()
+  }
+
+  predicate hasAlias(string name, DataFlow::Node value) {
+    getAliasObject().getAPropertyWrite(name).getRhs() = value
+  }
+
+  predicate hasAliasValue(string name, string value) {
+    exists(DataFlow::Node node |
+      hasAlias(name, node) and
+      value = [node.getStringValue(), node.asExpr().(PathExpr).getValue()]
+    )
+  }
+
+  /**
+   * Gets the folder affected by this webpack configuration.
+   *
+   * If there is no sibling `package.json` file, it will use the parent folder
+   * if a `package.json` file could be found there.
+   */
+  Folder getEffectiveFolder() {
+    exists(Folder folder | folder = getFile().getParentContainer() |
+      if
+        not exists(folder.getFile("package.json")) and
+        exists(folder.getParentContainer().getFile("package.json"))
+      then result = folder.getParentContainer()
+      else result = folder
+    )
+  }
+}
+
+private class WebpackPathAlias extends ImportResolution::ScopedPathMapping {
+  WebpackConfigModule config;
+
+  WebpackPathAlias() { this = config.getEffectiveFolder() }
+
+  override predicate replaceByPrefix(string oldPrefix, string newPrefix) {
+    config.hasAliasValue(oldPrefix, newPrefix)
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
@@ -168,9 +168,7 @@ module Babel {
       newPrefix = plugin.getAlias(oldPrefix)
     }
 
-    override predicate isAdditionalRoot(string root) {
-      root = plugin.getARoot()
-    }
+    override predicate isAdditionalRoot(string root) { root = plugin.getARoot() }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
@@ -135,45 +135,14 @@ module Babel {
     Folder getFolder() { result = getJsonFile().getParentContainer() }
   }
 
-  /**
-   * An import path expression that may be transformed by `babel-plugin-root-import`.
-   */
-  private class BabelRootTransformedPathExpr extends PathExpr, Expr {
+  private class BabelPathMapping extends ImportResolution::ScopedPathMapping {
     RootImportConfig plugin;
-    string rawPath;
-    string prefix;
-    string mappedPrefix;
-    string suffix;
 
-    BabelRootTransformedPathExpr() {
-      this instanceof PathExpr and
-      plugin.appliesTo(getTopLevel()) and
-      rawPath = getStringValue() and
-      prefix = rawPath.regexpCapture("(.)/(.*)", 1) and
-      suffix = rawPath.regexpCapture("(.)/(.*)", 2) and
-      mappedPrefix = plugin.getRoot(prefix)
+    BabelPathMapping() { this = plugin.getFolder() }
+
+    override predicate replaceByPrefix(string oldPrefix, string newPrefix) {
+      plugin.getRoot(oldPrefix) = newPrefix
     }
-
-    /** Gets the configuration that applies to this path. */
-    RootImportConfig getPlugin() { result = plugin }
-
-    override string getValue() { result = mappedPrefix + "/" + suffix }
-
-    override Folder getSearchRoot(int priority) {
-      priority = 0 and
-      result = plugin.getFolder()
-    }
-  }
-
-  /**
-   * An import path transformed by `babel-plugin-root-import`.
-   */
-  private class BabelRootTransformedPath extends PathString {
-    BabelRootTransformedPathExpr pathExpr;
-
-    BabelRootTransformedPath() { this = pathExpr.getValue() }
-
-    override Folder getARootFolder() { result = pathExpr.getPlugin().getFolder() }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
@@ -82,7 +82,7 @@ module Babel {
    * specifies a mapping from a path prefix to a root.
    */
   class RootImportConfig extends Plugin {
-    RootImportConfig() { pluginName = "babel-plugin-root-import" }
+    RootImportConfig() { pluginName = ["babel-plugin-root-import", "root-import"] }
 
     /**
      * Gets the root specified for the given prefix.
@@ -135,13 +135,41 @@ module Babel {
     Folder getFolder() { result = getJsonFile().getParentContainer() }
   }
 
-  private class BabelPathMapping extends ImportResolution::ScopedPathMapping {
+  private class RootImportPathMapping extends ImportResolution::ScopedPathMapping {
     RootImportConfig plugin;
 
-    BabelPathMapping() { this = plugin.getFolder() }
+    RootImportPathMapping() { this = plugin.getFolder() }
 
     override predicate replaceByPrefix(string oldPrefix, string newPrefix) {
       plugin.getRoot(oldPrefix) = newPrefix
+    }
+  }
+
+  /** A configuration object for the `babel-plugin-module-resolver` plugin. */
+  private class ModuleResolverConfig extends Plugin {
+    ModuleResolverConfig() { pluginName = ["babel-plugin-module-resolver", "module-resolver"] }
+
+    /** Gets a folder from which non-relative imports can be resolved. */
+    string getARoot() { result = getOption("root").getElementValue(_).getStringValue() }
+
+    /** Gets a path that the prefix `name` should be resolved to. */
+    string getAlias(string name) { result = getOption("alias").getPropValue(name).getStringValue() }
+
+    /** Gets the folder in which this configuration is located. */
+    Folder getFolder() { result = getJsonFile().getParentContainer() }
+  }
+
+  private class ModuleResolverPathMapping extends ImportResolution::ScopedPathMapping {
+    ModuleResolverConfig plugin;
+
+    ModuleResolverPathMapping() { this = plugin.getFolder() }
+
+    override predicate replaceByPrefix(string oldPrefix, string newPrefix) {
+      newPrefix = plugin.getAlias(oldPrefix)
+    }
+
+    override predicate isAdditionalRoot(string root) {
+      root = plugin.getARoot()
     }
   }
 

--- a/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack1/src/components/calendar/index.js
+++ b/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack1/src/components/calendar/index.js
@@ -1,0 +1,6 @@
+import { Notification } from "@/components/notification";
+import * as same from "SOURCE/components/notification";
+
+export function Calendar() {
+    Notification();
+}

--- a/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack1/src/components/notification/index.js
+++ b/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack1/src/components/notification/index.js
@@ -1,0 +1,2 @@
+export function Notification() {
+}

--- a/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/exact-imported.js
+++ b/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/exact-imported.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/special.js
+++ b/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/special.js
@@ -1,0 +1,1 @@
+export default 2;

--- a/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/src/components/monitor/index.js
+++ b/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/src/components/monitor/index.js
@@ -1,0 +1,10 @@
+import { Notification } from "@/components/notification";
+import * as same from "SOURCE/components/notification";
+import { Calendar } from "#/pack1/src/calendar";
+import Foo from "EXACT";
+import Src from "SOURCE";
+
+export function Monitor() {
+    Notification();
+    Calendar();
+}

--- a/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/src/components/notification/index.js
+++ b/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/src/components/notification/index.js
@@ -1,0 +1,2 @@
+export function Notification() {
+}

--- a/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/src/components/special/index.js
+++ b/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/src/components/special/index.js
@@ -1,0 +1,4 @@
+import { Notification } from "@/components/notification";
+import * as same from "SOURCE/components/notification";
+import { Calendar } from "#/pack1/src/calendar";
+import Foo from "EXACT"; // should resolve to special.js

--- a/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/src/index.js
+++ b/javascript/ql/test/library-tests/ImportResolutionApi/packages/pack2/src/index.js
@@ -1,0 +1,1 @@
+export default "src folder";

--- a/javascript/ql/test/library-tests/ImportResolutionApi/test.expected
+++ b/javascript/ql/test/library-tests/ImportResolutionApi/test.expected
@@ -1,0 +1,9 @@
+| packages/pack1/src/components/calendar/index.js:1:1:1:57 | import  ... ation"; | @/components/notification | packages/pack1/src/components/notification/index.js:1:1:3:0 | <toplevel> |
+| packages/pack1/src/components/calendar/index.js:2:1:2:55 | import  ... ation"; | SOURCE/components/notification | packages/pack1/src/components/notification/index.js:1:1:3:0 | <toplevel> |
+| packages/pack2/src/components/monitor/index.js:1:1:1:57 | import  ... ation"; | @/components/notification | packages/pack2/src/components/notification/index.js:1:1:3:0 | <toplevel> |
+| packages/pack2/src/components/monitor/index.js:2:1:2:55 | import  ... ation"; | SOURCE/components/notification | packages/pack2/src/components/notification/index.js:1:1:3:0 | <toplevel> |
+| packages/pack2/src/components/monitor/index.js:4:1:4:24 | import  ... EXACT"; | EXACT | packages/pack2/exact-imported.js:1:1:2:0 | <toplevel> |
+| packages/pack2/src/components/monitor/index.js:5:1:5:25 | import  ... OURCE"; | SOURCE | packages/pack2/src/index.js:1:1:2:0 | <toplevel> |
+| packages/pack2/src/components/special/index.js:1:1:1:57 | import  ... ation"; | @/components/notification | packages/pack2/src/components/notification/index.js:1:1:3:0 | <toplevel> |
+| packages/pack2/src/components/special/index.js:2:1:2:55 | import  ... ation"; | SOURCE/components/notification | packages/pack2/src/components/notification/index.js:1:1:3:0 | <toplevel> |
+| packages/pack2/src/components/special/index.js:4:1:4:24 | import  ... EXACT"; | EXACT | packages/pack2/special.js:1:1:2:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/ImportResolutionApi/test.ql
+++ b/javascript/ql/test/library-tests/ImportResolutionApi/test.ql
@@ -1,0 +1,43 @@
+import javascript
+
+class ImportSourceByRegExp extends ImportResolution::ScopedPathMapping {
+  ImportSourceByRegExp() { getParentContainer().getBaseName() = "packages" }
+
+  override predicate replaceByRegExp(string regexp, string replacement) {
+    regexp = "@/(.*)" and
+    replacement = "src/$1"
+  }
+}
+
+class ImportSourceByPrefix extends ImportResolution::ScopedPathMapping {
+  ImportSourceByPrefix() { getParentContainer().getBaseName() = "packages" }
+
+  override predicate replaceByPrefix(string prefix, string replacement) {
+    prefix = "SOURCE" and
+    replacement = "src/"
+  }
+}
+
+class ImportExact extends ImportResolution::ScopedPathMapping {
+  ImportExact() { getParentContainer().getBaseName() = "packages" }
+
+  override predicate replaceByPrefix(string prefix, string replacement) {
+    prefix = "EXACT" and
+    replacement = "exact-imported.js"
+  }
+}
+
+class ImportOverride extends ImportResolution::ScopedPathMapping {
+  ImportOverride() { getRelativePath() = any(string s) + "packages/pack2/src/components/special" }
+
+  override predicate replaceByPrefix(string prefix, string replacement, Folder root) {
+    prefix = "EXACT" and
+    replacement = "special.js" and
+    root.getBaseName() = "pack2"
+  }
+}
+
+query Module getImportedModule(Import imprt, string rawPath) {
+  result = imprt.getImportedModule() and
+  rawPath = imprt.getImportedPath().(Expr).getStringValue() // to make the test output easier to read
+}

--- a/javascript/ql/test/library-tests/Webpack/configuration/folderA/foo.js
+++ b/javascript/ql/test/library-tests/Webpack/configuration/folderA/foo.js
@@ -1,0 +1,1 @@
+export const x = 123;

--- a/javascript/ql/test/library-tests/Webpack/configuration/folderB/foo.js
+++ b/javascript/ql/test/library-tests/Webpack/configuration/folderB/foo.js
@@ -1,0 +1,1 @@
+export const x = 123;

--- a/javascript/ql/test/library-tests/Webpack/configuration/webpack.config.js
+++ b/javascript/ql/test/library-tests/Webpack/configuration/webpack.config.js
@@ -1,0 +1,14 @@
+const path = require('path');
+
+const alias = path.resolve(__dirname, "folderA");
+
+module.exports = {
+    resolve: {
+        alias: {
+            "@": alias,
+            "%": path.resolve(__dirname, "folderB"),
+            "#": path.resolve(__dirname, "../folderA"),
+            "~": "folderB",
+        }
+    }
+}

--- a/javascript/ql/test/library-tests/Webpack/folderA/foo.js
+++ b/javascript/ql/test/library-tests/Webpack/folderA/foo.js
@@ -1,0 +1,1 @@
+export const x = 123;

--- a/javascript/ql/test/library-tests/Webpack/folderB/foo.js
+++ b/javascript/ql/test/library-tests/Webpack/folderB/foo.js
@@ -1,0 +1,1 @@
+export const x = 123;

--- a/javascript/ql/test/library-tests/Webpack/package.json
+++ b/javascript/ql/test/library-tests/Webpack/package.json
@@ -1,0 +1,3 @@
+{
+    "private": true
+}

--- a/javascript/ql/test/library-tests/Webpack/src/main.js
+++ b/javascript/ql/test/library-tests/Webpack/src/main.js
@@ -1,0 +1,4 @@
+import * as a from "@/foo"; // configuration/folderA/foo.js
+import * as c from "%/foo"; // configuration/folderB/foo.js
+import * as d from "#/foo"; // folderA/foo.js
+import * as b from "~/foo"; // folderB/foo.js

--- a/javascript/ql/test/library-tests/Webpack/test.expected
+++ b/javascript/ql/test/library-tests/Webpack/test.expected
@@ -1,0 +1,4 @@
+| src/main.js:1:1:1:27 | import  ... @/foo"; | configuration/folderA/foo.js:1:1:1:21 | <toplevel> |
+| src/main.js:2:1:2:27 | import  ... %/foo"; | configuration/folderB/foo.js:1:1:1:21 | <toplevel> |
+| src/main.js:3:1:3:27 | import  ... #/foo"; | folderA/foo.js:1:1:1:21 | <toplevel> |
+| src/main.js:4:1:4:27 | import  ... ~/foo"; | folderB/foo.js:1:1:1:21 | <toplevel> |

--- a/javascript/ql/test/library-tests/Webpack/test.ql
+++ b/javascript/ql/test/library-tests/Webpack/test.ql
@@ -1,0 +1,5 @@
+import javascript
+
+query Module getImportedModule(Import imprt) {
+  result = imprt.getImportedModule()
+}

--- a/javascript/ql/test/library-tests/Webpack/test.ql
+++ b/javascript/ql/test/library-tests/Webpack/test.ql
@@ -1,5 +1,3 @@
 import javascript
 
-query Module getImportedModule(Import imprt) {
-  result = imprt.getImportedModule()
-}
+query Module getImportedModule(Import imprt) { result = imprt.getImportedModule() }

--- a/javascript/ql/test/library-tests/frameworks/babel/root-import/Imports.expected
+++ b/javascript/ql/test/library-tests/frameworks/babel/root-import/Imports.expected
@@ -2,8 +2,6 @@
 | tst1/nested/tst.js:1:1:1:20 | import f from '~/a'; | tst1/a.js:1:1:2:0 | <toplevel> |
 | tst2/index.js:1:1:1:23 | import  ... /b.js'; | tst2/src/js/b.js:1:1:2:0 | <toplevel> |
 | tst2/index.js:2:1:2:20 | import f from '#/a'; | tst1/a.js:1:1:2:0 | <toplevel> |
-| tst2/index.js:2:1:2:20 | import f from '#/a'; | tst1/index.js:1:1:2:0 | <toplevel> |
 | tst3/index.js:1:1:1:30 | import  ... /b.js'; | tst3/src/b.js:1:1:2:0 | <toplevel> |
 | tst4/index.js:1:1:1:23 | import  ... /b.js'; | tst4/src/js/b.js:1:1:2:0 | <toplevel> |
 | tst4/index.js:2:1:2:20 | import f from '#/a'; | tst1/a.js:1:1:2:0 | <toplevel> |
-| tst4/index.js:2:1:2:20 | import f from '#/a'; | tst1/index.js:1:1:2:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/frameworks/babel/root-import/Imports.expected
+++ b/javascript/ql/test/library-tests/frameworks/babel/root-import/Imports.expected
@@ -5,3 +5,7 @@
 | tst3/index.js:1:1:1:30 | import  ... /b.js'; | tst3/src/b.js:1:1:2:0 | <toplevel> |
 | tst4/index.js:1:1:1:23 | import  ... /b.js'; | tst4/src/js/b.js:1:1:2:0 | <toplevel> |
 | tst4/index.js:2:1:2:20 | import f from '#/a'; | tst1/a.js:1:1:2:0 | <toplevel> |
+| tst5/index.js:1:1:1:23 | import  ... /b.js'; | tst5/src/b.js:1:1:2:0 | <toplevel> |
+| tst5/index.js:2:1:2:21 | import  ... 'b.js'; | tst5/src/b.js:1:1:2:0 | <toplevel> |
+| tst5/src/c.js:1:1:1:22 | import  ... om 'b'; | tst5/src/b.js:1:1:2:0 | <toplevel> |
+| tst5/src/c.js:2:1:2:24 | import  ...  '~/b'; | tst5/src/b.js:1:1:2:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/frameworks/babel/root-import/tst5/index.js
+++ b/javascript/ql/test/library-tests/frameworks/babel/root-import/tst5/index.js
@@ -1,0 +1,2 @@
+import g from '~/b.js';
+import g from 'b.js';

--- a/javascript/ql/test/library-tests/frameworks/babel/root-import/tst5/package.json
+++ b/javascript/ql/test/library-tests/frameworks/babel/root-import/tst5/package.json
@@ -1,0 +1,12 @@
+{
+  "babel": {
+    "plugins": [
+      ["module-resolver", {
+        "root": ["./src"],
+        "alias": {
+          "~": "./src"
+        }
+      }]
+    ]
+  }
+}

--- a/javascript/ql/test/library-tests/frameworks/babel/root-import/tst5/src/b.js
+++ b/javascript/ql/test/library-tests/frameworks/babel/root-import/tst5/src/b.js
@@ -1,0 +1,1 @@
+export default function g() {};

--- a/javascript/ql/test/library-tests/frameworks/babel/root-import/tst5/src/c.js
+++ b/javascript/ql/test/library-tests/frameworks/babel/root-import/tst5/src/c.js
@@ -1,0 +1,2 @@
+import { g } from 'b';
+import { g } from '~/b';


### PR DESCRIPTION
This PR does a few things:
- Adds a new API for customizing import resolution, in particular how to map prefixes to folders.
- Ports the Babel path-mapping to the new API.
- Adds support for a few other path mappings (another babel plugin, as well as tsconfig, and webpack)
- A use of a variable that refers to a `PathExpr` is now itself seen as a `PathExpr` (using SSA).
- `path.resolve` is now seen as a `PathExpr`, heuristically treated the same as `path.join`.

## The `ImportResolution` module

This module has explicit extension points for customizing import resolution. There's QLdoc in the commit, but I'll just give a few examples here.

An ad-hoc customization that maps `~/` to `src/lib/` (in the root of the snapshot) can be done like this:
```codeql
class MyPathMapping extends ImportResolution::PathMapping {
  override predicate replaceByRegExp(string regexp, string replacement) {
    regexp = "~/(.*)" and
    replacement = "src/lib/$1" // $1 refers to the capture group above
  }
}
```
When subclassing `PathMapping`, the mapping applies everywhere.

To restrict the scope, we can instead subclass `ScopedPathMapping` instead and bind `this` to the folder where the path mapping is in effect:
```codeql
class MyPathMapping extends ImportResolution::ScopedPathMapping {
  MyPathMapping() { this.getRelativePath() = ["src", "test"] } // only apply within 'src' and 'test' directory

  override predicate replaceByRegExp(string regexp, string replacement) {
    regexp = "~/(.*)" and
    replacement = "lib/$1" // the path is relative to 'this', so either src/lib or test/lib
  }
}
```

### replaceByPrefix
For core library work, `replaceByPrefix` is a bit easier to use, as it just maps a string to another string. This would achieve something similar to the first example:
```codeql
class MyPathMapping extends ImportResolution::PathMapping {
  override predicate replaceByPrefix(string oldPrefix, string newPrefix) {
    oldPrefix = "~" and newPrefix = "src/lib"
  }
}
```

### isAdditionalRoot
This is morally the same as `replaceByPrefix` with an empty prefix, but with the restriction that relative paths never match. So if you want something like `foo/bar` to be resolved as `src/lib/foo/bar` you can do:
```codeql
class MyPathMapping extends ImportResolution::ScopedPathMapping {
  MyPathMapping() { this.getRelativePath() = "src" }

  override predicate isAdditionalRoot(string root) {
    root = "lib"
  }
}
```

## New path mapping support

- `babel-plugin-root-import` has been ported to the new API, and a bug has been fixed in the process (see test case output in second commit).
- `babel-plugin-module-resolver` is now supported
- `tsconfig.json` path mappings are now supported for `.js` files (previously only for TypeScript files, via the extractor).
- `webpack.config.js` files with `export default {resolve: { alias: { ... } } }` are now supported
