### PR TITLE
Python: Some minor fixes to `py/clear-text-logging-sensitive-data`

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/SensitiveDataSources.qll
+++ b/python/ql/src/semmle/python/dataflow/new/SensitiveDataSources.qll
@@ -93,8 +93,6 @@ private module SensitiveDataModeling {
   /**
    * Gets a reference to a string constant that, if used as the key in a lookup,
    * indicates the presence of sensitive data with `classification`.
-   *
-   * Also see `extraStepForCalls`.
    */
   DataFlow::Node sensitiveLookupStringConst(SensitiveDataClassification classification) {
     sensitiveLookupStringConst(DataFlow::TypeTracker::end(), classification).flowsTo(result)
@@ -118,6 +116,8 @@ private module SensitiveDataModeling {
   /**
    * Tracks any modeled source of sensitive data (with any classification),
    * to limit the scope of `extraStepForCalls`. See it's QLDoc for more context.
+   *
+   * Also see `extraStepForCalls`.
    */
   private DataFlow::LocalSourceNode possibleSensitiveCallable(DataFlow::TypeTracker t) {
     t.start() and
@@ -129,6 +129,8 @@ private module SensitiveDataModeling {
   /**
    * Tracks any modeled source of sensitive data (with any classification),
    * to limit the scope of `extraStepForCalls`. See it's QLDoc for more context.
+   *
+   * Also see `extraStepForCalls`.
    */
   private DataFlow::Node possibleSensitiveCallable() {
     possibleSensitiveCallable(DataFlow::TypeTracker::end()).flowsTo(result)

--- a/python/ql/src/semmle/python/dataflow/new/SensitiveDataSources.qll
+++ b/python/ql/src/semmle/python/dataflow/new/SensitiveDataSources.qll
@@ -76,26 +76,16 @@ private module SensitiveDataModeling {
   }
 
   /**
-   * Gets a reference to a string constant that, if used as the key in a lookup,
-   * indicates the presence of sensitive data with `classification`.
-   */
-  private DataFlow::LocalSourceNode sensitiveLookupStringConst(
-    DataFlow::TypeTracker t, SensitiveDataClassification classification
-  ) {
-    t.start() and
-    nameIndicatesSensitiveData(result.asExpr().(StrConst).getText(), classification)
-    or
-    exists(DataFlow::TypeTracker t2 |
-      result = sensitiveLookupStringConst(t2, classification).track(t2, t)
-    )
-  }
-
-  /**
-   * Gets a reference to a string constant that, if used as the key in a lookup,
-   * indicates the presence of sensitive data with `classification`.
+   * Gets a reference (in local scope) to a string constant that, if used as the key in
+   * a lookup, indicates the presence of sensitive data with `classification`.
    */
   DataFlow::Node sensitiveLookupStringConst(SensitiveDataClassification classification) {
-    sensitiveLookupStringConst(DataFlow::TypeTracker::end(), classification).flowsTo(result)
+    // Note: If this is implemented with type-tracking, we will get cross-talk as
+    // illustrated in python/ql/test/experimental/dataflow/sensitive-data/test.py
+    exists(DataFlow::LocalSourceNode source |
+      nameIndicatesSensitiveData(source.asExpr().(StrConst).getText(), classification) and
+      source.flowsTo(result)
+    )
   }
 
   /** A function call that is considered a source of sensitive data. */

--- a/python/ql/src/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/python/ql/src/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
@@ -51,7 +51,7 @@ module CleartextLogging {
   }
 
   /** A piece of data printed, considered as a flow sink. */
-  class PrintedDataAsSink extends Sink, DataFlow::CallCfgNode {
+  class PrintedDataAsSink extends Sink {
     PrintedDataAsSink() {
       this = API::builtin("print").getACall().getArg(_)
       or

--- a/python/ql/test/experimental/dataflow/sensitive-data/test.py
+++ b/python/ql/test/experimental/dataflow/sensitive-data/test.py
@@ -90,13 +90,13 @@ _configuration = {"sleep_timer": 5, "mysql_password": "1234"}
 def get_config(key):
     # Treating this as a SensitiveDataSource is questionable, since that will result in
     # _all_ calls to `get_config` being treated as giving sensitive data
-    return _configuration[key] # $ SensitiveDataSource=password
+    return _configuration[key]
 
 foo = get_config("mysql_password")
-print(foo) # $ SensitiveUse=password
+print(foo) # $ MISSING: SensitiveUse=password
 
 bar = get_config("sleep_timer")
-print(bar) # $ SPURIOUS: SensitiveUse=password
+print(bar)
 
 # Case 2: Providing function as argument
 


### PR DESCRIPTION
After the fix in d9e2f50, we had 10,016 results on saltstack/salt :O Many of them were due to the cross-talk fixed in b0309dd. So now we "only" have 982 results.

Many of them are FPs due to our taint-steps for dictionaries being inaccurate, as illustrated in this example

```py
def func1(password):
    kwargs = {"foo": 42, "bar": password}
    foo = kwargs.get("foo")
    print(foo) # <-- `foo` is treated like a password
```

A concrete example:

- [`sudo_password` parameter](https://github.com/saltstack/salt/blob/0d71775f51674109ac932aaefcc45b63f354ad5c/salt/utils/cloud.py#L1433)
- [which is added to the `ssh_kwargs` dict](https://github.com/saltstack/salt/blob/0d71775f51674109ac932aaefcc45b63f354ad5c/salt/utils/cloud.py#L1488-L1496)
- that eventually is passed as the [`kwargs` parameter](https://github.com/saltstack/salt/blob/0d71775f51674109ac932aaefcc45b63f354ad5c/salt/utils/cloud.py#L160)
- so when we do [`ssh_gateway_user = kwargs.get("ssh_gateway_user", "root")`](https://github.com/saltstack/salt/blob/0d71775f51674109ac932aaefcc45b63f354ad5c/salt/utils/cloud.py#L183)
- we think that is a password, and alert [when it is logged](https://github.com/saltstack/salt/blob/0d71775f51674109ac932aaefcc45b63f354ad5c/salt/utils/cloud.py#L200-L206)

In total this `sudo_password` flows to 19 different logging sinks :open_mouth:

On other projects, results look ok to me though.