### PR TITLE
JS: Add steps for array related utility libraries

### DIFF
--- a/javascript/change-notes/2021-07-15-array-libs.md
+++ b/javascript/change-notes/2021-07-15-array-libs.md
@@ -5,4 +5,7 @@ lgtm,codescanning
     [array.prototype.find](https://npmjs.com/package/array.prototype.find),
     [array-find](https://npmjs.com/package/array-find),
     [arrify](https://npmjs.com/package/arrify),
-    [array-ify](https://npmjs.com/package/array-ify)
+    [array-ify](https://npmjs.com/package/array-ify),
+    [array-union](https://npmjs.com/package/array-union),
+    [array-uniq](https://npmjs.com/package/array-uniq),
+    [uniq](https://npmjs.com/package/uniq)

--- a/javascript/change-notes/2021-07-15-array-libs.md
+++ b/javascript/change-notes/2021-07-15-array-libs.md
@@ -1,4 +1,6 @@
 lgtm,codescanning
 * The dataflow libraries now model dataflow through more array libraries.
   Affected packages are
-    [array-from](https://npmjs.com/package/array-from)
+    [array-from](https://npmjs.com/package/array-from),
+    [array.prototype.find](https://npmjs.com/package/array.prototype.find),
+    [array-find](https://npmjs.com/package/array-find)

--- a/javascript/change-notes/2021-07-15-array-libs.md
+++ b/javascript/change-notes/2021-07-15-array-libs.md
@@ -3,4 +3,6 @@ lgtm,codescanning
   Affected packages are
     [array-from](https://npmjs.com/package/array-from),
     [array.prototype.find](https://npmjs.com/package/array.prototype.find),
-    [array-find](https://npmjs.com/package/array-find)
+    [array-find](https://npmjs.com/package/array-find),
+    [arrify](https://npmjs.com/package/arrify),
+    [array-ify](https://npmjs.com/package/array-ify)

--- a/javascript/change-notes/2021-07-15-array-libs.md
+++ b/javascript/change-notes/2021-07-15-array-libs.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* The dataflow libraries now model dataflow through more array libraries.
+  Affected packages are
+    [array-from](https://npmjs.com/package/array-from)

--- a/javascript/change-notes/2021-07-15-array-libs.md
+++ b/javascript/change-notes/2021-07-15-array-libs.md
@@ -8,4 +8,8 @@ lgtm,codescanning
     [array-ify](https://npmjs.com/package/array-ify),
     [array-union](https://npmjs.com/package/array-union),
     [array-uniq](https://npmjs.com/package/array-uniq),
-    [uniq](https://npmjs.com/package/uniq)
+    [uniq](https://npmjs.com/package/uniq),
+    [array-flatten](https://npmjs.com/package/array-flatten),
+    [arr-flatten](https://npmjs.com/package/arr-flatten),
+    [flatten](https://npmjs.com/package/flatten),
+    [array.prototype.flat](https://npmjs.com/package/array.prototype.flat)

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -68,7 +68,7 @@ module ArrayTaintTracking {
     succ = call
     or
     // `e = Array.from(x)`: if `x` is tainted, then so is `e`.
-    call = DataFlow::globalVarRef("Array").getAPropertyRead("from").getACall() and
+    call = arrayFromCall() and
     pred = call.getAnArgument() and
     succ = call
     or
@@ -97,7 +97,7 @@ private module ArrayDataFlow {
       DataFlow::Node pred, DataFlow::Node succ, string fromProp, string toProp
     ) {
       exists(DataFlow::CallNode call |
-        call = DataFlow::globalVarRef("Array").getAMemberCall("from") and
+        call = arrayFromCall() and
         pred = call.getArgument(0) and
         succ = call and
         fromProp = arrayLikeElement() and
@@ -296,5 +296,21 @@ private module ArrayDataFlow {
         succ = call
       )
     }
+  }
+}
+
+private import ArrayLibraries
+
+/**
+ * Classes and predicates modelling various libraries that work on arrays or array-like structures.
+ */
+private module ArrayLibraries {
+  /**
+   * Gets a call to `Array.from` or a polyfill implementing the same functionality.
+   */
+  DataFlow::CallNode arrayFromCall() {
+    result = DataFlow::globalVarRef("Array").getAMemberCall("from")
+    or
+    result = DataFlow::moduleImport("array-from").getACall()
   }
 }

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -342,4 +342,15 @@ private module ArrayLibraries {
     result = DataFlow::moduleImport(["array.prototype.find", "array-find"]).getACall() and
     array = result.getArgument(0)
   }
+
+  /**
+   * A taint step through the `arrify` library, or other libraries that (maybe) convert values into arrays.
+   */
+  private class ArrayifyStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(API::CallNode call | call = API::moduleImport(["arrify", "array-ify"]).getACall() |
+        pred = call.getArgument(0) and succ = call
+      )
+    }
+  }
 }

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -389,4 +389,21 @@ private module ArrayLibraries {
       )
     }
   }
+
+  /**
+   * A taint step through a call to `Array.prototype.flat` or a polyfill implementing array flattening.
+   */
+  private class ArrayFlatStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::CallNode call | succ = call |
+        call.(DataFlow::MethodCallNode).getMethodName() = "flat" and
+        pred = call.getReceiver()
+        or
+        call =
+          API::moduleImport(["array-flatten", "arr-flatten", "flatten", "array.prototype.flat"])
+              .getACall() and
+        pred = call.getAnArgument()
+      )
+    }
+  }
 }

--- a/javascript/ql/test/library-tests/Arrays/DataFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/DataFlow.expected
@@ -10,6 +10,7 @@
 | arrays.js:2:16:2:23 | "source" | arrays.js:71:10:71:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:74:8:74:29 | arr.fin ... llback) |
 | arrays.js:2:16:2:23 | "source" | arrays.js:77:8:77:35 | arrayFi ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:81:10:81:10 | x |
 | arrays.js:18:22:18:29 | "source" | arrays.js:18:50:18:50 | e |
 | arrays.js:22:15:22:22 | "source" | arrays.js:23:8:23:17 | arr2.pop() |
 | arrays.js:25:15:25:22 | "source" | arrays.js:26:8:26:17 | arr3.pop() |

--- a/javascript/ql/test/library-tests/Arrays/DataFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/DataFlow.expected
@@ -8,6 +8,8 @@
 | arrays.js:2:16:2:23 | "source" | arrays.js:60:10:60:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:66:10:66:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:71:10:71:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:74:8:74:29 | arr.fin ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:77:8:77:35 | arrayFi ... llback) |
 | arrays.js:18:22:18:29 | "source" | arrays.js:18:50:18:50 | e |
 | arrays.js:22:15:22:22 | "source" | arrays.js:23:8:23:17 | arr2.pop() |
 | arrays.js:25:15:25:22 | "source" | arrays.js:26:8:26:17 | arr3.pop() |

--- a/javascript/ql/test/library-tests/Arrays/DataFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/DataFlow.expected
@@ -7,6 +7,7 @@
 | arrays.js:2:16:2:23 | "source" | arrays.js:56:10:56:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:60:10:60:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:66:10:66:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:71:10:71:10 | x |
 | arrays.js:18:22:18:29 | "source" | arrays.js:18:50:18:50 | e |
 | arrays.js:22:15:22:22 | "source" | arrays.js:23:8:23:17 | arr2.pop() |
 | arrays.js:25:15:25:22 | "source" | arrays.js:26:8:26:17 | arr3.pop() |

--- a/javascript/ql/test/library-tests/Arrays/arrays.js
+++ b/javascript/ql/test/library-tests/Arrays/arrays.js
@@ -75,4 +75,9 @@
 
   const arrayFind = require("array-find");
   sink(arrayFind(arr, someCallback)); // NOT OK
+
+  const uniq = require("uniq");
+  for (const x of uniq(arr)) {
+    sink(x); // NOT OK
+  }
 });

--- a/javascript/ql/test/library-tests/Arrays/arrays.js
+++ b/javascript/ql/test/library-tests/Arrays/arrays.js
@@ -70,4 +70,9 @@
   for (const x of arrayFrom(arr)) {
     sink(x); // NOT OK
   }
+
+  sink(arr.find(someCallback)); // NOT OK
+
+  const arrayFind = require("array-find");
+  sink(arrayFind(arr, someCallback)); // NOT OK
 });

--- a/javascript/ql/test/library-tests/Arrays/arrays.js
+++ b/javascript/ql/test/library-tests/Arrays/arrays.js
@@ -65,4 +65,9 @@
   for (const x of arr7) {
     sink(x); // NOT OK
   }
+
+  const arrayFrom = require("array-from");
+  for (const x of arrayFrom(arr)) {
+    sink(x); // NOT OK
+  }
 });

--- a/javascript/ql/test/library-tests/Arrays/printAst.expected
+++ b/javascript/ql/test/library-tests/Arrays/printAst.expected
@@ -1,9 +1,9 @@
 nodes
-| arrays.js:1:1:68:2 | [ParExpr] (functi ... } }) | semmle.label | [ParExpr] (functi ... } }) |
-| arrays.js:1:1:68:3 | [ExprStmt] (functi ... } }); | semmle.label | [ExprStmt] (functi ... } }); |
-| arrays.js:1:1:68:3 | [ExprStmt] (functi ... } }); | semmle.order | 1 |
-| arrays.js:1:2:68:1 | [FunctionExpr] functio ... K } } | semmle.label | [FunctionExpr] functio ... K } } |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | semmle.label | [BlockStmt] { let ... K } } |
+| arrays.js:1:1:83:2 | [ParExpr] (functi ... } }) | semmle.label | [ParExpr] (functi ... } }) |
+| arrays.js:1:1:83:3 | [ExprStmt] (functi ... } }); | semmle.label | [ExprStmt] (functi ... } }); |
+| arrays.js:1:1:83:3 | [ExprStmt] (functi ... } }); | semmle.order | 1 |
+| arrays.js:1:2:83:1 | [FunctionExpr] functio ... K } } | semmle.label | [FunctionExpr] functio ... K } } |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | semmle.label | [BlockStmt] { let ... K } } |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | [DeclStmt] let source = ... |
 | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | [VarDecl] source |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | [VariableDeclarator] source = "source" |
@@ -282,6 +282,74 @@ nodes
 | arrays.js:66:5:66:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
 | arrays.js:66:5:66:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
 | arrays.js:66:10:66:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | semmle.label | [DeclStmt] const arrayFrom = ... |
+| arrays.js:69:9:69:17 | [VarDecl] arrayFrom | semmle.label | [VarDecl] arrayFrom |
+| arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | semmle.label | [VariableDeclarator] arrayFr ... -from") |
+| arrays.js:69:21:69:27 | [VarRef] require | semmle.label | [VarRef] require |
+| arrays.js:69:21:69:41 | [CallExpr] require ... -from") | semmle.label | [CallExpr] require ... -from") |
+| arrays.js:69:29:69:40 | [Literal] "array-from" | semmle.label | [Literal] "array-from" |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:70:8:70:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:70:14:70:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:70:14:70:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:70:19:70:27 | [VarRef] arrayFrom | semmle.label | [VarRef] arrayFrom |
+| arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | semmle.label | [CallExpr] arrayFrom(arr) |
+| arrays.js:70:29:70:31 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:70:35:72:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:71:5:71:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:71:5:71:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:71:10:71:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:74:3:74:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | semmle.label | [CallExpr] sink(ar ... lback)) |
+| arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | semmle.label | [ExprStmt] sink(ar ... back)); |
+| arrays.js:74:8:74:10 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:74:8:74:15 | [DotExpr] arr.find | semmle.label | [DotExpr] arr.find |
+| arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | semmle.label | [MethodCallExpr] arr.fin ... llback) |
+| arrays.js:74:12:74:15 | [Label] find | semmle.label | [Label] find |
+| arrays.js:74:17:74:28 | [VarRef] someCallback | semmle.label | [VarRef] someCallback |
+| arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | semmle.label | [DeclStmt] const arrayFind = ... |
+| arrays.js:76:9:76:17 | [VarDecl] arrayFind | semmle.label | [VarDecl] arrayFind |
+| arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | semmle.label | [VariableDeclarator] arrayFi ... -find") |
+| arrays.js:76:21:76:27 | [VarRef] require | semmle.label | [VarRef] require |
+| arrays.js:76:21:76:41 | [CallExpr] require ... -find") | semmle.label | [CallExpr] require ... -find") |
+| arrays.js:76:29:76:40 | [Literal] "array-find" | semmle.label | [Literal] "array-find" |
+| arrays.js:77:3:77:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | semmle.label | [CallExpr] sink(ar ... lback)) |
+| arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | semmle.label | [ExprStmt] sink(ar ... back)); |
+| arrays.js:77:8:77:16 | [VarRef] arrayFind | semmle.label | [VarRef] arrayFind |
+| arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | semmle.label | [CallExpr] arrayFi ... llback) |
+| arrays.js:77:18:77:20 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:77:23:77:34 | [VarRef] someCallback | semmle.label | [VarRef] someCallback |
+| arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | semmle.label | [DeclStmt] const uniq = ... |
+| arrays.js:79:9:79:12 | [VarDecl] uniq | semmle.label | [VarDecl] uniq |
+| arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.label | [VariableDeclarator] uniq = ... "uniq") |
+| arrays.js:79:16:79:22 | [VarRef] require | semmle.label | [VarRef] require |
+| arrays.js:79:16:79:30 | [CallExpr] require("uniq") | semmle.label | [CallExpr] require("uniq") |
+| arrays.js:79:24:79:29 | [Literal] "uniq" | semmle.label | [Literal] "uniq" |
+| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | semmle.label | [ForOfStmt] for (co ... OK } |
+| arrays.js:80:8:80:14 | [DeclStmt] const x = ... | semmle.label | [DeclStmt] const x = ... |
+| arrays.js:80:14:80:14 | [VarDecl] x | semmle.label | [VarDecl] x |
+| arrays.js:80:14:80:14 | [VariableDeclarator] x | semmle.label | [VariableDeclarator] x |
+| arrays.js:80:19:80:22 | [VarRef] uniq | semmle.label | [VarRef] uniq |
+| arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | semmle.label | [CallExpr] uniq(arr) |
+| arrays.js:80:24:80:26 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:80:30:82:3 | [BlockStmt] { s ... OK } | semmle.label | [BlockStmt] { s ... OK } |
+| arrays.js:81:5:81:8 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:81:5:81:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
+| arrays.js:81:5:81:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
+| arrays.js:81:10:81:10 | [VarRef] x | semmle.label | [VarRef] x |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
@@ -318,74 +386,88 @@ nodes
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 edges
-| arrays.js:1:1:68:2 | [ParExpr] (functi ... } }) | arrays.js:1:2:68:1 | [FunctionExpr] functio ... K } } | semmle.label | 1 |
-| arrays.js:1:1:68:2 | [ParExpr] (functi ... } }) | arrays.js:1:2:68:1 | [FunctionExpr] functio ... K } } | semmle.order | 1 |
-| arrays.js:1:1:68:3 | [ExprStmt] (functi ... } }); | arrays.js:1:1:68:2 | [ParExpr] (functi ... } }) | semmle.label | 1 |
-| arrays.js:1:1:68:3 | [ExprStmt] (functi ... } }); | arrays.js:1:1:68:2 | [ParExpr] (functi ... } }) | semmle.order | 1 |
-| arrays.js:1:2:68:1 | [FunctionExpr] functio ... K } } | arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | semmle.label | 5 |
-| arrays.js:1:2:68:1 | [FunctionExpr] functio ... K } } | arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | semmle.order | 5 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | 1 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.order | 1 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.label | 2 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.order | 2 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.label | 3 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.order | 3 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.label | 4 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.order | 4 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.label | 5 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.order | 5 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.label | 6 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.order | 6 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.label | 7 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.order | 7 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.label | 8 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.order | 8 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.label | 9 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.order | 9 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.label | 10 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.order | 10 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.label | 11 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.order | 11 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.label | 12 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.order | 12 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.label | 13 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.order | 13 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.label | 14 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.order | 14 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.label | 15 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.order | 15 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.label | 16 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.label | 18 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.order | 18 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 19 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 19 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 20 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 20 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.label | 21 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.order | 21 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.label | 22 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.order | 22 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 23 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 23 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 24 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 24 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.label | 25 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.order | 25 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.label | 26 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.order | 26 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.label | 27 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.order | 27 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.label | 28 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.order | 28 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.label | 29 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.order | 29 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 30 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 30 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
-| arrays.js:1:14:68:1 | [BlockStmt] { let ... K } } | arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
+| arrays.js:1:1:83:2 | [ParExpr] (functi ... } }) | arrays.js:1:2:83:1 | [FunctionExpr] functio ... K } } | semmle.label | 1 |
+| arrays.js:1:1:83:2 | [ParExpr] (functi ... } }) | arrays.js:1:2:83:1 | [FunctionExpr] functio ... K } } | semmle.order | 1 |
+| arrays.js:1:1:83:3 | [ExprStmt] (functi ... } }); | arrays.js:1:1:83:2 | [ParExpr] (functi ... } }) | semmle.label | 1 |
+| arrays.js:1:1:83:3 | [ExprStmt] (functi ... } }); | arrays.js:1:1:83:2 | [ParExpr] (functi ... } }) | semmle.order | 1 |
+| arrays.js:1:2:83:1 | [FunctionExpr] functio ... K } } | arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | semmle.label | 5 |
+| arrays.js:1:2:83:1 | [FunctionExpr] functio ... K } } | arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | semmle.order | 5 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | 1 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.order | 1 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.label | 2 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.order | 2 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.label | 3 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.order | 3 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.label | 4 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.order | 4 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.label | 5 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.order | 5 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.label | 6 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.order | 6 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.label | 7 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.order | 7 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.label | 8 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.order | 8 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.label | 9 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.order | 9 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.label | 10 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.order | 10 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.label | 11 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.order | 11 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.label | 12 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.order | 12 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.label | 13 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.order | 13 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.label | 14 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.order | 14 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.label | 15 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.order | 15 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.label | 16 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.label | 18 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.order | 18 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 19 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 19 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 20 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 20 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.label | 21 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.order | 21 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.label | 22 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.order | 22 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 23 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 23 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 24 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 24 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.label | 25 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.order | 25 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.label | 26 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.order | 26 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.label | 27 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.order | 27 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.label | 28 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.order | 28 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.label | 29 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.order | 29 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 30 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 30 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 32 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 32 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | 33 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.order | 33 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 34 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 34 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | semmle.label | 35 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | semmle.order | 35 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 36 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 36 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | semmle.label | 37 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | semmle.order | 37 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | semmle.label | 38 |
+| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | semmle.order | 38 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | 1 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.order | 1 |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | 1 |
@@ -872,6 +954,104 @@ edges
 | arrays.js:66:5:66:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
 | arrays.js:66:5:66:12 | [ExprStmt] sink(x); | arrays.js:66:5:66:11 | [CallExpr] sink(x) | semmle.label | 1 |
 | arrays.js:66:5:66:12 | [ExprStmt] sink(x); | arrays.js:66:5:66:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | semmle.label | 1 |
+| arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | semmle.order | 1 |
+| arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:69:9:69:17 | [VarDecl] arrayFrom | semmle.label | 1 |
+| arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:69:9:69:17 | [VarDecl] arrayFrom | semmle.order | 1 |
+| arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:69:21:69:41 | [CallExpr] require ... -from") | semmle.label | 2 |
+| arrays.js:69:9:69:41 | [VariableDeclarator] arrayFr ... -from") | arrays.js:69:21:69:41 | [CallExpr] require ... -from") | semmle.order | 2 |
+| arrays.js:69:21:69:41 | [CallExpr] require ... -from") | arrays.js:69:21:69:27 | [VarRef] require | semmle.label | 0 |
+| arrays.js:69:21:69:41 | [CallExpr] require ... -from") | arrays.js:69:21:69:27 | [VarRef] require | semmle.order | 0 |
+| arrays.js:69:21:69:41 | [CallExpr] require ... -from") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:69:21:69:41 | [CallExpr] require ... -from") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:8:70:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:8:70:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | semmle.label | 2 |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | semmle.order | 2 |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:35:72:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | arrays.js:70:35:72:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:70:8:70:14 | [DeclStmt] const x = ... | arrays.js:70:14:70:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:70:8:70:14 | [DeclStmt] const x = ... | arrays.js:70:14:70:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:70:14:70:14 | [VariableDeclarator] x | arrays.js:70:14:70:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:70:14:70:14 | [VariableDeclarator] x | arrays.js:70:14:70:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | arrays.js:70:19:70:27 | [VarRef] arrayFrom | semmle.label | 0 |
+| arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | arrays.js:70:19:70:27 | [VarRef] arrayFrom | semmle.order | 0 |
+| arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:70:19:70:32 | [CallExpr] arrayFrom(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:70:35:72:3 | [BlockStmt] { s ... OK } | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:70:35:72:3 | [BlockStmt] { s ... OK } | arrays.js:71:5:71:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:71:5:71:11 | [CallExpr] sink(x) | arrays.js:71:5:71:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:71:5:71:11 | [CallExpr] sink(x) | arrays.js:71:5:71:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:71:5:71:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:71:5:71:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:71:5:71:12 | [ExprStmt] sink(x); | arrays.js:71:5:71:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:71:5:71:12 | [ExprStmt] sink(x); | arrays.js:71:5:71:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | arrays.js:74:3:74:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | arrays.js:74:3:74:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | semmle.label | 1 |
+| arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | arrays.js:74:3:74:30 | [CallExpr] sink(ar ... lback)) | semmle.order | 1 |
+| arrays.js:74:8:74:15 | [DotExpr] arr.find | arrays.js:74:8:74:10 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:74:8:74:15 | [DotExpr] arr.find | arrays.js:74:8:74:10 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:74:8:74:15 | [DotExpr] arr.find | arrays.js:74:12:74:15 | [Label] find | semmle.label | 2 |
+| arrays.js:74:8:74:15 | [DotExpr] arr.find | arrays.js:74:12:74:15 | [Label] find | semmle.order | 2 |
+| arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | arrays.js:74:8:74:15 | [DotExpr] arr.find | semmle.label | 0 |
+| arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | arrays.js:74:8:74:15 | [DotExpr] arr.find | semmle.order | 0 |
+| arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | semmle.label | 1 |
+| arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | semmle.order | 1 |
+| arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:76:9:76:17 | [VarDecl] arrayFind | semmle.label | 1 |
+| arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:76:9:76:17 | [VarDecl] arrayFind | semmle.order | 1 |
+| arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:76:21:76:41 | [CallExpr] require ... -find") | semmle.label | 2 |
+| arrays.js:76:9:76:41 | [VariableDeclarator] arrayFi ... -find") | arrays.js:76:21:76:41 | [CallExpr] require ... -find") | semmle.order | 2 |
+| arrays.js:76:21:76:41 | [CallExpr] require ... -find") | arrays.js:76:21:76:27 | [VarRef] require | semmle.label | 0 |
+| arrays.js:76:21:76:41 | [CallExpr] require ... -find") | arrays.js:76:21:76:27 | [VarRef] require | semmle.order | 0 |
+| arrays.js:76:21:76:41 | [CallExpr] require ... -find") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:76:21:76:41 | [CallExpr] require ... -find") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | arrays.js:77:3:77:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | arrays.js:77:3:77:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | semmle.label | 1 |
+| arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | arrays.js:77:3:77:36 | [CallExpr] sink(ar ... lback)) | semmle.order | 1 |
+| arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | arrays.js:77:8:77:16 | [VarRef] arrayFind | semmle.label | 0 |
+| arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | arrays.js:77:8:77:16 | [VarRef] arrayFind | semmle.order | 0 |
+| arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.label | 1 |
+| arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | semmle.order | 1 |
+| arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:79:9:79:12 | [VarDecl] uniq | semmle.label | 1 |
+| arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:79:9:79:12 | [VarDecl] uniq | semmle.order | 1 |
+| arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:79:16:79:30 | [CallExpr] require("uniq") | semmle.label | 2 |
+| arrays.js:79:9:79:30 | [VariableDeclarator] uniq = ... "uniq") | arrays.js:79:16:79:30 | [CallExpr] require("uniq") | semmle.order | 2 |
+| arrays.js:79:16:79:30 | [CallExpr] require("uniq") | arrays.js:79:16:79:22 | [VarRef] require | semmle.label | 0 |
+| arrays.js:79:16:79:30 | [CallExpr] require("uniq") | arrays.js:79:16:79:22 | [VarRef] require | semmle.order | 0 |
+| arrays.js:79:16:79:30 | [CallExpr] require("uniq") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:79:16:79:30 | [CallExpr] require("uniq") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:8:80:14 | [DeclStmt] const x = ... | semmle.label | 1 |
+| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:8:80:14 | [DeclStmt] const x = ... | semmle.order | 1 |
+| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | semmle.label | 2 |
+| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | semmle.order | 2 |
+| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:30:82:3 | [BlockStmt] { s ... OK } | semmle.label | 3 |
+| arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | arrays.js:80:30:82:3 | [BlockStmt] { s ... OK } | semmle.order | 3 |
+| arrays.js:80:8:80:14 | [DeclStmt] const x = ... | arrays.js:80:14:80:14 | [VariableDeclarator] x | semmle.label | 1 |
+| arrays.js:80:8:80:14 | [DeclStmt] const x = ... | arrays.js:80:14:80:14 | [VariableDeclarator] x | semmle.order | 1 |
+| arrays.js:80:14:80:14 | [VariableDeclarator] x | arrays.js:80:14:80:14 | [VarDecl] x | semmle.label | 1 |
+| arrays.js:80:14:80:14 | [VariableDeclarator] x | arrays.js:80:14:80:14 | [VarDecl] x | semmle.order | 1 |
+| arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | arrays.js:80:19:80:22 | [VarRef] uniq | semmle.label | 0 |
+| arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | arrays.js:80:19:80:22 | [VarRef] uniq | semmle.order | 0 |
+| arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:80:19:80:27 | [CallExpr] uniq(arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:80:30:82:3 | [BlockStmt] { s ... OK } | arrays.js:81:5:81:12 | [ExprStmt] sink(x); | semmle.label | 1 |
+| arrays.js:80:30:82:3 | [BlockStmt] { s ... OK } | arrays.js:81:5:81:12 | [ExprStmt] sink(x); | semmle.order | 1 |
+| arrays.js:81:5:81:11 | [CallExpr] sink(x) | arrays.js:81:5:81:8 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:81:5:81:11 | [CallExpr] sink(x) | arrays.js:81:5:81:8 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:81:5:81:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:81:5:81:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:81:5:81:12 | [ExprStmt] sink(x); | arrays.js:81:5:81:11 | [CallExpr] sink(x) | semmle.label | 1 |
+| arrays.js:81:5:81:12 | [ExprStmt] sink(x); | arrays.js:81:5:81:11 | [CallExpr] sink(x) | semmle.order | 1 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:5:8:5:14 | [DotExpr] obj.foo | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:5:8:5:14 | [DotExpr] obj.foo | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:8:12:8:17 | [VarRef] source | semmle.label | 0 |
@@ -936,6 +1116,30 @@ edges
 | file://:0:0:0:0 | (Arguments) | arrays.js:64:13:64:18 | [SpreadElement] ...arr | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:66:10:66:10 | [VarRef] x | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:66:10:66:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:69:29:69:40 | [Literal] "array-from" | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:69:29:69:40 | [Literal] "array-from" | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:70:29:70:31 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:70:29:70:31 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:71:10:71:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:71:10:71:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:74:8:74:29 | [MethodCallExpr] arr.fin ... llback) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:74:17:74:28 | [VarRef] someCallback | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:74:17:74:28 | [VarRef] someCallback | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:76:29:76:40 | [Literal] "array-find" | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:76:29:76:40 | [Literal] "array-find" | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:77:8:77:35 | [CallExpr] arrayFi ... llback) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:77:18:77:20 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:77:18:77:20 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:77:23:77:34 | [VarRef] someCallback | semmle.label | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:77:23:77:34 | [VarRef] someCallback | semmle.order | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:79:24:79:29 | [Literal] "uniq" | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:79:24:79:29 | [Literal] "uniq" | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:80:24:80:26 | [VarRef] arr | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:80:24:80:26 | [VarRef] arr | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:81:10:81:10 | [VarRef] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:81:10:81:10 | [VarRef] x | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:15:16:15:16 | [SimpleParameter] e | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:15:16:15:16 | [SimpleParameter] e | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:16:12:16:12 | [SimpleParameter] e | semmle.label | 0 |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -14,6 +14,7 @@ typeInferenceMismatch
 | array-mutation.js:39:17:39:24 | source() | array-mutation.js:40:8:40:8 | j |
 | arrays.js:2:15:2:22 | source() | arrays.js:5:10:5:20 | arrify(foo) |
 | arrays.js:2:15:2:22 | source() | arrays.js:8:10:8:22 | arrayIfy(foo) |
+| arrays.js:2:15:2:22 | source() | arrays.js:11:10:11:28 | union(["bla"], foo) |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:4:8:4:8 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:13:10:13:10 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:19:10:19:10 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -15,6 +15,7 @@ typeInferenceMismatch
 | arrays.js:2:15:2:22 | source() | arrays.js:5:10:5:20 | arrify(foo) |
 | arrays.js:2:15:2:22 | source() | arrays.js:8:10:8:22 | arrayIfy(foo) |
 | arrays.js:2:15:2:22 | source() | arrays.js:11:10:11:28 | union(["bla"], foo) |
+| arrays.js:2:15:2:22 | source() | arrays.js:14:10:14:18 | flat(foo) |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:4:8:4:8 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:13:10:13:10 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:19:10:19:10 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -12,6 +12,8 @@ typeInferenceMismatch
 | array-mutation.js:31:33:31:40 | source() | array-mutation.js:32:8:32:8 | h |
 | array-mutation.js:35:36:35:43 | source() | array-mutation.js:36:8:36:8 | i |
 | array-mutation.js:39:17:39:24 | source() | array-mutation.js:40:8:40:8 | j |
+| arrays.js:2:15:2:22 | source() | arrays.js:5:10:5:20 | arrify(foo) |
+| arrays.js:2:15:2:22 | source() | arrays.js:8:10:8:22 | arrayIfy(foo) |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:4:8:4:8 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:13:10:13:10 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:19:10:19:10 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/arrays.js
+++ b/javascript/ql/test/library-tests/TaintTracking/arrays.js
@@ -9,4 +9,7 @@ function test() {
 
     const union = require("array-union");
     sink(union(["bla"], foo)); // NOT OK
+
+    const flat = require("arr-flatten");
+    sink(flat(foo)); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/arrays.js
+++ b/javascript/ql/test/library-tests/TaintTracking/arrays.js
@@ -1,0 +1,9 @@
+function test() {
+    var foo = source();
+
+    const arrify = require("arrify");
+    sink(arrify(foo)); // NOT OK
+
+    const arrayIfy = require("array-ify");
+    sink(arrayIfy(foo)); // NOT OK
+}

--- a/javascript/ql/test/library-tests/TaintTracking/arrays.js
+++ b/javascript/ql/test/library-tests/TaintTracking/arrays.js
@@ -6,4 +6,7 @@ function test() {
 
     const arrayIfy = require("array-ify");
     sink(arrayIfy(foo)); // NOT OK
+
+    const union = require("array-union");
+    sink(union(["bla"], foo)); // NOT OK
 }


### PR DESCRIPTION
[Performance looks OK](https://github.com/dsp-testing/erik-krogh-dca/blob/run/arrify__nightly__security-extended/reports/alert-comparison.md).  

There are a few new results in `angular/angular`.  
They look OK to me. 
We get them due to `.find` calls like [this one](https://github.com/angular/angular/blob/642362a9c7fa5f8c7eb7d47c243729f8e750dc8b/packages/compiler/test/aot/static_symbol_resolver_spec.ts#L437). 