### PR TITLE
Codeowners: Add reviewer teams for CodeQL tools and associated docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,3 +17,9 @@
 /java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll @github/codeql-java @github/codeql-go
 /java/ql/src/semmle/code/java/dataflow/internal/tainttracking1/TaintTrackingImpl.qll @github/codeql-java @github/codeql-go
 /java/ql/src/semmle/code/java/dataflow/internal/tainttracking2/TaintTrackingImpl.qll @github/codeql-java @github/codeql-go
+
+# CodeQL tools and associated docs
+/docs/codeql-cli/ @github/codeql-cli-reviewers
+/docs/codeql-for-visual-studio-code/ @github/codeql-vscode-reviewers
+/docs/ql-language-reference/ @github/codeql-frontend-reviewers
+/docs/query-*-style-guide.md @github/codeql-analysis-reviewers


### PR DESCRIPTION
Update `CODEOWNERS` so that the relevant members of the CodeQL core team are requested for technical review of changes to the CodeQL tooling docs, the QL language reference, or the guides for query help and metadata.

@jf205 pointed out some unaddressed external contributions to these files, so hopefully this reduces the likelihood of missing such contributions.

If we need an additional review from the docs team on such PRs, we add the `ready-for-docs-review` label just like with other changes.