### PR TITLE
Java: Add `TypeLiteral.getReferencedType()`

### DIFF
--- a/java/ql/src/Likely Bugs/Concurrency/LazyInitStaticField.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/LazyInitStaticField.ql
@@ -51,7 +51,7 @@ class LockObjectField extends Field {
 class ValidSynchStmt extends Stmt {
   ValidSynchStmt() {
     // It's OK to lock the enclosing class.
-    this.(SynchronizedStmt).getExpr().(TypeLiteral).getTypeName().getType() =
+    this.(SynchronizedStmt).getExpr().(TypeLiteral).getReferencedType() =
       this.getEnclosingCallable().getDeclaringType()
     or
     // It's OK to lock on a "lock object field".

--- a/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
@@ -24,7 +24,7 @@ import java
 predicate isSynchronizedByBlock(Method m) {
   exists(SynchronizedStmt sync, Expr on | sync = m.getBody().getAChild*() and on = sync.getExpr() |
     if m.isStatic()
-    then on.(TypeLiteral).getTypeName().getType() = m.getDeclaringType()
+    then on.(TypeLiteral).getReferencedType() = m.getDeclaringType()
     else on.(ThisAccess).getType().(RefType).getSourceDeclaration() = m.getDeclaringType()
   )
 }

--- a/java/ql/src/semmle/code/java/Dependency.qll
+++ b/java/ql/src/semmle/code/java/Dependency.qll
@@ -62,7 +62,7 @@ predicate depends(RefType t, RefType dep) {
     or
     // the type of a type literal accessed in `t`,
     exists(TypeLiteral l | l.getEnclosingCallable().getDeclaringType() = t |
-      usesType(l.getTypeName().getType(), dep)
+      usesType(l.getReferencedType(), dep)
     )
     or
     // the type of an annotation (or one of its element values) that annotates `t` or one of its members,

--- a/java/ql/src/semmle/code/java/DependencyCounts.qll
+++ b/java/ql/src/semmle/code/java/DependencyCounts.qll
@@ -80,7 +80,7 @@ predicate numDepends(RefType t, RefType dep, int value) {
         elem = l and
         l.getEnclosingCallable().getDeclaringType() = t
       |
-        usesType(l.getTypeName().getType(), dep)
+        usesType(l.getReferencedType(), dep)
       )
       or
       // the type of an annotation (or one of its element values) that annotates `t` or one of its members,

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1425,6 +1425,12 @@ class TypeLiteral extends Expr, @typeliteral {
   /** Gets the access to the type whose class is accessed. */
   Expr getTypeName() { result.getParent() = this }
 
+  /**
+   * Gets the type this type literal refers to. For example for `String.class` the
+   * result is the type representing `String`.
+   */
+  Type getReferencedType() { result = getTypeName().getType() }
+
   /** Gets a printable representation of this expression. */
   override string toString() { result = this.getTypeName().toString() + ".class" }
 

--- a/java/ql/src/semmle/code/java/Reflection.qll
+++ b/java/ql/src/semmle/code/java/Reflection.qll
@@ -52,7 +52,7 @@ abstract private class ReflectiveClassIdentifier extends Expr {
 
 private class ReflectiveClassIdentifierLiteral extends ReflectiveClassIdentifier, TypeLiteral {
   override RefType getReflectivelyIdentifiedClass() {
-    result = getTypeName().getType().(RefType).getSourceDeclaration()
+    result = getReferencedType().(RefType).getSourceDeclaration()
   }
 }
 

--- a/java/ql/src/semmle/code/java/UnitTests.qll
+++ b/java/ql/src/semmle/code/java/UnitTests.qll
@@ -168,7 +168,7 @@ class TestNGTestMethod extends Method {
       or
       // Or the data provider class should be declared
       result.getDeclaringType() =
-        testAnnotation.getValue("dataProviderClass").(TypeLiteral).getTypeName().getType()
+        testAnnotation.getValue("dataProviderClass").(TypeLiteral).getReferencedType()
     )
   }
 }
@@ -227,7 +227,7 @@ class TestNGListenersAnnotation extends TestNGAnnotation {
    * Gets a listener defined in this annotation.
    */
   TestNGListenerImpl getAListener() {
-    result = getAValue("value").(TypeLiteral).getTypeName().getType()
+    result = getAValue("value").(TypeLiteral).getReferencedType()
   }
 }
 
@@ -303,7 +303,7 @@ class JUnitCategoryAnnotation extends Annotation {
         literal = value.(ArrayCreationExpr).getInit().getAnInit()
       )
     |
-      result = literal.getTypeName().getType()
+      result = literal.getReferencedType()
     )
   }
 }

--- a/java/ql/src/semmle/code/java/frameworks/JUnitAnnotations.qll
+++ b/java/ql/src/semmle/code/java/frameworks/JUnitAnnotations.qll
@@ -64,5 +64,5 @@ class RunWithAnnotation extends Annotation {
   /**
    * Gets the runner that will be used.
    */
-  Type getRunner() { result = getValue("value").(TypeLiteral).getTypeName().getType() }
+  Type getRunner() { result = getValue("value").(TypeLiteral).getReferencedType() }
 }

--- a/java/ql/src/semmle/code/java/frameworks/google/GoogleHttpClientApi.qll
+++ b/java/ql/src/semmle/code/java/frameworks/google/GoogleHttpClientApi.qll
@@ -33,7 +33,7 @@ class HttpResponseParseAsDeserializableField extends DeserializableField {
   HttpResponseParseAsDeserializableField() {
     exists(RefType decltype, TypeLiteralToParseAsFlowConfiguration conf |
       decltype = getDeclaringType() and
-      conf.getSourceWithFlowToParseAs().getTypeName().getType() = decltype and
+      conf.getSourceWithFlowToParseAs().getReferencedType() = decltype and
       decltype.fromSource()
     )
   }

--- a/java/ql/src/semmle/code/java/frameworks/jackson/JacksonSerializability.qll
+++ b/java/ql/src/semmle/code/java/frameworks/jackson/JacksonSerializability.qll
@@ -112,7 +112,7 @@ private class TypeLiteralToJacksonDatabindFlowConfiguration extends DataFlow5::C
 private class ExplicitlyReadJacksonDeserializableType extends JacksonDeserializableType {
   ExplicitlyReadJacksonDeserializableType() {
     exists(TypeLiteralToJacksonDatabindFlowConfiguration conf |
-      usesType(conf.getSourceWithFlowToJacksonDatabind().getTypeName().getType(), this)
+      usesType(conf.getSourceWithFlowToJacksonDatabind().getReferencedType(), this)
     )
     or
     exists(MethodAccess ma |

--- a/java/ql/src/semmle/code/java/frameworks/javaee/ejb/EJB.qll
+++ b/java/ql/src/semmle/code/java/frameworks/javaee/ejb/EJB.qll
@@ -199,7 +199,7 @@ abstract class EjbInterfaceAnnotation extends Annotation {
     // within the "value" element of this annotation.
     // Uses `getAChildExpr*()` since the "value" element can have type `Class` or `Class[]`.
     exists(TypeLiteral tl | tl = getValue("value").getAChildExpr*() |
-      exists(TypeAccess ta | ta = tl.getTypeName() | result = ta.getType())
+      result = tl.getReferencedType()
     )
   }
 }

--- a/java/ql/src/semmle/code/java/frameworks/spring/SpringComponentScan.qll
+++ b/java/ql/src/semmle/code/java/frameworks/spring/SpringComponentScan.qll
@@ -45,7 +45,7 @@ class SpringComponentScan extends Annotation {
       // Base package classes are type literals whose package should be considered a base package.
       typeLiteral = getAValue("basePackageClasses")
     |
-      result = typeLiteral.getTypeName().getType().(RefType).getPackage().getName()
+      result = typeLiteral.getReferencedType().(RefType).getPackage().getName()
     )
   }
 }


### PR DESCRIPTION
Adds the convenience predicate `TypeLiteral.getReferencedType()` delegating to `getTypeName().getType()`.
Getting the type a type literal refers to is pretty common task (as seen by the number of files updated by this pull request); and having a single predicate with an expressive name for this might also make it more obvious for users how to get the type.