### PR TITLE
JS: Rename Vue::Instance to Vue::Component

### DIFF
--- a/javascript/change-notes/2021-08-17-vue-component-renaming.md
+++ b/javascript/change-notes/2021-08-17-vue-component-renaming.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The class `Vue::Instance` has been renamed to `Vue::Component`.

--- a/javascript/ql/src/Vue/ArrowMethodOnVueInstance.ql
+++ b/javascript/ql/src/Vue/ArrowMethodOnVueInstance.ql
@@ -11,7 +11,7 @@
 
 import javascript
 
-from Vue::Instance instance, DataFlow::Node def, DataFlow::FunctionNode arrow, ThisExpr dis
+from Vue::Component instance, DataFlow::Node def, DataFlow::FunctionNode arrow, ThisExpr dis
 where
   instance.getABoundFunction() = def and
   arrow.flowsTo(def) and

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -82,6 +82,11 @@ module Vue {
   }
 
   /**
+   * DEPRECATED. This class has been renamed to `Vue::Component`.
+   */
+  deprecated class Instance = Component;
+
+  /**
    * A Vue component, such as a `new Vue({ ... })` call or a `.vue` file.
    *
    * Generally speaking, a component is always created by calling `Vue.extend()` or

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -535,13 +535,13 @@ module Vue {
    */
   class VHtmlSourceWrite extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(Vue::Component instance, string expr, VHtmlAttribute attr |
+      exists(Vue::Component component, string expr, VHtmlAttribute attr |
         attr.getAttr().getRoot() =
-          instance.getTemplateElement().(Vue::Template::HtmlElement).getElement() and
+          component.getTemplateElement().(Vue::Template::HtmlElement).getElement() and
         expr = attr.getAttr().getValue() and
         // only support for simple identifier expressions
         expr.regexpMatch("(?i)[a-z0-9_]+") and
-        pred = instance.getAPropertyValue(expr) and
+        pred = component.getAPropertyValue(expr) and
         succ = attr
       )
     }
@@ -642,15 +642,15 @@ module Vue {
       or
       result = routeConfig().getMember("beforeEnter").getParameter([0, 1]).getAnImmediateUse()
       or
-      exists(Component i |
-        result = i.getABoundFunction().getAFunctionValue().getReceiver().getAPropertyRead("$route")
+      exists(Component c |
+        result = c.getABoundFunction().getAFunctionValue().getReceiver().getAPropertyRead("$route")
         or
         result =
-          i.getALifecycleHook(["beforeRouteEnter", "beforeRouteUpdate", "beforeRouteLeave"])
+          c.getALifecycleHook(["beforeRouteEnter", "beforeRouteUpdate", "beforeRouteLeave"])
               .getAFunctionValue()
               .getParameter([0, 1])
         or
-        result = i.getWatchHandler("$route").getParameter([0, 1])
+        result = c.getWatchHandler("$route").getParameter([0, 1])
       )
     )
     or
@@ -668,7 +668,7 @@ module Vue {
         this = routeObject().getAPropertyRead(name)
         or
         exists(string prop |
-          this = any(Component i).getWatchHandler(prop).getParameter([0, 1]) and
+          this = any(Component c).getWatchHandler(prop).getParameter([0, 1]) and
           name = prop.regexpCapture("\\$route\\.(params|query|hash|path|fullPath)\\b.*", 1)
         )
       |

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -95,9 +95,9 @@ module Vue {
    *   - `Vue.component("my-component", {...})`
    *   - single file components in .vue files
    */
-  abstract class Instance extends TInstance {
+  class Instance extends TInstance {
     /** Gets a textual representation of this element. */
-    abstract string toString();
+    string toString() { none() } // overridden in subclasses
 
     /**
      * Holds if this element is at the specified location.
@@ -120,7 +120,7 @@ module Vue {
      * Gets the options passed to the Vue object, such as the object literal `{...}` in `new Vue{{...})`
      * or the default export of a single-file component.
      */
-    abstract DataFlow::Node getOwnOptionsObject();
+    DataFlow::Node getOwnOptionsObject() { none() } // overridden in subclasses
 
     /**
      * Gets the class component implementing this Vue instance, if any.
@@ -173,7 +173,7 @@ module Vue {
     /**
      * Gets the template element used by this instance, if any.
      */
-    abstract Template::Element getTemplateElement();
+    Template::Element getTemplateElement() { none() } // overridden in subclasses
 
     /**
      * Gets the node for the `data` option object of this instance.

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -132,15 +132,15 @@ module Vue {
     DataFlow::Node getOwnOptionsObject() { none() } // overridden in subclasses
 
     /**
-     * Gets the class component implementing this Vue instance, if any.
+     * Gets the class implementing this Vue component, if any.
      *
      * Specifically, this is a class annotated with `@Component` which flows to the options
-     * object of this Vue instance.
+     * object of this Vue component.
      */
     ClassComponent getAsClassComponent() { result.flowsTo(getOwnOptionsObject()) }
 
     /**
-     * Gets the node for option `name` for this instance, this does not include
+     * Gets the node for option `name` for this component, not including
      * those from extended objects and mixins.
      */
     DataFlow::Node getOwnOption(string name) {
@@ -148,7 +148,7 @@ module Vue {
     }
 
     /**
-     * Gets the node for option `name` for this instance, including those from
+     * Gets the node for option `name` for this component, including those from
      * extended objects and mixins.
      */
     DataFlow::Node getOption(string name) {
@@ -173,25 +173,25 @@ module Vue {
     }
 
     /**
-     * Gets a source node flowing into the option `name` of this instance, including those from
+     * Gets a source node flowing into the option `name` of this component, including those from
      * extended objects and mixins.
      */
     pragma[nomagic]
     DataFlow::SourceNode getOptionSource(string name) { result = getOption(name).getALocalSource() }
 
     /**
-     * Gets the template element used by this instance, if any.
+     * Gets the template element used by this component, if any.
      */
     Template::Element getTemplateElement() { none() } // overridden in subclasses
 
     /**
-     * Gets the node for the `data` option object of this instance.
+     * Gets the node for the `data` option object of this component.
      */
     DataFlow::Node getData() {
       exists(DataFlow::Node data | data = getOption("data") |
         result = data
         or
-        // a constructor variant is available for all instance definitions
+        // a constructor variant is available for all component definitions
         exists(DataFlow::FunctionNode f |
           f.flowsTo(data) and
           result = f.getAReturn()
@@ -204,13 +204,13 @@ module Vue {
     }
 
     /**
-     * Gets the node for the `template` option of this instance.
+     * Gets the node for the `template` option of this component.
      */
     pragma[nomagic]
     DataFlow::SourceNode getTemplate() { result = getOptionSource("template") }
 
     /**
-     * Gets the node for the `render` option of this instance.
+     * Gets the node for the `render` option of this component.
      */
     pragma[nomagic]
     DataFlow::SourceNode getRender() {
@@ -220,19 +220,19 @@ module Vue {
     }
 
     /**
-     * Gets the node for the `methods` option of this instance.
+     * Gets the node for the `methods` option of this component.
      */
     pragma[nomagic]
     DataFlow::SourceNode getMethods() { result = getOptionSource("methods") }
 
     /**
-     * Gets the node for the `computed` option of this instance.
+     * Gets the node for the `computed` option of this component.
      */
     pragma[nomagic]
     DataFlow::SourceNode getComputed() { result = getOptionSource("computed") }
 
     /**
-     * Gets the node for the `watch` option of this instance.
+     * Gets the node for the `watch` option of this component.
      */
     pragma[nomagic]
     DataFlow::SourceNode getWatch() { result = getOptionSource("watch") }
@@ -249,7 +249,7 @@ module Vue {
     }
 
     /**
-     * Gets a node for a member of the `methods` option of this instance.
+     * Gets a node for a member of the `methods` option of this component.
      */
     pragma[nomagic]
     private DataFlow::SourceNode getAMethod() {
@@ -260,7 +260,7 @@ module Vue {
     }
 
     /**
-     * Gets a node for a member of the `computed` option of this instance that matches `kind`.
+     * Gets a node for a member of the `computed` option of this component that matches `kind`.
      */
     pragma[nomagic]
     private DataFlow::SourceNode getAnAccessor(DataFlow::MemberKind kind) {
@@ -273,7 +273,7 @@ module Vue {
     }
 
     /**
-     * Gets a node for a member `name` of the `computed` option of this instance that matches `kind`.
+     * Gets a node for a member `name` of the `computed` option of this component that matches `kind`.
      */
     private DataFlow::SourceNode getAccessor(string name, DataFlow::MemberKind kind) {
       result = getComputed().getAPropertySource(name) and kind = DataFlow::MemberKind::getter()
@@ -285,7 +285,7 @@ module Vue {
     }
 
     /**
-     * Gets the node for the life cycle hook of the `hookName` option of this instance.
+     * Gets the node for the life cycle hook of the `hookName` option of this component.
      */
     pragma[nomagic]
     DataFlow::SourceNode getALifecycleHook(string hookName) {
@@ -298,7 +298,7 @@ module Vue {
     }
 
     /**
-     * Gets a node for a function that will be invoked with `this` bound to this instance.
+     * Gets a node for a function that will be invoked with `this` bound to this component.
      */
     DataFlow::FunctionNode getABoundFunction() {
       result = getAMethod()
@@ -325,7 +325,7 @@ module Vue {
     }
 
     /**
-     * Gets the data flow node that flows into the property `name` of this instance, or is
+     * Gets the data flow node that flows into the property `name` of this component, or is
      * returned form a getter defining that property.
      */
     DataFlow::Node getAPropertyValue(string name) {
@@ -339,7 +339,7 @@ module Vue {
   }
 
   /**
-   * A Vue instance from `new Vue({...})`.
+   * A Vue component from `new Vue({...})`.
    */
   class VueInstance extends Component, MkVueInstance {
     DataFlow::NewNode def;

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -27,7 +27,7 @@ module Vue {
     MkExtendedInstance(VueExtend extend, DataFlow::NewNode sub) {
       sub = extend.getAnInstantiation()
     } or
-    MkComponent(DataFlow::CallNode def) { def = vue().getAMemberCall("component") } or
+    MkComponentRegistration(DataFlow::CallNode def) { def = vue().getAMemberCall("component") } or
     MkSingleFileComponent(VueFile file)
 
   /** Gets the name of a lifecycle hook method. */
@@ -402,10 +402,10 @@ module Vue {
   /**
    * A Vue component from `Vue.component("my-component", { ... })`.
    */
-  class Component extends Instance, MkComponent {
+  class ComponentRegistration extends Instance, MkComponentRegistration {
     DataFlow::CallNode def;
 
-    Component() { this = MkComponent(def) }
+    ComponentRegistration() { this = MkComponentRegistration(def) }
 
     override string toString() { result = def.toString() }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Vuex.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vuex.qll
@@ -26,7 +26,7 @@ private module VueAPI {
    * or equivalent.
    */
   class VueConfigObject extends API::Node {
-    VueConfigObject() { this.getARhs() = any(Vue::Instance i).getOwnOptionsObject() }
+    VueConfigObject() { this.getARhs() = any(Vue::Component i).getOwnOptionsObject() }
 
     /** Gets an API node representing `this` in the Vue component. */
     API::Node getAnInstanceRef() {

--- a/javascript/ql/src/semmle/javascript/frameworks/Vuex.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vuex.qll
@@ -26,7 +26,7 @@ private module VueAPI {
    * or equivalent.
    */
   class VueConfigObject extends API::Node {
-    VueConfigObject() { this.getARhs() = any(Vue::Component i).getOwnOptionsObject() }
+    VueConfigObject() { this.getARhs() = any(Vue::Component c).getOwnOptionsObject() }
 
     /** Gets an API node representing `this` in the Vue component. */
     API::Node getAnInstanceRef() {

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -346,7 +346,7 @@ module DomBasedXss {
    */
   class VueTemplateSink extends DomBasedXss::Sink {
     VueTemplateSink() {
-      // Note: don't use Vue::Instance#getTemplate as it includes an unwanted getALocalSource() step
+      // Note: don't use Vue::Component#getTemplate as it includes an unwanted getALocalSource() step
       this = any(Vue::Component c).getOption("template")
     }
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -347,7 +347,7 @@ module DomBasedXss {
   class VueTemplateSink extends DomBasedXss::Sink {
     VueTemplateSink() {
       // Note: don't use Vue::Instance#getTemplate as it includes an unwanted getALocalSource() step
-      this = any(Vue::Component i).getOption("template")
+      this = any(Vue::Component c).getOption("template")
     }
   }
 
@@ -357,8 +357,8 @@ module DomBasedXss {
    */
   class VueCreateElementSink extends DomBasedXss::Sink {
     VueCreateElementSink() {
-      exists(Vue::Component i, DataFlow::FunctionNode f |
-        f.flowsTo(i.getRender()) and
+      exists(Vue::Component c, DataFlow::FunctionNode f |
+        f.flowsTo(c.getRender()) and
         this = f.getParameter(0).getACall().getArgument(0)
       )
     }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -347,7 +347,7 @@ module DomBasedXss {
   class VueTemplateSink extends DomBasedXss::Sink {
     VueTemplateSink() {
       // Note: don't use Vue::Instance#getTemplate as it includes an unwanted getALocalSource() step
-      this = any(Vue::Instance i).getOption("template")
+      this = any(Vue::Component i).getOption("template")
     }
   }
 
@@ -357,7 +357,7 @@ module DomBasedXss {
    */
   class VueCreateElementSink extends DomBasedXss::Sink {
     VueCreateElementSink() {
-      exists(Vue::Instance i, DataFlow::FunctionNode f |
+      exists(Vue::Component i, DataFlow::FunctionNode f |
         f.flowsTo(i.getRender()) and
         this = f.getParameter(0).getACall().getArgument(0)
       )

--- a/javascript/ql/test/library-tests/frameworks/Vue/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/tests.expected
@@ -1,4 +1,4 @@
-instance_getAPropertyValue
+component_getAPropertyValue
 | compont-with-route.vue:0:0:0:0 | compont-with-route.vue | dataA | compont-with-route.vue:31:14:31:34 | this.$r ... ery.foo |
 | compont-with-route.vue:0:0:0:0 | compont-with-route.vue | message | compont-with-route.vue:19:15:19:22 | 'Hello!' |
 | single-component-file-1.vue:0:0:0:0 | single-component-file-1.vue | dataA | single-component-file-1.vue:6:40:6:41 | 42 |
@@ -28,7 +28,7 @@ instance_getAPropertyValue
 | tst.js:85:1:87:2 | new Vue ... e; }\\n}) | created | tst.js:86:38:86:41 | true |
 | tst.js:94:2:96:3 | new Vue ...  f,\\n\\t}) | dataA | tst.js:89:22:89:23 | 42 |
 | tst.js:99:2:104:3 | new Vue ... \\t\\t}\\n\\t}) | dataA | tst.js:100:18:100:19 | 42 |
-instance_getOption
+component_getOption
 | compont-with-route.vue:0:0:0:0 | compont-with-route.vue | watch | compont-with-route.vue:10:12:16:5 | {\\n      ... }\\n    } |
 | single-component-file-1.vue:0:0:0:0 | single-component-file-1.vue | data | single-component-file-1.vue:6:11:6:45 | functio ...  42 } } |
 | single-file-component-3.vue:0:0:0:0 | single-file-component-3.vue | data | single-file-component-3-script.js:4:8:4:42 | functio ...  42 } } |
@@ -58,7 +58,7 @@ instance_getOption
 | tst.js:94:2:96:3 | new Vue ...  f,\\n\\t}) | data | tst.js:95:9:95:9 | f |
 | tst.js:99:2:104:3 | new Vue ... \\t\\t}\\n\\t}) | data | tst.js:100:9:100:21 | { dataA: 42 } |
 | tst.js:99:2:104:3 | new Vue ... \\t\\t}\\n\\t}) | methods | tst.js:101:12:103:3 | {\\n\\t\\t\\tm: ... ; }\\n\\t\\t} |
-instance
+component
 | compont-with-route.vue:0:0:0:0 | compont-with-route.vue |
 | single-component-file-1.vue:0:0:0:0 | single-component-file-1.vue |
 | single-file-component-2.vue:0:0:0:0 | single-file-component-2.vue |

--- a/javascript/ql/test/library-tests/frameworks/Vue/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/Vue/tests.ql
@@ -1,15 +1,15 @@
 import javascript
 import semmle.javascript.security.dataflow.Xss
 
-query predicate instance_getAPropertyValue(Vue::Component c, string name, DataFlow::Node prop) {
+query predicate component_getAPropertyValue(Vue::Component c, string name, DataFlow::Node prop) {
   c.getAPropertyValue(name) = prop
 }
 
-query predicate instance_getOption(Vue::Component c, string name, DataFlow::Node prop) {
+query predicate component_getOption(Vue::Component c, string name, DataFlow::Node prop) {
   c.getOption(name) = prop
 }
 
-query predicate instance(Vue::Component c) { any() }
+query predicate component(Vue::Component c) { any() }
 
 query predicate instance_heapStep(
   Vue::InstanceHeapStep step, DataFlow::Node pred, DataFlow::Node succ

--- a/javascript/ql/test/library-tests/frameworks/Vue/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/Vue/tests.ql
@@ -1,15 +1,15 @@
 import javascript
 import semmle.javascript.security.dataflow.Xss
 
-query predicate instance_getAPropertyValue(Vue::Component i, string name, DataFlow::Node prop) {
-  i.getAPropertyValue(name) = prop
+query predicate instance_getAPropertyValue(Vue::Component c, string name, DataFlow::Node prop) {
+  c.getAPropertyValue(name) = prop
 }
 
-query predicate instance_getOption(Vue::Component i, string name, DataFlow::Node prop) {
-  i.getOption(name) = prop
+query predicate instance_getOption(Vue::Component c, string name, DataFlow::Node prop) {
+  c.getOption(name) = prop
 }
 
-query predicate instance(Vue::Component i) { any() }
+query predicate instance(Vue::Component c) { any() }
 
 query predicate instance_heapStep(
   Vue::InstanceHeapStep step, DataFlow::Node pred, DataFlow::Node succ

--- a/javascript/ql/test/library-tests/frameworks/Vue/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/Vue/tests.ql
@@ -1,15 +1,15 @@
 import javascript
 import semmle.javascript.security.dataflow.Xss
 
-query predicate instance_getAPropertyValue(Vue::Instance i, string name, DataFlow::Node prop) {
+query predicate instance_getAPropertyValue(Vue::Component i, string name, DataFlow::Node prop) {
   i.getAPropertyValue(name) = prop
 }
 
-query predicate instance_getOption(Vue::Instance i, string name, DataFlow::Node prop) {
+query predicate instance_getOption(Vue::Component i, string name, DataFlow::Node prop) {
   i.getOption(name) = prop
 }
 
-query predicate instance(Vue::Instance i) { any() }
+query predicate instance(Vue::Component i) { any() }
 
 query predicate instance_heapStep(
   Vue::InstanceHeapStep step, DataFlow::Node pred, DataFlow::Node succ


### PR DESCRIPTION
In the Vue model we have `Vue::Instance` and in the React model we have `ReactComponent`. I'd like to unify these to talk about "components" as the central metaphor. When working in the Vue model, I have often been confused by the lack of a clear distinction between the component and the instance.

Here's the way I see it:
- `Vue.extend()` is the fundamental way to create a **component**.
- Calling `extend` on a component creates a "subclass" of that component.
- Calling a component with `new` is the way to create an **instance**.
- `new Vue(obj)` is a shorthand for `new (Vue.extend(obj))`

From this perspective it is clear that `new Vue(obj)` creates both a component and an instance, it's just that the component-creation is implicit. And looking at the member predicates of `Vue::Instance`, every single one describes the component aspect of this; we don't really model anything pertaining to the instantiation itself. If one were to replace `new Vue(obj)` with `Vue.extend(obj)` the model wouldn't know the difference, so I'd argue that this was always a model of a component.

Some technical caveats to make this renaming work:
- One of the subclasses of `Vue::Instance` was already called `Vue::Component`. That one has been renamed to `Vue::ComponentRegistration`. In the unlikely event that an external query was referring to `Vue::Component`, it should continue to work except it will match a larger set of components.
- The class has been made non-abstract. Its base class is a `newtype` which is not extensible anyway, so the abstractness didn't do anything.

[Smoke test](https://github.com/dsp-testing/asgerf-dca/tree/run/vue-component-renaming__smoke-test__smoke-test/reports) looks ok.