### PR TITLE
C#: Guard against virtual dispatch branching too much.

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dispatch/Dispatch.qll
@@ -508,7 +508,7 @@ private module Internal {
     override RuntimeCallable getADynamicTarget() {
       result = getAViableInherited()
       or
-      result = getAViableOverrider()
+      result = getAViableOverrider() and strictcount(getAViableOverrider()) < 1000
       or
       // Simple case: target method cannot be overridden
       result = getAStaticTarget() and


### PR DESCRIPTION
We have observed databases where dispatch to highly overridden
virtual methots (like Enumerable.GetEnumerator) ends up branching
to many thousands of overrides, if there is not sufficient type
context to prune. This causes performance problems for analyses
that use dataflow.

As an immediate fix, this commit prevents branching to virtual
method overrides if this would result in branching to 1,000 or
more methods.