### PR TITLE
JS: don't report dummy authentication headers as hardcoded-crendentials

### DIFF
--- a/javascript/change-notes/2021-08-03-hardcoded-auth-headers.md
+++ b/javascript/change-notes/2021-08-03-hardcoded-auth-headers.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The query "Hard-coded credentials" (`js/hardcoded-credentials`) no longer flags deliberately weak authentication headers.

--- a/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -28,6 +28,9 @@ where
       not (
         sink.getNode().(Sink).(DefaultCredentialsSink).getKind() = "password" and
         PasswordHeuristics::isDummyPassword(val)
+        or
+        sink.getNode().(Sink).getKind() = "authorization header" and
+        PasswordHeuristics::isDummyAuthHeader(val)
       ) and
       value = "The hard-coded value \"" + val + "\""
     )

--- a/javascript/ql/src/semmle/javascript/security/SensitiveActions.qll
+++ b/javascript/ql/src/semmle/javascript/security/SensitiveActions.qll
@@ -197,15 +197,15 @@ module PasswordHeuristics {
     isDummyPassword(header)
     or
     exists(string prefix, string suffix | prefix = getAnHTTPAuthenticationScheme() |
-      header = prefix + " " + suffix and
+      header.toLowerCase() = prefix + " " + suffix and
       isDummyPassword(suffix)
     )
     or
-    header.trim() = getAnHTTPAuthenticationScheme()
+    header.trim().toLowerCase() = getAnHTTPAuthenticationScheme()
   }
 
   /**
-   * Gets a HTTP authentication scheme.
+   * Gets a HTTP authentication scheme normalized to lowercase.
    * From this list: https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
    */
   private string getAnHTTPAuthenticationScheme() {
@@ -213,6 +213,6 @@ module PasswordHeuristics {
       [
         "Basic", "Bearer", "Digest", "HOBA", "Mutual", "Negotiate", "OAuth", "SCRAM-SHA-1",
         "SCRAM-SHA-256", "vapid"
-      ]
+      ].toLowerCase()
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/SensitiveActions.qll
+++ b/javascript/ql/src/semmle/javascript/security/SensitiveActions.qll
@@ -188,4 +188,31 @@ module PasswordHeuristics {
       normalized.regexpMatch(".*(pass|test|sample|example|secret|root|admin|user|change|auth).*")
     )
   }
+
+  /**
+   * Holds if `header` looks like a deliberately weak authentication header.
+   */
+  bindingset[header]
+  predicate isDummyAuthHeader(string header) {
+    isDummyPassword(header)
+    or
+    exists(string prefix, string suffix | prefix = getAnHTTPAuthenticationScheme() |
+      header = prefix + " " + suffix and
+      isDummyPassword(suffix)
+    )
+    or
+    header.trim() = getAnHTTPAuthenticationScheme()
+  }
+
+  /**
+   * Gets a HTTP authentication scheme.
+   * From this list: https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
+   */
+  private string getAnHTTPAuthenticationScheme() {
+    result =
+      [
+        "Basic", "Bearer", "Digest", "HOBA", "Mutual", "Negotiate", "OAuth", "SCRAM-SHA-1",
+        "SCRAM-SHA-256", "vapid"
+      ]
+  }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
@@ -213,6 +213,16 @@ nodes
 | HardcodedCredentials.js:245:22:245:44 | "myHard ... ateKey" |
 | HardcodedCredentials.js:246:42:246:51 | privateKey |
 | HardcodedCredentials.js:246:42:246:51 | privateKey |
+| HardcodedCredentials.js:260:30:260:40 | `Basic foo` |
+| HardcodedCredentials.js:260:30:260:40 | `Basic foo` |
+| HardcodedCredentials.js:260:30:260:40 | `Basic foo` |
+| HardcodedCredentials.js:268:30:268:73 | `${foo  ... Token}` |
+| HardcodedCredentials.js:268:30:268:73 | `${foo  ... Token}` |
+| HardcodedCredentials.js:268:33:268:56 | foo ? ' ... 'OAuth' |
+| HardcodedCredentials.js:268:39:268:46 | 'Bearer' |
+| HardcodedCredentials.js:268:39:268:46 | 'Bearer' |
+| HardcodedCredentials.js:268:50:268:56 | 'OAuth' |
+| HardcodedCredentials.js:268:50:268:56 | 'OAuth' |
 edges
 | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' |
 | HardcodedCredentials.js:8:19:8:28 | 'abcdefgh' | HardcodedCredentials.js:8:19:8:28 | 'abcdefgh' |
@@ -318,6 +328,13 @@ edges
 | HardcodedCredentials.js:245:9:245:44 | privateKey | HardcodedCredentials.js:246:42:246:51 | privateKey |
 | HardcodedCredentials.js:245:22:245:44 | "myHard ... ateKey" | HardcodedCredentials.js:245:9:245:44 | privateKey |
 | HardcodedCredentials.js:245:22:245:44 | "myHard ... ateKey" | HardcodedCredentials.js:245:9:245:44 | privateKey |
+| HardcodedCredentials.js:260:30:260:40 | `Basic foo` | HardcodedCredentials.js:260:30:260:40 | `Basic foo` |
+| HardcodedCredentials.js:268:33:268:56 | foo ? ' ... 'OAuth' | HardcodedCredentials.js:268:30:268:73 | `${foo  ... Token}` |
+| HardcodedCredentials.js:268:33:268:56 | foo ? ' ... 'OAuth' | HardcodedCredentials.js:268:30:268:73 | `${foo  ... Token}` |
+| HardcodedCredentials.js:268:39:268:46 | 'Bearer' | HardcodedCredentials.js:268:33:268:56 | foo ? ' ... 'OAuth' |
+| HardcodedCredentials.js:268:39:268:46 | 'Bearer' | HardcodedCredentials.js:268:33:268:56 | foo ? ' ... 'OAuth' |
+| HardcodedCredentials.js:268:50:268:56 | 'OAuth' | HardcodedCredentials.js:268:33:268:56 | foo ? ' ... 'OAuth' |
+| HardcodedCredentials.js:268:50:268:56 | 'OAuth' | HardcodedCredentials.js:268:33:268:56 | foo ? ' ... 'OAuth' |
 #select
 | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | The hard-coded value "dbuser" is used as $@. | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | user name |
 | HardcodedCredentials.js:8:19:8:28 | 'abcdefgh' | HardcodedCredentials.js:8:19:8:28 | 'abcdefgh' | HardcodedCredentials.js:8:19:8:28 | 'abcdefgh' | The hard-coded value "abcdefgh" is used as $@. | HardcodedCredentials.js:8:19:8:28 | 'abcdefgh' | password |

--- a/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.js
+++ b/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.js
@@ -250,3 +250,23 @@
         console.log(decoded);
     });
 })();
+
+(async function () {
+    const fetch = require("node-fetch");
+
+    const rsp = await fetch(ENDPOINT, {
+        method: 'get',
+        headers: new fetch.Headers({
+            "Authorization": `Basic foo`, // OK - dummy password
+            "Content-Type": 'application/json'
+        })
+    });
+
+    const rsp2 = await fetch(ENDPOINT, {
+        method: 'get',
+        headers: new fetch.Headers({
+            "Authorization": `${foo ? 'Bearer' : 'OAuth'} ${accessToken}`, // OK - just a protocol selector
+            "Content-Type": 'application/json'
+        })
+    });
+});


### PR DESCRIPTION
Fixes #4327

[Evaluation looks good](https://github.com/dsp-testing/erik-krogh-dca/tree/run/authHeader__nightly__CustomSuite/reports).  
There is a bunch of removed results.  
All of the removed results appear to be FPs.