### PR TITLE
Python: port redos .qhelp from js

### DIFF
--- a/python/ql/src/Security/CWE-730/PolynomialReDoS.qhelp
+++ b/python/ql/src/Security/CWE-730/PolynomialReDoS.qhelp
@@ -1,0 +1,108 @@
+<!DOCTYPE qhelp PUBLIC
+"-//Semmle//qhelp//EN"
+"qhelp.dtd">
+
+<qhelp>
+
+	<include src="ReDoSIntroduction.inc.qhelp" />
+
+	<example>
+		<p>
+
+			Consider this use of a regular expression, which removes
+			all leading and trailing whitespace in a string:
+
+		</p>
+
+		<sample language="python">
+			re.sub(r"^\s+|\s+$", "", text) # BAD
+		</sample>
+
+		<p>
+
+			The sub-expression <code>"\s+$"</code> will match the
+			whitespace characters in <code>text</code> from left to right, but it
+			can start matching anywhere within a whitespace sequence. This is
+			problematic for strings that do <strong>not</strong> end with a whitespace
+			character. Such a string will force the regular expression engine to
+			process each whitespace sequence once per whitespace character in the
+			sequence.
+
+		</p>
+
+		<p>
+
+			This ultimately means that the time cost of trimming a
+			string is quadratic in the length of the string. So a string like
+			<code>"a b"</code> will take milliseconds to process, but a similar
+			string with a million spaces instead of just one will take several
+			minutes.
+
+		</p>
+
+		<p>
+
+			Avoid this problem by rewriting the regular expression to
+			not contain the ambiguity about when to start matching whitespace
+			sequences. For instance, by using a negative look-behind
+			(<code>^\s+|(?&lt;!\s)\s+$</code>), or just by using the built-in strip
+			method (<code>text.strip()</code>).
+
+		</p>
+
+		<p>
+
+			Note that the sub-expression <code>"^\s+"</code> is
+			<strong>not</strong> problematic as the <code>^</code> anchor restricts
+			when that sub-expression can start matching, and as the regular
+			expression engine matches from left to right.
+
+		</p>
+
+	</example>
+
+	<example>
+
+		<p>
+
+			As a similar, but slightly subtler problem, consider the
+			regular expression that matches lines with numbers, possibly written
+			using scientific notation:
+		</p>
+
+		<sample language="python">
+			^0\.\d+E?\d+$ # BAD
+		</sample>
+
+		<p>
+
+			The problem with this regular expression is in the
+			sub-expression <code>\d+E?\d+</code> because the second
+			<code>\d+</code> can start matching digits anywhere after the first
+			match of the first <code>\d+</code> if there is no <code>E</code> in
+			the input string.
+
+		</p>
+
+		<p>
+
+			This is problematic for strings that do <strong>not</strong>
+			end with a digit. Such a string will force the regular expression
+			engine to process each digit sequence once per digit in the sequence,
+			again leading to a quadratic time complexity.
+
+		</p>
+
+		<p>
+
+			To make the processing faster, the regular expression
+			should be rewritten such that the two <code>\d+</code> sub-expressions
+			do not have overlapping matches: <code>^0\.\d+(E\d+)?$</code>.
+
+		</p>
+
+	</example>
+
+	<include src="ReDoSReferences.inc.qhelp"/>
+
+</qhelp>

--- a/python/ql/src/Security/CWE-730/ReDoS.qhelp
+++ b/python/ql/src/Security/CWE-730/ReDoS.qhelp
@@ -1,0 +1,34 @@
+<!DOCTYPE qhelp PUBLIC
+"-//Semmle//qhelp//EN"
+"qhelp.dtd">
+
+<qhelp>
+
+	<include src="ReDoSIntroduction.inc.qhelp" />
+
+	<example>
+		<p>
+			Consider this regular expression:
+		</p>
+		<sample language="python">
+			^_(__|.)+_$
+		</sample>
+		<p>
+			Its sub-expression <code>"(__|.)+?"</code> can match the string <code>"__"</code> either by the
+			first alternative <code>"__"</code> to the left of the <code>"|"</code> operator, or by two
+			repetitions of the second alternative <code>"."</code> to the right. Thus, a string consisting
+			of an odd number of underscores followed by some other character will cause the regular
+			expression engine to run for an exponential amount of time before rejecting the input.
+		</p>
+		<p>
+			This problem can be avoided by rewriting the regular expression to remove the ambiguity between
+			the two branches of the alternative inside the repetition:
+		</p>
+		<sample language="python">
+			^_(__|[^_])+_$
+		</sample>
+	</example>
+
+	<include src="ReDoSReferences.inc.qhelp"/>
+
+</qhelp>

--- a/python/ql/src/Security/CWE-730/ReDoSIntroduction.inc.qhelp
+++ b/python/ql/src/Security/CWE-730/ReDoSIntroduction.inc.qhelp
@@ -1,0 +1,54 @@
+<!DOCTYPE qhelp PUBLIC
+"-//Semmle//qhelp//EN"
+"qhelp.dtd">
+<qhelp>
+	<overview>
+		<p>
+
+			Some regular expressions take a long time to match certain
+			input strings to the point where the time it takes to match a string
+			of length <i>n</i> is proportional to <i>n<sup>k</sup></i> or even
+			<i>2<sup>n</sup></i>.  Such regular expressions can negatively affect
+			performance, or even allow a malicious user to perform a Denial of
+			Service ("DoS") attack by crafting an expensive input string for the
+			regular expression to match.
+
+		</p>
+
+		<p>
+
+			The regular expression engine provided by Python uses a backtracking non-deterministic finite
+			automata to implement regular expression matching. While this approach
+			is space-efficient and allows supporting advanced features like
+			capture groups, it is not time-efficient in general. The worst-case
+			time complexity of such an automaton can be polynomial or even
+			exponential, meaning that for strings of a certain shape, increasing
+			the input length by ten characters may make the automaton about 1000
+			times slower.
+
+		</p>
+
+		<p>
+
+			Typically, a regular expression is affected by this
+			problem if it contains a repetition of the form <code>r*</code> or
+			<code>r+</code> where the sub-expression <code>r</code> is ambiguous
+			in the sense that it can match some string in multiple ways. More
+			information about the precise circumstances can be found in the
+			references.
+
+		</p>
+	</overview>
+
+	<recommendation>
+
+		<p>
+
+			Modify the regular expression to remove the ambiguity, or
+			ensure that the strings matched with the regular expression are short
+			enough that the time-complexity does not matter.
+
+		</p>
+
+	</recommendation>
+</qhelp>

--- a/python/ql/src/Security/CWE-730/ReDoSReferences.inc.qhelp
+++ b/python/ql/src/Security/CWE-730/ReDoSReferences.inc.qhelp
@@ -1,0 +1,16 @@
+<!DOCTYPE qhelp PUBLIC
+"-//Semmle//qhelp//EN"
+"qhelp.dtd">
+<qhelp>
+	<references>
+		<li>
+			OWASP:
+			<a href="https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS">Regular expression Denial of Service - ReDoS</a>.
+		</li>
+		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/ReDoS">ReDoS</a>.</li>
+		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Time_complexity">Time complexity</a>.</li>
+		<li>James Kirrage, Asiri Rathnayake, Hayo Thielecke:
+		<a href="http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
+		</li>
+	</references>
+</qhelp>


### PR DESCRIPTION
During the recent redos port, the `.qhelp`-files were somehow missed. These are adapted and added in this PR.