### PR TITLE
cpp: Add query to detect unsigned integer to signed integer conversio…

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
@@ -1,0 +1,28 @@
+/**
+ * @author Jordy Zomer
+ * @name unsiged to signed used in pointer arithmetic
+ * @description finds unsigned to signed conversions used in pointer arithmetic, potentially causing an out-of-bound access
+ * @id cpp/out-of-bounds
+ * @kind problem
+ * @problem.severity warning
+ * @tags reliability
+ *       security
+ *       external/cwe/cwe-787
+ */
+
+import cpp
+import semmle.code.cpp.dataflow.DataFlow
+import semmle.code.cpp.security.Overflow
+
+from FunctionCall call, Function f, Parameter p, DataFlow::Node sink, PointerArithmeticOperation pao, Operation a, Operation b
+where
+f = call.getTarget() and
+p = f.getAParameter() and
+p.getType().getUnderlyingType().(IntegralType).isSigned() and
+call.getArgument(p.getIndex()).getType().getUnderlyingType().(IntegralType).isUnsigned() and
+pao.getAnOperand() = sink.asExpr() and
+not guardedLesser(a, sink.asExpr()) and
+not guardedGreater(b, call.getArgument(p.getIndex())) and
+not call.getArgument(p.getIndex()).isConstant() and
+DataFlow::localFlow(DataFlow::parameterNode(p), sink)
+select call, "This call: $@  passes an unsigned int to a function that requires a signed int: $@. And then used in pointer arithmetic: $@", call, call.toString(), f, f.toString(), sink, sink.toString()

--- a/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
@@ -2,7 +2,7 @@
  * @author Jordy Zomer
  * @name unsiged to signed used in pointer arithmetic
  * @description finds unsigned to signed conversions used in pointer arithmetic, potentially causing an out-of-bound access
- * @id cpp/out-of-bounds
+ * @id cpp/sign-conversion-pointer-arithmetic
  * @kind problem
  * @problem.severity warning
  * @tags reliability
@@ -14,15 +14,15 @@ import cpp
 import semmle.code.cpp.dataflow.DataFlow
 import semmle.code.cpp.security.Overflow
 
-from FunctionCall call, Function f, Parameter p, DataFlow::Node sink, PointerArithmeticOperation pao, Operation a, Operation b
+from FunctionCall call, Function f, Parameter p, DataFlow::Node sink, PointerArithmeticOperation pao
 where
 f = call.getTarget() and
 p = f.getAParameter() and
-p.getType().getUnderlyingType().(IntegralType).isSigned() and
-call.getArgument(p.getIndex()).getType().getUnderlyingType().(IntegralType).isUnsigned() and
+p.getUnspecifiedType().(IntegralType).isSigned() and
+call.getArgument(p.getIndex()).getUnspecifiedType().(IntegralType).isUnsigned() and
 pao.getAnOperand() = sink.asExpr() and
-not guardedLesser(a, sink.asExpr()) and
-not guardedGreater(b, call.getArgument(p.getIndex())) and
+not exists(Operation a | guardedLesser(a, sink.asExpr())) and
+not exists(Operation b | guardedGreater(b, call.getArgument(p.getIndex()))) and
 not call.getArgument(p.getIndex()).isConstant() and
 DataFlow::localFlow(DataFlow::parameterNode(p), sink)
 select call, "This call: $@  passes an unsigned int to a function that requires a signed int: $@. And then used in pointer arithmetic: $@", call, call.toString(), f, f.toString(), sink, sink.toString()

--- a/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
@@ -1,5 +1,4 @@
 /**
- * @author Jordy Zomer
  * @name unsiged to signed used in pointer arithmetic
  * @description finds unsigned to signed conversions used in pointer arithmetic, potentially causing an out-of-bound access
  * @id cpp/sign-conversion-pointer-arithmetic

--- a/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
@@ -15,13 +15,16 @@ import semmle.code.cpp.security.Overflow
 
 from FunctionCall call, Function f, Parameter p, DataFlow::Node sink, PointerArithmeticOperation pao
 where
-f = call.getTarget() and
-p = f.getAParameter() and
-p.getUnspecifiedType().(IntegralType).isSigned() and
-call.getArgument(p.getIndex()).getUnspecifiedType().(IntegralType).isUnsigned() and
-pao.getAnOperand() = sink.asExpr() and
-not exists(Operation a | guardedLesser(a, sink.asExpr())) and
-not exists(Operation b | guardedGreater(b, call.getArgument(p.getIndex()))) and
-not call.getArgument(p.getIndex()).isConstant() and
-DataFlow::localFlow(DataFlow::parameterNode(p), sink)
-select call, "This call: $@  passes an unsigned int to a function that requires a signed int: $@. And then used in pointer arithmetic: $@", call, call.toString(), f, f.toString(), sink, sink.toString()
+  f = call.getTarget() and
+  p = f.getAParameter() and
+  p.getUnspecifiedType().(IntegralType).isSigned() and
+  call.getArgument(p.getIndex()).getUnspecifiedType().(IntegralType).isUnsigned() and
+  pao.getAnOperand() = sink.asExpr() and
+  not exists(Operation a | guardedLesser(a, sink.asExpr())) and
+  not exists(Operation b | guardedGreater(b, call.getArgument(p.getIndex()))) and
+  not call.getArgument(p.getIndex()).isConstant() and
+  DataFlow::localFlow(DataFlow::parameterNode(p), sink) and
+  p.getUnspecifiedType().getSize() < 8
+select call,
+  "This call: $@  passes an unsigned int to a function that requires a signed int: $@. And then used in pointer arithmetic: $@",
+  call, call.toString(), f, f.toString(), sink, sink.toString()

--- a/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
@@ -1,5 +1,5 @@
 /**
- * @name unsiged to signed used in pointer arithmetic
+ * @name unsinged to signed used in pointer arithmetic
  * @description finds unsigned to signed conversions used in pointer arithmetic, potentially causing an out-of-bound access
  * @id cpp/sign-conversion-pointer-arithmetic
  * @kind problem


### PR DESCRIPTION
Hi!

I added a query to detect unsigned integer to signed integer conversions used in pointer arithmetic. This is a variant analysis of the recent 'Sequoia' bug.

So what we do here is obtain a FunctionCall to a Function with any parameter that requires a signed integer. Following that, we look for any function calls that provide an unsigned number to this function despite the fact that it expects a signed integer. After that, we will use the DataFlow library to “taint track” any use of this argument in pointer arithmetic. Running this query on the Linux kernel database successfully identifies the Sequoia vulnerability as well as hundreds of additional instances that may be vulnerable.

Because there are so many results, I decided to refine the query slightly, so I added three filters to narrow down the criteria.

Establish whether there is a size check where the source is more than something
Determine whether the sink is smaller than something
Identify whether the source is a constant.
I configured it such that it only displayed results if none of these filters matched.