### PR TITLE
Python: Avoid bad magic in `containsInScope`

### DIFF
--- a/python/ql/src/semmle/python/Scope.qll
+++ b/python/ql/src/semmle/python/Scope.qll
@@ -146,8 +146,9 @@ class Scope extends Scope_ {
   Stmt getLastStatement() { result = this.getBody().getLastItem().getLastStatement() }
 
   /** Whether this contains `inner` syntactically and `inner` has the same scope as `this` */
+  pragma[nomagic]
   predicate containsInScope(AstNode inner) {
     this.getBody().contains(inner) and
-    this = inner.getScope()
+    this = pragma[only_bind_out](inner).getScope()
   }
 }


### PR DESCRIPTION
I noticed this bad join order when running `UnreachableCode.ql`:

```
[2021-08-04 11:04:54] (3288s) Tuple counts for AstExtended::AstNode::containsInScope_dispred#bf/2@06c1ea:
                      485725      ~0%      {1} r1 = SCAN py_stmts OUTPUT In.0 'this'
                      485725      ~0%      {2} r2 = JOIN r1 WITH AstExtended::AstNode::getScope_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'this'
                      10971648538 ~0%      {2} r3 = JOIN r2 WITH AstExtended::AstNode::getScope_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1 'this', Rhs.1 'inner'
                      5089967     ~0%      {2} r4 = JOIN r3 WITH AstExtended::AstNode::contains_dispred#bf ON FIRST 2 OUTPUT Lhs.0 'this', Lhs.1 'inner'
                      5046621     ~1%      {2} r5 = r4 AND NOT @py_scope#f(Lhs.1 'inner')
                                           return r5
```

~https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/646/~
https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/649/