### PR TITLE
C#: Improve performance of `DeadStoreOfLocal.ql`

### DIFF
--- a/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
+++ b/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
@@ -141,20 +141,12 @@ class RelevantDefinition extends AssignableDefinition {
     // Ensure that the definition is not in dead code
     exists(this.getAControlFlowNode()) and
     not this.isMaybeLive() and
-    (
-      // Allow dead initializer assignments, such as `string s = string.Empty`, but only
-      // if the initializer expression assigns a default-like value, and there exists another
-      // definition of the same variable
-      this.isInitializer()
-      implies
-      (
-        not this.isDefaultLikeInitializer()
-        or
-        not exists(AssignableDefinition other | other.getTarget() = this.getTarget() |
-          other != this
-        )
-      )
-    )
+    // Allow dead initializer assignments, such as `string s = string.Empty`, but only
+    // if the initializer expression assigns a default-like value, and there exists another
+    // definition of the same variable
+    if this.isDefaultLikeInitializer()
+    then this = unique(AssignableDefinition def | def.getTarget() = this.getTarget())
+    else any()
   }
 }
 


### PR DESCRIPTION
Gets rid of a bad join-order:
```
[2021-07-16 09:16:56] (0s) Starting to evaluate predicate DeadStoreOfLocal::RelevantDefinition::isDead_dispred#f#antijoin_rhs/1@bbf428
[2021-07-16 09:47:09] (1812s) Tuple counts for DeadStoreOfLocal::RelevantDefinition::isDead_dispred#f#antijoin_rhs/1@bbf428:
                      675636      ~1%           {1} r1 = JOIN DeadStoreOfLocal::RelevantDefinition::isDead_dispred#f#shared WITH DeadStoreOfLocal::RelevantDefinition#class#f ON FIRST 1 OUTPUT Lhs.0 'arg0'
                      675623      ~0%           {2} r2 = JOIN r1 WITH Assignable::AssignableInternal::Cached::getTarget#ff@staged_ext ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'arg0'
                      32889849066 ~0%           {3} r3 = JOIN r2 WITH Assignable::AssignableInternal::Cached::getTarget#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1 'arg0', Lhs.0, Rhs.1
                      32889173443 ~0%           {3} r4 = SELECT r3 ON In.0 'arg0' != In.2
                      32889173443 ~6718165%     {1} r5 = SCAN r4 OUTPUT In.0 'arg0'
                                                return r5
```

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1209/