### PR TITLE
CPP/C#: use min() instead of rank[1]()

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/lib/semmle/code/cpp/PrintAST.qll
@@ -46,7 +46,7 @@ private string escapeString(string s) {
  * string representation comes first in lexicographical order.
  */
 private Location getRepresentativeLocation(Locatable ast) {
-  result = rank[1](Location loc | loc = ast.getLocation() | loc order by loc.toString())
+  result = min(Location loc | loc = ast.getLocation() | loc order by loc.toString())
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRConsistency.qll
@@ -35,7 +35,7 @@ module InstructionConsistency {
       // To avoid an overwhelming number of results when the extractor merges functions with the
       // same name, just pick a single location.
       result =
-        rank[1](Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
+        min(Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
     }
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRConsistency.qll
@@ -35,7 +35,7 @@ module InstructionConsistency {
       // To avoid an overwhelming number of results when the extractor merges functions with the
       // same name, just pick a single location.
       result =
-        rank[1](Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
+        min(Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
     }
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRConsistency.qll
@@ -35,7 +35,7 @@ module InstructionConsistency {
       // To avoid an overwhelming number of results when the extractor merges functions with the
       // same name, just pick a single location.
       result =
-        rank[1](Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
+        min(Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
     }
   }
 

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRConsistency.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRConsistency.qll
@@ -35,7 +35,7 @@ module InstructionConsistency {
       // To avoid an overwhelming number of results when the extractor merges functions with the
       // same name, just pick a single location.
       result =
-        rank[1](Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
+        min(Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
     }
   }
 

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRConsistency.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRConsistency.qll
@@ -35,7 +35,7 @@ module InstructionConsistency {
       // To avoid an overwhelming number of results when the extractor merges functions with the
       // same name, just pick a single location.
       result =
-        rank[1](Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
+        min(Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
     }
   }
 


### PR DESCRIPTION
`rank[1](...)` and `min(..)` does the same thing. But the latter performs better.  

For JS it gave a small performance improvement (see #6462). 