### PR TITLE
Java: Add `InstanceOfExpr.getCheckedType()`

### DIFF
--- a/java/ql/src/Language Abuse/DubiousTypeTestOfThis.ql
+++ b/java/ql/src/Language Abuse/DubiousTypeTestOfThis.ql
@@ -17,7 +17,7 @@ from InstanceOfExpr ioe, RefType t, RefType ct
 where
   ioe.getExpr() instanceof ThisAccess and
   t = ioe.getExpr().getType() and
-  ct = ioe.getTypeName().getType() and
+  ct = ioe.getCheckedType() and
   ct.getASupertype*() = t
 select ioe,
   "Testing whether 'this' is an instance of $@ in $@ introduces a dependency cycle between the two types.",

--- a/java/ql/src/Language Abuse/UselessTypeTest.ql
+++ b/java/ql/src/Language Abuse/UselessTypeTest.ql
@@ -15,7 +15,7 @@ import java
 from InstanceOfExpr ioe, RefType t, RefType ct
 where
   t = ioe.getExpr().getType() and
-  ct = ioe.getTypeName().getType() and
+  ct = ioe.getCheckedType() and
   ct = t.getASupertype+()
 select ioe,
   "There is no need to test whether an instance of $@ is also an instance of $@ - it always is.", t,

--- a/java/ql/src/Likely Bugs/Comparison/EqualsUsesInstanceOf.ql
+++ b/java/ql/src/Likely Bugs/Comparison/EqualsUsesInstanceOf.ql
@@ -17,8 +17,8 @@ predicate instanceofInEquals(EqualsMethod m, InstanceOfExpr e) {
   m.fromSource() and
   e.getEnclosingCallable() = m and
   e.getExpr().(VarAccess).getVariable() = m.getParameter() and
-  exists(Class instanceofType |
-    instanceofType = e.getTypeName().getType() and
+  exists(RefType instanceofType |
+    instanceofType = e.getCheckedType() and
     not instanceofType.isFinal()
   )
 }

--- a/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
@@ -18,7 +18,7 @@ import semmle.code.java.dataflow.SSA
 /** `ioe` is of the form `va instanceof t`. */
 predicate instanceOfCheck(InstanceOfExpr ioe, VarAccess va, RefType t) {
   ioe.getExpr() = va and
-  ioe.getTypeName().getType().(RefType).getSourceDeclaration() = t
+  ioe.getCheckedType().getSourceDeclaration() = t
 }
 
 /** Expression `e` assumes that `va` could be of type `t`. */

--- a/java/ql/src/Violations of Best Practice/Implementation Hiding/AbstractToConcreteCollection.ql
+++ b/java/ql/src/Violations of Best Practice/Implementation Hiding/AbstractToConcreteCollection.ql
@@ -16,9 +16,9 @@ import java
 import semmle.code.java.Collections
 
 predicate guardedByInstanceOf(VarAccess e, RefType t) {
-  exists(IfStmt s, InstanceOfExpr instanceCheck, Type checkType |
+  exists(IfStmt s, InstanceOfExpr instanceCheck, RefType checkType |
     s.getCondition() = instanceCheck and
-    instanceCheck.getTypeName().getType() = checkType and
+    instanceCheck.getCheckedType() = checkType and
     // The same variable appears as the subject of the `instanceof`.
     instanceCheck.getExpr() = e.getVariable().getAnAccess() and
     // The checked type is either the type itself, or a raw version. For example, it is usually

--- a/java/ql/src/semmle/code/java/Dependency.qll
+++ b/java/ql/src/semmle/code/java/Dependency.qll
@@ -76,7 +76,7 @@ predicate depends(RefType t, RefType dep) {
     or
     // the type accessed in an `instanceof` expression in `t`.
     exists(InstanceOfExpr ioe | t = ioe.getEnclosingCallable().getDeclaringType() |
-      usesType(ioe.getTypeName().getType(), dep)
+      usesType(ioe.getCheckedType(), dep)
     )
   )
 }

--- a/java/ql/src/semmle/code/java/DependencyCounts.qll
+++ b/java/ql/src/semmle/code/java/DependencyCounts.qll
@@ -100,7 +100,7 @@ predicate numDepends(RefType t, RefType dep, int value) {
         elem = ioe and
         t = ioe.getEnclosingCallable().getDeclaringType()
       |
-        usesType(ioe.getTypeName().getType(), dep)
+        usesType(ioe.getCheckedType(), dep)
       )
     )
 }

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1333,6 +1333,9 @@ class InstanceOfExpr extends Expr, @instanceofexpr {
   /** Gets the access to the type on the right-hand side of the `instanceof` operator. */
   Expr getTypeName() { result.isNthChildOf(this, 1) }
 
+  /** Gets the type this `instanceof` expression checks for. */
+  RefType getCheckedType() { result = getTypeName().getType() }
+
   /** Gets a printable representation of this expression. */
   override string toString() { result = "...instanceof..." }
 

--- a/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
+++ b/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
@@ -25,8 +25,8 @@ Expr enumConstEquality(Expr e, boolean polarity, EnumConstant c) {
 }
 
 /** Gets an instanceof expression of `v` with type `type` */
-InstanceOfExpr instanceofExpr(SsaVariable v, Type type) {
-  result.getTypeName().getType() = type and
+InstanceOfExpr instanceofExpr(SsaVariable v, RefType type) {
+  result.getCheckedType() = type and
   result.getExpr() = v.getAUse()
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/Nullness.qll
+++ b/java/ql/src/semmle/code/java/dataflow/Nullness.qll
@@ -504,7 +504,7 @@ private predicate correlatedConditions(
       inverted = pol1.booleanXor(pol2)
     )
     or
-    exists(SsaVariable v, Type type |
+    exists(SsaVariable v, RefType type |
       cond1.getCondition() = instanceofExpr(v, type) and
       cond2.getCondition() = instanceofExpr(v, type) and
       inverted = false

--- a/java/ql/src/semmle/code/java/dataflow/TypeFlow.qll
+++ b/java/ql/src/semmle/code/java/dataflow/TypeFlow.qll
@@ -299,7 +299,7 @@ private predicate downcastSuccessor(VarAccess va, RefType t) {
 private predicate instanceOfGuarded(VarAccess va, RefType t) {
   exists(InstanceOfExpr ioe, BaseSsaVariable v |
     ioe.getExpr() = v.getAUse() and
-    t = ioe.getTypeName().getType() and
+    t = ioe.getCheckedType() and
     va = v.getAUse() and
     guardControls_v1(ioe, va.getBasicBlock(), true)
   )
@@ -311,7 +311,7 @@ private predicate instanceOfGuarded(VarAccess va, RefType t) {
 predicate arrayInstanceOfGuarded(ArrayAccess aa, RefType t) {
   exists(InstanceOfExpr ioe, BaseSsaVariable v1, BaseSsaVariable v2, ArrayAccess aa1 |
     ioe.getExpr() = aa1 and
-    t = ioe.getTypeName().getType() and
+    t = ioe.getCheckedType() and
     aa1.getArray() = v1.getAUse() and
     aa1.getIndexExpr() = v2.getAUse() and
     aa.getArray() = v1.getAUse() and

--- a/java/ql/src/semmle/code/java/dispatch/VirtualDispatch.qll
+++ b/java/ql/src/semmle/code/java/dispatch/VirtualDispatch.qll
@@ -176,7 +176,7 @@ private module Dispatch {
       v.getAUse() = q and
       guardControls_v1(ioe, q.getBasicBlock(), false) and
       ioe.getExpr() = v.getAUse() and
-      ioe.getTypeName().getType().getErasure() = t and
+      ioe.getCheckedType().getErasure() = t and
       tgt.getDeclaringType().getSourceDeclaration().getASourceSupertype*() = t
     )
   }


### PR DESCRIPTION
Adds the convenience predicate `InstanceOfExpr.getCheckedType()` delegating to `getTypeName().getType()`.