### PR TITLE
C#: Remove redundant conjunct in `ssaDefReachesReadWithinBlock`

### DIFF
--- a/csharp/ql/src/semmle/code/cil/internal/SsaImplCommon.qll
+++ b/csharp/ql/src/semmle/code/cil/internal/SsaImplCommon.qll
@@ -284,8 +284,7 @@ private module SsaDefReaches {
   predicate ssaDefReachesReadWithinBlock(SourceVariable v, Definition def, BasicBlock bb, int i) {
     exists(int rnk |
       ssaDefReachesRank(bb, def, rnk, v) and
-      rnk = ssaRefRank(bb, i, v, SsaRead()) and
-      variableRead(bb, i, v, _)
+      rnk = ssaRefRank(bb, i, v, SsaRead())
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/pressa/SsaImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/pressa/SsaImplCommon.qll
@@ -284,8 +284,7 @@ private module SsaDefReaches {
   predicate ssaDefReachesReadWithinBlock(SourceVariable v, Definition def, BasicBlock bb, int i) {
     exists(int rnk |
       ssaDefReachesRank(bb, def, rnk, v) and
-      rnk = ssaRefRank(bb, i, v, SsaRead()) and
-      variableRead(bb, i, v, _)
+      rnk = ssaRefRank(bb, i, v, SsaRead())
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/SsaImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/SsaImplCommon.qll
@@ -284,8 +284,7 @@ private module SsaDefReaches {
   predicate ssaDefReachesReadWithinBlock(SourceVariable v, Definition def, BasicBlock bb, int i) {
     exists(int rnk |
       ssaDefReachesRank(bb, def, rnk, v) and
-      rnk = ssaRefRank(bb, i, v, SsaRead()) and
-      variableRead(bb, i, v, _)
+      rnk = ssaRefRank(bb, i, v, SsaRead())
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/basessa/SsaImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/basessa/SsaImplCommon.qll
@@ -284,8 +284,7 @@ private module SsaDefReaches {
   predicate ssaDefReachesReadWithinBlock(SourceVariable v, Definition def, BasicBlock bb, int i) {
     exists(int rnk |
       ssaDefReachesRank(bb, def, rnk, v) and
-      rnk = ssaRefRank(bb, i, v, SsaRead()) and
-      variableRead(bb, i, v, _)
+      rnk = ssaRefRank(bb, i, v, SsaRead())
     )
   }
 


### PR DESCRIPTION
My attention was drawn to this predicate because of a bad join-order
```
[2021-07-15 12:06:35] (483s) Tuple counts for SsaImplCommon::SsaDefReaches::ssaDefReachesReadWithinBlock#2#ffff/4@fe48da:
                      5261258218 ~1%     {5} r1 = JOIN SsaImplCommon::SsaDefReaches::ssaDefReachesRank#2#ffff_0312#join_rhs WITH SsaImplSpecific::variableRead#2#cpe#123#fff_021#join_rhs ON FIRST 2 OUTPUT Lhs.0 'bb', Rhs.2 'i', Lhs.1 'v', Lhs.3, Lhs.2 'def'
                      631031     ~5%     {5} r2 = JOIN r1 WITH SsaImplCommon::SsaDefReaches::ssaRefRank#2#fffff_01243#join_rhs ON FIRST 4 OUTPUT Rhs.4, Lhs.0 'bb', Lhs.4 'def', Lhs.2 'v', Lhs.1 'i'
                      631031     ~0%     {4} r3 = JOIN r2 WITH construct<TSsaRefKind#2,0>@dom#SsaImplCommon::SsaDefReaches::SsaRead#2#0#f ON FIRST 1 OUTPUT Lhs.3 'v', Lhs.2 'def', Lhs.1 'bb', Lhs.4 'i'
                                         return r3
```
where `ssaDefReachesRank` and `variableRead` were joined on just `bb` and `v`. It turns out that the `variableRead(bb, i, v, _)` conjunct is actually not needed, since it is implied by `ssaRefRank(bb, i, v, SsaRead())`. Removing the conjunct therefore both simplifies the logic, and improves the join order:
```
[2021-07-15 12:20:59] (4s) Tuple counts for SsaImplCommon::SsaDefReaches::ssaDefReachesReadWithinBlock#2#ffff/4@d86644:
                      941503  ~0%     {4} r1 = SCAN SsaImplCommon::SsaDefReaches::ssaDefReachesRank#2#ffff OUTPUT In.0 'bb', In.3 'v', In.2, In.1 'def'
                      941503  ~1%     {5} r2 = JOIN r1 WITH SsaImplCommon::SsaDefReaches::ssaRefRank#2#fffff_02413#join_rhs ON FIRST 3 OUTPUT Rhs.4, Lhs.0 'bb', Lhs.3 'def', Lhs.1 'v', Rhs.3 'i'
                      631031  ~0%     {4} r3 = JOIN r2 WITH construct<TSsaRefKind#2,0>@dom#SsaImplCommon::SsaDefReaches::SsaRead#2#0#f ON FIRST 1 OUTPUT Lhs.3 'v', Lhs.2 'def', Lhs.1 'bb', Lhs.4 'i'
                                      return r3
```

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1203/