### PR TITLE
Add missing keywords to language specification

### DIFF
--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -497,6 +497,7 @@ The following sequences of characters are keyword tokens:
    max
    min
    module
+   newtype
    none
    not
    or
@@ -514,6 +515,7 @@ The following sequences of characters are keyword tokens:
    then
    this
    true
+   unique
    where
 
 Operators


### PR DESCRIPTION
The keywords `newtype` and `unique` were mentioned in the docs, properly highlighed in snippets but not mentioned in the language reference.