### PR TITLE
C++: Improve cpp/uncontrolled-arithmetic

### DIFF
--- a/cpp/change-notes/2021-07-27-uncontrolled-arithmetic.md
+++ b/cpp/change-notes/2021-07-27-uncontrolled-arithmetic.md
@@ -1,0 +1,2 @@
+lgtm
+* Improvements made to the (`cpp/uncontrolled-arithmetic`) query, reducing the frequency of false positive results.

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -74,7 +74,10 @@ private class RandS extends RandomFunction {
 
 predicate missingGuard(VariableAccess va, string effect) {
   exists(Operation op | op.getAnOperand() = va |
-    missingGuardAgainstUnderflow(op, va) and effect = "underflow"
+    (
+      missingGuardAgainstUnderflow(op, va) and effect = "underflow" and
+      not op instanceof MulExpr // random numbers are usually non-negative, so multiplication doesn't underflow.
+    )
     or
     missingGuardAgainstOverflow(op, va) and effect = "overflow"
   )

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -74,10 +74,6 @@ private class RandS extends RandomFunction {
 
 predicate missingGuard(VariableAccess va, string effect) {
   exists(Operation op | op.getAnOperand() = va |
-    missingGuardAgainstUnderflow(op, va) and
-    effect = "underflow" and
-    not op instanceof MulExpr // random numbers are usually non-negative, so multiplication doesn't underflow.
-    or
     missingGuardAgainstOverflow(op, va) and effect = "overflow"
   )
 }

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -108,6 +108,9 @@ class UncontrolledArithConfiguration extends TaintTracking::Configuration {
         op instanceof BitwiseAndExpr or
         op instanceof ComplementExpr
       ).getAnOperand*()
+    or
+    // block unintended flow to pointers
+    node.asExpr().getUnspecifiedType() instanceof PointerType
   }
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -74,10 +74,9 @@ private class RandS extends RandomFunction {
 
 predicate missingGuard(VariableAccess va, string effect) {
   exists(Operation op | op.getAnOperand() = va |
-    (
-      missingGuardAgainstUnderflow(op, va) and effect = "underflow" and
-      not op instanceof MulExpr // random numbers are usually non-negative, so multiplication doesn't underflow.
-    )
+    missingGuardAgainstUnderflow(op, va) and
+    effect = "underflow" and
+    not op instanceof MulExpr // random numbers are usually non-negative, so multiplication doesn't underflow.
     or
     missingGuardAgainstOverflow(op, va) and effect = "overflow"
   )

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -2,11 +2,6 @@ edges
 | test.c:18:13:18:16 | call to rand | test.c:21:17:21:17 | r |
 | test.c:34:13:34:18 | call to rand | test.c:35:5:35:5 | r |
 | test.c:44:13:44:16 | call to rand | test.c:45:5:45:5 | r |
-| test.c:75:13:75:19 | call to rand | test.c:77:9:77:9 | r |
-| test.c:75:13:75:19 | call to rand | test.c:77:9:77:9 | r |
-| test.c:81:14:81:17 | call to rand | test.c:83:9:83:9 | r |
-| test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r |
-| test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r |
 | test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r |
 | test.cpp:8:9:8:12 | Store | test.cpp:24:11:24:18 | call to get_rand |
 | test.cpp:8:9:8:12 | call to rand | test.cpp:8:9:8:12 | Store |
@@ -19,7 +14,6 @@ edges
 | test.cpp:30:13:30:14 | get_rand2 output argument [[]] | test.cpp:30:13:30:14 | Chi |
 | test.cpp:36:13:36:13 | Chi | test.cpp:37:7:37:7 | r |
 | test.cpp:36:13:36:13 | get_rand3 output argument [[]] | test.cpp:36:13:36:13 | Chi |
-| test.cpp:54:10:54:13 | call to rand | test.cpp:57:9:57:9 | x |
 | test.cpp:78:10:78:13 | call to rand | test.cpp:82:10:82:10 | x |
 | test.cpp:90:10:90:13 | call to rand | test.cpp:94:10:94:10 | x |
 | test.cpp:129:10:129:13 | call to rand | test.cpp:132:10:132:10 | b |
@@ -32,14 +26,6 @@ nodes
 | test.c:35:5:35:5 | r | semmle.label | r |
 | test.c:44:13:44:16 | call to rand | semmle.label | call to rand |
 | test.c:45:5:45:5 | r | semmle.label | r |
-| test.c:75:13:75:19 | call to rand | semmle.label | call to rand |
-| test.c:75:13:75:19 | call to rand | semmle.label | call to rand |
-| test.c:77:9:77:9 | r | semmle.label | r |
-| test.c:81:14:81:17 | call to rand | semmle.label | call to rand |
-| test.c:81:23:81:26 | call to rand | semmle.label | call to rand |
-| test.c:83:9:83:9 | r | semmle.label | r |
-| test.c:99:14:99:19 | call to rand | semmle.label | call to rand |
-| test.c:100:5:100:5 | r | semmle.label | r |
 | test.c:125:13:125:16 | call to rand | semmle.label | call to rand |
 | test.c:127:9:127:9 | r | semmle.label | r |
 | test.cpp:8:9:8:12 | Store | semmle.label | Store |
@@ -56,8 +42,6 @@ nodes
 | test.cpp:36:13:36:13 | Chi | semmle.label | Chi |
 | test.cpp:36:13:36:13 | get_rand3 output argument [[]] | semmle.label | get_rand3 output argument [[]] |
 | test.cpp:37:7:37:7 | r | semmle.label | r |
-| test.cpp:54:10:54:13 | call to rand | semmle.label | call to rand |
-| test.cpp:57:9:57:9 | x | semmle.label | x |
 | test.cpp:78:10:78:13 | call to rand | semmle.label | call to rand |
 | test.cpp:82:10:82:10 | x | semmle.label | x |
 | test.cpp:90:10:90:13 | call to rand | semmle.label | call to rand |
@@ -71,16 +55,10 @@ nodes
 | test.c:21:17:21:17 | r | test.c:18:13:18:16 | call to rand | test.c:21:17:21:17 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:18:13:18:16 | call to rand | Uncontrolled value |
 | test.c:35:5:35:5 | r | test.c:34:13:34:18 | call to rand | test.c:35:5:35:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:34:13:34:18 | call to rand | Uncontrolled value |
 | test.c:45:5:45:5 | r | test.c:44:13:44:16 | call to rand | test.c:45:5:45:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:44:13:44:16 | call to rand | Uncontrolled value |
-| test.c:77:9:77:9 | r | test.c:75:13:75:19 | call to rand | test.c:77:9:77:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:75:13:75:19 | call to rand | Uncontrolled value |
-| test.c:77:9:77:9 | r | test.c:75:13:75:19 | call to rand | test.c:77:9:77:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:75:13:75:19 | call to rand | Uncontrolled value |
-| test.c:83:9:83:9 | r | test.c:81:14:81:17 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:81:14:81:17 | call to rand | Uncontrolled value |
-| test.c:83:9:83:9 | r | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:81:23:81:26 | call to rand | Uncontrolled value |
-| test.c:100:5:100:5 | r | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:99:14:99:19 | call to rand | Uncontrolled value |
 | test.c:127:9:127:9 | r | test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:125:13:125:16 | call to rand | Uncontrolled value |
 | test.cpp:25:7:25:7 | r | test.cpp:8:9:8:12 | call to rand | test.cpp:25:7:25:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:8:9:8:12 | call to rand | Uncontrolled value |
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | Uncontrolled value |
 | test.cpp:37:7:37:7 | r | test.cpp:18:9:18:12 | call to rand | test.cpp:37:7:37:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:18:9:18:12 | call to rand | Uncontrolled value |
-| test.cpp:57:9:57:9 | x | test.cpp:54:10:54:13 | call to rand | test.cpp:57:9:57:9 | x | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:54:10:54:13 | call to rand | Uncontrolled value |
 | test.cpp:82:10:82:10 | x | test.cpp:78:10:78:13 | call to rand | test.cpp:82:10:82:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:78:10:78:13 | call to rand | Uncontrolled value |
 | test.cpp:94:10:94:10 | x | test.cpp:90:10:90:13 | call to rand | test.cpp:94:10:94:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:90:10:90:13 | call to rand | Uncontrolled value |
 | test.cpp:132:10:132:10 | b | test.cpp:129:10:129:13 | call to rand | test.cpp:132:10:132:10 | b | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:129:10:129:13 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -8,6 +8,8 @@ edges
 | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r |
 | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r |
 | test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r |
+| test.c:148:22:148:25 | call to rand | test.c:150:9:150:9 | r |
+| test.c:148:22:148:27 | (unsigned int)... | test.c:150:9:150:9 | r |
 | test.cpp:8:9:8:12 | Store | test.cpp:24:11:24:18 | call to get_rand |
 | test.cpp:8:9:8:12 | call to rand | test.cpp:8:9:8:12 | Store |
 | test.cpp:13:2:13:15 | Chi [[]] | test.cpp:30:13:30:14 | get_rand2 output argument [[]] |
@@ -41,6 +43,9 @@ nodes
 | test.c:100:5:100:5 | r | semmle.label | r |
 | test.c:125:13:125:16 | call to rand | semmle.label | call to rand |
 | test.c:127:9:127:9 | r | semmle.label | r |
+| test.c:148:22:148:25 | call to rand | semmle.label | call to rand |
+| test.c:148:22:148:27 | (unsigned int)... | semmle.label | (unsigned int)... |
+| test.c:150:9:150:9 | r | semmle.label | r |
 | test.cpp:8:9:8:12 | Store | semmle.label | Store |
 | test.cpp:8:9:8:12 | call to rand | semmle.label | call to rand |
 | test.cpp:13:2:13:15 | Chi [[]] | semmle.label | Chi [[]] |
@@ -74,6 +79,8 @@ nodes
 | test.c:83:9:83:9 | r | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:81:23:81:26 | call to rand | Uncontrolled value |
 | test.c:100:5:100:5 | r | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:99:14:99:19 | call to rand | Uncontrolled value |
 | test.c:127:9:127:9 | r | test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:125:13:125:16 | call to rand | Uncontrolled value |
+| test.c:150:9:150:9 | r | test.c:148:22:148:25 | call to rand | test.c:150:9:150:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:148:22:148:25 | call to rand | Uncontrolled value |
+| test.c:150:9:150:9 | r | test.c:148:22:148:27 | (unsigned int)... | test.c:150:9:150:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:148:22:148:25 | call to rand | Uncontrolled value |
 | test.cpp:25:7:25:7 | r | test.cpp:8:9:8:12 | call to rand | test.cpp:25:7:25:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:8:9:8:12 | call to rand | Uncontrolled value |
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | Uncontrolled value |
 | test.cpp:37:7:37:7 | r | test.cpp:18:9:18:12 | call to rand | test.cpp:37:7:37:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:18:9:18:12 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -2,6 +2,11 @@ edges
 | test.c:18:13:18:16 | call to rand | test.c:21:17:21:17 | r |
 | test.c:34:13:34:18 | call to rand | test.c:35:5:35:5 | r |
 | test.c:44:13:44:16 | call to rand | test.c:45:5:45:5 | r |
+| test.c:75:13:75:19 | call to rand | test.c:77:9:77:9 | r |
+| test.c:75:13:75:19 | call to rand | test.c:77:9:77:9 | r |
+| test.c:81:14:81:17 | call to rand | test.c:83:9:83:9 | r |
+| test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r |
+| test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r |
 | test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r |
 | test.cpp:8:9:8:12 | Store | test.cpp:24:11:24:18 | call to get_rand |
 | test.cpp:8:9:8:12 | call to rand | test.cpp:8:9:8:12 | Store |
@@ -26,6 +31,14 @@ nodes
 | test.c:35:5:35:5 | r | semmle.label | r |
 | test.c:44:13:44:16 | call to rand | semmle.label | call to rand |
 | test.c:45:5:45:5 | r | semmle.label | r |
+| test.c:75:13:75:19 | call to rand | semmle.label | call to rand |
+| test.c:75:13:75:19 | call to rand | semmle.label | call to rand |
+| test.c:77:9:77:9 | r | semmle.label | r |
+| test.c:81:14:81:17 | call to rand | semmle.label | call to rand |
+| test.c:81:23:81:26 | call to rand | semmle.label | call to rand |
+| test.c:83:9:83:9 | r | semmle.label | r |
+| test.c:99:14:99:19 | call to rand | semmle.label | call to rand |
+| test.c:100:5:100:5 | r | semmle.label | r |
 | test.c:125:13:125:16 | call to rand | semmle.label | call to rand |
 | test.c:127:9:127:9 | r | semmle.label | r |
 | test.cpp:8:9:8:12 | Store | semmle.label | Store |
@@ -55,6 +68,11 @@ nodes
 | test.c:21:17:21:17 | r | test.c:18:13:18:16 | call to rand | test.c:21:17:21:17 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:18:13:18:16 | call to rand | Uncontrolled value |
 | test.c:35:5:35:5 | r | test.c:34:13:34:18 | call to rand | test.c:35:5:35:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:34:13:34:18 | call to rand | Uncontrolled value |
 | test.c:45:5:45:5 | r | test.c:44:13:44:16 | call to rand | test.c:45:5:45:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:44:13:44:16 | call to rand | Uncontrolled value |
+| test.c:77:9:77:9 | r | test.c:75:13:75:19 | call to rand | test.c:77:9:77:9 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:75:13:75:19 | call to rand | Uncontrolled value |
+| test.c:77:9:77:9 | r | test.c:75:13:75:19 | call to rand | test.c:77:9:77:9 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:75:13:75:19 | call to rand | Uncontrolled value |
+| test.c:83:9:83:9 | r | test.c:81:14:81:17 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:81:14:81:17 | call to rand | Uncontrolled value |
+| test.c:83:9:83:9 | r | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:81:23:81:26 | call to rand | Uncontrolled value |
+| test.c:100:5:100:5 | r | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:99:14:99:19 | call to rand | Uncontrolled value |
 | test.c:127:9:127:9 | r | test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:125:13:125:16 | call to rand | Uncontrolled value |
 | test.cpp:25:7:25:7 | r | test.cpp:8:9:8:12 | call to rand | test.cpp:25:7:25:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:8:9:8:12 | call to rand | Uncontrolled value |
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -20,12 +20,6 @@ edges
 | test.cpp:36:13:36:13 | Chi | test.cpp:37:7:37:7 | r |
 | test.cpp:36:13:36:13 | get_rand3 output argument [[]] | test.cpp:36:13:36:13 | Chi |
 | test.cpp:54:10:54:13 | call to rand | test.cpp:57:9:57:9 | x |
-| test.cpp:63:23:63:31 | buf_start | test.cpp:67:9:67:11 | len |
-| test.cpp:63:40:63:46 | buf_end | test.cpp:67:9:67:11 | len |
-| test.cpp:72:50:72:53 | call to rand | test.cpp:73:2:73:12 | ... + ... |
-| test.cpp:72:50:72:53 | call to rand | test.cpp:73:2:73:12 | buf |
-| test.cpp:73:2:73:12 | ... + ... | test.cpp:63:40:63:46 | buf_end |
-| test.cpp:73:2:73:12 | buf | test.cpp:63:23:63:31 | buf_start |
 | test.cpp:78:10:78:13 | call to rand | test.cpp:82:10:82:10 | x |
 | test.cpp:78:10:78:13 | call to rand | test.cpp:84:10:84:10 | x |
 | test.cpp:90:10:90:13 | call to rand | test.cpp:94:10:94:10 | x |
@@ -65,12 +59,6 @@ nodes
 | test.cpp:37:7:37:7 | r | semmle.label | r |
 | test.cpp:54:10:54:13 | call to rand | semmle.label | call to rand |
 | test.cpp:57:9:57:9 | x | semmle.label | x |
-| test.cpp:63:23:63:31 | buf_start | semmle.label | buf_start |
-| test.cpp:63:40:63:46 | buf_end | semmle.label | buf_end |
-| test.cpp:67:9:67:11 | len | semmle.label | len |
-| test.cpp:72:50:72:53 | call to rand | semmle.label | call to rand |
-| test.cpp:73:2:73:12 | ... + ... | semmle.label | ... + ... |
-| test.cpp:73:2:73:12 | buf | semmle.label | buf |
 | test.cpp:78:10:78:13 | call to rand | semmle.label | call to rand |
 | test.cpp:82:10:82:10 | x | semmle.label | x |
 | test.cpp:84:10:84:10 | x | semmle.label | x |
@@ -96,8 +84,6 @@ nodes
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | Uncontrolled value |
 | test.cpp:37:7:37:7 | r | test.cpp:18:9:18:12 | call to rand | test.cpp:37:7:37:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:18:9:18:12 | call to rand | Uncontrolled value |
 | test.cpp:57:9:57:9 | x | test.cpp:54:10:54:13 | call to rand | test.cpp:57:9:57:9 | x | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:54:10:54:13 | call to rand | Uncontrolled value |
-| test.cpp:67:9:67:11 | len | test.cpp:72:50:72:53 | call to rand | test.cpp:67:9:67:11 | len | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:72:50:72:53 | call to rand | Uncontrolled value |
-| test.cpp:67:9:67:11 | len | test.cpp:72:50:72:53 | call to rand | test.cpp:67:9:67:11 | len | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:72:50:72:53 | call to rand | Uncontrolled value |
 | test.cpp:82:10:82:10 | x | test.cpp:78:10:78:13 | call to rand | test.cpp:82:10:82:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:78:10:78:13 | call to rand | Uncontrolled value |
 | test.cpp:84:10:84:10 | x | test.cpp:78:10:78:13 | call to rand | test.cpp:84:10:84:10 | x | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:78:10:78:13 | call to rand | Uncontrolled value |
 | test.cpp:94:10:94:10 | x | test.cpp:90:10:90:13 | call to rand | test.cpp:94:10:94:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:90:10:90:13 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -21,11 +21,7 @@ edges
 | test.cpp:36:13:36:13 | get_rand3 output argument [[]] | test.cpp:36:13:36:13 | Chi |
 | test.cpp:54:10:54:13 | call to rand | test.cpp:57:9:57:9 | x |
 | test.cpp:78:10:78:13 | call to rand | test.cpp:82:10:82:10 | x |
-| test.cpp:78:10:78:13 | call to rand | test.cpp:84:10:84:10 | x |
 | test.cpp:90:10:90:13 | call to rand | test.cpp:94:10:94:10 | x |
-| test.cpp:90:10:90:13 | call to rand | test.cpp:97:9:97:9 | x |
-| test.cpp:102:10:102:13 | call to rand | test.cpp:108:10:108:10 | y |
-| test.cpp:116:10:116:13 | call to rand | test.cpp:124:9:124:9 | y |
 nodes
 | test.c:18:13:18:16 | call to rand | semmle.label | call to rand |
 | test.c:21:17:21:17 | r | semmle.label | r |
@@ -61,14 +57,8 @@ nodes
 | test.cpp:57:9:57:9 | x | semmle.label | x |
 | test.cpp:78:10:78:13 | call to rand | semmle.label | call to rand |
 | test.cpp:82:10:82:10 | x | semmle.label | x |
-| test.cpp:84:10:84:10 | x | semmle.label | x |
 | test.cpp:90:10:90:13 | call to rand | semmle.label | call to rand |
 | test.cpp:94:10:94:10 | x | semmle.label | x |
-| test.cpp:97:9:97:9 | x | semmle.label | x |
-| test.cpp:102:10:102:13 | call to rand | semmle.label | call to rand |
-| test.cpp:108:10:108:10 | y | semmle.label | y |
-| test.cpp:116:10:116:13 | call to rand | semmle.label | call to rand |
-| test.cpp:124:9:124:9 | y | semmle.label | y |
 #select
 | test.c:21:17:21:17 | r | test.c:18:13:18:16 | call to rand | test.c:21:17:21:17 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:18:13:18:16 | call to rand | Uncontrolled value |
 | test.c:35:5:35:5 | r | test.c:34:13:34:18 | call to rand | test.c:35:5:35:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:34:13:34:18 | call to rand | Uncontrolled value |
@@ -79,14 +69,9 @@ nodes
 | test.c:83:9:83:9 | r | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:81:23:81:26 | call to rand | Uncontrolled value |
 | test.c:100:5:100:5 | r | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:99:14:99:19 | call to rand | Uncontrolled value |
 | test.c:127:9:127:9 | r | test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:125:13:125:16 | call to rand | Uncontrolled value |
-| test.c:127:9:127:9 | r | test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:125:13:125:16 | call to rand | Uncontrolled value |
 | test.cpp:25:7:25:7 | r | test.cpp:8:9:8:12 | call to rand | test.cpp:25:7:25:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:8:9:8:12 | call to rand | Uncontrolled value |
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | Uncontrolled value |
 | test.cpp:37:7:37:7 | r | test.cpp:18:9:18:12 | call to rand | test.cpp:37:7:37:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:18:9:18:12 | call to rand | Uncontrolled value |
 | test.cpp:57:9:57:9 | x | test.cpp:54:10:54:13 | call to rand | test.cpp:57:9:57:9 | x | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:54:10:54:13 | call to rand | Uncontrolled value |
 | test.cpp:82:10:82:10 | x | test.cpp:78:10:78:13 | call to rand | test.cpp:82:10:82:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:78:10:78:13 | call to rand | Uncontrolled value |
-| test.cpp:84:10:84:10 | x | test.cpp:78:10:78:13 | call to rand | test.cpp:84:10:84:10 | x | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:78:10:78:13 | call to rand | Uncontrolled value |
 | test.cpp:94:10:94:10 | x | test.cpp:90:10:90:13 | call to rand | test.cpp:94:10:94:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:90:10:90:13 | call to rand | Uncontrolled value |
-| test.cpp:97:9:97:9 | x | test.cpp:90:10:90:13 | call to rand | test.cpp:97:9:97:9 | x | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:90:10:90:13 | call to rand | Uncontrolled value |
-| test.cpp:108:10:108:10 | y | test.cpp:102:10:102:13 | call to rand | test.cpp:108:10:108:10 | y | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:102:10:102:13 | call to rand | Uncontrolled value |
-| test.cpp:124:9:124:9 | y | test.cpp:116:10:116:13 | call to rand | test.cpp:124:9:124:9 | y | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:116:10:116:13 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -7,6 +7,7 @@ edges
 | test.c:81:14:81:17 | call to rand | test.c:83:9:83:9 | r |
 | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r |
 | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r |
+| test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r |
 | test.cpp:8:9:8:12 | Store | test.cpp:24:11:24:18 | call to get_rand |
 | test.cpp:8:9:8:12 | call to rand | test.cpp:8:9:8:12 | Store |
 | test.cpp:13:2:13:15 | Chi [[]] | test.cpp:30:13:30:14 | get_rand2 output argument [[]] |
@@ -18,6 +19,19 @@ edges
 | test.cpp:30:13:30:14 | get_rand2 output argument [[]] | test.cpp:30:13:30:14 | Chi |
 | test.cpp:36:13:36:13 | Chi | test.cpp:37:7:37:7 | r |
 | test.cpp:36:13:36:13 | get_rand3 output argument [[]] | test.cpp:36:13:36:13 | Chi |
+| test.cpp:54:10:54:13 | call to rand | test.cpp:57:9:57:9 | x |
+| test.cpp:63:23:63:31 | buf_start | test.cpp:67:9:67:11 | len |
+| test.cpp:63:40:63:46 | buf_end | test.cpp:67:9:67:11 | len |
+| test.cpp:72:50:72:53 | call to rand | test.cpp:73:2:73:12 | ... + ... |
+| test.cpp:72:50:72:53 | call to rand | test.cpp:73:2:73:12 | buf |
+| test.cpp:73:2:73:12 | ... + ... | test.cpp:63:40:63:46 | buf_end |
+| test.cpp:73:2:73:12 | buf | test.cpp:63:23:63:31 | buf_start |
+| test.cpp:78:10:78:13 | call to rand | test.cpp:82:10:82:10 | x |
+| test.cpp:78:10:78:13 | call to rand | test.cpp:84:10:84:10 | x |
+| test.cpp:90:10:90:13 | call to rand | test.cpp:94:10:94:10 | x |
+| test.cpp:90:10:90:13 | call to rand | test.cpp:97:9:97:9 | x |
+| test.cpp:102:10:102:13 | call to rand | test.cpp:108:10:108:10 | y |
+| test.cpp:116:10:116:13 | call to rand | test.cpp:124:9:124:9 | y |
 nodes
 | test.c:18:13:18:16 | call to rand | semmle.label | call to rand |
 | test.c:21:17:21:17 | r | semmle.label | r |
@@ -33,6 +47,8 @@ nodes
 | test.c:83:9:83:9 | r | semmle.label | r |
 | test.c:99:14:99:19 | call to rand | semmle.label | call to rand |
 | test.c:100:5:100:5 | r | semmle.label | r |
+| test.c:125:13:125:16 | call to rand | semmle.label | call to rand |
+| test.c:127:9:127:9 | r | semmle.label | r |
 | test.cpp:8:9:8:12 | Store | semmle.label | Store |
 | test.cpp:8:9:8:12 | call to rand | semmle.label | call to rand |
 | test.cpp:13:2:13:15 | Chi [[]] | semmle.label | Chi [[]] |
@@ -47,6 +63,24 @@ nodes
 | test.cpp:36:13:36:13 | Chi | semmle.label | Chi |
 | test.cpp:36:13:36:13 | get_rand3 output argument [[]] | semmle.label | get_rand3 output argument [[]] |
 | test.cpp:37:7:37:7 | r | semmle.label | r |
+| test.cpp:54:10:54:13 | call to rand | semmle.label | call to rand |
+| test.cpp:57:9:57:9 | x | semmle.label | x |
+| test.cpp:63:23:63:31 | buf_start | semmle.label | buf_start |
+| test.cpp:63:40:63:46 | buf_end | semmle.label | buf_end |
+| test.cpp:67:9:67:11 | len | semmle.label | len |
+| test.cpp:72:50:72:53 | call to rand | semmle.label | call to rand |
+| test.cpp:73:2:73:12 | ... + ... | semmle.label | ... + ... |
+| test.cpp:73:2:73:12 | buf | semmle.label | buf |
+| test.cpp:78:10:78:13 | call to rand | semmle.label | call to rand |
+| test.cpp:82:10:82:10 | x | semmle.label | x |
+| test.cpp:84:10:84:10 | x | semmle.label | x |
+| test.cpp:90:10:90:13 | call to rand | semmle.label | call to rand |
+| test.cpp:94:10:94:10 | x | semmle.label | x |
+| test.cpp:97:9:97:9 | x | semmle.label | x |
+| test.cpp:102:10:102:13 | call to rand | semmle.label | call to rand |
+| test.cpp:108:10:108:10 | y | semmle.label | y |
+| test.cpp:116:10:116:13 | call to rand | semmle.label | call to rand |
+| test.cpp:124:9:124:9 | y | semmle.label | y |
 #select
 | test.c:21:17:21:17 | r | test.c:18:13:18:16 | call to rand | test.c:21:17:21:17 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:18:13:18:16 | call to rand | Uncontrolled value |
 | test.c:35:5:35:5 | r | test.c:34:13:34:18 | call to rand | test.c:35:5:35:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:34:13:34:18 | call to rand | Uncontrolled value |
@@ -56,6 +90,17 @@ nodes
 | test.c:83:9:83:9 | r | test.c:81:14:81:17 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:81:14:81:17 | call to rand | Uncontrolled value |
 | test.c:83:9:83:9 | r | test.c:81:23:81:26 | call to rand | test.c:83:9:83:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:81:23:81:26 | call to rand | Uncontrolled value |
 | test.c:100:5:100:5 | r | test.c:99:14:99:19 | call to rand | test.c:100:5:100:5 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:99:14:99:19 | call to rand | Uncontrolled value |
+| test.c:127:9:127:9 | r | test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:125:13:125:16 | call to rand | Uncontrolled value |
+| test.c:127:9:127:9 | r | test.c:125:13:125:16 | call to rand | test.c:127:9:127:9 | r | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:125:13:125:16 | call to rand | Uncontrolled value |
 | test.cpp:25:7:25:7 | r | test.cpp:8:9:8:12 | call to rand | test.cpp:25:7:25:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:8:9:8:12 | call to rand | Uncontrolled value |
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | Uncontrolled value |
 | test.cpp:37:7:37:7 | r | test.cpp:18:9:18:12 | call to rand | test.cpp:37:7:37:7 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:18:9:18:12 | call to rand | Uncontrolled value |
+| test.cpp:57:9:57:9 | x | test.cpp:54:10:54:13 | call to rand | test.cpp:57:9:57:9 | x | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:54:10:54:13 | call to rand | Uncontrolled value |
+| test.cpp:67:9:67:11 | len | test.cpp:72:50:72:53 | call to rand | test.cpp:67:9:67:11 | len | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:72:50:72:53 | call to rand | Uncontrolled value |
+| test.cpp:67:9:67:11 | len | test.cpp:72:50:72:53 | call to rand | test.cpp:67:9:67:11 | len | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:72:50:72:53 | call to rand | Uncontrolled value |
+| test.cpp:82:10:82:10 | x | test.cpp:78:10:78:13 | call to rand | test.cpp:82:10:82:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:78:10:78:13 | call to rand | Uncontrolled value |
+| test.cpp:84:10:84:10 | x | test.cpp:78:10:78:13 | call to rand | test.cpp:84:10:84:10 | x | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:78:10:78:13 | call to rand | Uncontrolled value |
+| test.cpp:94:10:94:10 | x | test.cpp:90:10:90:13 | call to rand | test.cpp:94:10:94:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:90:10:90:13 | call to rand | Uncontrolled value |
+| test.cpp:97:9:97:9 | x | test.cpp:90:10:90:13 | call to rand | test.cpp:97:9:97:9 | x | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:90:10:90:13 | call to rand | Uncontrolled value |
+| test.cpp:108:10:108:10 | y | test.cpp:102:10:102:13 | call to rand | test.cpp:108:10:108:10 | y | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:102:10:102:13 | call to rand | Uncontrolled value |
+| test.cpp:124:9:124:9 | y | test.cpp:116:10:116:13 | call to rand | test.cpp:124:9:124:9 | y | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:116:10:116:13 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -22,6 +22,9 @@ edges
 | test.cpp:54:10:54:13 | call to rand | test.cpp:57:9:57:9 | x |
 | test.cpp:78:10:78:13 | call to rand | test.cpp:82:10:82:10 | x |
 | test.cpp:90:10:90:13 | call to rand | test.cpp:94:10:94:10 | x |
+| test.cpp:129:10:129:13 | call to rand | test.cpp:132:10:132:10 | b |
+| test.cpp:147:11:147:14 | call to rand | test.cpp:149:11:149:16 | (int)... |
+| test.cpp:147:11:147:14 | call to rand | test.cpp:149:16:149:16 | y |
 nodes
 | test.c:18:13:18:16 | call to rand | semmle.label | call to rand |
 | test.c:21:17:21:17 | r | semmle.label | r |
@@ -59,6 +62,11 @@ nodes
 | test.cpp:82:10:82:10 | x | semmle.label | x |
 | test.cpp:90:10:90:13 | call to rand | semmle.label | call to rand |
 | test.cpp:94:10:94:10 | x | semmle.label | x |
+| test.cpp:129:10:129:13 | call to rand | semmle.label | call to rand |
+| test.cpp:132:10:132:10 | b | semmle.label | b |
+| test.cpp:147:11:147:14 | call to rand | semmle.label | call to rand |
+| test.cpp:149:11:149:16 | (int)... | semmle.label | (int)... |
+| test.cpp:149:16:149:16 | y | semmle.label | y |
 #select
 | test.c:21:17:21:17 | r | test.c:18:13:18:16 | call to rand | test.c:21:17:21:17 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:18:13:18:16 | call to rand | Uncontrolled value |
 | test.c:35:5:35:5 | r | test.c:34:13:34:18 | call to rand | test.c:35:5:35:5 | r | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:34:13:34:18 | call to rand | Uncontrolled value |
@@ -75,3 +83,6 @@ nodes
 | test.cpp:57:9:57:9 | x | test.cpp:54:10:54:13 | call to rand | test.cpp:57:9:57:9 | x | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.cpp:54:10:54:13 | call to rand | Uncontrolled value |
 | test.cpp:82:10:82:10 | x | test.cpp:78:10:78:13 | call to rand | test.cpp:82:10:82:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:78:10:78:13 | call to rand | Uncontrolled value |
 | test.cpp:94:10:94:10 | x | test.cpp:90:10:90:13 | call to rand | test.cpp:94:10:94:10 | x | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:90:10:90:13 | call to rand | Uncontrolled value |
+| test.cpp:132:10:132:10 | b | test.cpp:129:10:129:13 | call to rand | test.cpp:132:10:132:10 | b | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:129:10:129:13 | call to rand | Uncontrolled value |
+| test.cpp:149:11:149:16 | (int)... | test.cpp:147:11:147:14 | call to rand | test.cpp:149:11:149:16 | (int)... | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:147:11:147:14 | call to rand | Uncontrolled value |
+| test.cpp:149:16:149:16 | y | test.cpp:147:11:147:14 | call to rand | test.cpp:149:16:149:16 | y | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.cpp:147:11:147:14 | call to rand | Uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
@@ -74,30 +74,30 @@ void randomTester() {
   {
     int r = RAND2();
 
-    r = r - 100; // GOOD
+    r = r + 100; // BAD
   }
 
   {
     int r = (rand() ^ rand());
 
-    r = r - 100; // GOOD
+    r = r + 100; // BAD
   }
 
   {
-    int r = RAND2() - 100; // BAD [NOT DETECTED]
+    int r = RAND2() + 100; // BAD [NOT DETECTED]
   }
 
   {
     int r = RAND();
     int *ptr_r = &r;
-    *ptr_r -= 100; // BAD [NOT DETECTED]
+    *ptr_r += 100; // BAD [NOT DETECTED]
   }
 
   {
     int r = 0;
     int *ptr_r = &r;
     *ptr_r = RAND();
-    r -= 100; // GOOD
+    r += 100; // BAD
   }
 
   {
@@ -136,5 +136,17 @@ void moreTests() {
     int r = rand();
     
     r <<= 8; // BAD [NOT DETECTED]
+  }
+
+  {
+    int r = rand();
+    
+    r = r - 100; // GOOD
+  }
+
+  {
+    unsigned int r = rand();
+    
+    r = r - 100; // BAD [NOT DETECTED]
   }
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
@@ -74,13 +74,13 @@ void randomTester() {
   {
     int r = RAND2();
 
-    r = r - 100; // BAD
+    r = r - 100; // GOOD
   }
 
   {
     int r = (rand() ^ rand());
 
-    r = r - 100; // BAD
+    r = r - 100; // GOOD
   }
 
   {
@@ -97,7 +97,7 @@ void randomTester() {
     int r = 0;
     int *ptr_r = &r;
     *ptr_r = RAND();
-    r -= 100; // BAD
+    r -= 100; // GOOD
   }
 
   {

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
@@ -147,6 +147,6 @@ void moreTests() {
   {
     unsigned int r = rand();
     
-    r = r - 100; // BAD [NOT DETECTED]
+    r = r - 100; // BAD
   }
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.c
@@ -119,3 +119,22 @@ void randomTester2(int bound, int min, int max) {
   int r2 = (rand() % (max - min + 1)) + min;
   r2 += 100; // GOOD (This is a common way to clamp the random value between [min, max])
 }
+
+void moreTests() {
+  {
+    int r = rand();
+    
+    r = r * 100; // BAD
+  }
+  {
+    int r = rand();
+    
+    r *= 100; // BAD [NOT DETECTED]
+  }
+
+  {
+    int r = rand();
+    
+    r <<= 8; // BAD [NOT DETECTED]
+  }
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
@@ -64,7 +64,7 @@ int test_buffer(char *buf_start, char *buf_end)
 {
 	int len = buf_end - buf_start;
 
-	return len * 2; // GOOD [FALSE POSITIVE]
+	return len * 2; // GOOD
 }
 
 int test_snprintf(char *buf, size_t buf_sz)

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
@@ -123,3 +123,41 @@ int test_conditional_assignment_2()
 	
 	return y * 10; // GOOD (as y <= 100)
 }
+
+int test_underflow()
+{
+	int x = rand();
+	int a = -x; // GOOD
+	int b = 10 - x; // GOOD
+	int c = b * 2; // BAD
+}
+
+int test_cast()
+{
+	int x = rand();
+	short a = x; // BAD [NOT DETECTED]
+	short b = -x; // BAD [NOT DETECTED]
+	long long c = x; // GOOD
+	long long d = -x; // GOOD
+}
+
+void test_float()
+{
+	{
+		int x = rand();
+		float y = x; // GOOD
+		int z = (int)y * 5; // BAD
+	}
+
+	{
+		int x = rand();
+		float y = x * 5.0f; // GOOD
+		int z = y; // BAD [NOT DETECTED]
+	}
+
+	{
+		int x = rand();
+		float y = x / 10.0f; // GOOD
+		int z = (int)y * 5; // GOOD
+	}
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
@@ -48,3 +48,78 @@ void test_with_bounded_randomness() {
 	unsigned unsigned_r = rand(10);
 	unsigned_r++; // GOOD
 }
+
+int test_remainder_subtract()
+{
+	int x = rand();
+	int y = x % 100; // y <= x
+
+	return x - y; // GOOD (as y <= x) [FALSE POSITIVE]
+}
+
+typedef unsigned long size_t;
+int snprintf(char *s, size_t n, const char *format, ...);
+
+int test_buffer(char *buf_start, char *buf_end)
+{
+	int len = buf_end - buf_start;
+
+	return len * 2; // GOOD [FALSE POSITIVE]
+}
+
+int test_snprintf(char *buf, size_t buf_sz)
+{
+	snprintf(buf, buf_sz, "my random number: %i\n", rand());
+	test_buffer(buf, buf + buf_sz);
+}
+
+int test_else_1()
+{
+	int x = rand();
+
+	if (x > 100)
+	{
+		return x * 10; // BAD
+	} else {
+		return x * 10; // GOOD (as x <= 100) [FALSE POSITIVE]
+	}
+}
+
+int test_else_2()
+{
+	int x = rand();
+
+	if (x > 100)
+	{
+		return x * 10; // BAD
+	}
+
+	return x * 10; // GOOD (as x <= 100) [FALSE POSITIVE]
+}
+
+int test_conditional_assignment_1()
+{
+	int x = rand();
+	int y = 100;
+
+	if (x < y)
+	{
+		y = x;
+		return y * 10; // GOOD (as y <= 100) [FALSE POSITIVE]
+	} else {
+		return y * 10; // GOOD (as y = 100)
+	}
+}
+
+int test_conditional_assignment_2()
+{
+	int x = rand();
+	int y = 100;
+
+	if (x < y)
+	{
+		y = x;
+	}
+	
+	return y * 10; // GOOD (as y <= 100) [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
@@ -54,7 +54,7 @@ int test_remainder_subtract()
 	int x = rand();
 	int y = x % 100; // y <= x
 
-	return x - y; // GOOD (as y <= x) [FALSE POSITIVE]
+	return x - y; // GOOD (as y <= x)
 }
 
 typedef unsigned long size_t;

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/test.cpp
@@ -81,7 +81,7 @@ int test_else_1()
 	{
 		return x * 10; // BAD
 	} else {
-		return x * 10; // GOOD (as x <= 100) [FALSE POSITIVE]
+		return x * 10; // GOOD (as x <= 100)
 	}
 }
 
@@ -94,7 +94,7 @@ int test_else_2()
 		return x * 10; // BAD
 	}
 
-	return x * 10; // GOOD (as x <= 100) [FALSE POSITIVE]
+	return x * 10; // GOOD (as x <= 100)
 }
 
 int test_conditional_assignment_1()
@@ -105,7 +105,7 @@ int test_conditional_assignment_1()
 	if (x < y)
 	{
 		y = x;
-		return y * 10; // GOOD (as y <= 100) [FALSE POSITIVE]
+		return y * 10; // GOOD (as y <= 100)
 	} else {
 		return y * 10; // GOOD (as y = 100)
 	}
@@ -121,5 +121,5 @@ int test_conditional_assignment_2()
 		y = x;
 	}
 	
-	return y * 10; // GOOD (as y <= 100) [FALSE POSITIVE]
+	return y * 10; // GOOD (as y <= 100)
 }


### PR DESCRIPTION
Improve `cpp/uncontrolled-arithmetic`.
 - add tests for three types of false positives, inspired by real world results (https://lgtm.com/query/4365328648079107314/).
 - fix two of them.

@mathiasvp has worked on this query recently.