### PR TITLE
Update Security-Severity for CWE-918

### DIFF
--- a/java/ql/src/Security/CWE/CWE-918/RequestForgery.ql
+++ b/java/ql/src/Security/CWE/CWE-918/RequestForgery.ql
@@ -4,6 +4,7 @@
  *              may cause the server to communicate with malicious servers.
  * @kind path-problem
  * @problem.severity error
+ * @security-severity 9.1
  * @precision high
  * @id java/ssrf
  * @tags security


### PR DESCRIPTION
According to [this guidance](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md#metricsummary-tags) all security-relevant queries should be tagged with a `security-severity` score. While testing code scanning on a larger Java codebase, I noticed the score was missing for CWE-918. It has been added using the latest `cwe-scores` (internal) tool.