### PR TITLE
JS: add a getMaybePromisified predicate to API-graphs, and use it to model `child_process`

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
@@ -246,6 +246,10 @@ nodes
 | lib/lib.js:482:40:482:43 | name |
 | lib/lib.js:483:30:483:33 | name |
 | lib/lib.js:483:30:483:33 | name |
+| lib/lib.js:498:45:498:48 | name |
+| lib/lib.js:498:45:498:48 | name |
+| lib/lib.js:499:31:499:34 | name |
+| lib/lib.js:499:31:499:34 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -558,6 +562,10 @@ edges
 | lib/lib.js:482:40:482:43 | name | lib/lib.js:483:30:483:33 | name |
 | lib/lib.js:482:40:482:43 | name | lib/lib.js:483:30:483:33 | name |
 | lib/lib.js:482:40:482:43 | name | lib/lib.js:483:30:483:33 | name |
+| lib/lib.js:498:45:498:48 | name | lib/lib.js:499:31:499:34 | name |
+| lib/lib.js:498:45:498:48 | name | lib/lib.js:499:31:499:34 | name |
+| lib/lib.js:498:45:498:48 | name | lib/lib.js:499:31:499:34 | name |
+| lib/lib.js:498:45:498:48 | name | lib/lib.js:499:31:499:34 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -648,6 +656,7 @@ edges
 | lib/lib.js:447:13:447:28 | "rm -rf " + name | lib/lib.js:446:20:446:23 | name | lib/lib.js:447:25:447:28 | name | $@ based on $@ is later used in $@. | lib/lib.js:447:13:447:28 | "rm -rf " + name | String concatenation | lib/lib.js:446:20:446:23 | name | library input | lib/lib.js:447:3:447:29 | asyncEx ... + name) | shell command |
 | lib/lib.js:478:27:478:46 | config.installedPath | lib/lib.js:477:33:477:38 | config | lib/lib.js:478:27:478:46 | config.installedPath | $@ based on $@ is later used in $@. | lib/lib.js:478:27:478:46 | config.installedPath | Path concatenation | lib/lib.js:477:33:477:38 | config | library input | lib/lib.js:479:12:479:20 | exec(cmd) | shell command |
 | lib/lib.js:483:13:483:33 | ' my na ...  + name | lib/lib.js:482:40:482:43 | name | lib/lib.js:483:30:483:33 | name | $@ based on $@ is later used in $@. | lib/lib.js:483:13:483:33 | ' my na ...  + name | String concatenation | lib/lib.js:482:40:482:43 | name | library input | lib/lib.js:485:2:485:20 | cp.exec(cmd + args) | shell command |
+| lib/lib.js:499:19:499:34 | "rm -rf " + name | lib/lib.js:498:45:498:48 | name | lib/lib.js:499:31:499:34 | name | $@ based on $@ is later used in $@. | lib/lib.js:499:19:499:34 | "rm -rf " + name | String concatenation | lib/lib.js:498:45:498:48 | name | library input | lib/lib.js:499:3:499:35 | MyThing ... + name) | shell command |
 | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name | $@ based on $@ is later used in $@. | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | String concatenation | lib/subLib2/compiled-file.ts:3:26:3:29 | name | library input | lib/subLib2/compiled-file.ts:4:5:4:29 | cp.exec ... + name) | shell command |
 | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | lib/subLib2/special-file.js:3:28:3:31 | name | lib/subLib2/special-file.js:4:22:4:25 | name | $@ based on $@ is later used in $@. | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/subLib2/special-file.js:3:28:3:31 | name | library input | lib/subLib2/special-file.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | lib/subLib3/my-file.ts:3:28:3:31 | name | lib/subLib3/my-file.ts:4:22:4:25 | name | $@ based on $@ is later used in $@. | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | String concatenation | lib/subLib3/my-file.ts:3:28:3:31 | name | library input | lib/subLib3/my-file.ts:4:2:4:26 | cp.exec ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
@@ -489,3 +489,14 @@ module.exports.myCommand = function (myCommand) {
 	let cmd = `cd ${cwd} ; ${myCommand}`; // OK - the parameter name suggests that it is purposely a shell command.
 	cp.exec(cmd);
 }
+
+(function () {
+	var MyThing = {
+		cp: require('child_process')
+	};
+
+	module.exports.myIndirectThing = function (name) {
+		MyThing.cp.exec("rm -rf " + name); // NOT OK
+	}
+});
+  


### PR DESCRIPTION
Recognizes the sink for CVE-2021-29300. 

Recognizing the new sink just required using API-graphs.  
But recognizing existing sinks using API-graphs required a `promisified` label in API-graphs. 

So I generalized the `promisified` part of API-graphs a bit. 

[No change in alerts](https://github.com/dsp-testing/erik-krogh-dca/blob/run/apiPromise-default-command/reports/alert-comparison.md). 
[And a performance evaluation on the security suite looks fine](https://github.com/dsp-testing/erik-krogh-dca/tree/run/apiPromise-performance-confirmation-run/reports). 