### PR TITLE
Python: Update comment for RegExpTreeView isExcluded

### DIFF
--- a/python/ql/src/semmle/python/security/performance/RegExpTreeView.qll
+++ b/python/ql/src/semmle/python/security/performance/RegExpTreeView.qll
@@ -8,7 +8,8 @@ import semmle.python.RegexTreeView
 /**
  * Holds if the regular expression should not be considered.
  *
- * For javascript we make the pragmatic performance optimization to ignore files we did not extract.
+ * We make the pragmatic performance optimization to ignore regular expressions in files
+ * that does not belong to the project code (such as installed dependencies).
  */
 predicate isExcluded(RegExpParent parent) {
   not exists(parent.getRegex().getLocation().getFile().getRelativePath())


### PR DESCRIPTION
I noticed after reading https://github.com/github/codeql/pull/6507, but didn't want to overload that PR.