### PR TITLE
Python: Avoid bad join in `AstExtended::AstNode::containsInScope`

### DIFF
--- a/python/ql/src/semmle/python/AstExtended.qll
+++ b/python/ql/src/semmle/python/AstExtended.qll
@@ -49,12 +49,15 @@ abstract class AstNode extends AstNode_ {
   /** Whether this contains `inner` syntactically */
   predicate contains(AstNode inner) { this.getAChildNode+() = inner }
 
-  /** Whether this contains `inner` syntactically and `inner` has the same scope as `this` */
-  predicate containsInScope(AstNode inner) {
+  pragma[noinline]
+  private predicate containsInScope(AstNode inner, Scope scope) {
     this.contains(inner) and
-    this.getScope() = inner.getScope() and
-    not inner instanceof Scope
+    not inner instanceof Scope and
+    scope = this.getScope()
   }
+
+  /** Whether this contains `inner` syntactically and `inner` has the same scope as `this` */
+  predicate containsInScope(AstNode inner) { this.containsInScope(inner, inner.getScope()) }
 }
 
 /* Parents */


### PR DESCRIPTION
I noticed this bad join order when running `UnreachableCode.ql`:

```
[2021-08-04 11:04:54] (3288s) Tuple counts for AstExtended::AstNode::containsInScope_dispred#bf/2@06c1ea:
                      485725      ~0%      {1} r1 = SCAN py_stmts OUTPUT In.0 'this'
                      485725      ~0%      {2} r2 = JOIN r1 WITH AstExtended::AstNode::getScope_dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'this'
                      10971648538 ~0%      {2} r3 = JOIN r2 WITH AstExtended::AstNode::getScope_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1 'this', Rhs.1 'inner'
                      5089967     ~0%      {2} r4 = JOIN r3 WITH AstExtended::AstNode::contains_dispred#bf ON FIRST 2 OUTPUT Lhs.0 'this', Lhs.1 'inner'
                      5046621     ~1%      {2} r5 = r4 AND NOT @py_scope#f(Lhs.1 'inner')
                                           return r5
```

https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/654/:

  | D0(s) | D1(s) | D1/D0
-- | -- | -- | --
g/openstack/nova | 2054 | 2085 | 1.01509
g/django/django | 1026 | 1033 | 1.00682
g/python/cpython | 1777 | 1785 | 1.00450
g/ytdl-org/youtube-dl | 437 | 438 | 1.00229
g/pallets/flask | 607 | 603 | 0.99341
g/saltstack/salt | 2008 | 1986 | 0.98904
g/FreeCAD/FreeCAD | 5770 | 4405 | 0.76343
