### PR TITLE
Add information on `overwrite` options to the CodeQL CLI docs

### DIFF
--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -63,6 +63,8 @@ more than one language:
 - ``--no-run-unnecessary-builds``: used with ``--db-cluster`` to suppress the build 
   command for languages where the CodeQL CLI does not need to monitor the build 
   (for example, Python and JavaScript/TypeScript).
+- ``--overwrite``: use to force the CodeQL CLI to replace a existing database or database
+  cluster even if it exists on disk. 
    
 For full details of all the options you can use when creating databases,
 see the `database create reference documentation <../manual/database-create>`__.  

--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -63,7 +63,7 @@ more than one language:
 - ``--no-run-unnecessary-builds``: used with ``--db-cluster`` to suppress the build 
   command for languages where the CodeQL CLI does not need to monitor the build 
   (for example, Python and JavaScript/TypeScript).
-- ``--overwrite``: use to force the CodeQL CLI to replace a existing database or database
+- ``--overwrite``: use to force the CodeQL CLI to replace an existing database or database
   cluster even if it exists on disk. 
    
 For full details of all the options you can use when creating databases,


### PR DESCRIPTION
Update the docs to include new options released with CodeQL CLI 2.5.6 [See here](https://github.com/github/codeql-cli-binaries/issues/44).

I did not see this option being documented anywhere in CodeQL docs. This option should actually be documented in https://codeql.github.com/docs/codeql-cli/manual/database-create/ but I could not find the file for codeql-cli manual in this repo.

Hopefully the team can add this option to the manual page.

The Sphinx output for this change look like this:
![image](https://user-images.githubusercontent.com/52971804/125268455-4e86d680-e33a-11eb-8832-b7146d95fdee.png)

I'm not sure whether this option should be documented to this page, feel free to close/make changes to this PR.