### PR TITLE
QL Language Spec: Trailing comma in set literal

### DIFF
--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -1323,13 +1323,15 @@ Set literals denote a choice from a collection of values.
 
 ::
 
-   setliteral ::= "[" expr ("," expr)* "]"
+   setliteral ::= "[" expr ("," expr)* ","? "]"
 
 Set literals can be of any type, but the types within a set literal have to be consistent according to the following criterion: At least one of the set elements has to be of a type that is a supertype of all the set element types. This supertype is the type of the set literal. For example, ``float`` is a supertype of ``float`` and ``int``, therefore ``x = [4, 5.6]`` is valid. On the other hand, ``y = [5, "test"]`` does not adhere to the criterion.
 
 The values of a set literal expression are all the values of all the contained element expressions.
 
 Set literals are supported from release 2.1.0 of the CodeQL CLI, and release 1.24 of LGTM Enterprise.
+
+Since release 2.6.3 of the CodeQL CLI, and release 1.28 of LGTM Enterprise, a trailing comma is allowed in a set literal.
 
 Disambiguation of expressions
 -----------------------------
@@ -2168,7 +2170,7 @@ The complete grammar for QL is as follows:
                    
    range ::= "[" expr ".." expr "]"
    
-   setliteral ::= "[" expr ("," expr)* "]"
+   setliteral ::= "[" expr ("," expr)* ","? "]"
 
    simpleId ::= lowerId | upperId
 


### PR DESCRIPTION
See https://github.com/github/codeql-cli-binaries/issues/76

Updates the QL language spec to allow for a trailing comma in set literals.