### PR TITLE
JS: Fixed description of `isUncertain()` predicate in CodeQL Language Guides: CodeQL Library for JavaScript

### DIFF
--- a/docs/codeql/codeql-language-guides/codeql-library-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/codeql-library-for-javascript.rst
@@ -694,7 +694,7 @@ Furthermore, there are three member predicates that indicate the quality of the 
 
 -  ``DataFlow::InvokeNode.isImprecise()``: holds for invocations where the call graph builder might infer spurious call targets.
 -  ``DataFlow::InvokeNode.isIncomplete()``: holds for invocations where the call graph builder might fail to infer possible call targets.
--  ``DataFlow::InvokeNode.isUncertain()``: holds if either ``isImprecise()`` or ``isUncertain()`` holds.
+-  ``DataFlow::InvokeNode.isUncertain()``: holds if either ``isImprecise()`` or ``isIncomplete()`` holds.
 
 As an example of a call-graph-based query, here is a query to find invocations for which the call graph builder could not find any callees, despite the analysis being complete for this invocation:
 


### PR DESCRIPTION
Fixed the description found in the [call graph section of CodeQL Library for JavaScript docs](https://codeql.github.com/docs/codeql-language-guides/codeql-library-for-javascript/#call-graph) where it originally states "`DataFlow::InvokeNode.isUncertain()`: holds if either `isImprecise()` or `isUncertain()` holds", when it should be "`DataFlow::InvokeNode.isUncertain()`: holds if either `isImprecise()` or `isIncomplete()` holds".

Reference to [`DataFlow::InvokeNode.isUncertain()`'s docstring](https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/dataflow/Nodes.qll/predicate.Nodes$InvokeNode$isUncertain.0.html) where it states "Holds if our approximation of possible callees for this call site is likely to be imprecise or **incomplete**."