### PR TITLE
C++: Fix FP in `cpp/uninitialized-local`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
@@ -41,7 +41,7 @@ DeclStmt declWithNoInit(LocalVariable v) {
   result.getADeclaration() = v and
   not exists(v.getInitializer()) and
   /* The type of the variable is not stack-allocated. */
-  not allocatedType(v.getType())
+  exists(Type t | t = v.getType() | not allocatedType(t))
 }
 
 class UninitialisedLocalReachability extends StackVariableReachability {


### PR DESCRIPTION
I was testing something completely different when I came across a result from `cpp/uninitialized-local` that was very unexpected. On `main` we currently raise an alert in [Joystick.cpp](https://lgtm.com/query/9058665303446741008/) due to the use of `not` in the following predicate:

```codeql
DeclStmt declWithNoInit(LocalVariable v) {
  result.getADeclaration() = v and
  not exists(v.getInitializer()) and
  /* The type of the variable is not stack-allocated. */
  not allocatedType(v.getType())
}
```

because the `jinput` variable has no result for `getType()`. This PR fixes that FP.