### PR TITLE
Added article for working with codeQL packs in VS Code

### DIFF
--- a/docs/codeql/codeql-for-visual-studio-code/index.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/index.rst
@@ -31,6 +31,9 @@ The CodeQL extension for Visual Studio Code adds rich language support for CodeQ
   <testing-codeql-queries-in-visual-studio-code>`: You can run unit tests for
   CodeQL queries using the Visual Studio Code extension.
 
+- :doc:`Working with CodeQL packs in Visual Studio Code
+  <working-with-codeql-packs-in-visual-studio-code>`: You can view and edit CodeQL packs in Visual Studio Code.
+
 - :doc:`Customizing settings
   <customizing-settings>`: You can edit the settings for the 
   CodeQL extension to suit your needs.
@@ -51,6 +54,7 @@ The CodeQL extension for Visual Studio Code adds rich language support for CodeQ
    exploring-the-structure-of-your-source-code
    exploring-data-flow-with-path-queries
    testing-codeql-queries-in-visual-studio-code
+   working-with-codeql-packs-in-visual-studio-code
    customizing-settings
    troubleshooting-codeql-for-visual-studio-code
    about-telemetry-in-codeql-for-visual-studio-code

--- a/docs/codeql/codeql-for-visual-studio-code/working-with-codeql-packs-in-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/working-with-codeql-packs-in-visual-studio-code.rst
@@ -11,19 +11,19 @@ You can view CodeQL packs and write and edit queries for them in Visual Studio C
 
 About CodeQL packs
 ------------------
-CodeQL packs are used to create, share, depend on, and run CodeQL queries and libraries. You can publish your own CodeQL packs and download packs created by others. For more information, see ":ref:`About CodeQL packs <about-codeql-packs>`".
+CodeQL packs are used to create, share, depend on, and run CodeQL queries and libraries. You can publish your own CodeQL packs and download packs created by others. For more information, see ":ref:`About CodeQL packs <about-codeql-packs>`."
 
 Creating and editing CodeQL packs in Visual Studio Code
 -------------------------------------------------------
-To create a new CodeQL pack, you will need to use the CodeQL CLI, which you can do within Visual Studio Code or outside of it with the ``codeql pack init`` command. Once you create an empty pack, you can edit the ``qlpack.yml`` file to add dependencies or change the name or version. For more information, see ":ref:`Creating and working with CodeQL packs <creating-and-working-with-codeql-packs>`".
+To create a new CodeQL pack, you will need to use the CodeQL CLI from a terminal, which you can do within Visual Studio Code or outside of it with the ``codeql pack init`` command. Once you create an empty pack, you can edit the ``qlpack.yml`` file or run the ``codeql pack add`` command to add dependencies or change the name or version. For more information, see ":ref:`Creating and working with CodeQL packs <creating-and-working-with-codeql-packs>`".
 
 You can create or edit queries in a CodeQL pack in Visual Studio Code as you would with any CodeQL query, using the standard code editing features such as autocomplete suggestions to find elements to use from the pack's dependencies. 
 
-You can then use the CodeQL CLI to publish your pack to share with others. For more information, see ":ref:`Publishing and using CodeQL packs <publishing-and-using-codeql-packs>`".
+You can then use the CodeQL CLI to publish your pack to share with others. For more information, see ":ref:`Publishing and using CodeQL packs <publishing-and-using-codeql-packs>`."
 
 Viewing CodeQL packs and their dependencies in Visual Studio Code
 -----------------------------------------------------------------
-Whether you have used the CodeQL CLI to download CodeQL packs that someone else has created, or created your own, you can open the ``qlpack.yml`` file in the root of a CodeQL pack directory in Visual Studio Code and view the dependencies section to see what libraries it depends on.
+Whether you have used the CodeQL CLI to download a CodeQL pack that someone else has created, or created your own, you can open the ``qlpack.yml`` file in the root of a CodeQL pack directory in Visual Studio Code and view the dependencies section to see what libraries the pack depends on.
 
 If you want to understand a query in a CodeQL pack better, you can open the query file and view the code, using the IntelliSense code editing features of Visual Studio Code. For example, if you hover over an element from a library depended on by the pack, Visual Studio Code will resolve it so you can see documentation about the element. 
 

--- a/docs/codeql/codeql-for-visual-studio-code/working-with-codeql-packs-in-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/working-with-codeql-packs-in-visual-studio-code.rst
@@ -17,7 +17,7 @@ Creating and editing CodeQL packs in Visual Studio Code
 -------------------------------------------------------
 To create a new CodeQL pack, you will need to use the CodeQL CLI, which you can do within Visual Studio Code or outside of it with the ``codeql pack init`` command. Once you create an empty pack, you can edit the ``qlpack.yml`` file to add dependencies or change the name or version. For more information, see ":ref:`Creating and working with CodeQL packs <creating-and-working-with-codeql-packs>`".
 
-You can create or edit queries in a CodeQL pack in Visual Studio Code as you would with any CodeQL query, using the standard code editing features such as autocomplete suggestions to find objects to use from the pack's dependencies. 
+You can create or edit queries in a CodeQL pack in Visual Studio Code as you would with any CodeQL query, using the standard code editing features such as autocomplete suggestions to find elements to use from the pack's dependencies. 
 
 You can then use the CodeQL CLI to publish your pack to share with others. For more information, see ":ref:`Publishing and using CodeQL packs <publishing-and-using-codeql-packs>`".
 
@@ -25,6 +25,6 @@ Viewing CodeQL packs and their dependencies in Visual Studio Code
 -----------------------------------------------------------------
 Whether you have used the CodeQL CLI to download CodeQL packs that someone else has created, or created your own, you can open the ``qlpack.yml`` file in the root of a CodeQL pack directory in Visual Studio Code and view the dependencies section to see what libraries it depends on.
 
-If you want to understand a query in a CodeQL pack better, you can open the query file and view the code, using the IntelliSense code editing features of Visual Studio Code. For example, if you hover over an object from a library depended on by the pack, Visual Studio Code will resolve it so you can see documentation about the object. 
+If you want to understand a query in a CodeQL pack better, you can open the query file and view the code, using the IntelliSense code editing features of Visual Studio Code. For example, if you hover over an element from a library depended on by the pack, Visual Studio Code will resolve it so you can see documentation about the element. 
 
-To view the full definition of an object from a library, you can right-click and choose **Go to Definition**. This will take you to the object definition in the library in your package cache, the shared location where downloaded dependencies are stored, which is in your home directory by default.
+To view the full definition of an element of a query, you can right-click and choose **Go to Definition**. If the library pack is present within the same Visual Studio Code workspace, this will take you to the definition within the workspace. Otherwise it will take you to the definition within your package cache, the shared location where downloaded dependencies are stored, which is in your home directory by default.

--- a/docs/codeql/codeql-for-visual-studio-code/working-with-codeql-packs-in-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/working-with-codeql-packs-in-visual-studio-code.rst
@@ -1,0 +1,30 @@
+:tocdepth: 1
+
+.. _working-with-codeql-packs-in-visual-studio-code:
+
+Working with CodeQL packs in Visual Studio Code
+===============================================
+
+.. include:: ../reusables/beta-note-package-management.rst
+
+You can view CodeQL packs and write and edit queries for them in Visual Studio Code. 
+
+About CodeQL packs
+------------------
+CodeQL packs are used to create, share, depend on, and run CodeQL queries and libraries. You can publish your own CodeQL packs and download packs created by others. For more information, see ":ref:`About CodeQL packs <about-codeql-packs>`".
+
+Creating and editing CodeQL packs in Visual Studio Code
+-------------------------------------------------------
+To create a new CodeQL pack, you will need to use the CodeQL CLI, which you can do within Visual Studio Code or outside of it with the ``codeql pack init`` command. Once you create an empty pack, you can edit the ``qlpack.yml`` file to add dependencies or change the name or version. For more information, see ":ref:`Creating and working with CodeQL packs <creating-and-working-with-codeql-packs>`".
+
+You can create or edit queries in a CodeQL pack in Visual Studio Code as you would with any CodeQL query, using the standard code editing features such as autocomplete suggestions to find objects to use from the pack's dependencies. 
+
+You can then use the CodeQL CLI to publish your pack to share with others. For more information, see ":ref:`Publishing and using CodeQL packs <publishing-and-using-codeql-packs>`".
+
+Viewing CodeQL packs and their dependencies in Visual Studio Code
+-----------------------------------------------------------------
+Whether you have used the CodeQL CLI to download CodeQL packs that someone else has created, or created your own, you can open the ``qlpack.yml`` file in the root of a CodeQL pack directory in Visual Studio Code and view the dependencies section to see what libraries it depends on.
+
+If you want to understand a query in a CodeQL pack better, you can open the query file and view the code, using the IntelliSense code editing features of Visual Studio Code. For example, if you hover over an object from a library depended on by the pack, Visual Studio Code will resolve it so you can see documentation about the object. 
+
+To view the full definition of an object from a library, you can right-click and choose **Go to Definition**. This will take you to the object definition in the library in your package cache, the shared location where downloaded dependencies are stored, which is in your home directory by default.

--- a/docs/codeql/codeql-for-visual-studio-code/working-with-codeql-packs-in-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/working-with-codeql-packs-in-visual-studio-code.rst
@@ -15,7 +15,7 @@ CodeQL packs are used to create, share, depend on, and run CodeQL queries and li
 
 Creating and editing CodeQL packs in Visual Studio Code
 -------------------------------------------------------
-To create a new CodeQL pack, you will need to use the CodeQL CLI from a terminal, which you can do within Visual Studio Code or outside of it with the ``codeql pack init`` command. Once you create an empty pack, you can edit the ``qlpack.yml`` file or run the ``codeql pack add`` command to add dependencies or change the name or version. For more information, see ":ref:`Creating and working with CodeQL packs <creating-and-working-with-codeql-packs>`".
+To create a new CodeQL pack, you will need to use the CodeQL CLI from a terminal, which you can do within Visual Studio Code or outside of it with the ``codeql pack init`` command. Once you create an empty pack, you can edit the ``qlpack.yml`` file or run the ``codeql pack add`` command to add dependencies or change the name or version. For more information, see ":ref:`Creating and working with CodeQL packs <creating-and-working-with-codeql-packs>`."
 
 You can create or edit queries in a CodeQL pack in Visual Studio Code as you would with any CodeQL query, using the standard code editing features such as autocomplete suggestions to find elements to use from the pack's dependencies. 
 


### PR DESCRIPTION
This PR adds an article about working with codeQL packs in VS Code. It mainly covers that codeQL packs (in beta currently) can be viewed in VS Code, and the qlpack.yml file as well as queries, can be edited. It also mentions that VS Code code editing features such as autocomplete, hovering to get documentation, and right-clicking to see the definition, work. 

### Changes in this PR

| Article | Change |
|--------|---------|
| Working with CodeQL packs in Visual Studio Code | New article about working with codeQL packs in VS Code