### PR TITLE
C++: Fix false-positive in 'cpp/incorrect-allocation-error-handling'

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.ql
+++ b/cpp/ql/src/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.ql
@@ -182,7 +182,7 @@ class ThrowingAllocator extends Function {
       // 3. the allocator isn't marked with `throw()` or `noexcept`.
       not exists(this.getBlock()) and
       not exists(Parameter p | p = this.getAParameter() |
-        p.getUnspecifiedType() instanceof NoThrowType
+        p.getUnspecifiedType().stripType() instanceof NoThrowType
       ) and
       not this.isNoExcept() and
       not this.isNoThrow()

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.expected
@@ -16,4 +16,3 @@
 | test.cpp:151:9:151:24 | new | This allocation cannot throw. $@ is unnecessary. | test.cpp:152:15:152:18 | { ... } | This catch block |
 | test.cpp:199:15:199:35 | new | This allocation cannot throw. $@ is unnecessary. | test.cpp:201:16:201:19 | { ... } | This catch block |
 | test.cpp:212:14:212:34 | new | This allocation cannot throw. $@ is unnecessary. | test.cpp:213:34:213:36 | { ... } | This catch block |
-| test.cpp:233:12:233:36 | new | This allocation cannot return null. $@ is unnecessary. | test.cpp:234:6:234:17 | ... == ... | This check |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.expected
@@ -16,3 +16,4 @@
 | test.cpp:151:9:151:24 | new | This allocation cannot throw. $@ is unnecessary. | test.cpp:152:15:152:18 | { ... } | This catch block |
 | test.cpp:199:15:199:35 | new | This allocation cannot throw. $@ is unnecessary. | test.cpp:201:16:201:19 | { ... } | This catch block |
 | test.cpp:212:14:212:34 | new | This allocation cannot throw. $@ is unnecessary. | test.cpp:213:34:213:36 | { ... } | This catch block |
+| test.cpp:233:12:233:36 | new | This allocation cannot return null. $@ is unnecessary. | test.cpp:234:6:234:17 | ... == ... | This check |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-570/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-570/test.cpp
@@ -225,3 +225,11 @@ void good_new_catch_exception_in_conversion() {
     long* p = (long*) new int; // GOOD
   } catch(const std::bad_alloc&) { }
 }
+
+// The 'n' parameter is just to distinquish it from the overload further up in this file.
+void *operator new(std::size_t, int n, const std::nothrow_t &);
+
+void test_operator_new_without_exception_spec() {
+  int* p = new(42, std::nothrow) int; // GOOD [FALSE POSITIVE]
+  if(p == nullptr) {}
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-570/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-570/test.cpp
@@ -230,6 +230,6 @@ void good_new_catch_exception_in_conversion() {
 void *operator new(std::size_t, int n, const std::nothrow_t &);
 
 void test_operator_new_without_exception_spec() {
-  int* p = new(42, std::nothrow) int; // GOOD [FALSE POSITIVE]
+  int* p = new(42, std::nothrow) int; // GOOD
   if(p == nullptr) {}
 }


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/6435.

Turns out we didn't recognize the `std::nothrow` parameter in `void *operator new(std::size_t, const std::nothrow_t &);` because it was hidden behind a reference type.

We didn't catch this in the original PR because I included a `noexcept` specifier in all of the overloads where we had a `std::nothrow_t &` parameter 🤦 .
