### PR TITLE
Data flow: Fix bad join-orders in `summaryNodeType`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -375,7 +375,9 @@ module Private {
         or
         exists(ReturnKind rk |
           head = TReturnSummaryComponent(rk) and
-          result = getCallbackReturnType(getNodeType(summaryNodeInputState(c, s.drop(1))), rk)
+          result =
+            getCallbackReturnType(getNodeType(summaryNodeInputState(pragma[only_bind_out](c),
+                  s.drop(1))), rk)
         )
       )
       or
@@ -392,7 +394,9 @@ module Private {
         )
         or
         exists(int i | head = TParameterSummaryComponent(i) |
-          result = getCallbackParameterType(getNodeType(summaryNodeOutputState(c, s.drop(1))), i)
+          result =
+            getCallbackParameterType(getNodeType(summaryNodeOutputState(pragma[only_bind_out](c),
+                  s.drop(1))), i)
         )
       )
     )

--- a/java/ql/src/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -375,7 +375,9 @@ module Private {
         or
         exists(ReturnKind rk |
           head = TReturnSummaryComponent(rk) and
-          result = getCallbackReturnType(getNodeType(summaryNodeInputState(c, s.drop(1))), rk)
+          result =
+            getCallbackReturnType(getNodeType(summaryNodeInputState(pragma[only_bind_out](c),
+                  s.drop(1))), rk)
         )
       )
       or
@@ -392,7 +394,9 @@ module Private {
         )
         or
         exists(int i | head = TParameterSummaryComponent(i) |
-          result = getCallbackParameterType(getNodeType(summaryNodeOutputState(c, s.drop(1))), i)
+          result =
+            getCallbackParameterType(getNodeType(summaryNodeOutputState(pragma[only_bind_out](c),
+                  s.drop(1))), i)
         )
       )
     )


### PR DESCRIPTION
Before:
```
[2021-07-12 11:41:57] (608s) Tuple counts for FlowSummaryImpl::Private::summaryNodeType#ff#join_rhs#1/3@6219ab:
                      66848     ~4%      {3} r1 = SCAN FlowSummaryImpl::Private::summaryNodeOutputState#fff OUTPUT In.2 'arg0', In.0, In.1
                      66848     ~0%      {3} r2 = JOIN r1 WITH DataFlowPrivate::NodeImpl#class#f ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.0 'arg0'
                      781342050 ~0%      {5} r3 = JOIN r2 WITH FlowSummaryImpl::Private::summaryNodeOutputState#fff ON FIRST 1 OUTPUT Rhs.1, 1, Lhs.1, Lhs.2 'arg0', Rhs.2 'arg0'
                      58817     ~0%      {3} r4 = JOIN r3 WITH FlowSummaryImpl::Public::SummaryComponentStack::drop#fff ON FIRST 3 OUTPUT Lhs.0, Lhs.3 'arg0', Lhs.4 'arg1'
                      58817     ~1%      {3} r5 = JOIN r4 WITH FlowSummaryImpl::Public::SummaryComponentStack::head_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'arg0', Lhs.2 'arg1'
                      504       ~2%      {3} r6 = JOIN r5 WITH construct<TSummaryComponent,1>@dom#FlowSummaryImpl::Private::TParameterSummaryComponent#1#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1 'arg0', Lhs.2 'arg1', Rhs.1 'arg2'
                                         return r6


[2021-07-12 11:43:35] (706s) Tuple counts for FlowSummaryImpl::Private::summaryNodeType#ff/2@i3#4a74bx:
                      0         ~0%     {2} r1 = JOIN DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff#prev_delta WITH FlowSummaryImpl::Private::summaryPostUpdateNode#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'n', Lhs.1 'result'
                      
                      0         ~0%     {3} r2 = JOIN DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff#prev_delta WITH FlowSummaryImpl::Private::summaryNodeType#ff#join_rhs#2 ON FIRST 1 OUTPUT Rhs.2, Rhs.1, Lhs.1 'result'
                      0         ~0%     {2} r3 = JOIN r2 WITH FlowSummaryImpl::Private::summaryNodeInputState#fff ON FIRST 2 OUTPUT Lhs.2, Rhs.2 'n'
                      0         ~0%     {2} r4 = JOIN r3 WITH FlowSummaryImplSpecific::getCallbackReturnType#cpe#13#ff ON FIRST 1 OUTPUT Lhs.1 'n', Rhs.1 'result'
                      
                      64113     ~0%     {3} r5 = JOIN DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff#prev_delta WITH FlowSummaryImpl::Private::summaryNodeType#ff#join_rhs#3 ON FIRST 1 OUTPUT Rhs.1, Rhs.2, Lhs.1 'result'
                      781333898 ~0%     {5} r6 = JOIN r5 WITH FlowSummaryImpl::Private::summaryNodeOutputState#fff ON FIRST 1 OUTPUT Rhs.1, 1, Lhs.1, Lhs.2, Rhs.2 'n'
                      57159     ~0%     {3} r7 = JOIN r6 WITH FlowSummaryImpl::Public::SummaryComponentStack::drop#fff ON FIRST 3 OUTPUT Lhs.0, Lhs.3, Lhs.4 'n'
                      57159     ~0%     {3} r8 = JOIN r7 WITH FlowSummaryImpl::Public::SummaryComponentStack::head_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2 'n'
                      0         ~0%     {3} r9 = JOIN r8 WITH construct<TSummaryComponent,1>@dom#FlowSummaryImpl::Private::TParameterSummaryComponent#1#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2 'n'
                      0         ~0%     {2} r10 = JOIN r9 WITH FlowSummaryImplSpecific::getCallbackParameterType#fff ON FIRST 2 OUTPUT Lhs.2 'n', Rhs.2 'result'
                      
                      0         ~0%     {2} r11 = r4 UNION r10
                      0         ~0%     {2} r12 = r1 UNION r11
                      0         ~0%     {2} r13 = r12 AND NOT FlowSummaryImpl::Private::summaryNodeType#ff#prev(Lhs.0 'n', Lhs.1 'result')
                                        return r13
```


After
```
[2021-07-12 12:08:52] (572s) Tuple counts for FlowSummaryImpl::Private::summaryNodeType#ff#join_rhs#1/3@41a32a:
                      66848   ~4%      {3} r1 = SCAN FlowSummaryImpl::Private::summaryNodeOutputState#fff OUTPUT In.2 'arg0', In.0, In.1
                      66848   ~1%      {4} r2 = JOIN r1 WITH DataFlowPrivate::NodeImpl#class#f ON FIRST 1 OUTPUT 1, Lhs.2, Lhs.1, Lhs.0 'arg0'
                      1406384 ~0%      {3} r3 = JOIN r2 WITH FlowSummaryImpl::Public::SummaryComponentStack::drop#fff_120#join_rhs ON FIRST 2 OUTPUT Lhs.2, Rhs.2, Lhs.3 'arg0'
                      58817   ~0%      {3} r4 = JOIN r3 WITH FlowSummaryImpl::Private::summaryNodeOutputState#fff ON FIRST 2 OUTPUT Lhs.1, Lhs.2 'arg0', Rhs.2 'arg0'
                      58817   ~1%      {3} r5 = JOIN r4 WITH FlowSummaryImpl::Public::SummaryComponentStack::head_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'arg0', Lhs.2 'arg1'
                      504     ~2%      {3} r6 = JOIN r5 WITH construct<TSummaryComponent,1>@dom#FlowSummaryImpl::Private::TParameterSummaryComponent#1#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1 'arg0', Lhs.2 'arg1', Rhs.1 'arg2'
                                       return r6


[2021-07-12 12:09:06] (586s) Tuple counts for FlowSummaryImpl::Private::summaryNodeType#ff/2@i3#67f70x:
                      0       ~0%      {2} r1 = JOIN DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff#prev_delta WITH FlowSummaryImpl::Private::summaryPostUpdateNode#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'n', Lhs.1 'result'
                      
                      0       ~0%      {2} r2 = JOIN DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff#prev_delta WITH FlowSummaryImpl::Private::summaryNodeType#ff#join_rhs ON FIRST 1 OUTPUT Lhs.1 'result', Rhs.1 'n'
                      0       ~0%      {2} r3 = JOIN r2 WITH FlowSummaryImplSpecific::getCallbackReturnType#cpe#13#ff ON FIRST 1 OUTPUT Lhs.1 'n', Rhs.1 'result'
                      
                      64113   ~0%      {4} r4 = JOIN DataFlowPrivate::NodeImpl::getDataFlowType_dispred#ff#prev_delta WITH FlowSummaryImpl::Private::summaryNodeType#ff#join_rhs#2 ON FIRST 1 OUTPUT 1, Rhs.2, Rhs.1, Lhs.1 'result'
                      742352  ~10%     {3} r5 = JOIN r4 WITH FlowSummaryImpl::Public::SummaryComponentStack::drop#fff_120#join_rhs ON FIRST 2 OUTPUT Lhs.2, Rhs.2, Lhs.3
                      57159   ~0%      {3} r6 = JOIN r5 WITH FlowSummaryImpl::Private::summaryNodeOutputState#fff ON FIRST 2 OUTPUT Lhs.1, Lhs.2, Rhs.2 'n'
                      57159   ~0%      {3} r7 = JOIN r6 WITH FlowSummaryImpl::Public::SummaryComponentStack::head_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2 'n'
                      0       ~0%      {3} r8 = JOIN r7 WITH construct<TSummaryComponent,1>@dom#FlowSummaryImpl::Private::TParameterSummaryComponent#1#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2 'n'
                      0       ~0%      {2} r9 = JOIN r8 WITH FlowSummaryImplSpecific::getCallbackParameterType#fff ON FIRST 2 OUTPUT Lhs.2 'n', Rhs.2 'result'
                      
                      0       ~0%      {2} r10 = r3 UNION r9
                      0       ~0%      {2} r11 = r1 UNION r10
                      0       ~0%      {2} r12 = r11 AND NOT FlowSummaryImpl::Private::summaryNodeType#ff#prev(Lhs.0 'n', Lhs.1 'result')
                                       return r12
```

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1192/
https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/1499/