### PR TITLE
C++: Import 'GVN' in 'Overflow.qll' to prevent IR reevaluation.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
@@ -5,6 +5,8 @@
 
 import cpp
 import semmle.code.cpp.controlflow.Dominance
+// `GlobalValueNumbering` is only imported to prevent IR re-evaluation.
+private import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
 


### PR DESCRIPTION
When we merged https://github.com/github/codeql/pull/6340 we re-introduced a caching issue that caused the IR to be re-evaluated. This PR fixes that re-evaluation bug.

<s>I'm leaving this as a draft while I'm verifying that this indeed fixes the problem: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/2167/</s> https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/2167/ shows that this PR fixes the problem:

![analysis_time](https://user-images.githubusercontent.com/4527323/126638978-c0149304-6de4-42a7-bf43-3077834a3ad5.png)
