### PR TITLE
Python: Remove flow between globals...

### DIFF
--- a/python/ql/src/semmle/python/dataflow/new/internal/LocalSources.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/LocalSources.qll
@@ -179,9 +179,19 @@ private module Cached {
     source = sink
     or
     exists(Node second |
-      simpleLocalFlowStep(source, second) and
-      simpleLocalFlowStep*(second, sink)
+      localSourceFlowStep(source, second) and
+      localSourceFlowStep*(second, sink)
     )
+  }
+
+  /**
+   * Helper predicate for `hasLocalSource`. Removes any steps go to module variable reads, as these
+   * are already local source nodes in their own right.
+   */
+  cached
+  private predicate localSourceFlowStep(Node nodeFrom, Node nodeTo) {
+    simpleLocalFlowStep(nodeFrom, nodeTo) and
+    not nodeTo = any(ModuleVariableNode v).getARead()
   }
 
   /**


### PR DESCRIPTION
... in a local scope. Or rather, remove these from the `hasLocalSource`
relation.

This prevents a quadratic blowup when the same global is mentioned
_a lot_ of times within a single function scope.