### PR TITLE
CPP: drop opaque-id properties

### DIFF
--- a/cpp/ql/src/Microsoft/IgnoreReturnValueSAL.ql
+++ b/cpp/ql/src/Microsoft/IgnoreReturnValueSAL.ql
@@ -9,7 +9,6 @@
  * @tags reliability
  *       external/cwe/cwe-573
  *       external/cwe/cwe-252
- * @opaque-id SM02344
  * @microsoft.severity Important
  */
 

--- a/cpp/ql/src/Security/CWE/CWE-457/ConditionallyUninitializedVariable.ql
+++ b/cpp/ql/src/Security/CWE/CWE-457/ConditionallyUninitializedVariable.ql
@@ -6,7 +6,6 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 7.8
- * @opaque-id SM02313
  * @id cpp/conditionally-uninitialized-variable
  * @tags security
  *       external/cwe/cwe-457


### PR DESCRIPTION
The undocumented @opaque-id property takes precendence over the normal @id
property and causes the SARIF output produced by CodeQL to use that ID for
rules. Luckily these queries are no run by default due to lacking `@precision` tags.

@lcartey 