### PR TITLE
Python: Add `@security-severity` to `py/unused-global-variable`

### DIFF
--- a/python/ql/src/Variables/UnusedModuleVariable.ql
+++ b/python/ql/src/Variables/UnusedModuleVariable.ql
@@ -7,6 +7,7 @@
  *       external/cwe/cwe-563
  * @problem.severity recommendation
  * @sub-severity low
+ * @security-severity 2.0
  * @precision high
  * @id py/unused-global-variable
  */


### PR DESCRIPTION
Since this is now required (so tests are currently failing). We couldn't find any good number for this query, so we ended up just picking 2.0 as this makes it fall into the _Low_ Severity category (0.1-3.9)

/cc @calumgrant 