### PR TITLE
C++: Potentially improve performance of call-context calculation

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
@@ -238,12 +238,11 @@ predicate mayBenefitFromCallContext(CallInstruction call, Function f) {
 /**
  * Holds if `call` is a call through a function pointer, and the pointer
  * value is given as the `arg`'th argument to `f`.
- *
- * Note that `f` may be several layers up through the call chain.
  */
 private predicate mayBenefitFromCallContext(
   VirtualDispatch::DataSensitiveCall call, Function f, int arg
 ) {
+  f = pragma[only_bind_out](call).getEnclosingCallable() and
   exists(InitializeParameterInstruction init |
     not exists(call.getStaticCallTarget()) and
     init.getEnclosingFunction() = f and


### PR DESCRIPTION
As @aschackmull explained [here](https://github.com/github/codeql/pull/6158#discussion_r669396346), the dataflow library only has one level of call context, so it doesn't really make sense to include a `Function` that is not the enclosing callable of `call` in `mayBenefitFromCallContext`.

Performance looks fine on `openjdk/jdk`:
```
Tuple counts for DataFlowDispatch::mayBenefitFromCallContext#2#fff/3@f94a48:
  1186173 ~0%     {2} r1 = SCAN DataFlowDispatch::VirtualDispatch::DataSensitiveCall::flowsFrom#fff OUTPUT In.0 'call', In.1
  1184881 ~0%     {2} r2 = STREAM DEDUP r1
  42178   ~0%     {2} r3 = r2 AND NOT DataFlowDispatch::mayBenefitFromCallContext#2#fff#antijoin_rhs(Lhs.0 'call', Lhs.1)
  42178   ~5%     {3} r4 = SCAN r3 OUTPUT In.0 'call', In.0 'call', In.1
  42178   ~7%     {3} r5 = JOIN r4 WITH DataFlowDispatch::VirtualDispatch::DataSensitiveCall#class#f ON FIRST 1 OUTPUT Lhs.2, Lhs.1 'call', Lhs.0
  21614   ~0%     {3} r6 = JOIN r5 WITH DataFlowUtil::Cached::TInstructionNode#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.2, Lhs.1 'call', Rhs.1
  21614   ~0%     {3} r7 = JOIN r6 WITH DataFlowImplCommon::Cached::callEnclosingCallable#ff ON FIRST 1 OUTPUT Lhs.2, Rhs.1 'f', Lhs.1 'call'
  13373   ~1%     {3} r8 = JOIN r7 WITH Instruction::Instruction::getEnclosingFunction_dispred#3#ff ON FIRST 2 OUTPUT Lhs.0, Lhs.2 'call', Lhs.1 'f'
  227     ~0%     {3} r9 = JOIN r8 WITH Instruction::InitializeParameterInstruction::getParameter_dispred#3#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'call', Lhs.2 'f'
  233     ~0%     {3} r10 = JOIN r9 WITH params ON FIRST 1 OUTPUT Lhs.1 'call', Lhs.2 'f', Rhs.2 'arg'
  return r10
```