### PR TITLE
C#: Silence XML extraction commands

### DIFF
--- a/csharp/tools/pre-finalize.cmd
+++ b/csharp/tools/pre-finalize.cmd
@@ -8,7 +8,8 @@ type NUL && "%CODEQL_DIST%\codeql" database index-files ^
     --size-limit 10m ^
     --language xml ^
     -- ^
-    "%CODEQL_EXTRACTOR_CSHARP_WIP_DATABASE%"
+    "%CODEQL_EXTRACTOR_CSHARP_WIP_DATABASE%" ^
+    >nul 2>&1
 IF %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
 
 type NUL && "%CODEQL_JAVA_HOME%\bin\java.exe" -jar "%CODEQL_EXTRACTOR_CSHARP_ROOT%\tools\extractor-asp.jar" .

--- a/csharp/tools/pre-finalize.sh
+++ b/csharp/tools/pre-finalize.sh
@@ -10,6 +10,7 @@ set -eu
     --size-limit 10m \
     --language xml \
     -- \
-    "$CODEQL_EXTRACTOR_CSHARP_WIP_DATABASE"
+    "$CODEQL_EXTRACTOR_CSHARP_WIP_DATABASE" \
+    > /dev/null 2>&1
 
 "$CODEQL_JAVA_HOME/bin/java" -jar "$CODEQL_EXTRACTOR_CSHARP_ROOT/tools/extractor-asp.jar" .


### PR DESCRIPTION
Output from the XML extractor like

```
[2021-08-05 15:16:48] [build-stdout] [2021-08-05 15:16:48] [build-stdout] [2021-08-05 15:16:48] [WARN] Parsing error in file /temp/cs/Web.config: Unexpected character '.' (code 46) (expected a name start character)
```

is more confusing than helpful, since it may hide real build errors. This PR completely silences the XML extraction, as we don't really care about parse errors (they will still be available in log files such as `database-index-files-20210805.151925.747.log`).