### PR TITLE
Docs: Mention setting for running tests in VS Code (already shipped)

### DIFF
--- a/docs/codeql/codeql-for-visual-studio-code/customizing-settings.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/customizing-settings.rst
@@ -62,6 +62,8 @@ Configuring settings for testing queries
 
 To increase the number of threads used for testing queries, you can update the **Running Tests > Number Of Threads** setting.
 
+To pass additional arguments to the CodeQL CLI when running tests, you can update the **Running Tests > Additional Test Arguments** setting. For more information about the available arguments, see "`test run <https://codeql.github.com/docs/codeql-cli/manual/test-run/>`_" in the CodeQL CLI help. 
+
 Configuring settings for telemetry and data collection
 --------------------------------------------------------
 


### PR DESCRIPTION
This setting was added a few releases ago. Added a quick note to the settings page!

