### PR TITLE
JS: add missing qldoc in MooTools.qll

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/MooTools.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/MooTools.qll
@@ -4,6 +4,9 @@
 
 import javascript
 
+/**
+ * Classes and predicates for working with MooTools code.
+ */
 module MooTools {
   private class Element extends DataFlow::NewNode {
     Element() {


### PR DESCRIPTION
For some reason [the PR](https://github.com/github/codeql/pull/6193) got merged even though the QLDoc checks failed. 