### PR TITLE
C++: Increase cpp/toctou-race-condition query precision.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-367/TOCTOUFilesystemRace.ql
+++ b/cpp/ql/src/Security/CWE/CWE-367/TOCTOUFilesystemRace.ql
@@ -6,7 +6,7 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 7.7
- * @precision medium
+ * @precision high
  * @id cpp/toctou-race-condition
  * @tags security
  *       external/cwe/cwe-367


### PR DESCRIPTION
Upgrade the `cpp/toctou-race-condition` query to `@precision high` (following https://github.com/github/codeql/pull/6335 and discussion there with @rdmarsh2).

---

I experimented with one further change, removing cases where the check is on the return value / success of a call to `stat`, but keeping results on the `stat` buffer pointer / data itself.  This removed a tiny number of dubious results I noticed in https://github.com/github/codeql/pull/6335, along the lines of:
```
if (stat(path, &buf))
{
	f = fopen(path, "r");
}
```
The above is dubious because it only checks the return value of stat, i.e. roughly speaking that the file exists, not the data about it in `buf`.  As a result it's more likely to be a race condition than an exploitable bug.

In addition the change reducated duplication of results in some cases (favouring the more helpful check location where we had two), though the LGTM interface at least presents this kind of duplicate result pretty cleanly in any case.

I decided against this change in part because the improvement for users would be debatable (race conditions are still bugs; and more creative exploits might exist), in part because it turns out it costs us 50% of the results of SAMATE - which do actually look just like the example above.  I still have the code if anyone wants to persuade me it is a worthwhile tradeoff.