### PR TITLE
Python: Prevent explosion in poly-ReDoS query

### DIFF
--- a/python/ql/src/semmle/python/security/performance/RegExpTreeView.qll
+++ b/python/ql/src/semmle/python/security/performance/RegExpTreeView.qll
@@ -11,5 +11,8 @@ import semmle.python.RegexTreeView
  * For javascript we make the pragmatic performance optimization to ignore files we did not extract.
  */
 predicate isExcluded(RegExpParent parent) {
-  not exists(parent.getRegex().getLocation().getFile().getRelativePath())
+  not exists(parent.getRegex().getLocation().getFile().getRelativePath()) or
+  // Regexes with many occurrences of ".*" may cause the polynomial ReDoS computation to explode, so
+  // we explicitly exclude these.
+  count(int i | exists(parent.getRegex().getText().regexpFind("\\.\\*", i, _)) | i) > 10
 }

--- a/python/ql/src/semmle/python/security/performance/RegExpTreeView.qll
+++ b/python/ql/src/semmle/python/security/performance/RegExpTreeView.qll
@@ -11,7 +11,8 @@ import semmle.python.RegexTreeView
  * For javascript we make the pragmatic performance optimization to ignore files we did not extract.
  */
 predicate isExcluded(RegExpParent parent) {
-  not exists(parent.getRegex().getLocation().getFile().getRelativePath()) or
+  not exists(parent.getRegex().getLocation().getFile().getRelativePath())
+  or
   // Regexes with many occurrences of ".*" may cause the polynomial ReDoS computation to explode, so
   // we explicitly exclude these.
   count(int i | exists(parent.getRegex().getText().regexpFind("\\.\\*", i, _)) | i) > 10


### PR DESCRIPTION
I consider this to be a short-term solution to the performance problems
we identified. The choice of "at most ten occurrences of `.*`" is
somewhat arbitrary, and it's possible a higher limit would work just as
well.

---

This just fixes performance issues, so I don't think a change note is needed.

I have verified manually that this alleviates the problem we witnessed previously.