### PR TITLE
C#: Add missing `nodes` predicate to XSS queries

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/XSSQuery.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/XSSQuery.qll
@@ -53,6 +53,15 @@ module PathGraph {
     xssFlow(pred, succ, _) and
     pred instanceof XssAspNode
   }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(XssNode n, string key, string val) {
+    DataFlow2::PathGraph::nodes(n.asDataFlowNode(), key, val)
+    or
+    xssFlow(n, n, _) and
+    key = "semmle.label" and
+    val = n.(XssAspNode).toString()
+  }
 }
 
 private newtype TXssNode =

--- a/csharp/ql/test/query-tests/Security Features/CWE-079/StoredXSS/XSS.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-079/StoredXSS/XSS.expected
@@ -17,6 +17,33 @@ edges
 | script.aspx:12:1:12:14 | <%= ... %> | script.aspx:12:1:12:14 | <%= ... %> |
 | script.aspx:16:1:16:34 | <%= ... %> | script.aspx:16:1:16:34 | <%= ... %> |
 | script.aspx:20:1:20:41 | <%= ... %> | script.aspx:20:1:20:41 | <%= ... %> |
+nodes
+| XSS.cs:25:13:25:21 | [post] access to local variable userInput [element] : String | semmle.label | [post] access to local variable userInput [element] : String |
+| XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | semmle.label | access to field categoryTextBox : TextBox |
+| XSS.cs:25:48:25:67 | access to property Text : String | semmle.label | access to property Text : String |
+| XSS.cs:26:32:26:40 | access to local variable userInput [element] : String | semmle.label | access to local variable userInput [element] : String |
+| XSS.cs:26:32:26:51 | call to method ToString | semmle.label | call to method ToString |
+| XSS.cs:27:29:27:37 | access to local variable userInput [element] : String | semmle.label | access to local variable userInput [element] : String |
+| XSS.cs:27:29:27:48 | call to method ToString | semmle.label | call to method ToString |
+| XSS.cs:28:26:28:34 | access to local variable userInput [element] : String | semmle.label | access to local variable userInput [element] : String |
+| XSS.cs:28:26:28:45 | call to method ToString | semmle.label | call to method ToString |
+| XSS.cs:37:27:37:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:38:36:38:39 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:57:27:57:65 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:59:22:59:25 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:75:27:75:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:76:36:76:39 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:78:28:78:42 | access to property Request : HttpRequestBase | semmle.label | access to property Request : HttpRequestBase |
+| XSS.cs:79:36:79:40 | access to local variable name2 | semmle.label | access to local variable name2 |
+| XSS.cs:85:27:85:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:86:28:86:31 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:87:31:87:34 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:94:27:94:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:95:31:95:34 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:134:20:134:33 | access to property RawUrl | semmle.label | access to property RawUrl |
+| script.aspx:12:1:12:14 | <%= ... %> | semmle.label | <%= ... %> |
+| script.aspx:16:1:16:34 | <%= ... %> | semmle.label | <%= ... %> |
+| script.aspx:20:1:20:41 | <%= ... %> | semmle.label | <%= ... %> |
 #select
 | XSS.cs:26:32:26:51 | call to method ToString | XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | XSS.cs:26:32:26:51 | call to method ToString | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | User-provided value |
 | XSS.cs:27:29:27:48 | call to method ToString | XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | XSS.cs:27:29:27:48 | call to method ToString | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-079/XSS/XSS.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-079/XSS/XSS.expected
@@ -12,6 +12,28 @@ edges
 | XSSAspNetCore.cs:61:44:61:63 | access to indexer : StringValues | XSSAspNetCore.cs:61:44:61:66 | access to indexer |
 | XSSAspNetCore.cs:72:51:72:65 | access to property Headers : IHeaderDictionary | XSSAspNetCore.cs:72:51:72:72 | access to indexer : StringValues |
 | XSSAspNetCore.cs:72:51:72:72 | access to indexer : StringValues | XSSAspNetCore.cs:72:51:72:72 | call to operator implicit conversion |
+nodes
+| XSSAspNet.cs:19:25:19:43 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSSAspNet.cs:26:30:26:34 | access to local variable sayHi | semmle.label | access to local variable sayHi |
+| XSSAspNet.cs:36:40:36:44 | access to local variable sayHi | semmle.label | access to local variable sayHi |
+| XSSAspNet.cs:43:28:43:46 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSSAspNet.cs:43:28:43:55 | access to indexer | semmle.label | access to indexer |
+| XSSAspNetCore.cs:21:52:21:64 | access to property Query : IQueryCollection | semmle.label | access to property Query : IQueryCollection |
+| XSSAspNetCore.cs:21:52:21:76 | access to indexer : StringValues | semmle.label | access to indexer : StringValues |
+| XSSAspNetCore.cs:21:52:21:76 | call to operator implicit conversion | semmle.label | call to operator implicit conversion |
+| XSSAspNetCore.cs:40:56:40:58 | foo : String | semmle.label | foo : String |
+| XSSAspNetCore.cs:44:51:44:53 | access to parameter foo | semmle.label | access to parameter foo |
+| XSSAspNetCore.cs:51:43:51:67 | access to property Value | semmle.label | access to property Value |
+| XSSAspNetCore.cs:58:43:58:55 | access to property Query : IQueryCollection | semmle.label | access to property Query : IQueryCollection |
+| XSSAspNetCore.cs:58:43:58:62 | access to indexer : StringValues | semmle.label | access to indexer : StringValues |
+| XSSAspNetCore.cs:58:43:58:73 | call to method ToString | semmle.label | call to method ToString |
+| XSSAspNetCore.cs:61:44:61:56 | access to property Query : IQueryCollection | semmle.label | access to property Query : IQueryCollection |
+| XSSAspNetCore.cs:61:44:61:63 | access to indexer : StringValues | semmle.label | access to indexer : StringValues |
+| XSSAspNetCore.cs:61:44:61:66 | access to indexer | semmle.label | access to indexer |
+| XSSAspNetCore.cs:69:43:69:61 | access to property ContentType | semmle.label | access to property ContentType |
+| XSSAspNetCore.cs:72:51:72:65 | access to property Headers : IHeaderDictionary | semmle.label | access to property Headers : IHeaderDictionary |
+| XSSAspNetCore.cs:72:51:72:72 | access to indexer : StringValues | semmle.label | access to indexer : StringValues |
+| XSSAspNetCore.cs:72:51:72:72 | call to operator implicit conversion | semmle.label | call to operator implicit conversion |
 #select
 | XSSAspNet.cs:26:30:26:34 | access to local variable sayHi | XSSAspNet.cs:19:25:19:43 | access to property QueryString : NameValueCollection | XSSAspNet.cs:26:30:26:34 | access to local variable sayHi | $@ flows to here and is written to HTML or JavaScript: System.Web.WebPages.WebPage.WriteLiteral() method. | XSSAspNet.cs:19:25:19:43 | access to property QueryString : NameValueCollection | User-provided value |
 | XSSAspNet.cs:36:40:36:44 | access to local variable sayHi | XSSAspNet.cs:19:25:19:43 | access to property QueryString : NameValueCollection | XSSAspNet.cs:36:40:36:44 | access to local variable sayHi | $@ flows to here and is written to HTML or JavaScript: System.Web.WebPages.WebPage.WriteLiteralTo() method. | XSSAspNet.cs:19:25:19:43 | access to property QueryString : NameValueCollection | User-provided value |


### PR DESCRIPTION
The predicate is required for 0-step flow paths. This was revealed by https://github.com/dsp-testing/hvitved-dca/issues/4.