### PR TITLE
Java: Fix bad magic.

### DIFF
--- a/java/ql/src/semmle/code/java/Collections.qll
+++ b/java/ql/src/semmle/code/java/Collections.qll
@@ -35,6 +35,7 @@ predicate instantiates(RefType t, GenericType g, int i, RefType arg) {
  * - a class `MyIntMap<V> extends HashMap<Integer, V>` instantiates `Map` (among others)
  *   with the `0`-th type parameter being `Integer` and the `1`-th type parameter being `V`.
  */
+pragma[nomagic]
 predicate indirectlyInstantiates(RefType t, GenericType g, int i, RefType arg) {
   instantiates(t, g, i, arg)
   or


### PR DESCRIPTION
This fixes a case of bad magic when evaluating `ContainsTypeMismatch.ql` and `RemoveTypeMismatch.ql`.