### PR TITLE
JS: add support for the `slash` library

### DIFF
--- a/javascript/change-notes/2021-07-12-slash.md
+++ b/javascript/change-notes/2021-07-12-slash.md
@@ -1,0 +1,6 @@
+lgtm,codescanning
+* The `js/tainted-path` and `js/zipslip` queries now recognize path that have been 
+  normalized using the `slash` library.
+    Affected packages are
+    [slash](https://npmjs.com/package/slash)
+

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -798,6 +798,12 @@ module TaintedPath {
       srclabel instanceof Label::SplitPath and
       dstlabel.(Label::PosixPath).canContainDotDotSlash()
     )
+    or
+    exists(API::CallNode call | call = API::moduleImport("slash").getACall() |
+      src = call.getArgument(0) and
+      dst = call and
+      srclabel = dstlabel
+    )
   }
 
   /**

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1843,6 +1843,29 @@ nodes
 | normalizedPaths.js:363:21:363:31 | requestPath |
 | normalizedPaths.js:363:21:363:31 | requestPath |
 | normalizedPaths.js:363:21:363:31 | requestPath |
+| normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:14:377:27 | req.query.path |
+| normalizedPaths.js:377:14:377:27 | req.query.path |
+| normalizedPaths.js:377:14:377:27 | req.query.path |
+| normalizedPaths.js:377:14:377:27 | req.query.path |
+| normalizedPaths.js:377:14:377:27 | req.query.path |
+| normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:25:381:28 | path |
+| normalizedPaths.js:381:25:381:28 | path |
+| normalizedPaths.js:381:25:381:28 | path |
+| normalizedPaths.js:381:25:381:28 | path |
 | other-fs-libraries.js:9:7:9:48 | path |
 | other-fs-libraries.js:9:7:9:48 | path |
 | other-fs-libraries.js:9:7:9:48 | path |
@@ -6111,6 +6134,34 @@ edges
 | normalizedPaths.js:358:47:358:50 | path | normalizedPaths.js:358:21:358:51 | pathMod ... , path) |
 | normalizedPaths.js:358:47:358:50 | path | normalizedPaths.js:358:21:358:51 | pathMod ... , path) |
 | normalizedPaths.js:358:47:358:50 | path | normalizedPaths.js:358:21:358:51 | pathMod ... , path) |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:379:19:379:22 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:381:25:381:28 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:381:25:381:28 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:381:25:381:28 | path |
+| normalizedPaths.js:377:7:377:27 | path | normalizedPaths.js:381:25:381:28 | path |
+| normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:377:7:377:27 | path |
+| normalizedPaths.js:381:25:381:28 | path | normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:25:381:28 | path | normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:25:381:28 | path | normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:25:381:28 | path | normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:25:381:28 | path | normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:25:381:28 | path | normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:25:381:28 | path | normalizedPaths.js:381:19:381:29 | slash(path) |
+| normalizedPaths.js:381:25:381:28 | path | normalizedPaths.js:381:19:381:29 | slash(path) |
 | other-fs-libraries.js:9:7:9:48 | path | other-fs-libraries.js:11:19:11:22 | path |
 | other-fs-libraries.js:9:7:9:48 | path | other-fs-libraries.js:11:19:11:22 | path |
 | other-fs-libraries.js:9:7:9:48 | path | other-fs-libraries.js:11:19:11:22 | path |
@@ -8535,6 +8586,8 @@ edges
 | normalizedPaths.js:346:19:346:22 | path | normalizedPaths.js:339:32:339:45 | req.query.path | normalizedPaths.js:346:19:346:22 | path | This path depends on $@. | normalizedPaths.js:339:32:339:45 | req.query.path | a user-provided value |
 | normalizedPaths.js:356:19:356:22 | path | normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:356:19:356:22 | path | This path depends on $@. | normalizedPaths.js:354:14:354:27 | req.query.path | a user-provided value |
 | normalizedPaths.js:363:21:363:31 | requestPath | normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:363:21:363:31 | requestPath | This path depends on $@. | normalizedPaths.js:354:14:354:27 | req.query.path | a user-provided value |
+| normalizedPaths.js:379:19:379:22 | path | normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:379:19:379:22 | path | This path depends on $@. | normalizedPaths.js:377:14:377:27 | req.query.path | a user-provided value |
+| normalizedPaths.js:381:19:381:29 | slash(path) | normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:381:19:381:29 | slash(path) | This path depends on $@. | normalizedPaths.js:377:14:377:27 | req.query.path | a user-provided value |
 | other-fs-libraries.js:11:19:11:22 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:11:19:11:22 | path | This path depends on $@. | other-fs-libraries.js:9:24:9:30 | req.url | a user-provided value |
 | other-fs-libraries.js:12:27:12:30 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:12:27:12:30 | path | This path depends on $@. | other-fs-libraries.js:9:24:9:30 | req.url | a user-provided value |
 | other-fs-libraries.js:13:24:13:27 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:13:24:13:27 | path | This path depends on $@. | other-fs-libraries.js:9:24:9:30 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/normalizedPaths.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/normalizedPaths.js
@@ -371,3 +371,12 @@ app.get('/yet-another-prefix2', (req, res) => {
     return requestPath.indexOf(rootPath) === 0;
   }
 });
+
+import slash from 'slash';
+app.get('/slash-stuff', (req, res) => {
+  let path = req.query.path;
+
+  fs.readFileSync(path); // NOT OK
+
+  fs.readFileSync(slash(path)); // NOT OK
+});


### PR DESCRIPTION
[Evaluation was uneventful](https://github.com/dsp-testing/erik-krogh-dca/tree/run/slash-eval/reports). 