### PR TITLE
JS: remove nunjucks internal links from the target-blank query

### DIFF
--- a/javascript/ql/src/DOM/TargetBlank.ql
+++ b/javascript/ql/src/DOM/TargetBlank.ql
@@ -43,8 +43,8 @@ predicate hasDynamicHrefHostAttributeValue(DOM::ElementDefinition elem) {
       url.regexpMatch(Templating::getDelimiterMatchingRegexpWithPrefix("[^?#]*")) and
       // ... that does not start with a fixed host or a relative path (common formats)
       not url.regexpMatch("(?i)((https?:)?//)?[-a-z0-9.]*/.*") and
-      // .. that is not a call to `url_for` in a Flask application
-      not url.regexpMatch("\\{\\{\\s*url_for.*")
+      // .. that is not a call to `url_for` in a Flask / nunjucks application
+      not url.regexpMatch("\\{\\{\\s*url(_for)?\\(.+\\).*")
     )
   )
 }

--- a/javascript/ql/test/query-tests/DOM/TargetBlank/tst.js
+++ b/javascript/ql/test/query-tests/DOM/TargetBlank/tst.js
@@ -63,3 +63,6 @@ function f() {
 <a href="{{url_for('foo.html', 'foo')}}" target="_blank">Example</a>;
 <a href="{{ url_for('foo.html', 'foo')}}" target="_blank">Example</a>;
 <a href="{{ 	url_for('foo.html', 'foo')}}" target="_blank">Example</a>;
+
+// OK, nunjucks template
+<a href="{{ url('foo', query={bla}) }}" target="_blank">Example</a>


### PR DESCRIPTION
Fixes #6359

It's similar to how we already removed `Flask` internal links. 

[An evaluation looks OK](https://github.com/dsp-testing/erik-krogh-dca/tree/run/nunjucks__nightly__CustomSuite__1/reports).  
No change in results. 