### PR TITLE
C#: Avoid bad magic in `hasNonOverriddenMember`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/Type.qll
+++ b/csharp/ql/src/semmle/code/csharp/Type.qll
@@ -266,6 +266,7 @@ class ValueOrRefType extends DotNet::ValueOrRefType, Type, Attributable, @value_
     hasOverriddenMember(m)
   }
 
+  pragma[nomagic]
   private predicate hasNonOverriddenMember(Member m) {
     isNonOverridden(m) and
     (


### PR DESCRIPTION
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1190/