### PR TITLE
JS: Handle method calls on DOM elements

### DIFF
--- a/javascript/change-notes/2021-07-16-dom-element-methods.md
+++ b/javascript/change-notes/2021-07-16-dom-element-methods.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* Some methods from the DOM API are now modeled more precisely, potentially
+  leading to more `js/xss` results.

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -699,6 +699,15 @@ nodes
 | tst.js:456:18:456:42 | ansiToH ... source) |
 | tst.js:456:18:456:42 | ansiToH ... source) |
 | tst.js:456:36:456:41 | source |
+| tst.js:460:6:460:38 | source |
+| tst.js:460:15:460:38 | documen ... .search |
+| tst.js:460:15:460:38 | documen ... .search |
+| tst.js:463:21:463:26 | source |
+| tst.js:463:21:463:26 | source |
+| tst.js:465:19:465:24 | source |
+| tst.js:465:19:465:24 | source |
+| tst.js:467:20:467:25 | source |
+| tst.js:467:20:467:25 | source |
 | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:20:22:20:45 | documen ... .search |
@@ -1369,6 +1378,14 @@ edges
 | tst.js:453:16:453:39 | documen ... .search | tst.js:453:7:453:39 | source |
 | tst.js:456:36:456:41 | source | tst.js:456:18:456:42 | ansiToH ... source) |
 | tst.js:456:36:456:41 | source | tst.js:456:18:456:42 | ansiToH ... source) |
+| tst.js:460:6:460:38 | source | tst.js:463:21:463:26 | source |
+| tst.js:460:6:460:38 | source | tst.js:463:21:463:26 | source |
+| tst.js:460:6:460:38 | source | tst.js:465:19:465:24 | source |
+| tst.js:460:6:460:38 | source | tst.js:465:19:465:24 | source |
+| tst.js:460:6:460:38 | source | tst.js:467:20:467:25 | source |
+| tst.js:460:6:460:38 | source | tst.js:467:20:467:25 | source |
+| tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
+| tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
@@ -1598,6 +1615,9 @@ edges
 | tst.js:445:32:445:37 | source | tst.js:436:15:436:38 | documen ... .search | tst.js:445:32:445:37 | source | Cross-site scripting vulnerability due to $@. | tst.js:436:15:436:38 | documen ... .search | user-provided value |
 | tst.js:455:18:455:23 | source | tst.js:453:16:453:39 | documen ... .search | tst.js:455:18:455:23 | source | Cross-site scripting vulnerability due to $@. | tst.js:453:16:453:39 | documen ... .search | user-provided value |
 | tst.js:456:18:456:42 | ansiToH ... source) | tst.js:453:16:453:39 | documen ... .search | tst.js:456:18:456:42 | ansiToH ... source) | Cross-site scripting vulnerability due to $@. | tst.js:453:16:453:39 | documen ... .search | user-provided value |
+| tst.js:463:21:463:26 | source | tst.js:460:15:460:38 | documen ... .search | tst.js:463:21:463:26 | source | Cross-site scripting vulnerability due to $@. | tst.js:460:15:460:38 | documen ... .search | user-provided value |
+| tst.js:465:19:465:24 | source | tst.js:460:15:460:38 | documen ... .search | tst.js:465:19:465:24 | source | Cross-site scripting vulnerability due to $@. | tst.js:460:15:460:38 | documen ... .search | user-provided value |
+| tst.js:467:20:467:25 | source | tst.js:460:15:460:38 | documen ... .search | tst.js:467:20:467:25 | source | Cross-site scripting vulnerability due to $@. | tst.js:460:15:460:38 | documen ... .search | user-provided value |
 | typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:45 | documen ... .search | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
 | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -706,6 +706,15 @@ nodes
 | tst.js:456:18:456:42 | ansiToH ... source) |
 | tst.js:456:18:456:42 | ansiToH ... source) |
 | tst.js:456:36:456:41 | source |
+| tst.js:460:6:460:38 | source |
+| tst.js:460:15:460:38 | documen ... .search |
+| tst.js:460:15:460:38 | documen ... .search |
+| tst.js:463:21:463:26 | source |
+| tst.js:463:21:463:26 | source |
+| tst.js:465:19:465:24 | source |
+| tst.js:465:19:465:24 | source |
+| tst.js:467:20:467:25 | source |
+| tst.js:467:20:467:25 | source |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:10:16:10:18 | loc |
@@ -1393,6 +1402,14 @@ edges
 | tst.js:453:16:453:39 | documen ... .search | tst.js:453:7:453:39 | source |
 | tst.js:456:36:456:41 | source | tst.js:456:18:456:42 | ansiToH ... source) |
 | tst.js:456:36:456:41 | source | tst.js:456:18:456:42 | ansiToH ... source) |
+| tst.js:460:6:460:38 | source | tst.js:463:21:463:26 | source |
+| tst.js:460:6:460:38 | source | tst.js:463:21:463:26 | source |
+| tst.js:460:6:460:38 | source | tst.js:465:19:465:24 | source |
+| tst.js:460:6:460:38 | source | tst.js:465:19:465:24 | source |
+| tst.js:460:6:460:38 | source | tst.js:467:20:467:25 | source |
+| tst.js:460:6:460:38 | source | tst.js:467:20:467:25 | source |
+| tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
+| tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/externs.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/externs.js
@@ -57,3 +57,13 @@ function Node() {}
  * @type {Node}
  */
 Node.prototype.parentNode;
+
+/**
+ * @return {DomObjectStub}
+ */
+DomObjectStub.prototype.insertRow = function() {};
+
+/**
+ * @return {DomObjectStub}
+ */
+DomObjectStub.prototype.insertCell = function() {};

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
@@ -455,3 +455,14 @@ function ansiToHTML() {
   $("#foo").html(source); // NOT OK
   $("#foo").html(ansiToHtml.toHtml(source)); // NOT OK
 }
+
+function domMethods() {
+	var source = document.location.search;
+
+  let table = document.getElementById('mytable');
+  table.innerHTML = source; // NOT OK
+  let row = table.insertRow(-1);
+  row.innerHTML = source; // NOT OK
+  let cell = row.insertCell();
+  cell.innerHTML = source; // NOT OK
+}


### PR DESCRIPTION
Methods on DOM elements which themselves return DOM elements are now recognized, such as `HTMLTableElement.insertRow`.

[Evaluation](https://github.com/dsp-testing/asgerf-dca/tree/run/dom-element-methods__default__dist-compare/reports) shows good performance and very good results:
- 606 new XSS sinks
- 9 new XSS results
- 5 XSS-through-dom results

<details>
<summary>List of recognized DOM element names (from quick-evaling <code>getAMethodProducingDomElements</code>)</summary>
<pre>
1 | clone
2 | closest
3 | insertBefore
4 | open
5 | cloneNode
6 | captureStream
7 | getRootNode
8 | createShadowRoot
9 | webkitCreateShadowRoot
10 | addTextTrack
11 | getTrackById
12 | getElementById
13 | elementFromPoint
14 | createNode
15 | nodeFromID
16 | selectSingleNode
17 | removeNode
18 | addSourceBuffer
19 | appendChild
20 | removeChild
21 | replaceChild
22 | createAttribute
23 | createComment
24 | createCDATASection
25 | createDocumentFragment
26 | createElement
27 | createEntityReference
28 | createProcessingInstruction
29 | createTextNode
30 | getAttributeNode
31 | removeAttributeNode
32 | setAttributeNode
33 | splitText
34 | createElementNS
35 | createAttributeNS
36 | importNode
37 | createCaption
38 | createTFoot
39 | createTHead
40 | deleteRow
41 | insertRow
42 | insertCell
43 | adoptNode
44 | renameNode
45 | querySelector
46 | getAttributeNodeNS
47 | setAttributeNodeNS
48 | replaceWholeText
49 | setVersion
50 | getStreamById
51 | createDataChannel
</pre>
</details>