### PR TITLE
Data flow: More call context pruning

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1226,11 +1226,10 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
+      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
+        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), argAp0,
-        pragma[only_bind_into](config))
+      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
     )
   }
 
@@ -2022,11 +2021,10 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
+      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
+        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), argAp0,
-        pragma[only_bind_into](config))
+      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
     )
   }
 
@@ -2842,11 +2840,10 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
+      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
+        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), argAp0,
-        pragma[only_bind_into](config))
+      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -923,28 +923,29 @@ private module Stage2 {
 
   ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
 
-  class Cc = boolean;
+  class Cc = CallContext;
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
+  class CcCall = CallContextCall;
 
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
+  class CcNoCall = CallContextNoCall;
 
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
+  Cc ccNone() { result instanceof CallContextAny }
 
   private class LocalCc = Unit;
 
   bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+    checkCallContextCall(outercc, call, c) and
+    if recordDataFlowCallSiteDispatch(call, c)
+    then result = TSpecificCall(call)
+    else result = TSomeCall()
+  }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+    checkCallContextReturn(innercc, c, call) and
+    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
+  }
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(NodeEx node, Cc cc, Configuration config) { any() }
@@ -2117,7 +2118,7 @@ private module Stage3 {
 private predicate flowCandSummaryCtx(NodeEx node, AccessPathFront argApf, Configuration config) {
   exists(AccessPathFront apf |
     Stage3::revFlow(node, true, _, apf, config) and
-    Stage3::fwdFlow(node, true, TAccessPathFrontSome(argApf), apf, config)
+    Stage3::fwdFlow(node, any(Stage3::CcCall ccc), TAccessPathFrontSome(argApf), apf, config)
   )
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -630,8 +630,8 @@ private module Cached {
      * Holds if the set of viable implementations that can be called by `call`
      * might be improved by knowing the call context.
      */
-    pragma[nomagic]
-    private predicate mayBenefitFromCallContextExt(DataFlowCall call, DataFlowCallable callable) {
+    cached
+    predicate mayBenefitFromCallContextExt(DataFlowCall call, DataFlowCallable callable) {
       mayBenefitFromCallContext(call, callable)
       or
       callEnclosingCallable(call, callable) and

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -786,13 +786,18 @@ private module Cached {
   }
 
   /**
-   * Holds if the call context `call` either improves virtual dispatch in
-   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   * Holds if the call context `call` improves virtual dispatch in `callable`.
    */
   cached
-  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  predicate recordDataFlowCallSiteDispatch(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
-    or
+  }
+
+  /**
+   * Holds if the call context `call` allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable callable) {
     exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCallCached(n, call))
   }
 
@@ -844,6 +849,15 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+}
+
+/**
+ * Holds if the call context `call` either improves virtual dispatch in
+ * `callable` or if it allows us to prune unreachable nodes in `callable`.
+ */
+predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  recordDataFlowCallSiteDispatch(call, callable) or
+  recordDataFlowCallSiteUnreachable(call, callable)
 }
 
 /**

--- a/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
@@ -508,7 +508,7 @@ private module Internal {
     override RuntimeCallable getADynamicTarget() {
       result = getAViableInherited()
       or
-      result = getAViableOverrider() and strictcount(getAViableOverrider()) < 1000
+      result = getAViableOverrider()
       or
       // Simple case: target method cannot be overridden
       result = getAStaticTarget() and

--- a/csharp/ql/test/library-tests/dataflow/collections/CollectionFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/collections/CollectionFlow.expected
@@ -160,12 +160,6 @@ edges
 | CollectionFlow.cs:373:52:373:53 | access to parameter ts [element] : A | CollectionFlow.cs:373:52:373:56 | access to array element |
 | CollectionFlow.cs:373:52:373:53 | access to parameter ts [element] : A | CollectionFlow.cs:373:52:373:56 | access to array element |
 | CollectionFlow.cs:375:49:375:52 | list [element] : A | CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A |
-| CollectionFlow.cs:375:49:375:52 | list [element] : A | CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A |
-| CollectionFlow.cs:375:49:375:52 | list [element] : A | CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A |
-| CollectionFlow.cs:375:49:375:52 | list [element] : A | CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A |
-| CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A | CollectionFlow.cs:375:63:375:69 | access to indexer |
-| CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A | CollectionFlow.cs:375:63:375:69 | access to indexer |
-| CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A | CollectionFlow.cs:375:63:375:69 | access to indexer |
 | CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A | CollectionFlow.cs:375:63:375:69 | access to indexer |
 | CollectionFlow.cs:377:61:377:64 | dict [element, property Value] : A | CollectionFlow.cs:377:75:377:78 | access to parameter dict [element, property Value] : A |
 | CollectionFlow.cs:377:75:377:78 | access to parameter dict [element, property Value] : A | CollectionFlow.cs:377:75:377:81 | access to indexer |
@@ -343,12 +337,6 @@ nodes
 | CollectionFlow.cs:373:52:373:53 | access to parameter ts [element] : A | semmle.label | access to parameter ts [element] : A |
 | CollectionFlow.cs:373:52:373:56 | access to array element | semmle.label | access to array element |
 | CollectionFlow.cs:375:49:375:52 | list [element] : A | semmle.label | list [element] : A |
-| CollectionFlow.cs:375:49:375:52 | list [element] : A | semmle.label | list [element] : A |
-| CollectionFlow.cs:375:49:375:52 | list [element] : A | semmle.label | list [element] : A |
-| CollectionFlow.cs:375:49:375:52 | list [element] : A | semmle.label | list [element] : A |
-| CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A | semmle.label | access to parameter list [element] : A |
-| CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A | semmle.label | access to parameter list [element] : A |
-| CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A | semmle.label | access to parameter list [element] : A |
 | CollectionFlow.cs:375:63:375:66 | access to parameter list [element] : A | semmle.label | access to parameter list [element] : A |
 | CollectionFlow.cs:375:63:375:69 | access to indexer | semmle.label | access to indexer |
 | CollectionFlow.cs:377:61:377:64 | dict [element, property Value] : A | semmle.label | dict [element, property Value] : A |

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -1226,10 +1226,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2021,10 +2023,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2840,10 +2844,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 


### PR DESCRIPTION
<details>
 <summary>Before this PR (including https://github.com/github/codeql/pull/6394):</summary>

```
	XSS.ql-33:DataFlowImpl2::additionalJumpStep#fff#shared ....................................................................................... 1m10s
	XSS.ql-33:DataFlowPrivate::NodeImpl::getTypeImpl_dispred#ff_10#join_rhs ...................................................................... 54.6s
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlow#2#fff ............................................................................................... 54.3s (1756 evaluations with max 1.4s in DataFlowImpl2::Stage1::fwdFlow#2#fff/3@i95#d1de60)
	XSS.ql-33:DataFlowImpl2::viableParamArgEx#fff ................................................................................................ 50.1s
	XSS.ql-33:num#DataFlowImpl2::TNodeNormal#ff .................................................................................................. 44.1s
	XSS.ql-33:num#DataFlowImpl2::TNil#ff ......................................................................................................... 43.9s
	XSS.ql-33:num#DataFlowImpl2::TSummaryCtxNone#f ............................................................................................... 41.1s
	XSS.ql-33:locations_default_102345#join_rhs .................................................................................................. 37.9s
	XSS.ql-33:DataFlowImpl2::localFlowStep#fff ................................................................................................... 35.4s
	XSS.ql-33:#Type::ValueOrRefType::getBaseClass_dispredPlus#ff ................................................................................. 33.1s
	XSS.ql-33:Location::Location::hasLocationInfo_dispred#ffffff ................................................................................. 32s
	XSS.ql-33:DataFlowImpl2::jumpStep#fff#shared ................................................................................................. 27.5s
	XSS.ql-33:DataFlowImpl2::NodeEx::getDataFlowType0#ff ......................................................................................... 25.8s
	XSS.ql-33:project#DataFlowImpl2::viableParamArgEx#fff ........................................................................................ 24.7s
	XSS.ql-33:DataFlowImpl2::NodeEx::getEnclosingCallable0#ff .................................................................................... 24.2s
	XSS.ql-33:ControlFlowGraph::ControlFlow::Node::getEnclosingCallable_dispred#ff ............................................................... 23.2s
	XSS.ql-33:DataFlowImpl2::Stage1::revFlow0#fff ................................................................................................ 22.2s (797 evaluations with max 385ms in DataFlowImpl2::Stage1::revFlow0#fff/3@i243#09cb13)
	XSS.ql-33:XSSSinks::HtmlSinkSink#class#f ..................................................................................................... 21.6s
	XSS.ql-33:DataFlowPublic::Content::toString_dispred#ff ....................................................................................... 18.9s
	XSS.ql-33:m#Assignable::nameOfChild#fb ....................................................................................................... 16.9s (240 evaluations with max 7.5s in m#Assignable::nameOfChild#fb/1@i3#e5ba6w)
	XSS.ql-33:DataFlowImplCommon::Cached::viableParamArg#fff_102#join_rhs ........................................................................ 16.3s
```
</details>


<details>
 <summary>First commit of this PR (revert https://github.com/github/codeql/pull/6394):</summary>

```
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowIn#fffffff ........................................ 192m53s (366 evaluations with max 13m37s in DataFlowImpl2::Stage3::fwdFlowIn#fffffff/7@i174#0675c0)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlow0#fffff ........................................... 46m40s (369 evaluations with max 2m45s in DataFlowImpl2::Stage3::fwdFlow0#fffff/5@i181#0675c4)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3 ................ 35m46s (365 evaluations with max 2m11s in DataFlowImpl2::Stage3::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3/5@i174#0675cy)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlow#fffff ............................................ 33m23s (367 evaluations with max 40.5s in DataFlowImpl2::Stage3::fwdFlow#fffff/5@i168#0675c3)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2 ................. 16m28s (360 evaluations with max 1m16s in DataFlowImpl2::Stage3::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2/5@i181#0675cx)
	XSS.ql-33:DataFlowImpl2::Stage3::revFlowInToReturn#fffff#reorder_0_2_4_1_3 ................ 9m23s (362 evaluations with max 52.8s in DataFlowImpl2::Stage3::revFlowInToReturn#fffff#reorder_0_2_4_1_3/5@i28#6b414z)
	XSS.ql-33:DataFlowImpl2::Stage3::callMayFlowThroughFwd#ff ................................. 3m53s
	XSS.ql-33:DataFlowImpl2::Stage4::fwdFlowIn#fffffff ........................................ 3m32s (403 evaluations with max 29.8s in DataFlowImpl2::Stage4::fwdFlowIn#fffffff/7@i113#b7163z)
	XSS.ql-33:DataFlowImpl2::Stage3::revFlow0#fffff ........................................... 2m49s (380 evaluations with max 6.4s in DataFlowImpl2::Stage3::revFlow0#fffff/5@i19#6b4143)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowOutNotFromArg#fffff ............................... 2m44s (364 evaluations with max 1.9s in DataFlowImpl2::Stage3::fwdFlowOutNotFromArg#fffff/5@i136#0675c2)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowStore#fffffff ..................................... 2m35s (366 evaluations with max 8.2s in DataFlowImpl2::Stage3::fwdFlowStore#fffffff/7@i205#0675c1)
	XSS.ql-33:DataFlowImpl2::viableParamArgEx#fff ............................................. 2m18s
	XSS.ql-33:DataFlowImpl2::viableReturnPosOutEx#fff ......................................... 1m59s
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlow#2#fff ............................................ 1m37s (1753 evaluations with max 2.9s in DataFlowImpl2::Stage1::fwdFlow#2#fff/3@i30#d93cc0)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowRead#fffffff#reorder_0_1_6_2_3_4_5#join_rhs ....... 1m34s
	XSS.ql-33:DataFlowImpl2::viableReturnPosOutEx#fff_102#join_rhs ............................ 1m21s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowRead#fffffff#reorder_0_1_6_2_3_4_5 ................ 1m17s (363 evaluations with max 5.3s in DataFlowImpl2::Stage3::fwdFlowRead#fffffff#reorder_0_1_6_2_3_4_5/7@i137#0675cz)
	XSS.ql-33:num#DataFlowImpl2::TNodeNormal#ff ............................................... 1m8s
	XSS.ql-33:DataFlowImpl2::Stage3::revFlowOut#ffffff ........................................ 57.7s (361 evaluations with max 7.7s in DataFlowImpl2::Stage3::revFlowOut#ffffff/6@i18#6b4140)
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlowOut#ffff .......................................... 52.4s (1735 evaluations with max 3.3s in DataFlowImpl2::Stage1::fwdFlowOut#ffff/4@i23#d93cc2)
	XSS.ql-33:project#DataFlowImpl2::viableParamArgEx#fff ..................................... 48.4s
	XSS.ql-33:DataFlowImplCommon::Cached::viableParamArg#fff_102#join_rhs ..................... 46.2s
```

</details>


<details>
 <summary>This PR:</summary>

```
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowIn#fffffff .................................. 7m27s (402 evaluations with max 21.3s in DataFlowImpl2::Stage3::fwdFlowIn#fffffff/7@i148#101c50)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlow#fffff ...................................... 3m25s (405 evaluations with max 10.5s in DataFlowImpl2::Stage3::fwdFlow#fffff/5@i190#101c52)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlow0#fffff ..................................... 2m33s (405 evaluations with max 10.1s in DataFlowImpl2::Stage3::fwdFlow0#fffff/5@i149#101c54)
	XSS.ql-33:DataFlowImplCommon::Cached::viableReturnPosOut#fff_201#join_rhs ........... 2m22s
	XSS.ql-33:DataFlowImpl2::viableParamArgEx#fff ....................................... 2m18s
	XSS.ql-33:DataFlowImpl2::viableReturnPosOutEx#fff_102#join_rhs ...................... 2m13s
	XSS.ql-33:DataFlowImpl2::Stage3::clear#ff ........................................... 2m12s
	XSS.ql-33:DataFlowImpl2::additionalJumpStep#fff#shared .............................. 1m53s
	XSS.ql-33:DataFlowImpl2::viableReturnPosOutEx#fff ................................... 1m44s
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlow#2#fff ...................................... 1m34s (1753 evaluations with max 3.4s in DataFlowImpl2::Stage1::fwdFlow#2#fff/3@i30#b11340)
	XSS.ql-33:DataFlowImplCommon::viableCallableExt#ff_10#join_rhs ...................... 1m27s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3 .......... 1m25s (401 evaluations with max 8.3s in DataFlowImpl2::Stage3::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3/5@i235#101c5y)
	XSS.ql-33:DataFlowPrivate::NodeImpl::getTypeImpl_dispred#ff_10#join_rhs ............. 1m18s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2 ........... 1m10s (397 evaluations with max 4.5s in DataFlowImpl2::Stage3::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2/5@i149#101c5x)
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlowOut#ffff .................................... 1m10s (1735 evaluations with max 5.2s in DataFlowImpl2::Stage1::fwdFlowOut#ffff/4@i23#b11342)
	XSS.ql-33:DataFlowImpl2::localFlowStep#fff .......................................... 1m9s
	XSS.ql-33:num#DataFlowImpl2::TNodeNormal#ff ......................................... 1m4s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowRead#fffffff#reorder_0_1_6_2_3_4_5#join_rhs . 1m3s
	XSS.ql-33:#Type::ValueOrRefType::getBaseClass_dispredPlus#ff ........................ 57.5s
	XSS.ql-33:DataFlowImpl2::Stage1::reducedViableImplInReturn#fff ...................... 57.1s
	XSS.ql-33:DataFlowImpl2::NodeEx::getEnclosingCallable0#ff ........................... 54.9s
	XSS.ql-33:project#DataFlowImpl2::viableParamArgEx#fff ............................... 53s
	XSS.ql-33:DataFlowImplCommon::Cached::viableParamArg#fff_102#join_rhs ............... 50.2s
```

</details>


<details>
 <summary>This PR (except performance improvements):</summary>

```
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowIn#fffffff .................................. 14m53s (402 evaluations with max 58.4s in DataFlowImpl2::Stage3::fwdFlowIn#fffffff/7@i108#e18ca0)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlow0#fffff ..................................... 4m16s (405 evaluations with max 14.2s in DataFlowImpl2::Stage3::fwdFlow0#fffff/5@i109#e18ca4)
	XSS.ql-33:DataFlowImpl2::viableParamArgEx#fff ....................................... 3m12s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlow#fffff ...................................... 3m9s (405 evaluations with max 9.9s in DataFlowImpl2::Stage3::fwdFlow#fffff/5@i190#e18ca3)
	XSS.ql-33:DataFlowImpl2::viableReturnPosOutEx#fff ................................... 3m4s
	XSS.ql-33:DataFlowImpl2::viableReturnPosOutEx#fff_102#join_rhs ...................... 2m30s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2 ........... 2m23s (397 evaluations with max 10.5s in DataFlowImpl2::Stage3::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2/5@i109#e18cax)
	XSS.ql-33:DataFlowImpl2::additionalJumpStep#fff#shared .............................. 1m55s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3 .......... 1m46s (401 evaluations with max 11.2s in DataFlowImpl2::Stage3::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3/5@i235#e18cay)
	XSS.ql-33:DataFlowImpl2::Stage3::callMayFlowThroughFwd#ff ........................... 1m45s
	XSS.ql-33:project#DataFlowImpl2::viableParamArgEx#fff ............................... 1m38s
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlow#2#fff ...................................... 1m35s (1753 evaluations with max 3.2s in DataFlowImpl2::Stage1::fwdFlow#2#fff/3@i30#d93cc0)
	XSS.ql-33:DataFlowImplCommon::viableCallableExt#ff_10#join_rhs ...................... 1m30s
	XSS.ql-33:DataFlowPrivate::NodeImpl::getTypeImpl_dispred#ff_10#join_rhs ............. 1m19s
	XSS.ql-33:DataFlowImplCommon::Cached::viableParamArg#fff_102#join_rhs ............... 1m14s
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlowOut#ffff .................................... 1m10s (1735 evaluations with max 4.9s in DataFlowImpl2::Stage1::fwdFlowOut#ffff/4@i23#d93cc2)
	XSS.ql-33:num#DataFlowImpl2::TNodeNormal#ff ......................................... 1m9s
	XSS.ql-33:DataFlowImpl2::Stage2::fwdFlowIn#fffffff .................................. 1m3s (1502 evaluations with max 2.2s in DataFlowImpl2::Stage2::fwdFlowIn#fffffff/7@i71#63d620)
	XSS.ql-33:#Type::ValueOrRefType::getBaseClass_dispredPlus#ff ........................ 1m0s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowRead#fffffff#reorder_0_1_6_2_3_4_5#join_rhs . 56.9s
```

</details>

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1299/ (first commit against base)
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1302/ (PR against first commit)
https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/2214/
https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/1576/
https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/668/