### PR TITLE
C++: Add 'Configuration' to 'SimpleRangeAnalysis'

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/ComparisonWithCancelingSubExpr.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/ComparisonWithCancelingSubExpr.ql
@@ -17,6 +17,24 @@ import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import BadAdditionOverflowCheck
 import PointlessSelfComparison
 
+class Config extends Configuration {
+  Config() { this = "ComparisonWithCancelingSubExprConfig" }
+
+  override predicate isUnconvertedSink(Expr e) { cmpLinearSubExpr0(_, e, _) }
+}
+
+predicate cmpLinearSubExpr0(ComparisonOperation cmp, Expr child, float multiplier) {
+  child = cmp.getLeftOperand() and multiplier = 1.0
+  or
+  child = cmp.getRightOperand() and multiplier = -1.0
+  or
+  exists(Expr parent, float m1, float m2 |
+    cmpLinearSubExpr0(cmp, parent, m1) and
+    linearChild(parent, child, m2) and
+    multiplier = m1 * m2
+  )
+}
+
 /**
  * Holds if `parent` is a linear expression of `child`. For example:
  *

--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -22,6 +22,12 @@ import semmle.code.cpp.controlflow.SSA
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
 
+class Config extends Configuration {
+  Config() { this = "IntMultToLongConfig" }
+
+  override predicate isUnconvertedSink(Expr e) { select0(e, _, _) }
+}
+
 /**
  * Holds if `e` is either:
  *  - a constant
@@ -176,8 +182,7 @@ predicate overflows(MulExpr me, Type t) {
   )
 }
 
-from MulExpr me, Type t1, Type t2
-where
+predicate select0(MulExpr me, Type t1, Type t2) {
   t1 = me.getType().getUnderlyingType() and
   t2 = me.getConversion().getType().getUnderlyingType() and
   t1.getSize() < t2.getSize() and
@@ -213,7 +218,12 @@ where
       e = other.(BinaryOperation).getAnOperand*()
     ) and
     e.(Literal).getType().getSize() = t2.getSize()
-  ) and
+  )
+}
+
+from MulExpr me, Type t1, Type t2
+where
+  select0(me, t1, t2) and
   // only report if we cannot prove that the result of the
   // multiplication will be less (resp. greater) than the
   // maximum (resp. minimum) number we can compute.

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
@@ -15,8 +15,9 @@
 import cpp
 import semmle.code.cpp.security.Overflow
 import semmle.code.cpp.security.Security
-import semmle.code.cpp.security.TaintTracking
-import TaintedWithPath
+import semmle.code.cpp.security.FlowSources
+import semmle.code.cpp.ir.dataflow.TaintTracking
+import DataFlow::PathGraph
 import Bounded
 
 bindingset[op]
@@ -28,25 +29,35 @@ predicate missingGuard(Operation op, Expr e, string effect) {
   not e instanceof VariableAccess and effect = "overflow"
 }
 
-class Configuration extends TaintTrackingConfiguration {
-  override predicate isSink(Element e) {
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "ArithmeticTaintedConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof FlowSource }
+
+  override predicate isSink(DataFlow::Node sink) {
     exists(Operation op |
-      missingGuard(op, e, _) and
-      op.getAnOperand() = e
+      missingGuard(op, sink.asExpr(), _) and
+      op.getAnOperand() = sink.asExpr()
     |
       op instanceof UnaryArithmeticOperation or
       op instanceof BinaryArithmeticOperation
     )
   }
 
-  override predicate isBarrier(Expr e) {
-    super.isBarrier(e) or bounded(e) or e.getUnspecifiedType().(IntegralType).getSize() <= 1
+  override predicate isSanitizer(DataFlow::Node node) {
+    exists(Expr e | e = node.asExpr() |
+      bounded(e) or e.getUnspecifiedType().(IntegralType).getSize() <= 1
+    )
   }
 }
 
-from Expr origin, Expr e, string effect, PathNode sourceNode, PathNode sinkNode, Operation op
+from
+  Expr origin, Expr e, string effect, DataFlow::PathNode sourceNode, DataFlow::PathNode sinkNode,
+  Operation op, Configuration conf
 where
-  taintedWithPath(origin, e, sourceNode, sinkNode) and
+  conf.hasFlowPath(sourceNode, sinkNode) and
+  sourceNode.getNode().asExpr() = origin and
+  sinkNode.getNode().asExpr() = e and
   op.getAnOperand() = e and
   missingGuard(op, e, effect)
 select e, sourceNode, sinkNode,

--- a/cpp/ql/src/Security/CWE/CWE-190/Bounded.qll
+++ b/cpp/ql/src/Security/CWE/CWE-190/Bounded.qll
@@ -7,6 +7,18 @@ private import cpp
 private import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 private import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
 
+private class Config extends Configuration {
+  Config() { this = "BoundedConfig" }
+
+  override predicate isUnconvertedSink(Expr e) {
+    e instanceof UnaryArithmeticOperation or
+    e instanceof BinaryArithmeticOperation or
+    e instanceof AssignArithmeticOperation or
+    e = any(BitwiseAndExpr andExpr).getAnOperand() or
+    e = any(AssignAndExpr andExpr).getAnOperand()
+  }
+}
+
 /**
  * An operand `e` of a bitwise and expression `andExpr` (i.e., `andExpr` is either an `BitwiseAndExpr`
  * or an `AssignAndExpr`) with operands `operand1` and `operand2` is the operand that is not `e` is upper

--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -18,6 +18,16 @@ import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import semmle.code.cpp.security.TaintTracking
 import TaintedWithPath
 
+class Config extends Configuration {
+  Config() { this = "TaintedAllocationSizeConfig" }
+
+  override predicate isUnconvertedSink(Expr e) {
+    e instanceof UnaryArithmeticOperation or
+    e instanceof BinaryArithmeticOperation or
+    e instanceof AssignArithmeticOperation
+  }
+}
+
 /**
  * Holds if `alloc` is an allocation, and `tainted` is a child of it that is a
  * taint sink.

--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -15,18 +15,10 @@
 
 import cpp
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
-import semmle.code.cpp.security.TaintTracking
-import TaintedWithPath
-
-class Config extends Configuration {
-  Config() { this = "TaintedAllocationSizeConfig" }
-
-  override predicate isUnconvertedSink(Expr e) {
-    e instanceof UnaryArithmeticOperation or
-    e instanceof BinaryArithmeticOperation or
-    e instanceof AssignArithmeticOperation
-  }
-}
+import semmle.code.cpp.security.FlowSources
+import semmle.code.cpp.ir.dataflow.TaintTracking
+import DataFlow::PathGraph
+import Bounded
 
 /**
  * Holds if `alloc` is an allocation, and `tainted` is a child of it that is a
@@ -38,42 +30,33 @@ predicate allocSink(Expr alloc, Expr tainted) {
   tainted.getUnspecifiedType() instanceof IntegralType
 }
 
-class TaintedAllocationSizeConfiguration extends TaintTrackingConfiguration {
-  override predicate isSink(Element tainted) { allocSink(_, tainted) }
+class TaintedAllocationSizeConfiguration extends TaintTracking::Configuration {
+  TaintedAllocationSizeConfiguration() { this = "TaintedAllocationSizeConfigurations" }
 
-  override predicate isBarrier(Expr e) {
-    super.isBarrier(e)
-    or
-    // There can be two separate reasons for `convertedExprMightOverflow` not holding:
-    // 1. `e` really cannot overflow.
-    // 2. `e` isn't analyzable.
-    // If we didn't rule out case 2 we would place barriers on anything that isn't analyzable.
-    (
-      e instanceof UnaryArithmeticOperation or
-      e instanceof BinaryArithmeticOperation or
-      e instanceof AssignArithmeticOperation
-    ) and
-    not convertedExprMightOverflow(e)
-    or
-    // Subtracting two pointers is either well-defined (and the result will likely be small), or
-    // terribly undefined and dangerous. Here, we assume that the programmer has ensured that the
-    // result is well-defined (i.e., the two pointers point to the same object), and thus the result
-    // will likely be small.
-    e = any(PointerDiffExpr diff).getAnOperand()
+  override predicate isSource(DataFlow::Node source) { source instanceof FlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { allocSink(_, sink.asExpr()) }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    exists(Expr e | e = node.asExpr() |
+      bounded(e)
+      or
+      // Subtracting two pointers is either well-defined (and the result will likely be small), or
+      // terribly undefined and dangerous. Here, we assume that the programmer has ensured that the
+      // result is well-defined (i.e., the two pointers point to the same object), and thus the result
+      // will likely be small.
+      e = any(PointerDiffExpr diff).getAnOperand()
+    )
   }
 }
 
-predicate taintedAllocSize(
-  Expr source, Expr alloc, PathNode sourceNode, PathNode sinkNode, string taintCause
-) {
-  isUserInput(source, taintCause) and
-  exists(Expr tainted |
-    allocSink(alloc, tainted) and
-    taintedWithPath(source, tainted, sourceNode, sinkNode)
-  )
-}
-
-from Expr source, Expr alloc, PathNode sourceNode, PathNode sinkNode, string taintCause
-where taintedAllocSize(source, alloc, sourceNode, sinkNode, taintCause)
+from
+  Expr source, Expr alloc, DataFlow::PathNode sourceNode, DataFlow::PathNode sinkNode,
+  string taintCause, TaintedAllocationSizeConfiguration conf
+where
+  taintCause = sourceNode.getNode().(FlowSource).getSourceType() and
+  conf.hasFlowPath(sourceNode, sinkNode) and
+  allocSink(alloc, sinkNode.getNode().asExpr()) and
+  source = sourceNode.getNode().asExpr()
 select alloc, sourceNode, sinkNode, "This allocation size is derived from $@ and might overflow",
   source, "user input (" + taintCause + ")"

--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -14,6 +14,7 @@
  */
 
 import cpp
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering // Only here to prevent IR re-evaluation
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import semmle.code.cpp.security.FlowSources
 import semmle.code.cpp.ir.dataflow.TaintTracking

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/PointlessComparison.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/PointlessComparison.qll
@@ -5,6 +5,12 @@
 import cpp
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 
+class Config extends Configuration {
+  Config() { this = "PointlessComparisonConfig" }
+
+  override predicate isUnconvertedSink(Expr e) { e = any(ComparisonOperation cmp).getAnOperand() }
+}
+
 /** Gets the lower bound of the fully converted expression. */
 private float lowerBoundFC(Expr expr) { result = lowerBound(expr.getFullyConverted()) }
 

--- a/cpp/ql/test/experimental/library-tests/rangeanalysis/bitwiseand/bitwiseand.ql
+++ b/cpp/ql/test/experimental/library-tests/rangeanalysis/bitwiseand/bitwiseand.ql
@@ -1,5 +1,13 @@
 import experimental.semmle.code.cpp.rangeanalysis.ExtendedRangeAnalysis
 
+class Config extends Configuration {
+  Config() { this = "BitwiseAndConfig" }
+
+  override predicate isUnconvertedSink(Expr e) {
+    e instanceof BitwiseAndExpr or e instanceof AssignAndExpr
+  }
+}
+
 from Operation expr, float lower, float upper
 where
   (expr instanceof BitwiseAndExpr or expr instanceof AssignAndExpr) and

--- a/cpp/ql/test/experimental/library-tests/rangeanalysis/extended/extended.ql
+++ b/cpp/ql/test/experimental/library-tests/rangeanalysis/extended/extended.ql
@@ -1,5 +1,11 @@
 import experimental.semmle.code.cpp.rangeanalysis.ExtendedRangeAnalysis
 
+class Config extends Configuration {
+  Config() { this = "ExtendedConfig" }
+
+  override predicate isUnconvertedSink(Expr e) { e instanceof VariableAccess }
+}
+
 from VariableAccess expr, float lower, float upper
 where
   lower = lowerBound(expr) and

--- a/cpp/ql/test/experimental/library-tests/rangeanalysis/extensibility/extensibility.ql
+++ b/cpp/ql/test/experimental/library-tests/rangeanalysis/extensibility/extensibility.ql
@@ -3,6 +3,12 @@ import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
 import experimental.semmle.code.cpp.models.interfaces.SimpleRangeAnalysisExpr
 import experimental.semmle.code.cpp.models.interfaces.SimpleRangeAnalysisDefinition
 
+class Config extends Configuration {
+  Config() { this = "ExtensibilityConfig" }
+
+  override predicate isUnconvertedSink(Expr e) { e instanceof VariableAccess }
+}
+
 class CustomAddFunctionCall extends SimpleRangeAnalysisExpr, FunctionCall {
   CustomAddFunctionCall() { this.getTarget().hasGlobalName("custom_add_function") }
 

--- a/cpp/ql/test/library-tests/rangeanalysis/SimpleRangeAnalysis/lowerBound.ql
+++ b/cpp/ql/test/library-tests/rangeanalysis/SimpleRangeAnalysis/lowerBound.ql
@@ -1,4 +1,10 @@
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 
+class Config extends Configuration {
+  Config() { this = "LowerBoundConfig" }
+
+  override predicate isUnconvertedSink(Expr e) { e instanceof VariableAccess }
+}
+
 from VariableAccess expr
 select expr, lowerBound(expr).toString()

--- a/cpp/ql/test/library-tests/rangeanalysis/SimpleRangeAnalysis/ternaryLower.ql
+++ b/cpp/ql/test/library-tests/rangeanalysis/SimpleRangeAnalysis/ternaryLower.ql
@@ -1,5 +1,14 @@
 import cpp
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 
+class Config extends Configuration {
+  Config() { this = "TernaryLowerConfig" }
+
+  override predicate isUnconvertedSink(Expr e) {
+    e instanceof ConditionalExpr or
+    exists(ConditionalExpr ce | e = [ce.getThen(), ce.getElse()])
+  }
+}
+
 from ConditionalExpr ce
 select ce, lowerBound(ce), lowerBound(ce.getThen()), lowerBound(ce.getElse())

--- a/cpp/ql/test/library-tests/rangeanalysis/SimpleRangeAnalysis/ternaryUpper.ql
+++ b/cpp/ql/test/library-tests/rangeanalysis/SimpleRangeAnalysis/ternaryUpper.ql
@@ -1,5 +1,14 @@
 import cpp
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 
+class Config extends Configuration {
+  Config() { this = "TernaryUpperConfig" }
+
+  override predicate isUnconvertedSink(Expr e) {
+    e instanceof ConditionalExpr or
+    exists(ConditionalExpr ce | e = [ce.getThen(), ce.getElse()])
+  }
+}
+
 from ConditionalExpr ce
 select ce, upperBound(ce), upperBound(ce.getThen()), upperBound(ce.getElse())

--- a/cpp/ql/test/library-tests/rangeanalysis/SimpleRangeAnalysis/upperBound.ql
+++ b/cpp/ql/test/library-tests/rangeanalysis/SimpleRangeAnalysis/upperBound.ql
@@ -1,4 +1,10 @@
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 
+class Config extends Configuration {
+  Config() { this = "UpperBoundConfig" }
+
+  override predicate isUnconvertedSink(Expr e) { e instanceof VariableAccess }
+}
+
 from VariableAccess expr
 select expr, upperBound(expr).toString()

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -1,174 +1,109 @@
 edges
 | test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | (size_t)... |
-| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | (size_t)... |
-| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
-| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
-| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
 | test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
 | test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
 | test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
 | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | (size_t)... |
-| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | (size_t)... |
-| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
 | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
 | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
 | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
+| test.cpp:124:18:124:23 | call to getenv | test.cpp:125:21:125:27 | size |
 | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
-| test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
-| test.cpp:124:18:124:31 | (const char *)... | test.cpp:128:24:128:41 | ... * ... |
-| test.cpp:124:18:124:31 | (const char *)... | test.cpp:128:24:128:41 | ... * ... |
+| test.cpp:125:21:125:27 | call to bounded | test.cpp:127:24:127:49 | ... * ... |
+| test.cpp:125:21:125:27 | size | test.cpp:125:21:125:27 | call to bounded |
 | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... |
-| test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... |
-| test.cpp:133:19:133:32 | (const char *)... | test.cpp:135:10:135:27 | ... * ... |
-| test.cpp:133:19:133:32 | (const char *)... | test.cpp:135:10:135:27 | ... * ... |
 | test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... |
-| test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... |
-| test.cpp:148:20:148:33 | (const char *)... | test.cpp:152:11:152:28 | ... * ... |
-| test.cpp:148:20:148:33 | (const char *)... | test.cpp:152:11:152:28 | ... * ... |
-| test.cpp:211:9:211:42 | Store | test.cpp:241:9:241:24 | call to get_tainted_size |
+| test.cpp:157:19:157:24 | call to getenv | test.cpp:161:11:161:28 | ... * ... |
+| test.cpp:184:19:184:24 | call to getenv | test.cpp:186:10:186:27 | ... * ... |
 | test.cpp:211:9:211:42 | Store | test.cpp:241:9:241:24 | call to get_tainted_size |
 | test.cpp:211:14:211:19 | call to getenv | test.cpp:211:9:211:42 | Store |
-| test.cpp:211:14:211:27 | (const char *)... | test.cpp:211:9:211:42 | Store |
+| test.cpp:216:18:216:23 | call to getenv | test.cpp:221:9:221:9 | Store |
+| test.cpp:221:9:221:9 | Store | test.cpp:242:9:242:24 | call to get_bounded_size |
 | test.cpp:224:23:224:23 | s | test.cpp:225:21:225:21 | s |
-| test.cpp:224:23:224:23 | s | test.cpp:225:21:225:21 | s |
-| test.cpp:230:21:230:21 | s | test.cpp:231:21:231:21 | s |
 | test.cpp:230:21:230:21 | s | test.cpp:231:21:231:21 | s |
 | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | (size_t)... |
 | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size |
-| test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size |
 | test.cpp:237:24:237:29 | call to getenv | test.cpp:245:2:245:9 | local_size |
 | test.cpp:237:24:237:29 | call to getenv | test.cpp:247:2:247:8 | local_size |
-| test.cpp:237:24:237:37 | (const char *)... | test.cpp:239:9:239:18 | (size_t)... |
-| test.cpp:237:24:237:37 | (const char *)... | test.cpp:239:9:239:18 | local_size |
-| test.cpp:237:24:237:37 | (const char *)... | test.cpp:239:9:239:18 | local_size |
-| test.cpp:237:24:237:37 | (const char *)... | test.cpp:245:2:245:9 | local_size |
-| test.cpp:237:24:237:37 | (const char *)... | test.cpp:247:2:247:8 | local_size |
 | test.cpp:245:2:245:9 | local_size | test.cpp:224:23:224:23 | s |
 | test.cpp:247:2:247:8 | local_size | test.cpp:230:21:230:21 | s |
 | test.cpp:251:2:251:32 | Chi [[]] | test.cpp:289:17:289:20 | get_size output argument [[]] |
 | test.cpp:251:2:251:32 | Chi [[]] | test.cpp:305:18:305:21 | get_size output argument [[]] |
 | test.cpp:251:18:251:23 | call to getenv | test.cpp:251:2:251:32 | Chi [[]] |
-| test.cpp:251:18:251:31 | (const char *)... | test.cpp:251:2:251:32 | Chi [[]] |
 | test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... |
-| test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... |
-| test.cpp:259:20:259:33 | (const char *)... | test.cpp:263:11:263:29 | ... * ... |
-| test.cpp:259:20:259:33 | (const char *)... | test.cpp:263:11:263:29 | ... * ... |
-| test.cpp:289:17:289:20 | Chi | test.cpp:291:11:291:28 | ... * ... |
 | test.cpp:289:17:289:20 | Chi | test.cpp:291:11:291:28 | ... * ... |
 | test.cpp:289:17:289:20 | get_size output argument [[]] | test.cpp:289:17:289:20 | Chi |
-| test.cpp:305:18:305:21 | Chi | test.cpp:308:10:308:27 | ... * ... |
 | test.cpp:305:18:305:21 | Chi | test.cpp:308:10:308:27 | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument [[]] | test.cpp:305:18:305:21 | Chi |
 nodes
 | test.cpp:40:21:40:24 | argv | semmle.label | argv |
-| test.cpp:40:21:40:24 | argv | semmle.label | argv |
-| test.cpp:43:38:43:44 | (size_t)... | semmle.label | (size_t)... |
 | test.cpp:43:38:43:44 | (size_t)... | semmle.label | (size_t)... |
 | test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
-| test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
-| test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
 | test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
-| test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
-| test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
-| test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
-| test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
 | test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
 | test.cpp:49:32:49:35 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:49:32:49:35 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:49:32:49:35 | size | semmle.label | size |
-| test.cpp:49:32:49:35 | size | semmle.label | size |
 | test.cpp:49:32:49:35 | size | semmle.label | size |
 | test.cpp:50:26:50:29 | size | semmle.label | size |
-| test.cpp:50:26:50:29 | size | semmle.label | size |
-| test.cpp:50:26:50:29 | size | semmle.label | size |
-| test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
-| test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
 | test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
 | test.cpp:124:18:124:23 | call to getenv | semmle.label | call to getenv |
-| test.cpp:124:18:124:31 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
-| test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
+| test.cpp:125:21:125:27 | call to bounded | semmle.label | call to bounded |
+| test.cpp:125:21:125:27 | size | semmle.label | size |
+| test.cpp:127:24:127:49 | ... * ... | semmle.label | ... * ... |
 | test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
 | test.cpp:133:19:133:24 | call to getenv | semmle.label | call to getenv |
-| test.cpp:133:19:133:32 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:148:20:148:25 | call to getenv | semmle.label | call to getenv |
-| test.cpp:148:20:148:33 | (const char *)... | semmle.label | (const char *)... |
 | test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:157:19:157:24 | call to getenv | semmle.label | call to getenv |
+| test.cpp:161:11:161:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:184:19:184:24 | call to getenv | semmle.label | call to getenv |
+| test.cpp:186:10:186:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:211:9:211:42 | Store | semmle.label | Store |
 | test.cpp:211:14:211:19 | call to getenv | semmle.label | call to getenv |
-| test.cpp:211:14:211:27 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:216:18:216:23 | call to getenv | semmle.label | call to getenv |
+| test.cpp:221:9:221:9 | Store | semmle.label | Store |
 | test.cpp:224:23:224:23 | s | semmle.label | s |
-| test.cpp:225:21:225:21 | s | semmle.label | s |
-| test.cpp:225:21:225:21 | s | semmle.label | s |
 | test.cpp:225:21:225:21 | s | semmle.label | s |
 | test.cpp:230:21:230:21 | s | semmle.label | s |
 | test.cpp:231:21:231:21 | s | semmle.label | s |
-| test.cpp:231:21:231:21 | s | semmle.label | s |
-| test.cpp:231:21:231:21 | s | semmle.label | s |
 | test.cpp:237:24:237:29 | call to getenv | semmle.label | call to getenv |
-| test.cpp:237:24:237:37 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:239:9:239:18 | (size_t)... | semmle.label | (size_t)... |
 | test.cpp:239:9:239:18 | (size_t)... | semmle.label | (size_t)... |
 | test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
-| test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
-| test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
 | test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
-| test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
-| test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
+| test.cpp:242:9:242:24 | call to get_bounded_size | semmle.label | call to get_bounded_size |
 | test.cpp:245:2:245:9 | local_size | semmle.label | local_size |
 | test.cpp:247:2:247:8 | local_size | semmle.label | local_size |
 | test.cpp:251:2:251:32 | Chi [[]] | semmle.label | Chi [[]] |
-| test.cpp:251:2:251:32 | ChiPartial | semmle.label | ChiPartial |
 | test.cpp:251:18:251:23 | call to getenv | semmle.label | call to getenv |
-| test.cpp:251:18:251:31 | (const char *)... | semmle.label | (const char *)... |
 | test.cpp:259:20:259:25 | call to getenv | semmle.label | call to getenv |
-| test.cpp:259:20:259:33 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
-| test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
 | test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
 | test.cpp:289:17:289:20 | Chi | semmle.label | Chi |
 | test.cpp:289:17:289:20 | get_size output argument [[]] | semmle.label | get_size output argument [[]] |
 | test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:305:18:305:21 | Chi | semmle.label | Chi |
 | test.cpp:305:18:305:21 | get_size output argument [[]] | semmle.label | get_size output argument [[]] |
 | test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
 #select
-| test.cpp:43:31:43:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:44:31:44:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:46:31:46:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:49:25:49:30 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:50:17:50:30 | new[] | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:53:21:53:27 | call to realloc | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:124:18:124:23 | call to getenv | user input (getenv) |
-| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:133:19:133:24 | call to getenv | user input (getenv) |
-| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:148:20:148:25 | call to getenv | user input (getenv) |
-| test.cpp:225:14:225:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:225:21:225:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (getenv) |
-| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (getenv) |
-| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (getenv) |
-| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:19 | call to getenv | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow | test.cpp:211:14:211:19 | call to getenv | user input (getenv) |
-| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:259:20:259:25 | call to getenv | user input (getenv) |
-| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:251:18:251:23 | call to getenv | user input (getenv) |
-| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:251:18:251:23 | call to getenv | user input (getenv) |
+| test.cpp:43:31:43:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | (size_t)... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:43:31:43:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:44:31:44:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:46:31:46:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:49:25:49:30 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | (size_t)... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:49:25:49:30 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:50:17:50:30 | new[] | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:53:21:53:27 | call to realloc | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:127:17:127:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:127:24:127:49 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:124:18:124:23 | call to getenv | user input (an environment variable) |
+| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:124:18:124:23 | call to getenv | user input (an environment variable) |
+| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:133:19:133:24 | call to getenv | user input (an environment variable) |
+| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:148:20:148:25 | call to getenv | user input (an environment variable) |
+| test.cpp:161:4:161:9 | call to malloc | test.cpp:157:19:157:24 | call to getenv | test.cpp:161:11:161:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:157:19:157:24 | call to getenv | user input (an environment variable) |
+| test.cpp:186:3:186:8 | call to malloc | test.cpp:184:19:184:24 | call to getenv | test.cpp:186:10:186:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:184:19:184:24 | call to getenv | user input (an environment variable) |
+| test.cpp:225:14:225:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:225:21:225:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | (size_t)... | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:19 | call to getenv | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow | test.cpp:211:14:211:19 | call to getenv | user input (an environment variable) |
+| test.cpp:242:2:242:7 | call to malloc | test.cpp:216:18:216:23 | call to getenv | test.cpp:242:9:242:24 | call to get_bounded_size | This allocation size is derived from $@ and might overflow | test.cpp:216:18:216:23 | call to getenv | user input (an environment variable) |
+| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:259:20:259:25 | call to getenv | user input (an environment variable) |
+| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:251:18:251:23 | call to getenv | user input (an environment variable) |
+| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:251:18:251:23 | call to getenv | user input (an environment variable) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
@@ -1,68 +1,29 @@
 edges
-| test2.cpp:12:21:12:21 | v | test2.cpp:14:11:14:11 | v |
-| test2.cpp:12:21:12:21 | v | test2.cpp:14:11:14:11 | v |
-| test2.cpp:25:22:25:23 | & ... | test2.cpp:27:2:27:11 | v |
-| test2.cpp:25:22:25:23 | fscanf output argument | test2.cpp:27:2:27:11 | v |
-| test2.cpp:27:2:27:11 | v | test2.cpp:12:21:12:21 | v |
-| test5.cpp:9:7:9:9 | buf | test5.cpp:10:9:10:27 | Store |
 | test5.cpp:9:7:9:9 | gets output argument | test5.cpp:10:9:10:27 | Store |
-| test5.cpp:10:9:10:27 | Store | test5.cpp:17:6:17:18 | call to getTaintedInt |
 | test5.cpp:10:9:10:27 | Store | test5.cpp:17:6:17:18 | call to getTaintedInt |
 | test5.cpp:10:9:10:27 | Store | test5.cpp:18:6:18:18 | call to getTaintedInt |
 | test5.cpp:18:6:18:18 | call to getTaintedInt | test5.cpp:19:6:19:6 | y |
-| test5.cpp:18:6:18:18 | call to getTaintedInt | test5.cpp:19:6:19:6 | y |
 | test.c:11:29:11:32 | argv | test.c:14:15:14:28 | maxConnections |
-| test.c:11:29:11:32 | argv | test.c:14:15:14:28 | maxConnections |
-| test.c:11:29:11:32 | argv | test.c:14:15:14:28 | maxConnections |
-| test.c:11:29:11:32 | argv | test.c:14:15:14:28 | maxConnections |
+| test.c:17:30:17:33 | argv | test.c:19:17:19:31 | maxConnections2 |
 | test.c:41:17:41:20 | argv | test.c:44:7:44:10 | len2 |
-| test.c:41:17:41:20 | argv | test.c:44:7:44:10 | len2 |
-| test.c:41:17:41:20 | argv | test.c:44:7:44:10 | len2 |
-| test.c:41:17:41:20 | argv | test.c:44:7:44:10 | len2 |
-| test.c:51:17:51:20 | argv | test.c:54:7:54:10 | len3 |
-| test.c:51:17:51:20 | argv | test.c:54:7:54:10 | len3 |
-| test.c:51:17:51:20 | argv | test.c:54:7:54:10 | len3 |
 | test.c:51:17:51:20 | argv | test.c:54:7:54:10 | len3 |
 nodes
-| test2.cpp:12:21:12:21 | v | semmle.label | v |
-| test2.cpp:14:11:14:11 | v | semmle.label | v |
-| test2.cpp:14:11:14:11 | v | semmle.label | v |
-| test2.cpp:14:11:14:11 | v | semmle.label | v |
-| test2.cpp:25:22:25:23 | & ... | semmle.label | & ... |
-| test2.cpp:25:22:25:23 | fscanf output argument | semmle.label | fscanf output argument |
-| test2.cpp:27:2:27:11 | v | semmle.label | v |
-| test5.cpp:9:7:9:9 | buf | semmle.label | buf |
 | test5.cpp:9:7:9:9 | gets output argument | semmle.label | gets output argument |
 | test5.cpp:10:9:10:27 | Store | semmle.label | Store |
 | test5.cpp:17:6:17:18 | call to getTaintedInt | semmle.label | call to getTaintedInt |
-| test5.cpp:17:6:17:18 | call to getTaintedInt | semmle.label | call to getTaintedInt |
-| test5.cpp:17:6:17:18 | call to getTaintedInt | semmle.label | call to getTaintedInt |
 | test5.cpp:18:6:18:18 | call to getTaintedInt | semmle.label | call to getTaintedInt |
 | test5.cpp:19:6:19:6 | y | semmle.label | y |
-| test5.cpp:19:6:19:6 | y | semmle.label | y |
-| test5.cpp:19:6:19:6 | y | semmle.label | y |
-| test.c:11:29:11:32 | argv | semmle.label | argv |
 | test.c:11:29:11:32 | argv | semmle.label | argv |
 | test.c:14:15:14:28 | maxConnections | semmle.label | maxConnections |
-| test.c:14:15:14:28 | maxConnections | semmle.label | maxConnections |
-| test.c:14:15:14:28 | maxConnections | semmle.label | maxConnections |
+| test.c:17:30:17:33 | argv | semmle.label | argv |
+| test.c:19:17:19:31 | maxConnections2 | semmle.label | maxConnections2 |
 | test.c:41:17:41:20 | argv | semmle.label | argv |
-| test.c:41:17:41:20 | argv | semmle.label | argv |
-| test.c:44:7:44:10 | len2 | semmle.label | len2 |
-| test.c:44:7:44:10 | len2 | semmle.label | len2 |
 | test.c:44:7:44:10 | len2 | semmle.label | len2 |
 | test.c:51:17:51:20 | argv | semmle.label | argv |
-| test.c:51:17:51:20 | argv | semmle.label | argv |
-| test.c:54:7:54:10 | len3 | semmle.label | len3 |
-| test.c:54:7:54:10 | len3 | semmle.label | len3 |
 | test.c:54:7:54:10 | len3 | semmle.label | len3 |
 #select
-| test2.cpp:14:11:14:11 | v | test2.cpp:25:22:25:23 | & ... | test2.cpp:14:11:14:11 | v | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test2.cpp:25:22:25:23 | & ... | User-provided value |
-| test2.cpp:14:11:14:11 | v | test2.cpp:25:22:25:23 | & ... | test2.cpp:14:11:14:11 | v | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test2.cpp:25:22:25:23 | & ... | User-provided value |
-| test5.cpp:17:6:17:18 | call to getTaintedInt | test5.cpp:9:7:9:9 | buf | test5.cpp:17:6:17:18 | call to getTaintedInt | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
-| test5.cpp:19:6:19:6 | y | test5.cpp:9:7:9:9 | buf | test5.cpp:19:6:19:6 | y | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
-| test5.cpp:19:6:19:6 | y | test5.cpp:9:7:9:9 | buf | test5.cpp:19:6:19:6 | y | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test5.cpp:9:7:9:9 | buf | User-provided value |
 | test.c:14:15:14:28 | maxConnections | test.c:11:29:11:32 | argv | test.c:14:15:14:28 | maxConnections | $@ flows to here and is used in arithmetic, potentially causing an overflow. | test.c:11:29:11:32 | argv | User-provided value |
 | test.c:14:15:14:28 | maxConnections | test.c:11:29:11:32 | argv | test.c:14:15:14:28 | maxConnections | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:11:29:11:32 | argv | User-provided value |
+| test.c:19:17:19:31 | maxConnections2 | test.c:17:30:17:33 | argv | test.c:19:17:19:31 | maxConnections2 | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:17:30:17:33 | argv | User-provided value |
 | test.c:44:7:44:10 | len2 | test.c:41:17:41:20 | argv | test.c:44:7:44:10 | len2 | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:41:17:41:20 | argv | User-provided value |
 | test.c:54:7:54:10 | len3 | test.c:51:17:51:20 | argv | test.c:54:7:54:10 | len3 | $@ flows to here and is used in arithmetic, potentially causing an underflow. | test.c:51:17:51:20 | argv | User-provided value |


### PR DESCRIPTION
This (very experimental) PR replaces the cached compute-range-analysis-for-all-expressions-once-and-for-all with a `Configuration`-based approach that hopefully ends up spending less time computing range information for the expressions whose range we actually need.

- Commit e23febf3144d92bdedaea7f59b641243eb6bb389 adds a `Configuration` to `SimpleRangeAnalysis` and adds an implementation of the abstract class to all the queries and libraries that uses `SimpleRangeAnalysis`.
- Commit e6cdd557c69ebe16ee6cd4c0c10f6a8817a34f55 is what causes the test (and possible results on CPP-Differences) changes. It changes a couple of the CWE-190 queries from `DefaultTaintTracking` to a `TaintTracking::Configuration` so that it's possible to use a dataflow configuration to specify the expressions that need range analysis information, followed by a final dataflow configuration that uses the range analysis results as barriers. This should be a lot more efficient than the naive transformation in e23febf3144d92bdedaea7f59b641243eb6bb389 does to the CWE-190 queries.

I'm leaving this as a draft PR to test it on [Jenkins](https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/2208/). I doubt we will ever merge this PR (it's a giant API breakage!), but it's good to know whether or not this idea _could_ work or not.