### PR TITLE
JS: Add models for more JSON utility libraries

### DIFF
--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -5,4 +5,5 @@ lgtm,codescanning
     [json5](https://npmjs.com/package/json5),
     [prettyjson](https://npmjs.com/package/prettyjson),
     [flatted](https://npmjs.com/package/flatted),
-    [teleport-javascript](https://npmjs.com/package/teleport-javascript)
+    [teleport-javascript](https://npmjs.com/package/teleport-javascript),
+    [replicator](https://npmjs.com/package/replicator)

--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -9,4 +9,5 @@ lgtm,codescanning
     [replicator](https://npmjs.com/package/replicator),
     [safe-stable-stringify](https://npmjs.com/package/safe-stable-stringify),
     [fclone](https://npmjs.com/package/fclone),
-    [json-cycle](https://npmjs.com/package/json-cycle)
+    [json-cycle](https://npmjs.com/package/json-cycle),
+    [strip-json-comments](https://npmjs.com/package/strip-json-comments)

--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -3,4 +3,5 @@ lgtm,codescanning
   Affected packages are
     [json2csv](https://npmjs.com/package/json2csv),
     [json5](https://npmjs.com/package/json5),
-    [prettyjson](https://npmjs.com/package/prettyjson)
+    [prettyjson](https://npmjs.com/package/prettyjson),
+    [flatted](https://npmjs.com/package/flatted)

--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -6,4 +6,5 @@ lgtm,codescanning
     [prettyjson](https://npmjs.com/package/prettyjson),
     [flatted](https://npmjs.com/package/flatted),
     [teleport-javascript](https://npmjs.com/package/teleport-javascript),
-    [replicator](https://npmjs.com/package/replicator)
+    [replicator](https://npmjs.com/package/replicator),
+    [safe-stable-stringify](https://npmjs.com/package/safe-stable-stringify)

--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -1,4 +1,5 @@
 lgtm,codescanning
 * The dataflow libraries now model dataflow through more JSON utility libraries.
   Affected packages are
-    [json2csv](https://npmjs.com/package/json2csv)
+    [json2csv](https://npmjs.com/package/json2csv),
+    [json5](https://npmjs.com/package/json5)

--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -7,4 +7,5 @@ lgtm,codescanning
     [flatted](https://npmjs.com/package/flatted),
     [teleport-javascript](https://npmjs.com/package/teleport-javascript),
     [replicator](https://npmjs.com/package/replicator),
-    [safe-stable-stringify](https://npmjs.com/package/safe-stable-stringify)
+    [safe-stable-stringify](https://npmjs.com/package/safe-stable-stringify),
+    [fclone](https://npmjs.com/package/fclone)

--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -8,4 +8,5 @@ lgtm,codescanning
     [teleport-javascript](https://npmjs.com/package/teleport-javascript),
     [replicator](https://npmjs.com/package/replicator),
     [safe-stable-stringify](https://npmjs.com/package/safe-stable-stringify),
-    [fclone](https://npmjs.com/package/fclone)
+    [fclone](https://npmjs.com/package/fclone),
+    [json-cycle](https://npmjs.com/package/json-cycle)

--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -2,4 +2,5 @@ lgtm,codescanning
 * The dataflow libraries now model dataflow through more JSON utility libraries.
   Affected packages are
     [json2csv](https://npmjs.com/package/json2csv),
-    [json5](https://npmjs.com/package/json5)
+    [json5](https://npmjs.com/package/json5),
+    [prettyjson](https://npmjs.com/package/prettyjson)

--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -10,4 +10,5 @@ lgtm,codescanning
     [safe-stable-stringify](https://npmjs.com/package/safe-stable-stringify),
     [fclone](https://npmjs.com/package/fclone),
     [json-cycle](https://npmjs.com/package/json-cycle),
-    [strip-json-comments](https://npmjs.com/package/strip-json-comments)
+    [strip-json-comments](https://npmjs.com/package/strip-json-comments),
+    [fast-json-stringify](https://npmjs.com/package/fast-json-stringify)

--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* The dataflow libraries now model dataflow through more JSON utility libraries.
+  Affected packages are
+    [json2csv](https://npmjs.com/package/json2csv)

--- a/javascript/change-notes/2021-06-24-json.md
+++ b/javascript/change-notes/2021-06-24-json.md
@@ -4,4 +4,5 @@ lgtm,codescanning
     [json2csv](https://npmjs.com/package/json2csv),
     [json5](https://npmjs.com/package/json5),
     [prettyjson](https://npmjs.com/package/prettyjson),
-    [flatted](https://npmjs.com/package/flatted)
+    [flatted](https://npmjs.com/package/flatted),
+    [teleport-javascript](https://npmjs.com/package/teleport-javascript)

--- a/javascript/ql/src/semmle/javascript/Extend.qll
+++ b/javascript/ql/src/semmle/javascript/Extend.qll
@@ -178,11 +178,11 @@ private class ExtendCallTaintStep extends TaintTracking::SharedTaintStep {
 private import semmle.javascript.dataflow.internal.PreCallGraphStep
 
 /**
- * A step for the `clone` package.
+ * A step through a cloning library, such as `clone` or `fclone`.
  */
 private class CloneStep extends PreCallGraphStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(DataFlow::CallNode call | call = DataFlow::moduleImport("clone").getACall() |
+    exists(DataFlow::CallNode call | call = DataFlow::moduleImport(["clone", "fclone"]).getACall() |
       pred = call.getArgument(0) and
       succ = call
     )

--- a/javascript/ql/src/semmle/javascript/Extend.qll
+++ b/javascript/ql/src/semmle/javascript/Extend.qll
@@ -182,7 +182,11 @@ private import semmle.javascript.dataflow.internal.PreCallGraphStep
  */
 private class CloneStep extends PreCallGraphStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(DataFlow::CallNode call | call = DataFlow::moduleImport(["clone", "fclone"]).getACall() |
+    exists(DataFlow::CallNode call |
+      call = DataFlow::moduleImport(["clone", "fclone"]).getACall()
+      or
+      call = DataFlow::moduleMember("json-cycle", ["decycle", "retrocycle"]).getACall()
+    |
       pred = call.getArgument(0) and
       succ = call
     )

--- a/javascript/ql/src/semmle/javascript/JsonParsers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonParsers.qll
@@ -78,3 +78,15 @@ private class JsonParserCallWithCallback extends JsonParserCall {
 
   override DataFlow::SourceNode getOutput() { result = getCallback(1).getParameter(1) }
 }
+
+/**
+ * A taint step through the `strip-json-comments` library.
+ */
+private class StripJsonCommentsStep extends TaintTracking::SharedTaintStep {
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call | call = API::moduleImport("strip-json-comments").getACall() |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/JsonParsers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonParsers.qll
@@ -26,7 +26,7 @@ private class PlainJsonParserCall extends JsonParserCall {
   PlainJsonParserCall() {
     exists(DataFlow::SourceNode callee | this = callee.getACall() |
       callee = DataFlow::globalVarRef("JSON").getAPropertyRead("parse") or
-      callee = DataFlow::moduleMember(["json3", "json5", "flatted"], "parse") or
+      callee = DataFlow::moduleMember(["json3", "json5", "flatted", "teleport-javascript"], "parse") or
       callee = DataFlow::moduleImport("parse-json") or
       callee = DataFlow::moduleImport("json-parse-better-errors") or
       callee = DataFlow::moduleImport("json-safe-parse") or

--- a/javascript/ql/src/semmle/javascript/JsonParsers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonParsers.qll
@@ -26,7 +26,9 @@ private class PlainJsonParserCall extends JsonParserCall {
   PlainJsonParserCall() {
     exists(DataFlow::SourceNode callee | this = callee.getACall() |
       callee = DataFlow::globalVarRef("JSON").getAPropertyRead("parse") or
-      callee = DataFlow::moduleMember(["json3", "json5", "flatted", "teleport-javascript"], "parse") or
+      callee =
+        DataFlow::moduleMember(["json3", "json5", "flatted", "teleport-javascript", "json-cycle"],
+          "parse") or
       callee = API::moduleImport("replicator").getInstance().getMember("decode").getAnImmediateUse() or
       callee = DataFlow::moduleImport("parse-json") or
       callee = DataFlow::moduleImport("json-parse-better-errors") or

--- a/javascript/ql/src/semmle/javascript/JsonParsers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonParsers.qll
@@ -26,7 +26,7 @@ private class PlainJsonParserCall extends JsonParserCall {
   PlainJsonParserCall() {
     exists(DataFlow::SourceNode callee | this = callee.getACall() |
       callee = DataFlow::globalVarRef("JSON").getAPropertyRead("parse") or
-      callee = DataFlow::moduleMember(["json3", "json5"], "parse") or
+      callee = DataFlow::moduleMember(["json3", "json5", "flatted"], "parse") or
       callee = DataFlow::moduleImport("parse-json") or
       callee = DataFlow::moduleImport("json-parse-better-errors") or
       callee = DataFlow::moduleImport("json-safe-parse") or

--- a/javascript/ql/src/semmle/javascript/JsonParsers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonParsers.qll
@@ -26,6 +26,7 @@ private class PlainJsonParserCall extends JsonParserCall {
   PlainJsonParserCall() {
     exists(DataFlow::SourceNode callee | this = callee.getACall() |
       callee = DataFlow::globalVarRef("JSON").getAPropertyRead("parse") or
+      callee = DataFlow::moduleMember(["json3", "json5"], "parse") or
       callee = DataFlow::moduleImport("parse-json") or
       callee = DataFlow::moduleImport("json-parse-better-errors") or
       callee = DataFlow::moduleImport("json-safe-parse") or

--- a/javascript/ql/src/semmle/javascript/JsonParsers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonParsers.qll
@@ -27,6 +27,7 @@ private class PlainJsonParserCall extends JsonParserCall {
     exists(DataFlow::SourceNode callee | this = callee.getACall() |
       callee = DataFlow::globalVarRef("JSON").getAPropertyRead("parse") or
       callee = DataFlow::moduleMember(["json3", "json5", "flatted", "teleport-javascript"], "parse") or
+      callee = API::moduleImport("replicator").getInstance().getMember("decode").getAnImmediateUse() or
       callee = DataFlow::moduleImport("parse-json") or
       callee = DataFlow::moduleImport("json-parse-better-errors") or
       callee = DataFlow::moduleImport("json-safe-parse") or

--- a/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
@@ -12,7 +12,8 @@ class JsonStringifyCall extends DataFlow::CallNode {
     exists(DataFlow::SourceNode callee | this = callee.getACall() |
       callee = DataFlow::globalVarRef("JSON").getAPropertyRead("stringify") or
       callee =
-        DataFlow::moduleMember(["json3", "json5", "flatted", "teleport-javascript"], "stringify") or
+        DataFlow::moduleMember(["json3", "json5", "flatted", "teleport-javascript", "json-cycle"],
+          "stringify") or
       callee = API::moduleImport("replicator").getInstance().getMember("encode").getAnImmediateUse() or
       callee =
         DataFlow::moduleImport([

--- a/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
@@ -53,3 +53,19 @@ class JSON2CSVTaintStep extends TaintTracking::SharedTaintStep {
     )
   }
 }
+
+/**
+ * A step through the [`prettyjson`](https://www.npmjs.com/package/prettyjson) library.
+ * This is not quite a `JSON.stringify` call, as it e.g. does not wrap keys in double quotes.
+ * It's therefore modelled as a taint-step rather than as a `JSON.stringify` call.
+ */
+class PrettyJSONTaintStep extends TaintTracking::SharedTaintStep {
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call |
+      call = API::moduleImport("prettyjson").getMember("render").getACall()
+    |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
@@ -13,6 +13,7 @@ class JsonStringifyCall extends DataFlow::CallNode {
       callee = DataFlow::globalVarRef("JSON").getAPropertyRead("stringify") or
       callee =
         DataFlow::moduleMember(["json3", "json5", "flatted", "teleport-javascript"], "stringify") or
+      callee = API::moduleImport("replicator").getInstance().getMember("encode").getAnImmediateUse() or
       callee =
         DataFlow::moduleImport([
             "json-stringify-safe", "json-stable-stringify", "stringify-object",

--- a/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
@@ -19,7 +19,7 @@ class JsonStringifyCall extends DataFlow::CallNode {
         DataFlow::moduleImport([
             "json-stringify-safe", "json-stable-stringify", "stringify-object",
             "fast-json-stable-stringify", "fast-safe-stringify", "javascript-stringify",
-            "js-stringify", "safe-stable-stringify"
+            "js-stringify", "safe-stable-stringify", "fast-json-stringify"
           ]) or
       // require("util").inspect() and similar
       callee = DataFlow::moduleMember("util", "inspect") or

--- a/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
@@ -34,3 +34,22 @@ class JsonStringifyCall extends DataFlow::CallNode {
    */
   DataFlow::SourceNode getOutput() { result = this }
 }
+
+/**
+ * A taint step through the [`json2csv`](https://www.npmjs.com/package/json2csv) library.
+ */
+class JSON2CSVTaintStep extends TaintTracking::SharedTaintStep {
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call |
+      call =
+        API::moduleImport("json2csv")
+            .getMember("Parser")
+            .getInstance()
+            .getMember("parse")
+            .getACall()
+    |
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
@@ -11,7 +11,8 @@ class JsonStringifyCall extends DataFlow::CallNode {
   JsonStringifyCall() {
     exists(DataFlow::SourceNode callee | this = callee.getACall() |
       callee = DataFlow::globalVarRef("JSON").getAPropertyRead("stringify") or
-      callee = DataFlow::moduleMember(["json3", "json5", "flatted"], "stringify") or
+      callee =
+        DataFlow::moduleMember(["json3", "json5", "flatted", "teleport-javascript"], "stringify") or
       callee =
         DataFlow::moduleImport([
             "json-stringify-safe", "json-stable-stringify", "stringify-object",

--- a/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
@@ -11,7 +11,7 @@ class JsonStringifyCall extends DataFlow::CallNode {
   JsonStringifyCall() {
     exists(DataFlow::SourceNode callee | this = callee.getACall() |
       callee = DataFlow::globalVarRef("JSON").getAPropertyRead("stringify") or
-      callee = DataFlow::moduleMember("json3", "stringify") or
+      callee = DataFlow::moduleMember(["json3", "json5"], "stringify") or
       callee =
         DataFlow::moduleImport([
             "json-stringify-safe", "json-stable-stringify", "stringify-object",

--- a/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
@@ -11,7 +11,7 @@ class JsonStringifyCall extends DataFlow::CallNode {
   JsonStringifyCall() {
     exists(DataFlow::SourceNode callee | this = callee.getACall() |
       callee = DataFlow::globalVarRef("JSON").getAPropertyRead("stringify") or
-      callee = DataFlow::moduleMember(["json3", "json5"], "stringify") or
+      callee = DataFlow::moduleMember(["json3", "json5", "flatted"], "stringify") or
       callee =
         DataFlow::moduleImport([
             "json-stringify-safe", "json-stable-stringify", "stringify-object",

--- a/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
+++ b/javascript/ql/src/semmle/javascript/JsonStringifiers.qll
@@ -18,7 +18,7 @@ class JsonStringifyCall extends DataFlow::CallNode {
         DataFlow::moduleImport([
             "json-stringify-safe", "json-stable-stringify", "stringify-object",
             "fast-json-stable-stringify", "fast-safe-stringify", "javascript-stringify",
-            "js-stringify"
+            "js-stringify", "safe-stable-stringify"
           ]) or
       // require("util").inspect() and similar
       callee = DataFlow::moduleMember("util", "inspect") or

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -91,6 +91,7 @@ typeInferenceMismatch
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:17:8:17:39 | require ... source) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:18:8:18:40 | require ... source) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:21:8:21:46 | new jso ... source) |
+| json-stringify.js:2:16:2:23 | source() | json-stringify.js:24:8:24:43 | json5.s ... ource)) |
 | json-stringify.js:3:15:3:22 | source() | json-stringify.js:8:8:8:31 | jsonStr ... (taint) |
 | nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
 | nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -95,6 +95,7 @@ typeInferenceMismatch
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:27:8:27:47 | flatted ... ource)) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:30:8:30:49 | telepor ... ource)) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:34:8:34:51 | replica ... ource)) |
+| json-stringify.js:2:16:2:23 | source() | json-stringify.js:36:8:36:47 | require ... source) |
 | json-stringify.js:3:15:3:22 | source() | json-stringify.js:8:8:8:31 | jsonStr ... (taint) |
 | nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
 | nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -98,6 +98,7 @@ typeInferenceMismatch
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:36:8:36:47 | require ... source) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:39:8:39:37 | jc.stri ... ource)) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:42:8:42:51 | JSON.st ... urce))) |
+| json-stringify.js:2:16:2:23 | source() | json-stringify.js:45:8:45:23 | fastJson(source) |
 | json-stringify.js:3:15:3:22 | source() | json-stringify.js:8:8:8:31 | jsonStr ... (taint) |
 | nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
 | nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -97,6 +97,7 @@ typeInferenceMismatch
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:34:8:34:51 | replica ... ource)) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:36:8:36:47 | require ... source) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:39:8:39:37 | jc.stri ... ource)) |
+| json-stringify.js:2:16:2:23 | source() | json-stringify.js:42:8:42:51 | JSON.st ... urce))) |
 | json-stringify.js:3:15:3:22 | source() | json-stringify.js:8:8:8:31 | jsonStr ... (taint) |
 | nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
 | nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -96,6 +96,7 @@ typeInferenceMismatch
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:30:8:30:49 | telepor ... ource)) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:34:8:34:51 | replica ... ource)) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:36:8:36:47 | require ... source) |
+| json-stringify.js:2:16:2:23 | source() | json-stringify.js:39:8:39:37 | jc.stri ... ource)) |
 | json-stringify.js:3:15:3:22 | source() | json-stringify.js:8:8:8:31 | jsonStr ... (taint) |
 | nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
 | nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -93,6 +93,7 @@ typeInferenceMismatch
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:21:8:21:46 | new jso ... source) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:24:8:24:43 | json5.s ... ource)) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:27:8:27:47 | flatted ... ource)) |
+| json-stringify.js:2:16:2:23 | source() | json-stringify.js:30:8:30:49 | telepor ... ource)) |
 | json-stringify.js:3:15:3:22 | source() | json-stringify.js:8:8:8:31 | jsonStr ... (taint) |
 | nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
 | nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -92,6 +92,7 @@ typeInferenceMismatch
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:18:8:18:40 | require ... source) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:21:8:21:46 | new jso ... source) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:24:8:24:43 | json5.s ... ource)) |
+| json-stringify.js:2:16:2:23 | source() | json-stringify.js:27:8:27:47 | flatted ... ource)) |
 | json-stringify.js:3:15:3:22 | source() | json-stringify.js:8:8:8:31 | jsonStr ... (taint) |
 | nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
 | nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -90,6 +90,7 @@ typeInferenceMismatch
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:16:8:16:38 | require ... source) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:17:8:17:39 | require ... source) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:18:8:18:40 | require ... source) |
+| json-stringify.js:2:16:2:23 | source() | json-stringify.js:21:8:21:46 | new jso ... source) |
 | json-stringify.js:3:15:3:22 | source() | json-stringify.js:8:8:8:31 | jsonStr ... (taint) |
 | nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
 | nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -94,6 +94,7 @@ typeInferenceMismatch
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:24:8:24:43 | json5.s ... ource)) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:27:8:27:47 | flatted ... ource)) |
 | json-stringify.js:2:16:2:23 | source() | json-stringify.js:30:8:30:49 | telepor ... ource)) |
+| json-stringify.js:2:16:2:23 | source() | json-stringify.js:34:8:34:51 | replica ... ource)) |
 | json-stringify.js:3:15:3:22 | source() | json-stringify.js:8:8:8:31 | jsonStr ... (taint) |
 | nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
 | nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |

--- a/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
+++ b/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
@@ -25,4 +25,7 @@ function foo() {
 
   const flatted = require('flatted');
   sink(flatted.stringify(flatted.parse(source))); // NOT OK
+
+  const teleport = require('teleport-javascript');
+  sink(teleport.stringify(teleport.parse(source))); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
+++ b/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
@@ -32,4 +32,6 @@ function foo() {
   const Replicator = require('replicator');
   const replicator = new Replicator();
   sink(replicator.encode(replicator.decode(source))); // NOT OK
+
+  sink(require("safe-stable-stringify")(source)); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
+++ b/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
@@ -16,4 +16,7 @@ function foo() {
   sink(require("util").inspect(source)); // NOT OK
   sink(require("pretty-format")(source)); // NOT OK
   sink(require("object-inspect")(source)); // NOT OK
+  
+  const json2csv = require('json2csv');
+  sink(new json2csv.Parser(opts).parse(source)); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
+++ b/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
@@ -40,4 +40,7 @@ function foo() {
 
   const stripper = require("strip-json-comments");
   sink(JSON.stringify(JSON.parse(stripper(source)))); // NOT OK
+
+  const fastJson = require('fast-json-stringify');
+  sink(fastJson(source)); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
+++ b/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
@@ -22,4 +22,7 @@ function foo() {
 
   const json5 = require('json5');
   sink(json5.stringify(json5.parse(source))); // NOT OK
+
+  const flatted = require('flatted');
+  sink(flatted.stringify(flatted.parse(source))); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
+++ b/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
@@ -34,4 +34,7 @@ function foo() {
   sink(replicator.encode(replicator.decode(source))); // NOT OK
 
   sink(require("safe-stable-stringify")(source)); // NOT OK
+
+  const jc = require('json-cycle');
+  sink(jc.stringify(jc.parse(source))); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
+++ b/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
@@ -19,4 +19,7 @@ function foo() {
   
   const json2csv = require('json2csv');
   sink(new json2csv.Parser(opts).parse(source)); // NOT OK
+
+  const json5 = require('json5');
+  sink(json5.stringify(json5.parse(source))); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
+++ b/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
@@ -37,4 +37,7 @@ function foo() {
 
   const jc = require('json-cycle');
   sink(jc.stringify(jc.parse(source))); // NOT OK
+
+  const stripper = require("strip-json-comments");
+  sink(JSON.stringify(JSON.parse(stripper(source)))); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
+++ b/javascript/ql/test/library-tests/TaintTracking/json-stringify.js
@@ -28,4 +28,8 @@ function foo() {
 
   const teleport = require('teleport-javascript');
   sink(teleport.stringify(teleport.parse(source))); // NOT OK
+
+  const Replicator = require('replicator');
+  const replicator = new Replicator();
+  sink(replicator.encode(replicator.decode(source))); // NOT OK
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -190,6 +190,14 @@ nodes
 | tst2.js:49:36:49:36 | p |
 | tst2.js:51:12:51:17 | unsafe |
 | tst2.js:51:12:51:17 | unsafe |
+| tst2.js:57:7:57:24 | p |
+| tst2.js:57:9:57:9 | p |
+| tst2.js:57:9:57:9 | p |
+| tst2.js:60:11:60:11 | p |
+| tst2.js:63:12:63:12 | p |
+| tst2.js:63:12:63:12 | p |
+| tst2.js:64:12:64:18 | other.p |
+| tst2.js:64:12:64:18 | other.p |
 | tst3.js:5:7:5:24 | p |
 | tst3.js:5:9:5:9 | p |
 | tst3.js:5:9:5:9 | p |
@@ -359,6 +367,13 @@ edges
 | tst2.js:49:7:49:53 | unsafe | tst2.js:51:12:51:17 | unsafe |
 | tst2.js:49:16:49:53 | seriali ...  true}) | tst2.js:49:7:49:53 | unsafe |
 | tst2.js:49:36:49:36 | p | tst2.js:49:16:49:53 | seriali ...  true}) |
+| tst2.js:57:7:57:24 | p | tst2.js:60:11:60:11 | p |
+| tst2.js:57:7:57:24 | p | tst2.js:63:12:63:12 | p |
+| tst2.js:57:7:57:24 | p | tst2.js:63:12:63:12 | p |
+| tst2.js:57:9:57:9 | p | tst2.js:57:7:57:24 | p |
+| tst2.js:57:9:57:9 | p | tst2.js:57:7:57:24 | p |
+| tst2.js:60:11:60:11 | p | tst2.js:64:12:64:18 | other.p |
+| tst2.js:60:11:60:11 | p | tst2.js:64:12:64:18 | other.p |
 | tst3.js:5:7:5:24 | p | tst3.js:6:12:6:12 | p |
 | tst3.js:5:7:5:24 | p | tst3.js:6:12:6:12 | p |
 | tst3.js:5:9:5:9 | p | tst3.js:5:7:5:24 | p |
@@ -412,5 +427,7 @@ edges
 | tst2.js:36:12:36:12 | p | tst2.js:30:9:30:9 | p | tst2.js:36:12:36:12 | p | Cross-site scripting vulnerability due to $@. | tst2.js:30:9:30:9 | p | user-provided value |
 | tst2.js:37:12:37:18 | other.p | tst2.js:30:9:30:9 | p | tst2.js:37:12:37:18 | other.p | Cross-site scripting vulnerability due to $@. | tst2.js:30:9:30:9 | p | user-provided value |
 | tst2.js:51:12:51:17 | unsafe | tst2.js:43:9:43:9 | p | tst2.js:51:12:51:17 | unsafe | Cross-site scripting vulnerability due to $@. | tst2.js:43:9:43:9 | p | user-provided value |
+| tst2.js:63:12:63:12 | p | tst2.js:57:9:57:9 | p | tst2.js:63:12:63:12 | p | Cross-site scripting vulnerability due to $@. | tst2.js:57:9:57:9 | p | user-provided value |
+| tst2.js:64:12:64:18 | other.p | tst2.js:57:9:57:9 | p | tst2.js:64:12:64:18 | other.p | Cross-site scripting vulnerability due to $@. | tst2.js:57:9:57:9 | p | user-provided value |
 | tst3.js:6:12:6:12 | p | tst3.js:5:9:5:9 | p | tst3.js:6:12:6:12 | p | Cross-site scripting vulnerability due to $@. | tst3.js:5:9:5:9 | p | user-provided value |
 | tst3.js:12:12:12:15 | code | tst3.js:11:32:11:39 | reg.body | tst3.js:12:12:12:15 | code | Cross-site scripting vulnerability due to $@. | tst3.js:11:32:11:39 | reg.body | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -198,6 +198,14 @@ nodes
 | tst2.js:63:12:63:12 | p |
 | tst2.js:64:12:64:18 | other.p |
 | tst2.js:64:12:64:18 | other.p |
+| tst2.js:69:7:69:24 | p |
+| tst2.js:69:9:69:9 | p |
+| tst2.js:69:9:69:9 | p |
+| tst2.js:72:11:72:11 | p |
+| tst2.js:75:12:75:12 | p |
+| tst2.js:75:12:75:12 | p |
+| tst2.js:76:12:76:18 | other.p |
+| tst2.js:76:12:76:18 | other.p |
 | tst3.js:5:7:5:24 | p |
 | tst3.js:5:9:5:9 | p |
 | tst3.js:5:9:5:9 | p |
@@ -374,6 +382,13 @@ edges
 | tst2.js:57:9:57:9 | p | tst2.js:57:7:57:24 | p |
 | tst2.js:60:11:60:11 | p | tst2.js:64:12:64:18 | other.p |
 | tst2.js:60:11:60:11 | p | tst2.js:64:12:64:18 | other.p |
+| tst2.js:69:7:69:24 | p | tst2.js:72:11:72:11 | p |
+| tst2.js:69:7:69:24 | p | tst2.js:75:12:75:12 | p |
+| tst2.js:69:7:69:24 | p | tst2.js:75:12:75:12 | p |
+| tst2.js:69:9:69:9 | p | tst2.js:69:7:69:24 | p |
+| tst2.js:69:9:69:9 | p | tst2.js:69:7:69:24 | p |
+| tst2.js:72:11:72:11 | p | tst2.js:76:12:76:18 | other.p |
+| tst2.js:72:11:72:11 | p | tst2.js:76:12:76:18 | other.p |
 | tst3.js:5:7:5:24 | p | tst3.js:6:12:6:12 | p |
 | tst3.js:5:7:5:24 | p | tst3.js:6:12:6:12 | p |
 | tst3.js:5:9:5:9 | p | tst3.js:5:7:5:24 | p |
@@ -429,5 +444,7 @@ edges
 | tst2.js:51:12:51:17 | unsafe | tst2.js:43:9:43:9 | p | tst2.js:51:12:51:17 | unsafe | Cross-site scripting vulnerability due to $@. | tst2.js:43:9:43:9 | p | user-provided value |
 | tst2.js:63:12:63:12 | p | tst2.js:57:9:57:9 | p | tst2.js:63:12:63:12 | p | Cross-site scripting vulnerability due to $@. | tst2.js:57:9:57:9 | p | user-provided value |
 | tst2.js:64:12:64:18 | other.p | tst2.js:57:9:57:9 | p | tst2.js:64:12:64:18 | other.p | Cross-site scripting vulnerability due to $@. | tst2.js:57:9:57:9 | p | user-provided value |
+| tst2.js:75:12:75:12 | p | tst2.js:69:9:69:9 | p | tst2.js:75:12:75:12 | p | Cross-site scripting vulnerability due to $@. | tst2.js:69:9:69:9 | p | user-provided value |
+| tst2.js:76:12:76:18 | other.p | tst2.js:69:9:69:9 | p | tst2.js:76:12:76:18 | other.p | Cross-site scripting vulnerability due to $@. | tst2.js:69:9:69:9 | p | user-provided value |
 | tst3.js:6:12:6:12 | p | tst3.js:5:9:5:9 | p | tst3.js:6:12:6:12 | p | Cross-site scripting vulnerability due to $@. | tst3.js:5:9:5:9 | p | user-provided value |
 | tst3.js:12:12:12:15 | code | tst3.js:11:32:11:39 | reg.body | tst3.js:12:12:12:15 | code | Cross-site scripting vulnerability due to $@. | tst3.js:11:32:11:39 | reg.body | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
@@ -40,5 +40,7 @@
 | tst2.js:36:12:36:12 | p | Cross-site scripting vulnerability due to $@. | tst2.js:30:9:30:9 | p | user-provided value |
 | tst2.js:37:12:37:18 | other.p | Cross-site scripting vulnerability due to $@. | tst2.js:30:9:30:9 | p | user-provided value |
 | tst2.js:51:12:51:17 | unsafe | Cross-site scripting vulnerability due to $@. | tst2.js:43:9:43:9 | p | user-provided value |
+| tst2.js:63:12:63:12 | p | Cross-site scripting vulnerability due to $@. | tst2.js:57:9:57:9 | p | user-provided value |
+| tst2.js:64:12:64:18 | other.p | Cross-site scripting vulnerability due to $@. | tst2.js:57:9:57:9 | p | user-provided value |
 | tst3.js:6:12:6:12 | p | Cross-site scripting vulnerability due to $@. | tst3.js:5:9:5:9 | p | user-provided value |
 | tst3.js:12:12:12:15 | code | Cross-site scripting vulnerability due to $@. | tst3.js:11:32:11:39 | reg.body | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
@@ -42,5 +42,7 @@
 | tst2.js:51:12:51:17 | unsafe | Cross-site scripting vulnerability due to $@. | tst2.js:43:9:43:9 | p | user-provided value |
 | tst2.js:63:12:63:12 | p | Cross-site scripting vulnerability due to $@. | tst2.js:57:9:57:9 | p | user-provided value |
 | tst2.js:64:12:64:18 | other.p | Cross-site scripting vulnerability due to $@. | tst2.js:57:9:57:9 | p | user-provided value |
+| tst2.js:75:12:75:12 | p | Cross-site scripting vulnerability due to $@. | tst2.js:69:9:69:9 | p | user-provided value |
+| tst2.js:76:12:76:18 | other.p | Cross-site scripting vulnerability due to $@. | tst2.js:69:9:69:9 | p | user-provided value |
 | tst3.js:6:12:6:12 | p | Cross-site scripting vulnerability due to $@. | tst3.js:5:9:5:9 | p | user-provided value |
 | tst3.js:12:12:12:15 | code | Cross-site scripting vulnerability due to $@. | tst3.js:11:32:11:39 | reg.body | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/tst2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/tst2.js
@@ -63,3 +63,15 @@ app.get('/baz', function(req, res) {
   res.send(p); // NOT OK
   res.send(other.p); // NOT OK
 });
+
+const jc = require('json-cycle');
+app.get('/baz', function(req, res) {
+  let { p } = req.params;
+
+  var obj = {};
+  obj.p = p;
+  var other = jc.retrocycle(jc.decycle(obj));
+
+  res.send(p); // NOT OK
+  res.send(other.p); // NOT OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/tst2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/tst2.js
@@ -50,3 +50,16 @@ app.get('/baz', function(req, res) {
 
   res.send(unsafe); // NOT OK
 });
+
+const fclone = require('fclone');
+
+app.get('/baz', function(req, res) {
+  let { p } = req.params;
+
+  var obj = {};
+  obj.p = p;
+  var other = fclone(obj);
+
+  res.send(p); // NOT OK
+  res.send(other.p); // NOT OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -65,6 +65,17 @@ nodes
 | logInjectionBad.js:58:17:58:59 | stripAn ... rname)) |
 | logInjectionBad.js:58:27:58:58 | chalk.u ... ername) |
 | logInjectionBad.js:58:50:58:57 | username |
+| logInjectionBad.js:63:9:63:36 | q |
+| logInjectionBad.js:63:13:63:36 | url.par ... , true) |
+| logInjectionBad.js:63:23:63:29 | req.url |
+| logInjectionBad.js:63:23:63:29 | req.url |
+| logInjectionBad.js:64:9:64:35 | username |
+| logInjectionBad.js:64:20:64:20 | q |
+| logInjectionBad.js:64:20:64:26 | q.query |
+| logInjectionBad.js:64:20:64:35 | q.query.username |
+| logInjectionBad.js:66:17:66:43 | prettyj ... ername) |
+| logInjectionBad.js:66:17:66:43 | prettyj ... ername) |
+| logInjectionBad.js:66:35:66:42 | username |
 edges
 | logInjectionBad.js:19:9:19:36 | q | logInjectionBad.js:20:20:20:20 | q |
 | logInjectionBad.js:19:13:19:36 | url.par ... , true) | logInjectionBad.js:19:9:19:36 | q |
@@ -130,6 +141,16 @@ edges
 | logInjectionBad.js:58:27:58:58 | chalk.u ... ername) | logInjectionBad.js:58:17:58:59 | stripAn ... rname)) |
 | logInjectionBad.js:58:27:58:58 | chalk.u ... ername) | logInjectionBad.js:58:17:58:59 | stripAn ... rname)) |
 | logInjectionBad.js:58:50:58:57 | username | logInjectionBad.js:58:27:58:58 | chalk.u ... ername) |
+| logInjectionBad.js:63:9:63:36 | q | logInjectionBad.js:64:20:64:20 | q |
+| logInjectionBad.js:63:13:63:36 | url.par ... , true) | logInjectionBad.js:63:9:63:36 | q |
+| logInjectionBad.js:63:23:63:29 | req.url | logInjectionBad.js:63:13:63:36 | url.par ... , true) |
+| logInjectionBad.js:63:23:63:29 | req.url | logInjectionBad.js:63:13:63:36 | url.par ... , true) |
+| logInjectionBad.js:64:9:64:35 | username | logInjectionBad.js:66:35:66:42 | username |
+| logInjectionBad.js:64:20:64:20 | q | logInjectionBad.js:64:20:64:26 | q.query |
+| logInjectionBad.js:64:20:64:26 | q.query | logInjectionBad.js:64:20:64:35 | q.query.username |
+| logInjectionBad.js:64:20:64:35 | q.query.username | logInjectionBad.js:64:9:64:35 | username |
+| logInjectionBad.js:66:35:66:42 | username | logInjectionBad.js:66:17:66:43 | prettyj ... ername) |
+| logInjectionBad.js:66:35:66:42 | username | logInjectionBad.js:66:17:66:43 | prettyj ... ername) |
 #select
 | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:22:18:22:43 | `[INFO] ... rname}` | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
 | logInjectionBad.js:23:37:23:44 | username | logInjectionBad.js:19:23:19:29 | req.url | logInjectionBad.js:23:37:23:44 | username | $@ flows to log entry. | logInjectionBad.js:19:23:19:29 | req.url | User-provided value |
@@ -146,3 +167,4 @@ edges
 | logInjectionBad.js:56:17:56:55 | kleur.b ... ername) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:56:17:56:55 | kleur.b ... ername) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
 | logInjectionBad.js:57:17:57:48 | chalk.u ... ername) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:57:17:57:48 | chalk.u ... ername) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
 | logInjectionBad.js:58:17:58:59 | stripAn ... rname)) | logInjectionBad.js:46:23:46:29 | req.url | logInjectionBad.js:58:17:58:59 | stripAn ... rname)) | $@ flows to log entry. | logInjectionBad.js:46:23:46:29 | req.url | User-provided value |
+| logInjectionBad.js:66:17:66:43 | prettyj ... ername) | logInjectionBad.js:63:23:63:29 | req.url | logInjectionBad.js:66:17:66:43 | prettyj ... ername) | $@ flows to log entry. | logInjectionBad.js:63:23:63:29 | req.url | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-117/logInjectionBad.js
@@ -57,3 +57,11 @@ const server2 = http.createServer((req, res) => {
     console.log(chalk.underline.bgBlue(username)); // NOT OK
     console.log(stripAnsi(chalk.underline.bgBlue(username))); // NOT OK
 });
+
+var prettyjson = require('prettyjson');
+const server3 = http.createServer((req, res) => {
+    let q = url.parse(req.url, true);
+    let username = q.query.username;
+
+    console.log(prettyjson.render(username)); // NOT OK
+});


### PR DESCRIPTION
Inspired by missing support for the highly dependent upon library [`json2csv`](https://www.npmjs.com/package/json2csv). 
And I found a few others to model by searching NPM tags.