### PR TITLE
Java: An experimental query for ignored hostname verification

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-297/CheckedHostnameVerification.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/CheckedHostnameVerification.java
@@ -1,8 +1,10 @@
-SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
-socket.startHandshake();
-boolean successful = verifier.verify(host, socket.getSession());
-if (!successful) {
-    socket.close();
-    throw new SSLException("Oops! Hostname verification failed!");
+public SSLSocket connect(String host, int port, HostnameVerifier verifier) {
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
+    socket.startHandshake();
+    boolean successful = verifier.verify(host, socket.getSession());
+    if (!successful) {
+        socket.close();
+        throw new SSLException("Oops! Hostname verification failed!");
+    }
+    return socket;
 }
-return socket;

--- a/java/ql/src/experimental/Security/CWE/CWE-297/CheckedHostnameVerification.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/CheckedHostnameVerification.java
@@ -1,0 +1,8 @@
+SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
+socket.startHandshake();
+boolean successful = verifier.verify(host, socket.getSession());
+if (!successful) {
+    socket.close();
+    throw new SSLException("Oops! Hostname verification failed!");
+}
+return socket;

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.java
@@ -1,0 +1,4 @@
+SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
+socket.startHandshake();
+verifier.verify(host, socket.getSession());
+return socket;

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.java
@@ -1,4 +1,6 @@
-SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
-socket.startHandshake();
-verifier.verify(host, socket.getSession());
-return socket;
+public SSLSocket connect(String host, int port, HostnameVerifier verifier) {
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
+    socket.startHandshake();
+    verifier.verify(host, socket.getSession());
+    return socket;
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.qhelp
@@ -1,0 +1,42 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+The method <code>HostnameVerifier.verify()</code> checks that the hostname from the server's certificate
+matches the server hostname after an HTTPS connection is established.
+The method returns true if the hostname is acceptable and false otherwise. The contract of the method
+does not require it to throw an exception if the verification failed.
+Therefore, a caller has to check the result and drop the connection if the hostname verification failed.
+Otherwise, an attacker may be able to implement a man-in-the-middle attack and impersonate the server.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Always check the result of <code>HostnameVerifier.verify()</code> and drop the connection
+if the method returns false.
+</p>
+</recommendation>
+
+<example>
+<p>
+In the following example, the method <code>HostnameVerifier.verify()</code> but its result is ignored.
+As a result, no hostname verification actually happens.
+</p>
+<sample src="IgnoredHostnameVerification.java" />
+
+<p>
+In the next example, the result of the <code>HostnameVerifier.verify()</code> method is checked
+and an exeption is thrown if it the verification failed.
+</p>
+<sample src="CheckedHostnameVerification.java" />
+</example>
+
+<references>
+<li>
+  Java API Specification:
+  <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/net/ssl/HostnameVerifier.html#verify(java.lang.String,javax.net.ssl.SSLSession)">HostnameVerifier.veify() method</a>.
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.qhelp
@@ -5,7 +5,7 @@
 <p>
 The method <code>HostnameVerifier.verify()</code> checks that the hostname from the server's certificate
 matches the server hostname after an HTTPS connection is established.
-The method returns true if the hostname is acceptable and false otherwise. The contract of the method
+The method returns <code>true</code> if the hostname is acceptable and <code>false</code> otherwise. The contract of the method
 does not require it to throw an exception if the verification failed.
 Therefore, a caller has to check the result and drop the connection if the hostname verification failed.
 Otherwise, an attacker may be able to implement a man-in-the-middle attack and impersonate the server.
@@ -28,7 +28,7 @@ As a result, no hostname verification actually happens.
 
 <p>
 In the next example, the result of the <code>HostnameVerifier.verify()</code> method is checked
-and an exeption is thrown if the verification failed.
+and an exception is thrown if the verification failed.
 </p>
 <sample src="CheckedHostnameVerification.java" />
 </example>

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.qhelp
@@ -21,14 +21,14 @@ if the method returns false.
 
 <example>
 <p>
-In the following example, the method <code>HostnameVerifier.verify()</code> but its result is ignored.
+In the following example, the method <code>HostnameVerifier.verify()</code> is called but its result is ignored.
 As a result, no hostname verification actually happens.
 </p>
 <sample src="IgnoredHostnameVerification.java" />
 
 <p>
 In the next example, the result of the <code>HostnameVerifier.verify()</code> method is checked
-and an exeption is thrown if it the verification failed.
+and an exeption is thrown if the verification failed.
 </p>
 <sample src="CheckedHostnameVerification.java" />
 </example>
@@ -36,7 +36,7 @@ and an exeption is thrown if it the verification failed.
 <references>
 <li>
   Java API Specification:
-  <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/net/ssl/HostnameVerifier.html#verify(java.lang.String,javax.net.ssl.SSLSession)">HostnameVerifier.veify() method</a>.
+  <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/net/ssl/HostnameVerifier.html#verify(java.lang.String,javax.net.ssl.SSLSession)">HostnameVerifier.verify() method</a>.
 </li>
 </references>
 </qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
@@ -1,0 +1,55 @@
+/**
+ * @name Ignored result of hostname verification
+ * @description The method HostnameVerifier.verify() returns a result of hostname verification.
+ *              A caller has to check the result and drop the connection if the verification failed.
+ * @kind problem
+ * @problem.severity error
+ * @precision medium
+ * @id java/ignored-hostname-verification
+ * @tags security
+ *       external/cwe/cwe-295
+ */
+
+import java
+import semmle.code.java.controlflow.Guards
+import semmle.code.java.dataflow.DataFlow
+
+private class HostnameVerificationCall extends MethodAccess {
+  HostnameVerificationCall() {
+    getMethod()
+        .getDeclaringType()
+        .getASupertype*()
+        .hasQualifiedName("javax.net.ssl", "HostnameVerifier") and
+    getMethod().hasStringSignature("verify(String, SSLSession)")
+  }
+
+  predicate ignored() {
+    not exists(
+      DataFlow::Node source, DataFlow::Node sink, CheckFailedHostnameVerificationConfig config
+    |
+      this = source.asExpr() and config.hasFlow(source, sink)
+    )
+  }
+}
+
+private class CheckFailedHostnameVerificationConfig extends DataFlow::Configuration {
+  CheckFailedHostnameVerificationConfig() { this = "CheckFailedHostnameVerificationConfig" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source.asExpr() instanceof HostnameVerificationCall
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(Guard guard, ThrowStmt throwStmt |
+      guard.controls(throwStmt.getBasicBlock(), _) and
+      (
+        guard.(EqualityTest).getAnOperand() = sink.asExpr() or
+        guard.(HostnameVerificationCall) = sink.asExpr()
+      )
+    )
+  }
+}
+
+from HostnameVerificationCall verification
+where verification.ignored()
+select verification, "Ignored result of hostname verification."

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
@@ -51,8 +51,11 @@ private class CheckFailedHostnameVerificationConfig extends DataFlow::Configurat
   }
 
   override predicate isSink(DataFlow::Node sink) {
-    exists(Guard guard, ThrowStmt throwStmt |
-      guard.controls(throwStmt.getBasicBlock(), _) and
+    exists(Guard guard, ThrowStmt throwStmt, ReturnStmt returnStmt |
+      (
+        guard.controls(throwStmt.getBasicBlock(), false) or
+        guard.controls(returnStmt.getBasicBlock(), true)
+      ) and
       (
         guard = sink.asExpr() or
         guard.(EqualityTest).getAnOperand() = sink.asExpr() or

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
@@ -11,20 +11,13 @@
  */
 
 import java
-
-/** The `HostnameVerifier.verify()` method. */
-private class HostnameVerifierVerifyMethod extends Method {
-  HostnameVerifierVerifyMethod() {
-    this.getDeclaringType().getASupertype*().hasQualifiedName("javax.net.ssl", "HostnameVerifier") and
-    this.hasStringSignature("verify(String, SSLSession)")
-  }
-}
+import semmle.code.java.security.Encryption
 
 /** A `HostnameVerifier.verify()` call that is not wrapped in another `HostnameVerifier`. */
 private class HostnameVerificationCall extends MethodAccess {
   HostnameVerificationCall() {
-    this.getMethod() instanceof HostnameVerifierVerifyMethod and
-    not this.getCaller() instanceof HostnameVerifierVerifyMethod
+    this.getMethod() instanceof HostnameVerifierVerify and
+    not this.getCaller() instanceof HostnameVerifierVerify
   }
 
   /** Holds if the result of the call is not used. */

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
@@ -20,7 +20,7 @@ private class HostnameVerifierVerifyMethod extends Method {
   }
 }
 
-/** Defines `HostnameVerifier.verity()` calls that is not wrapped in another `HostnameVerifier`. */
+/** A `HostnameVerifier.verify()` call that is not wrapped in another `HostnameVerifier`. */
 private class HostnameVerificationCall extends MethodAccess {
   HostnameVerificationCall() {
     this.getMethod() instanceof HostnameVerifierVerifyMethod and

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
@@ -21,9 +21,7 @@ private class HostnameVerificationCall extends MethodAccess {
   }
 
   /** Holds if the result of the call is not used. */
-  predicate isIgnored() {
-    this = any(ExprStmt es).getExpr()
-  }
+  predicate isIgnored() { this = any(ExprStmt es).getExpr() }
 }
 
 from HostnameVerificationCall verification

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
@@ -22,8 +22,6 @@ private class HostnameVerificationCall extends MethodAccess {
 
   /** Holds if the result of the call is not used. */
   predicate isIgnored() {
-    not exists(Expr expr | this = expr.getAChildExpr()) and
-    not exists(IfStmt ifStmt | this = ifStmt.getCondition()) and
     this = any(ExprStmt es).getExpr()
   }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
@@ -22,9 +22,9 @@ private class HostnameVerificationCall extends MethodAccess {
 
   /** Holds if the result of the call is not used. */
   predicate isIgnored() {
-    not exists(Expr expr, IfStmt ifStmt, MethodAccess ma |
-      this = [expr.getAChildExpr(), ifStmt.getCondition(), ma.getAnArgument()]
-    )
+    not exists(Expr expr | this = expr.getAChildExpr()) and
+    not exists(IfStmt ifStmt | this = ifStmt.getCondition()) and
+    this = any(ExprStmt es).getExpr()
   }
 }
 

--- a/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.expected
@@ -1,3 +1,3 @@
-| IgnoredHostnameVerification.java:15:5:15:46 | verify(...) | Ignored result of hostname verification. |
-| IgnoredHostnameVerification.java:25:22:25:63 | verify(...) | Ignored result of hostname verification. |
-| IgnoredHostnameVerification.java:36:22:36:63 | verify(...) | Ignored result of hostname verification. |
+| IgnoredHostnameVerification.java:16:5:16:46 | verify(...) | Ignored result of hostname verification. |
+| IgnoredHostnameVerification.java:26:22:26:63 | verify(...) | Ignored result of hostname verification. |
+| IgnoredHostnameVerification.java:37:22:37:63 | verify(...) | Ignored result of hostname verification. |

--- a/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.expected
@@ -1,0 +1,3 @@
+| IgnoredHostnameVerification.java:15:5:15:46 | verify(...) | Ignored result of hostname verification. |
+| IgnoredHostnameVerification.java:25:22:25:63 | verify(...) | Ignored result of hostname verification. |
+| IgnoredHostnameVerification.java:36:22:36:63 | verify(...) | Ignored result of hostname verification. |

--- a/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.expected
@@ -1,3 +1,1 @@
 | IgnoredHostnameVerification.java:16:5:16:46 | verify(...) | Ignored result of hostname verification. |
-| IgnoredHostnameVerification.java:26:22:26:63 | verify(...) | Ignored result of hostname verification. |
-| IgnoredHostnameVerification.java:37:22:37:63 | verify(...) | Ignored result of hostname verification. |

--- a/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.java
@@ -17,28 +17,19 @@ public class IgnoredHostnameVerification {
     return socket;
   }
 
-  // BAD: ignored result of HostnameVerifier.verify()
-  public static SSLSocket connectAndOnlyPrintResultOfHostnameVerification(
-      String host, int port, HostnameVerifier verifier) throws IOException {
-
-    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
-    socket.startHandshake();
-    boolean result = verifier.verify(host, socket.getSession());
-    System.out.println("Result of hostname verification: " + result);
-    return socket;
+  public static void check(boolean result) throws SSLException {
+    if (!result) {
+      throw new SSLException("Oops! Hostname verification failed!");
+    }
   }
 
-  // BAD: ignored result of HostnameVerifier.verify()
-  public static SSLSocket connectAndOnlyPrintFailureOfHostnameVerification(
+  // GOOD: connect and check result of HostnameVerifier.verify()
+  public static SSLSocket connectWithHostnameVerification00(
       String host, int port, HostnameVerifier verifier) throws IOException {
 
     SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
     socket.startHandshake();
-    boolean failed = verifier.verify(host, socket.getSession());
-    if (failed) {
-      System.out.println("Hostname verification failed");
-    }
-
+    check(verifier.verify(host, socket.getSession()));
     return socket;
   }
 

--- a/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.java
@@ -1,6 +1,7 @@
 import java.io.IOException;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
@@ -87,6 +88,21 @@ public class IgnoredHostnameVerification {
 
     socket.close();
     throw new SSLException("Oops! Hostname verification failed!");
+  }
+
+  public static class HostnameVerifierWrapper implements HostnameVerifier {
+
+    private final HostnameVerifier verifier;
+
+    public HostnameVerifierWrapper(HostnameVerifier verifier) {
+        this.verifier = verifier;
+    }
+
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        return verifier.verify(hostname, session); // GOOD: wrapped calls should not be reported
+    }
+
   }
 
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.java
@@ -90,17 +90,30 @@ public class IgnoredHostnameVerification {
     throw new SSLException("Oops! Hostname verification failed!");
   }
 
+  // GOOD: connect and check result of HostnameVerifier.verify()
+  public static String connectWithHostnameVerification04(
+      String[] hosts, HostnameVerifier verifier, SSLSession session) throws IOException {
+
+    for (String host : hosts) {
+      if (verifier.verify(host, session)) {
+        return host;
+      }
+    }
+
+    throw new SSLException("Oops! Hostname verification failed!");
+  }
+
   public static class HostnameVerifierWrapper implements HostnameVerifier {
 
     private final HostnameVerifier verifier;
 
     public HostnameVerifierWrapper(HostnameVerifier verifier) {
-        this.verifier = verifier;
+      this.verifier = verifier;
     }
 
     @Override
     public boolean verify(String hostname, SSLSession session) {
-        return verifier.verify(hostname, session); // GOOD: wrapped calls should not be reported
+      return verifier.verify(hostname, session); // GOOD: wrapped calls should not be reported
     }
 
   }

--- a/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.java
@@ -62,7 +62,10 @@ public class IgnoredHostnameVerification {
 
     SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
     socket.startHandshake();
-    boolean successful = verifier.verify(host, socket.getSession());
+    boolean successful = false;
+    if (verifier != null) {
+      successful = verifier.verify(host, socket.getSession());
+    }
     if (!successful) {
       socket.close();
       throw new SSLException("Oops! Hostname verification failed!");

--- a/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.java
@@ -1,0 +1,89 @@
+import java.io.IOException;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+public class IgnoredHostnameVerification {
+
+  // BAD: ignored result of HostnameVerifier.verify()
+  public static SSLSocket connectWithIgnoredHostnameVerification(
+      String host, int port, HostnameVerifier verifier) throws IOException {
+
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
+    socket.startHandshake();
+    verifier.verify(host, socket.getSession());
+    return socket;
+  }
+
+  // BAD: ignored result of HostnameVerifier.verify()
+  public static SSLSocket connectAndOnlyPrintResultOfHostnameVerification(
+      String host, int port, HostnameVerifier verifier) throws IOException {
+
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
+    socket.startHandshake();
+    boolean result = verifier.verify(host, socket.getSession());
+    System.out.println("Result of hostname verification: " + result);
+    return socket;
+  }
+
+  // BAD: ignored result of HostnameVerifier.verify()
+  public static SSLSocket connectAndOnlyPrintFailureOfHostnameVerification(
+      String host, int port, HostnameVerifier verifier) throws IOException {
+
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
+    socket.startHandshake();
+    boolean failed = verifier.verify(host, socket.getSession());
+    if (failed) {
+      System.out.println("Hostname verification failed");
+    }
+
+    return socket;
+  }
+
+  // GOOD: connect and check result of HostnameVerifier.verify()
+  public static SSLSocket connectWithHostnameVerification01(
+      String host, int port, HostnameVerifier verifier) throws IOException {
+
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
+    socket.startHandshake();
+    boolean successful = verifier.verify(host, socket.getSession());
+    if (successful == false) {
+      socket.close();
+      throw new SSLException("Oops! Hostname verification failed!");
+    }
+
+    return socket;
+  }
+
+  // GOOD: connect and check result of HostnameVerifier.verify()
+  public static SSLSocket connectWithHostnameVerification02(
+      String host, int port, HostnameVerifier verifier) throws IOException {
+
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
+    socket.startHandshake();
+    boolean successful = verifier.verify(host, socket.getSession());
+    if (!successful) {
+      socket.close();
+      throw new SSLException("Oops! Hostname verification failed!");
+    }
+
+    return socket;
+  }
+
+  // GOOD: connect and check result of HostnameVerifier.verify()
+  public static SSLSocket connectWithHostnameVerification03(
+      String host, int port, HostnameVerifier verifier) throws IOException {
+
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket(host, port);
+    socket.startHandshake();
+    boolean successful = verifier.verify(host, socket.getSession());
+    if (successful) {
+      return socket;
+    }
+
+    socket.close();
+    throw new SSLException("Oops! Hostname verification failed!");
+  }
+
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-297/IgnoredHostnameVerification.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql


### PR DESCRIPTION
The method `HostnameVerifier.verify()` checks that the hostname from the server's certificate matches the server hostname after an HTTPS connection is established. The method returns true if the hostname is acceptable and false otherwise. The contract of the method does not require it to throw an exception if the verification failed. Therefore, a caller has to check the result and drop the connection if the hostname verification failed.

I'd like to add an experimental query that checks whether the result of hostname verification is checked or not. Currently, the query requires en exception to be thrown based on the result of `HostnameVerifier.verify()`. This makes the query pretty strict. It may result in false positives when an application checks the result of hostname verification but reports a failure without throwing an exception right away. The requirement may be softened. For example, the query can only check that the returned value is evaluated in an if-block. Looking forward to your feedback.

The query detects CVE-2019-11777 in the Eclipse Paho Java client library version 1.2.0.