### PR TITLE
C++: Improve the CleartextFileWrite query

### DIFF
--- a/cpp/change-notes/2021-07-13-cleartext-storage-file.md
+++ b/cpp/change-notes/2021-07-13-cleartext-storage-file.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* The "Cleartext storage of sensitive information in file" (cpp/cleartext-storage-file) query now uses dataflow to produce additional results.
+* Heuristics in the SensitiveExprs.qll library have been improved, making the "Cleartext storage of sensitive information in file" (cpp/cleartext-storage-file), "Cleartext storage of sensitive information in buffer" (cpp/cleartext-storage-buffer) and "Cleartext storage of sensitive information in an SQLite" (cpp/cleartext-storage-database) queries more accurate.

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
@@ -14,10 +14,11 @@
 import cpp
 import semmle.code.cpp.security.SensitiveExprs
 import semmle.code.cpp.security.FileWrite
+import semmle.code.cpp.dataflow.DataFlow
 
 from FileWrite w, SensitiveExpr source, Expr dest
 where
-  source = w.getASource() and
+  DataFlow::localFlow(DataFlow::exprNode(source), DataFlow::exprNode(w.getASource())) and
   dest = w.getDest()
 select w, "This write into file '" + dest.toString() + "' may contain unencrypted data from $@",
   source, "this source."

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
@@ -15,10 +15,37 @@ import cpp
 import semmle.code.cpp.security.SensitiveExprs
 import semmle.code.cpp.security.FileWrite
 import semmle.code.cpp.dataflow.DataFlow
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
+
+/**
+ * An operation on a filename.
+ */
+predicate filenameOperation(FunctionCall op, Expr path) {
+  exists(string name | name = op.getTarget().getName() |
+    name =
+      [
+        "remove", "unlink", "rmdir", "rename", "fopen", "open", "freopen", "_open", "_wopen",
+        "_wfopen", "_fsopen", "_wfsopen", "chmod", "chown", "stat", "lstat", "fstat", "access", "_access", "_waccess", "_access_s", "_waccess_s"
+      ] and
+      path = op.getArgument(0)
+    or
+    name = ["fopen_s", "wfopen_s", "rename"] and
+    path = op.getArgument(1)
+  )
+}
+
+predicate isFileName(GVN gvn)
+{
+  exists(FunctionCall op, Expr path |
+    filenameOperation(op, path) and
+    gvn = globalValueNumber(path)
+  )
+}
 
 from FileWrite w, SensitiveExpr source, Expr dest
 where
   DataFlow::localFlow(DataFlow::exprNode(source), DataFlow::exprNode(w.getASource())) and
-  dest = w.getDest()
+  dest = w.getDest() and
+  not isFileName(globalValueNumber(source)) // file names are not passwords
 select w, "This write into file '" + dest.toString() + "' may contain unencrypted data from $@",
   source, "this source."

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 7.5
- * @precision medium
+ * @precision high
  * @id cpp/cleartext-storage-file
  * @tags security
  *       external/cwe/cwe-313

--- a/cpp/ql/src/semmle/code/cpp/security/FileWrite.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FileWrite.qll
@@ -166,9 +166,7 @@ private predicate fileWrite(Call write, Expr source, Expr dest) {
  * character, or if it is unknown (for example the format string is not a
  * constant).
  */
-private predicate fileWriteWithConvChar(
-  FormattingFunctionCall ffc, Expr source, string conv
-) {
+private predicate fileWriteWithConvChar(FormattingFunctionCall ffc, Expr source, string conv) {
   // fprintf
   exists(FormattingFunction f, int n |
     f = ffc.getTarget() and

--- a/cpp/ql/src/semmle/code/cpp/security/SensitiveExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/SensitiveExprs.qll
@@ -19,9 +19,10 @@ private predicate suspicious(string s) {
     s.matches("%trusted%")
   ) and
   not (
-    s.matches("%hashed%") or
-    s.matches("%encrypted%") or
-    s.matches("%crypt%")
+    s.matches("%hash%") or
+    s.matches("%crypt%") or
+    s.matches("%file%") or
+    s.matches("%conf%")
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/security/SensitiveExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/SensitiveExprs.qll
@@ -19,7 +19,8 @@ private predicate suspicious(string s) {
   not (
     s.matches("%hash%") or
     s.matches("%crypt%") or
-    s.matches("%file%")
+    s.matches("%file%") or
+    s.matches("%path%")
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/security/SensitiveExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/SensitiveExprs.qll
@@ -27,14 +27,20 @@ private predicate suspicious(string s) {
  * A variable that might contain a password or other sensitive information.
  */
 class SensitiveVariable extends Variable {
-  SensitiveVariable() { suspicious(getName().toLowerCase()) }
+  SensitiveVariable() {
+    suspicious(getName().toLowerCase()) and
+    not this.getUnspecifiedType() instanceof IntegralType
+  }
 }
 
 /**
  * A function that might return a password or other sensitive information.
  */
 class SensitiveFunction extends Function {
-  SensitiveFunction() { suspicious(getName().toLowerCase()) }
+  SensitiveFunction() {
+    suspicious(getName().toLowerCase()) and
+    not this.getUnspecifiedType() instanceof IntegralType
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/security/SensitiveExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/SensitiveExprs.qll
@@ -14,15 +14,12 @@ private predicate suspicious(string s) {
   (
     s.matches("%password%") or
     s.matches("%passwd%") or
-    s.matches("%account%") or
-    s.matches("%accnt%") or
     s.matches("%trusted%")
   ) and
   not (
     s.matches("%hash%") or
     s.matches("%crypt%") or
-    s.matches("%file%") or
-    s.matches("%conf%")
+    s.matches("%file%")
   )
 }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,9 +1,6 @@
 | test2.cpp:28:2:28:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:28:36:28:43 | password | this source. |
 | test2.cpp:29:2:29:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:29:37:29:45 | thepasswd | this source. |
 | test2.cpp:30:2:30:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:30:38:30:47 | accountkey | this source. |
-| test2.cpp:31:2:31:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:31:41:31:53 | password_hash | this source. |
-| test2.cpp:33:2:33:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:33:41:33:53 | password_file | this source. |
-| test2.cpp:34:2:34:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:34:41:34:53 | passwd_config | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
 | test.cpp:73:37:73:41 | call to write | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,8 +1,13 @@
-| test2.cpp:35:2:35:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:35:36:35:43 | password | this source. |
-| test2.cpp:36:2:36:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:36:37:36:45 | thepasswd | this source. |
-| test2.cpp:41:2:41:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:41:41:41:53 | passwd_config | this source. |
-| test2.cpp:45:2:45:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:45:39:45:49 | call to getPassword | this source. |
-| test2.cpp:53:3:53:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:50:18:50:25 | password | this source. |
+| test2.cpp:43:2:43:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:43:36:43:43 | password | this source. |
+| test2.cpp:44:2:44:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:44:37:44:45 | thepasswd | this source. |
+| test2.cpp:49:2:49:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:49:41:49:53 | password_path | this source. |
+| test2.cpp:50:2:50:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:50:41:50:53 | passwd_config | this source. |
+| test2.cpp:54:2:54:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:54:41:54:52 | widepassword | this source. |
+| test2.cpp:55:2:55:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:55:40:55:51 | widepassword | this source. |
+| test2.cpp:57:2:57:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:57:39:57:49 | call to getPassword | this source. |
+| test2.cpp:65:3:65:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:62:18:62:25 | password | this source. |
+| test2.cpp:79:2:79:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:79:36:79:43 | password | this source. |
+| test2.cpp:84:4:84:10 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:84:50:84:63 | passwd_config2 | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
 | test.cpp:73:37:73:41 | call to write | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,7 +1,11 @@
-| test2.cpp:28:2:28:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:28:36:28:43 | password | this source. |
-| test2.cpp:29:2:29:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:29:37:29:45 | thepasswd | this source. |
-| test2.cpp:34:2:34:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:34:41:34:53 | passwd_config | this source. |
-| test2.cpp:40:3:40:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:37:18:37:25 | password | this source. |
+| test2.cpp:35:2:35:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:35:36:35:43 | password | this source. |
+| test2.cpp:36:2:36:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:36:37:36:45 | thepasswd | this source. |
+| test2.cpp:41:2:41:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:41:41:41:53 | passwd_config | this source. |
+| test2.cpp:42:2:42:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:42:41:42:53 | num_passwords | this source. |
+| test2.cpp:43:2:43:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:43:39:43:49 | have_passwd | this source. |
+| test2.cpp:45:2:45:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:45:39:45:49 | call to getPassword | this source. |
+| test2.cpp:47:2:47:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:47:47:47:65 | call to getPasswordMaxChars | this source. |
+| test2.cpp:53:3:53:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:50:18:50:25 | password | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
 | test.cpp:73:37:73:41 | call to write | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,6 +1,6 @@
 | test2.cpp:28:2:28:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:28:36:28:43 | password | this source. |
 | test2.cpp:29:2:29:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:29:37:29:45 | thepasswd | this source. |
-| test2.cpp:30:2:30:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:30:38:30:47 | accountkey | this source. |
+| test2.cpp:34:2:34:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:34:41:34:53 | passwd_config | this source. |
 | test2.cpp:40:3:40:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:37:18:37:25 | password | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,3 +1,9 @@
+| test2.cpp:28:2:28:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:28:36:28:43 | password | this source. |
+| test2.cpp:29:2:29:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:29:37:29:45 | thepasswd | this source. |
+| test2.cpp:30:2:30:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:30:38:30:47 | accountkey | this source. |
+| test2.cpp:31:2:31:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:31:41:31:53 | password_hash | this source. |
+| test2.cpp:33:2:33:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:33:41:33:53 | password_file | this source. |
+| test2.cpp:34:2:34:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:34:41:34:53 | passwd_config | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
 | test.cpp:73:37:73:41 | call to write | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -6,7 +6,6 @@
 | test2.cpp:57:2:57:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:57:39:57:49 | call to getPassword | this source. |
 | test2.cpp:65:3:65:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:62:18:62:25 | password | this source. |
 | test2.cpp:79:2:79:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:79:36:79:43 | password | this source. |
-| test2.cpp:84:4:84:10 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:84:50:84:63 | passwd_config2 | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
 | test.cpp:73:37:73:41 | call to write | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,10 +1,7 @@
 | test2.cpp:35:2:35:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:35:36:35:43 | password | this source. |
 | test2.cpp:36:2:36:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:36:37:36:45 | thepasswd | this source. |
 | test2.cpp:41:2:41:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:41:41:41:53 | passwd_config | this source. |
-| test2.cpp:42:2:42:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:42:41:42:53 | num_passwords | this source. |
-| test2.cpp:43:2:43:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:43:39:43:49 | have_passwd | this source. |
 | test2.cpp:45:2:45:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:45:39:45:49 | call to getPassword | this source. |
-| test2.cpp:47:2:47:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:47:47:47:65 | call to getPasswordMaxChars | this source. |
 | test2.cpp:53:3:53:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:50:18:50:25 | password | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,6 +1,5 @@
 | test2.cpp:43:2:43:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:43:36:43:43 | password | this source. |
 | test2.cpp:44:2:44:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:44:37:44:45 | thepasswd | this source. |
-| test2.cpp:49:2:49:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:49:41:49:53 | password_path | this source. |
 | test2.cpp:50:2:50:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:50:41:50:53 | passwd_config | this source. |
 | test2.cpp:54:2:54:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:54:41:54:52 | widepassword | this source. |
 | test2.cpp:55:2:55:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:55:40:55:51 | widepassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -5,7 +5,6 @@
 | test2.cpp:55:2:55:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:55:40:55:51 | widepassword | this source. |
 | test2.cpp:57:2:57:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:57:39:57:49 | call to getPassword | this source. |
 | test2.cpp:65:3:65:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:62:18:62:25 | password | this source. |
-| test2.cpp:79:2:79:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:79:36:79:43 | password | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
 | test.cpp:73:37:73:41 | call to write | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,6 +1,7 @@
 | test2.cpp:28:2:28:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:28:36:28:43 | password | this source. |
 | test2.cpp:29:2:29:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:29:37:29:45 | thepasswd | this source. |
 | test2.cpp:30:2:30:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:30:38:30:47 | accountkey | this source. |
+| test2.cpp:40:3:40:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:37:18:37:25 | password | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
 | test.cpp:73:37:73:41 | call to write | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -81,7 +81,7 @@ void tests(FILE *log, myStruct &s)
 	{
 		if (fopen(s.passwd_config2, "rt") == 0)
 		{
-			fprintf(log, "could not open file '%s'.\n", s.passwd_config2); // GOOD [FALSE POSITIVE]
+			fprintf(log, "could not open file '%s'.\n", s.passwd_config2); // GOOD
 		}
 	}
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -39,12 +39,12 @@ void tests(FILE *log, myStruct &s)
 	fprintf(log, "encrypted_passwd = %s\n", s.encrypted_passwd); // GOOD
 	fprintf(log, "password_file = %s\n", s.password_file); // GOOD
 	fprintf(log, "passwd_config = %s\n", s.passwd_config); // DUBIOUS [REPORTED]
-	fprintf(log, "num_passwords = %i\n", s.num_passwords); // GOOD [FALSE POSITIVE]
-	fprintf(log, "have_passwd = %i\n", s.have_passwd); // GOOD [FALSE POSITIVE]
+	fprintf(log, "num_passwords = %i\n", s.num_passwords); // GOOD
+	fprintf(log, "have_passwd = %i\n", s.have_passwd); // GOOD
 
 	fprintf(log, "getPassword() = %i\n", getPassword()); // BAD
 	fprintf(log, "getPasswordHash() = %i\n", getPasswordHash()); // GOOD
-	fprintf(log, "getPasswordMaxChars() = %i\n", getPasswordMaxChars()); // GOOD [FALSE POSITIVE]
+	fprintf(log, "getPasswordMaxChars() = %i\n", getPasswordMaxChars()); // GOOD
 
 	{
 		char *cpy1 = s.password;

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -46,7 +46,7 @@ void tests(FILE *log, myStruct &s)
 	fprintf(log, "password_hash = %s\n", s.password_hash); // GOOD
 	fprintf(log, "encrypted_passwd = %s\n", s.encrypted_passwd); // GOOD
 	fprintf(log, "password_file = %s\n", s.password_file); // GOOD
-	fprintf(log, "password_path = %s\n", s.password_path); // GOOD [FALSE POSITIVE]
+	fprintf(log, "password_path = %s\n", s.password_path); // GOOD
 	fprintf(log, "passwd_config = %s\n", s.passwd_config); // DUBIOUS [REPORTED]
 	fprintf(log, "num_passwords = %i\n", s.num_passwords); // GOOD
 	fprintf(log, "password_tries = %i\n", *(s.password_tries)); // GOOD

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -37,7 +37,7 @@ void tests(FILE *log, myStruct &s)
 		char *cpy1 = s.password;
 		char *cpy2 = crypt(s.password);
 
-		fprintf(log, "cpy1 = %s\n", cpy1); // BAD
+		fprintf(log, "cpy1 = %s\n", cpy1); // BAD [NOT DETECTED]
 		fprintf(log, "cpy2 = %s\n", cpy2); // GOOD
 	}
 
@@ -45,10 +45,9 @@ void tests(FILE *log, myStruct &s)
 		char buf[1024];
 
 		strcpy(buf, s.password);
-		fprintf(log, "buf = %s\n", buf); // BAD
+		fprintf(log, "buf = %s\n", buf); // BAD [NOT DETECTED]
 		
 		strcpy(buf, s.password_hash);
 		fprintf(log, "buf = %s\n", buf); // GOOD
 	}
 }
-

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -19,19 +19,19 @@ struct myStruct
 
 	// not sensitive
 	char *password_file;
-	char *passwd_config;
-	
-};
 
+	// dubious
+	char *passwd_config;
+};
 void tests(FILE *log, myStruct &s)
 {
 	fprintf(log, "password = %s\n", s.password); // BAD
 	fprintf(log, "thepasswd = %s\n", s.thepasswd); // BAD
-	fprintf(log, "accountkey = %s\n", s.accountkey); // BAD
+	fprintf(log, "accountkey = %s\n", s.accountkey); // DUBIOUS [NOT REPORTED]
 	fprintf(log, "password_hash = %s\n", s.password_hash); // GOOD
 	fprintf(log, "encrypted_passwd = %s\n", s.encrypted_passwd); // GOOD
 	fprintf(log, "password_file = %s\n", s.password_file); // GOOD
-	fprintf(log, "passwd_config = %s\n", s.passwd_config); // GOOD
+	fprintf(log, "passwd_config = %s\n", s.passwd_config); // DUBIOUS [REPORTED]
 
 	{
 		char *cpy1 = s.password;

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -37,7 +37,7 @@ void tests(FILE *log, myStruct &s)
 		char *cpy1 = s.password;
 		char *cpy2 = crypt(s.password);
 
-		fprintf(log, "cpy1 = %s\n", cpy1); // BAD [NOT DETECTED]
+		fprintf(log, "cpy1 = %s\n", cpy1); // BAD
 		fprintf(log, "cpy2 = %s\n", cpy2); // GOOD
 	}
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -19,10 +19,17 @@ struct myStruct
 
 	// not sensitive
 	char *password_file;
+	int num_passwords;
+	bool have_passwd;
 
 	// dubious
 	char *passwd_config;
 };
+
+char *getPassword();
+char *getPasswordHash();
+int getPasswordMaxChars();
+
 void tests(FILE *log, myStruct &s)
 {
 	fprintf(log, "password = %s\n", s.password); // BAD
@@ -32,6 +39,12 @@ void tests(FILE *log, myStruct &s)
 	fprintf(log, "encrypted_passwd = %s\n", s.encrypted_passwd); // GOOD
 	fprintf(log, "password_file = %s\n", s.password_file); // GOOD
 	fprintf(log, "passwd_config = %s\n", s.passwd_config); // DUBIOUS [REPORTED]
+	fprintf(log, "num_passwords = %i\n", s.num_passwords); // GOOD [FALSE POSITIVE]
+	fprintf(log, "have_passwd = %i\n", s.have_passwd); // GOOD [FALSE POSITIVE]
+
+	fprintf(log, "getPassword() = %i\n", getPassword()); // BAD
+	fprintf(log, "getPasswordHash() = %i\n", getPasswordHash()); // GOOD
+	fprintf(log, "getPasswordMaxChars() = %i\n", getPasswordMaxChars()); // GOOD [FALSE POSITIVE]
 
 	{
 		char *cpy1 = s.password;

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -1,6 +1,10 @@
 
 #define FILE int
 
+typedef unsigned long size_t;
+
+FILE *fopen(const char *filename, const char *mode);
+int snprintf(char *s, size_t n, const char *format, ...);
 int fprintf(FILE *stream, const char *format, ...);
 char *strcpy(char *s1, const char *s2);
 
@@ -12,6 +16,7 @@ struct myStruct
 	char *password;
 	char *thepasswd;
 	char *accountkey;
+	wchar_t *widepassword;
 
 	// encrypted
 	char password_hash[64];
@@ -19,11 +24,14 @@ struct myStruct
 
 	// not sensitive
 	char *password_file;
+	char *password_path;
 	int num_passwords;
+	int *password_tries;
 	bool have_passwd;
 
 	// dubious
 	char *passwd_config;
+	char *passwd_config2;
 };
 
 char *getPassword();
@@ -38,12 +46,16 @@ void tests(FILE *log, myStruct &s)
 	fprintf(log, "password_hash = %s\n", s.password_hash); // GOOD
 	fprintf(log, "encrypted_passwd = %s\n", s.encrypted_passwd); // GOOD
 	fprintf(log, "password_file = %s\n", s.password_file); // GOOD
+	fprintf(log, "password_path = %s\n", s.password_path); // GOOD [FALSE POSITIVE]
 	fprintf(log, "passwd_config = %s\n", s.passwd_config); // DUBIOUS [REPORTED]
 	fprintf(log, "num_passwords = %i\n", s.num_passwords); // GOOD
+	fprintf(log, "password_tries = %i\n", *(s.password_tries)); // GOOD
 	fprintf(log, "have_passwd = %i\n", s.have_passwd); // GOOD
+	fprintf(log, "widepassword = %ls\n", s.widepassword); // BAD
+	fprintf(log, "widepassword = %S\n", s.widepassword); // BAD
 
-	fprintf(log, "getPassword() = %i\n", getPassword()); // BAD
-	fprintf(log, "getPasswordHash() = %i\n", getPasswordHash()); // GOOD
+	fprintf(log, "getPassword() = %s\n", getPassword()); // BAD
+	fprintf(log, "getPasswordHash() = %s\n", getPasswordHash()); // GOOD
 	fprintf(log, "getPasswordMaxChars() = %i\n", getPasswordMaxChars()); // GOOD
 
 	{
@@ -62,5 +74,21 @@ void tests(FILE *log, myStruct &s)
 		
 		strcpy(buf, s.password_hash);
 		fprintf(log, "buf = %s\n", buf); // GOOD
+	}
+
+	fprintf(log, "password = %p\n", s.password); // GOOD [FALSE POSITIVE]
+
+	{
+		if (fopen(s.passwd_config2, "rt") == 0)
+		{
+			fprintf(log, "could not open file '%s'.\n", s.passwd_config2); // GOOD [FALSE POSITIVE]
+		}
+	}
+
+	{
+		char buffer[1024];
+
+		snprintf(buffer, 1024, "password = %s", s.password);
+		fprintf(log, "log: %s", buffer); // BAD [NOT DETECTED]
 	}
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -1,0 +1,54 @@
+
+#define FILE int
+
+int fprintf(FILE *stream, const char *format, ...);
+char *strcpy(char *s1, const char *s2);
+
+char *crypt(char *input);
+
+struct myStruct
+{
+	// sensitive
+	char *password;
+	char *thepasswd;
+	char *accountkey;
+
+	// encrypted
+	char password_hash[64];
+	char *encrypted_passwd;
+
+	// not sensitive
+	char *password_file;
+	char *passwd_config;
+	
+};
+
+void tests(FILE *log, myStruct &s)
+{
+	fprintf(log, "password = %s\n", s.password); // BAD
+	fprintf(log, "thepasswd = %s\n", s.thepasswd); // BAD
+	fprintf(log, "accountkey = %s\n", s.accountkey); // BAD
+	fprintf(log, "password_hash = %s\n", s.password_hash); // GOOD
+	fprintf(log, "encrypted_passwd = %s\n", s.encrypted_passwd); // GOOD
+	fprintf(log, "password_file = %s\n", s.password_file); // GOOD
+	fprintf(log, "passwd_config = %s\n", s.passwd_config); // GOOD
+
+	{
+		char *cpy1 = s.password;
+		char *cpy2 = crypt(s.password);
+
+		fprintf(log, "cpy1 = %s\n", cpy1); // BAD
+		fprintf(log, "cpy2 = %s\n", cpy2); // GOOD
+	}
+
+	{
+		char buf[1024];
+
+		strcpy(buf, s.password);
+		fprintf(log, "buf = %s\n", buf); // BAD
+		
+		strcpy(buf, s.password_hash);
+		fprintf(log, "buf = %s\n", buf); // GOOD
+	}
+}
+

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -76,7 +76,7 @@ void tests(FILE *log, myStruct &s)
 		fprintf(log, "buf = %s\n", buf); // GOOD
 	}
 
-	fprintf(log, "password = %p\n", s.password); // GOOD [FALSE POSITIVE]
+	fprintf(log, "password = %p\n", s.password); // GOOD
 
 	{
 		if (fopen(s.passwd_config2, "rt") == 0)


### PR DESCRIPTION
Improve the `CleartextFileWrite.ql` query:
 - add test cases inspired by things I found on LGTM.
 - straightforward improvements to the heuristic rules in `SensitiveExprs.qll` (reduces FPs in this query and a couple of others that also use the same library).
 - add simple dataflow to `CleartextFileWrite.ql` (increases TPs).
 - promote the query to `@precision high`.

I'm open to discussion about whether this is really enough to justify `@precision high`.  I've only spent a few hours on these improvements, but the results look good to me (https://lgtm.com/query/5235174286264674280/) and enabling it will modestly improve our SAMATE results as well as flagging this bad practice to users.